### PR TITLE
convox 20160606232025 (new formula)

### DIFF
--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -1,0 +1,15 @@
+class Convox < Formula
+  desc "The convox AWS PaaS CLI tool"
+  homepage "https://convox.com/"
+  url "https://bin.equinox.io/a/9RUvivxx6Lm/convox-20160606232025-darwin-amd64.tar.gz"
+  version "20160606232025"
+  sha256 "ad9c6cee12b8b34096ee7ce85cd980a5b1784cc05e02df8e1be1ef3ce86a684d"
+
+  def install
+    bin.install "convox"
+  end
+
+  test do
+    system "#{bin}/convox"
+  end
+end

--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -1,12 +1,16 @@
 class Convox < Formula
   desc "The convox AWS PaaS CLI tool"
   homepage "https://convox.com/"
-  url "https://bin.equinox.io/a/9RUvivxx6Lm/convox-20160606232025-darwin-amd64.tar.gz"
-  version "20160606232025"
-  sha256 "ad9c6cee12b8b34096ee7ce85cd980a5b1784cc05e02df8e1be1ef3ce86a684d"
+  url "https://github.com/convox/rack/archive/20160615213630.tar.gz"
+  version "20160615213630"
+  sha256 "f09b6adda368d67efa87b097299d9cdae1852d1a0c255f6740ff990f0064d937"
+
+  depends_on "go" => :build
 
   def install
-    bin.install "convox"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/convox/rack").install Dir["*"]
+    system "go", "build", "-o", "#{bin}/convox", "-v", "github.com/convox/rack/cmd/convox"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Question: Is there a better way to deal with versioning / shas for this formula? The convox CLI is updated quite regularly.

The download site is linked from the docs here: https://convox.com/docs/getting-started/

> You can [download the CLI package](https://dl.equinox.io/convox/convox/stable) or install it via the command line

Fixes https://github.com/convox/rack/issues/603.
