### PR TITLE
llvm 3.8.0

### DIFF
--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -3,7 +3,7 @@ class Castxml < Formula
   homepage "https://github.com/CastXML/CastXML"
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
-  version "0.1+git20160202-1"
+  version "0.1+git20160202-2"
   sha256 "8de10ad3e930a48a6602c3adf23ed27d3845de24c231d562ca5c23e6df8dd94a"
 
   head "https://github.com/CastXML/castxml.git"
@@ -15,7 +15,7 @@ class Castxml < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm" => "with-clang"
+  depends_on "llvm"
 
   def install
     mkdir "build" do

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -1,11 +1,10 @@
 class Castxml < Formula
   desc "C-family Abstract Syntax Tree XML Output"
   homepage "https://github.com/CastXML/CastXML"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
-  version "0.1+git20160202-1"
-  sha256 "8de10ad3e930a48a6602c3adf23ed27d3845de24c231d562ca5c23e6df8dd94a"
-  revision 1
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160412.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160412.orig.tar.gz"
+  version "0.1+git20160412"
+  sha256 "d65a4e447e1315021c8230f806100c4a812edeff48b8ce564998066315599c86"
 
   head "https://github.com/CastXML/castxml.git"
 

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -3,8 +3,9 @@ class Castxml < Formula
   homepage "https://github.com/CastXML/CastXML"
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160202.orig.tar.xz"
-  version "0.1+git20160202-2"
+  version "0.1+git20160202-1"
   sha256 "8de10ad3e930a48a6602c3adf23ed27d3845de24c231d562ca5c23e6df8dd94a"
+  revision 1
 
   head "https://github.com/CastXML/castxml.git"
 

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -2,7 +2,7 @@ class Creduce < Formula
   desc "Reduce a C/C++ program while keeping a property of interest"
   homepage "https://embed.cs.utah.edu/creduce/"
   url "https://github.com/csmith-project/creduce/archive/creduce-2.5.0.tar.gz"
-	mirror "http://embed.cs.utah.edu/creduce/creduce-2.5.0.tar.gz"
+  mirror "http://embed.cs.utah.edu/creduce/creduce-2.5.0.tar.gz"
   sha256 "6d860adaeac10589441b6075f78778b70a25d1305c7c1638f02e953c804ab16d"
   head "https://github.com/csmith-project/creduce.git"
 

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -15,7 +15,7 @@ class Creduce < Formula
 
   depends_on "astyle"
   depends_on "delta"
-  depends_on "llvm" => ["with-clang", "with-libcxx"]
+  depends_on "llvm"
 
   depends_on :macos => :mavericks
 

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -1,9 +1,8 @@
 class Creduce < Formula
   desc "Reduce a C/C++ program while keeping a property of interest"
   homepage "https://embed.cs.utah.edu/creduce/"
-  url "https://github.com/csmith-project/creduce/archive/creduce-2.5.0.tar.gz"
-  mirror "http://embed.cs.utah.edu/creduce/creduce-2.5.0.tar.gz"
-  sha256 "6d860adaeac10589441b6075f78778b70a25d1305c7c1638f02e953c804ab16d"
+  url "http://embed.cs.utah.edu/creduce/creduce-2.5.0.tar.gz"
+  sha256 "2dcd784e1d27df60f4ea1d92c4c556c02da4152db353d544dce8b7813fa443e4"
   head "https://github.com/csmith-project/creduce.git"
 
   bottle do

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -20,37 +20,37 @@ class Creduce < Formula
 
   resource "Benchmark::Timer" do
     url "https://cpan.metacpan.org/authors/id/D/DC/DCOPPIT/Benchmark-Timer-0.7107.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DC/DCOPPIT/Benchmark-Timer-0.7107.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/D/DC/DCOPPIT/Benchmark-Timer-0.7107.tar.gz"
     sha256 "64f70fabc896236520bfbf43c2683fdcb0f2c637d77333aed0fd926b92226b60"
   end
 
   resource "Exporter::Lite" do
     url "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
     sha256 "c05b3909af4cb86f36495e94a599d23ebab42be7a18efd0d141fc1586309dac2"
   end
 
   resource "File::Which" do
     url "https://cpan.metacpan.org/authors/id/A/AD/ADAMK/File-Which-1.09.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/File-Which-1.09.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/File-Which-1.09.tar.gz"
     sha256 "b72fec6590160737cba97293c094962adf4f7d44d9e68dde7062ecec13f4b2c3"
   end
 
   resource "Getopt::Tabular" do
     url "https://cpan.metacpan.org/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz"
     sha256 "9bdf067633b5913127820f4e8035edc53d08372faace56ba6bfa00c968a25377"
   end
 
   resource "Regexp::Common" do
     url "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/Regexp-Common-2016060101.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/A/AB/ABIGAIL/Regexp-Common-2016060101.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/A/AB/ABIGAIL/Regexp-Common-2016060101.tar.gz"
     sha256 "8d052550e1ddc222f498104f4ce3d56d953e7640b55805c59493060ae6f06815"
   end
 
   resource "Sys::CPU" do
     url "https://cpan.metacpan.org/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz"
+    mirror "https://search.cpan.org/CPAN/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz"
     sha256 "250a86b79c231001c4ae71d2f66428092a4fbb2070971acafd471aa49739c9e4"
   end
 

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -1,9 +1,9 @@
 class Creduce < Formula
   desc "Reduce a C/C++ program while keeping a property of interest"
   homepage "https://embed.cs.utah.edu/creduce/"
-  url "https://github.com/csmith-project/creduce/archive/creduce-2.3.0.tar.gz"
-  sha256 "47a42751aab8b51bc10d8df62f359bdc1b4a644f16feb85b9f7325f0c5bce4a3"
-  revision 2
+  url "https://github.com/csmith-project/creduce/archive/creduce-2.5.0.tar.gz"
+	mirror "http://embed.cs.utah.edu/creduce/creduce-2.5.0.tar.gz"
+  sha256 "6d860adaeac10589441b6075f78778b70a25d1305c7c1638f02e953c804ab16d"
   head "https://github.com/csmith-project/creduce.git"
 
   bottle do
@@ -26,9 +26,9 @@ class Creduce < Formula
   end
 
   resource "Exporter::Lite" do
-    url "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Exporter-Lite-0.06.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Exporter-Lite-0.06.tar.gz"
-    sha256 "f252562176c48cdc29c543d31ba3e0eed71042e9ad2b20f9f6283bd2e29e8f4c"
+    url "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
+    mirror "http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
+    sha256 "c05b3909af4cb86f36495e94a599d23ebab42be7a18efd0d141fc1586309dac2"
   end
 
   resource "File::Which" do
@@ -44,9 +44,9 @@ class Creduce < Formula
   end
 
   resource "Regexp::Common" do
