### PR TITLE
lua: move sigaction patch to patches repository

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -45,7 +45,8 @@ class Lua < Formula
   # sigaction provided by posix signalling power patch
   if build.with? "sigaction"
     patch do
-      url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
+		 # url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
+			url "https://gist.githubusercontent.com/anonymous/99614c27bcac2aa86181fabe78c85915/raw/7abdf0234ffd38fc9094078d8128938f5e2accd4/lua-5.2.3-sig_catch.patch"
       sha256 "f2e77f73791c08169573658caa3c97ba8b574c870a0a165972ddfbddb948c164"
     end
   end

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -45,8 +45,8 @@ class Lua < Formula
   # sigaction provided by posix signalling power patch
   if build.with? "sigaction"
     patch do
-		 # url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
-			url "https://gist.githubusercontent.com/anonymous/99614c27bcac2aa86181fabe78c85915/raw/7abdf0234ffd38fc9094078d8128938f5e2accd4/lua-5.2.3-sig_catch.patch"
+      # url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
+      url "https://gist.githubusercontent.com/anonymous/99614c27bcac2aa86181fabe78c85915/raw/7abdf0234ffd38fc9094078d8128938f5e2accd4/lua-5.2.3-sig_catch.patch"
       sha256 "f2e77f73791c08169573658caa3c97ba8b574c870a0a165972ddfbddb948c164"
     end
   end

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -45,8 +45,8 @@ class Lua < Formula
   # sigaction provided by posix signalling power patch
   if build.with? "sigaction"
     patch do
-      # url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
-      url "https://gist.githubusercontent.com/anonymous/99614c27bcac2aa86181fabe78c85915/raw/7abdf0234ffd38fc9094078d8128938f5e2accd4/lua-5.2.3-sig_catch.patch"
+      # original patch file (not available): http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch
+      url "https://raw.githubusercontent.com/Homebrew/patches/d674e02d1097b21032198854080204680b616b61/lua/lua-5.2.3-sig_catch.patch"
       sha256 "f2e77f73791c08169573658caa3c97ba8b574c870a0a165972ddfbddb948c164"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Currently, there is something wrong with [lua-users](http://lua-users.org/files) website that stores the patch, so the url for the patch specified in the formula is no longer valid. 
I found the patch at http://lua-users.org/files/wiki_insecure/jZgoWXtW/5.2/lua-5.2.3-sig_catch.patch and copied it to gist.github.com. That's it.
