### PR TITLE
txt2man: fix audit warnings

### DIFF
--- a/Formula/txt2man.rb
+++ b/Formula/txt2man.rb
@@ -33,7 +33,7 @@ class Txt2man < Formula
     EOS
 
     assert_equal "main.3\n", shell_output("#{bin}/src2man test.c 2>&1")
-    assert File.read("main.3").include?(%q(\fBmain \fP- do stuff))
+    assert_match(/\\fBmain\ \\fP\-\ do\ stuff\n/, File.read("main.3").lines.to_a[4])
 
     # bookman
     system "#{bin}/bookman", "-t", "Test", "-o", "test", Dir["#{man1}/*"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

The fix addresses these audit warnings:
`* Use `assert_match` instead of `assert ...include?``
`* Use %q only for strings that contain both single quotes and double quotes.`

`brew audit --online` returns this warning, but I'm guessing it's OK:
`* GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)`

Thanks!