-    url "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/Regexp-Common-2013031301.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/A/AB/ABIGAIL/Regexp-Common-2013031301.tar.gz"
-    sha256 "729a8198d264aa64ecbb233ff990507f97fbb66bda746b95f3286f50f5f25c84"
+    url "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/Regexp-Common-2016060101.tar.gz"
+    mirror "http://search.cpan.org/CPAN/authors/id/A/AB/ABIGAIL/Regexp-Common-2016060101.tar.gz"
+    sha256 "8d052550e1ddc222f498104f4ce3d56d953e7640b55805c59493060ae6f06815"
   end
 
   resource "Sys::CPU" do

--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -23,7 +23,7 @@ class Doxygen < Formula
   depends_on "cmake" => :build
   depends_on "graphviz" => :optional
   depends_on "qt5" => :optional
-  depends_on "llvm" => "with-clang" if build.with? "libclang"
+  depends_on "llvm" if build.with? "libclang"
 
   def install
     args = std_cmake_args

--- a/Formula/emacs-clang-complete-async.rb
+++ b/Formula/emacs-clang-complete-async.rb
@@ -2,6 +2,7 @@ class EmacsClangCompleteAsync < Formula
   desc "Emacs plugin using libclang to complete C/C++ code"
   homepage "https://github.com/Golevka/emacs-clang-complete-async"
   head "https://github.com/Golevka/emacs-clang-complete-async.git"
+  revision 1
 
   stable do
     url "https://github.com/Golevka/emacs-clang-complete-async/archive/v0.5.tar.gz"
@@ -19,7 +20,7 @@ class EmacsClangCompleteAsync < Formula
 
   option "with-elisp", "Include Emacs lisp package"
 
-  depends_on "llvm" => "with-clang"
+  depends_on "llvm"
 
   # https://github.com/Golevka/emacs-clang-complete-async/pull/59
   patch do

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -319,7 +319,7 @@ class Llvm < Formula
 
       if MacOS::CLT.installed?
         # Test with CLT
-        system "#{bin}/clang++", "-v", "-std=c++11", "-stdlib=libc++", "-I/usr/include", "-L/usr/lib", "test.cpp", "-o", "test"
+        system "#{bin}/clang++", "-v", "-std=c++11", "-stdlib=libc++", "test.cpp", "-o", "test"
         system "./test"
       end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -53,7 +53,12 @@ class Llvm < Formula
       sha256 "c5ee0871aff6ec741380c4899007a7d97f0b791c81df69d25b744eebc5cee504"
     end
 
-    resource "lld" do
+    resource "libunwind" do
+      url    "http://llvm.org/releases/#{llvm_version}/libunwind-#{llvm_version}.src.tar.xz"
+      sha256 "af3eaf39ecdc3b9e89863fb62e1aa3c135cfde7e9415424e4e396d7486a9422b"
+    end
+
+   resource "lld" do
       url "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
       sha256 "94704dda228c9f75f4403051085001440b458501ec97192eee06e8e67f7f9f0c"
     end

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -21,47 +21,73 @@ class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "http://llvm.org/"
 
+  llvm_version = "3.8.0"
+
   stable do
-    url "http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz"
-    sha256 "f60dc158bfda6822de167e87275848969f0558b3134892ff54fced87e4667b94"
+    # LLVM source code
+    url "http://llvm.org/releases/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
+    sha256 "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
 
+    # Clang
     resource "clang" do
-      url "http://llvm.org/releases/3.6.2/cfe-3.6.2.src.tar.xz"
-      sha256 "ae9180466a23acb426d12444d866b266ff2289b266064d362462e44f8d4699f3"
+      url    "http://llvm.org/releases/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
+      sha256 "04149236de03cf05232d68eb7cb9c50f03062e339b68f4f8a03b650a11536cf9"
     end
 
+    # Clang extra tools
     resource "clang-extra-tools" do
-      url "http://llvm.org/releases/3.6.2/clang-tools-extra-3.6.2.src.tar.xz"
-      sha256 "6a0ec627d398f501ddf347060f7a2ccea4802b2494f1d4fd7bda3e0442d04feb"
+      url    "http://llvm.org/releases/#{llvm_version}/clang-tools-extra-#{llvm_version}.src.tar.xz"
+      sha256 "afbda810106a6e64444bc164b921be928af46829117c95b996f2678ce4cb1ec4"
     end
 
+    # compiler-rt
     resource "compiler-rt" do
-      url "http://llvm.org/releases/3.6.2/compiler-rt-3.6.2.src.tar.xz"
-      sha256 "0f2ff37d80a64575fecd8cf0d5c50f7ac1f837ddf700d1855412bb7547431d87"
+      url    "http://llvm.org/releases/#{llvm_version}/compiler-rt-#{llvm_version}.src.tar.xz"
+      sha256 "c8d3387e55f229543dac1941769120f24dc50183150bf19d1b070d53d29d56b0"
     end
 
+    # libc++
+    # only required to build and run Compiler-RT tests on OS X, optional otherwise. clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "http://llvm.org/releases/3.6.2/libcxx-3.6.2.src.tar.xz"
-      sha256 "52f3d452f48209c9df1792158fdbd7f3e98ed9bca8ebb51fcd524f67437c8b81"
+      url    "http://llvm.org/releases/#{llvm_version}/libcxx-#{llvm_version}.src.tar.xz"
+      sha256 "36804511b940bc8a7cefc7cb391a6b28f5e3f53f6372965642020db91174237b"
     end
 
+    # libc++abi
+    resource "libcxxabi" do
+      url    "http://llvm.org/releases/#{llvm_version}/libcxxabi-#{llvm_version}.src.tar.xz"
+      sha256 "c5ee0871aff6ec741380c4899007a7d97f0b791c81df69d25b744eebc5cee504"
+    end
+
+    # libunwind
+    resource "libunwind" do
+      url    "http://llvm.org/releases/#{llvm_version}/libunwind-#{llvm_version}.src.tar.xz"
+      sha256 "af3eaf39ecdc3b9e89863fb62e1aa3c135cfde7e9415424e4e396d7486a9422b"
+    end
+
+    # LLD
     resource "lld" do
-      url "http://llvm.org/releases/3.6.2/lld-3.6.2.src.tar.xz"
-      sha256 "43f553c115563600577764262f1f2fac3740f0c639750f81e125963c90030b33"
+      url "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
+      sha256 "94704dda228c9f75f4403051085001440b458501ec97192eee06e8e67f7f9f0c"
     end
 
+    # LLDB
     resource "lldb" do
-      url "http://llvm.org/releases/3.6.2/lldb-3.6.2.src.tar.xz"
-      sha256 "940dc96b64919b7dbf32c37e0e1d1fc88cc18e1d4b3acf1e7dfe5a46eb6523a9"
+      url "http://llvm.org/releases/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
+      sha256 "e3f68f44147df0433e7989bf6ed1c58ff28d7c68b9c47553cb9915f744785a35"
     end
-  end
 
