### PR TITLE
gawk: Fix arithmetic by building against MPFR. (And readline)

### DIFF
--- a/Formula/gawk.rb
+++ b/Formula/gawk.rb
@@ -4,6 +4,7 @@ class Gawk < Formula
   url "http://ftpmirror.gnu.org/gawk/gawk-4.1.3.tar.xz"
   mirror "https://ftp.gnu.org/gnu/gawk/gawk-4.1.3.tar.xz"
   sha256 "e3cf55e91e31ea2845f8338bedd91e40671fc30e4d82ea147d220e687abda625"
+  revision 1
 
   bottle do
     sha256 "ed2c5f0b20e4b4af151177a750b1287435aad66bb0c8c4b60daf753f3955332c" => :el_capitan
@@ -17,12 +18,13 @@ class Gawk < Formula
     cause "Undefined symbols when linking"
   end
 
+  depends_on "mpfr"
+  depends_on "readline"
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--without-readline",
-                          "--without-mpfr",
                           "--without-libsigsegv-prefix"
     system "make"
     system "make", "check"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Before:

```
    gawk -M 'BEGIN { printf "%d\n", 9007199254740991+9007199254740992 }'
    gawk: warning: -M ignored: MPFR/GMP support not compiled in
    18014398509481984
```

After:

```
    gawk -M 'BEGIN { printf "%d\n", 9007199254740991+9007199254740992 }'
    18014398509481983
```
