### PR TITLE
chromedriver: fix plist_options to not include `startup:` key

### DIFF
--- a/Formula/chromedriver.rb
+++ b/Formula/chromedriver.rb
@@ -11,7 +11,7 @@ class Chromedriver < Formula
     bin.install "chromedriver"
   end
 
-  plist_options :startup => "true", :manual => "chromedriver"
+  plist_options :manual => "chromedriver"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This is a followup to https://github.com/Homebrew/homebrew-core/pull/1817/files/383fd5d601e9de88d5f8fec1358c9db0b3743239#r66720150 after the discussion there about the `plist_option` values.
