### PR TITLE
openssl@1.1 1.1.0 (new formula)

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -1,0 +1,171 @@
+class OpensslAT11 < Formula
+  desc "Cryptography and SSL/TLS Toolkit"
+  homepage "https://openssl.org/"
+  url "https://www.openssl.org/source/openssl-1.1.0.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.0.tar.gz"
+  sha256 "f5c69ff9ac1472c80b868efc1c1c0d8dcfc746d29ebe563de2365dd56dbd8c82"
+
+  keg_only :provided_by_osx,
+    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
+
+  option :universal
+  option "without-test", "Skip build-time tests (not recommended)"
+
+  # Only needs 5.10 to run, but needs >5.13.4 to run the testsuite.
+  # https://github.com/openssl/openssl/blob/4b16fa791d3ad8/README.PERL
+  # The MacOS ML tag is same hack as the way we handle most :python deps.
+  if build.with? "test"
+    depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
+  else
+    depends_on :perl => "5.10"
+  end
+
+  def arch_args
+    {
+      :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
+      :i386   => %w[darwin-i386-cc],
+    }
+  end
+
+  # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
+  # SSLv3 & zlib are off by default with 1.1.0 but this may not
+  # be obvious to everyone, so explicitly state it for now to
+  # help debug inevitable breakage.
+  def configure_args; %W[
+    --prefix=#{prefix}
+    --openssldir=#{openssldir}
+    no-ssl3
+    no-ssl3-method
+    no-zlib
+    enable-cms
+  ]
+  end
+
+  def install
+    # This could interfere with how we expect OpenSSL to build.
+    ENV.delete("OPENSSL_LOCAL_CONFIG_DIR")
+
+    # This ensures where Homebrew's Perl is needed the Cellar path isn't
+    # hardcoded into OpenSSL's scripts, causing them to break every Perl update.
+    # Whilst our env points to opt_bin, by default OpenSSL resolves the symlink.
+    if which("perl") == Formula["perl"].opt_bin/"perl"
+      ENV["PERL"] = Formula["perl"].opt_bin/"perl"
+    end
+
+    if build.universal?
+      ENV.permit_arch_flags
+      archs = Hardware::CPU.universal_archs
+    elsif MacOS.prefer_64_bit?
+      archs = [Hardware::CPU.arch_64_bit]
+    else
+      archs = [Hardware::CPU.arch_32_bit]
+    end
+
+    dirs = []
+
+    archs.each do |arch|
+      if build.universal?
+        dir = "build-#{arch}"
+        dirs << dir
+        mkdir dir
+        mkdir "#{dir}/engines"
+      end
+
+      ENV.deparallelize
+      system "perl", "./Configure", *(configure_args + arch_args[arch])
+      system "make", "clean" if build.universal?
+      system "make"
+      system "make", "test" if build.with?("test")
+
+      next unless build.universal?
+      cp "include/openssl/opensslconf.h", dir
+      cp Dir["*.?.?.dylib", "*.a", "apps/openssl"], dir
+      cp Dir["engines/**/*.dylib"], "#{dir}/engines"
+    end
+
+    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
+
+    if build.universal?
+      %w[libcrypto libssl].each do |libname|
+        system "lipo", "-create", "#{dirs.first}/#{libname}.1.1.dylib",
+                                  "#{dirs.last}/#{libname}.1.1.dylib",
+                       "-output", "#{lib}/#{libname}.1.1.dylib"
+        system "lipo", "-create", "#{dirs.first}/#{libname}.a",
+                                  "#{dirs.last}/#{libname}.a",
+                       "-output", "#{lib}/#{libname}.a"
+      end
+
+      Dir.glob("#{dirs.first}/engines/*.dylib") do |engine|
+        libname = File.basename(engine)
+        system "lipo", "-create", "#{dirs.first}/engines/#{libname}",
+                                  "#{dirs.last}/engines/#{libname}",
+                       "-output", "#{lib}/engines-1.1/#{libname}"
+      end
+
+      system "lipo", "-create", "#{dirs.first}/openssl",
+                                "#{dirs.last}/openssl",
+                     "-output", "#{bin}/openssl"
+
+      confs = archs.map do |arch|
+        <<-EOS.undent
+          #ifdef __#{arch}__
+          #{(buildpath/"build-#{arch}/opensslconf.h").read}
+          #endif
+        EOS
+      end
+      (include/"openssl/opensslconf.h").atomic_write confs.join("\n")
+    end
+  end
+
+  def openssldir
+    etc/"openssl@1.1"
+  end
+
+  def post_install
+    keychains = %w[
+      /System/Library/Keychains/SystemRootCertificates.keychain
+    ]
+
+    certs_list = `security find-certificate -a -p #{keychains.join(" ")}`
+    certs = certs_list.scan(
+      /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
+    )
+
+    valid_certs = certs.select do |cert|
+      IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
+        openssl_io.write(cert)
+        openssl_io.close_write
+      end
+
+      $?.success?
+    end
+
+    openssldir.mkpath
+    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+  end
+
+  def caveats; <<-EOS.undent
+    A CA file has been bootstrapped using certificates from the system
+    keychain. To add additional certificates, place .pem files in
+      #{openssldir}/certs
+
+    and run
+      #{opt_bin}/c_rehash
+    EOS
+  end
+
+  test do
+    # Make sure the necessary .cnf file exists, otherwise OpenSSL gets moody.
+    assert (HOMEBREW_PREFIX/"etc/openssl@1.1/openssl.cnf").exist?,
+            "OpenSSL requires the .cnf file for some functionality"
+
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system bin/"openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  _(Apart from one issue, which I've deliberately ignored for consistency)._

---

It's going to take us a long time to transition every formula across to the new OpenSSL release _(when it's stable)_ given the not insignificant API changes, as well as upstream deprecation of zlib compression and SSLv3.

Consequently, we're going to be running two OpenSSL releases for the foreseeable. The OpenSSL formula will remain for now the 1.0.2 branch which is supported until 2019, this formula will track 1.1.0 which is supported upstream till ~2018 under current plans.

Some things in this formula are on by default, such as the overdue death of SSLv3 and zlib compression, but since those are fairly big departures from OpenSSL releases to date it's explicitly stated in-formula so when people report _"This is broken using this"_ some of the very obvious breakage points are highlighted at cursory glance.

This OpenSSL release also introduces a fairly high Perl requirement. I'd like to note at this point this isn't our choice and is something we're trying to minimise, but to be somewhat blunt if you're running 10.8 or less you're going to have to accept the system utilities on those OS X versions are increasingly problematic today.

This formula is a fairly large departure from the way people have come to expect Homebrew to behave in terms of always running the latest. OpenSSL is a particularly punchy example of this, but going forwards incompatible releases are going to be given a little more leeway to remain around until a transition can happen in a mildly smoother manner than we've perhaps managed previously at times.
