### PR TITLE
the_silver_searcher: build without xz by disabling LZMA support

### DIFF
--- a/Formula/the_silver_searcher.rb
+++ b/Formula/the_silver_searcher.rb
@@ -17,7 +17,7 @@ class TheSilverSearcher < Formula
 
   depends_on "pkg-config" => :build
   depends_on "pcre"
-  depends_on "xz"
+  depends_on "xz" => :recommended
 
   def install
     # Stable tarball does not include pre-generated configure script
@@ -26,8 +26,14 @@ class TheSilverSearcher < Formula
     system "autoheader"
     system "automake", "--add-missing"
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+    ]
+
+    args << "--disable-lzma" if build.without?("xz")
+
+    system "./configure", *args
     system "make"
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Make `xz` a recommended dependency of `the_silver_searcher`. Configure `the_silver_searcher` with `--disable-lzma` if installing `--without-xz`.
