### PR TITLE
dante: remove ftp mirror

### DIFF
--- a/Formula/dante.rb
+++ b/Formula/dante.rb
@@ -3,7 +3,6 @@ class Dante < Formula
   homepage "https://www.inet.no/dante/"
   url "https://www.inet.no/dante/files/dante-1.4.1.tar.gz"
   mirror "http://www.inet.no/dante/files/dante-1.4.1.tar.gz"
-  mirror "ftp://ftp.inet.no/pub/socks/dante-1.4.1.tar.gz"
   sha256 "b6d232bd6fefc87d14bf97e447e4fcdeef4b28b16b048d804b50b48f261c4f53"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

It's probably safe now, that it has an HTTP mirror.
