### PR TITLE
dwarf 0.3.1

### DIFF
--- a/Formula/dwarf.rb
+++ b/Formula/dwarf.rb
@@ -1,29 +1,51 @@
 class Dwarf < Formula
   desc "Object file manipulation tool"
   homepage "https://code.google.com/p/dwarf-ng/"
-  url "https://dwarf-ng.googlecode.com/files/dwarf-0.3.0.tar.gz"
-  sha256 "85062d0d3e8aa31374dd085cb79ce02c2b8737e9b143f640a262556233715763"
+  url "https://github.com/elboza/dwarf-ng/archive/dwarf-0.3.1.tar.gz"
+  sha256 "921667018e0edb057d695cdb6b7ed3bd8922a4050506252c21fffe4f7e77be2e"
 
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
   depends_on "readline"
 
-  # Imports inttypes.h in a generated lex file instead of stdint.h
-  # Reported upstream: https://code.autistici.org/trac/dwarf/ticket/8
-  # Also has missing & unwanted return values in some functions
-  # If the above are fixed, the newer 0.3.1 fails with a missing make target
-  fails_with :clang do
-    cause "error: unknown type name 'intmax_t'"
+  # Build fails with clang due to -Wreturn-type errors
+  # Reported 2nd May 2016: https://github.com/elboza/dwarf-ng/issues/2
+  # Opened PR with a fix 2nd May 2016: https://github.com/elboza/dwarf-ng/pull/4
+  patch do
+    url "https://github.com/elboza/dwarf-ng/pull/4.patch"
+    sha256 "081be99b41c9af0940cae6a4398baaab8dec61df80358fa54defb9e20360f416"
   end
 
-  # /usr/include/inttypes.h:256:8: error: unknown type name 'uintmax_t'
-  # https://github.com/elboza/dwarf-ng/issues/1
-  fails_with :gcc => "5"
-
   def install
+    %w[src/libdwarf/libdwarf.c doc/dwarf.man].each do |f|
+      inreplace f, "/etc/dwarfrc", etc/"dwarfrc"
+    end
+
+    # Fix "error: unknown type name 'intmax_t'" and the same for 'uintmax_t'
+    # Reported 22nd Aug 2015: https://github.com/elboza/dwarf-ng/issues/1
+    inreplace "src/libdwarf/stdint.h",
+      "typedef unsigned long long   uint64_t;",
+      "typedef unsigned long long   uint64_t;\ntypedef long intmax_t;\ntypedef unsigned long uintmax_t;"
+
+    system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+
+    # Fix parallelized build failure: "no rule to make target `y.tab.h'"
+    # Reported 2nd May 2016: https://github.com/elboza/dwarf-ng/issues/3
+    %w[src/cmdline src/libdwarf].each { |d| system "make", "-C", d, "y.tab.c" }
+
     system "make", "install"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/dwarf --help", 1)
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+
+      int main(int argc, char *argv[]) {
+        printf("hello world\\n");
+      }
+    EOS
+    system ENV.cc, "test.c", "-o", "test"
+    assert_equal "magic: 0xfeedfacf (-17958193)", pipe_output("#{bin}/dwarf -c 'print $mac' test").lines.first.chomp
   end
 end


### PR DESCRIPTION
- version bump
- new test: compile hello world and inspect Macho main header
- fix clang return-type errors
- fix parallelized build failure with missing target y.tab.h
- work around header issue with unknown types intmax_t and uintmax_t
