### PR TITLE
ghc: regenerate cache after installation.

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -118,6 +118,11 @@ class Ghc < Formula
     end
 
     ENV.deparallelize { system "make", "install" }
+    Dir.glob(lib/"*/package.conf.d/package.cache") {|f| rm f }
+  end
+
+  def post_install
+    system "#{bin}/ghc-pkg", "recache"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
### Description

This file can be regenerated really quickly (<1s on my machine), it's not a text file and stops the `ghc` bottle being `cellar :any`.

Note that this PR as-is will not make `ghc` `cellar :any` by itself; it will also require https://github.com/Homebrew/brew/pull/141 to be merged and rebuilt after that.

CC @lucafavatella https://github.com/Homebrew/homebrew-core/pull/577
