### PR TITLE
confuse 3.0

### DIFF
--- a/Formula/confuse.rb
+++ b/Formula/confuse.rb
@@ -1,8 +1,8 @@
 class Confuse < Formula
   desc "Configuration file parser library written in C"
   homepage "https://github.com/martinh/libconfuse"
-  url "https://github.com/martinh/libconfuse/releases/download/v2.8/confuse-2.8.tar.xz"
-  sha256 "2a8102bfa3ccc846c14d94a81b0abfb4f5e855809f89ff3722aca1a9f314ea0d"
+  url "https://github.com/martinh/libconfuse/releases/download/v3.0/confuse-3.0.tar.xz"
+  sha256 "bb75174e02aa8b44fa1a872a47beeea1f5fe715ab669694c97803eb6127cc861"
 
   bottle do
     cellar :any

--- a/Formula/fwup.rb
+++ b/Formula/fwup.rb
@@ -3,6 +3,7 @@ class Fwup < Formula
   homepage "https://github.com/fhunleth/fwup"
   url "https://github.com/fhunleth/fwup/releases/download/v0.6.0/fwup-0.6.0.tar.gz"
   sha256 "11d8d3a6e7464584b89d88571ee2d2dc1da758fe98525191e77982c60f35bcf3"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/ganglia.rb
+++ b/Formula/ganglia.rb
@@ -3,6 +3,7 @@ class Ganglia < Formula
   homepage "http://ganglia.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/ganglia/ganglia%20monitoring%20core/3.7.1/ganglia-3.7.1.tar.gz"
   sha256 "e735a6218986a0ff77c737e5888426b103196c12dc2d679494ca9a4269ca69a3"
+  revision 1
 
   bottle do
     revision 1


### PR DESCRIPTION
Follows up  #260, adding dependent revision bumps.
