### PR TITLE
qt5:  Add missing install targets to Mac QtBase widget examples.  

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -39,6 +39,18 @@ class Qt5 < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
 
+  # Fix for a build error involving missing Mac QtBase widget example targets
+  # detected by the logic introduced in <https://codereview.qt-project.org/#/c/156610/1>,
+  # possibly affecting Poppler, et. al..
+  #
+  # https://codereview.qt-project.org/#/c/161001/
+  #
+  # Should land in either v5.6.2 and/or v5.7.1.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6ffd0e250d374193613a51beda8830dda9b67e56/qt5/QTBUG-54110.patch"
+    sha256 "2cf77b820f46f0c404284882b4a4a97bf005b680062842cdc53e107a821deeda"
+  end
+
   keg_only "Qt 5 conflicts Qt 4 (which is currently much more widely used)."
 
   option "with-docs", "Build documentation"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?  
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?  
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?  
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?  

---

Otherwise, building from source with the `--with-examples` option set fails.  

Closes #1948.  

<hr />

NOTE:  In regard to whether or not I've attempted to build Qt v5.x after making my changes to its formula, I actually _have_ done that.  I did _not_, however, check the relevant checkbox because the build in question _did not succeed_ (it failed while attempting to apply the patch that this pull request introduces.)  I did not collect any build logs the first time around, but I can produce some with another installation attempt if requested.  