-  bottle do
-    cellar :any
-    revision 2
-    sha256 "3b4b2c50e018125c0fa7aa9a14e8066b301afa6ebe2c36a198962e4c9af318a7" => :el_capitan
-    sha256 "382eb51bb69c52fb3800c0498d1c6799b9046af8413be15217fc58effc9963b3" => :yosemite
-    sha256 "57f2bb04233429051ff77deeaf74612c2d56be5d6bc13d1c6f8457cd057bc9e7" => :mavericks
+    # OpenMP
+    resource "openmp" do
+      url "http://llvm.org/releases/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
+      sha256 "92510e3f62e3de955e3a0b6708cebee1ca344d92fb02369cba5fdd5c68f773a0"
+    end
+
+    # Polly
+    resource "polly" do
+      url "http://llvm.org/releases/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
+      sha256 "84cbabc0b6a10a664797907d291b6955d5ea61aef04e3f3bb464e42374d1d1f2"
+    end
   end
 
   head do
@@ -87,6 +113,10 @@ class Llvm < Formula
       url "http://llvm.org/git/libcxxabi.git"
     end
 
+    resource "libunwind" do
+      url "git://git.sv.gnu.org/libunwind.git"
+    end
+
     resource "lld" do
       url "http://llvm.org/git/lld.git"
     end
@@ -95,66 +125,95 @@ class Llvm < Formula
       url "http://llvm.org/git/lldb.git"
     end
 
-    # Polly is --HEAD-only because it requires isl and the version of Polly
-    # shipped with 3.6.2 only compiles with isl 0.14 and earlier (current
-    # version is 0.15). isl is distributed with the Polly source code from LLVM
-    # 3.7 and up, so --HEAD builds do not need to depend on homebrew isl.
-    option "with-polly", "Build with the experimental Polly optimizer"
     resource "polly" do
       url "http://llvm.org/git/polly.git"
     end
   end
 
-  keg_only :provided_by_osx
+  # keg_only :provided_by_osx if OS.mac?
 
-  option :universal
-  option "with-clang", "Build the Clang compiler and support libraries"
+  # Options
+  option :universal if OS.mac?
+  option "with-clang",             "Build the Clang compiler and support libraries"
   option "with-clang-extra-tools", "Build extra tools for Clang"
-  option "with-compiler-rt", "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
-  option "with-libcxx", "Build the libc++ standard library"
-  option "with-lld", "Build LLD linker"
-  option "with-lldb", "Build LLDB debugger"
-  option "with-python", "Build Python bindings against Homebrew Python"
-  option "with-rtti", "Build with C++ RTTI"
-  option "with-utils", "Install utility binaries"
+  option "with-compiler-rt",       "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
+  option "with-libcxx",            "Build the libc++ standard library"
+  option "with-libcxxabi",         "Build the libc++abi standard library"
+  option "with-libunwind",         "Build the libunwind library"
+  option "with-lld",               "Build LLD linker"
+  option "with-lldb",              "Build LLDB debugger"
+  option "with-rtti",              "Build with C++ RTTI"
+  option "with-utils",             "Install utility binaries"
+  option "with-polly",             "Build with the experimental Polly optimizer"
+  option "with-python",            "Build Python bindings against Homebrew Python"
+  option "with-test",              "Build LLVM unit tests"
+  option "with-shared-libs",       "Build all libs as shared instead of static"
+  option "with-libffi",            "Use libffi to call external functions from the interpreter"
 
   deprecated_option "rtti" => "with-rtti"
 
-  if MacOS.version <= :snow_leopard
+  # Dependencies
+  depends_on "cmake"    => :build
+  depends_on "doxygen"  => :optional # for C++ API reference (lldb)
+  depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
+
+  depends_on "ocaml"   => :optional
+
+  # Python
+  if build.with?("python")
+    # with-python   has been requested
+    depends_on "python"
+  elsif MacOS.version <= :snow_leopard || OS.linux?
     depends_on :python
   else
-    depends_on :python => :optional
+    depends_on :python => :optional # not sure this is correct
   end
-  depends_on "cmake" => :build
+  fails_with :python3
 
-  if build.with? "lldb"
-    depends_on "swig"
+  if build.with?("lldb")
+    depends_on "swig" if (OS.mac? && MacOS.version >= :lion) || OS.linux?
     depends_on CodesignRequirement
   end
 
+  # llvm.org/docs/GettingStarted.grml#requirements
+  depends_on "libffi" if build.with?("libffi") # libffi
+
+  unless OS.mac?
+    depends_on "homebrew/dupes/libedit" # llvm requires <histedit.h>
+    depends_on "libxml2"
+    depends_on "ncurses"
+    depends_on "valgrind" => :recommended
+    depends_on "zlib"
+    depends_on "gcc"
+  end
+
   # Apple's libstdc++ is too old to build LLVM
+  fails_with :llvm if OS.mac?
+  # According to the official llvm readme, GCC 4.7+ is required
+  fails_with :gcc_4_0
   fails_with :gcc
-  fails_with :llvm
+  ("4.3".."4.6").each do |n|
+    fails_with :gcc => n
+  end
 
   def install
     # Apple's libstdc++ is too old to build LLVM
-    ENV.libcxx if ENV.compiler == :clang
+    ENV.libcxx if ENV.compiler == :clang && OS.mac?
 
-    (buildpath/"tools/clang").install resource("clang") if build.with? "clang"
+    (buildpath/"tools/clang").install resource("clang") if build.with?("clang")
 
     if build.with? "clang-extra-tools"
