### PR TITLE
parallel 20160522

### DIFF
--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -1,9 +1,9 @@
 class Parallel < Formula
   desc "GNU parallel shell command"
   homepage "https://savannah.gnu.org/projects/parallel/"
-  url "http://ftpmirror.gnu.org/parallel/parallel-20160422.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/parallel/parallel-20160422.tar.bz2"
-  sha256 "065a8f471266361218a9eb45c5f8ab995d73b181cc1180600ee08cc768c9ac42"
+  url "http://ftpmirror.gnu.org/parallel/parallel-20160522.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/parallel/parallel-20160522.tar.bz2"
+  sha256 "de77430ae90db4ec3851cdfc95d842b9d1e7e28e46e8d40d49bd17def53c200f"
   head "http://git.savannah.gnu.org/r/parallel.git"
 
   bottle do


### PR DESCRIPTION
- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This build (2016522) fixes --workdir not working.

New version information available at: http://savannah.gnu.org/forum/forum.php?forum_id=8553
