### PR TITLE
moc 2.5.1

### DIFF
--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -1,25 +1,23 @@
 class Moc < Formula
   desc "Terminal-based music player"
   homepage "https://moc.daper.net"
-  revision 2
   head "svn://daper.net/moc/trunk"
 
   stable do
-    url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.0.tar.bz2"
-    sha256 "d29ea52240af76c4aa56fa293553da9d66675823e689249cee5f8a60657a6091"
-
-    # Backport r2779: Adapt to FFmpeg/LibAV's audioconvert.h rename (commit 5980f5dd).
-    # Necessary for building against FFmpeg 3.0. See https://moc.daper.net/node/1496.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/patches/1282e60/moc/moc-2.5.0.diff"
-      sha256 "1a7d2d7f967c8182db01dd95d5a05aac8f2acae2eac6fcda419baaed068bc8ef"
-    end
+    url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.1.tar.bz2"
+    sha256 "1b419c75a92a85ff4ee7670c65d660c86fef32032c65e89e868b988f80fac4f2"
   end
 
   bottle do
     sha256 "717d61c1ffe92dc06eb29d4041983fe2ef521abd3d9b97028013b8c496e02aca" => :el_capitan
     sha256 "ef91d680c58d0f949e56d209967f75737ba48c919537824d8f25233672a783c3" => :yosemite
     sha256 "39a6dc0a11c173a4e4556d7774061c12fdaf532a218ca1891ce367c453c75c31" => :mavericks
+  end
+
+  devel do
+    url "http://ftp.daper.net/pub/soft/moc/unstable/moc-2.6-alpha2.tar.xz"
+    version "2.6-alpha2"
+    sha256 "0a3a4fb11227ec58025f7177a3212aca9c9955226a2983939e8db662af13434b"
   end
 
   option "with-ncurses", "Build with wide character support."
@@ -42,6 +40,8 @@ class Moc < Formula
   depends_on "timidity" => :optional
   depends_on "libmagic" => :optional
   depends_on "homebrew/dupes/ncurses" => :optional
+
+  depends_on "popt" if build.devel?
 
   def install
     system "autoreconf", "-fvi"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Also add devel version 2.6-alpha2.

Release announcement: https://moc.daper.net/node/1504.

By the way, brew can't parse the version `2.6-alpha2` from `http://ftp.daper.net/pub/soft/moc/unstable/moc-2.6-alpha2.tar.xz` (the parsed version is `2`). Maybe a case should be added in `version.rb` to recognize `\d+(\.\d+)*-(alpha|beta|rc)\d+`?
