### PR TITLE
xvid: update url (was 410 Gone)

### DIFF
--- a/Formula/xvid.rb
+++ b/Formula/xvid.rb
@@ -1,7 +1,7 @@
 class Xvid < Formula
   desc "High-performance, high-quality MPEG-4 video library"
   homepage "https://www.xvid.org"
-  url "https://fossies.org/unix/privat/xvidcore-1.3.4.tar.gz"
+  url "https://fossies.org/linux/misc/xvidcore-1.3.4.tar.gz"
   # Official download takes a long time to fail, so set it as the mirror for now
   mirror "http://downloads.xvid.org/downloads/xvidcore-1.3.4.tar.gz"
   sha256 "4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f"


### PR DESCRIPTION
```
==> Downloading https://fossies.org/unix/privat/xvidcore-1.3.4.tar.gz
==> Downloading from https://fossies.org/linux/privat/xvidcore-1.3.4.tar.gz

curl: (22) The requested URL returned error: 410 Gone
Trying a mirror...
==> Downloading http://downloads.xvid.org/downloads/xvidcore-1.3.4.tar.gz
######################################################################## 100.0%
```
