### PR TITLE
libvterm 681 (new formula)

### DIFF
--- a/Formula/libvterm.rb
+++ b/Formula/libvterm.rb
@@ -1,0 +1,26 @@
+class Libvterm < Formula
+  desc "C99 library which implements a VT220 or xterm terminal emulator."
+  homepage "http://www.leonerd.org.uk/code/libvterm/"
+  url "http://www.leonerd.org.uk/code/libvterm/libvterm-0+bzr681.tar.gz"
+  sha256 "abea46d1b0b831dec2af5d582319635cece63d260f8298d9ccce7c1c2e62a6e8"
+
+  depends_on "libtool" => :build
+
+  def install
+    ENV.deparallelize
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <vterm.h>
+
+      int main() {
+        vterm_free(vterm_new(1, 1));
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-lvterm", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libvterm.rb
+++ b/Formula/libvterm.rb
@@ -7,7 +7,6 @@ class Libvterm < Formula
   depends_on "libtool" => :build
 
   def install
-    ENV.deparallelize
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This commit adds the libvterm library, version 681.
