### PR TITLE
Elasticsearch 2.3.3 and Kibana 4.5.1

### DIFF
--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -4,8 +4,8 @@ class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
   url "https://github.com/elastic/kibana.git",
-    :tag => "v4.5.0",
-    :revision => "ff5cfc5d05a58e53f7acaa762428fa803318d31e"
+    :tag => "v4.5.1",
+    :revision => "addb28966a74b61791ceda352cd5b8b1200f2b2a"
 
   head "https://github.com/elastic/kibana.git"
 
@@ -24,8 +24,8 @@ class Kibana < Formula
   end
 
   resource "node" do
-    url "https://nodejs.org/dist/v4.3.2/node-v4.3.2.tar.gz"
-    sha256 "1f92f6d31f7292ce56db57d6703efccf3e6c945948f5901610cefa69e78d3498"
+    url "https://nodejs.org/dist/v4.4.4/node-v4.4.4.tar.gz"
+    sha256 "53c694c203ee18e7cd393612be08c61ed6ab8b2a165260984a99c014d1741414"
   end
 
   def install


### PR DESCRIPTION
This pull request updates the Elasticsearch and Kibana formula:
- Elasticsearch 2.3.2 -> [2.3.3](https://www.elastic.co/blog/elasticsearch-2-3-3-released), bug fix release
- Kibana 4.5.0 -> [4.5.1](https://www.elastic.co/blog/kibana-4-5-1-and-4-1-7), updates Node.js for important high-severity security fixes

These are the latest stable versions as of 2016-05-18.
