### PR TITLE
add x86 support for proxychains

### DIFF
--- a/Formula/proxychains-ng.rb
+++ b/Formula/proxychains-ng.rb
@@ -15,7 +15,7 @@ class ProxychainsNg < Formula
   option :universal
 
   def install
-    args = ["--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc"]
+    args = ["--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc", "-arch i386"]
     if build.universal?
       ENV.universal_binary
       args << "--fat-binary"

--- a/Formula/proxychains-ng.rb
+++ b/Formula/proxychains-ng.rb
@@ -15,10 +15,11 @@ class ProxychainsNg < Formula
   option :universal
 
   def install
-    args = ["--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc", "-arch i386"]
+    args = ["--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc"]
     if build.universal?
       ENV.universal_binary
       args << "--fat-binary"
+      args << "-arch i386"
     end
     system "./configure", *args
     system "make"


### PR DESCRIPTION
This PR adds x86 support for proxychains. See here for the error for an older version:
https://gist.github.com/y3dips/0972e13256f947b0004a

Tried with `proxychains-ng-4.11.tar.bz2`
