### PR TITLE
alpine: add option for compiling with Maildir mailbox support

### DIFF
--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -11,7 +11,14 @@ class Alpine < Formula
     sha256 "8f52d4ebe9e445ec975cabdd74c4a48cef80eebb21f18c33644e99de1a6d2173" => :mountain_lion
   end
 
+  option "with-maildir", "Compile with support for Maildir format mailboxes"
+
   depends_on "openssl"
+
+  patch do
+    url "http://patches.freeiz.com/alpine/patches/alpine-2.20/maildir.patch.gz"
+    sha256 "1ef0932b80d7f790ce6577a521a7b613b5ce277bb13cbaf0116bb5de1499caaa"
+  end if build.with? "maildir"
 
   def install
     ENV.j1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Adds an option to compile alpine with the official Maildir patch included.
