### PR TITLE
git: fix indentation/formatting in gitconfig

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -149,9 +149,9 @@ class Git < Formula
 
     # Set the OS X keychain credential helper by default
     # (as Apple's CLT's git also does this).
-    (buildpath/"gitconfig").write <<-EOS
+    (buildpath/"gitconfig").write <<-EOS.undent
       [credential]
-        helper = osxkeychain
+      \thelper = osxkeychain
     EOS
     etc.install "gitconfig"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Add the missing `undent` and replace what was supposed to be a tab stop character with `\t` for robustness (as many editors replace literal tab stops with spaces on save).

cc @MikeMcQuaid @DomT4

(This is a follow-up to #1597. The tab stop mentioned there seems to never have made it into the commit or was cleaned away by `brew pull --clean`. Normally would have committed directly to the repository, but this requires a new bottle to actually make it to our users.)
