### PR TITLE
zsh-navigation-tools 2.0.5 (new formula)

### DIFF
--- a/Formula/zsh-navigation-tools.rb
+++ b/Formula/zsh-navigation-tools.rb
@@ -1,0 +1,31 @@
+class ZshNavigationTools < Formula
+  desc "Zsh curses-based tools, e.g. multi-word history searcher"
+  homepage "https://github.com/psprint/zsh-navigation-tools"
+  url "https://github.com/psprint/zsh-navigation-tools/archive/v2.0.5.tar.gz"
+  sha256 "f599a36693b9bacaccdb5ce9939f5be3695b59ef5b84485f618164bb2c77fe95"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  def caveats
+    <<-EOS.undent
+    To run zsh-navigation-tools, add the following at the end of your .zshrc:
+
+      fpath+=( #{HOMEBREW_PREFIX}/share/zsh-navigation-tools )
+      source #{HOMEBREW_PREFIX}/share/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+
+    You will also need to force reload of your .zshrc:
+
+      source ~/.zshrc
+
+    EOS
+  end
+
+  test do
+    # This compiles package's main file
+    # Zcompile is very capable of detecting syntax errors
+    cp pkgshare/"n-list", testpath
+    system "zsh", "-c", "zcompile n-list"
+  end
+end


### PR DESCRIPTION
This set of tools provides advanced history searcher for Zsh. It uses Curses, supports color themes, etc. but most of all: is multi-word. There is "zsh-history-substring-search" package and this is similar. Full description:

Set of tools like n-history – multi-word history searcher, n-cd – directory bookmark manager, n-kill – htop like kill utility, and more. Feature highlights include incremental multi-word searching, ANSI coloring, unique mode, horizontal scroll, non-selectable elements, grepping and various integrations with Zsh.
- n-history: the full-screen history searcher
- n-kill - browses processes list, allows quick searching and sending signal to selected processes
- n-panelize - loads output of given command into the list for browsing and multi-word searching
- n-cd - browses dirstack and bookmarked directories, allows to enter selected directory
- n-aliases - browses aliases, relegates editing to vared
- n-functions - browses functions, relegates editing to zed or vared
- n-env - browses environment, relegates editing to vared
- n-options - browses options, allows to toggle their state

This is written in pure Zsh, homepage is: https://github.com/psprint/zsh-navigation-tools