-      odie "--with-extra-tools requires --with-clang" if build.without? "clang"
+      odie "--with-extra-tools requires --with-clang" if build.without?("clang")
       (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     end
 
-    if build.with? "libcxx"
-      (buildpath/"projects/libcxx").install resource("libcxx")
-    end
-
-    (buildpath/"tools/lld").install resource("lld") if build.with? "lld"
+    (buildpath/"projects/libcxx").install    resource("libcxx")    if build.with?("libcxx")
+    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if build.with?("libcxxabi")
+    (buildpath/"projects/libunwind").install resource("libunwind") if build.with?("libunwind")
+    (buildpath/"tools/lld").install          resource("lld")       if build.with?("lld")
 
     if build.with? "lldb"
-      odie "--with-lldb requires --with-clang" if build.without? "clang"
+      odie "--with-lldb requires --with-clang" if build.without?("clang")
       (buildpath/"tools/lldb").install resource("lldb")
 
       # Building lldb requires a code signing certificate.
@@ -163,18 +222,20 @@ class Llvm < Formula
       # the search path in a superenv build. The following three lines add
       # the login keychain to ~/Library/Preferences/com.apple.security.plist,
       # which adds it to the superenv keychain search path.
-      mkdir_p "#{ENV["HOME"]}/Library/Preferences"
-      username = ENV["USER"]
-      system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
+      if OS.mac?
+        mkdir_p "#{ENV["HOME"]}/Library/Preferences"
+        username = ENV["USER"]
+        system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
+      end
     end
 
     if build.with? "polly"
-      odie "--with-polly requires --with-clang" if build.without? "clang"
+      odie "--with-polly requires --with-clang" if build.without?("clang")
       (buildpath/"tools/polly").install resource("polly")
     end
 
     if build.with? "compiler-rt"
-      odie "--with-compiler-rt requires --with-clang" if build.without? "clang"
+      odie "--with-compiler-rt requires --with-clang" if build.without?("clang")
       (buildpath/"projects/compiler-rt").install resource("compiler-rt")
 
       # compiler-rt has some iOS simulator features that require i386 symbols
@@ -188,17 +249,35 @@ class Llvm < Formula
     args = %w[
       -DLLVM_OPTIMIZED_TABLEGEN=On
       -DLLVM_BUILD_LLVM_DYLIB=On
+      -DLLVM_TARGETS_TO_BUILD=X86
     ]
 
-    args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
-    args << "-DLLVM_INSTALL_UTILS=On" if build.with? "utils"
+    args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=On" if build.with?("compiler-rt")
+    args << "-DLLVM_BUILD_TESTS=On" if build.with?("test")
+    args << "-DLLVM_ABI_BREAKING_CHECKS=On" if build.with?("test")
+
+    args << "-DLLVM_ENABLE_RTTI=On" if build.with?("rtti")
+    args << "-DLLVM_INSTALL_UTILS=On" if build.with?("utils")
+    args << "-DLLVM_ENABLE_LIBCXX=On" if build.with?("libcxx")
+    args << "-DLLVM_ENABLE_LIBCXXABI=On" if build.with?("libcxxabi")
+    args << "-DLLVM_ENABLE_DOXYGEN=On" if build.with?("doxygen")
+    args << "-DBUILD_SHARED_LIBS=On" if build.with?("shared-libs") # for developers
+
+    if build.with?("libffi")
+      args << "-DLLVM_ENABLE_FFI=On"
+      args << "-DFFI_INCLUDE_DIR=#{Formula["libffi"].lib}/libffi-#{Formula["libffi"].version}/include" # upstream bug?
+      args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].lib}"
+    end
 
     if build.universal?
       ENV.permit_arch_flags
       args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
     end
 
-    args << "-DLINK_POLLY_INTO_TOOLS:Bool=ON" if build.with? "polly"
+    if build.with?("polly")
+      args << "-DWITH_POLLY=On"
+      args << "-DLINK_POLLY_INTO_TOOLS=On"
+    end
 
     mktemp do
       system "cmake", "-G", "Unix Makefiles", buildpath, *(std_cmake_args + args)
