### PR TITLE
cabal-install: fix installation on Lion

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -12,7 +12,7 @@ class CabalInstall < Formula
 
   depends_on "ghc"
 
-  fails_with :clang if MacOS.version < :lion # Same as ghc.rb
+  fails_with :clang if MacOS.version <= :lion # Same as ghc.rb
 
   def install
     system "sh", "bootstrap.sh", "--sandbox"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This change allows the formula to be built on Lion (10.7.5). The primary error was:

```
Data/Text/IO.hs:236:29:
    The last statement in a 'do' block must be an expression
      n1 <- writeCharBuf raw n '\r' writeCharBuf raw n1 '\n' >>= inner s'
```
