### PR TITLE
percona-xtrabackup 2.4.2 (new formula)

### DIFF
--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -1,14 +1,14 @@
-
 class PerconaXtrabackup < Formula
   desc "Open source hot backup tool for InnoDB and XtraDB databases"
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
   url "https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.2/source/tarball/percona-xtrabackup-2.4.2.tar.gz"
   sha256 "faeac6f1db4a1270e5263e48c8a94cc5c81c772fdea36879d1be18dcbcd1926e"
 
-  option "with-man-pages", "Build man pages. Needs python-sphinx to be installed"
+  option "with-docs", "Build man pages"
 
   depends_on "cmake" => :build
   depends_on "libev" => :build
+  depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "libgcrypt"
   depends_on :mysql => :recommended
 
@@ -19,11 +19,8 @@ class PerconaXtrabackup < Formula
       -DWITH_BOOST=boost
     ]
 
-    if build.without? "man-pages"
+    if build.without? "docs"
       cmake_args << "-DWITH_MAN_PAGES=OFF"
-      ohai "Building without man pages"
-    else
-      ohai "Building with man pages"
     end
 
     cmake_args.concat std_cmake_args
@@ -42,9 +39,6 @@ class PerconaXtrabackup < Formula
 
       brew install perl cpanminus
       cpanm DBD::mysql
-
-    All binaries are installed to #{bin}
-    and are symlinked to /usr/local/bin
 
     EOS
   end

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -57,7 +57,7 @@ class PerconaXtrabackup < Formula
     system "cmake", *cmake_args
     system "make"
     system "make", "install"
-    
+
     share.install "share/man" if build.with? "docs"
 
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -26,8 +26,8 @@ class PerconaXtrabackup < Formula
       ohai "Building with man pages"
     end
 
-    system "cmake", *cmake_args, *std_cmake_args,
-           "&& make", "-j4"
+    system "cmake", *cmake_args, *std_cmake_args
+    system "make", "-j4"
     system "make", "install"
 
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -4,7 +4,7 @@ class PerconaXtrabackup < Formula
   url "https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.2/source/tarball/percona-xtrabackup-2.4.2.tar.gz"
   sha256 "faeac6f1db4a1270e5263e48c8a94cc5c81c772fdea36879d1be18dcbcd1926e"
 
-  option "with-docs", "Build man pages"
+  option "without-docs", "Build without man pages (which requires python-sphinx)"
 
   depends_on "cmake" => :build
   depends_on "libev" => :build

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -33,18 +33,28 @@ class PerconaXtrabackup < Formula
 
     cmake_args = %W[
       -DBUILD_CONFIG=xtrabackup_release
+      -DCOMPILATION_COMMENT=Homebrew
     ]
 
+    if build.with? "docs"
+      cmake_args.concat %W[
+        -DWITH_MAN_PAGES=ON
+        -DINSTALL_MANDIR=share/man
+      ]
+
+      # OSX has this value empty by default.
+      # See https://bugs.python.org/issue18378#msg215215
+      ENV["LC_ALL"] = "en_US.UTF-8"
+    else
+      cmake_args << "-DWITH_MAN_PAGES=OFF"
+    end
+    
     # MySQL >5.7.x mandates Boost as a requirement to build & has a strict
     # version check in place to ensure it only builds against expected release.
     # This is problematic when Boost releases don't align with MySQL releases.
     (buildpath/"boost_1_59_0").install resource("boost")
     cmake_args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
-
-    if build.without? "docs"
-      cmake_args << "-DWITH_MAN_PAGES=OFF"
-    end
-
+    
     cmake_args.concat std_cmake_args
 
     system "cmake", *cmake_args
@@ -53,6 +63,7 @@ class PerconaXtrabackup < Formula
 
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files
 
+    share.install "share/man" if build.with? "docs"
     bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
   end
 

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -32,19 +32,7 @@ class PerconaXtrabackup < Formula
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files
   end
 
-  def caveats; <<-EOS.undent
-    You'll need the DBD::mysql Perl module.  To install it
-    without modifying OSX's own Perl installation:
-    (reopen terminal after each command)
-
-      brew install perl cpanminus
-      cpanm DBD::mysql
-
-    EOS
-  end
-
   test do
     system "#{bin}/xtrabackup", "--version"