@@ -209,11 +288,11 @@ class Llvm < Formula
     if build.with? "clang"
       (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
       if build.head?
-        inreplace "#{share}/clang/tools/scan-build/bin/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
+        # inreplace "#{share}/clang/tools/scan-build/bin/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
         bin.install_symlink share/"clang/tools/scan-build/bin/scan-build", share/"clang/tools/scan-view/bin/scan-view"
         man1.install_symlink share/"clang/tools/scan-build/man/scan-build.1"
       else
-        inreplace "#{share}/clang/tools/scan-build/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
+        # inreplace "#{share}/clang/tools/scan-build/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
         bin.install_symlink share/"clang/tools/scan-build/scan-build", share/"clang/tools/scan-view/scan-view"
         man1.install_symlink share/"clang/tools/scan-build/scan-build.1"
       end
@@ -227,13 +306,13 @@ class Llvm < Formula
   def caveats
     s = <<-EOS.undent
       LLVM executables are installed in #{opt_bin}.
-      Extra tools are installed in #{opt_share}/llvm.
+    Extra tools are installed in #{opt_share}/llvm.
     EOS
 
     if build.with? "libcxx"
       s += <<-EOS.undent
         To use the bundled libc++ please add the following LDFLAGS:
-          LDFLAGS="-L#{opt_lib} -lc++abi"
+          LDFLAGS="-L#{opt_lib} -lc++"
       EOS
     end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -190,7 +190,7 @@ class Llvm < Formula
 
     (buildpath/"projects/libcxx").install resource("libcxx") if build_libcxx
     (buildpath/"tools/lld").install resource("lld") if build.with? "lld"
-    [ "libcxxabi", "libunwind", "openmp" ].each do |r|
+    ["libcxxabi", "libunwind", "openmp"].each do |r|
       (buildpath/"projects"/r).install resource(r) if build.with? r
     end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -146,8 +146,6 @@ class Llvm < Formula
   option "without-libffi", "Use libffi to call external functions from the interpreter"
 
   depends_on "libffi" => :recommended # llvm.org/docs/GettingStarted.grml#requirements
-  # depends_on "doxygen"  => :optional # for C++ API reference (lldb)
-  # commenting this out for now to avoid circular dependency with doxygen
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
   depends_on "ocaml" => :optional
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -150,9 +150,7 @@ class Llvm < Formula
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
   depends_on "ocaml" => :optional
 
-  if build.with? "python"
-    depends_on "python"
-  elsif MacOS.version <= :snow_leopard
+  if MacOS.version <= :snow_leopard
     depends_on :python
   else
     depends_on :python => :optional

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -134,7 +134,7 @@ class Llvm < Formula
   option "without-libcxx", "Do not build the libc++ standard library"
   option "with-libcxxabi", "Build the libc++abi standard library"
   option "with-libunwind", "Build the libunwind library"
-  option "with-lld", "Build LLD linker"
+  option "without-lld", "Do not build LLD linker"
   option "with-lldb", "Build LLDB debugger"
   option "with-openmp", "Build additional OpenMP Runtime Libraries"
   option "with-python", "Build Python bindings against Homebrew Python"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -137,7 +137,7 @@ class Llvm < Formula
   option "without-lld", "Do not build LLD linker"
   option "with-lldb", "Build LLDB debugger"
   option "without-openmp", "Do not build additional OpenMP runtime libraries"
-  option "without-python", "Do not build bindings against custom Python"
+  option "with-python", "Build bindings against custom Python"
   option "without-rtti", "Build without C++ RTTI"
   option "without-utils", "Do not install utility binaries"
   option "without-polly", "Do not build Polly optimizer"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -249,10 +249,10 @@ class Llvm < Formula
     args << "-DLLVM_ENABLE_LIBCXXABI=ON" if build.with? "libcxxabi"
     # args << "-DLLVM_ENABLE_DOXYGEN=ON" if build.with? "doxygen"
 
-    if build.with? "lldb" && build.with? "python"
-        args << "-DLLDB_RELOCATABLE_PYTHON=ON"
-        args << "-DPYTHON_LIBRARY=#{pylib}"
-        args << "-DPYTHON_INCLUDE_DIR=#{pyinclude}"
+    if build.with?("lldb") && build.with?("python")
+      args << "-DLLDB_RELOCATABLE_PYTHON=ON"
+      args << "-DPYTHON_LIBRARY=#{pylib}"
+      args << "-DPYTHON_INCLUDE_DIR=#{pyinclude}"
     end
 
     if build.with? "openmp"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -24,66 +24,50 @@ class Llvm < Formula
   llvm_version = "3.8.0"
 
   stable do
-    # LLVM source code
     url "http://llvm.org/releases/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
     sha256 "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
 
-    # Clang
     resource "clang" do
       url    "http://llvm.org/releases/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
       sha256 "04149236de03cf05232d68eb7cb9c50f03062e339b68f4f8a03b650a11536cf9"
     end
 
-    # Clang extra tools
     resource "clang-extra-tools" do
       url    "http://llvm.org/releases/#{llvm_version}/clang-tools-extra-#{llvm_version}.src.tar.xz"
       sha256 "afbda810106a6e64444bc164b921be928af46829117c95b996f2678ce4cb1ec4"
     end
 
-    # compiler-rt
     resource "compiler-rt" do
       url    "http://llvm.org/releases/#{llvm_version}/compiler-rt-#{llvm_version}.src.tar.xz"
       sha256 "c8d3387e55f229543dac1941769120f24dc50183150bf19d1b070d53d29d56b0"
     end
 
-    # libc++
     # only required to build and run Compiler-RT tests on OS X, optional otherwise. clang.llvm.org/get_started.html
     resource "libcxx" do
       url    "http://llvm.org/releases/#{llvm_version}/libcxx-#{llvm_version}.src.tar.xz"
       sha256 "36804511b940bc8a7cefc7cb391a6b28f5e3f53f6372965642020db91174237b"
     end
 
-    # libc++abi
     resource "libcxxabi" do
       url    "http://llvm.org/releases/#{llvm_version}/libcxxabi-#{llvm_version}.src.tar.xz"
       sha256 "c5ee0871aff6ec741380c4899007a7d97f0b791c81df69d25b744eebc5cee504"
     end
 
-    # libunwind
-    resource "libunwind" do
-      url    "http://llvm.org/releases/#{llvm_version}/libunwind-#{llvm_version}.src.tar.xz"
-      sha256 "af3eaf39ecdc3b9e89863fb62e1aa3c135cfde7e9415424e4e396d7486a9422b"
-    end
-
-    # LLD
     resource "lld" do
       url "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
       sha256 "94704dda228c9f75f4403051085001440b458501ec97192eee06e8e67f7f9f0c"
     end
 
-    # LLDB
     resource "lldb" do
       url "http://llvm.org/releases/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
       sha256 "e3f68f44147df0433e7989bf6ed1c58ff28d7c68b9c47553cb9915f744785a35"
     end
 
-    # OpenMP
     resource "openmp" do
       url "http://llvm.org/releases/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
       sha256 "92510e3f62e3de955e3a0b6708cebee1ca344d92fb02369cba5fdd5c68f773a0"
     end
 
-    # Polly
     resource "polly" do
       url "http://llvm.org/releases/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
       sha256 "84cbabc0b6a10a664797907d291b6955d5ea61aef04e3f3bb464e42374d1d1f2"
@@ -130,11 +114,12 @@ class Llvm < Formula
     end
   end
 
-  # keg_only :provided_by_osx if OS.mac?
+  keg_only :provided_by_osx
 
   # Options
-  option :universal if OS.mac?
-  option "with-clang",             "Build the Clang compiler and support libraries"
+  option :universal
+  # option "with-clang",             "Build the Clang compiler and support libraries"
+  option "without-clang",          "Do not build the Clang compiler and support libraries"
   option "with-clang-extra-tools", "Build extra tools for Clang"
   option "with-compiler-rt",       "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
   option "with-libcxx",            "Build the libc++ standard library"
@@ -142,7 +127,8 @@ class Llvm < Formula
   option "with-libunwind",         "Build the libunwind library"
   option "with-lld",               "Build LLD linker"
   option "with-lldb",              "Build LLDB debugger"
-  option "with-rtti",              "Build with C++ RTTI"
+  # option "with-rtti",              "Build with C++ RTTI"
+  option "without-rtti",           "Do not build C++ RTTI"
   option "with-utils",             "Install utility binaries"
   option "with-polly",             "Build with the experimental Polly optimizer"
   option "with-python",            "Build Python bindings against Homebrew Python"
@@ -150,45 +136,30 @@ class Llvm < Formula
   option "with-shared-libs",       "Build all libs as shared instead of static"
   option "with-libffi",            "Use libffi to call external functions from the interpreter"
 
-  deprecated_option "rtti" => "with-rtti"
-
   # Dependencies
   depends_on "cmake"    => :build
+
+  depends_on "libffi"   => :optional # llvm.org/docs/GettingStarted.grml#requirements
   depends_on "doxygen"  => :optional # for C++ API reference (lldb)
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
-
-  depends_on "ocaml"   => :optional
+  depends_on "ocaml"    => :optional
 
   # Python
   if build.with?("python")
-    # with-python   has been requested
     depends_on "python"
-  elsif MacOS.version <= :snow_leopard || OS.linux?
+  elsif MacOS.version <= :snow_leopard
     depends_on :python
   else
     depends_on :python => :optional # not sure this is correct
   end
-  fails_with :python3
 
   if build.with?("lldb")
-    depends_on "swig" if (OS.mac? && MacOS.version >= :lion) || OS.linux?
+    depends_on "swig" if MacOS.version >= :lion
     depends_on CodesignRequirement
   end
 
-  # llvm.org/docs/GettingStarted.grml#requirements
-  depends_on "libffi" if build.with?("libffi") # libffi
-
-  unless OS.mac?
-    depends_on "homebrew/dupes/libedit" # llvm requires <histedit.h>
-    depends_on "libxml2"
-    depends_on "ncurses"
-    depends_on "valgrind" => :recommended
-    depends_on "zlib"
-    depends_on "gcc"
-  end
-
   # Apple's libstdc++ is too old to build LLVM
-  fails_with :llvm if OS.mac?
+  fails_with :llvm
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
   fails_with :gcc
@@ -198,22 +169,22 @@ class Llvm < Formula
 
   def install
     # Apple's libstdc++ is too old to build LLVM
-    ENV.libcxx if ENV.compiler == :clang && OS.mac?
+    ENV.libcxx if ENV.compiler == :clang
 
-    (buildpath/"tools/clang").install resource("clang") if build.with?("clang")
+    (buildpath/"tools/clang").install resource("clang") if build.with? "clang"
 
     if build.with? "clang-extra-tools"
-      odie "--with-extra-tools requires --with-clang" if build.without?("clang")
+      odie "--with-extra-tools requires --with-clang" if build.without? "clang"
       (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     end
 
-    (buildpath/"projects/libcxx").install    resource("libcxx")    if build.with?("libcxx")
-    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if build.with?("libcxxabi")
-    (buildpath/"projects/libunwind").install resource("libunwind") if build.with?("libunwind")
-    (buildpath/"tools/lld").install          resource("lld")       if build.with?("lld")
+    (buildpath/"projects/libcxx").install    resource("libcxx")    if build.with? "libcxx"
+    (buildpath/"projects/libcxxabi").install resource("libcxxabi") if build.with? "libcxxabi"
+    (buildpath/"projects/libunwind").install resource("libunwind") if build.with? "libunwind"
+    (buildpath/"tools/lld").install          resource("lld")       if build.with? "lld"
 
     if build.with? "lldb"
-      odie "--with-lldb requires --with-clang" if build.without?("clang")
+      odie "--with-lldb requires --with-clang" if build.without? "clang"
       (buildpath/"tools/lldb").install resource("lldb")
 
       # Building lldb requires a code signing certificate.
@@ -222,20 +193,18 @@ class Llvm < Formula
       # the search path in a superenv build. The following three lines add
       # the login keychain to ~/Library/Preferences/com.apple.security.plist,
       # which adds it to the superenv keychain search path.
-      if OS.mac?
-        mkdir_p "#{ENV["HOME"]}/Library/Preferences"
-        username = ENV["USER"]
-        system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
-      end
+      mkdir_p "#{ENV["HOME"]}/Library/Preferences"
+      username = ENV["USER"]
+      system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
     end
 
     if build.with? "polly"
-      odie "--with-polly requires --with-clang" if build.without?("clang")
+      odie "--with-polly requires --with-clang" if build.without? "clang"
       (buildpath/"tools/polly").install resource("polly")
     end
 
     if build.with? "compiler-rt"
-      odie "--with-compiler-rt requires --with-clang" if build.without?("clang")
+      odie "--with-compiler-rt requires --with-clang" if build.without? "clang"
       (buildpath/"projects/compiler-rt").install resource("compiler-rt")
 
       # compiler-rt has some iOS simulator features that require i386 symbols
@@ -252,18 +221,19 @@ class Llvm < Formula
       -DLLVM_TARGETS_TO_BUILD=X86
     ]
 
-    args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=On" if build.with?("compiler-rt")
-    args << "-DLLVM_BUILD_TESTS=On" if build.with?("test")
-    args << "-DLLVM_ABI_BREAKING_CHECKS=On" if build.with?("test")
+    args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=On" if build.with? "compiler-rt"
+    if build.with? "test"
+      args << "-DLLVM_BUILD_TESTS=On"
+      args << "-DLLVM_ABI_BREAKING_CHECKS=On"
+    end
+    args << "-DLLVM_ENABLE_RTTI=On"      if build.with? "rtti"
+    args << "-DLLVM_INSTALL_UTILS=On"    if build.with? "utils"
+    args << "-DLLVM_ENABLE_LIBCXX=On"    if build.with? "libcxx"
+    args << "-DLLVM_ENABLE_LIBCXXABI=On" if build.with? "libcxxabi"
+    args << "-DLLVM_ENABLE_DOXYGEN=On"   if build.with? "doxygen"
+    args << "-DBUILD_SHARED_LIBS=On"     if build.with? "shared-libs" # for developers
 
-    args << "-DLLVM_ENABLE_RTTI=On" if build.with?("rtti")
-    args << "-DLLVM_INSTALL_UTILS=On" if build.with?("utils")
-    args << "-DLLVM_ENABLE_LIBCXX=On" if build.with?("libcxx")
-    args << "-DLLVM_ENABLE_LIBCXXABI=On" if build.with?("libcxxabi")
-    args << "-DLLVM_ENABLE_DOXYGEN=On" if build.with?("doxygen")
-    args << "-DBUILD_SHARED_LIBS=On" if build.with?("shared-libs") # for developers
-
-    if build.with?("libffi")
+    if build.with? "libffi"
       args << "-DLLVM_ENABLE_FFI=On"
       args << "-DFFI_INCLUDE_DIR=#{Formula["libffi"].lib}/libffi-#{Formula["libffi"].version}/include" # upstream bug?
       args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].lib}"
