### PR TITLE
darcs: GHC 8 compatibility

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -20,6 +20,14 @@ class Darcs < Formula
   depends_on "gmp"
 
   def install
+    # GHC 8 compat
+    # Fixes the build error:
+    #   checking whether to use -liconv...
+    #   dist/dist-sandbox-296ea86f/setup/setup.hs:149:15-41: Irrefutable pattern
+    #   failed for pattern Just lib
+    # Reported 26 May 2016: http://bugs.darcs.net/issue2498
+    (buildpath/"cabal.config").write("allow-newer: base\n")
+
     install_cabal_package
   end
 


### PR DESCRIPTION
Without adding "allow-newer" for the package "base," I get the build failure

```
Configuring darcs-2.12.0...
clang: warning: -Wl,-headerpad_max_install_names: 'linker' input unused
clang: warning: argument unused during compilation: '-L/usr/local/lib'
clang: warning: argument unused during compilation:
'-L/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries'
checking whether to use -liconv...
dist/dist-sandbox-296ea86f/setup/setup.hs:149:15-41: Irrefutable pattern
failed for pattern Just lib
cabal: Leaving directory '.'
cabal: Error: some packages failed to install:
darcs-2.12.0 failed during the configure step. The exception was:
ExitFailure 1
```

Can be removed as soon as upstream bumps the base version, assuming the same
problem doesn't affect any of the dependencies at that time.
