### PR TITLE
sipp 3.5.1 - 3.4.1 is 2 years old and missing options, namely -screen_file

### DIFF
--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -23,9 +23,6 @@ class Sipp < Formula
   end
 
   test do
-    # sipp_output = `#{bin}/sipp -v`.split(/$/)
-    # sipp_output.each { |o| print o }
-    # assert_match "SIPp v#{version}", sipp_output[0]
-    assert_match "SIPp v#{version}", shell_output("#{bin}/sipp -v 2>&1 || true")
+    assert_match "SIPp v#{version}", shell_output("#{bin}/sipp -v", 99)
   end
 end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -23,9 +23,9 @@ class Sipp < Formula
   end
 
   test do
-    sipp_output = `#{bin}/sipp -v`.split(/$/)
-    sipp_output.each { |o| print o }
-    assert_match "SIPp v#{version}", sipp_output[0]
-    # assert_match "SIPp", shell_output("#{bin}/sipp -v 2>&1")
+    # sipp_output = `#{bin}/sipp -v`.split(/$/)
+    # sipp_output.each { |o| print o }
+    # assert_match "SIPp v#{version}", sipp_output[0]
+    assert_match "SIPp v#{version}", shell_output("#{bin}/sipp -v 2>&1 || true")
   end
 end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -25,6 +25,7 @@ class Sipp < Formula
   test do
     sipp_output = `#{bin}/sipp -v`.split(/$/)
     sipp_output.each { |o| print o }
-    assert_match "SIPp v3.5.1", sipp_output[0]
+    assert_match "SIPp v#{version}", sipp_output[0]
+    # assert_match "SIPp", shell_output("#{bin}/sipp -v 2>&1")
   end
 end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -1,9 +1,8 @@
 class Sipp < Formula
   desc "Traffic generator for the SIP protocol"
   homepage "http://sipp.sourceforge.net/"
-  url "https://github.com/SIPp/sipp/archive/v3.4.1.tar.gz"
-  sha256 "bb6829a1f3af8d8b5f08ffcd7de40e2692b4dfb9a83eccec3653a51f77a82bc4"
-  revision 1
+  url "https://github.com/SIPp/sipp/releases/download/v3.5.1/sipp-3.5.1.tar.gz"
+  sha256 "56421ba7b43b67e9b04e21894b726502a82a6149fc86ba06df33dfc7252a1891"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,5 +20,9 @@ class Sipp < Formula
     system "./configure", *args
     system "make", "DESTDIR=#{prefix}"
     bin.install "sipp"
+  end
+
+  test do
+    assert_equal "SIPp", shell_output("#{bin}/sipp -v | grep SIPp | awk '{ print $1 }'").strip
   end
 end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -23,6 +23,8 @@ class Sipp < Formula
   end
 
   test do
-    assert_equal "SIPp", shell_output("#{bin}/sipp -v | grep SIPp | awk '{ print $1 }'").strip
+    sipp_output = `#{bin}/sipp -v`.split(/$/)
+    sipp_output.each { |o| print o }
+    assert_match "SIPp v3.5.1", sipp_output[0]
   end
 end


### PR DESCRIPTION
The existing formula for sipp is version 3.4.1 which is 2 years old and is missing options that I need for my test scripts. I'm trying to setup a simple test suite for our QA department and rather than have each compile the latest version, I prefer them using homebrew. I've run the entire gamut of conditions under https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md and even added a "test do" that wasn't there before. It's checking version output, but that's really the only test I can come up with for this utility since a proper test requires an active SIP endpoint.
