### PR TITLE
travis.yml: pass `--tap` argument.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ulimit -n 1024
 
 script:
-  - brew test-bot
+  - brew test-bot --tap=homebrew/core
 
 notifications:
   slack:


### PR DESCRIPTION
This should get `master` testing formulae again.

Closes https://github.com/Homebrew/brew/issues/100. CC @xu-cheng 
