### PR TITLE
Use modern 7.3 TDSVER default for modern FreeTDS

### DIFF
--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -38,7 +38,7 @@ class Freetds < Formula
   def install
     args = %W[
       --prefix=#{prefix}
-      --with-tdsver=7.1
+      --with-tdsver=7.3
       --mandir=#{man}
     ]
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

I am the author of Ruby's TinyTDS and ActiveRecord SQL Server stack. I work close with the FreeTDS team too. The 0.95 version brings long awaited support to 2008 and upward data types like [datetime2]. These types are only usable under the TDSVER of 7.3 and upward. Changing the default does not stop others from using lower versions, but it does modernize expectations for data types that have been out since 2008.
