### PR TITLE
libao: Add HEAD and tests

### DIFF
--- a/Formula/libao.rb
+++ b/Formula/libao.rb
@@ -12,12 +12,35 @@ class Libao < Formula
     sha256 "21aa15e92c5577a4a610de8fbb3f5a72638a0c37a40c4ebebc14826359932efa" => :mountain_lion
   end
 
+  head do
+    url "https://git.xiph.org/libao.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
 
   def install
+    if build.head?
+      ENV["AUTOMAKE_FLAGS"] = "--include-deps"
+      system "./autogen.sh"
+    end
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-static"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <ao/ao.h>
+      int main() {
+        ao_initialize();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lao", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Adds head URL for libao, which is of interest recently because they've finally moved off of a deprecated osx API (Carbon Component Manager). Also adds a test which builds a simple test.cpp that initializes the ao library, based on the tinyxml2 test that is recommended in the formula contribution doc. 
