### PR TITLE
openssl: run make test on all arches

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -85,10 +85,7 @@ class Openssl < Formula
       system "perl", "./Configure", *(configure_args + arch_args[arch])
       system "make", "depend"
       system "make"
-
-      if (MacOS.prefer_64_bit? || arch == MacOS.preferred_arch) && build.with?("test")
-        system "make", "test"
-      end
+      system "make", "test" if build.with?("test")
 
       if build.universal?
         cp "include/openssl/opensslconf.h", dir


### PR DESCRIPTION
OpenSSL build time test for i386 was disabled in 10e1691578929ed9350162e36c72fcac8205efcf.
But as I tested recently on OS X 10.11 and 10.5, it works fine.
So let's enable it, since it's generally a bad idea to disable build
time test for crypto libraries.
