### PR TITLE
Fribidi: Required pkg-config and glib

### DIFF
--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -3,8 +3,8 @@ class Allegro < Formula
   homepage "http://liballeg.org/"
 
   stable do
-    url "http://download.gna.org/allegro/allegro/5.0.11/allegro-5.0.11.tar.gz"
-    sha256 "49fe14c9571463ba08db4ff778d1fbb15e49f9c33bdada3ac8599e04330ea531"
+  url "http://download.gna.org/allegro/allegro/5.2.0/allegro-5.2.0.tar.gz"
+  sha256 "af5a69cd423d05189e92952633f9c0dd0ff3a061d91fbce62fb32c4bd87f9fd7"
   end
 
   bottle do
@@ -15,17 +15,8 @@ class Allegro < Formula
     sha256 "65a04aa3c0901264e54ca91f8982da085ea90bccabcb885fac054ba5219e19bd" => :mavericks
   end
 
-  devel do
-    url "http://download.gna.org/allegro/allegro-unstable/5.1.13.1/allegro-5.1.13.1.tar.gz"
-    sha256 "c6e6265c3d661d46270971b7fbf7db34c1873af62882a9ea4025ca1298edf14d"
-
-    depends_on "theora" => :recommended
-  end
-
   head do
-    url "https://github.com/liballeg/allegro5.git", :branch => "5.1"
-
-    depends_on "theora" => :recommended
+    url "https://github.com/liballeg/allegro5.git", :branch => "5.2"
   end
 
   depends_on "cmake" => :build
@@ -33,6 +24,9 @@ class Allegro < Formula
   depends_on "freetype" => :recommended
   depends_on "flac" => :recommended
   depends_on "physfs" => :recommended
+  depends_on "dumb" => :recommended
+  depends_on "libogg" => :recommended
+  depends_on "theora" => :recommended
 
   def install
     mkdir "build" do

--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -3,8 +3,8 @@ class Allegro < Formula
   homepage "http://liballeg.org/"
 
   stable do
-  url "http://download.gna.org/allegro/allegro/5.2.0/allegro-5.2.0.tar.gz"
-  sha256 "af5a69cd423d05189e92952633f9c0dd0ff3a061d91fbce62fb32c4bd87f9fd7"
+    url "http://download.gna.org/allegro/allegro/5.0.11/allegro-5.0.11.tar.gz"
+    sha256 "49fe14c9571463ba08db4ff778d1fbb15e49f9c33bdada3ac8599e04330ea531"
   end
 
   bottle do
@@ -15,8 +15,17 @@ class Allegro < Formula
     sha256 "65a04aa3c0901264e54ca91f8982da085ea90bccabcb885fac054ba5219e19bd" => :mavericks
   end
 
+  devel do
+    url "http://download.gna.org/allegro/allegro-unstable/5.1.13.1/allegro-5.1.13.1.tar.gz"
+    sha256 "c6e6265c3d661d46270971b7fbf7db34c1873af62882a9ea4025ca1298edf14d"
+
+    depends_on "theora" => :recommended
+  end
+
   head do
-    url "https://github.com/liballeg/allegro5.git", :branch => "5.2"
+    url "https://github.com/liballeg/allegro5.git", :branch => "5.1"
+
+    depends_on "theora" => :recommended
   end
 
   depends_on "cmake" => :build
@@ -24,9 +33,6 @@ class Allegro < Formula
   depends_on "freetype" => :recommended
   depends_on "flac" => :recommended
   depends_on "physfs" => :recommended
-  depends_on "dumb" => :recommended
-  depends_on "libogg" => :recommended
-  depends_on "theora" => :recommended
 
   def install
     mkdir "build" do

--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -3,6 +3,7 @@ class Fribidi < Formula
   homepage "http://fribidi.org/"
   url "http://fribidi.org/download/fribidi-0.19.7.tar.bz2"
   sha256 "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,9 +15,14 @@ class Fribidi < Formula
 
   option :universal
 
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "pcre"
+
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+    ENV.prepend_path ["PKG_CONFIG_PATH"], "#{Formula["glib"].opt_lib}/pkgconfig"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking", "--with-glib",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

 args `--with-glib` is default **auto**. But `pkg-config` is needed to find out `glib`.

> $ otool -L /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib 
> /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib:
>   /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib (compatibility version 4.0.0, current version 4.6.0)
>   /usr/local/Cellar/glib/2.46.2/lib/libglib-2.0.0.dylib (compatibility version 4601.0.0, current version 4601.2.0)
>   /usr/local/Cellar/pcre/8.38/lib/libpcre.1.dylib (compatibility version 4.0.0, current version 4.6.0)
>   /usr/local/Cellar/gettext/0.19.7/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.4.0)
>   /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
>   /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
