### PR TITLE
docbook2x: remove pointless deps

### DIFF
--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -12,10 +12,6 @@ class Docbook2x < Formula
   end
 
   depends_on "docbook"
-  depends_on "XML::NamespaceSupport" => :perl
-  depends_on "XML::SAX" => :perl
-  depends_on "XML::Parser" => :perl
-  depends_on "XML::SAX::Expat" => :perl
 
   def install
     inreplace "perl/db2x_xsltproc.pl", "http://docbook2x.sf.net/latest/xslt", "#{share}/docbook2X/xslt"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

https://github.com/Homebrew/homebrew-core/commit/2bc2de81240f810b27acab3f20c82e00b5ff98ae was just about a valid commit at the time, but isn't really today. All of these Perl dependencies have shipped as part of Apple's Perl installation since at least Perl 5.10, which was added to OS X in 10.6 (Snow Leopard), and 10.6 is the oldest OS X release the core supports.

Linuxbrew or Tigerbrew may want to look into this more, but for >= 10.6 it's a completely misleading and never-invoked block.
