### PR TITLE
lablgtk: fix missing gtksourceview dependency

### DIFF
--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -3,7 +3,7 @@ class Lablgtk < Formula
   homepage "http://lablgtk.forge.ocamlcore.org"
   url "https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
   sha256 "975bebf2f9ca74dc3bf7431ebb640ff6a924bb80c8ee5f4467c475a7e4b0cbaf"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -17,6 +17,7 @@ class Lablgtk < Formula
   depends_on "ocaml"
   depends_on "gtk+"
   depends_on "librsvg"
+  depends_on "gtksourceview"
 
   def install
     system "./configure", "--bindir=#{bin}",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Without this, lablgtk is built ignoring gtksourceview. Normally, lablgtk configure script looks for this package and if available links with it. By adding this dependency, the configure script can find gtksourceview and link with it.
