### PR TITLE
nfdump: enable readpcap by default

### DIFF
--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -11,8 +11,16 @@ class Nfdump < Formula
     sha256 "5bbd8ec9a51cde3c6ed0aaeb1b77a4f2ba59bea99d5304fa1415a7e2e0d5280b" => :mountain_lion
   end
 
+  option "with-readpcap", "Read netflow packets from a give pcap_file instead of the network. Is intended for debugging only."
+
+
   def install
-    system "./configure", "--prefix=#{prefix}"
+    args = %W[
+      --prefix=#{prefix}
+    ]
+
+    args << "--enable-readpcap" if build.with? "readpcap"
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -11,12 +11,12 @@ class Nfdump < Formula
     sha256 "5bbd8ec9a51cde3c6ed0aaeb1b77a4f2ba59bea99d5304fa1415a7e2e0d5280b" => :mountain_lion
   end
 
-  option "with-readpcap", "Enable reading netflow packets from pcap_file instead of network"
-
   def install
-    args = %W[--prefix=#{prefix}]
+    args = %W[
+      --prefix=#{prefix}
+      --enable-readpcap
+    ]
 
-    args << "--enable-readpcap" if build.with? "readpcap"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -11,7 +11,7 @@ class Nfdump < Formula
     sha256 "5bbd8ec9a51cde3c6ed0aaeb1b77a4f2ba59bea99d5304fa1415a7e2e0d5280b" => :mountain_lion
   end
 
-  option "with-readpcap", "Read netflow packets from a give pcap_file instead of the network. Is intended for debugging only."
+  option "with-readpcap", "Enable reading netflow packets from pcap_file instead of network"
 
   def install
     args = %W[--prefix=#{prefix}]

--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -13,11 +13,8 @@ class Nfdump < Formula
 
   option "with-readpcap", "Read netflow packets from a give pcap_file instead of the network. Is intended for debugging only."
 
-
   def install
-    args = %W[
-      --prefix=#{prefix}
-    ]
+    args = %W[--prefix=#{prefix}]
 
     args << "--enable-readpcap" if build.with? "readpcap"
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
