### PR TITLE
subversion: fix serf download URL, fix audit warning

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -25,7 +25,7 @@ class Subversion < Formula
   depends_on :apr => :build
 
   resource "serf" do
-    url "https://serf.googlecode.com/svn/src_releases/serf-1.3.8.tar.bz2", :using => :curl
+    url "https://archive.apache.org/dist/serf/serf-1.3.8.tar.bz2"
     sha256 "e0500be065dbbce490449837bb2ab624e46d64fc0b090474d9acaa87c82b2590"
   end
 


### PR DESCRIPTION
`subversion --with-python` formula fails with error 404:

```
$ brew update
Already up-to-date.
$ brew install --with-python subversion
==> Downloading https://www.apache.org/dyn/closer.cgi?path=subversion/subversion-1.9.4.tar.bz2
Already downloaded: /Library/Caches/Homebrew/subversion-1.9.4.tar.bz2
==> Patching
patching file configure
Hunk #1 succeeded at 26150 (offset 784 lines).
patching file subversion/bindings/swig/perl/native/Makefile.PL.in
patching file build/get-py-info.py
==> Downloading https://serf.googlecode.com/svn/src_releases/serf-1.3.8.tar.bz2

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "subversion--serf"
Download failed: https://serf.googlecode.com/svn/src_releases/serf-1.3.8.tar.bz2
```

The fix changes the download location to apache.org and fixes the audit warning.
