### PR TITLE
idris: install using haskell-stack

### DIFF
--- a/Formula/idris.rb
+++ b/Formula/idris.rb
@@ -7,6 +7,7 @@ class Idris < Formula
   homepage "http://www.idris-lang.org"
   url "https://github.com/idris-lang/Idris-dev/archive/v0.11.2.tar.gz"
   sha256 "eddc8d8d6401d5c5743df43003a11d031be42eb6b09800dc1111606c39a3c8bc"
+  revision 1
   head "https://github.com/idris-lang/Idris-dev.git"
 
   bottle do
@@ -15,18 +16,31 @@ class Idris < Formula
     sha256 "652da19c6f08b65483df86768813f6ce7eca2d8c31cf0a0f4f624a22344cdbef" => :mavericks
   end
 
-  depends_on "ghc" => :build
-  depends_on "cabal-install" => :build
+  depends_on "haskell-stack" => :build
+  depends_on "pkg-config" => :build
   depends_on "gmp"
-
-  depends_on "libffi" => :recommended
-  depends_on "pkg-config" => :build if build.with? "libffi"
+  depends_on "libffi"
 
   def install
-    args = []
-    args << "-f FFI" if build.with? "libffi"
-    args << "-f release" if build.stable?
-    install_cabal_package *args
+    ENV["STACK_ROOT"] = "#{HOMEBREW_CACHE}/stack_root"
+    (libexec/"stack").install Dir["#{buildpath}/*"]
+
+    cd libexec/"stack" do
+      system "stack", "setup"
+      system "stack", "build"
+
+      bin.mkpath
+      system "stack", "install", "--local-bin-path=#{bin}"
+
+      install_dir = Utils.popen_read("stack", "path", "--local-install-root").chomp
+
+      share.mkpath
+      mv "#{install_dir}/share/man", share
+      mv "#{install_dir}/doc", share
+
+      libexec.install_symlink "#{install_dir}/lib"
+      libexec.install_symlink "#{install_dir}/share"
+    end
   end
 
   test do
@@ -44,14 +58,10 @@ class Idris < Formula
       main : IO ()
       main = puts "Hello, interpreter!"
     EOS
-    shell_output "#{bin}/idris #{testpath}/hello.idr -o #{testpath}/hello"
-    result = shell_output "#{testpath}/hello"
-    assert_match /Hello, Homebrew!/, result
+    system bin/"idris", testpath/"hello.idr", "-o", testpath/"hello"
+    assert_match /Hello, Homebrew!/, shell_output(testpath/"hello")
 
-    if build.with? "libffi"
-      shell_output "#{bin}/idris #{testpath}/ffi.idr -o #{testpath}/ffi"
-      result = shell_output "#{testpath}/ffi"
-      assert_match /Hello, interpreter!/, result
-    end
+    system bin/"idris", testpath/"ffi.idr", "-o", testpath/"ffi"
+    assert_match /Hello, interpreter!/, shell_output(testpath/"ffi")
   end
 end


### PR DESCRIPTION
- use haskell-stack to build idris to work around GHC 8 incompatibility
- minor style changes to the test-do block

Issue #1486.
