### PR TITLE
JSON-Fortran and FORD new versions

### DIFF
--- a/Formula/ford.rb
+++ b/Formula/ford.rb
@@ -1,8 +1,8 @@
 class Ford < Formula
   desc "Automatic documentation generator for modern Fortran programs"
   homepage "https://github.com/cmacmackin/ford/"
-  url "https://pypi.python.org/packages/source/F/FORD/FORD-4.5.4.tar.gz"
-  sha256 "fc32eb17c2aa6bfd89e4168f237b7f66a9892c00dcc94a7ce6af08d05cdfdfc1"
+  url "https://pypi.python.org/packages/14/45/5fe474b94e9fa1a94ccced22f8c699c3aab60b93c365941ae075bc374522/FORD-4.6.0.tar.gz"
+  sha256 "e95146a6e82c3b0c2c9aaabeef60148130a8dd39347f0985c2283f0098fdddaf"
 
   head "https://github.com/cmacmackin/ford.git"
 
@@ -17,42 +17,42 @@ class Ford < Formula
   depends_on :python if MacOS.version <= :snow_leopard
 
   resource "beautifulsoup4" do
-    url "https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.4.1.tar.gz"
+    url "https://pypi.python.org/packages/26/79/ef9a8bcbec5abc4c618a80737b44b56f1cb393b40238574078c5002b97ce/beautifulsoup4-4.4.1.tar.gz"
     sha256 "87d4013d0625d4789a4f56b8d79a04d5ce6db1152bb65f1d39744f7709a366b4"
   end
 
   resource "graphviz" do
-    url "https://pypi.python.org/packages/source/g/graphviz/graphviz-0.4.10.zip"
+    url "https://pypi.python.org/packages/3d/6d/406cec4d782d3cd6cb02d90bb17fbd364cab4a2a96d8ad0b5ccb46fd7442/graphviz-0.4.10.zip"
     sha256 "61e9f7126f5efdd11fb9269d4622277fbf8ed92046b73f3e78529e3be6a95f15"
   end
 
   resource "Jinja2" do
-    url "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz"
+    url "https://pypi.python.org/packages/f2/2f/0b98b06a345a761bec91a079ccae392d282690c2d8272e708f4d10829e22/Jinja2-2.8.tar.gz"
     sha256 "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4"
   end
 
   resource "Markdown" do
-    url "https://pypi.python.org/packages/source/M/Markdown/Markdown-2.6.6.tar.gz"
+    url "https://pypi.python.org/packages/9b/53/4492f2888408a2462fd7f364028b6c708f3ecaa52a028587d7dd729f40b4/Markdown-2.6.6.tar.gz"
     sha256 "9a292bb40d6d29abac8024887bcfc1159d7a32dc1d6f1f6e8d6d8e293666c504"
   end
 
   resource "markdown-include" do
-    url "https://pypi.python.org/packages/source/m/markdown-include/markdown-include-0.5.1.tar.gz"
+    url "https://pypi.python.org/packages/ef/44/eb6e9b4fa1110b719abb876c9b6dd8b46af886a94536ec4e9117fe5e7b97/markdown-include-0.5.1.tar.gz"
     sha256 "72a45461b589489a088753893bc95c5fa5909936186485f4ed55caa57d10250f"
   end
 
   resource "MarkupSafe" do
-    url "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz"
+    url "https://pypi.python.org/packages/c0/41/bae1254e0396c0cc8cf1751cb7d9afc90a602353695af5952530482c963f/MarkupSafe-0.23.tar.gz"
     sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
   end
 
   resource "Pygments" do
-    url "https://pypi.python.org/packages/source/P/Pygments/Pygments-2.1.3.tar.gz"
+    url "https://pypi.python.org/packages/b8/67/ab177979be1c81bc99c8d0592ef22d547e70bb4c6815c383286ed5dec504/Pygments-2.1.3.tar.gz"
     sha256 "88e4c8a91b2af5962bfa5ea2447ec6dd357018e86e94c7d14bd8cacbc5b55d81"
   end
 
   resource "toposort" do
-    url "https://pypi.python.org/packages/source/t/toposort/toposort-1.4.tar.gz"
+    url "https://pypi.python.org/packages/f6/f7/875e23067652488ae40603336fdd63510a1e1853672b5b829a78452fd31c/toposort-1.4.tar.gz"
     sha256 "c190b9d9a9e53ae2835f4d524130147af601fbd63677d19381c65067a80fa903"
   end
 

--- a/Formula/json-fortran.rb
+++ b/Formula/json-fortran.rb
@@ -1,8 +1,8 @@
 class JsonFortran < Formula
   desc "Fortran 2008 JSON API"
   homepage "https://github.com/jacobwilliams/json-fortran"
-  url "https://github.com/jacobwilliams/json-fortran/archive/4.3.0.tar.gz"
-  sha256 "c97f8de53e2ca9ee91fb3148bfa971b00eaea6e757b5e3d67cc4b4ff197e392e"
+  url "https://github.com/jacobwilliams/json-fortran/archive/5.0.0.tar.gz"
+  sha256 "0a1bf8788bdf8bdc6af009ae078ed374b2c95e0cfc3f30354b5dc5d3d35e5e66"
 
   head "https://github.com/jacobwilliams/json-fortran.git"
 
@@ -38,16 +38,21 @@ class JsonFortran < Formula
   test do
     ENV.fortran
     (testpath/"json_test.f90").write <<-EOS.undent
-      program json_test
-        use json_module
-        use ,intrinsic :: iso_fortran_env ,only: error_unit
-        implicit none
-        call json_initialize()
-        if ( json_failed() ) then
-          call json_print_error_message(error_unit)
-          stop 2
-        endif
-      end program
+      program example
+      use json_module, RK => json_RK
+      use iso_fortran_env, only: stdout => output_unit
+      implicit none
+      type(json_core) :: json
+      type(json_value),pointer :: p, inp
+      call json%initialize()
+      call json%create_object(p,'')
+      call json%create_object(inp,'inputs')
+      call json%add(p, inp)
+      call json%add(inp, 't0', 0.1_RK)
+      call json%print(p,stdout)
+      call json%destroy(p)
+      if (json%failed()) error stop 'error'
+      end program example
     EOS
     system ENV.fc, "-ojson_test", "-ljsonfortran", "-I#{HOMEBREW_PREFIX}/include", testpath/"json_test.f90"
     system "./json_test"


### PR DESCRIPTION
JSON-Fortran 5.0.0 released. Includes work around for regression in GFortran 6.1 (See PR #676 for more info/context)
FORD 4.6.0 released
