### PR TITLE
mkvtoolnix 9.1.0

### DIFF
--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -1,8 +1,8 @@
 class Mkvtoolnix < Formula
   desc "Matroska media files manipulation tools"
   homepage "https://www.bunkus.org/videotools/mkvtoolnix/"
-  url "https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-9.0.1.tar.xz"
-  sha256 "292504633d714c42f73f08474137e462827f6d8d570292005bbaebb8fee8e52e"
+  url "https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-9.1.0.tar.xz"
+  sha256 "1471370251ff8414f3c02a0e21ec41c644f9d54bf4f1f5253d0cd9406281ce60"
 
   bottle do
     sha256 "a1a2e6f93f8a942c992b4abf47b78259421ab7ceed82441132adc058f6ed4533" => :el_capitan


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Updates mkvtoolnix to version 9.1.0. This resolves a bug in v9.0.1 that causes `mkvinfo` to fail to work correctly when installed using the default flags: it only works properly when using --with-qt5. The newer version does not have this problem.
