### PR TITLE
swiftlint 0.10.0

### DIFF
--- a/Formula/swiftlint.rb
+++ b/Formula/swiftlint.rb
@@ -1,7 +1,7 @@
 class Swiftlint < Formula
   desc "Tool to enforce Swift style and conventions"
   homepage "https://github.com/realm/SwiftLint"
-  url "https://github.com/realm/SwiftLint.git", :tag => "0.9.2", :revision => "6cafa08e70dab64c39c38ea5b9542126389d27aa"
+  url "https://github.com/realm/SwiftLint.git", :tag => "0.10.0", :revision => "fbd2bcd0edc264e04d02f87b0d0f98add754ac88"
   head "https://github.com/realm/SwiftLint.git"
 
   bottle do
@@ -10,7 +10,7 @@ class Swiftlint < Formula
     sha256 "dc70240351452d4a9fe8b46030b7d4e4db93c005445a5b712956515fafa5ec88" => :yosemite
   end
 
-  depends_on :xcode => ["7.1", :build]
+  depends_on :xcode => ["7.3", :build]
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SwiftLint.dst"


### PR DESCRIPTION
This might fail CI for the same reasons as documented here https://github.com/Homebrew/legacy-homebrew/pull/50211, if that's the case, I'll apply the same workaround by unfortunately weakening the validation test.
