### PR TITLE
compcert: trigger ci

### DIFF
--- a/Formula/compcert.rb
+++ b/Formula/compcert.rb
@@ -15,6 +15,7 @@ class Compcert < Formula
   homepage "http://compcert.inria.fr"
   url "https://github.com/AbsInt/CompCert/archive/v2.6.tar.gz"
   sha256 "a1f21365c41c2462fce52a4a25e1c7e4b7fea7a0cd60b6bae1d31f2edeeb4d17"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
```
File "lib/lib.cma(Errors)", line 1:
Warning 31: files lib/lib.cma(Errors) and /usr/local/lib/ocaml/compiler-libs/ocamlbytecomp.cma(Errors) both define a module named Errors
File "pretyping/pretyping.cma(Matching)", line 1:
Warning 31: files pretyping/pretyping.cma(Matching) and /usr/local/lib/ocaml/compiler-libs/ocamlcommon.cma(Matching) both define a module named Matching
File "interp/interp.cma(Lexer)", line 1:
Warning 31: files interp/interp.cma(Lexer) and /usr/local/lib/ocaml/compiler-libs/ocamlcommon.cma(Lexer) both define a module named Lexer
File "/var/folders/03/jqjv4qms2b18_hwt2dcgsghc0000gp/T/coqmain7ffabb.ml", line 1:
Error: Some fatal warnings were triggered (3 occurrences)

```
