### PR TITLE
zsh-navigation-tools: fix permissions

### DIFF
--- a/Formula/zsh-navigation-tools.rb
+++ b/Formula/zsh-navigation-tools.rb
@@ -1,8 +1,8 @@
 class ZshNavigationTools < Formula
   desc "Zsh curses-based tools, e.g. multi-word history searcher"
   homepage "https://github.com/psprint/zsh-navigation-tools"
-  url "https://github.com/psprint/zsh-navigation-tools/archive/v2.1.16.tar.gz"
-  sha256 "534f55155d288c7177dcfe10951c2cb8f6b9729043a550d8976da8eb2b3fb013"
+  url "https://github.com/psprint/zsh-navigation-tools/archive/v2.1.17.tar.gz"
+  sha256 "eaa05b67f49bafdf5a396183365745ddf14fae138be03a63f1c5d87fd34694e0"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +12,7 @@ class ZshNavigationTools < Formula
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "install-brew", "PREFIX=#{prefix}"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Now that ZNT has completion I realized I need chmod 750 on main directory. Had to add additional target in Makefile for Homebrew, thus version 2.1.17. This will save users from Zsh message about improper permissions.
