### PR TITLE
file-roller 3.20.2

### DIFF
--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -1,8 +1,8 @@
 class FileRoller < Formula
   desc "GNOME archive manager"
   homepage "https://wiki.gnome.org/Apps/FileRoller"
-  url "https://download.gnome.org/sources/file-roller/3.16/file-roller-3.16.4.tar.xz"
-  sha256 "5455980b2c9c7eb063d2d65560ae7ab2e7f01b208ea3947e151680231c7a4185"
+  url "https://download.gnome.org/sources/file-roller/3.20/file-roller-3.20.2.tar.xz"
+  sha256 "93188a7ac9285cb85551c327082aeaeb51ac39a9722cb96b0e29d5ec2ae353c6"
 
   bottle do
     revision 1
@@ -37,11 +37,6 @@ class FileRoller < Formula
     inreplace "data/Makefile.in", "gtk-update-icon-cache", "gtk3-update-icon-cache"
     ENV.append "CFLAGS", "-I#{Formula["libmagic"].opt_include}"
     ENV.append "LIBS", "-L#{Formula["libmagic"].opt_lib}"
-
-    # Upstream bug: https://bugzilla.gnome.org/show_bug.cgi?id=756607
-    # A more elaborate, "correct" fix would be similar to this:
-    # https://github.com/mate-desktop/mate-utils/commit/c4df12f12d21ea7d4bc0d656bd5f93539c078d93
-    inreplace "configure", "$(GLIB_COMPILE_SCHEMAS) --strict", "$(GLIB_COMPILE_SCHEMAS)"
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -22,6 +22,14 @@ class FileRoller < Formula
   depends_on "hicolor-icon-theme"
   depends_on "gnome-icon-theme"
 
+  # Add linked-library dependencies
+  depends_on "atk"
+  depends_on "cairo"
+  depends_on "gdk-pixbuf"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "pango"
+
   def install
     # forces use of gtk3-update-icon-cache instead of gtk-update-icon-cache. No bugreport should
     # be filed for this since it only occurs because Homebrew renames gtk+3's gtk-update-icon-cache

--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -59,6 +59,6 @@ class FileRoller < Formula
   end
 
   test do
-    system "#{bin}/file-roller", "--version"
+    assert_match version.to_s, shell_output("#{bin}/file-roller --version 2>&1")
   end
 end


### PR DESCRIPTION
- version bump
- schema validation bug is fixed (#716), so yank the `inreplace`
- add linked-library dependencies
- use assert_match in the version test
