### PR TITLE
imagemagick: fix coders previously vulnerable to CVE-2016-3714

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -7,6 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/ImageMagick-6.9.4-1.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.4-1.tar.xz"
   sha256 "2ea0fef839cd5d6f134502b7cf7ee0e57a3f230b19771515d4aa44354f4c6b3b"
+  revision 1
 
   head "http://git.imagemagick.org/repos/ImageMagick.git"
 

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -56,14 +56,6 @@ class Imagemagick < Formula
 
   skip_clean :la
 
-  # Disables vulnerable coders: https://medium.com/@rhuber/imagemagick-is-on-fire-cve-2016-3714-379faf762247#.2tjfb3iks
-  # Next release will probably have a patch for the coders themselves,
-  # allowing us to remove this workaround.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/2e4d1d1c2b13cca6292ab534b8a68cb2ac334c6c/imagemagick/disable-coders.diff"
-    sha256 "8824d64bd62b75c2cff4c54bc0afc874f3e1b1a11b8916daadafe799600b6f6a"
-  end
-
   def install
     args = %W[
       --disable-osx-universal-binary


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

https://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2016-3714 has details for the vulnerability.  This vulnerability was addressed in 6.9.3-10 according to that page and its references.  So it should be safe to remove this policy.xml patch to workaround the vulnerability in earlier versions.

Without this change we need to unpatch policy.xml manually to avoid disrupting development were we get have been getting not authorized errors.
