### PR TITLE
aws-sdk-cpp add logging-only and minimize-size build options

### DIFF
--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -14,6 +14,8 @@ class AwsSdkCpp < Formula
 
   option "with-static", "Build with static linking"
   option "without-http-client", "Don't include the libcurl HTTP client"
+  option "with-logging-only", "Only build logging-related SDKs"
+  option "with-minimize-size", "Request size optimization"
 
   depends_on "cmake" => :build
 
@@ -21,6 +23,8 @@ class AwsSdkCpp < Formula
     args = std_cmake_args
     args << "-DSTATIC_LINKING=1" if build.with? "static"
     args << "-DNO_HTTP_CLIENT=1" if build.without? "http-client"
+    args << "-DBUILD_ONLY=firehose;kinesis" if build.with? "logging-only"
+    args << "-DMINIMIZE_SIZE=ON" if build.with? "minimize-size"
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

These 2 options are highly desired for the osquery package/build. Using the AWS SDKs has become mandatory for the osquery build and the embedded logging-related SDKs are the only ones we link. Including a homebrew option to only build/install these SDKs will be constantly tested and used by osquery. This "greatly" enhances our CI by reducing the time to build by about 30 minutes and reduces the size of build host disks by about 300MB. 
