### PR TITLE
warn the user that `fc-cache` may take a long time to run

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -47,6 +47,7 @@ class Fontconfig < Formula
   end
 
   def post_install
+    ohai "Regenerating font cache, this may take a while"
     system "#{bin}/fc-cache", "-frv"
   end
 


### PR DESCRIPTION
Should mitigate e.g. https://github.com/Homebrew/legacy-homebrew/issues/45260 
