### PR TITLE
pandoc: GHC 8 compatibility

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -21,6 +21,11 @@ class Pandoc < Formula
   depends_on "gmp"
 
   def install
+    # GHC 8 compat
+    # Fixes "cabal: Could not resolve dependencies"
+    # Reported 26 May 2016: https://github.com/jgm/pandoc/issues/2948
+    (buildpath/"cabal.config").write("allow-newer: base,time\n")
+
     args = []
     args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
     install_cabal_package *args


### PR DESCRIPTION
Without adding "allow-newer" for the packages base and time, I get the
build failure

```
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: pandoc-1.17.0.3 (user goal)
trying: base-4.9.0.0/installed-4.9... (dependency of pandoc-1.17.0.3)
next goal: haddock-library (dependency of pandoc-1.17.0.3)
rejecting: haddock-library-1.4.1 (conflict: pandoc => haddock-library>=1.1 &&
<1.3)
etc. etc.
```

Can be removed as soon as upstream and its dependencies lift the
unnecessary restrictions or pandoc itself has a builtin workaround.
