### PR TITLE
mighttpd2: revision for GHC 8

### DIFF
--- a/Formula/mighttpd2.rb
+++ b/Formula/mighttpd2.rb
@@ -7,6 +7,7 @@ class Mighttpd2 < Formula
   homepage "http://www.mew.org/~kazu/proj/mighttpd/en/"
   url "https://hackage.haskell.org/package/mighttpd2-3.2.10/mighttpd2-3.2.10.tar.gz"
   sha256 "b5d8b8a310598d952f3b4329808ef8211a6a0b224d66fcc18cef4f0a737d25f1"
+  revision 1
 
   bottle do
     sha256 "cd1946c30b560973e279d21b1a59e8b5d2d09d51d32283275ce876c21f627c7e" => :el_capitan


### PR DESCRIPTION
- builds under GHC 8 without changes
- bump revision now that #1339 has shipped

~~Note: there is now a 3.3.1 which I have not checked yet~~ https://github.com/Homebrew/homebrew-core/pull/1471
