### PR TITLE
ios-class-guard: audit fix

### DIFF
--- a/Formula/ios-class-guard.rb
+++ b/Formula/ios-class-guard.rb
@@ -1,9 +1,9 @@
 class IosClassGuard < Formula
   desc "Objective-C obfuscator for Mach-O executables"
   homepage "https://github.com/Polidea/ios-class-guard/"
-  head "https://github.com/Polidea/ios-class-guard.git"
   url "https://github.com/Polidea/ios-class-guard/archive/0.8.tar.gz"
   sha256 "4446993378f1e84ce1d1b3cbace0375661e3fe2fa1a63b9bf2c5e9370a6058ff"
+  head "https://github.com/Polidea/ios-class-guard.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
### Note

Online audit fails because the download is from a Github fork rather than the original, but it was like that before.
