### PR TITLE
depqbf: fix typo in head url

### DIFF
--- a/Formula/depqbf.rb
+++ b/Formula/depqbf.rb
@@ -3,7 +3,7 @@ class Depqbf < Formula
   homepage "https://lonsing.github.io/depqbf/"
   url "https://github.com/lonsing/depqbf/archive/version-4.01.tar.gz"
   sha256 "0246022128890d24b926a9bd17a9d4aa89b179dc05a0fedee33fa282c0ceba5b"
-  head "https://github.com/lonsig/depqbf.git"
+  head "https://github.com/lonsing/depqbf.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
lonsing not lonsig
