### PR TITLE
webp: avoid build issue with freeglut installed

### DIFF
--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -30,6 +30,7 @@ class Webp < Formula
 
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
+                          "--disable-gl",
                           "--enable-libwebpmux",
                           "--enable-libwebpdemux",
                           "--enable-libwebpdecoder",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This disables checking for OpenGL/GLUT and effectively results in the `vwebp` binary (a simple WebP viewer) not being built.

The problem being worked around by this is: If `freeglut` (from the `homebrew/x11` tap) is installed and was built without the `--universal` option but then `webp` is built with the `--universal` option (either directly or as a dependency of another formula), then it will find the GLUT headers and libraries provided by `freeglut` (instead of the `GLUT` framework in `/System/Library`) which appears to be fine during the
`./configure` run, but then causes failure during the build due to lacking architecture support.

Closes #1736.

cc @mistydemeo
