### PR TITLE
citus 5.0.1 (new formula)

### DIFF
--- a/Formula/citus.rb
+++ b/Formula/citus.rb
@@ -1,0 +1,56 @@
+class Citus < Formula
+  desc "PostgreSQL-based distributed RDBMS"
+  homepage "https://www.citusdata.com"
+  url "https://github.com/citusdata/citus/archive/v5.0.1.tar.gz"
+  sha256 "dd81a2f2a0fb5bb6e4a990b96f04857d7e6d8fcd607d7aabf70087506f7a2fc9"
+
+  head "https://github.com/citusdata/citus.git"
+
+  depends_on "postgresql"
+
+  def install
+    ENV["PG_CONFIG"] = Formula["postgresql"].opt_bin/"pg_config"
+
+    system "./configure"
+
+    # workaround for https://github.com/Homebrew/homebrew/issues/49948
+    system "make", "libpq=-L#{Formula["postgresql"].opt_lib} -lpq"
+
+    # Use stage directory to prevent installing to pg_config-defined dirs,
+    # which would not be within this package's Cellar.
+    mkdir "stage"
+    system "make", "install", "DESTDIR=#{buildpath}/stage"
+
+    bin.install Dir["stage/**/bin/*"]
+    lib.install Dir["stage/**/lib/*"]
+    include.install Dir["stage/**/include/*"]
+    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
+  end
+
+  test do
+    pg_bin = Formula["postgresql"].opt_bin
+    pg_port = "55561"
+    system "#{pg_bin}/initdb", testpath/"test"
+    pid = fork do
+      exec("#{pg_bin}/postgres",
+           "-D", testpath/"test",
+           "-c", "shared_preload_libraries=citus",
+           "-p", pg_port)
+    end
+
+    begin
+      sleep 2
+
+      count_workers_query = "SELECT COUNT(*) FROM master_get_active_worker_nodes();"
+
+      system "#{pg_bin}/createdb", "-p", pg_port, "test"
+      system "#{pg_bin}/psql", "-p", pg_port, "-d", "test", "--command", "CREATE EXTENSION citus;"
+
+      assert_equal "0", shell_output("#{pg_bin}/psql -p #{pg_port} -d test -Atc" \
+                                     "'#{count_workers_query}'").strip
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
Previously submitted as Homebrew/legacy-homebrew#50392, where it has already undergone some code review.

Last month, [Citus Data](https://www.citusdata.com) "unforked" Citus, their PostgreSQL-based distributed database and [open-sourced the whole project](https://www.citusdata.com/blog/17-ozgun-erdogan/403-citus-unforks-postgresql-goes-open-source). This means Citus, previously a private fork of the PostgreSQL codebase, can now be added to an existing PostgreSQL install using the standard PostgreSQL `CREATE EXTENSION` command.

This is analogous to e.g. PostGIS, whose formula was used as an example when writing the formula for Citus. Other PostgreSQL-related formula provided good examples of a test block that actually starts PostgreSQL and verifies installation of the extension.
