### PR TITLE
chruby-fish 0.8.0

### DIFF
--- a/Formula/chruby-fish.rb
+++ b/Formula/chruby-fish.rb
@@ -1,8 +1,8 @@
 class ChrubyFish < Formula
   desc "Thin wrapper around chruby to make it work with the Fish shell"
   homepage "https://github.com/JeanMertz/chruby-fish#readme"
-  url "https://github.com/JeanMertz/chruby-fish/archive/v0.7.2.tar.gz"
-  sha256 "d64248ce9b80dfdb327b69f4db3cfd0901957a745fd8b3b0f8c2a31fd0840297"
+  url "https://github.com/JeanMertz/chruby-fish/archive/v0.8.0.tar.gz"
+  sha256 "d74fada4c4e22689d08a715a2772e73776975337640bd036fbfc01d90fbf67b7"
   head "https://github.com/JeanMertz/chruby-fish.git"
 
   bottle do
@@ -12,9 +12,14 @@ class ChrubyFish < Formula
     sha256 "d56f48b0a49d0c381bffc28ffe320019b89a87a708ec51f24218a0911104bd78" => :mavericks
   end
 
+  depends_on "fish" => :recommended
   depends_on "chruby" => :recommended
 
   def install
     system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    assert_match /chruby-fish/, shell_output("fish -c '. #{share}/chruby/chruby.fish; chruby --version'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The last one is unchecked due to:

```
$ brew audit --strict --online chruby-fish
chruby-fish:
  * A `test do` test block should be added
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
Error: 2 problems in 1 formula
```

I guess there is a new policy about package popularity? Should the package be removed from Homebrew? (those numbers are currently at 14, 7, 45).
