### PR TITLE
sourcekitten 0.12.0

### DIFF
--- a/Formula/sourcekitten.rb
+++ b/Formula/sourcekitten.rb
@@ -1,7 +1,7 @@
 class Sourcekitten < Formula
   desc "Framework and command-line tool for interacting with SourceKit"
   homepage "https://github.com/jpsim/SourceKitten"
-  url "https://github.com/jpsim/SourceKitten.git", :tag => "0.11.0", :revision => "6415bc91fde389c9b4866e2b61e1189be4c9796c"
+  url "https://github.com/jpsim/SourceKitten.git", :tag => "0.12.0", :revision => "c4da1e86f441ee9596c441ec3321e5d023beca19"
   head "https://github.com/jpsim/SourceKitten.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

This might require Xcode 7.3, but Homebrew CI doesn't appear to have that version available.
