### PR TITLE
agda: revision for GHC 8

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -5,6 +5,7 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
+  revision 1
 
   stable do
     url "https://github.com/agda/agda/archive/2.5.1.tar.gz"


### PR DESCRIPTION
- builds under GHC 8 without changes
- bump revision now that #1339 has shipped
