### PR TITLE
mpd: add modplug decoder support

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -1,6 +1,7 @@
 class Mpd < Formula
   desc "Music Player Daemon"
   homepage "http://www.musicpd.org/"
+  revision 1
 
   stable do
     url "http://www.musicpd.org/download/mpd/0.19/mpd-0.19.14.tar.xz"
@@ -31,6 +32,7 @@ class Mpd < Formula
   option "with-libvorbis", "Build with vorbis support (for Ogg encoding)"
   option "with-yajl", "Build with yajl support (for playing from soundcloud)"
   option "with-opus", "Build with opus support (for Opus encoding and decoding)"
+  option "with-libmodplug", "Build with modplug support (for decoding modules supported by MODPlug)"
 
   deprecated_option "with-vorbis" => "with-libvorbis"
 
@@ -63,6 +65,7 @@ class Mpd < Formula
   depends_on "libvorbis" => :optional
   depends_on "libnfs" => :optional
   depends_on "mad" => :optional
+  depends_on "libmodplug" => :optional  # MODPlug decoder
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -93,6 +96,7 @@ class Mpd < Formula
     args << "--disable-soundcloud" if build.without? "yajl"
     args << "--enable-vorbis-encoder" if build.with? "libvorbis"
     args << "--enable-nfs" if build.with? "libnfs"
+    args << "--enable-modplug" if build.with? "libmodplug"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Module (*.mod, *.s3m, *.xm, etc) playback with the modplug decoder can be enabled with the
`--with-libmodplug` flag.
https://www.musicpd.org/doc/user/decoder_plugins.html#idm45666765924944
