### PR TITLE
goaccess 1.0.2

### DIFF
--- a/Formula/goaccess.rb
+++ b/Formula/goaccess.rb
@@ -1,8 +1,9 @@
 class Goaccess < Formula
   desc "Log analyzer and interactive viewer for the Apache Webserver"
   homepage "https://goaccess.io/"
-  url "http://tar.goaccess.io/goaccess-0.9.8.tar.gz"
-  sha256 "45bea0a2d87130f23869a26b103eb1b752a2b4a5b0f6f210cb6ffe8d7b2a18f1"
+  url "http://tar.goaccess.io/goaccess-1.0.2.tar.gz"
+  sha256 "58a83e201f29f0127b89032fbd40677558a643f6141b8c8413afd1e182f104f1"
+  head "https://github.com/allinurl/goaccess.git"
 
   bottle do
     sha256 "79c0c79415f5e634afd15c5208bab66eed2e36ad507ad104c508c0885b69c01d" => :el_capitan
@@ -10,26 +11,22 @@ class Goaccess < Formula
     sha256 "fd070338e95c84373b3a70559f35a6afcf89f908af1816235d4b1f6b4ccb5f48" => :mavericks
   end
 
-  head do
-    url "https://github.com/allinurl/goaccess.git"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
-
   option "with-geoip", "Enable IP location information using GeoIP"
 
   deprecated_option "enable-geoip" => "with-geoip"
 
-  depends_on "pkg-config" => :build
-  depends_on "glib"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "geoip" => :optional
 
   def install
-    system "autoreconf", "-vfi" if build.head?
+    system "autoreconf", "-vfi"
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
+      --enable-utf8
     ]
 
     args << "--enable-geoip" if build.with? "geoip"
@@ -47,6 +44,6 @@ class Goaccess < Formula
 
     output = shell_output("#{bin}/goaccess --time-format=%T --date-format=%d/%b/%Y --log-format='%h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"' -f access.log -o json 2>/dev/null")
 
-    assert_equal "Chrome", Utils::JSON.load(output)["browsers"][0]["data"]
+    assert_equal "Chrome", Utils::JSON.load(output)["browsers"]["data"][0]["data"]
   end
 end


### PR DESCRIPTION
- stable spec also needs Autotools now
- remove glib and pkg-config dependencies
- enable utf8 support
- update the test
