### PR TITLE
fribidi: add pkg-config and glib deps

### DIFF
--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -21,9 +21,8 @@ class Fribidi < Formula
 
   def install
     ENV.universal_binary if build.universal?
-    ENV.prepend_path ["PKG_CONFIG_PATH"], "#{Formula["glib"].opt_lib}/pkgconfig"
-    system "./configure", "--disable-debug", "--disable-dependency-tracking", "--with-glib",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--with-glib", "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -3,6 +3,7 @@ class Fribidi < Formula
   homepage "http://fribidi.org/"
   url "http://fribidi.org/download/fribidi-0.19.7.tar.bz2"
   sha256 "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,9 +15,14 @@ class Fribidi < Formula
 
   option :universal
 
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "pcre"
+
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+    ENV.prepend_path ["PKG_CONFIG_PATH"], "#{Formula["glib"].opt_lib}/pkgconfig"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking", "--with-glib",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
I`m sorry that this is re-open of  #712. 
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

 args `--with-glib` is default **auto**. But `pkg-config` is needed to find out `glib`.

> $ otool -L /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib 
> /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib:
>   /usr/local/Cellar/fribidi/0.19.7/lib/libfribidi.0.dylib (compatibility version 4.0.0, current version 4.6.0)
>   /usr/local/Cellar/glib/2.46.2/lib/libglib-2.0.0.dylib (compatibility version 4601.0.0, current version 4601.2.0)
>   /usr/local/Cellar/pcre/8.38/lib/libpcre.1.dylib (compatibility version 4.0.0, current version 4.6.0)
>   /usr/local/Cellar/gettext/0.19.7/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.4.0)
>   /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
>   /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
