### PR TITLE
keybase: add gnupg dependency

### DIFF
--- a/Formula/keybase.rb
+++ b/Formula/keybase.rb
@@ -14,6 +14,7 @@ class Keybase < Formula
   end
 
   depends_on "go" => :build
+  depends_on "gnupg"
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Gnupg was not in dependencies, but must be presented in the system for keybase
