### PR TITLE
chezscheme 9.4 (new formula)

### DIFF
--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -1,0 +1,27 @@
+class Chezscheme < Formula
+  desc "Chez Scheme"
+  homepage "https://cisco.github.io/ChezScheme/"
+  url "https://github.com/cisco/ChezScheme/archive/v9.4.tar.gz"
+  sha256 "9f4e6fe737300878c3c9ca6ed09ed97fc2edbf40e4cf37bd61f48a27f5adf952"
+
+  depends_on :x11 => build
+
+  conflicts_with "mit-scheme", :because => "both install `scheme` binaries"
+
+  def install
+    system "./configure", "--installprefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.ss").write <<-EOS.undent
+      (display "Hello, World!") (newline)
+    EOS
+
+    expected = <<-EOS.undent
+      Hello, World!
+    EOS
+
+    assert_equal expected, shell_output("#{bin}/scheme --script hello.ss")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Chez Scheme is a compiler and run-time system for the language of the
Revised6 Report on Scheme (R6RS), with numerous extensions. The compiler
generates native code for each target processor, with support for x86,
x86_64, and 32-bit PowerPC architectures.
