### PR TITLE
dummy akka 2.4.2

### DIFF
--- a/Formula/akka.rb
+++ b/Formula/akka.rb
@@ -1,8 +1,8 @@
 class Akka < Formula
   desc "Toolkit for building concurrent, distributed, and fault tolerant apps"
   homepage "http://akka.io/"
-  url "https://downloads.typesafe.com/akka/akka_2.11-2.4.0.zip"
-  sha256 "22155144e5828a1dc40fa0a74031d5bf10292e8fb574d1c7fc5fc0ddebd03667"
+  url "https://downloads.typesafe.com/akka/akka_2.11-2.4.2.zip"
+  sha256 "cedd3e7c3108a25275d44459a5afb94e62b5bdfbe82505b4352b61854e00acf3"
 
   bottle :unneeded
 


### PR DESCRIPTION
Dummy version bump for akka. Used for testing `test-bot` fixes for the "invalid UTF-8 XML" problem at https://github.com/Homebrew/brew/issues/16.

Contains same update as https://github.com/Homebrew/legacy-homebrew/pull/49971; will merge it over there once `test-bot` is fixed.
