### PR TITLE
git-multipush: fix devel build, audit fixes

### DIFF
--- a/Formula/git-multipush.rb
+++ b/Formula/git-multipush.rb
@@ -4,18 +4,27 @@ class GitMultipush < Formula
   url "https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2"
   sha256 "1f3b51e84310673045c3240048b44dd415a8a70568f365b6b48e7970afdafb67"
 
+  head "https://github.com/gavinbeatty/git-multipush.git"
+
   devel do
     url "https://github.com/gavinbeatty/git-multipush/archive/git-multipush-v2.4.rc2.tar.gz"
     sha256 "999d9304f322c1b97d150c96be64ecde30980f97eaaa9d66f365b8b11894c46d"
-    version "2.4-rc2"
+    version "2.4.rc2"
   end
-
-  head "https://github.com/gavinbeatty/git-multipush.git"
 
   depends_on "asciidoc" => :build
 
   def install
     system "make" if build.head?
+    # Devel tarballs don't have versions marked, maybe due to GitHub release process
+    # https://github.com/gavinbeatty/git-multipush/issues/1
+    (buildpath/"release").write "VERSION = #{version}" if build.devel?
     system "make", "prefix=#{prefix}", "install"
+  end
+
+  test do
+    # git-multipush will error even on --version if not in a repo
+    system "git", "init"
+    assert_match version.to_s, shell_output("git-multipush --version")
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?
### Description

Upstream's devel tarball releases don't build; probably due to an issue with the GitHub release packaging method, and it being tested only from cloned repos. This just sticks in a missing release tag.

Upstream issue: https://github.com/gavinbeatty/git-multipush/issues/1

Plus audit fixes.

Closes homebrew/homebrew#50530
