### PR TITLE
qt5: add -separate-debug-info configure option

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -66,6 +66,8 @@ class Qt5 < Formula
       -verbose
       -prefix #{prefix}
       -release
+      -separate-debug-info
+      -force-debug-info
       -opensource -confirm-license
       -system-zlib
       -qt-libpng


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This generates .dSYM bundles for each Qt module and thus allows Qt
applications to be properly debugged with full stack traces and source
info.
