### PR TITLE
pulseaudio: fix dependency d-bus renamed to dbus

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -38,7 +38,7 @@ class Pulseaudio < Formula
   depends_on :x11 => :optional
   depends_on "glib" => :optional
   depends_on "gconf" => :optional
-  depends_on "d-bus" => :optional
+  depends_on "dbus" => :optional
   depends_on "gtk+3" => :optional
   depends_on "jack" => :optional
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online pulseaudio` returns:

```
pulseaudio:
  * Dependency 'd-bus' was renamed; use new name 'dbus'.
  * Dependency 'd-bus' was renamed; use new name 'dbus'.
Error: 2 problems in 1 formula
```
