### PR TITLE
wmc v0.1.2-alpha (new formula)

### DIFF
--- a/Formula/wmc.rb
+++ b/Formula/wmc.rb
@@ -1,0 +1,23 @@
+class Wmc < Formula
+  desc "Command-line loader for the WifiMCU platform"
+  homepage "https://github.com/zpeters/wmc"
+  url "https://github.com/zpeters/wmc/archive/v0.1.2-alpha.tar.gz"
+  version "0.1.2-alpha"
+  sha256 "b9d3fdc1a6a9cb4fe66081cef6d52e56d4a90a126b0dcb7e26addc6376228d8b"
+
+  depends_on "go"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    system "go", "get", "github.com/spf13/viper"
+    system "go", "get", "github.com/spf13/cobra"
+    system "go", "get", "github.com/tarm/serial"
+
+    system "go", "build", "-o", "wmc"
+    bin.install "wmc"
+  end
+
+  test do
+    system "wmc", "config"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [/] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)? Doesn't pass "popularity" checks but all other checks pass

---

WMC is a command-line "loader" for the WifiMCU platform. This application is an alternative to some of the features offered in the Windows GUI app WifiMCU Studio
