### PR TITLE
pcre2 10.21

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -1,11 +1,18 @@
 class Pcre2 < Formula
   desc "Perl compatible regular expressions library with a new API"
   homepage "http://www.pcre.org/"
-  url "https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.20.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre2/10.20/pcre2-10.20.tar.bz2"
-  sha256 "332e287101c9e9567d1ed55391b338b32f1f72c5b5ee7cc81ef2274a53ad487a"
 
   head "svn://vcs.exim.org/pcre2/code/trunk"
+
+  stable do
+    url "https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2"
+    mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre2/10.21/pcre2-10.21.tar.bz2"
+    sha256 "c66a17509328a7251782691093e75ede7484a203ebc6bed3c08122b092ccd4e0"
+    # Patch from http://vcs.pcre.org/pcre2/code/trunk/src/pcre2_compile.c?view=patch&r1=489&r2=488&pathrev=489
+    # Fixes CVE-2016-3191
+    # Can be dropped once 10.22 is released
+    patch :p2, :DATA
+  end
 
   bottle do
     cellar :any
@@ -36,3 +43,31 @@ class Pcre2 < Formula
     system "#{bin}/pcre2grep", "regular expression", "#{prefix}/README"
   end
 end
+__END__
+--- code/trunk/src/pcre2_compile.c	2016/02/06 16:40:59	488
++++ code/trunk/src/pcre2_compile.c	2016/02/10 18:24:02	489
+@@ -5901,10 +5901,22 @@
+               goto FAILED;
+               }
+             cb->had_accept = TRUE;
++            
++            /* In the first pass, just accumulate the length required;
++            otherwise hitting (*ACCEPT) inside many nested parentheses can
++            cause workspace overflow. */
++              
+             for (oc = cb->open_caps; oc != NULL; oc = oc->next)
+               {
+-              *code++ = OP_CLOSE;
+-              PUT2INC(code, 0, oc->number);
++              if (lengthptr != NULL)
++                {
++                *lengthptr += CU2BYTES(1) + IMM2_SIZE; 
++                }
++              else
++                {       
++                *code++ = OP_CLOSE;
++                PUT2INC(code, 0, oc->number);
++                } 
+               }
+             setverb = *code++ =
+               (cb->assert_depth > 0)? OP_ASSERT_ACCEPT : OP_ACCEPT;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Update the PCRE2 library to the latest release, 10.21.

Includes patch for CVE-2016-3191.
