### PR TITLE
qriollo: revision for GHC 8

### DIFF
--- a/Formula/qriollo.rb
+++ b/Formula/qriollo.rb
@@ -3,6 +3,7 @@ class Qriollo < Formula
   homepage "https://qriollo.github.io"
   url "https://qriollo.github.io/Qriollo-0.91.tar.gz"
   sha256 "c8357af8254a082d8e4da1de1bbf13bee27cfde8adb31ea0a5a0966bfbb7b28d"
+  revision 1
   head "https://github.com/qriollo/qriollo.git"
 
   bottle do


### PR DESCRIPTION
- builds under GHC 8 without changes
- bump revision now that #1339 has shipped
