### PR TITLE
htop: add --HEAD, switch to distribution on main site

### DIFF
--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -1,8 +1,9 @@
 class Htop < Formula
   desc "Improved top (interactive process viewer)"
-  homepage "https://github.com/hishamhm/htop"
-  url "https://github.com/hishamhm/htop/archive/2.0.1.tar.gz"
-  sha256 "636c1e8b703058e793e8d25423af4b74059290ef9e48fa261ba58555069517b5"
+  homepage "https://hisham.hm/htop/"
+  url "https://hisham.hm/htop/releases/2.0.1/htop-2.0.1.tar.gz"
+  sha256 "f410626dfaf6b70fdf73cd7bb33cae768869707028d847fed94a978e974f5666"
+  revision 1
 
   bottle do
     sha256 "b8afe978bc97ef2d18767c769941b81e0501c20566d2427e2e421bb69ca94e5a" => :el_capitan
@@ -10,17 +11,22 @@ class Htop < Formula
     sha256 "47fd6612ee8889637c3aa47a6c8cdc5812b8b8f8fa4853f35f2131bb8da43884" => :mavericks
   end
 
+  head do
+    url "https://github.com/hishamhm/htop.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   option "with-ncurses", "Build using homebrew ncurses (enables mouse scroll)"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "homebrew/dupes/ncurses" => :optional
 
   conflicts_with "htop-osx", :because => "both install an `htop` binary"
 
   def install
-    system "./autogen.sh"
+    system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Closes homebrew/homebrew#50321. This contains the updates @s3ishr made there, along with edjustments requested by maintainers. I'm eager to get it closed out, so submitting here.

I've also bumped the revision because, since we're using a different distribution file, even though it's the same version and in theory will build the same, it might not, and this ensures that the bottles exactly match the current source and build process.
