### PR TITLE
git-annex 6.20160511

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -5,8 +5,8 @@ class GitAnnex < Formula
 
   desc "Manage files with git without checking in file contents"
   homepage "https://git-annex.branchable.com/"
-  url "https://hackage.haskell.org/package/git-annex-6.20160418/git-annex-6.20160418.tar.gz"
-  sha256 "9d13586cc38d78bcd94c1f3a245d5283e67f43b0ea88033c40d54e78f6544fa2"
+  url "https://hackage.haskell.org/package/git-annex-6.20160511/git-annex-6.20160511.tar.gz"
+  sha256 "85fc8853166fe57d91dc2776d5df4acb5911a91815f8aa12881928a1afe8ba01"
 
   head "git://git-annex.branchable.com/"
 
@@ -28,7 +28,7 @@ class GitAnnex < Formula
   depends_on "quvi"
 
   def install
-    install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["webapp"] do
+    install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["s3", "webapp"] do
       # this can be made the default behavior again once git-union-merge builds properly when bottling
       if build.with? "git-union-merge"
         system "make", "git-union-merge", "PREFIX=#{prefix}"


### PR DESCRIPTION
git-annex 6.20160511
- version bump
- restore s3 support

The "strong" (i.e., explicit) flag is currently needed to stop Cabal's solver from dropping S3 support. There's no need to remove the explicit flag in the future unless its name changes.

Reported 20 May 2016 to git-annex upstream:
http://git-annex.branchable.com/bugs/default_cabal_install_on_OSX_lacks_S3/

aws upstream has already fixed the underlying cause:
https://github.com/aristidb/aws/commit/402bfe5aa9ef4bec84186880faafcbfdae1ad91d

New aws version (including that commit) requested 20 May 2016:
https://github.com/aristidb/aws/issues/202

Issue https://github.com/Homebrew/legacy-homebrew/issues/47737.
Closes #1268.
