### PR TITLE
tiny-fugue: Added SSL support 

### DIFF
--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -14,6 +14,7 @@ class TinyFugue < Formula
   conflicts_with "tee-clc", :because => "both install a `tf` binary"
 
   depends_on "libnet"
+  depends_on "openssl"
   depends_on "pcre"
 
   # pcre deprecated pcre_info. Switch to HB pcre-8.31 and pcre_fullinfo.
@@ -21,6 +22,8 @@ class TinyFugue < Formula
   patch :DATA
 
   def install
+    ENV.append "CPPFLAGS", "-I#{Formula["openssl"].opt_prefix}include"
+    ENV.append "LDFLAGS", "-L#{Formula["openssl"].opt_prefix}lib"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-getaddrinfo",

--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -2,8 +2,8 @@ class TinyFugue < Formula
   desc "Programmable MUD client"
   homepage "http://tinyfugue.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/tinyfugue/tinyfugue/5.0%20beta%208/tf-50b8.tar.gz"
-  sha256 "3750a114cf947b1e3d71cecbe258cb830c39f3186c369e368d4662de9c50d989"
   version "5.0b8"
+  sha256 "3750a114cf947b1e3d71cecbe258cb830c39f3186c369e368d4662de9c50d989"
 
   bottle do
     sha256 "4ed6867f50a84cea3d90669ca06e8e3b491ed6660c5502b2441a59df6ddc1574" => :el_capitan
@@ -22,8 +22,6 @@ class TinyFugue < Formula
   patch :DATA
 
   def install
-    ENV.append "CPPFLAGS", "-I#{Formula["openssl"].opt_prefix}include"
-    ENV.append "LDFLAGS", "-L#{Formula["openssl"].opt_prefix}lib"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-getaddrinfo",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

(Disclaimer: The package did not pass brew audit --strict --online before my changes either, but I did not change the state of the art there; notably, no idea about how to add tests so cannot fix it either.)

I did not make openssl support an option because openssl is probably installed anyway (and overhead in the tiny-fugue code itself is ~4kb).
