### PR TITLE
README: duplicate more of Homebrew/brew README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@ Core formulae for the Homebrew package manager.
 Just `brew install <formula>`. This is the default tap for Homebrew and is installed by default.
 
 ## Troubleshooting
-First, please run `brew update` and `brew doctor`.
+First, please run `brew update` (twice) and `brew doctor`.
 
 Second, read the [Troubleshooting Checklist](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting).
 
 **If you don’t read these it will take us far longer to help you with your problem.**
+
+## Contributing
+Read [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
+
+Creating new formulae, updating existing ones, and fixing build issues is easier than you think!
+
+Try `brew edit $FORMULA` and see how you fare.
 
 ## Documentation
 `brew help`, `man brew`, [Homebrew/brew's README](https://github.com/Homebrew/brew#homebrew) or check [Homebrew's documentation](https://github.com/Homebrew/brew/tree/master/share/doc/homebrew#readme).


### PR DESCRIPTION
This makes the homebrew-core CONTRIBUTING.md reachable from README.md

Closes #35
