### PR TITLE
osx-cpu-temp HEAD (new formula)

### DIFF
--- a/Formula/osx-cpu-temp.rb
+++ b/Formula/osx-cpu-temp.rb
@@ -1,0 +1,14 @@
+class OsxCpuTemp < Formula
+  desc "Outputs current CPU temperature for OS X"
+  homepage "https://github.com/lavoiesl/osx-cpu-temp"
+  head "https://github.com/lavoiesl/osx-cpu-temp.git", :revision => "376883f1d5251e104216dbdb80cb0c7a77a2bf7e"
+
+  def install
+    system "make"
+    bin.install "osx-cpu-temp"
+  end
+
+  test do
+    system "#{bin}/osx-cpu-temp"
+  end
+end


### PR DESCRIPTION
A temperature monitoring tool for the OS X command line. HEAD-only, since upstream haven't released any stable versions, but it is useful as is.
