### PR TITLE
cless: GHC 8 compatibility

### DIFF
--- a/Formula/cless.rb
+++ b/Formula/cless.rb
@@ -9,10 +9,6 @@ class Cless < Formula
   sha256 "382ad9b2ce6bf216bf2da1b9cadd9a7561526bfbab418c933b646d03e56833b2"
   revision 1
 
-  # fix compilation with GHC 7.10
-  # to be removed once https://github.com/tanakh/cless/pull/2 is merged
-  patch :DATA
-
   bottle do
     sha256 "69b6e6441633e58e2c48483b2bf6122daed6d1dfe3d7ce31525024dc0ce2d4d6" => :el_capitan
     sha256 "49b15946ec65f85e5b94333485ba8a8eee1b7ec6d2f53c4619d894c9aaf3e6a8" => :yosemite
@@ -24,6 +20,12 @@ class Cless < Formula
   depends_on "cabal-install" => :build
 
   def install
+    # GHC 8 compat
+    # Reported 25 May 2016: https://github.com/tanakh/cless/issues/3
+    # Also see "fix compilation with GHC 7.10", which has the base bump but not
+    # the transformers bump: https://github.com/tanakh/cless/pull/2
+    (buildpath/"cabal.config").write("allow-newer: base,transformers\n")
+
     install_cabal_package
   end
 
@@ -33,18 +35,3 @@ class Cless < Formula
     system "#{bin}/cless", "--list-styles"
   end
 end
-
-__END__
-diff --git a/cless.cabal b/cless.cabal
-index 0e8913d..105a7c9 100644
---- a/cless.cabal
-+++ b/cless.cabal
-@@ -19,7 +19,7 @@ source-repository head
- executable cless
-   main-is:             Main.hs
-
--  build-depends:       base >=4.7 && <4.8
-+  build-depends:       base >=4.7 && <5
-                      , highlighting-kate >=0.5
-                      , wl-pprint-terminfo >=3.7
-                      , wl-pprint-extras


### PR DESCRIPTION
We've been using a patch to raise the base requirement from < 4.8 to <5
for the sake of GHC 7.10, but without also raising the cap for
transformers, I get the following build failure under GHC 8:

```
cabal: Could not resolve dependencies:
trying: cless-0.3.0.0 (user goal)
trying: transformers-0.5.2.0/installed-0.5... (dependency of
optparse-applicative-0.12.1.0)
trying: nats-1.1 (dependency of wl-pprint-extras-3.5.0.5)
next goal: wl-pprint-terminfo (dependency of cless-0.3.0.0)
rejecting: wl-pprint-terminfo-3.7.1.3 (conflict:
transformers==0.5.2.0/installed-0.5..., wl-pprint-terminfo =>
transformers>=0.2 && <0.5)
etc. etc.
```

For simplicity I'm creating a cabal.config rather than using a patch to
set "allow-newer" for transformers. Adding base to that "allow-newer"
list makes it so that the earlier patch for just base can be removed
since it would be redundant.

We can remove base from the cabal.config if tanakh/cless#2 is merged and
we can stop creating the cabal.config entirely as soon as the
dependencies setting unnecessary restrictions on transformers catch up,
or as soon as cless itself has a built-in workaround.
