### PR TITLE
png++ 0.2.9

### DIFF
--- a/Formula/png++.rb
+++ b/Formula/png++.rb
@@ -14,7 +14,61 @@ class Pngxx < Formula
 
   depends_on "libpng"
 
+  # Fix strerror_r usage for OS X clang
+  # patch from <https://savannah.nongnu.org/bugs/?46312>
+  patch :DATA
+
   def install
     system "make", "PREFIX=#{prefix}", "install"
   end
+
+  test do
+    (testpath/"test.cc").write <<-EOF.undent
+      #include <png++/png.hpp>
+      #include <iostream>
+
+      int main(int argc, char **argv) {
+        try {
+          png::image<png::rgb_pixel> image(argv[1]);
+          png::rgb_pixel const pixel = image.get_pixel(0, 0);
+          if (pixel.red != 0x00 || pixel.green != 0x00 || pixel.blue != 0xFF) {
+            return 1;
+          }
+        } catch(png::error &e) {
+          std::cerr << e.what() << std::endl;
+          throw;
+        }
+        return 0;
+      }
+    EOF
+
+    system ENV.cxx, "test.cc", "-I#{include}", "-I#{Formula["libpng"].include}", "-L#{Formula["libpng"].lib}", "-lpng", "-o", "test"
+    system "./test", test_fixtures("test.png")
+  end
 end
+
+__END__
+--- a/error.hpp
++++ b/error.hpp
+@@ -93,20 +93,15 @@ namespace png
+     protected:
+         static std::string thread_safe_strerror(int errnum)
+         {
+-#define ERRBUF_SIZE 512
++#define ERRBUF_SIZE 8192
+             char buf[ERRBUF_SIZE] = { 0 };
+ 
+ #ifdef HAVE_STRERROR_S
+             strerror_s(buf, ERRBUF_SIZE, errnum);
+             return std::string(buf);
+ #else
+-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE
+             strerror_r(errnum, buf, ERRBUF_SIZE);
+             return std::string(buf);
+-#else
+-            /* GNU variant can return a pointer to static buffer instead of buf */
+-            return std::string(strerror_r(errnum, buf, ERRBUF_SIZE));
+-#endif
+ #endif
+ 
+ #undef ERRBUF_SIZE

--- a/Formula/png++.rb
+++ b/Formula/png++.rb
@@ -1,9 +1,8 @@
 class Pngxx < Formula
   desc "C++ wrapper for libpng library"
   homepage "http://www.nongnu.org/pngpp/"
-  url "https://savannah.nongnu.org/download/pngpp/png++-0.2.5.tar.gz"
-  sha256 "339fa2dff2cdd117efb43768cb272745faef4d02705b5e0e840537a2c1467b72"
-  revision 1
+  url "https://savannah.nongnu.org/download/pngpp/png++-0.2.9.tar.gz"
+  sha256 "abbc6a0565122b6c402d61743451830b4faee6ece454601c5711e1c1b4238791"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/png++.rb
+++ b/Formula/png++.rb
@@ -3,6 +3,7 @@ class Pngxx < Formula
   homepage "http://www.nongnu.org/pngpp/"
   url "https://savannah.nongnu.org/download/pngpp/png++-0.2.9.tar.gz"
   sha256 "abbc6a0565122b6c402d61743451830b4faee6ece454601c5711e1c1b4238791"
+  head "svn://svn.savannah.nongnu.org/pngpp/trunk"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

This patch upgrades png++ formula to the latest release 0.2.9. 0.2.9 requires patching to build with OS X clang.
