### PR TITLE
docbook: workaround for Ruby 1.8.7

### DIFF
--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -47,7 +47,8 @@ class Docbook < Formula
     (etc/"xml").mkpath
 
     %w[42 412 43 44 45 50].each do |version|
-      resource("xml#{version}").stage do |r|
+      # Ruby 1.8.7 workaround: without the second argument, r will be an Array
+      resource("xml#{version}").stage do |r, _|
         if version == "412"
           cp prefix/"docbook/xml/4.2/catalog.xml", "catalog.xml"
 


### PR DESCRIPTION
For Ruby 1.8.7, unless the block has a list of arguments, the single
argument `|r|` will be an Array with all the arguments passed by
`yield`, not just the first one. The `yield` in Resource#unpack passes
`self, staging` so listing `|r, _|` will make sure `r` is a Resource not
an Array.
