### PR TITLE
rust: remove git submodule workaround for HEAD

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -49,12 +49,6 @@ class Rust < Formula
   end
 
   def install
-    # Because we copy the source tree to a temporary build directory,
-    # the absolute paths written to the `gitdir` files of the
-    # submodules are no longer accurate, and running `git submodule
-    # update` during the configure step fails.
-    ENV["CFG_DISABLE_MANAGE_SUBMODULES"] = "1" if build.head?
-
     args = ["--prefix=#{prefix}"]
     args << "--disable-rpath" if build.head?
     args << "--enable-clang" if ENV.compiler == :clang


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This reverts commit cb8a5f141de0c70d71a1becf3ff8a6417fc159da. The workaround introduced in Homebrew/legacy-homebrew#49370 and motivated by the failure in Homebrew/legacy-homebrew#48980 is no longer necessary and/or has been fixed by Homebrew/brew#303.

cc @dunn @DomT4 because you handled the original issue and provided the workaround.

---

Transcript of a successful HEAD build after applying this change (about 12 hours ago):

```
$ brew install rust --HEAD
==> Using the sandbox
==> Cloning https://github.com/rust-lang/rust.git
Updating /opt/brewery/langs/.brew-cache/rust--git
==> Checking out branch master
Synchronizing submodule url for 'test/rust-installer-v1'
Synchronizing submodule url for 'test/rust-installer-v2'
Synchronizing submodule url for 'test/rust-installer-v1'
==> ./configure --prefix=/opt/brewery/langs/Cellar/rust/HEAD --disable-rpath --enable-clang --release-channel=nightly
==> make
==> make install
==> Cloning https://github.com/rust-lang/cargo.git
Updating /opt/brewery/langs/.brew-cache/rust--cargo--git
==> Checking out branch master
Synchronizing submodule url for 'test/rust-installer-v1'
Synchronizing submodule url for 'test/rust-installer-v2'
Synchronizing submodule url for 'test/rust-installer-v1'
==> ./configure --prefix=/opt/brewery/langs/Cellar/rust/HEAD --local-rust-root=/opt/brewery/langs/Cellar/rust/HEAD --ena
==> make
==> make install
==> Caveats
Bash completion has been installed to:
  /opt/brewery/langs/etc/bash_completion.d

zsh completion has been installed to:
  /opt/brewery/langs/share/zsh/site-functions
==> Summary
🍵  /opt/brewery/langs/Cellar/rust/HEAD: 12,747 files, 263.5M, built in 142 minutes 55 seconds
```
