### PR TITLE
aria2: fix homepage URL

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -1,6 +1,6 @@
 class Aria2 < Formula
   desc "Download with resuming and segmented downloading"
-  homepage "http://aria2.sourceforge.net/"
+  homepage "https://aria2.github.io/"
   url "https://github.com/tatsuhiro-t/aria2/releases/download/release-1.21.0/aria2-1.21.0.tar.xz"
   sha256 "225c5f2c8acc899e0a802cdf198f82bd0d3282218e80cdce251b1f9ffacf6580"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

The project's homepage has moved. The old link redirects to the link I provided.

**Edit:** Running `brew audit --strict --online aria2` results in the error:

```
  * C: 20: col 1: Extra empty line detected at method body beginning.
```

Since this was present before I modified the formula I did not change it. It probably belongs in a separate fix.
