### PR TITLE
zorba: build dependencies and revision for icu4c

### DIFF
--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -3,7 +3,7 @@ class Zorba < Formula
   homepage "http://www.zorba.io/"
   url "https://github.com/28msec/zorba/archive/3.0.tar.gz"
   sha256 "75661fed35fb143498ba6539314a21e0e2b0cc18c4eaa5782d488430ac4dd9c8"
-  revision 2
+  revision 3
 
   bottle do
     revision 1

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -1,9 +1,8 @@
 class Zorba < Formula
   desc "NoSQL query processor"
   homepage "http://www.zorba.io/"
-  url "https://github.com/28msec/zorba/archive/3.0.tar.gz"
-  sha256 "75661fed35fb143498ba6539314a21e0e2b0cc18c4eaa5782d488430ac4dd9c8"
-  revision 3
+  url "https://github.com/28msec/zorba/archive/3.1.tar.gz"
+  sha256 "a27e8160aca5d3aa5a6525b930da7edde44f8824dd4fba39aaef3b9af2717b74"
 
   bottle do
     revision 1
@@ -17,13 +16,9 @@ class Zorba < Formula
 
   depends_on :macos => :mavericks
   depends_on "cmake" => :build
-  depends_on "swig" => [:build, :recommended]
   depends_on "flex"
   depends_on "icu4c"
   depends_on "xerces-c"
-  depends_on :java => :build
-  depends_on :ruby => ["1.9", :build]
-  depends_on :python => :build
 
   conflicts_with "xqilla", :because => "Both supply xqc.h"
 
@@ -35,11 +30,6 @@ class Zorba < Formula
     args = std_cmake_args
     args << "-DZORBA_VERIFY_PEER_SSL_CERTIFICATE=ON" if build.with? "ssl-verification"
     args << "-DZORBA_WITH_BIG_INTEGER=ON" if build.with? "big-integer"
-
-    # https://github.com/Homebrew/homebrew/issues/42372
-    # Seems to be an assumption `/usr/include/php` will exist without an obvious
-    # override to that logic.
-    args << "-DZORBA_SUPPRESS_SWIG=ON" if !MacOS::CLT.installed? || build.without?("swig")
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -21,6 +21,9 @@ class Zorba < Formula
   depends_on "flex"
   depends_on "icu4c"
   depends_on "xerces-c"
+  depends_on :java => :build
+  depends_on :ruby => ["1.9", :build]
+  depends_on :python => :build
 
   conflicts_with "xqilla", :because => "Both supply xqc.h"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
## Changes

Revision bump for zorba for the icu4c rebuild (see #183).

Not sure how to denote that this depends on php being installed in order to build the php language bindings, seeing as there isn't a simple `depends_on :php => :build` like I thought there might be.

<s>My guess is that we'll still have test failures until Homebrew/homebrew-php#3090 is merged?</s> Nevermind; I misunderstood how the CI works.
