### PR TITLE
node 6.2.1

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -1,8 +1,8 @@
 class Node < Formula
   desc "Platform built on the V8 JavaScript runtime to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v6.2.0/node-v6.2.0.tar.xz"
-  sha256 "8633fe606fd1f2235d26901c6bc4c11b5b88fd3c772af18a902e3efd1254e492"
+  url "https://nodejs.org/dist/v6.2.1/node-v6.2.1.tar.xz"
+  sha256 "dbaeb8fb68a599e5164b17c74f66d24f424ee4ab3a25d8de8a3c6808e5b42bfb"
   head "https://github.com/nodejs/node.git"
 
   bottle do
@@ -36,8 +36,8 @@ class Node < Formula
   # We will accept *important* npm patch releases when necessary.
   # https://github.com/Homebrew/homebrew/pull/46098#issuecomment-157802319
   resource "npm" do
-    url "https://registry.npmjs.org/npm/-/npm-3.8.9.tgz"
-    sha256 "97c831727e9cc0543ca437ab688a4eeba862f2238f4d57ff13ee1888402a9c7b"
+    url "https://registry.npmjs.org/npm/-/npm-3.9.3.tgz"
+    sha256 "34e191630a5c736f505925df2855342faa3a13c5b6e59cac9253dea4e22b3014"
   end
 
   resource "icu4c" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This PR upgrades node to the latest v6.2.1 release: https://nodejs.org/en/blog/release/v6.2.1/.
It also upgrades npm to v3.9.3 (same as in the official binaries).

It looks like there is nothing to do on our side to work around the accidentally published coverage report data in the official npm 3.9.3/4 releases (fixed in [npm 3.9.5](https://github.com/npm/npm/releases/tag/v3.9.5)). Unfortunately we have to download a 10x bigger than usual (>300mb) npm resource, but luckily npm is clever enough to not install the `.nyc_output` folder to the `libexec` prefix.
