### PR TITLE
granite 0.3.1 (new formula)

### DIFF
--- a/Formula/granite.rb
+++ b/Formula/granite.rb
@@ -1,0 +1,35 @@
+class Granite < Formula
+  desc "GTK+ extensions for elementary OS"
+  homepage "https://launchpad.net/granite"
+  url "https://launchpad.net/granite/0.3/0.3.1/+download/granite-0.3.1.tar.xz"
+  sha256 "8ec1d61f9aba75f1b3a745e721288b0dfb34cb11d1307be80cef7b0571c2dec6"
+
+  depends_on "gtk+3"
+  depends_on "libgee"
+  depends_on "cmake" => :build
+  depends_on "vala" => :build
+
+  # patch for https://bugs.launchpad.net/granite/+bug/1581531
+  patch :p0 do
+    url "https://gist.githubusercontent.com/TuurDutoit/4997904aa5fec96c8f188d88615edbeb/raw/32916b507f7e6918d207279f66fbb8655f173fea/granite-0.3.1-1581531.patch"
+    sha256 "fe87cbf98823369a5c918f068a2a135c77f276a8ef6d0f217f4682346e629110"
+  end
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.vala").write <<-EOS.undent
+      using Granite;
+      int main (string[] args) {
+        var time_format = Granite.DateTime.get_default_time_format ();
+        return 0;
+      }
+    EOS
+
+    system "valac", "--pkg", "gtk+-3.0", "--pkg", "granite", "test.vala"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Added a formula for the [Granite](https://launchpad.net/granite) GTK+ extensions designed for [elementary OS](https://elementary.io/)
Includes a simple test and passes `brew audit --strict --online granite`.
Also includes a patch for bug https://bugs.launchpad.net/granite/+bug/1581531. (needed to build the package)
