### PR TITLE
gpx 2.4.3 (new formula)

### DIFF
--- a/Formula/gpx.rb
+++ b/Formula/gpx.rb
@@ -1,0 +1,18 @@
+class Gpx < Formula
+  desc "Gcode to x3g converter for 3D printers running Sailfish"
+  homepage "https://github.com/markwal/GPX/blob/master/README.md"
+  url "https://github.com/markwal/GPX/archive/2.4.3.tar.gz"
+  sha256 "e2d67fd11b63b7ec30b122a4c4af6910305911dc3632ce18d213196be848993c"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.gcode").write("G28 X Y Z")
+    system "#{bin}/gpx", "test.gcode"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

```
gpx:
  * GitHub fork (not canonical repository)
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
Error: 2 problems in 1 formula### Description
```

Description

This adds a new formula for the 3D printing utility GPX which converts reprap gcode into Sailfish (and Makerbot) x3g.  The original author is WHPThomas and the current maintainers are MWalker and DNewman who both now work in the markwal fork.

This means that the letter of the two rules: canonical repo and two few watch/star/fork, are violated, but the spirit of the rules are satisfied. The markwal fork is the canonical fork (the debian package comes from it), but it is relatively new so the interest measures should use the aggregate of the three forks.