@@ -274,7 +244,7 @@ class Llvm < Formula
       args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
     end
 
-    if build.with?("polly")
+    if build.with? "polly"
       args << "-DWITH_POLLY=On"
       args << "-DLINK_POLLY_INTO_TOOLS=On"
     end

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -21,71 +21,68 @@ class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "http://llvm.org/"
 
-  llvm_version = "3.8.0"
-
   stable do
-    url      "http://llvm.org/releases/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
-    sha256   "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
+    url "http://llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz"
+    sha256 "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
 
     resource "clang" do
-      url    "http://llvm.org/releases/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/cfe-3.8.0.src.tar.xz"
       sha256 "04149236de03cf05232d68eb7cb9c50f03062e339b68f4f8a03b650a11536cf9"
     end
 
     resource "clang-extra-tools" do
-      url    "http://llvm.org/releases/#{llvm_version}/clang-tools-extra-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/clang-tools-extra-3.8.0.src.tar.xz"
       sha256 "afbda810106a6e64444bc164b921be928af46829117c95b996f2678ce4cb1ec4"
     end
 
     resource "compiler-rt" do
-      url    "http://llvm.org/releases/#{llvm_version}/compiler-rt-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/compiler-rt-3.8.0.src.tar.xz"
       sha256 "c8d3387e55f229543dac1941769120f24dc50183150bf19d1b070d53d29d56b0"
     end
 
     # only required to build and run Compiler-RT tests on OS X, optional otherwise. clang.llvm.org/get_started.html
     resource "libcxx" do
-      url    "http://llvm.org/releases/#{llvm_version}/libcxx-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/libcxx-3.8.0.src.tar.xz"
       sha256 "36804511b940bc8a7cefc7cb391a6b28f5e3f53f6372965642020db91174237b"
     end
 
     resource "libcxxabi" do
-      url    "http://llvm.org/releases/#{llvm_version}/libcxxabi-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/libcxxabi-3.8.0.src.tar.xz"
       sha256 "c5ee0871aff6ec741380c4899007a7d97f0b791c81df69d25b744eebc5cee504"
     end
 
     resource "libunwind" do
-      url    "http://llvm.org/releases/#{llvm_version}/libunwind-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/libunwind-3.8.0.src.tar.xz"
       sha256 "af3eaf39ecdc3b9e89863fb62e1aa3c135cfde7e9415424e4e396d7486a9422b"
     end
 
     resource "lld" do
-      url    "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/lld-3.8.0.src.tar.xz"
       sha256 "94704dda228c9f75f4403051085001440b458501ec97192eee06e8e67f7f9f0c"
     end
 
     resource "lldb" do
-      url    "http://llvm.org/releases/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/lldb-3.8.0.src.tar.xz"
       sha256 "e3f68f44147df0433e7989bf6ed1c58ff28d7c68b9c47553cb9915f744785a35"
     end
 
     resource "openmp" do
-      url    "http://llvm.org/releases/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/openmp-3.8.0.src.tar.xz"
       sha256 "92510e3f62e3de955e3a0b6708cebee1ca344d92fb02369cba5fdd5c68f773a0"
     end
 
     resource "polly" do
-      url    "http://llvm.org/releases/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
+      url "http://llvm.org/releases/3.8.0/polly-3.8.0.src.tar.xz"
       sha256 "84cbabc0b6a10a664797907d291b6955d5ea61aef04e3f3bb464e42374d1d1f2"
     end
