### PR TITLE
macvim: permit non-system ruby/perl

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -25,7 +25,7 @@ class Macvim < Formula
   # Help us! We'd like to use superenv in these environments, too
   env :std if MacOS.version <= :snow_leopard
 
-  def language_type language
+  def language_type(language)
     type = if which(language).to_s == "/usr/bin/#{language}"
       "system"
     elsif which(language).to_s == "#{HOMEBREW_PREFIX}/opt/#{language}/bin/#{language}"

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -18,6 +18,7 @@ class Macvim < Formula
   depends_on "cscope" => :recommended
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
+  depends_on :perl => "5.6"
   depends_on :python => :recommended
   depends_on :python3 => :optional
 

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -18,6 +18,7 @@ class Macvim < Formula
   depends_on "cscope" => :recommended
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
+  depends_on :ruby => "1.6"
   depends_on :perl => "5.6"
   depends_on :python => :recommended
   depends_on :python3 => :optional


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

CC @MikeMcQuaid - This should ensure your changes the other day here are representative to what most users can actually obtain (i.e. prior to this PR there's no automatic way for any user running >10.6 to use a custom Ruby/Perl here).
