### PR TITLE
creduce: add with-libcxx to llvm dependency

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -15,7 +15,7 @@ class Creduce < Formula
 
   depends_on "astyle"
   depends_on "delta"
-  depends_on "llvm" => "with-clang"
+  depends_on "llvm" => ["with-clang", "with-libcxx"]
 
   depends_on :macos => :mavericks
 


### PR DESCRIPTION
Fixes a missing dependency in `creduce`.

Before:

```
$ brew linkage creduce
System libraries:
  /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
  /usr/lib/libSystem.B.dylib
  /usr/lib/libncurses.5.4.dylib
  /usr/lib/libz.1.dylib
Missing libraries:
  /usr/local/opt/llvm/lib/libc++.1.dylib
```

After:

```
$ brew linkage creduce
System libraries:
  /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
  /usr/lib/libSystem.B.dylib
  /usr/lib/libncurses.5.4.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/llvm/lib/libc++.1.dylib (llvm)
```

Fixes breakage in #599.
