### PR TITLE
masscan: fix audit warning

### DIFF
--- a/Formula/masscan.rb
+++ b/Formula/masscan.rb
@@ -11,6 +11,6 @@ class Masscan < Formula
   end
 
   test do
-    assert `#{bin}/masscan --echo`.include? "adapter ="
+    assert_match(/adapter =/, `#{bin}/masscan --echo | head -n 6 | tail -n 1`)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

This commit addresses the following audit warning:
`* Use `assert_match` instead of `assert ...include?``
