### PR TITLE
lbdb: add abook module to bottle

### DIFF
--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -13,6 +13,7 @@ class Lbdb < Formula
   end
 
   depends_on :gpg => :optional
+  depends_on "abook" => :recommended
 
   def install
     args = %W[


### PR DESCRIPTION
See issue #775.

This makes abook a recommended dependency (thus causes it to be installed by default, along with the m_abook module, as it is when using the lbdb tarball).
