### PR TITLE
doctl 1.2.0

### DIFF
--- a/Formula/doctl.rb
+++ b/Formula/doctl.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Doctl < Formula
   desc "Command-line tool for DigitalOcean"
   homepage "https://github.com/digitalocean/doctl"
-  url "https://github.com/digitalocean/doctl/archive/v1.1.0.tar.gz"
-  sha256 "4504965edfa8e32a1b65f890b3141f6bd16428640c7b4d365dcf76709633b68f"
+  url "https://github.com/digitalocean/doctl/archive/v1.2.0.tar.gz"
+  sha256 "2c39570b8f5f69283ac2889b6de532680f7164ad326cd028410a8152b75b3389"
   head "https://github.com/digitalocean/doctl.git"
 
   bottle do
@@ -21,7 +21,6 @@ class Doctl < Formula
 
     mkdir_p buildpath/"src/github.com/digitalocean/"
     ln_sf buildpath, buildpath/"src/github.com/digitalocean/doctl"
-    Language::Go.stage_deps resources, buildpath/"src"
 
     doctl_version = version.to_s.split(/\./)
     base_flag = "-X github.com/digitalocean/doctl"
@@ -36,6 +35,6 @@ class Doctl < Formula
   end
 
   test do
-    assert_match "doctl version #{version.to_s}-release", shell_output("#{bin}/doctl version")
+    assert_match "doctl version #{version}-release", shell_output("#{bin}/doctl version")
   end
 end


### PR DESCRIPTION
Also,
- fix audit error about redundant to_s inside interpolation
- fix warning about trying to stage empty resources array
