### PR TITLE
Modify lv url

### DIFF
--- a/Formula/lv.rb
+++ b/Formula/lv.rb
@@ -1,6 +1,6 @@
 class Lv < Formula
   desc "Powerful multi-lingual file viewer/grep"
-  homepage "http://www.ff.iij4u.or.jp/~nrt/lv/"
+  homepage "https://web.archive.org/web/20160310122517/http://www.ff.iij4u.or.jp/~nrt/lv/"
   url "https://web.archive.org/web/20160310122517/http://www.ff.iij4u.or.jp/~nrt/freeware/lv451.tar.gz"
   version "4.51"
   sha256 "e1cd2e27109fbdbc6d435f2c3a99c8a6ef2898941f5d2f7bacf0c1ad70158bcf"

--- a/Formula/lv.rb
+++ b/Formula/lv.rb
@@ -1,7 +1,7 @@
 class Lv < Formula
   desc "Powerful multi-lingual file viewer/grep"
   homepage "http://www.ff.iij4u.or.jp/~nrt/lv/"
-  url "http://www.ff.iij4u.or.jp/~nrt/freeware/lv451.tar.gz"
+  url "https://web.archive.org/web/20160310122517/http://www.ff.iij4u.or.jp/~nrt/freeware/lv451.tar.gz"
   version "4.51"
   sha256 "e1cd2e27109fbdbc6d435f2c3a99c8a6ef2898941f5d2f7bacf0c1ad70158bcf"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

The host of lv is not found, because the host, iij4u is [closed at 31th March](https://www.iij4u.or.jp/).
In order to prevent failing installation, I will change URL of lv.

I'm not a author of lv, but If there is any better place to host it, please tell me.
