### PR TITLE
perl: fix url/mirror mismatch

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -1,9 +1,9 @@
 class Perl < Formula
   desc "Highly capable, feature-rich programming language"
   homepage "https://www.perl.org/"
-  url "http://www.cpan.org/src/5.0/perl-5.22.1.tar.gz"
+  url "http://www.cpan.org/src/5.0/perl-5.22.1.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/perl/perl_5.22.1.orig.tar.xz"
-  sha256 "2b475d0849d54c4250e9cba4241b7b7291cffb45dfd083b677ca7b5d38118f27"
+  sha256 "9e87317d693ce828095204be0d09af8d60b8785533fadea1a82b6f0e071e5c79"
 
   head "https://perl5.git.perl.org/perl.git", :branch => "blead"
 
@@ -38,8 +38,8 @@ class Perl < Formula
     system "./Configure", *args
     system "make"
 
-    # OS X El Capitan's SIP feature prevents DYLD_LIBRARY_PATH from being passed to child
-    # processes, which causes the make test step to fail.
+    # OS X El Capitan's SIP feature prevents DYLD_LIBRARY_PATH from being
+    # passed to child processes, which causes the make test step to fail.
     # https://rt.perl.org/Ticket/Display.html?id=126706
     # https://github.com/Homebrew/homebrew/issues/41716
     if MacOS.version < :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

When I updated this formula previously I accidentally changed the tarball type back from .xz to .gz which Debian doesn't mimic, and consequently broke fetch when it falls back to the mirror and throws a checksum failure.

Ref: https://github.com/Homebrew/homebrew-core/commit/4d840a319b4e16b15ce183fdc4314c122d87b9bb
