### PR TITLE
urweb 20160621 (migrate from boneyard)

### DIFF
--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -1,0 +1,28 @@
+class Urweb < Formula
+  desc "Ur/Web programming language"
+  homepage "http://www.impredicative.com/ur/"
+  url "http://www.impredicative.com/ur/urweb-20160515.tgz"
+  sha256 "58c5cc0e96f0c311de468b4475e4bf595e6de5c04095136eed4148545e70442f"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "openssl"
+  depends_on "mlton" => :build
+  depends_on :postgresql => :optional
+  depends_on :mysql => :optional
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--with-openssl=/usr/local/opt/openssl",
+                          "--prefix=#{prefix}"
+
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/urweb"
+  end
+end

--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -7,8 +7,9 @@ class Urweb < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
   depends_on "mlton" => :build
+  depends_on "openssl"
+  depends_on "gmp"
   depends_on :postgresql => :optional
   depends_on :mysql => :optional
 

--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -13,12 +13,16 @@ class Urweb < Formula
   depends_on :mysql => :optional
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--with-openssl=/usr/local/opt/openssl",
-                          "--prefix=#{prefix}"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --prefix=#{prefix}
+      SITELISP=$prefix/share/emacs/site-lisp/urweb
+    ]
 
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -1,8 +1,8 @@
 class Urweb < Formula
   desc "Ur/Web programming language"
   homepage "http://www.impredicative.com/ur/"
-  url "http://www.impredicative.com/ur/urweb-20160515.tgz"
-  sha256 "58c5cc0e96f0c311de468b4475e4bf595e6de5c04095136eed4148545e70442f"
+  url "http://www.impredicative.com/ur/urweb-20160621.tgz"
+  sha256 "c5e487b11d44ab9945c04c305e644215282a60fcb2776d4939d79748a1497522"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -251,7 +251,6 @@
   "uim": "homebrew/x11",
   "ume": "homebrew/games",
   "upnp-router-control": "homebrew/gui",
-  "urweb": "homebrew/boneyard",
   "ushare": "homebrew/boneyard",
   "validns": "homebrew/boneyard",
   "viewglob": "homebrew/boneyard",


### PR DESCRIPTION
urweb.rb was moved to the boneyard because it used old binary-only mlton
formula (see Homebrew/legacy-homebrew#21780).

A new mlton formula was already merged (Homebrew/legacy-homebrew#48694)
and the urweb formula is now updated as well.
