### PR TITLE
mpv: remove --enable-gpl3

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -61,7 +61,8 @@ class Mpv < Formula
     end
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
-    args = ["--prefix=#{prefix}", "--enable-gpl3", "--enable-zsh-comp"]
+    args = ["--prefix=#{prefix}", "--enable-zsh-comp"]
+    args << "--enable-gpl3" if build.stable?
     args << "--enable-libmpv-shared" if build.with? "shared"
 
     waf = resource("waf")


### PR DESCRIPTION
The option, enabled by default, was removed in git master and it causes the HEAD build to fail.
