### PR TITLE
purescript: revision for GHC 8

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -7,6 +7,7 @@ class Purescript < Formula
   homepage "http://www.purescript.org"
   url "https://github.com/purescript/purescript/archive/v0.8.5.tar.gz"
   sha256 "352c0c311710907d112e5d2745e7b152adc4d7b23aff3f069c463eceedddec17"
+  revision 1
 
   bottle do
     sha256 "9d9cf746058847a06cfbfdb7fb3a74c9a8c7eaf7dd1edafc604dfb720cdb8c83" => :el_capitan


### PR DESCRIPTION
- builds under GHC 8 without changes
- bump revision now that #1339 has shipped

~~Note: there is a pre-release https://github.com/purescript/purescript/releases/tag/v0.9.0 for which we might want to add a `:devel` spec~~ https://github.com/Homebrew/homebrew-core/pull/1474
