### PR TITLE
nginx: stop permitting userpaths.

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -32,8 +32,10 @@ class Nginx < Formula
 
   def install
     # Changes default port to 8080
-    inreplace "conf/nginx.conf", "listen       80;", "listen       8080;"
-    inreplace "conf/nginx.conf", "    #}\n\n}", "    #}\n    include servers/*;\n}"
+    inreplace "conf/nginx.conf" do |s|
+      s.gsub! "listen       80;", "listen       8080;"
+      s.gsub! "    #}\n\n}", "    #}\n    include servers/*;\n}"
+    end
 
     pcre = Formula["pcre"]
     openssl = Formula["openssl"]

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -16,8 +16,6 @@ class Nginx < Formula
     sha256 "2b4893076d28e6b4384bba8c4fdebfca6de6f8f68ec48a1ca94b9b855ff457d2"
   end
 
-  env :userpaths
-
   # Before submitting more options to this formula please check they aren't
   # already in Homebrew/homebrew-nginx/nginx-full:
   # https://github.com/Homebrew/homebrew-nginx/blob/master/Formula/nginx-full.rb
@@ -112,7 +110,7 @@ class Nginx < Formula
     # to #{HOMEBREW_PREFIX}/var/www. The reason we symlink instead of patching
     # is so the user can redirect it easily to something else if they choose.
     html = prefix/"html"
-    dst  = var/"www"
+    dst = var/"www"
 
     if dst.exist?
       html.rmtree


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

The history on this formula is rather long but as far as I can trace `userpaths` was needed because for a significant amount of time we permitted the passenger option to pluck out the first `passenger-config` in the $PATH and use that.

That changed about two years ago now in 690ab25 and `userpaths` should have probably been removed at that point, but since it wasn't explicitly breaking anything it went unnoticed and hasn't been discussed since.

Nothing about the remaining formula suggests userpaths should still be needed and it doesn't break if you remove that element, so let's remove it.
