### PR TITLE
gradle: fix incorrect devel version reporting

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -7,6 +7,7 @@ class Gradle < Formula
   devel do
     url "https://downloads.gradle.org/distributions/gradle-2.14-rc-1-bin.zip"
     sha256 "2ff85eb9eda60f13bc8debec69849e1e2a72b7bfc5af5d26e61a293b5dcbceba"
+    version "2.14-rc-1"
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
- Fix incorrect gradle.rb devel version reporting
