### PR TITLE
geckodriver 0.8.0, rename from wires

### DIFF
--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -1,4 +1,4 @@
-class Wires < Formula
+class Geckodriver < Formula
   desc "WebDriver <-> Marionette proxy"
   homepage "https://github.com/mozilla/geckodriver"
   url "https://github.com/mozilla/geckodriver/archive/v0.8.0.tar.gz"

--- a/Formula/wires.rb
+++ b/Formula/wires.rb
@@ -1,8 +1,8 @@
 class Wires < Formula
   desc "WebDriver <-> Marionette proxy"
-  homepage "https://github.com/jgraham/wires"
-  url "https://github.com/jgraham/wires/archive/v0.6.2.tar.gz"
-  sha256 "bbc73c1014dd218b424a82da6e656f638aa672fd0990229eff8c1a005166db07"
+  homepage "https://github.com/mozilla/geckodriver"
+  url "https://github.com/mozilla/geckodriver/archive/v0.8.0.tar.gz"
+  sha256 "a3b2cc5fd48622cdc811f952565ab235e5b64b5776e1f03c889a5c5c02367e1a"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,10 +15,11 @@ class Wires < Formula
 
   def install
     system "cargo", "build"
-    bin.install "target/debug/wires"
+    bin.install "target/debug/geckodriver"
+    bin.install_symlink bin/"geckodriver" => "wires"
   end
 
   test do
-    system "#{bin}/wires", "--help"
+    system "#{bin}/geckodriver", "--help"
   end
 end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -22,5 +22,6 @@
   "offline-imap": "offlineimap",
   "plt-racket": "racket",
   "polarssl": "mbedtls",
-  "screenbrightness": "brightness"
+  "screenbrightness": "brightness",
+  "wires": "geckodriver"
 }


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`wires` has been adopted by Mozilla and renamed `geckodriver`
