### PR TITLE
rakudo-star: add alias from perl6 to rakudo-star

### DIFF
--- a/Aliases/perl6
+++ b/Aliases/perl6
@@ -1,0 +1,1 @@
+../Formula/rakudo-star.rb


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This commit:
- Aliases `perl6` to `rakudo-star`

Because:
- `rakudo-star` actually installs a binary named `perl6`
- Users looking for Perl 6 support may run `brew search perl`
  and assume it would actually find something with perl6 support.

Note: http://rakudo.org/2016/04/25/announce-rakudo-star-release-2016-04/

> “In the Perl 6 world, we make a distinction between the language (“Perl 6″)
> and specific implementations of the language such as “Rakudo Perl”.

However, http://perl6.org recommends loading Rakudo Star to get started
with Perl6.

I don’t pretend to understand the full implications of the above statement.
I assume this alias could be replaced with something else if need be
in the future.
