### PR TITLE
pelikan 0.1.1 (new formula)

### DIFF
--- a/Formula/pelikan.rb
+++ b/Formula/pelikan.rb
@@ -1,0 +1,21 @@
+class Pelikan < Formula
+  desc "production-ready cache services"
+  homepage "http://pelikan.io"
+  url "https://github.com/twitter/pelikan/archive/0.1.1.tar.gz"
+  sha256 "24a84bd9be7bb25da507a355b7ed3a35f7cb2a8c9447092f5acc91ff32f98775"
+  head "https://github.com/twitter/pelikan.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "_build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/pelikan_twemcache", "-c"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Description

Pelikan is a cache framework written in C. Currently it provides three
binaries that run as servers, including:
- pelikan_twemcache: a memcached/twemcache compatible server
- pelikan_slimcache: a memcached server using cuckoo hashing
- pelikan_pingserver: a ping server
