### PR TITLE
fop: depend on Java (6 or higher)

### DIFF
--- a/Formula/fop.rb
+++ b/Formula/fop.rb
@@ -11,6 +11,8 @@ class Fop < Formula
     sha256 "38602cef629a33f05149c3411ea6b82451deec872aa6cbe1fa8203ad2ee875fb" => :mavericks
   end
 
+  depends_on :java => "1.6+"
+
   resource "hyph" do
     url "https://downloads.sourceforge.net/project/offo/offo-hyphenation-utf8/0.1/offo-hyphenation-fop-stable-utf8.zip"
     sha256 "0b4e074635605b47a7b82892d68e90b6ba90fd2af83142d05878d75762510128"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`fop` depends on Java 1.6 or higher (source: https://xmlgraphics.apache.org/fop/2.1/compiling.html).

Homebrew doesn't compile it from source, so the JAR files _might_ work with Java 5, but I think it's reasonable to depend on 6+.
