### PR TITLE
tasksh: fix audit --strict warning

### DIFF
--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -23,6 +23,6 @@ class Tasksh < Formula
   test do
     system "#{bin}/tasksh", "--version"
     (testpath/".taskrc").write "data.location=#{testpath}/.task\n"
-    assert pipe_output("#{bin}/tasksh", "add Test Task").include?("Created task")
+    assert_match(/Created task 1./, pipe_output("#{bin}/tasksh", "add Test Task"))
   end
 end

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -2,8 +2,8 @@ class Tasksh < Formula
   desc "Shell wrapper for Taskwarrior commands"
   homepage "https://tasktools.org/projects/tasksh.html"
   url "https://taskwarrior.org/download/tasksh-1.0.0.tar.gz"
-  head "https://git.tasktools.org/scm/ex/tasksh.git"
   sha256 "9accc81f5ae3a985e33be728d56aba0401889d21f856cd94734d73c221bf8652"
+  head "https://git.tasktools.org/scm/ex/tasksh.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

This commit addresses the following audit warning:
`* Use `assert_match` instead of `assert ...include?``

It also addresses the warning that was returned with `brew audit --strict`:
`* `checksum` (line 6) should be put before `head` (line 5)`
