### PR TITLE
gst-plugins-base: add opus dependency to make opusenc and opusdec plugins for gstreamer available

### DIFF
--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -31,6 +31,7 @@ class GstPluginsBase < Formula
   depends_on "pango" => :optional
   depends_on "theora" => :optional
   depends_on "libvorbis" => :optional
+  depends_on "opus" => :optional
 
   def install
     # gnome-vfs turned off due to lack of formula for it.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

when compiling with opus, the following gstreamer plugins will be available (excerpt from `gst-inspect 1.0 | grep opus`):
opus:  opusdec: Opus audio decoder
opus:  opusenc: Opus audio encoder
