### PR TITLE
Instructions for installing older formulae/packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Core formulae for the Homebrew package manager.
 ## How do I install these formulae?
 Just `brew install <formula>`. This is the default tap for Homebrew and is installed by default.
 
+### Installing older formulae
+To install an older version of a package, use `brew install <url>`, where `<url>` is the path to the raw formula for that package, at the version you want. For example, the following command will install elasticsearch 2.0.0:
+
+`brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/935d360323965ec31beec774b64d52778c41afdf/Formula/elasticsearch.rb`
+
+If you do not find the version of a package you need in [homebrew-core](https://github.com/Homebrew/homebrew-core), try checking [legacy-homebrew](https://github.com/Homebrew/legacy-homebrew).
+
 ## Troubleshooting
 First, please run `brew update` (twice) and `brew doctor`.
 


### PR DESCRIPTION
This adds instructions for installing older versions of packages. From this [SO answer](http://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula/17757092#17757092).
