### PR TITLE
tmux: update completion source

### DIFF
--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -39,8 +39,8 @@ class Tmux < Formula
   depends_on "libevent"
 
   resource "completion" do
-    url "https://raw.githubusercontent.com/przepompownia/tmux-bash-completion/v0.0.1/completions/tmux"
-    sha256 "a0905c595fec7f0258fba5466315d42d67eca3bd2d3b12f4af8936d7f168b6c6"
+    url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/homebrew_1.0.0/completions/tmux"
+    sha256 "05e79fc1ecb27637dc9d6a52c315b8f207cf010cdcee9928805525076c9020ae"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Fixed completion giving `_init_completion: command not found` and updated link to point to my version, because now I am current maintainer of tmux bash completion https://github.com/tmux/tmux/commit/89c17e44fbc9a646b7a5ad54b84132fcaa978b3b. So if there will be any errors people will contact me.
