### PR TITLE
tomcat 8.0.35 (stable), tomcat 8.5.2 (beta)

### DIFF
--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -3,31 +3,30 @@ class Tomcat < Formula
   homepage "https://tomcat.apache.org/"
 
   stable do
-    url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33.tar.gz"
-    mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33.tar.gz"
-    sha256 "c77873c1861ed81617abb8bedc392fb0ff5ebf871de33cd1fcd49d4c072e38b7"
+    url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.tar.gz"
+    mirror "https://www.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.tar.gz"
+    sha256 "6bc380aeebe0b56cf9b37b8c3c128919d2e8ac84d756448fc8e9d8af122f88fd"
 
     depends_on :java => "1.7+"
 
     resource "fulldocs" do
-      url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33-fulldocs.tar.gz"
-      mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33-fulldocs.tar.gz"
-      version "8.0.33"
-      sha256 "211dd1d95fbb838914169828de64cf8a12ffc0ae6d3c77b8027592849c89ebb4"
+      url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35-fulldocs.tar.gz"
+      mirror "https://www.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35-fulldocs.tar.gz"
+      version "8.0.35"
+      sha256 "572e91559b7ade53f69ef5d0277db19717c672963ef10b719b8f4b7cd2c79ccf"
     end
   end
 
   devel do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-9/v9.0.0.M4/bin/apache-tomcat-9.0.0.M4.tar.gz"
-    version "9.0.0.M4"
-    sha256 "7586582b3498d4fb874a82f96f408ee51c8d3bf38eb5af1ea987f65de90ac685"
-
-    depends_on :java => "1.8+"
+    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.5.2/bin/apache-tomcat-8.5.2.tar.gz"
+    mirror "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.2/bin/apache-tomcat-8.5.2.tar.gz"
+    sha256 "6b504d7de9b33f234b1c1639b187208ef5dbf5d0f0d413b6f351fc115196396e"
 
     resource "fulldocs" do
-      url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-9/v9.0.0.M4/bin/apache-tomcat-9.0.0.M4-fulldocs.tar.gz"
-      version "9.0.0.M4"
-      sha256 "3311cdbf18696090b233bd2bf59740c5583dbf19d3de6b7c97e2f348c625b2b5"
+      url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.5.2/bin/apache-tomcat-8.5.2-fulldocs.tar.gz"
+      mirror "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.2/bin/apache-tomcat-8.5.2-fulldocs.tar.gz"
+      version "8.5.2"
+      sha256 "9e150f98803ceef8be0bb415a9eaf8de4e689c20a4c020b5aec85c05547dccd1"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I included the newly introduced 8.5.x beta series instead of the 9.x alpha series. As per announcement of 8.5.x

> Apache Tomcat 8.5.0 is intended to replace 8.0.x and includes new features pulled forward from Tomcat 9.0.x.
