### PR TITLE
ZSH: fix audit warnings

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -28,11 +28,11 @@ class Zsh < Formula
 
     args = %W[
       --prefix=#{prefix}
-      --enable-fndir=#{pkgshare}/zsh/functions
-      --enable-scriptdir=#{pkgshare}/zsh/scripts
+      --enable-fndir=#{pkgshare}/functions
+      --enable-scriptdir=#{pkgshare}/scripts
       --enable-site-fndir=#{HOMEBREW_PREFIX}/share/zsh/site-functions
       --enable-site-scriptdir=#{HOMEBREW_PREFIX}/share/zsh/site-scripts
-      --enable-runhelpdir=#{pkgshare}/zsh/help
+      --enable-runhelpdir=#{pkgshare}/help
       --enable-cap
       --enable-maildir-support
       --enable-multibyte

--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -28,11 +28,11 @@ class Zsh < Formula
 
     args = %W[
       --prefix=#{prefix}
-      --enable-fndir=#{share}/zsh/functions
-      --enable-scriptdir=#{share}/zsh/scripts
+      --enable-fndir=#{pkgshare}/zsh/functions
+      --enable-scriptdir=#{pkgshare}/zsh/scripts
       --enable-site-fndir=#{HOMEBREW_PREFIX}/share/zsh/site-functions
       --enable-site-scriptdir=#{HOMEBREW_PREFIX}/share/zsh/site-scripts
-      --enable-runhelpdir=#{share}/zsh/help
+      --enable-runhelpdir=#{pkgshare}/zsh/help
       --enable-cap
       --enable-maildir-support
       --enable-multibyte


### PR DESCRIPTION
This pull request resolves the following three audit warnings when running `brew audit --strict zsh`:

```
zsh:
 * Use #{pkgshare} instead of #{share}/zsh
 * Use #{pkgshare} instead of #{share}/zsh
 * Use #{pkgshare} instead of #{share}/zsh
```

/cc @mikemcquaid 
## 
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? I believe so! [This search](https://github.com/Homebrew/homebrew-core/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+zsh) appears to come up empty.
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
  
  Indeed it does:
  
  ```
  ==> brew style zsh
  
  1 file inspected, no offenses detected
  ```
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
  
  I have, but because it's already installed, I get the below message. Is that 🆗?
  
  ```
  Warning: zsh-5.2 already installed
  ```
