### PR TITLE
ios-deploy 1.8.6 (new formula)

### DIFF
--- a/Formula/ios-deploy.rb
+++ b/Formula/ios-deploy.rb
@@ -1,0 +1,24 @@
+class IosDeploy < Formula
+  desc "Install and debug iPhone apps from the command-line"
+  homepage "https://github.com/phonegap/ios-deploy"
+  url "https://github.com/phonegap/ios-deploy/archive/1.8.6.tar.gz"
+  sha256 "e0c20294e43bc231292cc9f3172113e0da8f728b1ed988fb4fe883ae99b20056"
+  head "https://github.com/phonegap/ios-deploy.git"
+
+  depends_on :xcode => :build
+  depends_on :macos => :yosemite
+
+  def install
+    xcodebuild "-configuration", "Release", "SYMROOT=build"
+
+    xcodebuild "test", "-scheme", "ios-deploy-tests", "-configuration", "Release", "SYMROOT=build"
+
+    bin.install "build/Release/ios-deploy"
+    include.install "build/Release/libios_deploy.h"
+    lib.install "build/Release/libios-deploy.a"
+  end
+
+  test do
+    system "#{bin}/ios-deploy", "-V"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This fails the strict audit with: "GitHub fork (not canonical repository)", because ios-deploy is a fork from fruitstrap (not maintened anymore). Any ideas how to fix this check?
