### PR TITLE
nesc: assign minimum emacs version

### DIFF
--- a/Formula/nesc.rb
+++ b/Formula/nesc.rb
@@ -7,7 +7,7 @@ class Nesc < Formula
   depends_on "automake" => :build
   depends_on "autoconf" => :build
   depends_on :java => :build
-  depends_on :emacs => :build
+  depends_on :emacs => ["21.1", :build]
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
On certain system(e.g. fe22f59), `brew update` will report
`Error: Specify a version for EmacsRequirement` before it could run
migration for brew 0.9.9.

This commit workaround this problem.

(cherry picked from commit Homebrew/legacy-homebrew@c7ded23)
