### PR TITLE
mplayer: add (back) freetype OSD support

### DIFF
--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -20,6 +20,7 @@ class Mplayer < Formula
   end
 
   depends_on "yasm" => :build
+  depends_on "freetype" => :build
   depends_on "libcaca" => :optional
 
   unless MacOS.prefer_64_bit?
@@ -46,6 +47,7 @@ class Mplayer < Formula
       --disable-cdparanoia
       --prefix=#{prefix}
       --disable-x11
+      --enable-freetype
     ]
 
     args << "--enable-caca" if build.with? "libcaca"

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -21,6 +21,7 @@ class Mplayer < Formula
 
   depends_on "yasm" => :build
   depends_on "freetype" => :build
+  depends_on "libpng" => :build # required by freetype
   depends_on "libcaca" => :optional
 
   unless MacOS.prefer_64_bit?


### PR DESCRIPTION
### Description

The OSD is no longer enabled by default without including `freetype` and building with the `--enable-freetype` option (at least on OS X 10.11.4). Seems essential to me.
