### PR TITLE
pastebinit 1.5

### DIFF
--- a/Formula/pastebinit.rb
+++ b/Formula/pastebinit.rb
@@ -1,9 +1,8 @@
 class Pastebinit < Formula
   desc "Send things to pastebin from the command-line"
   homepage "https://launchpad.net/pastebinit"
-  url "https://launchpad.net/pastebinit/trunk/1.4.1/+download/pastebinit-1.4.1.tar.gz"
-  sha256 "39e3dcb98d2aa9d65f86c648c375ca75fa312fc773e568963e9aefffea0c9bf7"
-  revision 1
+  url "https://launchpad.net/pastebinit/trunk/1.5/+download/pastebinit-1.5.tar.gz"
+  sha256 "0d931dddb3744ed38aa2d319dd2d8a2f38a391011ff99db68ce7c83ab8f5b62f"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

In v1.4.1, got error message `Bad API request, invalid api_dev_key` when use [http://pastebin.com](http://pastebin.com) as the target. And this bug has been fixed in v1.5 [1]([https://bugs.launchpad.net/pastebinit/+bug/1427394]%28https://bugs.launchpad.net/pastebinit/+bug/1427394%29).

Because `etc.install` can not overwrite the existed config files, I use `rm_r etc/"pastebin.d"` to remove the config files. If there is a better way to do that, please tell me! Thank you!
