### PR TITLE
plantuml fix for homebrew installed in non-standard prefix

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -11,7 +11,10 @@ class Plantuml < Formula
   def install
     jar = "plantuml.#{version}.jar"
     prefix.install jar
-    bin.write_jar_script prefix/jar, "plantuml"
+    (bin+"plantuml").write <<-EOS.undent
+      #!/bin/bash
+      GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{prefix}/#{jar} "$@"
+    EOS
   end
 
   test do

--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -1,8 +1,8 @@
 class Plantuml < Formula
   desc "Draw UML diagrams"
   homepage "http://plantuml.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/plantuml/plantuml.8039.jar"
-  sha256 "a82d120fbb5109b6187f53bb8f9c479706ba305352e7bcaaecef5d2b3fed0470"
+  url "https://downloads.sourceforge.net/project/plantuml/plantuml.8041.jar"
+  sha256 "8964b8ea316e37492d9a4533a57338c46f629cdd920d48ddae53e2b62f5b6c8d"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Depends on #1462 because I performed testing on it, but it should be independent otherwise.

Closes #1462.
