### PR TITLE
spidermonkey 38.2.1, with dependent revision bumps

### DIFF
--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -1,7 +1,7 @@
 class Couchdb < Formula
   desc "Document database server"
   homepage "https://couchdb.apache.org/"
-  revision 5
+  revision 6
 
   stable do
     url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.6.1/apache-couchdb-1.6.1.tar.gz"

--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -1,19 +1,13 @@
 class Spidermonkey < Formula
   desc "JavaScript-C Engine"
   homepage "https://developer.mozilla.org/en/SpiderMonkey"
-  url "https://archive.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz"
-  version "1.8.5"
-  sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
-  revision 1
+  url "https://people.mozilla.org/~sstangl/mozjs-38.2.1.rc0.tar.bz2"
+  version "38.2.1"
+  sha256 "01994c758174bc173bcf4960f05ecb4da21014f09641a63b2952bbf9eeaa8b5c"
 
   head "https://hg.mozilla.org/tracemonkey/archive/tip.tar.gz"
 
   bottle do
-    cellar :any
-    revision 1
-    sha256 "7a5c888484415d2de3d0b1e980a0895578f1d5df816863dc553ef499b488c203" => :el_capitan
-    sha256 "3770ceced1be2ef3de507894ed98548c72ecd469e49176f6cf1f8e7c890a8d84" => :yosemite
-    sha256 "a48533ba8f2e0edbb635d5b7270740c8f86c3800e71489ed02cbf9869c874748" => :mavericks
   end
 
   conflicts_with "narwhal", :because => "both install a js binary"
@@ -22,28 +16,24 @@ class Spidermonkey < Formula
   depends_on "nspr"
 
   def install
-    cd "js/src" do
-      # Remove the broken *(for anyone but FF) install_name
-      inreplace "config/rules.mk",
-        "-install_name @executable_path/$(SHARED_LIBRARY) ",
-        "-install_name #{lib}/$(SHARED_LIBRARY) "
-    end
-
     mkdir "brew-build" do
+      # Configure needs python to figure out which version of libmozjs it is
+      # building.
+      ENV["PYTHON"] = which "python"
       system "../js/src/configure", "--prefix=#{prefix}",
+                                    "--enable-dtrace",
                                     "--enable-readline",
                                     "--enable-threadsafe",
                                     "--with-system-nspr",
                                     "--with-nspr-prefix=#{Formula["nspr"].opt_prefix}",
                                     "--enable-macos-target=#{MacOS.version}"
 
-      inreplace "js-config", /JS_CONFIG_LIBS=.*?$/, "JS_CONFIG_LIBS=''"
       # These need to be in separate steps.
       system "make"
-      system "make", "install"
+      system "make", "install", "STATIC_LIBRARY_NAME=js_static"
 
       # Also install js REPL.
-      bin.install "shell/js"
+      bin.install "js/src/shell/js"
     end
   end
 


### PR DESCRIPTION
This PR subsumes #820 (preserving author credit) and adds a revision bump for `couchdb`.

This is not urgent; I'm primarily doing this to test recent `brew pull` updates and practice with GitHub's issue functionality.

Closes #820
