### PR TITLE
byobu 5.108

### DIFF
--- a/Formula/byobu.rb
+++ b/Formula/byobu.rb
@@ -1,8 +1,8 @@
 class Byobu < Formula
   desc "Text-based window manager and terminal multiplexer"
   homepage "http://byobu.co"
-  url "https://launchpad.net/byobu/trunk/5.106/+download/byobu_5.106.orig.tar.gz"
-  sha256 "e22bf8e680db322d21a9df4114620622f340c5fa0e3149698df39598c4779148"
+  url "https://launchpad.net/byobu/trunk/5.108/+download/byobu_5.108.orig.tar.gz"
+  sha256 "a8ad1e99b32dbafcd1cb6a58b6541ea177850567d504218af08ffac79a01e39e"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Provides a more reliable uptime status notification on OS X.

Full changelog:

```
byobu (5.108-0ubuntu1) yakkety; urgency=medium

  [ Dustin Kirkland ]
  * usr/lib/byobu/updates_available:
    - remove trailing whitespace
  * usr/lib/byobu/battery:
    - only use POWER_SUPPLY_CAPACITY if neither POWER_SUPPLY_ENERGY_NOW nor
      POWER_SUPPLY_CHARGE_NOW are available; important for summing
      multiple batteries

  [ Kevin Mark and Dustin Kirkland ]
  * usr/lib/byobu/uptime:
    - fix uptime status on MacOS

 -- Dustin Kirkland <kirkland@ubuntu.com> Tue, 31 May 2016 10:03:12 -0500
```
