### PR TITLE
boost: revision for icu4c

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -3,7 +3,7 @@ class Boost < Formula
   homepage "https://www.boost.org/"
   url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
   sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
-  revision 1
+  revision 2
 
   head "https://github.com/boostorg/boost.git"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

The default configuration of `boost` does not depend on `icu4c`, but the somewhat popular formula `ncmpcpp` depends on `boost --with-icu4c`. Bump revision as there's no other way to trigger a rebuild of `boost` for those users (and other users who have installed it with `--with-icu4c`). This is necessary for `boost` to pick up the updated `icu4c` and thus fix the dylib linkage for the affected users.

This is not something we would normally do as `icu4c` is an optional dependency, but there are already multiple issue reports (both upstream and in Homebrew) that warrant this bump:
- #395 (also contains the brief discussion about whether or not to bump)
- Homebrew/brew#90
- arybczak/ncmpcpp#125
- arybczak/ncmpcpp#128
