### PR TITLE
skinny 2.1.1

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.1.0/skinny-2.1.0.tar.gz"
-  sha256 "bb39dfa400b0fb5fbae32959ef9695569da94117424dccf60b98c1fda26313e3"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.1.1/skinny-2.1.1.tar.gz"
+  sha256 "ae0d0dcf60ed8252c8dc97beb1844c0fb5bb36e6137682e459928480d9914fbc"
 
   bottle :unneeded
 


### PR DESCRIPTION
Skinny 2.1.1 is out. http://skinny-framework.org/
Thanks as always 🙇 

---
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

```
 brew install ./Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.1.1/skinny-2.1.1.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/f608421a-1f84-11e6-94b5-ea2529420bcb.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20160521%2Fus-east-1%2Fs3%2Faws
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.1.1: 802 files, 101.0M, built in 29 seconds
```
