### PR TITLE
airport-bssid 0.1.0 (new formula)

### DIFF
--- a/Formula/airport-bssid.rb
+++ b/Formula/airport-bssid.rb
@@ -1,0 +1,15 @@
+class AirportBssid < Formula
+  desc "associate to a specific bssid"
+  homepage "https://qpshinqp.github.io/airport-bssid/"
+  url "https://github.com/qpSHiNqp/airport-bssid/archive/0.1.0.tar.gz"
+  sha256 "cf1e81298838aa3d072c280ef5d85dc574958479083f39684647a8c63865a113"
+  head "https://github.com/qpSHiNqp/airport-bssid.git"
+  def install
+    xcodebuild
+    bin.install "build/Release/airport-bssid"
+  end
+
+  test do
+    system "airport-bssid"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [/] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
  It doesn't pass the test, it complains about the repository not being popular enough. I propose to add the formula despite that, because it is the only known way to associate to a network with a specific bssid.
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
