### PR TITLE
prettyping: fix ipv6 support

### DIFF
--- a/Formula/prettyping.rb
+++ b/Formula/prettyping.rb
@@ -6,6 +6,11 @@ class Prettyping < Formula
 
   bottle :unneeded
 
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/848211f/prettyping/ipv6.patch"
+    sha256 "263113acb0c2c99d0fefe979ac450cf00361cb0283df21564958cc4c38e98aad"
+  end
+
   def install
     bin.install "prettyping"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The BSD/OS X ping6 utility produces slightly different output than the
GNU utility does. This patch has been pending upstream for a while but
the maintainer has been very quiet in the past half year.

Since this results in a broken experience on OS X including the patch
here until it gets merged seems like a good way forward.
