### PR TITLE
pandoc-citeproc: GHC 8 compatibility

### DIFF
--- a/Formula/pandoc-citeproc.rb
+++ b/Formula/pandoc-citeproc.rb
@@ -19,6 +19,11 @@ class PandocCiteproc < Formula
   depends_on "pandoc"
 
   def install
+    # GHC 8 compat
+    # Fixes "cabal: Could not resolve dependencies"
+    # Reported 26 May 2016: https://github.com/jgm/pandoc-citeproc/issues/235
+    (buildpath/"cabal.config").write("allow-newer: base,data-default,time\n")
+
     args = []
     args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
     install_cabal_package *args


### PR DESCRIPTION
Without adding "allow-newer" for the packages base, data-default, and
time, I get build failures like the following (depends which subset
you're trying) when using GHC 8:

```
cabal: Could not resolve dependencies:
trying: pandoc-citeproc-0.9.1.1 (user goal)
trying: data-default-0.7.0 (dependency of pandoc-citeproc-0.9.1.1)
trying: aeson-0.11.2.0 (dependency of pandoc-citeproc-0.9.1.1)
next goal: pandoc (dependency of pandoc-citeproc-0.9.1.1)
rejecting: pandoc-1.17.0.3 (conflict: data-default==0.7.0, pandoc =>
data-default>=0.4 && <0.7)
etc. etc.
```

Can be removed as soon as pandoc-citeproc and its dependencies lift the
unnecessary caps, or until pandoc-citeproc itself has a built-in
workaround.
