### PR TITLE
readline: Fix test

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -59,7 +59,8 @@ class Readline < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-lreadline", "-o", "test"
-    assert_equal "Hello, World!", pipe_output("./test", "Hello, World!\n").strip
+    system ENV.cc, "-L", lib, "test.c", "-lreadline", "-o", "test"
+    assert_equal "test> Hello, World!\nHello, World!",
+      pipe_output("./test", "Hello, World!\n").strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

The current test output is correct for libedit but not for readline.
Without specifying the library search path, this test was in fact
linking against /usr/lib/libreadline.dylib, which is simply a symlink
to libedit.3.dylib
