### PR TITLE
kore: El Capitan fixes

### DIFF
--- a/Formula/kore.rb
+++ b/Formula/kore.rb
@@ -1,10 +1,24 @@
 class Kore < Formula
   desc "Web application framework for writing web APIs in C"
   homepage "https://kore.io/"
-  url "https://kore.io/release/kore-1.2.3-release.tgz"
-  sha256 "24f1a88f4ef3199d6585f821e1ef134bb448a1c9409a76d18fcccd4af940d32f"
+  revision 1
 
   head "https://github.com/jorisvink/kore.git"
+
+  stable do
+    url "https://kore.io/release/kore-1.2.3-release.tgz"
+    sha256 "24f1a88f4ef3199d6585f821e1ef134bb448a1c9409a76d18fcccd4af940d32f"
+
+    # 1.2.3 release doesn't respect user-passed CFLAGS nor does it store
+    # information on where the OpenSSL headers used during build reside.
+    # On El Capitan this results in `kore build test` failing.
+    # Backport of https://github.com/jorisvink/kore/commit/4dff0b57ae6ed113d15b
+    # https://github.com/jorisvink/kore/issues/70
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/c86b133e2c137cd/kore/123findssl.diff"
+      sha256 "70751661705993deab7d47c5505666738477f44f5b5bc1399b0ed9f30ebad6ec"
+    end
+  end
 
   bottle do
     sha256 "acdd632ceba6698b1a52292a1f58f7b7adaefa6a677d138c3f16a1fb3ddd19e1" => :el_capitan
@@ -17,6 +31,14 @@ class Kore < Formula
   depends_on "postgresql" => :optional
 
   def install
+    # Ensure make finds our OpenSSL when Homebrew isn't in /usr/local.
+    # Current Makefile hardcodes paths for default MacPorts/Homebrew.
+    ENV.prepend "CFLAGS", "-I#{Formula["openssl"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib}"
+    # Also hardcoded paths in src/cli.c at compile.
+    inreplace "src/cli.c", "/usr/local/opt/openssl/include",
+                            Formula["openssl"].opt_include
+
     args = []
 
     args << "PGSQL=1" if build.with? "postgresql"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Currently the test (including outside Homebrew) fails because it can't find our OpenSSL outside of the build due to not "remembering" the path, and also doesn't respect user CFLAGS, so this is currently broken pretty nicely for El Cap users. This should fix it.

Also fixes for Homebrew users who haven't placed their Homebrew in the default prefix.
