### PR TITLE
dockviz 0.4

### DIFF
--- a/Formula/dockviz.rb
+++ b/Formula/dockviz.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Dockviz < Formula
   desc "Visualizing docker data"
   homepage "https://github.com/justone/dockviz"
-  url "https://github.com/justone/dockviz.git", :tag => "v0.3",
-                                                :revision => "ae855d6a5a540c3563948e7035f9d19cab17f5b0"
+  url "https://github.com/justone/dockviz.git", :tag => "v0.4",
+                                                :revision => "551ef0434f74aa7ed0c8807b4e2dc9874a49160c"
   head "https://github.com/justone/dockviz.git"
 
   bottle do
@@ -16,14 +16,44 @@ class Dockviz < Formula
 
   depends_on "go" => :build
 
+  go_resource "github.com/Sirupsen/logrus" do
+    url "https://github.com/Sirupsen/logrus.git",
+    :revision => "cd7d1bbe41066b6c1f19780f895901052150a575"
+  end
+
+  go_resource "github.com/docker/docker" do
+    url "https://github.com/docker/docker.git",
+    :revision => "ac2f4dd71b9d1e7d028bf3e7cb3b662c109c5836"
+  end
+
+  go_resource "github.com/docker/go-units" do
+    url "https://github.com/docker/go-units.git",
+    :revision => "5d2041e26a699eaca682e2ea41c8f891e1060444"
+  end
+
   go_resource "github.com/fsouza/go-dockerclient" do
     url "https://github.com/fsouza/go-dockerclient.git",
-        :revision => "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+    :revision => "7cbfc4525fb2aeeeff56dc5c6fe18a5536a51f6b"
+  end
+
+  go_resource "github.com/hashicorp/go-cleanhttp" do
+    url "https://github.com/hashicorp/go-cleanhttp.git",
+    :revision => "ad28ea4487f05916463e2423a55166280e8254b5"
   end
 
   go_resource "github.com/jessevdk/go-flags" do
     url "https://github.com/jessevdk/go-flags.git",
-        :revision => "0a28dbe50f23d8fce6b016975b964cfe7b97a20a"
+    :revision => "6b9493b3cb60367edd942144879646604089e3f7"
+  end
+
+  go_resource "github.com/opencontainers/runc" do
+    url "https://github.com/opencontainers/runc.git",
+    :revision => "4ad7bbc172f2aed1ebaf5c0ddf1ea8c8136c2e93"
+  end
+
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+    :revision => "2a35e686583654a1b89ca79c4ac78cb3d6529ca3"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I closed a previous request because I realized that the internal dockviz tests were failing in the tagged version of the dockviz 0.4 source, but then I realized that this was probably because of some Docker changes that are mentioned in the dockviz issue tracker.  Manual testing of all the dockviz options that I could figure out how to test shows that the homebrew version works the same way as the 0.4 release binary on OS X.  And, 0.4 gains a number of nice new features including incremental size display.
