### PR TITLE
ocaml: fix bottles with nonstandard prefix

### DIFF
--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -21,6 +21,13 @@ class Ocaml < Formula
     sha256 "928fb5f64f4e141980ba567ff57b62d8dc7b951b58be9590ffb1be2172887a72"
   end
 
+  pour_bottle? do
+    # The ocaml compilers embed prefix information in weird ways that the default
+    # brew detection doesn't find, and so needs to be explicitly blacklisted.
+    reason "The bottle needs to be installed into /usr/local."
+    satisfy { HOMEBREW_PREFIX.to_s == "/usr/local" }
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "72fca832d91bda2ed37a72b11207c511f1b3291357ab508e5974431da1602bd7" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  - The only failures are pre-existing issues.
### Description

Unfortunately ocaml embeds the prefix into a bunch of its files, meaning
that bottles can only be used if they were built for exactly the prefix
they're being installed into.

The location of `ocamlrun` is the most obvious place the prefix is
embedded, but it seems there are others -- `ocamlc` seems to use the
hardcoded prefix for the location of `caml.h`, for instance. There are
probably others.

This somehow got added in
https://github.com/Homebrew/homebrew-core/commit/d597a9835db02748e22a89c8508c9340e5d5303b,
I'm not familiar enough with brew infra to know why the bot added it.
But it shouldn't be here.
