### PR TITLE
udis86: fix audit warning

### DIFF
--- a/Formula/udis86.rb
+++ b/Formula/udis86.rb
@@ -15,6 +15,6 @@ class Udis86 < Formula
   end
 
   test do
-    assert pipe_output("#{bin}/udcli -x", "cd 80").include?("int 0x80")
+    assert_match("int 0x80", pipe_output("#{bin}/udcli -x", "cd 80").split.last(2).join(" "))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

This commit addresses the following audit warning:
`* Use `assert_match` instead of `assert ...include?``
