### PR TITLE
platformio 2.10.3

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -1,8 +1,8 @@
 class Platformio < Formula
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/7c/f1/77b52434c0407b28111220925726f2b84d550023d0b9366b998fa8d0d91c/platformio-2.10.1.tar.gz"
-  sha256 "52ecc66826f5b146731ea3c032343748d8d21c785ec01a93484c7c3708b09643"
+  url "https://pypi.python.org/packages/b7/a3/1d3a9d7bae91df1b607e0f31549ec3e0006f29484cc6a1431b3fe3c5b02e/platformio-2.10.3.tar.gz"
+  sha256 "f3a646871f9baed05f336a32576edaab90abf0737d8adb54f2acb7bcad42a65f"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
## 2.10.3 (2016-06-15)
- Added support for ST Nucleo L031K6 board to ARM mbed framework
- Process `build_unflags` option for ARM mbed framework
- Updated Intel ARC32 Arduino framework to v1.0.6
  ([issue #695](https://github.com/platformio/platformio/issues/695))
- Improved a check of program size before uploading to the board
- Fixed issue with ARM mbed framework `-u _printf_float` and
  `-u _scanf_float` when parsing `$LINKFLAGS`
- Fixed issue with ARM mbed framework and extra includes for the custom boards,
  such as Seeeduino Arch Pro
