### PR TITLE
httping: use brew OpenSSL rather than system OpenSSL

### DIFF
--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -4,6 +4,8 @@ class Httping < Formula
   url "https://www.vanheusden.com/httping/httping-2.4.tgz"
   sha256 "dab59f02b08bfbbc978c005bb16d2db6fe21e1fc841fde96af3d497ddfc82084"
 
+  revision 1
+
   head "https://github.com/flok99/httping.git"
 
   bottle do
@@ -14,6 +16,7 @@ class Httping < Formula
   end
 
   depends_on "gettext"
+  depends_on "openssl"
   depends_on "fftw" => :optional
 
   def install


### PR DESCRIPTION
v2.4 as compiled in master on 10.11 will fail all HTTPS endpoints which
I've tested:

```
$ httping https://google.com
Auto enabling SSL due to https-URLPING google.com:443 (/):
short read during receiving reply-headers from host
```

(Using the system OpenSSL 0.9.8zh)

Recompiling with the dependency on the current OpenSSL (1.0.2g) works as
expected:

```
$ httping https://google.com
Auto enabling SSL due to https-URLPING google.com:443 (/):
connected to 216.58.218.238:443 (419 bytes), seq=0 time= 41.93 ms
```

See https://github.com/flok99/httping/issues/4
