### PR TITLE
boost: Fix auto-pointer registration in 1.60

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -20,6 +20,14 @@ class Boost < Formula
   # patch derived from https://github.com/boostorg/graph/commit/1d5f43d
   patch :DATA
 
+  # Fix auto-pointer registration in 1.60
+  # https://github.com/boostorg/python/pull/59
+  # patch derived from https://github.com/boostorg/python/commit/f2c465f
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/9e56b45/boost/boost1_60_0_python_class_metadata.diff"
+    sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
+  end
+
   env :userpaths
 
   option :universal


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Add a patch that backports an upstream commit to fix a bug in boost 1.60.

The motivation for this is primarily that this boost bug breaks the RDKit chemistry toolkit. See:
https://github.com/rdkit/homebrew-rdkit/issues/32

The way the boost and boost-python formulae are split makes it difficult to compile against the 1.59 version via homebrew/versions (without overriding the keg_only and symlinking) so I think a patch is the only solution.

Patch derived from boostorg/python@e9c265a
Pull request https://github.com/boostorg/python/pull/59
Further discussion of this bug https://github.com/boostorg/python/issues/56
