### PR TITLE
gst-*: add tests

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -61,4 +61,10 @@ class GstPluginsBad < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin dvbsuboverlay")
+    assert_match version.to_s, output
+  end
 end

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -58,4 +58,10 @@ class GstPluginsBase < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin volume")
+    assert_match version.to_s, output
+  end
 end

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -83,4 +83,10 @@ class GstPluginsGood < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin cairo")
+    assert_match version.to_s, output
+  end
 end

--- a/Formula/gst-plugins-ugly.rb
+++ b/Formula/gst-plugins-ugly.rb
@@ -75,4 +75,10 @@ class GstPluginsUgly < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin dvdsub")
+    assert_match version.to_s, output
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?

Just adds tests to the `gst-*` formulae that don't have them. The command in the tests throws a bad exit code (and consequently `brew test` will fail) if the plugin cannot be found.
