### PR TITLE
imagemagick: disable vulnerable coders

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -8,6 +8,8 @@ class Imagemagick < Formula
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.3-7.tar.xz"
   sha256 "6731c414b5b939713a73a088840ed68c22c91d1335514d228d6687d07ce2e1c8"
 
+  revision 1
+
   head "http://git.imagemagick.org/repos/ImageMagick.git"
 
   bottle do
@@ -55,6 +57,14 @@ class Imagemagick < Formula
   needs :openmp if build.with? "openmp"
 
   skip_clean :la
+
+  # Disables vulnerable coders: https://medium.com/@rhuber/imagemagick-is-on-fire-cve-2016-3714-379faf762247#.2tjfb3iks
+  # Next release will probably have a patch for the coders themselves,
+  # allowing us to remove this workaround.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/ca3940923286cc1f763848eccbef6dcfd3e5fe1c/imagemagick/disable-coders.diff"
+    sha256 "b5950e047cdcc3a787c91bbdfbc0a76537f1c8febeb9c054768c5c7325ddf409"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This is a mitigation for the [recently-announced Imagemagick vulnerabilities](https://medium.com/@rhuber/imagemagick-is-on-fire-cve-2016-3714-379faf762247). A real patch is likely coming in a few days, so we can update when that's available.
