### PR TITLE
cli53 0.7.4 (new formula)

### DIFF
--- a/Formula/cli53.rb
+++ b/Formula/cli53.rb
@@ -1,0 +1,21 @@
+class Cli53 < Formula
+  desc "command-line tool for Amazon Route 53"
+  homepage "https://github.com/barnybug/cli53"
+  url "https://github.com/barnybug/cli53/archive/0.7.4.tar.gz"
+  sha256 "3cb89e6aa91676ffd0577798a4b06b056667d18ad836de4fa31c0564ee48474e"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    mkdir_p buildpath/"src/github.com/barnybug"
+    ln_s buildpath, buildpath/"src/github.com/barnybug/cli53"
+
+    system "make", "build"
+    bin.install "cli53"
+  end
+
+  test do
+    system "#{bin}/cli53", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

cli53 provides import and export from BIND format and simple command line management of Route 53 domains.
