### PR TITLE
file-roller: use upstream patch for schema bug

### DIFF
--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -22,6 +22,14 @@ class FileRoller < Formula
   depends_on "hicolor-icon-theme"
   depends_on "gnome-icon-theme"
 
+  # Add linked-library dependencies
+  depends_on "atk"
+  depends_on "cairo"
+  depends_on "gdk-pixbuf"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "pango"
+
   def install
     # forces use of gtk3-update-icon-cache instead of gtk-update-icon-cache. No bugreport should
     # be filed for this since it only occurs because Homebrew renames gtk+3's gtk-update-icon-cache

--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -59,6 +59,6 @@ class FileRoller < Formula
   end
 
   test do
-    system "#{bin}/file-roller", "--version"
+    assert_match version.to_s, shell_output("#{bin}/file-roller --version 2>&1")
   end
 end


### PR DESCRIPTION
- Add undeclared dependencies: make the undeclared dependencies reported by `brew linkage` explicit: atk, cairo, gdk-pixbuf, gettext, glib, pango
- Use assert_match in the version test: Verify the version is correct instead of just running the command; redirect stderr to stdout so that it will only show the following harmless, but distracting, message when the test is run verbosely:

```
    file-roller[80748:8815155] *** WARNING: Method userSpaceScaleFactor
    in class NSView is deprecated on 10.7 and later. It should not be
    used in new applications. Use convertRectToBacking: instead. 
```
- Use upstream patch for schema bug: This patch forces autoconf, automake, libtool, and yelp-tools to be
  build-time dependencies temporarily. Both the patch and these temporary dependencies can be removed when >13.16.4 is released.
