### PR TITLE
mit-scheme: migrate from x11

### DIFF
--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -1,0 +1,116 @@
+class MitScheme < Formula
+  desc "MIT/GNU Scheme development tools and runtime library"
+  homepage "https://www.gnu.org/software/mit-scheme/"
+  url "http://ftpmirror.gnu.org/mit-scheme/stable.pkg/9.2/mit-scheme-c-9.2.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/9.2/mit-scheme-c-9.2.tar.gz"
+  sha256 "4f6a16f9c7d4b4b7bb3aa53ef523cad39b54ae1eaa3ab3205930b6a87759b170"
+  revision 1
+
+  bottle do
+    revision 1
+    sha256 "1a449d9c1f1043c1a557962332c7ee18664f5f15ea9eca8e754c0c3cb3c4aef4" => :el_capitan
+    sha256 "7966d841f92346a68ee088b0e25394e541b690aafbb306e27b352ee35a1e24c7" => :yosemite
+    sha256 "a782017f01f5c385e343c802a33cd634b1cfd89ec7eed94a43d753034eaa15ab" => :mavericks
+  end
+
+  conflicts_with "tinyscheme", :because => "both install a `scheme` binary"
+
+  # Has a hardcoded compile check for /Applications/Xcode.app
+  # Dies on "configure: error: SIZEOF_CHAR is not 1" without Xcode.
+  # https://github.com/Homebrew/homebrew-x11/issues/103#issuecomment-125014423
+  depends_on :xcode => :build
+  depends_on "openssl"
+  depends_on :x11 => :optional
+
+  def install
+    # Setting -march=native, which is what --build-from-source does, can fail
+    # with the error "the object ..., passed as the second argument to apply, is
+    # not the correct type." Only Haswell and above appear to be impacted.
+    # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47767
+    # Note that `unless build.bottle?` avoids overriding --bottle-arch=[...].
+    ENV["HOMEBREW_OPTFLAGS"] = "-march=#{Hardware.oldest_cpu}" unless build.bottle?
+
+    # The build breaks __HORRIBLY__ with parallel make -- one target will
+    # erase something before another target gets it, so it's easier to change
+    # the environment than to change_make_var, because there are Makefiles
+    # littered everywhere
+    ENV.deparallelize
+
+    # Liarc builds must launch within the src dir, not using the top-level
+    # Makefile
+    cd "src"
+
+    # Take care of some hard-coded paths
+    %w[
+      6001/edextra.scm
+      6001/floppy.scm
+      compiler/etc/disload.scm
+      edwin/techinfo.scm
+      edwin/unix.scm
+      swat/c/tk3.2-custom/Makefile
+      swat/c/tk3.2-custom/tcl/Makefile
+      swat/scheme/other/btest.scm
+    ].each do |f|
+      inreplace f, "/usr/local", prefix
+    end
+
+    inreplace "microcode/configure" do |s|
+      s.gsub! "/usr/local", prefix
+      # Fixes "configure: error: No MacOSX SDK for version: 10.10"
+      # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47769
+      s.gsub! /SDK=MacOSX\${MACOSX}$/, "SDK=MacOSX#{MacOS.sdk.version}"
+    end
+
+    if build.without? "x11"
+      inreplace "etc/make-liarc.sh" do |s|
+        # Allows us to build without X11
+        # https://savannah.gnu.org/bugs/?47887
+        s.gsub! "run_configure", "run_configure --without-x"
+      end
+    end
+
+    system "etc/make-liarc.sh", "--prefix=#{prefix}", "--mandir=#{man}"
+    system "make", "install"
+  end
+
+  test do
+    # ftp://ftp.cs.indiana.edu/pub/scheme-repository/code/num/primes.scm
+    (testpath/"primes.scm").write <<-EOS.undent
+      ;
+      ; primes
+      ; By Ozan Yigit
+      ;
+      (define  (interval-list m n)
+        (if (> m n)
+            '()
+            (cons m (interval-list (+ 1 m) n))))
+
+      (define (sieve l)
+        (define (remove-multiples n l)
+          (if (null? l)
+        '()
+        (if  (= (modulo (car l) n) 0)      ; division test
+             (remove-multiples n (cdr l))
+             (cons (car l)
+             (remove-multiples n (cdr l))))))
+
+        (if (null? l)
+            '()
+            (cons (car l)
+            (sieve (remove-multiples (car l) (cdr l))))))
+
+      (define (primes<= n)
+        (sieve (interval-list 2 n)))
+
+      ; (primes<= 300)
+    EOS
+
+    output = shell_output(
+      "mit-scheme --load primes.scm --eval '(primes<= 72)' < /dev/null"
+    )
+    assert_match(
+      /;Value 2: \(2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71\)/,
+      output
+    )
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -140,7 +140,6 @@
   "mesalib-glw": "homebrew/x11",
   "mess": "homebrew/games",
   "metalua": "homebrew/boneyard",
-  "mit-scheme": "homebrew/x11",
   "morse": "homebrew/x11",
   "mp3fs": "homebrew/fuse",
   "mpio": "homebrew/boneyard",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Moves `mit-scheme` from the x11 tap to core with modifications for disabling the X11 dependency.

Corresponding PR in homebrew-x11: Homebrew/homebrew-x11#208

cc @UniqMartin @ilovezfs 
