### PR TITLE
bash-completion: improve description, clean up

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -1,7 +1,7 @@
 # NOTE: version 2.0 is out, but it requires Bash 4, and OS X ships
 # with 3.2.48. See homebrew-versions for a 2.0 formula.
 class BashCompletion < Formula
-  desc "Programmable bash completion"
+  desc "Programmable completion for Bash 3.2"
   homepage "https://bash-completion.alioth.debian.org/"
   url "https://bash-completion.alioth.debian.org/files/bash-completion-1.3.tar.bz2"
   mirror "http://pkgs.fedoraproject.org/repo/pkgs/bash-completion/bash-completion-1.3.tar.bz2/a1262659b4bbf44dc9e59d034de505ec/bash-completion-1.3.tar.bz2"
@@ -18,10 +18,9 @@ class BashCompletion < Formula
   # Backports the following upstream patch from 2.x:
   # https://anonscm.debian.org/gitweb/?p=bash-completion/bash-completion.git;a=commitdiff_plain;h=50ae57927365a16c830899cc1714be73237bdcb2
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740971
-  patch :DATA
-
-  def compdir
-    etc/"bash_completion.d"
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c1d87451da3b5b147bed95b2dc783a1b02520ac5/bash-completion/bug-740971.patch"
+    sha256 "bd242a35b8664c340add068bcfac74eada41ed26d52dc0f1b39eebe591c2ea97"
   end
 
   def install
@@ -39,9 +38,6 @@ class BashCompletion < Formula
       if [ -f $(brew --prefix)/etc/bash_completion ]; then
         . $(brew --prefix)/etc/bash_completion
       fi
-
-    Homebrew's own bash completion script has been installed to
-      #{compdir}
     EOS
   end
 
@@ -49,27 +45,3 @@ class BashCompletion < Formula
     system "bash", "-c", ". #{etc}/profile.d/bash_completion.sh"
   end
 end
-
-__END__
-diff --git a/bash_completion b/bash_completion
-index 6601937..5184767 100644
---- a/bash_completion
-+++ b/bash_completion
-@@ -640,7 +640,7 @@
-
-     _quote_readline_by_ref "$cur" quoted
-     toks=( ${toks[@]-} $(
--        compgen -d -- "$quoted" | {
-+        compgen -d -- "$cur" | {
-             while read -r tmp; do
-                 # TODO: I have removed a "[ -n $tmp ] &&" before 'printf ..',
-                 #       and everything works again. If this bug suddenly
-@@ -1334,7 +1334,7 @@ _known_hosts_real()
- 
-     # append any available aliases from config files
-     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
--        local hosts=$( sed -ne 's/^[ \t]*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['"$'\t '"']\{1,\}\([^#*?]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
-+        local hosts=$( sed -ne 's/^[[:blank:]]*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}[[:blank:]]\{1,\}\([^#*?]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
-         COMPREPLY=( "${COMPREPLY[@]}" $( compgen  -P "$prefix$user" \
-             -S "$suffix" -W "$hosts" -- "$cur" ) )
-     fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Migrate inline patch to `formula-patches` repository, remove `compdir` method (referenced also in `homebrew/versions/bash-completion2`), and adapt caveats (don't claim something it actually didn't do).

This should only be merged once Homebrew/homebrew-versions#1286 is done and committed.
