### PR TITLE
iso-codes 3.68

### DIFF
--- a/Formula/iso-codes.rb
+++ b/Formula/iso-codes.rb
@@ -1,10 +1,10 @@
 class IsoCodes < Formula
-  desc "ISO language, territory, currency, script codes, and their translations"
+  desc "Provides lists of various ISO standards"
   homepage "https://pkg-isocodes.alioth.debian.org/"
-  url "https://pkg-isocodes.alioth.debian.org/downloads/iso-codes-3.64.tar.xz"
-  sha256 "5ef061381e37e9576760df1ad504d4bbc84c270da30512b2891baed9add70729"
-
-  head "git://git.debian.org/git/iso-codes/iso-codes.git", :shallow => false
+  url "https://pkg-isocodes.alioth.debian.org/downloads/iso-codes-3.68.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iso-codes/iso-codes_3.68.orig.tar.xz"
+  sha256 "5881cf7caa5adfffb14ade99138949324c28a277babe8d07dafbff521acef9d1"
+  head "https://anonscm.debian.org/git/pkg-isocodes/iso-codes.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -14,9 +14,19 @@ class IsoCodes < Formula
   end
 
   depends_on "gettext" => :build
+  depends_on :python3
+  depends_on "pkg-config" => :run
 
   def install
     system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
     system "make", "install"
+  end
+
+  test do
+    pkg_config = Formula["pkg-config"].opt_bin/"pkg-config"
+    output = shell_output("#{pkg_config} --variable=domains iso-codes")
+    assert_match "iso_639-2 iso_639-3 iso_639-5 iso_3166-1", output
   end
 end


### PR DESCRIPTION
Also,
- fix audit error about the description length
- update the head url
- add :python3 requirement since python3 is now invoked by make
- run make check
- add run-time dependency on pkg-config
- add a test
