### PR TITLE
godep 74

### DIFF
--- a/Formula/godep.rb
+++ b/Formula/godep.rb
@@ -1,8 +1,8 @@
 class Godep < Formula
   desc "Dependency tool for go"
   homepage "https://godoc.org/github.com/tools/godep"
-  url "https://github.com/tools/godep/archive/v73.tar.gz"
-  sha256 "c2a2b37c20620d19cf341c479442067434049171e9cc3e226cdddde34aa6b3d9"
+  url "https://github.com/tools/godep/archive/v74.tar.gz"
+  sha256 "e68c7766c06c59327a4189fb929d390e1cc7a0c4910e33cada54cf40f40ca546"
   head "https://github.com/tools/godep.git"
 
   bottle do
@@ -16,24 +16,21 @@ class Godep < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    mkdir_p buildpath/"src/github.com/tools/"
-    ln_sf buildpath, buildpath/"src/github.com/tools/godep"
-
-    cd "src/github.com/tools/godep" do
-      system "go", "build", "-o", bin/"godep"
-    end
+    (buildpath/"src/github.com/tools/godep").install buildpath.children
+    cd("src/github.com/tools/godep") { system "go", "build", "-o", bin/"godep" }
   end
 
   test do
     ENV["GO15VENDOREXPERIMENT"] = "0"
-    mkdir "Godeps"
-    (testpath/"Godeps/Godeps.json").write <<-EOS.undent
+    ENV["GOPATH"] = testpath.realpath
+    (testpath/"Godeps.json").write <<-EOS.undent
       {
         "ImportPath": "github.com/tools/godep",
         "GoVersion": "go1.6",
         "Deps": []
       }
     EOS
-    system bin/"godep", "path"
+    (testpath/"src/foo/bar/Godeps").install "Godeps.json"
+    cd("src/foo/bar") { system bin/"godep", "path" }
   end
 end


### PR DESCRIPTION
Also,
- due to upstream changes, `go build` needs to be executed from a path
  containing "src/github.com/tools/godep" or it will fail
- change the test so that it doesn't cause warnings

Closes #1665.
