### PR TITLE
mupdf-tools 1.9a (and add 'mudraw' symlink)

### DIFF
--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -23,6 +23,10 @@ class MupdfTools < Formula
            "HAVE_X11=no",
            "CC=#{ENV.cc}",
            "prefix=#{prefix}"
+
+    # Symlink `mutool` as `mudraw` (a popular shortcut for `mutool draw`).
+    bin.install_symlink bin/"mutool" => "mudraw"
+    man1.install_symlink man1/"mutool.1" => "mudraw.1"
   end
 
   test do

--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -1,8 +1,8 @@
 class MupdfTools < Formula
   desc "Lightweight PDF and XPS viewer"
   homepage "http://mupdf.com"
-  url "http://mupdf.com/downloads/archive/mupdf-1.8-source.tar.gz"
-  sha256 "a2a3c64d8b24920f87cf4ea9339a25abf7388496440f13b37482d1403c33c206"
+  url "http://mupdf.com/downloads/archive/mupdf-1.9a-source.tar.gz"
+  sha256 "8015c55f4e6dd892d3c50db4f395c1e46660a10b460e2ecd180a497f55bbc4cc"
   head "git://git.ghostscript.com/mupdf.git"
 
   bottle do
@@ -14,7 +14,6 @@ class MupdfTools < Formula
   end
 
   depends_on :macos => :snow_leopard
-  depends_on "openssl"
 
   def install
     system "make", "install",
@@ -31,6 +30,6 @@ class MupdfTools < Formula
 
   test do
     pdf = test_fixtures("test.pdf")
-    assert_match /Homebrew test/, shell_output("#{bin}/mutool draw -F txt #{pdf}")
+    assert_match "Homebrew test", shell_output("#{bin}/mutool draw -F txt #{pdf}")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Other distributions (e.g. Debian) provide a `mudraw` binary by default. Appease users and scripts accustomed to this by providing a matching symbolic link that behaves identically to `mutool draw`.

Also address a Ruby syntax warning by replacing an unnecessary regular expression with a plain string.

Closes #1747.