+  end
 
-    bottle do
-      cellar :any
-      revision 2
-      sha256 "3b4b2c50e018125c0fa7aa9a14e8066b301afa6ebe2c36a198962e4c9af318a7" => :el_capitan
-      sha256 "382eb51bb69c52fb3800c0498d1c6799b9046af8413be15217fc58effc9963b3" => :yosemite
-      sha256 "57f2bb04233429051ff77deeaf74612c2d56be5d6bc13d1c6f8457cd057bc9e7" => :mavericks
-    end
-
+  bottle do
+    cellar :any
+    revision 2
+    sha256 "3b4b2c50e018125c0fa7aa9a14e8066b301afa6ebe2c36a198962e4c9af318a7" => :el_capitan
+    sha256 "382eb51bb69c52fb3800c0498d1c6799b9046af8413be15217fc58effc9963b3" => :yosemite
+    sha256 "57f2bb04233429051ff77deeaf74612c2d56be5d6bc13d1c6f8457cd057bc9e7" => :mavericks
   end
 
   head do
@@ -132,41 +129,39 @@ class Llvm < Formula
 
   # Options
   option :universal
-  option "without-clang",          "Do not build the Clang compiler and support libraries"
-  option "without-libcxx",         "Do not build the libc++ standard library"
-  option "without-rtti",           "Do not build C++ RTTI"
-
+  option "without-clang", "Do not build the Clang compiler and support libraries"
   option "with-clang-extra-tools", "Build extra tools for Clang"
-  option "with-compiler-rt",       "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
-  option "with-libcxxabi",         "Build the libc++abi standard library"
-  option "with-libunwind",         "Build the libunwind library"
-  option "with-lld",               "Build LLD linker"
-  option "with-lldb",              "Build LLDB debugger"
-  option "with-utils",             "Install utility binaries"
-  option "with-polly",             "Build with the experimental Polly optimizer"
-  option "with-python",            "Build Python bindings against Homebrew Python"
-  option "with-test",              "Build LLVM unit tests"
-  option "with-shared-libs",       "Build all libs as shared instead of static"
-  option "with-libffi",            "Use libffi to call external functions from the interpreter"
+  option "with-compiler-rt", "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
+  option "without-libcxx", "Do not build the libc++ standard library"
+  option "with-libcxxabi", "Build the libc++abi standard library"
+  option "with-libunwind", "Build the libunwind library"
+  option "with-lld", "Build LLD linker"
+  option "with-lldb", "Build LLDB debugger"
+  option "with-python", "Build Python bindings against Homebrew Python"
+  option "without-rtti", "Do not build C++ RTTI"
+  option "with-utils", "Install utility binaries"
+  option "with-polly", "Build with the experimental Polly optimizer"
+  option "with-test", "Build LLVM unit tests"
+  option "with-shared-libs", "Build all libs as shared instead of static"
+  option "with-libffi", "Use libffi to call external functions from the interpreter"
 
   # Dependencies
-  depends_on "cmake"    => :build
-
   depends_on "libffi"   => :optional # llvm.org/docs/GettingStarted.grml#requirements
   depends_on "doxygen"  => :optional # for C++ API reference (lldb)
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
   depends_on "ocaml"    => :optional
 
   # Python
-  if build.with?("python")
+  if build.with? "python"
     depends_on "python"
   elsif MacOS.version <= :snow_leopard
     depends_on :python
   else
     depends_on :python => :optional # not sure this is correct
   end
+  depends_on "cmake" => :build
 
-  if build.with?("lldb")
+  if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
     depends_on CodesignRequirement
   end
@@ -191,10 +186,10 @@ class Llvm < Formula
       (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     end
 
-    (buildpath/"projects/libcxx").install    resource("libcxx")    if build.with? "libcxx" || (build.with? "clang" && !MacOS::CLT.installed?)
+    (buildpath/"projects/libcxx").install resource("libcxx") if build.with? "libcxx" || (build.with? "clang" && !MacOS::CLT.installed?)
+    (buildpath/"tools/lld").install resource("lld") if build.with? "lld"
     (buildpath/"projects/libcxxabi").install resource("libcxxabi") if build.with? "libcxxabi"
     (buildpath/"projects/libunwind").install resource("libunwind") if build.with? "libunwind"
-    (buildpath/"tools/lld").install          resource("lld")       if build.with? "lld"
 
     if build.with? "lldb"
       odie "--with-lldb requires --with-clang" if build.without? "clang"
@@ -239,12 +234,12 @@ class Llvm < Formula
       args << "-DLLVM_BUILD_TESTS=On"
       args << "-DLLVM_ABI_BREAKING_CHECKS=On"
     end
-    args << "-DLLVM_ENABLE_RTTI=On"      if build.with? "rtti"
-    args << "-DLLVM_INSTALL_UTILS=On"    if build.with? "utils"
-    args << "-DLLVM_ENABLE_LIBCXX=On"    if build.with? "libcxx" || (build.with? "clang" && !MacOS::CLT.installed?)
+    args << "-DLLVM_ENABLE_RTTI=On" if build.with? "rtti"
+    args << "-DLLVM_INSTALL_UTILS=On" if build.with? "utils"
+    args << "-DLLVM_ENABLE_LIBCXX=On" if build.with? "libcxx" || (build.with? "clang" && !MacOS::CLT.installed?)
     args << "-DLLVM_ENABLE_LIBCXXABI=On" if build.with? "libcxxabi"
-    args << "-DLLVM_ENABLE_DOXYGEN=On"   if build.with? "doxygen"
-    args << "-DBUILD_SHARED_LIBS=On"     if build.with? "shared-libs" # for developers
+    args << "-DLLVM_ENABLE_DOXYGEN=On" if build.with? "doxygen"
+    args << "-DBUILD_SHARED_LIBS=On" if build.with? "shared-libs" # for developers
 
     if build.with? "libffi"
       args << "-DLLVM_ENABLE_FFI=On"
@@ -317,6 +312,8 @@ class Llvm < Formula
         }
       EOS
 
+      ohai "#{ENV.cflags}"
+
       if MacOS::CLT.installed?
         # Test with CLT
         system "#{bin}/clang++", "-v", "-std=c++11", "-stdlib=libc++", "test.cpp", "-o", "test"
@@ -325,7 +322,7 @@ class Llvm < Formula
 
       if build.with? "libcxx" || ! MacOS::CLT.installed?
         # Test with libcxx
-        system "#{bin}/clang++", "-v", "-std=c++11", "-stdlib=libc++", "-I#{include}", "-L#{lib}", "test.cpp", "-o", "test"
+        system "#{bin}/clang++", "-v", "-std=c++11", "-stdlib=libc++","-I#{include}", "-L#{lib}", "test.cpp", "-o", "test"
         system "./test"
       end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -24,8 +24,8 @@ class Llvm < Formula
   llvm_version = "3.8.0"
 
   stable do
