### PR TITLE
Fix RPATH of satellite sfml libraries

### DIFF
--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -16,6 +16,9 @@ class Sfml < Formula
     sha256 "915c46a78ca356b9637b8e46821a6a58a0eebf9c960f143d40a92974757a5697" => :mountain_lion
   end
 
+  # Fix incorrect handling of RPATH for a system-wide installation of SFML libraries
+  patch :DATA
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :optional
   depends_on "flac"
@@ -55,3 +58,20 @@ class Sfml < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/cmake/Macros.cmake b/cmake/Macros.cmake
+index 0cf8826..171d1e1 100644
+--- a/cmake/Macros.cmake
++++ b/cmake/Macros.cmake
+@@ -83,8 +83,8 @@ macro(sfml_add_library target)
+
+         # adapt install directory to allow distributing dylibs/frameworks in user's frameworks/application bundle
+         set_target_properties(${target} PROPERTIES
+-                              BUILD_WITH_INSTALL_RPATH 1
+-                              INSTALL_NAME_DIR "@rpath")
++                              BUILD_WITH_INSTALL_RPATH 0)
++        #                      INSTALL_NAME_DIR "@rpath")
+     endif()
+
+     # enable automatic reference counting on iOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

SFML has issues when being installed as a system-wide library (/usr/local/lib) due to the fact that satellite libraries like `libsfml-graphics.dylib` specify relative links to other core sfml libraries like `sfml-window.dylib` and `sfml-system.dylib` in terms of `@rpath`

This creates compilation ambiguities if another library's `@rpath` happens to contain SFML dylibs.
I've included a simple patch file that changes the `@rpath` to `@loader_path` for the installed libraries.
