### PR TITLE
evas: add conflict with EFL

### DIFF
--- a/Formula/evas.rb
+++ b/Formula/evas.rb
@@ -11,6 +11,8 @@ class Evas < Formula
     sha256 "71e90d343bd3355ff57bdf84fb7ffdad0e8e060cdfc13c887216bd94b5f317c9" => :mountain_lion
   end
 
+  conflicts_with "efl", :because => "efl aggregates formerly distinct libs, one of which is evas"
+
   option "with-docs", "Install development libraries/headers and HTML docs"
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`efl.rb` already has the conflict marked.

Blocking #741.
