### PR TITLE
autojump: Change . to source for fish shell

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -30,7 +30,7 @@ class Autojump < Formula
       [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh
 
     If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
-      [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ]; and . #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
+      [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ]; and source #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
     EOS
   end
 


### PR DESCRIPTION
The . command has been deprecated and source is now preferred
(https://github.com/fish-shell/fish-shell/issues/310).
