### PR TITLE
SDL_image: exactly link with libpng and other recommended libraries

### DIFF
--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -30,7 +30,7 @@ class SdlImage < Formula
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
     args << "--enable-jpg-shared=no" << "--enable-png-shared=no" << "--enable-tif-shared=no"
-    args << (build.with?("webp") ? "--enable-webp-shared=no" : "--enable-webp-shared")
+    args << "--enable-webp-shared" + (build.with?("webp") ? "=no": "")
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -18,7 +18,7 @@ class SdlImage < Formula
   depends_on "sdl"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "webp" => :optionall
+  depends_on "webp" => :optional
 
   def install
     ENV.universal_binary if build.universal?
@@ -29,7 +29,7 @@ class SdlImage < Formula
     args << "--disable-imageio"
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
-    args << "--enable-jpg-shared=no << "--enable-png-shared=no << "--enable-tif-shared=no
+    args << "--enable-jpg-shared=no" << "--enable-png-shared=no" << "--enable-tif-shared=no"
     args << "--enable-webp-shared=no" if build.with? "webp"
     system "./configure", *args
     system "make", "install"

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -30,7 +30,7 @@ class SdlImage < Formula
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
     args << "--enable-jpg-shared=no" << "--enable-png-shared=no" << "--enable-tif-shared=no"
-    args << build.with?("webp") ? "--enable-webp-shared=no" : "--enable-webp-shared"
+    args << (build.with?("webp") ? "--enable-webp-shared=no" : "--enable-webp-shared")
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -16,10 +16,9 @@ class SdlImage < Formula
 
   depends_on "pkg-config" => :build
   depends_on "sdl"
-  depends_on "jpeg" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "libtiff" => :recommended
-  depends_on "webp" => :recommended
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "webp" => :optionall
 
   def install
     ENV.universal_binary if build.universal?
@@ -30,10 +29,8 @@ class SdlImage < Formula
     args << "--disable-imageio"
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
-    args << "--enable-jpg-shared" + ((build.without? "jpeg") ? "" : "=no")
-    args << "--enable-png-shared" + ((build.without? "libpng") ? "" : "=no")
-    args << "--enable-tif-shared" + ((build.without? "libtiff") ? "" : "=no")
-    args << "--enable-webp-shared" + ((build.without? "webp") ? "" : "=no")
+    args << "--enable-jpg-shared=no << "--enable-png-shared=no << "--enable-tif-shared=no
+    args << "--enable-webp-shared=no" if build.with? "webp"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -30,7 +30,7 @@ class SdlImage < Formula
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
     args << "--enable-jpg-shared=no" << "--enable-png-shared=no" << "--enable-tif-shared=no"
-    args << "--enable-webp-shared=no" if build.with? "webp"
+    args << build.with?("webp") ? "--enable-webp-shared=no" : "--enable-webp-shared"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -30,10 +30,10 @@ class SdlImage < Formula
     args << "--disable-imageio"
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
-    args << "--enable-jpg-shared=no" if build.with? "jpeg"
-    args << "--enable-png-shared=no" if build.with? "libpng"
-    args << "--enable-tif-shared=no" if build.with? "libtiff"
-    args << "--enable-webp-shared=no" if build.with? "webp"
+    args << "--enable-jpg-shared" + ((build.without? "jpeg") ? "" : "=no")
+    args << "--enable-png-shared" + ((build.without? "libpng") ? "" : "=no")
+    args << "--enable-tif-shared" + ((build.without? "libtiff") ? "" : "=no")
+    args << "--enable-webp-shared" + ((build.without? "webp") ? "" : "=no")
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -12,6 +12,8 @@ class SdlImage < Formula
     sha256 "84272135304e7c475e8000a90af113127858273a4449ce6566805f5b4c2cb476" => :mavericks
   end
 
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "jpeg" => :recommended
@@ -19,12 +21,13 @@ class SdlImage < Formula
   depends_on "libtiff" => :recommended
   depends_on "webp" => :recommended
 
-  option :universal
-
   def install
     ENV.universal_binary if build.universal?
     inreplace "SDL_image.pc.in", "@prefix@", HOMEBREW_PREFIX
     args = %W[--prefix=#{prefix} --disable-dependency-tracking --disable-sdltest]
+    # The alternative of ImagIO framework or libpng, jpeg, libttf and webp.
+    # http://forums.libsdl.org/viewtopic.php?p=42910&sid=76c5b793b1e8f19d350a94773b1ced3b#42907
+    args << "--disable-imageio"
     # --enable-feature-shared args work as inverse.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
     args << "--enable-jpg-shared=no" if build.with? "jpeg"

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -17,6 +17,7 @@ class SdlImage < Formula
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "libpng"
+  depends_on "jpeg"
   depends_on "libtiff"
   depends_on "webp" => :optional
 

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -3,7 +3,7 @@ class SdlImage < Formula
   homepage "https://www.libsdl.org/projects/SDL_image"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -24,10 +24,14 @@ class SdlImage < Formula
   def install
     ENV.universal_binary if build.universal?
     inreplace "SDL_image.pc.in", "@prefix@", HOMEBREW_PREFIX
-
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
-                          "--disable-sdltest"
+    args = %W[--prefix=#{prefix} --disable-dependency-tracking --disable-sdltest]
+    # --enable-feature-shared args work as inverse.
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=3308
+    args << "--enable-jpg-shared=no" if build.with? "jpeg"
+    args << "--enable-png-shared=no" if build.with? "libpng"
+    args << "--enable-tif-shared=no" if build.with? "libtiff"
+    args << "--enable-webp-shared=no" if build.with? "webp"
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

libSDL_image.dylib in  `sdl_image-1.2.12_2.el_capitan.bottle.tar.gz` was not linked libpng and other recommended libraries. There are two reasons.

First one is that --enable-feature-shared args work as inverse. See https://bugzilla.libsdl.org/show_bug.cgi?id=3308
The upper example in bug report page is libSDL_image.dylib in  `sdl_image-1.2.12_2.el_capitan.bottle.tar.gz`.
This revision's one links with depended libraries and zlib (the lower example). So we may set `--enable-feature-shared=no`.  But there was no shared object for libpng yet.

Second, to link with libpng and other recommended libraries needs to disable linkage with ImageIO framework. This is alternative.

Now we can get the shared symbols for libpng and others.
