### PR TITLE
jq: remove bison requirement plus fix `brew audit` spacing nit

### DIFF
--- a/Formula/jq.rb
+++ b/Formula/jq.rb
@@ -21,13 +21,13 @@ class Jq < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "oniguruma"  # jq depends > 1.5
-  depends_on "bison" => :build # jq depends on bison > 2.5
+  depends_on "oniguruma" # jq depends > 1.5
 
   def install
     system "autoreconf", "-iv" unless build.stable?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--disable-maintainer-mode",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Please refer to https://github.com/stedolan/jq/blob/master/configure.ac#L38 to see the Bison requirement.
