### PR TITLE
avidemux: revision for x264

### DIFF
--- a/Formula/avidemux.rb
+++ b/Formula/avidemux.rb
@@ -1,7 +1,7 @@
 class Avidemux < Formula
   desc "Multiformat video editor that cuts, filters, and encodes"
   homepage "http://fixounet.free.fr/avidemux/"
-  revision 1
+  revision 2
 
   stable do
     url "https://downloads.sourceforge.net/avidemux/avidemux_2.6.8.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

One plugin still links to `libx264.146.dylib` that no longer exists. Broken linkage was discovered during a routine test bot run in #733.
