### PR TITLE
audit fixes for formulae with available upgrades

### DIFF
--- a/Formula/lcdproc.rb
+++ b/Formula/lcdproc.rb
@@ -24,4 +24,8 @@ class Lcdproc < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lcdproc -v 2>&1")
+  end
 end

--- a/Formula/leafnode.rb
+++ b/Formula/leafnode.rb
@@ -1,6 +1,6 @@
 class Leafnode < Formula
-  desc "Leafnode is a store and forward NNTP proxy"
-  homepage "https://sourceforge.net/projects/leafnode/"
+  desc "NNTP server for small sites"
+  homepage "http://www.leafnode.org/"
   url "https://downloads.sourceforge.net/project/leafnode/leafnode/1.11.10/leafnode-1.11.10.tar.bz2"
   sha256 "d75ba79961a8900b273eb74c3ad6976bf9fd64c2fa0284273e65f98190c5f2bc"
 

--- a/Formula/libfreenect.rb
+++ b/Formula/libfreenect.rb
@@ -34,4 +34,8 @@ class Libfreenect < Formula
       system "make", "install"
     end
   end
+
+  test do
+    system bin/"fakenect-record", "-h"
+  end
 end

--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -27,5 +27,15 @@ class Libmicrohttpd < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
+    pkgshare.install "doc/examples"
+  end
+
+  test do
+    cp pkgshare/"examples/simplepost.c", testpath
+    inreplace "simplepost.c",
+      "return 0",
+      "printf(\"daemon %p\", daemon) ; return 0"
+    system ENV.cc, "-o", "foo", "simplepost.c", "-I#{include}", "-L#{lib}", "-lmicrohttpd"
+    assert_match /daemon 0x[0-9a-f]+[1-9a-f]+/, pipe_output("./foo")
   end
 end

--- a/Formula/libmtp.rb
+++ b/Formula/libmtp.rb
@@ -20,4 +20,8 @@ class Libmtp < Formula
                           "--disable-mtpz"
     system "make", "install"
   end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mtp-getfile")
+  end
 end

--- a/Formula/libofx.rb
+++ b/Formula/libofx.rb
@@ -19,4 +19,8 @@ class Libofx < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
   end
+
+  test do
+    assert_equal "ofxdump #{version}", shell_output("ofxdump -V").chomp
+  end
 end

--- a/Formula/mpop.rb
+++ b/Formula/mpop.rb
@@ -18,4 +18,8 @@ class Mpop < Formula
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mpop --version")
+  end
 end

--- a/Formula/poco.rb
+++ b/Formula/poco.rb
@@ -38,4 +38,8 @@ class Poco < Formula
       system "make", "install"
     end
   end
+
+  test do
+    system bin/"cpspc", "-h"
+  end
 end

--- a/Formula/scalariform.rb
+++ b/Formula/scalariform.rb
@@ -4,12 +4,12 @@ class Scalariform < Formula
   url "https://github.com/daniel-trinh/scalariform/releases/download/0.1.6/scalariform.jar"
   sha256 "346276c5f3a25a44d64ed38f43739813933487299a651f7c64db748427641c54"
 
-  bottle :unneeded
-
   head do
     url "https://github.com/daniel-trinh/scalariform.git"
     depends_on "sbt" => :build
   end
+
+  bottle :unneeded
 
   def install
     if build.head?

--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -40,6 +40,30 @@ class ShadowsocksLibev < Formula
     man1.install Dir["man/*.1"]
   end
 
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/ss-local</string>
+          <string>-c</string>
+          <string>#{etc}/shadowsocks-libev.json</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+      </dict>
+    </plist>
+    EOS
+  end
+
   test do
     (testpath/"shadowsocks-libev.json").write <<-EOS.undent
       {
@@ -63,29 +87,5 @@ class ShadowsocksLibev < Formula
       Process.kill 9, client
       Process.wait client
     end
-  end
-
-  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json"
-
-  def plist; <<-EOS.undent
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/ss-local</string>
-          <string>-c</string>
-          <string>#{etc}/shadowsocks-libev.json</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-      </dict>
-    </plist>
-    EOS
   end
 end

--- a/Formula/viennacl.rb
+++ b/Formula/viennacl.rb
@@ -1,5 +1,5 @@
 class Viennacl < Formula
-  desc "ViennaCL is a linear algebra library leveraging parallel computation."
+  desc "Linear algebra library for many-core architectures and multi-core CPUs"
   homepage "http://viennacl.sourceforge.net"
   url "https://downloads.sourceforge.net/project/viennacl/1.7.x/ViennaCL-1.7.0.tar.gz"
   sha256 "0dd062770f8cf92309b2473d5defc7a6b4c874170e350e6a7ad0f4c791c49eff"


### PR DESCRIPTION
Note that the libmicrohttpd commit was moved to https://github.com/Homebrew/homebrew-core/pull/2230.
