### PR TITLE
docker-machine-driver-scaleway 1.0.1 (new formula)

### DIFF
--- a/Formula/docker-machine-driver-scaleway.rb
+++ b/Formula/docker-machine-driver-scaleway.rb
@@ -1,0 +1,28 @@
+require "language/go"
+
+class DockerMachineDriverScaleway < Formula
+  desc "Docker Machine driver for Scaleway"
+  homepage "https://github.com/scaleway/docker-machine-driver-scaleway/"
+  url "https://github.com/scaleway/docker-machine-driver-scaleway/archive/v1.0.1.tar.gz"
+  sha256 "90caba19fa78bd5c6e01c0696ff37eb9d877cb252ae37dacc63ffde86a3cbe7a"
+
+  head "https://github.com/scaleway/docker-machine-driver-scaleway.git"
+
+  depends_on "go" => :build
+  depends_on "docker-machine" => :recommended
+
+  def install
+    ENV["GOPATH"] = buildpath
+    path = buildpath/"src/github.com/scaleway/docker-machine-driver-scaleway"
+    path.install Dir["{*,.git,.gitignore}"]
+
+    cd path do
+      system "go", "build", "-o", "#{bin}/docker-machine-driver-scaleway", "./main.go"
+    end
+  end
+
+  test do
+    output = shell_output("#{Formula["docker-machine"].bin}/docker-machine create --driver scaleway -h")
+    assert_match "scaleway-name", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- Does your submission pass
  - [x] `brew audit --strict <formula>`
  - [ ] `brew audit --strict --online <formula>` _(note: not yet)_
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

:bouquet: the repository is too young to pass `brew audit --online`, however, this package is just a driver for the `docker-machine` project.
Can we expect to bypass this requirement ?
