### PR TITLE
tippecanoe 1.9.16

### DIFF
--- a/Formula/tippecanoe.rb
+++ b/Formula/tippecanoe.rb
@@ -1,8 +1,8 @@
 class Tippecanoe < Formula
   desc "Build vector tilesets from collections of GeoJSON features"
   homepage "https://github.com/mapbox/tippecanoe"
-  url "https://github.com/mapbox/tippecanoe/archive/1.9.15.tar.gz"
-  sha256 "e58cac588842a5f70d263d0e9b2eb940e32b06ab3c6560bbd650059484bab184"
+  url "https://github.com/mapbox/tippecanoe/archive/1.9.16.tar.gz"
+  sha256 "6e8e1378bef34894c01a4b53eba83c240257e210bf352060754adb062472fa71"
 
   bottle do
     cellar :any
@@ -10,8 +10,6 @@ class Tippecanoe < Formula
     sha256 "54505632c32d8bc698c392508d82e68fce3ba249b04da8df5d5ef8f40f793b92" => :yosemite
     sha256 "0f0253a1d1bb08a368c9f8c95f7b757e9aa7f6b20e8dfa03dcb95cc63ecb8abe" => :mavericks
   end
-
-  depends_on "protobuf-c"
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Upgrade `tippecanoe` to 1.9.16

Significantly, this version removes the dependency on `protobuf-c`.
