### PR TITLE
sproxy: fix permissions error in `make install`

### DIFF
--- a/Formula/sproxy.rb
+++ b/Formula/sproxy.rb
@@ -11,12 +11,31 @@ class Sproxy < Formula
     sha256 "344332d9ca503184f80ab8ea6505574316d4bd994070d86dc2ddc138b77e331e" => :mountain_lion
   end
 
+  # Only needed due to the change to "Makefile.am"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    # Prevents "ERROR: Can't create '/usr/local/share/man/man3'"; also fixes an
+    # audit violation triggered if the man page is installed in #{prefix}/man.
+    # After making the change below and running autoreconf, the default ends up
+    # being the same as #{man}, so there's no need for us to pass --mandir to
+    # configure, though, as a result of this change, that flag would be honored.
+    # Reported 10th May 2016 to https://www.joedog.org/support/
+    inreplace "doc/Makefile.am", "$(prefix)/man", "$(mandir)"
+    inreplace "lib/Makefile.am", "Makefile.PL", "Makefile.PL PREFIX=$(prefix)"
+
+    # Only needed due to the change to "Makefile.am"
+    system "autoreconf", "-fiv"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"
     system "make", "install"
-    # Makefile doesn't honor mandir, so move manpages post-install
-    share.install prefix+"man"
+  end
+
+  test do
+    assert_match "SPROXY v#{version}-", shell_output("#{bin}/sproxy -V")
   end
 end


### PR DESCRIPTION
Prevents
  ERROR: Can't create '/usr/local/share/man/man3'
  Do not have write permissions on '/usr/local/share/man/man3'

Have the Makefile pass "PREFIX=..." when it invokes Makefile.PL

Also, add a test.
