### PR TITLE
cputhrottle: fix build

### DIFF
--- a/Formula/cputhrottle.rb
+++ b/Formula/cputhrottle.rb
@@ -4,6 +4,7 @@ class Cputhrottle < Formula
   url "http://www.willnolan.com/cputhrottle/cputhrottle.tar.gz"
   version "20100515"
   sha256 "fdf284e1c278e4a98417bbd3eeeacf40db684f4e79a9d4ae030632957491163b"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,16 @@ class Cputhrottle < Formula
   depends_on "boost" => :build
 
   def install
-    system "make", "all"
+    boost = Formula["boost"]
+    system "make", "BOOST_PREFIX=#{boost.opt_prefix}",
+                   "BOOST_INCLUDES=#{boost.opt_include}",
+                   "all"
     bin.install "cputhrottle"
+  end
+
+  test do
+    # Needs root for proper functionality test.
+    output = pipe_output("#{bin}/cputhrottle 2>&1")
+    assert_match "Please supply PID to throttle", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The upstream Makefile isn't great, passing it direct variables should keep it compatible going forwards.

Normally we wouldn't accept formulae like this, where the URL isn't versioned and can change silently, but I guess here since it hasn't for nearly 6 years it isn't likely to now.

Closes #958.
