### PR TITLE
tomee 1.7.4

### DIFF
--- a/Formula/tomee-jax-rs.rb
+++ b/Formula/tomee-jax-rs.rb
@@ -1,9 +1,9 @@
 class TomeeJaxRs < Formula
   desc "TomeEE Web Profile plus JAX-RS"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz"
-  version "1.7.3"
-  sha256 "5a79578d02b5d2896f416f04592e5b48b036b297cb4e25717a1fe61249dbc877"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.4/apache-tomee-1.7.4-jaxrs.tar.gz"
+  version "1.7.4"
+  sha256 "35f56e5f79dfa3ebfe220c2c45b280b204dcd265c4e905b994669391f4672e71"
 
   bottle :unneeded
 

--- a/Formula/tomee-plume.rb
+++ b/Formula/tomee-plume.rb
@@ -1,9 +1,9 @@
 class TomeePlume < Formula
   desc "Apache TomEE Plume"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz"
-  version "1.7.3"
-  sha256 "ba7978252fa63e2a6cdc0b699330bf3a523178e6dc1a015997542fa98698c521"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.4/apache-tomee-1.7.4-plume.tar.gz"
+  version "1.7.4"
+  sha256 "0f37dbe25c3a68a365f440cfaac01e63158e6ccce943f367203418038b5be402"
 
   bottle :unneeded
 

--- a/Formula/tomee-plus.rb
+++ b/Formula/tomee-plus.rb
@@ -1,9 +1,9 @@
 class TomeePlus < Formula
   desc "Everything in TomEE Web Profile and JAX-RS, plus more"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz"
-  version "1.7.3"
-  sha256 "194bf10ca40a14bbea3b32ec37c1144cce3bb642c3338038bed4d35fcd019a1c"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.4/apache-tomee-1.7.4-plus.tar.gz"
+  version "1.7.4"
+  sha256 "be43806d65bde4fdd393e0d78f91f910f9bf2e468425738d817afe0fefaffbc3"
 
   bottle :unneeded
 

--- a/Formula/tomee-webprofile.rb
+++ b/Formula/tomee-webprofile.rb
@@ -1,9 +1,9 @@
 class TomeeWebprofile < Formula
   desc "All-Apache Java EE 6 Web Profile stack"
   homepage "https://tomee.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz"
-  version "1.7.3"
-  sha256 "d738c56b96537a5157a827e73ceac60b6cc43a1c8d6d31b65ae69c77b6a9e7b6"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.4/apache-tomee-1.7.4-webprofile.tar.gz"
+  version "1.7.4"
+  sha256 "4a1c13e60fcf1289980b0c14f8e67daf31b1c91f4e208fbc7aeec0a252655897"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
## Why is This Change Needed?

TomEE 1.7.4 fixes a [known security problem](http://tomee.apache.org/security/tomee.html) present in TomEE 1.7.3. This pull request updates the four formulas related to Apache TomEE:
- tomee-jax-rs
- tomee-plume
- tomee-plus
- tomee-webprofile
