### PR TITLE
saltstack 2015.8.9 & 2016.3.0rc3 (devel)

### DIFF
--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -17,8 +17,8 @@ class Saltstack < Formula
   end
 
   devel do
-    url "https://github.com/saltstack/salt/releases/download/v2016.3.0rc2/salt-2016.3.0rc2.tar.gz"
-    sha256 "aaa136ad5b7ce2478f352fadaddba66deba65b939fd146e772635d79b20fd8f3"
+    url "https://github.com/saltstack/salt/releases/download/v2016.3.0rc3/salt-2016.3.0rc3.tar.gz"
+    sha256 "994a2468ea5bb854237f4d7f1efcbf651438cc1e8ae16fbd22b8d2f37f68707f"
   end
 
   depends_on "swig" => :build

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -5,8 +5,8 @@ class Saltstack < Formula
   # (URLs starting with https://github.com/saltstack/salt/releases/download)
   # github tag archives will report wrong version number
   # https://github.com/Homebrew/homebrew/issues/43493
-  url "https://github.com/saltstack/salt/releases/download/v2015.8.8.2/salt-2015.8.8.2.tar.gz"
-  sha256 "67d690bd47296cf3475afabf78815f223c6757edb9e584bc4bfd42f1deff3aa9"
+  url "https://github.com/saltstack/salt/releases/download/v2015.8.9/salt-2015.8.9.tar.gz"
+  sha256 "ad20416b5a59db5063c93f780fdae71723d7337296b9223797ea0e2d59f79208"
   head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
- Bump saltstack stable version from 2015.8.8 to 2015.8.9
- Bump saltstack devel version from 2016.3.0rc2 to 2016.3.0rc3
