### PR TITLE
bazel: add HEAD

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -3,6 +3,7 @@ class Bazel < Formula
   homepage "http://bazel.io/"
   url "https://github.com/bazelbuild/bazel/archive/0.2.1.tar.gz"
   sha256 "be964f98480ed258f249fc44c467a293e3a143aa750149b970da3d6719ba6ff1"
+  head "https://github.com/bazelbuild/bazel.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Adds a HEAD to `bazel`. Hopefully makes #595 (bazel 0.2.2b) less urgent, so we can hold off until the next release, which won't require superenv-circumventing hacks.
