### PR TITLE
povray: trim overly expensive test, fix scripts for non-standard install

### DIFF
--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -87,7 +87,12 @@ class Povray < Formula
   end
 
   test do
-    ohai "Rendering all test scenes; this may take a while"
-    system "#{share}/povray-3.7/scripts/allscene.sh", "-o", "."
+    # Condensed version of `share/povray-3.7/scripts/allscene.sh` that only
+    # renders variants of the famous Utah teapot as a quick smoke test.
+    scenes = Dir["#{share}/povray-3.7/scenes/advanced/teapot/*.pov"]
+    assert !scenes.empty?, "Failed to find test scenes."
+    scenes.each do |scene|
+      system "#{share}/povray-3.7/scripts/render_scene.sh", ".", scene
+    end
   end
 end

--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -72,6 +72,12 @@ class Povray < Formula
 
     args << "--with-openexr=#{HOMEBREW_PREFIX}" if build.with? "openexr"
 
+    # Adjust some scripts to search for `etc` in HOMEBREW_PREFIX.
+    %w[allanim allscene portfolio].each do |script|
+      inreplace "unix/scripts/#{script}.sh",
+                /^DEFAULT_DIR=.*$/, "DEFAULT_DIR=#{HOMEBREW_PREFIX}"
+    end
+
     cd "unix" do
       system "./prebuild.sh"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

The new test limits itself to rendering a few variants of the famous Utah teapot to check basic functionality. The previous test rendered a total of 437 scenes and usually exceeded the time limit for tests. (It took about 15 minutes to complete on a fairly recent dual-core machine).

Also adjusts some helper scripts that have a hard-coded `/usr/local` so they can be used with a non-standard Homebrew installation.
