### PR TITLE
cmake: linux fix libcurl tls

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -3,6 +3,7 @@ class Cmake < Formula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz"
   sha256 "92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a"
+  revision 1
 
   head "https://cmake.org/cmake.git"
 
@@ -35,7 +36,7 @@ class Cmake < Formula
     ]
 
     # https://github.com/Homebrew/homebrew/issues/45989
-    if MacOS.version <= :lion
+    if OS.mac? && MacOS.version <= :lion
       args << "--no-system-curl"
     else
       args << "--system-curl"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Fixes the following problem:
On Linux cmake is build with --no-system-curl instead of
--system-curl due to an unclear if statement
this breaks https support
