### PR TITLE
libcanberra: depend on libtool

### DIFF
--- a/Formula/libcanberra.rb
+++ b/Formula/libcanberra.rb
@@ -1,27 +1,53 @@
 class Libcanberra < Formula
   desc "Implementation of XDG Sound Theme and Name Specifications"
   homepage "http://0pointer.de/lennart/projects/libcanberra/"
-  url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
-  sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
 
-  head "git://git.0pointer.de/libcanberra"
+  stable do
+    url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
+    sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+
+    depends_on "gtk-doc" => :optional
+  end
+
+  head do
+    url "git://git.0pointer.de/libcanberra"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gtk-doc"
+  end
 
   depends_on "pkg-config" => :build
+  depends_on "libtool" => :run
   depends_on "libvorbis"
   depends_on "pulseaudio" => :optional
   depends_on "gstreamer" => :optional
   depends_on "gtk+" => :optional
   depends_on "gtk+3" => :optional
 
-  # Remove --as-needed and --gc-sections linker flag as it causes linking to fail
-  patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/patches/b2cf078b/libcanberra/patch-configure.diff"
-    sha256 "614084839beb507c705d1b8d32f6ad1fa0c8379d6705fb3c866e6d7c5d3cf0b8"
-  end
-
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}"
+
+    # ld: unknown option: --as-needed" and then the same for `--gc-sections`
+    # Reported 7 May 2016: lennart@poettering.net and mzyvopnaoreen@0pointer.de
+    system "./configure", "--prefix=#{prefix}", "--no-create"
+    inreplace "config.status", "-Wl,--as-needed -Wl,--gc-sections", ""
+    system "./config.status"
+
     system "make", "install"
+  end
+
+  test do
+    (testpath/"lc.c").write <<-EOS.undent
+      #include <canberra.h>
+      int main()
+      {
+        ca_context *ctx = NULL;
+        (void) ca_context_create(&ctx);
+        return (ctx == NULL);
+      }
+    EOS
+    system ENV.cc, "lc.c", "-I#{include}", "-L#{lib}", "-lcanberra", "-o", "lc"
+    system "./lc"
   end
 end


### PR DESCRIPTION
libcanberra: depend on libtool
- Fix "configure: error: Unable to find libltdl"
- Remove patch for the "--as-needed" and "--gc-sections" LDFLAGS bug and
  use `inreplace` on "config.status" instead, which also works for HEAD
- Add Autotools deps for HEAD builds
- Require `gtk-doc` for HEAD builds to prevent failure during configure
- Add a test, adapted from http://www.gtkforums.com/viewtopic.php?t=6753
