### PR TITLE
Add .github templates in homebrew-core

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Homebrew
+
+First time contributing to Homebrew? Read our [Code of Conduct](https://github.com/Homebrew/homebrew/blob/master/CODEOFCONDUCT.md#code-of-conduct).
+
+### Report a bug
+
+* run `brew update` (twice)
+* run and read `brew doctor`
+* read [the Troubleshooting Checklist](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting)
+* open an issue on the formula's repository
+
+### Submit a `1.2.3` version upgrade for the `foo` formula
+
+* check if the same upgrade has been already submitted by [searching the open pull requests for `foo`](https://github.com/Homebrew/homebrew-core/pulls?utf8=✓&q=is%3Apr+is%3Aopen+foo).
+* `brew edit foo`
+* edit [`url`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#url-class_method) and [`sha256`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#sha256%3D-class_method)/[`tag`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#url-class_method), leave the [`bottle`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#bottle-class_method) as-is
+* `brew install foo`
+* run `brew audit foo` and fix any issues
+* `git commit` with commit subject `foo 1.2.3`
+* [open a pull request](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-homebrew-pull-request-and-get-it-merged) and fix any failing tests
+
+### Add a new formula for `foo` version `2.3.4` from `$URL`
+
+* read [the Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md#formula-cookbook) or: `brew create $URL` and make edits
+* `brew install foo`
+* `brew audit --online --strict foo`
+* `git commit` with message formatted `foo 2.3.4 (new formula)`
+* [open a pull request](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-homebrew-pull-request-and-get-it-merged) and fix any failing tests
+
+### Contribute a fix to the `foo` formula
+
+* `brew edit foo` and make edits
+* leave the [`bottle`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#bottle-class_method) as-is
+* `brew install foo`, `brew test foo`, and `brew audit foo`
+* `git commit` with message formatted `foo: fix <insert details>`
+* [open a pull request](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-homebrew-pull-request-and-get-it-merged) and fix any failing tests
+
+Thanks!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Please follow the general troubleshooting steps first:
+
+- [ ] Ran `brew update` and retried your prior step?
+- [ ] Ran `brew doctor`, fixed as many issues as possible and retried your prior step?
+- [ ] If you're seeing permission errors tried running `sudo chown -R $(whoami) $(brew --prefix)`?
+
+_You can erase any parts of this template not applicable to your Issue._
+
+### Bug reports:
+
+Please replace this line with a brief summary of your issue **AND** if reporting a build issue include the link from:
+
+`brew gist-logs <formula>`
+(where `<formula>` is the name of the formula that failed to build).
+
+### Feature/Formula Requests:
+
+**Please note by far the quickest way to get a new feature or formula into Homebrew is to file a [Pull Request](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md).**
+
+We will consider your request but it may be closed if it's something we're not actively planning to work on.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### All Submissions:
+
+- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
+- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same update/change?
+
+### New or Updated Formulae Submissions:
+
+- [ ] Does your submission pass
+`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
+- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?


### PR DESCRIPTION
Copies over `ISSUE_TEMPLATE.md` and `PULL_REQUEST_TEMPLATE.md` from the main homebrew repo, with modifications to make them specific to formula PRs, now that the core/formula split has happened.
