### PR TITLE
snort: fix chmod suggestion for /dev/bpf* files

### DIFF
--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -60,7 +60,7 @@ class Snort < Formula
   def caveats; <<-EOS.undent
     For snort to be functional, you need to update the permissions for /dev/bpf*
     so that they can be read by non-root users.  This can be done manually using:
-        sudo chmod 644 /dev/bpf*
+        sudo chmod o+r /dev/bpf*
     or you could create a startup item to do this for you.
     EOS
   end


### PR DESCRIPTION
- [ v] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ v] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ v] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ v] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Fix in "caveats" - suggest changing permissions only for `other` user, do not alter `owner` and `group` permissions.
