### PR TITLE
zeromq: update download URL

### DIFF
--- a/Formula/zeromq.rb
+++ b/Formula/zeromq.rb
@@ -1,7 +1,7 @@
 class Zeromq < Formula
   desc "High-performance, asynchronous messaging library"
   homepage "http://www.zeromq.org/"
-  url "http://download.zeromq.org/zeromq-4.1.4.tar.gz"
+  url "https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz"
   sha256 "e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378"
 
   bottle do


### PR DESCRIPTION
download.zeromq.org is gone, releases are now on GitHub
