### PR TITLE
Update IPFS formulae to official v0.4.0 release

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -4,8 +4,8 @@ class Ipfs < Formula
   desc "IPFS is The Permanent Web - A new peer-to-peer hypermedia protocol"
   homepage "https://ipfs.io/"
   url "https://github.com/ipfs/go-ipfs.git",
-    :tag => "v0.3.11",
-    :revision => "7070b4d878baad57dcc8da80080dd293aa46cabd"
+    :tag => "v0.4.0",
+    :revision => "600c95eb53e576530d73afe856bf11ae219b3acb"
   head "https://github.com/ipfs/go-ipfs.git"
 
   bottle do


### PR DESCRIPTION
Release: https://github.com/ipfs/go-ipfs/releases/tag/v0.4.0
