### PR TITLE
wxmac 3.1.0

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,23 +1,9 @@
 class Wxmac < Formula
   desc "wxWidgets, a cross-platform C++ GUI toolkit (for OS X)"
   homepage "https://www.wxwidgets.org"
-  revision 2
-
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
+  sha256 "e082460fb6bf14b7dd6e8ac142598d1d3d0b08a7b5ba402fdbf8711da7e66da8"
   head "https://github.com/wxWidgets/wxWidgets.git"
-
-  stable do
-    url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.2/wxWidgets-3.0.2.tar.bz2"
-    sha256 "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d"
-
-    # Various fixes related to Yosemite. Revisit in next stable release.
-    # Please keep an eye on http://trac.wxwidgets.org/ticket/16329 as well
-    # Theoretically the above linked patch should still be needed, but it isn't. Try to find out why.
-    patch :DATA
-
-    # Fails to find QuickTime headers; fixed in 3.1.0 and newer.
-    # https://github.com/Homebrew/homebrew-core/issues/1957
-    depends_on MaximumMacOSRequirement => :el_capitan
-  end
 
   bottle do
     cellar :any
@@ -26,27 +12,22 @@ class Wxmac < Formula
     sha256 "9b137f0338358bdce6afc21e94226a09aa32432563a95173f6f050709e5c8f37" => :mavericks
   end
 
-  devel do
-    url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
-    sha256 "e082460fb6bf14b7dd6e8ac142598d1d3d0b08a7b5ba402fdbf8711da7e66da8"
+  # Fix Issue: Creating wxComboCtrl without wxTE_PROCESS_ENTER style results in an assert.
+  patch do
+    url "https://github.com/wxWidgets/wxWidgets/commit/cee3188c1abaa5b222c57b87cc94064e56921db8.patch"
+    sha256 "c6503ba36a166c031426be4554b033bae5b0d9da6fabd33c10ffbcb8672a0c2d"
+  end
 
-    # Fix Issue: Creating wxComboCtrl without wxTE_PROCESS_ENTER style results in an assert.
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/cee3188c1abaa5b222c57b87cc94064e56921db8.patch"
-      sha256 "c6503ba36a166c031426be4554b033bae5b0d9da6fabd33c10ffbcb8672a0c2d"
-    end
+  # Fix Issue: Building under OS X in C++11 mode for i386 architecture (but not amd64) results in an error about narrowing conversion.
+  patch do
+    url "https://github.com/wxWidgets/wxWidgets/commit/ee486dba32d02c744ae4007940f41a5b24b8c574.patch"
+    sha256 "88ef4c5ec0422d00ae01aff18143216d1e20608f37090be7f18e924c631ab678"
+  end
 
-    # Fix Issue: Building under OS X in C++11 mode for i386 architecture (but not amd64) results in an error about narrowing conversion.
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/ee486dba32d02c744ae4007940f41a5b24b8c574.patch"
-      sha256 "88ef4c5ec0422d00ae01aff18143216d1e20608f37090be7f18e924c631ab678"
-    end
-
-    # Fix Issue: Building under OS X in C++11 results in several -Winconsistent-missing-override warnings.
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/173ecd77c4280e48541c33bdfe499985852935ba.patch"
-      sha256 "018fdb6abda38f5d017cffae5925fa4ae8afa9c84912c61e0afd26cd4f7b5473"
-    end
+  # Fix Issue: Building under OS X in C++11 results in several -Winconsistent-missing-override warnings.
+  patch do
+    url "https://github.com/wxWidgets/wxWidgets/commit/173ecd77c4280e48541c33bdfe499985852935ba.patch"
+    sha256 "018fdb6abda38f5d017cffae5925fa4ae8afa9c84912c61e0afd26cd4f7b5473"
   end
 
   option :universal
@@ -120,65 +101,3 @@ class Wxmac < Formula
     system bin/"wx-config", "--libs"
   end
 end
-
-__END__
-
-diff --git a/include/wx/defs.h b/include/wx/defs.h
-index 397ddd7..d128083 100644
---- a/include/wx/defs.h
-+++ b/include/wx/defs.h
-@@ -3169,12 +3169,20 @@ DECLARE_WXCOCOA_OBJC_CLASS(UIImage);
- DECLARE_WXCOCOA_OBJC_CLASS(UIEvent);
- DECLARE_WXCOCOA_OBJC_CLASS(NSSet);
- DECLARE_WXCOCOA_OBJC_CLASS(EAGLContext);
-+DECLARE_WXCOCOA_OBJC_CLASS(UIWebView);
- 
- typedef WX_UIWindow WXWindow;
- typedef WX_UIView WXWidget;
- typedef WX_EAGLContext WXGLContext;
- typedef WX_NSString* WXGLPixelFormat;
- 
-+typedef WX_UIWebView OSXWebViewPtr;
-+
-+#endif
-+
-+#if wxOSX_USE_COCOA_OR_CARBON
-+DECLARE_WXCOCOA_OBJC_CLASS(WebView);
-+typedef WX_WebView OSXWebViewPtr;
- #endif
- 
- #endif /* __WXMAC__ */
-diff --git a/include/wx/html/webkit.h b/include/wx/html/webkit.h
-index 8700367..f805099 100644
---- a/include/wx/html/webkit.h
-+++ b/include/wx/html/webkit.h
-@@ -18,7 +18,6 @@
- #endif
- 
- #include "wx/control.h"
--DECLARE_WXCOCOA_OBJC_CLASS(WebView); 
- 
- // ----------------------------------------------------------------------------
- // Web Kit Control
-@@ -107,7 +106,7 @@ private:
-     wxString m_currentURL;
-     wxString m_pageTitle;
- 
--    WX_WebView m_webView;
-+    OSXWebViewPtr m_webView;
- 
-     // we may use this later to setup our own mouse events,
-     // so leave it in for now.
-diff --git a/include/wx/osx/webview_webkit.h b/include/wx/osx/webview_webkit.h
-index 803f8b0..438e532 100644
---- a/include/wx/osx/webview_webkit.h
-+++ b/include/wx/osx/webview_webkit.h
-@@ -158,7 +158,7 @@ private:
-     wxWindowID m_windowID;
-     wxString m_pageTitle;
- 
--    wxObjCID m_webView;
-+    OSXWebViewPtr m_webView;
- 
-     // we may use this later to setup our own mouse events,
-     // so leave it in for now.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

According to [this](https://github.com/wxWidgets/wxWidgets/releases/tag/v3.1.0) wxmac released 3.1.0 officially back in February. Moving 3.1.0 to stable also fixes any build issues with formula like erlang...

Let me know if there was a reason to keep the outdated wxmac version....
