### PR TITLE
sdl_image: fix graphical glitching

### DIFF
--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -3,7 +3,7 @@ class SdlImage < Formula
   homepage "https://www.libsdl.org/projects/SDL_image"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -12,6 +12,8 @@ class SdlImage < Formula
     sha256 "84272135304e7c475e8000a90af113127858273a4449ce6566805f5b4c2cb476" => :mavericks
   end
 
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "jpeg" => :recommended
@@ -19,7 +21,13 @@ class SdlImage < Formula
   depends_on "libtiff" => :recommended
   depends_on "webp" => :recommended
 
-  option :universal
+  # Fix graphical glitching
+  # https://github.com/Homebrew/homebrew-python/issues/281
+  # https://trac.macports.org/ticket/37453
+  patch :p0 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/sdl_image/IMG_ImageIO.m.patch"
+    sha256 "c43c5defe63b6f459325798e41fe3fdf0a2d32a6f4a57e76a056e752372d7b09"
+  end
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The current version of `sdl_image` has graphical problems on El Capitan and affects many applications including Homebrew/homebrew-python#281.

It was fixed in `sdl2_image`, but never back-ported. Here we borrow a patch from [MacPorts](https://trac.macports.org/ticket/37453).
#739 may fix the same issue by disabling ImageIO, but that was a solution for another similar issue on 10.5 according to [the discussion](https://trac.macports.org/ticket/38012). As I don't have an access to 10.5 for testing, I'll just leave it for now.
