### PR TITLE
melt v6.2.0, + bugfix

### DIFF
--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -1,9 +1,8 @@
 class Mlt < Formula
   desc "Author, manage, and run multitrack audio/video compositions"
   homepage "https://www.mltframework.org/"
-  url "https://github.com/mltframework/mlt/archive/v6.0.0.tar.gz"
-  sha256 "34f0cb60eb2e7400e9964de5ee439851b3e51a942206cccc2961fd41b42ee5d2"
-  revision 1
+  url "https://github.com/mltframework/mlt/archive/v6.2.0.tar.gz"
+  sha256 "dd2ee742e89620de78a259790f92a7cadad67f0e0a6c1ea7ed932f96fb739fff"
 
   bottle do
     sha256 "b12a98b91f51fa92d9b170556a1e622bba20a65734ba12eaefb79ed52a0357bd" => :el_capitan
@@ -25,7 +24,8 @@ class Mlt < Formula
     args = ["--prefix=#{prefix}",
             "--disable-jackrack",
             "--disable-swfdec",
-            "--disable-gtk"]
+            "--disable-gtk",
+            "--enable-gpl"]
 
     system "./configure", *args
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This branch:
- updates to the latest [melt](https://www.mltframework.org)  source.
- adds a new configure flag (`--enable-gpl`) [recommended by the melt authors](https://www.mltframework.org/bin/view/MLT/BuildTips), which resolves a bug which would cause all `melt` CLI commands to return with:
  
  ```
  melt(51153,0x7fff7b8d8000) malloc: *** error for object 0x7f833c06ac00: pointer being freed was not allocated
  *** set a breakpoint in malloc_error_break to debug
  ```
- removes the `revision` parameter, which was recommended by `brew audit mlt`