-    url "http://llvm.org/releases/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
-    sha256 "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
+    url      "http://llvm.org/releases/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
+    sha256   "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
 
     resource "clang" do
       url    "http://llvm.org/releases/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
@@ -59,24 +59,33 @@ class Llvm < Formula
     end
 
     resource "lld" do
-      url "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
+      url    "http://llvm.org/releases/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
       sha256 "94704dda228c9f75f4403051085001440b458501ec97192eee06e8e67f7f9f0c"
     end
 
     resource "lldb" do
-      url "http://llvm.org/releases/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
+      url    "http://llvm.org/releases/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
       sha256 "e3f68f44147df0433e7989bf6ed1c58ff28d7c68b9c47553cb9915f744785a35"
     end
 
     resource "openmp" do
-      url "http://llvm.org/releases/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
+      url    "http://llvm.org/releases/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
       sha256 "92510e3f62e3de955e3a0b6708cebee1ca344d92fb02369cba5fdd5c68f773a0"
     end
 
     resource "polly" do
-      url "http://llvm.org/releases/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
+      url    "http://llvm.org/releases/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
       sha256 "84cbabc0b6a10a664797907d291b6955d5ea61aef04e3f3bb464e42374d1d1f2"
     end
+
+    bottle do
+      cellar :any
+      revision 2
+      sha256 "3b4b2c50e018125c0fa7aa9a14e8066b301afa6ebe2c36a198962e4c9af318a7" => :el_capitan
+      sha256 "382eb51bb69c52fb3800c0498d1c6799b9046af8413be15217fc58effc9963b3" => :yosemite
+      sha256 "57f2bb04233429051ff77deeaf74612c2d56be5d6bc13d1c6f8457cd057bc9e7" => :mavericks
+    end
+
   end
 
   head do
@@ -123,7 +132,6 @@ class Llvm < Formula
 
   # Options
   option :universal
-  # option "with-clang",             "Build the Clang compiler and support libraries"
   option "without-clang",          "Do not build the Clang compiler and support libraries"
   option "without-libcxx",         "Do not build the libc++ standard library"
   option "without-rtti",           "Do not build C++ RTTI"

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -13,7 +13,7 @@ class Ponyc < Formula
     sha256 "007c43a75741ecd4c7c96c9fc67d816ebc845c0aac94687c4e2cbb1ee959ebfb" => :mavericks
   end
 
-  depends_on "llvm" => "with-rtti"
+  depends_on "llvm"
   depends_on "libressl"
   depends_on "pcre2"
   needs :cxx11

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -1,10 +1,9 @@
 class Ponyc < Formula
   desc "Object-oriented, actor-model, capabilities-secure programming language"
   homepage "http://www.ponylang.org"
-  url "https://github.com/ponylang/ponyc/archive/0.2.1.tar.gz"
-  sha256 "cb8d6830565ab6b47ecef07dc1243029cef962df7ff926140022abb69d1e554e"
-  revision 1
-  head "https://github.com/ponylang/ponyc.git"
+  url "https://github.com/ponylang/ponyc.git",
+    :revision => "aafebac938273d4786c02dfb2ba9ec7a164675e7"
+  version "0.2.2-candidate"
 
   bottle do
     cellar :any_skip_relocation
@@ -20,10 +19,20 @@ class Ponyc < Formula
 
   def install
     ENV.cxx11
-    system "make", "install", "config=release", "destdir=#{prefix}", "verbose=1"
+    ENV["LLVM_CONFIG"]="#{Formula["llvm"].bin}/llvm-config"
+    system "make", "config=release", "destdir=#{prefix}", "install", "verbose=1"
   end
 
   test do
     system "#{bin}/ponyc", "-rexpr", "#{prefix}/packages/stdlib"
+
+    (testpath/"test/main.pony").write <<-EOS.undent
+    actor Main
+      new create(env: Env) =>
+        env.out.print("Hello World!")
+    EOS
+    system "#{bin}/ponyc", "test"
+    assert_equal "Hello World!", shell_output("./test1").strip
+
   end
 end

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -3,7 +3,7 @@ class Ponyc < Formula
   homepage "http://www.ponylang.org"
   url "https://github.com/ponylang/ponyc.git",
     :revision => "aafebac938273d4786c02dfb2ba9ec7a164675e7"
-  version "0.2.2-candidate"
+  version "0.2.2-alpha"
 
   bottle do
     cellar :any_skip_relocation
@@ -19,7 +19,7 @@ class Ponyc < Formula
 
   def install
     ENV.cxx11
-    ENV["LLVM_CONFIG"]="#{Formula["llvm"].bin}/llvm-config"
+    ENV["LLVM_CONFIG"]="#{Formula["llvm"].opt_bin}/llvm-config"
     system "make", "config=release", "destdir=#{prefix}", "install", "verbose=1"
   end
 
@@ -33,6 +33,5 @@ class Ponyc < Formula
     EOS
     system "#{bin}/ponyc", "test"
     assert_equal "Hello World!", shell_output("./test1").strip
-
   end
 end

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -4,7 +4,7 @@ class Rtags < Formula
   url "https://github.com/Andersbakken/rtags.git",
       :tag => "v2.2",
       :revision => "925a188e4038fa6e4a7c8ea4d30d682609c46578"
-	revision 1
+  revision 1
 
   head "https://github.com/Andersbakken/rtags.git"
 

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -4,6 +4,7 @@ class Rtags < Formula
   url "https://github.com/Andersbakken/rtags.git",
       :tag => "v2.2",
       :revision => "925a188e4038fa6e4a7c8ea4d30d682609c46578"
+	revision 1
 
   head "https://github.com/Andersbakken/rtags.git"
 
@@ -14,7 +15,7 @@ class Rtags < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm" => "with-clang"
+  depends_on "llvm"
   depends_on "openssl"
 
   def install

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -2,9 +2,8 @@ class Rtags < Formula
   desc "ctags-like source code cross-referencer with a clang frontend"
   homepage "https://github.com/Andersbakken/rtags"
   url "https://github.com/Andersbakken/rtags.git",
-      :tag => "v2.2",
-      :revision => "925a188e4038fa6e4a7c8ea4d30d682609c46578"
-  revision 1
+      :tag => "v2.3",
+      :revision => "da75268b1caa973402ab17e501718da7fc748b34"
 
   head "https://github.com/Andersbakken/rtags.git"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Other changes: bring back libcxxabi, add libunwind, libffi, and add shared-libs
option. Linux and OS X compatible. Extra dependencies for Linux:
libedit, libxml2, ncurses, valgrind (recommended), zlib, and gcc. New
llvm build flags: LLVM_TARGETS_TO_BUILD=X86 (speeds up build process),
LLVM_ENABLE_DOXYGEN (if build with doxygen), BUILD_SHARED_LIBS (build
all libraries as shared instead of static, DLLVM_ENABLE_FFI and related
DFFI_INCLUDE_DIR and FFI_LIBRARY_DIR.
