### PR TITLE
brew-news 1.0 (new formula)

### DIFF
--- a/Formula/brew-news.rb
+++ b/Formula/brew-news.rb
@@ -1,0 +1,14 @@
+class BrewNews < Formula
+  desc "Software exploration tool for brew"
+  homepage "https://github.com/devsli/brew-news"
+  url "https://github.com/devsli/brew-news/archive/v1.0.tar.gz"
+  sha256 "74d730b9b887bb2bcdd805340ebc135c28833303263d89d6e2cd907f4a11b17b"
+
+  def install
+    bin.install "brew-news"
+  end
+
+  test do
+    system "#{bin}/brew-news", "-v"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

```
==> audit problems
brew-news:
 * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
 * GitHub repository too new (<30 days old)

Error: 2 problems in 1 formula
```

[`brew-news`](https://github.com/devsli/brew-news) is a tiny `brew update` wrapper to view info (`brew info`) or visit homepage (`brew home`) of updated formulae.
I think it could be useful for curious people, who want to take a closer look at new available software.

Regarding problems:
- I'm not too popular person and this util has limited auditory
- For a long time it was in Github Gist, without special repository

So it's not a problem if you will decide to reject it.
