### PR TITLE
fail2ban: add HEAD, bump stable version to 0.9.4, & add devel version 0.10

### DIFF
--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -14,6 +14,11 @@ class Fail2ban < Formula
     sha256 "f39d0f4aa122b1e40ce05ad9010901beefacd560c5d84960eed4448daa3915f2" => :mavericks
   end
 
+  devel do
+    url "https://github.com/fail2ban/fail2ban/archive/0.10.tar.gz"
+    sha256 "0ba941d3c419ef31a42654c20e4a371615b0713326921defa92aea4fda9c8cd8"
+  end
+
   def install
     rm "setup.cfg"
     inreplace "setup.py" do |s|

--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -1,8 +1,8 @@
 class Fail2ban < Formula
   desc "Scan log files and ban IPs showing malicious signs"
   homepage "http://www.fail2ban.org/"
-  url "https://github.com/fail2ban/fail2ban/archive/0.8.14.tar.gz"
-  sha256 "2d579d9f403eb95064781ffb28aca2b258ca55d7a2ba056a8fa2b3e6b79721f2"
+  url "https://github.com/fail2ban/fail2ban/archive/0.9.4.tar.gz"
+  sha256 "870b99dd0110f10d705d0ca5743d42d358e0b5a0a4de8b69ed1d41b40dd98fa4"
 
   head "https://github.com/fail2ban/fail2ban.git"
 

--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -4,6 +4,8 @@ class Fail2ban < Formula
   url "https://github.com/fail2ban/fail2ban/archive/0.8.14.tar.gz"
   sha256 "2d579d9f403eb95064781ffb28aca2b258ca55d7a2ba056a8fa2b3e6b79721f2"
 
+  head "https://github.com/fail2ban/fail2ban.git"
+
   bottle do
     cellar :any_skip_relocation
     revision 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
- Add HEAD spec
- Bump stable version from 0.8.14 to 0.9.4
- Add devel version 0.10
