### PR TITLE
youtube-dl with optional dependencies

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -19,6 +19,11 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
+  option "with-ffmpeg", "Install ffmpeg as well to use post-processing options"
+  option "with-libav", "Install libav as well to use post-processing options"
+
+  depends_on "ffmpeg" => :optional
+  depends_on "libav" => :optional
   depends_on "rtmpdump" => :optional
 
   def install
@@ -28,10 +33,6 @@ class YoutubeDl < Formula
     bash_completion.install "youtube-dl.bash-completion"
     zsh_completion.install "youtube-dl.zsh" => "_youtube-dl"
     fish_completion.install "youtube-dl.fish"
-  end
-
-  def caveats
-    "To use post-processing options, `brew install ffmpeg` or `brew install libav`."
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

The previous formula only mentioned optional dependencies ffmpeg and libav in the caveats section. I now included them as optional dependencies.

I use the "and" option to check if really both dependencies are not present. Brew audit complains and I should use && instead but it doesn't work and according to [random person on the internet™](http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/) it isn't the same. But to be honest, I have no clue as I can't write Ruby code really. ;-) So if you tell me how to change the if block, I'm happy to do that!