-    system "#{bin}/innobackupex", "--version"
   end
 end

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -1,0 +1,54 @@
+
+class PerconaXtrabackup < Formula
+  desc "Open source hot backup tool for InnoDB and XtraDB databases"
+  homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
+  url "https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.2/source/tarball/percona-xtrabackup-2.4.2.tar.gz"
+  sha256 "faeac6f1db4a1270e5263e48c8a94cc5c81c772fdea36879d1be18dcbcd1926e"
+
+  option "with-man-pages", "Build man pages. Needs python-sphinx to be installed"
+
+  depends_on "cmake" => :build
+  depends_on "libev" => :build
+  depends_on "libgcrypt"
+  depends_on :mysql => :recommended
+
+  def install
+    cmake_args = %W[
+      -DBUILD_CONFIG=xtrabackup_release
+      -DDOWNLOAD_BOOST=1
+      -DWITH_BOOST=boost
+    ]
+
+    if build.without? "man-pages"
+      cmake_args << "-DWITH_MAN_PAGES=OFF"
+      ohai "Building without man pages"
+    else
+      ohai "Building with man pages"
+    end
+
+    system "cmake", *cmake_args, *std_cmake_args,
+           "&& make", "-j4"
+    system "make", "install"
+
+    rm_rf prefix/"xtrabackup-test" # Remove unnecessary files
+  end
+
+  def caveats; <<-EOS.undent
+    You'll need the DBD::mysql Perl module.  To install it
+    without modifying OSX's own Perl installation:
+    (reopen terminal after each command)
+
+      brew install perl cpanminus
+      cpanm DBD::mysql
+
+    All binaries are installed to #{bin}
+    and are symlinked to /usr/local/bin
+
+    EOS
+  end
+
+  test do
+    system "#{bin}/xtrabackup", "--version"
+    system "#{bin}/innobackupex", "--version"
+  end
+end

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -10,6 +10,7 @@ class PerconaXtrabackup < Formula
   depends_on "libev" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "libgcrypt"
+  depends_on "openssl"
   depends_on :mysql => :recommended
 
   resource "DBD::mysql" do

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -12,7 +12,20 @@ class PerconaXtrabackup < Formula
   depends_on "libgcrypt"
   depends_on :mysql => :recommended
 
+  resource "DBD::mysql" do
+    url "https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz"
+    mirror "http://search.cpan.org/CPAN/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz"
+    sha256 "cc98bbcc33581fbc55b42ae681c6946b70a26f549b3c64466740dfe9a7eac91c"
+  end
+
   def install
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
+    resource("DBD::mysql").stage do
+      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+      system "make", "install"
+    end
+
     cmake_args = %W[
       -DBUILD_CONFIG=xtrabackup_release
       -DDOWNLOAD_BOOST=1
@@ -30,6 +43,8 @@ class PerconaXtrabackup < Formula
     system "make", "install"
 
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files
+
+    bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
   end
 
   test do

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -48,13 +48,13 @@ class PerconaXtrabackup < Formula
     else
       cmake_args << "-DWITH_MAN_PAGES=OFF"
     end
-    
+
     # MySQL >5.7.x mandates Boost as a requirement to build & has a strict
     # version check in place to ensure it only builds against expected release.
     # This is problematic when Boost releases don't align with MySQL releases.
     (buildpath/"boost_1_59_0").install resource("boost")
     cmake_args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
-    
+
     cmake_args.concat std_cmake_args
 
     system "cmake", *cmake_args

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -49,7 +49,7 @@ class PerconaXtrabackup < Formula
     cmake_args.concat std_cmake_args
 
     system "cmake", *cmake_args
-    system "make", "-j4"
+    system "make"
     system "make", "install"
 
     rm_rf prefix/"xtrabackup-test" # Remove unnecessary files

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -26,7 +26,9 @@ class PerconaXtrabackup < Formula
       ohai "Building with man pages"
     end
 
-    system "cmake", *cmake_args, *std_cmake_args
+    cmake_args.concat std_cmake_args
+
+    system "cmake", *cmake_args
     system "make", "-j4"
     system "make", "install"
 

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -11,7 +11,6 @@ class PerconaXtrabackup < Formula
   depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "libgcrypt"
   depends_on "openssl"
-  depends_on :mysql => :recommended
 
   resource "DBD::mysql" do
     url "https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz"

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -18,6 +18,11 @@ class PerconaXtrabackup < Formula
     sha256 "cc98bbcc33581fbc55b42ae681c6946b70a26f549b3c64466740dfe9a7eac91c"
   end
 
+  resource "boost" do
+    url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
+    sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
@@ -28,9 +33,13 @@ class PerconaXtrabackup < Formula
 
     cmake_args = %W[
       -DBUILD_CONFIG=xtrabackup_release
-      -DDOWNLOAD_BOOST=1
-      -DWITH_BOOST=boost
     ]
+
+    # MySQL >5.7.x mandates Boost as a requirement to build & has a strict
+    # version check in place to ensure it only builds against expected release.
+    # This is problematic when Boost releases don't align with MySQL releases.
+    (buildpath/"boost_1_59_0").install resource("boost")
+    cmake_args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
 
     if build.without? "docs"
       cmake_args << "-DWITH_MAN_PAGES=OFF"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Adds Percona XtraBackup 2.4.2 to Homebrew.
Documentation: https://www.percona.com/doc/percona-xtrabackup/2.4/index.html
