### PR TITLE
unar: fix description

### DIFF
--- a/Formula/unar.rb
+++ b/Formula/unar.rb
@@ -1,19 +1,19 @@
 class Unar < Formula
-  desc "RAR archive command-line tools"
+  desc "Command-line unarchiving tools supporting multiple formats"
   homepage "https://unarchiver.c3.cx/commandline"
   url "https://wakaba.c3.cx/releases/TheUnarchiver/unar1.9.1_src.zip"
-  sha256 "28045fb688563c002b7c2807e80575d3f9af8eb024739f9ab836f681bb8e822c"
   version "1.9.1"
+  sha256 "28045fb688563c002b7c2807e80575d3f9af8eb024739f9ab836f681bb8e822c"
 
   head "https://bitbucket.org/WAHa_06x36/theunarchiver", :using => :hg
-
-  depends_on :xcode => :build
 
   bottle do
     cellar :any
     sha256 "3f0abeedfdc17860ef6f8f8406b34cc6fb2b334e13c3081d00fb7c2ef98f7cc1" => :el_capitan
     sha256 "829f81a91ebb65385bb5b39944f40a8a6a3a900e4717ef00cf608fec2884e3d6" => :yosemite
   end
+
+  depends_on :xcode => :build
 
   def install
     # Files in unar1.9.1_src.zip have "The Unarchiver" path prefix, but HEAD checkout does not.


### PR DESCRIPTION
`unar` is the command line version of the popular OS X unarchiving app The Unarchiver. It supports dozens of formats (see full list at https://unarchiver.c3.cx/formats). Definitely not limited to RAR. In fact, supporting multiple formats is the main reason why unar is insteresting when there are already canonical tools for each format, e.g., 7z, gunzip, tar, unrar, unxz, unzip, etc.

Also fixed two minor audit problems along the way.
