### PR TITLE
mozjpeg: Add important crash and fdct fixes from jpeg-turbo

### DIFF
--- a/Formula/mozjpeg.rb
+++ b/Formula/mozjpeg.rb
@@ -3,6 +3,24 @@ class Mozjpeg < Formula
   homepage "https://github.com/mozilla/mozjpeg"
   url "https://github.com/mozilla/mozjpeg/releases/download/v3.1/mozjpeg-3.1-release-source.tar.gz"
   sha256 "deedd88342c5da219f0047d9a290cd58eebe1b7a513564fcd8ebc49670077a1f"
+  revision 1
+
+  # Fix crashes in ASM code with current llvm/clang versions.
+  # See https://github.com/libjpeg-turbo/libjpeg-turbo/pull/20
+  # and https://github.com/mozilla/mozjpeg/issues/202 for info.
+  patch do
+    url "https://patch-diff.githubusercontent.com/raw/libjpeg-turbo/libjpeg-turbo/pull/20.diff"
+    sha256 "d29a4b48fff3d3f22d1281f4125ff2bdf84eb25819facd724a8096ae04e6cd94"
+  end
+
+  # Fix negative shift with IFAST FDCT and qual=100
+  # Patch from freebsd/freebsd-ports based on commit:
+  # https://github.com/libjpeg-turbo/libjpeg-turbo/commit/4cfa3f4
+  # See https://github.com/mozilla/mozjpeg/pull/186 for info.
+  patch :p0 do
+    url "https://raw.githubusercontent.com/freebsd/freebsd-ports/a608b6f56cca57cebe410682434706e8a45d548e/graphics/mozjpeg/files/patch-jcdctmgr.c"
+    sha256 "1b94aac7d0e4dcadc9dae1dc33607faa468f0de3c4f07c8f918de64a54478253"
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
This adds 64-bit assembly fixes for mozilla/mozjpeg/issues/202 which are required to avoid segfaults with current clang and a fix for corruption with the IFAST DCT at quality 100 from mozilla/mozjpeg/pull/186.

Both fixes have been in libjpeg-turbo – which mozjpeg is based on – for a long time and have been approved by mozjpeg's pornel for inclusion in a future mozjpeg release.

See the linked issue / pull request for more info.

The revision bump is because this fixes crashes for existing installs.

Also updated formula order to comply with strict audit, which makes the diff a bit hard to read.
