### PR TITLE
qt5: Add PostgreSQL plugin support

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -57,6 +57,7 @@ class Qt5 < Formula
 
   depends_on "dbus" => :optional
   depends_on :mysql => :optional
+  depends_on :postgresql => :optional
   depends_on :xcode => :build
 
   depends_on OracleHomeVarRequirement if build.with? "oci"
@@ -79,6 +80,7 @@ class Qt5 < Formula
     args << "-nomake" << "examples" if build.without? "examples"
 
     args << "-plugin-sql-mysql" if build.with? "mysql"
+    args << "-plugin-sql-psql" if build.with? "postgresql"
 
     if build.with? "dbus"
       dbus_opt = Formula["dbus"].opt_prefix


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The audit process gives an error about the MySQL plugin being linked against system OpenSSL, but that is unrelated to this patch, and should probably be fixed with another pull request.
