### PR TITLE
cabal-install 1.24.0.0

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -1,8 +1,14 @@
 class CabalInstall < Formula
   desc "Command-line interface for Cabal and Hackage"
   homepage "https://www.haskell.org/cabal/"
-  url "https://hackage.haskell.org/package/cabal-install-1.22.9.0/cabal-install-1.22.9.0.tar.gz"
-  sha256 "874035e5730263653c7aa459f270efbffc06da92ea0c828e09ebc04400e94940"
+  url "https://hackage.haskell.org/package/cabal-install-1.24.0.0/cabal-install-1.24.0.0.tar.gz"
+  sha256 "d840ecfd0a95a96e956b57fb2f3e9c81d9fc160e1fd0ea350b0d37d169d9e87e"
+
+  # disables haddock for hackage-security
+  patch :p2 do
+    url "https://patch-diff.githubusercontent.com/raw/haskell/cabal/pull/3393.patch"
+    sha256 "5506d46507f38c72270efc4bb301a85799a7710804e033eaef7434668a012c5e"
+  end
 
   bottle do
     sha256 "e0aeba6df425d2e6d3c9f40059eeafffc4c7ab50fcf9e8a018a6bafed859c253" => :el_capitan

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -6,7 +6,7 @@ class CabalInstall < Formula
 
   # disables haddock for hackage-security
   patch :p2 do
-    url "https://patch-diff.githubusercontent.com/raw/haskell/cabal/pull/3393.patch"
+    url "https://github.com/haskell/cabal/commit/9441fe.patch"
     sha256 "5506d46507f38c72270efc4bb301a85799a7710804e033eaef7434668a012c5e"
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Update cabal-install to 1.24.0.0.
Patch is needed for cabal-install to work with released ghc versions (< 8).
