### PR TITLE
libkml: fix head url (https -> http)

### DIFF
--- a/Formula/libkml.rb
+++ b/Formula/libkml.rb
@@ -27,7 +27,7 @@ class Libkml < Formula
   end
 
   head do
-    url "https://libkml.googlecode.com/svn/trunk/"
+    url "http://libkml.googlecode.com/svn/trunk/"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

This seems to be wrong based on my rejected attempts to do the same.
