### PR TITLE
typesafe-activator 1.3.10

### DIFF
--- a/Formula/typesafe-activator.rb
+++ b/Formula/typesafe-activator.rb
@@ -1,16 +1,23 @@
 class TypesafeActivator < Formula
-  desc "Tools for working with Typesafe Reactive Platform"
-  homepage "https://typesafe.com/activator"
-  url "https://downloads.typesafe.com/typesafe-activator/1.3.9/typesafe-activator-1.3.9-minimal.zip"
-  version "1.3.9"
-  sha256 "a418cdc7f204aca9cc8777df6d3a18c1bae1157fd972d60d135fce43e217cd64"
+  desc "Tools for working with Lightbend Reactive Platform"
+  homepage "https://www.lightbend.com/community/core-tools/activator-and-sbt"
+  url "https://downloads.typesafe.com/typesafe-activator/1.3.10/typesafe-activator-1.3.10-minimal.zip"
+  version "1.3.10"
+  sha256 "15352ce253aa804f707ef8be86390ee1ee91da4b78dbb2729ab1e9cae01d8937"
 
   bottle :unneeded
+
+  depends_on :java => "1.8+"
 
   def install
     rm Dir["bin/*.bat"] # Remove Windows .bat files
     libexec.install Dir["libexec/*"]
     bin.install Dir["bin/*"]
     chmod 0755, bin/"activator"
+  end
+
+  test do
+    out = shell_output(bin/"activator -help", 1).split("\n")[0]
+    assert_equal "Usage: activator [options]", out
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Updates Typesafe (now Lightbend) Activator to version 1.3.10. Description text has been changed to reflect the corporate name change, though I don't see a reason to consider renaming the formula yet as their downloads still say Typesafe.

Adds a test (I think `-help` is the only thing you can do without triggering a bunch of dependencies to download), and a dependency on Java 8. The download page says JDK 1.8+, but if anyone knows for certain it should match Scala 2.11's Java 6 compatibility instead, let's do that.
