### PR TITLE
wolfssl: work around build issue, enable Java JNI support

### DIFF
--- a/Formula/wolfssl.rb
+++ b/Formula/wolfssl.rb
@@ -21,6 +21,10 @@ class Wolfssl < Formula
   depends_on "libtool" => :build
 
   def install
+    # https://github.com/Homebrew/homebrew-core/pull/1046
+    # https://github.com/Homebrew/brew/pull/251
+    ENV.delete("SDKROOT")
+
     args = %W[
       --disable-silent-rules
       --disable-dependency-tracking

--- a/Formula/wolfssl.rb
+++ b/Formula/wolfssl.rb
@@ -59,6 +59,7 @@ class Wolfssl < Formula
       --enable-hkdf
       --enable-inline
       --enable-ipv6
+      --enable-jni
       --enable-keygen
       --enable-ocsp
       --enable-opensslextra


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This combines a fix for the SDK-related build issues with the changes proposed in #1859.
