### PR TITLE
webkitgtk: revision for icu4c

### DIFF
--- a/Formula/webkitgtk.rb
+++ b/Formula/webkitgtk.rb
@@ -3,6 +3,7 @@ class Webkitgtk < Formula
   homepage "http://webkitgtk.org"
   url "http://webkitgtk.org/releases/webkitgtk-2.10.9.tar.xz"
   sha256 "bbb18d741780b1b7fa284beb9a97361ac57cda2e42bad2ae2fcdbf797919e969"
+  revision 1
 
   bottle do
     sha256 "34d4b523b20515fbbebcfc8371a184e58c6b311e0124880b166798f7213a713b" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Bottles (and existing installations) are broken, because WebKitGTK ends up linking to some ICU libraries that have since been updated to a newer version, resulting in broken linkage.

Closes #1701.
