### PR TITLE
govendor 1.0.3 (new formula)

### DIFF
--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -1,0 +1,35 @@
+class Govendor < Formula
+  desc "Go vendor tool that works with the standard vendor file."
+  homepage "https://github.com/kardianos/govendor"
+  url "https://github.com/kardianos/govendor/archive/v1.0.3.tar.gz"
+  sha256 "7d7a032355ee4117822150db72a9db745d9a147a2e32972e58a65fe7545444f2"
+  head "https://github.com/kardianos/govendor.git"
+
+  depends_on "go"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GOOS"] = "darwin"
+    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+
+    (buildpath/"src/github.com/kardianos/").mkpath
+    ln_sf buildpath, buildpath/"src/github.com/kardianos/govendor"
+    system "go", "build", "-o", bin/"govendor"
+  end
+
+  test do
+    # Default HOMEBREW_TEMP is /tmp, which is actually a symlink to /private/tmp.
+    # `govendor` bails without `.realpath` as it expects $GOPATH to be "real" path.
+    ENV["GOPATH"] = testpath.realpath
+    commit = "89d9e62992539701a49a19c52ebb33e84cbbe80f"
+    (testpath/"src/github.com/project/testing").mkpath
+
+    cd "src/github.com/project/testing" do
+      system bin/"govendor", "init"
+      assert File.exist?("vendor"), "Failed to init!"
+      system bin/"govendor", "fetch", "-tree", "golang.org/x/crypto@#{commit}"
+      assert_match commit, File.read("vendor/vendor.json")
+      assert_match "golang.org/x/crypto/blowfish", shell_output("#{bin}/govendor list")
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

New formula for https://github.com/kardianos/govendor. Adding in the naive hope developers discover this formula & consider migrating their go projects over to the vendor system ❤️.

`gvt` by Filippo is a pretty solid alternative too, but doesn't do tagged releases.
