### PR TITLE
git: gitk: support pre-'lime' Tcl/Tk versions

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -3,6 +3,7 @@ class Git < Formula
   homepage "https://git-scm.com"
   url "https://www.kernel.org/pub/software/scm/git/git-2.8.2.tar.xz"
   sha256 "ec0283d78a0f1c8408c5fd43610697b953fbaafe4077bb1e41446a9ee3a2f83d"
+  revision 1
 
   head "https://github.com/git/git.git", :shallow => false
 
@@ -49,6 +50,11 @@ class Git < Formula
     ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
     ENV["PYTHON_PATH"] = which "python"
     ENV["PERL_PATH"] = which "perl"
+
+    # Support Tcl versions before "lime" color name was introduced
+    # https://github.com/Homebrew/homebrew-core/issues/115
+    # http://www.mail-archive.com/git%40vger.kernel.org/msg92017.html
+    inreplace "gitk-git/gitk", "lime", '"#99FF00"'
 
     perl_version = /\d\.\d+/.match(`perl --version`)
 
@@ -158,3 +164,4 @@ class Git < Formula
     end
   end
 end
+


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/115

Looks like the color name `lime` was only introduced in recent versions of Tcl/Tk newer than the ones shipped with 10.9 and some other OS X versions. The `gitk` script uses `lime`, so if you try to run it, you'll get a launch failure.

```
$ gitk
Error in startup script: unknown color name "lime"
    (processing "-fore" option)
    invoked from within
"$ctext tag conf m2 -fore [lindex $mergecolors 2]"
    (procedure "makewindow" line 347)
    invoked from within
"makewindow"
    (file "/usr/local/bin/gitk" line 12434)
```

This fixes it by replacing the symbolic name `lime` in `gitk` with a numeric RGB color so it'll work with older Tcl/tk versions.
