### PR TITLE
gst-plugins-bad: fix applemedia

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -1,8 +1,27 @@
 class GstPluginsBad < Formula
-  desc "GStreamer plugins (less supported, missing docs, not fully tested)"
+  desc "GStreamer plugins less supported, not fully tested"
   homepage "https://gstreamer.freedesktop.org/"
-  url "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.8.1.tar.xz"
-  sha256 "0bbd58f363734fc0c4a620b2d6fb01d427fdafdbda7b90b4e15d03b751ca40f5"
+
+  stable do
+    url "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.8.1.tar.xz"
+    sha256 "0bbd58f363734fc0c4a620b2d6fb01d427fdafdbda7b90b4e15d03b751ca40f5"
+
+    # corevideomemory.h and iosurfacememory.h are missing from the tarball
+    # should be removed after >1.8.1 is released
+    # https://bugzilla.gnome.org/show_bug.cgi?id=766163
+    # https://github.com/GStreamer/gst-plugins-bad/commit/43487482e5c5ec71867acb887d50b8c3f813cd63
+    resource "corevideomemory_header" do
+      url "https://raw.githubusercontent.com/GStreamer/gst-plugins-bad/1.8.1/sys/applemedia/corevideomemory.h"
+      sha256 "9d8c0fc6b310cb510a2af93a7614db80ec272ebd3dd943ecd47e65130b43aeea"
+    end
+
+    # same as above
+    # should be removed after >1.8.1 is released
+    resource "iosurfacememory_header" do
+      url "https://raw.githubusercontent.com/GStreamer/gst-plugins-bad/1.8.1/sys/applemedia/iosurfacememory.h"
+      sha256 "c617ff11e5abd8d71e97afe33d8e573685ab209a1a22184d56ad2cdb916d826c"
+    end
+  end
 
   bottle do
     sha256 "e6e94ec67d134677945b99b04310cc4ce8c24e9b23d1b234e4c0125941972991" => :el_capitan
@@ -17,8 +36,6 @@ class GstPluginsBad < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
-
-  option "with-applemedia", "Build with applemedia support"
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
@@ -49,7 +66,17 @@ class GstPluginsBad < Formula
       --disable-dependency-tracking
     ]
 
-    args << "--disable-apple_media" if build.without? "applemedia"
+    # upstream does not support Apple video for older SDKs
+    # error: use of undeclared identifier 'AVQueuedSampleBufferRenderingStatusFailed'
+    # https://github.com/Homebrew/legacy-homebrew/pull/35284
+    if MacOS.version <= :mavericks
+      args << "--disable-apple_media"
+    elsif !build.head?
+      # should be removed after >1.8.1 is released
+      resource("corevideomemory_header").stage buildpath/"sys/applemedia"
+      resource("iosurfacememory_header").stage buildpath/"sys/applemedia"
+    end
+
     args << "--with-gtk=3.0" if build.with? "gtk+3"
 
     if build.head?


### PR DESCRIPTION
- add resources for the two missing headers to fix applemedia option
- make applemedia a "without"/recommended option

Since a fix has already been merged upstream, the two new resource
blocks should be removed when >1.8.1 is released.

https://bugzilla.gnome.org/show_bug.cgi?id=766163
https://github.com/GStreamer/gst-plugins-bad/commit/43487482e5c5ec71867acb887d50b8c3f813cd63

Closes #1006.
