### PR TITLE
python3: skip the xcode-stubs patch if using --HEAD

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -60,9 +60,11 @@ class Python3 < Formula
   # Fix extension module builds against Xcode 7 SDKs
   # https://github.com/Homebrew/homebrew/issues/41085
   # https://bugs.python.org/issue25136
-  patch do
-    url "https://bugs.python.org/file40478/xcode-stubs.diff"
-    sha256 "029cc0dc72b1bcf4ddc5f913cc4a3fd970378073c6355921891f041aca2f8b12"
+  stable do
+    patch do
+      url "https://bugs.python.org/file40478/xcode-stubs.diff"
+      sha256 "029cc0dc72b1bcf4ddc5f913cc4a3fd970378073c6355921891f041aca2f8b12"
+    end
   end
 
   def lib_cellar


### PR DESCRIPTION
I was playing around with python 3.6 and it doesn't install by default (`--HEAD`) because of the `xcode-stubs` patch. Ignoring it works fine. 

Not sure whether this deserves a version bump. It's a very quick fix anyway. This is my first pull request in this project so don't be too harsh :)
