### PR TITLE
haskell-stack: GHC 8 compatibility

### DIFF
--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -20,6 +20,11 @@ class HaskellStack < Formula
   depends_on "cabal-install" => :build
 
   def install
+    # GHC 8 compat
+    # Fixes cabal: Could not resolve dependencies
+    # Reported 25 May 2016: https://github.com/commercialhaskell/stack/issues/2192
+    (buildpath/"cabal.config").write("allow-newer: base,transformers\n")
+
     install_cabal_package
   end
 


### PR DESCRIPTION
Without adding "allow-newer" for the packages base and transformers, I
get build failures like the following:

```
clang: warning: argument unused during compilation: '-L/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries'
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: stack-1.1.2 (user goal)
trying: base-4.9.0.0/installed-4.9... (dependency of stack-1.1.2)
trying: transformers-0.5.2.0/installed-0.5... (dependency of stack-1.1.2)
next goal: retry (dependency of stack-1.1.2)
rejecting: retry-0.7.2 (conflict: base => ghc-prim==0.5.0.0/installed-0.5...,
retry => ghc-prim<0.5)
etc. etc.
```

Can be removed as soon as the dependencies setting unecessary
restrictions on these versions catch up, or as soon as stack itself has
a similar built-in workaround.
