### PR TITLE
PR template: do install before audit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 - [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-- [ ] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
-- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?
+- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
+- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
+
+### Description


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

This new order matches the order in the test-bot process, and allows
audit to catch issues with file installation locations, which require
the formula to be installed.

Also puts little section headers above the checklist and the user-entered description, to help with readability once it's posted.

See https://github.com/Homebrew/homebrew-core/pull/304#issuecomment-212109945 for an example of the "audit before install" causes things to be missed.
