### PR TITLE
vim: Add option to build Vim with 24-bit color support

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -15,6 +15,7 @@ class Vim < Formula
   option "with-override-system-vi", "Override system vi"
   option "without-nls", "Build vim without National Language Support (translated messages, keymaps)"
   option "with-client-server", "Enable client/server mode"
+  option "with-termguicolors", "Enable 24-bit color (requires a ISO-8613-3 compatible terminal)"
 
   LANGUAGES_OPTIONAL = %w[lua mzscheme python3 tcl]
   LANGUAGES_DEFAULT  = %w[perl python ruby]
@@ -81,6 +82,7 @@ class Vim < Formula
 
     opts << "--disable-nls" if build.without? "nls"
     opts << "--enable-gui=no"
+    opts << "--enable-termguicolors" if build.with? "termguicolors"
 
     if build.with? "client-server"
       opts << "--with-x"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Vim supports true color on the terminal since [patch 7.4.1770](https://github.com/vim/vim/commit/8a633e3427b47286869aa4b96f2bfc1fe65b25cd). Later, the option was renamed to `termguicolors` in [patch 7.4.1799](https://github.com/vim/vim/commit/61be73bb0f965a895bfb064ea3e55476ac175162).

This commit adds an option to build Vim with 24-bit color support.
