### PR TITLE
dpkg: fix pkg-config file installed to wrong place

### DIFF
--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -40,6 +40,7 @@ class Dpkg < Formula
 
     bin.install Dir["#{libexec}/bin/*"]
     man.install Dir["#{libexec}/share/man/*"]
+    (lib/"pkgconfig").install Dir["#{libexec}/lib/pkgconfig/*.pc"]
     bin.env_script_all_files(libexec+"bin", :PERL5LIB => ENV["PERL5LIB"])
 
     (buildpath/"dummy").write "Vendor: dummy\n"

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -40,7 +40,7 @@ class Dpkg < Formula
 
     bin.install Dir["#{libexec}/bin/*"]
     man.install Dir["#{libexec}/share/man/*"]
-    (lib/"pkgconfig").install Dir["#{libexec}/lib/pkgconfig/*.pc"]
+    (lib/"pkgconfig").install_symlink Dir["#{libexec}/lib/pkgconfig/*.pc"]
     bin.env_script_all_files(libexec+"bin", :PERL5LIB => ENV["PERL5LIB"])
 
     (buildpath/"dummy").write "Vendor: dummy\n"


### PR DESCRIPTION
libdpkg includes a pkg-config file -- it works if I manually specified
PKG_CONFIG_PATH=$(brew --prefix dpkg)/libexec/lib/pkgconfig so this
fixes it to install the .pc file into the right default search path.
