### PR TITLE
pyenv-ccache: fix audit warning

### DIFF
--- a/Formula/pyenv-ccache.rb
+++ b/Formula/pyenv-ccache.rb
@@ -15,6 +15,6 @@ class PyenvCcache < Formula
   end
 
   test do
-    assert shell_output("eval \"$(pyenv init -)\" && pyenv hooks install").include?("ccache.bash")
+    assert_match(/ccache.bash/, shell_output("eval \"$(pyenv init -)\" && pyenv hooks install && ls"))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

This commit addresses the following audit warning:
`* Use `assert_match` instead of `assert ...include?``

It passes `brew audit --strict` but `brew audit --online` raises:
`* GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)`

How should we proceed with that error? I think this formula was submitted before the Formula Cookbook was updated to note the requirement for the `--online` audit option?
