### PR TITLE
ghc: make bottle relocatable

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -5,7 +5,8 @@ class Ghc < Formula
   sha256 "b0bb177b8095de6074e5a3538e55fd1fc187dae6eb6ae36b05582c55f7d2db6f"
 
   bottle do
-    revision 1
+    cellar :any
+    revision 2
     sha256 "35f640eb0f58ef517a829bfdbc046a03c84e179fb2100421b9b0c8dbc1f18e2a" => :el_capitan
     sha256 "6ac060e495d6373ed9051da8ba55bcab2d51f30ebf9f68a48f842171ee5181a6" => :yosemite
     sha256 "0f846d17016873ebf740729844286978f9673982fe686a5308ee4cd444de59cb" => :mavericks


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
  - No. I rather ran `brew install --build-bottle --verbose ghc` then `brew bottle ghc` finally `brew install ghc-7.10.3b.el_capitan.bottle.2.tar.gz` as I understand it is the correct building and installation test to do for the change proposed i.e. relocatable bottle.
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  - My submission passes `brew audit --strict --online ghc` after doing `brew install ghc-7.10.3b.el_capitan.bottle.2.tar.gz`;
  - I did not try `brew audit --strict --online ghc` after `brew install ghc` as I understand it is out of scope for the proposed change i.e. relocatable bottle.
### References used
- Bottle [production and bottling](https://github.com/Homebrew/brew/blob/1451553188276117a574b2abe8957cb60ef7ced7/share/doc/homebrew/Bottles.md#bottles) and [local bottle installation](https://github.com/Homebrew/brew/blob/1451553188276117a574b2abe8957cb60ef7ced7/share/doc/homebrew/Bottles.md#local-bottle-usage);
- [Why non-relocatable bottle is not used](https://github.com/Homebrew/brew/blob/1451553188276117a574b2abe8957cb60ef7ced7/share/doc/homebrew/Bottles.md#bottle-usage) and [relocatable bottle in bottle DSL](https://github.com/Homebrew/brew/blob/1451553188276117a574b2abe8957cb60ef7ced7/share/doc/homebrew/Bottles.md#cellar);
- [Jenkins recent ghc bottle-related operations](http://bot.brew.sh/job/Homebrew%20Core%20Pull%20Requests/756/version=el_capitan/console) i.e.
  
  ```
  ...
  ==> brew uses ghc
  ==> brew fetch --retry xz
  ==> brew fetch --retry ghc --build-bottle --force
  ==> brew install --only-dependencies --build-bottle --verbose ghc
  ==> brew install --build-bottle --verbose ghc
  ==> brew audit ghc
  ==> brew bottle --verbose --rb ghc
  ==> brew bottle --merge --write --no-commit ./ghc-7.10.3b.el_capitan.bottle.rb
  ==> brew uninstall --force ghc
  ==> brew uninstall --force xz
  ==> brew install ./ghc-7.10.3b.el_capitan.bottle.1.tar.gz
  ==> brew test ghc --verbose
  ...
  ```
### Description

I propose to make the ghc bottle relocatable so that users using cellar different from the recommended can avoid compiling it every time.

I performed two types of testing:
1. In order to check that binaries provided by the ghc formula can work from any location, I run `brew install ghc` with the upstream unmodified formula (that caused the formula to be compiled from source - I guess because of cellar different from the recommended), then I copied the whole cellar in a different location on the filesystem, then I reset my PATH to the OSX standard one (i.e. no homebrew binaries in PATH e.g. no ghc binaries), then I smoke tested all of the binaries (in bin/) inside the copied cellar;
2. I order to check that the new bottle definition is working, I built and installed the bottle locally as described above.
