### PR TITLE
diff-so-fancy 0.7.1

### DIFF
--- a/Formula/diff-so-fancy.rb
+++ b/Formula/diff-so-fancy.rb
@@ -1,17 +1,23 @@
 class DiffSoFancy < Formula
   desc "Good-lookin' diffs with diff-highlight and more"
   homepage "https://github.com/so-fancy/diff-so-fancy"
-  url "https://github.com/so-fancy/diff-so-fancy/archive/v0.6.3.tar.gz"
-  sha256 "b56213f08e5f1de1b0529d1a9a62024913ad2f12e043f9818f8cfcf00bed55c4"
+  url "https://github.com/so-fancy/diff-so-fancy/archive/v0.7.1.tar.gz"
+  sha256 "dcf795df0b398f393215d78679f34427e65aa263be3f4016e7e618706b1b4049"
 
   bottle :unneeded
 
   def install
-    prefix.install Dir["third_party", "libs", "diff-so-fancy"]
+    # temporary fix until upstream uses a directory other
+    # than lib for the perl script.
+    inreplace "diff-so-fancy", "/lib/", "/libexec/"
+    prefix.install "lib" => "libexec"
+
+    prefix.install Dir["third_party", "diff-so-fancy"]
     bin.install_symlink prefix/"diff-so-fancy"
   end
 
   test do
+    ENV["TERM"] = "xterm"
     system bin/"diff-so-fancy"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?

```
==> audit problems
diff-so-fancy:
 * Non-libraries were installed to "/usr/local/Cellar/diff-so-fancy/0.7.1/lib"
Installing non-libraries to "lib" is discouraged.
The offending files are:
  /usr/local/Cellar/diff-so-fancy/0.7.1/lib/diff-so-fancy.pl
```

Upstream seems to have renamed `libs` directory as `lib`.
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
