### PR TITLE
cgrep: revision for GHC 8

### DIFF
--- a/Formula/cgrep.rb
+++ b/Formula/cgrep.rb
@@ -7,6 +7,7 @@ class Cgrep < Formula
   homepage "https://github.com/awgn/cgrep"
   url "https://hackage.haskell.org/package/cgrep-6.6.4/cgrep-6.6.4.tar.gz"
   sha256 "c192928788b336d23b549f4a9bacfae7f4698f3e76a148f2d9fa557465b7a54d"
+  revision 1
   head "https://github.com/awgn/cgrep.git"
 
   bottle do


### PR DESCRIPTION
- builds under GHC 8 without changes
- bump revision now that #1339 has shipped
