### PR TITLE
rclone 1.29 (new formula)

### DIFF
--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -1,0 +1,17 @@
+class Rclone < Formula
+  desc "Sync files to and from Google Drive, Amazon Cloud Drive, etc."
+  homepage "http://rclone.org"
+  url "https://github.com/ncw/rclone/releases/download/v1.29/rclone-v1.29-osx-amd64.zip"
+  version "1.29"
+  sha256 "64c95564ae69f5238000c6adb2f4d178923176ecfd9d64cddfd80bfa538e1c15"
+  head "https://github.com/ncw/rclone.git"
+
+  def install
+    bin.install "rclone"
+    man1.install Dir["*.1"]
+  end
+
+  test do
+    system "#{bin}/rclone", "--help"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

adding new formula rclone, version 1.29, for syncing with cloud services
