### PR TITLE
dynamodb-local: fix wrapper to exec java

### DIFF
--- a/Formula/dynamodb-local.rb
+++ b/Formula/dynamodb-local.rb
@@ -17,7 +17,7 @@ class DynamodbLocal < Formula
 
   def bin_wrapper; <<-EOS.undent
     #!/bin/sh
-    cd #{data_path} && java -Djava.library.path=#{libexec}/DynamodbLocal_lib -jar #{libexec}/DynamoDBLocal.jar "$@"
+    cd #{data_path} && exec java -Djava.library.path=#{libexec}/DynamodbLocal_lib -jar #{libexec}/DynamoDBLocal.jar "$@"
     EOS
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  **No, it fails due to lack of a `test do`, which was not present in the `master` version of the formula. Shall I add one in order to get this accepted?**
### Description

This pull request adds the use of `exec` in the `dynamodb-local` wrapper script, which allows the `java` process to replace the `/bin/sh` process. This is simpler, more efficient, and allows `dynamodb-local` to be controlled by managers like [Supervisor](http://supervisord.org/) which do not play well with `java` launched as a subprocess.
