### PR TITLE
genders 1.22

### DIFF
--- a/Formula/genders.rb
+++ b/Formula/genders.rb
@@ -1,8 +1,8 @@
 class Genders < Formula
   desc "Static cluster configuration database for cluster management"
   homepage "https://computing.llnl.gov/linux/genders.html"
-  url "https://downloads.sourceforge.net/project/genders/genders/1.20-1/genders-1.20.tar.gz"
-  sha256 "374ef2833ad53ea9ca4ccbabd7a66d77ab0b46785e299c0e64f95577eed96ac9"
+  url "https://downloads.sourceforge.net/project/genders/genders/1.22-1/genders-1.22.tar.gz"
+  sha256 "0ff292825a29201106239c4d47d9ce4c6bda3f51c78c0463eb2634ecc337b774"
 
   bottle do
     cellar :any
@@ -15,6 +15,8 @@ class Genders < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
+
+    args << "--with-java-extensions=no"
 
     args << "--with-non-shortened-hostnames" if build.with? "non-shortened-hostnames"
 


### PR DESCRIPTION
compile with --with-java-extensions=no because the build is broken.
note that current version 1.20 lead to segmentation fault when
using psdh with genders
