### PR TITLE
ghc: fix build on 10.12

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -48,6 +48,13 @@ class Ghc < Formula
     sha256 "bc57163656ece462ef61072559d491b72c5cdd694f3c39b80ac0f6b9a3dc8151"
   end
 
+  # fix clock_gettime support on 10.12
+  # https://ghc.haskell.org/trac/ghc/ticket/12195
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/9eef46168ca5daa1629082af5532fc4b521d1a8d/ghc/clock_gettime.patch"
+    sha256 "42444b381840d9d90202ff619f0070c28a753243af5d7e6b60efd227c6cf308c"
+  end
+
   def install
     # Setting -march=native, which is what --build-from-source does, fails
     # on Skylake (and possibly other architectures as well) with the error


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Fixes an issue with building GHC on 10.12 because of the `clock_gettime` function. See #1957.
