### PR TITLE
clamav: make pcre recommended

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -3,6 +3,7 @@ class Clamav < Formula
   homepage "https://www.clamav.net/"
   url "https://www.clamav.net/downloads/production/clamav-0.99.2.tar.gz"
   sha256 "167bd6a13e05ece326b968fdb539b05c2ffcfef6018a274a10aeda85c2c0027a"
+  revision 1
 
   bottle do
     sha256 "057465d3af56d272c79cb46fafad7d73846cc94af383b73ff91413d8f4ff7039" => :el_capitan
@@ -20,9 +21,9 @@ class Clamav < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
+  depends_on "pcre" => :recommended
   depends_on "yara" => :optional
   depends_on "json-c" => :optional
-  depends_on "pcre" => :optional
 
   skip_clean "share/clamav"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

It's actually pretty important at runtime & `clamav` will throw irritating warnings that it's missing at every opportunity without it. Ref: https://github.com/Homebrew/homebrew-core/issues/1900

Since `pcre` is already an epidemic in Homebrew, spreading it a little further probably won't catch many additional users.
