### PR TITLE
zenity: add recommended webkitgtk and option libnotify

### DIFF
--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -3,6 +3,7 @@ class Zenity < Formula
   homepage "https://live.gnome.org/Zenity"
   url "https://download.gnome.org/sources/zenity/3.18/zenity-3.18.1.tar.xz"
   sha256 "089d45f8e82bb48ae80fcb78693bcd7a29579631234709d752afed6c5a107ba8"
+  revison:1
 
   bottle do
     sha256 "f0017ba4ecdcdb89d8339ea2efefed1c1d7753544899cde824cd59864761710e" => :el_capitan

--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -1,8 +1,8 @@
 class Zenity < Formula
   desc "GTK+ dialog boxes for the command-line"
   homepage "https://live.gnome.org/Zenity"
-  url "https://download.gnome.org/sources/zenity/3.18/zenity-3.18.1.tar.xz"
-  sha256 "089d45f8e82bb48ae80fcb78693bcd7a29579631234709d752afed6c5a107ba8"
+  url "https://download.gnome.org/sources/zenity/3.20/zenity-3.20.0.tar.xz"
+  sha256 "02e8759397f813c0a620b93ebeacdab9956191c9dc0d0fcba1815c5ea3f15a48"
 
   bottle do
     sha256 "f0017ba4ecdcdb89d8339ea2efefed1c1d7753544899cde824cd59864761710e" => :el_capitan
@@ -17,9 +17,7 @@ class Zenity < Formula
   depends_on "gtk+3"
   depends_on "gnome-doc-utils"
   depends_on "scrollkeeper"
-
-  # submitted upstream at https://bugzilla.gnome.org/show_bug.cgi?id=756756
-  patch :DATA
+  depends_on "libnotify" => :optional
 
   def install
     ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python2.7/site-packages"
@@ -32,21 +30,3 @@ class Zenity < Formula
     system "#{bin}/zenity", "--help"
   end
 end
-
-__END__
-diff --git a/src/option.c b/src/option.c
-index 79a6f92..246cf22 100644
---- a/src/option.c
-+++ b/src/option.c
-@@ -2074,9 +2074,11 @@ zenity_text_post_callback (GOptionContext *context,
-     if (zenity_text_font)
-       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_font),
-                            ERROR_SUPPORT);
-+#ifdef HAVE_WEBKITGTK
-     if (zenity_text_enable_html)
-       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_enable_html),
-                            ERROR_SUPPORT);
-+#endif
-   }
-   return TRUE;
- }

--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -1,8 +1,8 @@
 class Zenity < Formula
   desc "GTK+ dialog boxes for the command-line"
   homepage "https://live.gnome.org/Zenity"
-  url "https://download.gnome.org/sources/zenity/3.20/zenity-3.20.0.tar.xz"
-  sha256 "02e8759397f813c0a620b93ebeacdab9956191c9dc0d0fcba1815c5ea3f15a48"
+  url "https://download.gnome.org/sources/zenity/3.18/zenity-3.18.1.tar.xz"
+  sha256 "089d45f8e82bb48ae80fcb78693bcd7a29579631234709d752afed6c5a107ba8"
 
   bottle do
     sha256 "f0017ba4ecdcdb89d8339ea2efefed1c1d7753544899cde824cd59864761710e" => :el_capitan
@@ -17,7 +17,11 @@ class Zenity < Formula
   depends_on "gtk+3"
   depends_on "gnome-doc-utils"
   depends_on "scrollkeeper"
+  depends_on "webkitgtk" => :recommended
   depends_on "libnotify" => :optional
+
+  # submitted upstream at https://bugzilla.gnome.org/show_bug.cgi?id=756756
+  patch :DATA
 
   def install
     ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python2.7/site-packages"
@@ -30,3 +34,21 @@ class Zenity < Formula
     system "#{bin}/zenity", "--help"
   end
 end
+
+__END__
+diff --git a/src/option.c b/src/option.c
+index 79a6f92..246cf22 100644
+--- a/src/option.c
++++ b/src/option.c
+@@ -2074,9 +2074,11 @@ zenity_text_post_callback (GOptionContext *context,
+     if (zenity_text_font)
+       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_font),
+                            ERROR_SUPPORT);
++#ifdef HAVE_WEBKITGTK
+     if (zenity_text_enable_html)
+       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_enable_html),
+                            ERROR_SUPPORT);
++#endif
+   }
+   return TRUE;
+ }

--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -3,7 +3,6 @@ class Zenity < Formula
   homepage "https://live.gnome.org/Zenity"
   url "https://download.gnome.org/sources/zenity/3.18/zenity-3.18.1.tar.xz"
   sha256 "089d45f8e82bb48ae80fcb78693bcd7a29579631234709d752afed6c5a107ba8"
-  revison:1
 
   bottle do
     sha256 "f0017ba4ecdcdb89d8339ea2efefed1c1d7753544899cde824cd59864761710e" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Add: option libnotify.

$ ./configure --help

> `configure' configures Zenity 3.20.0 to adapt to many kinds of systems. 
> ...
> --enable-libnotify      Enable libnotify support

$ otool -L /usr/local/Cellar/zenity/3.20.0/bin/zenity |grep -v : |sed -e "s/(.*$//"

>   /usr/local/Cellar/gtk+3/3.18.9/lib/libgtk-3.0.dylib 
>     /usr/local/Cellar/gtk+3/3.18.9/lib/libgdk-3.0.dylib 
>     /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa 
>     /usr/local/Cellar/pango/1.38.1/lib/libpangocairo-1.0.0.dylib 
>     /usr/local/Cellar/pango/1.38.1/lib/libpango-1.0.0.dylib 
>     /usr/local/lib/libatk-1.0.0.dylib 
>     /usr/local/lib/libcairo-gobject.2.dylib 
>     /usr/local/lib/libcairo.2.dylib 
>     /usr/local/opt/gdk-pixbuf/lib/libgdk_pixbuf-2.0.0.dylib 
>     /usr/local/lib/libgio-2.0.0.dylib 
>     /usr/local/lib/libgobject-2.0.0.dylib 
>     /usr/local/lib/libglib-2.0.0.dylib 
>     /usr/local/lib/libintl.8.dylib 
>     /usr/local/Cellar/libnotify/0.7.6/lib/libnotify.4.dylib 
>     /usr/lib/libSystem.B.dylib 
