### PR TITLE
elm: GHC 8 compatibility

### DIFF
--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -44,6 +44,11 @@ class Elm < Formula
     # elm-compiler needs to be staged in a subdirectory for the build process to succeed
     (buildpath/"elm-compiler").install Dir["*"]
 
+    # GHC 8 compat
+    # Fixes "cabal: Could not resolve dependencies"
+    # Reported 25 May 2016: https://github.com/elm-lang/elm-compiler/issues/1397
+    (buildpath/"cabal.config").write("allow-newer: aeson,base,HTTP,time,transformers\n")
+
     extras_no_reactor = ["elm-package", "elm-make", "elm-repl"]
     extras = extras_no_reactor + ["elm-reactor"]
     extras.each do |extra|


### PR DESCRIPTION
Without adding "allow-newer" for the packages aeson, base, HTTP, time,
and transformers, I get build failures like the following (depends which
subset you're trying):

```
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: elm-compiler-0.17 (user goal)
trying: base-4.9.0.0/installed-4.9... (dependency of elm-compiler-0.17)
trying: unix-2.7.2.0/installed-2.7... (dependency of
process-1.4.2.0/installed-1.4...)
next goal: aeson (dependency of elm-compiler-0.17)
rejecting: aeson-0.11.2.0, aeson-0.11.1.4, aeson-0.11.1.3, aeson-0.11.1.2,
aeson-0.11.1.1, aeson-0.11.1.0, aeson-0.11.0.0, aeson-0.9.0.1, aeson-0.9.0.0
(conflict: elm-compiler => aeson>=0.7 && <0.9)
rejecting: aeson-0.8.1.1, aeson-0.8.1.0, aeson-0.8.0.2 (conflict:
base==4.9.0.0/installed-4.9..., aeson => base>=4.5 && <4.9)
rejecting: aeson-0.7.0.6, aeson-0.7.0.4 (conflict: unix =>
etc. etc.
```

Can be removed as soon as the dependencies setting unecessary
restrictions on these versions catch up, or as soon as elm itself has a
similar built-in workaround.
