### PR TITLE
various: transition formulae over to `gpg2` default.

### DIFF
--- a/Formula/blackbox.rb
+++ b/Formula/blackbox.rb
@@ -3,18 +3,22 @@ class Blackbox < Formula
   homepage "https://github.com/StackExchange/blackbox"
   url "https://github.com/StackExchange/blackbox/archive/v1.20160122.tar.gz"
   sha256 "ac5de1d74fdbe88604b34949f3949e53cb72e55e148e46b8c2be98806c888a10"
+  revision 1
 
   bottle :unneeded
 
-  depends_on :gpg
+  depends_on :gpg => :run
 
   def install
+    # Prefer GPG2 by default.
+    inreplace "bin/_blackbox_common.sh", ":=gpg", ":=gpg2"
+
     libexec.install Dir["bin/*"]
     bin.write_exec_script Dir[libexec/"*"].select { |f| File.executable? f }
   end
 
   test do
     system "git", "init"
-    system "#{bin}/blackbox_initialize", "yes"
+    system bin/"blackbox_initialize", "yes"
   end
 end

--- a/Formula/blackbox.rb
+++ b/Formula/blackbox.rb
@@ -18,7 +18,24 @@ class Blackbox < Formula
   end
 
   test do
+    # Note that test do is always in temporary path, with HOME captured,
+    # so this doesn't interfere with a user's pre-existing keychain.
+    (testpath/"batchgpg").write <<-EOS.undent
+    Key-Type: RSA
+    Key-Length: 2048
+    Subkey-Type: RSA
+    Subkey-Length: 2048
+    Name-Real: Testing
+    Name-Email: testing@foo.bar
+    Expire-Date: 1d
+    Passphrase: brew
+    %commit
+    EOS
+    system "gpg2", "--batch", "--gen-key", "batchgpg"
+
     system "git", "init"
     system bin/"blackbox_initialize", "yes"
+    add_created_key = shell_output("#{bin}/blackbox_addadmin Testing 2>&1")
+    assert_match "<testing@foo.bar>", add_created_key
   end
 end

--- a/Formula/duplicity.rb
+++ b/Formula/duplicity.rb
@@ -3,6 +3,7 @@ class Duplicity < Formula
   homepage "http://www.nongnu.org/duplicity/"
   url "https://code.launchpad.net/duplicity/0.7-series/0.7.07.1/+download/duplicity-0.7.07.1.tar.gz"
   sha256 "594c6d0e723e56f8a7114d57811c613622d535cafdef4a3643a4d4c89c1904f8"
+  revision 1
 
   bottle do
     sha256 "47cdf42038348b3a3e009ccd8d148a05f41a33769bdbbf82b0a59cbc1ab16ed3" => :el_capitan
@@ -324,7 +325,12 @@ class Duplicity < Formula
     # OSX doesn't provide a /usr/bin/python2. Upstream has been notified but
     # cannot fix the issue. See:
     #   https://github.com/Homebrew/homebrew/pull/34165#discussion_r22342214
-    inreplace "#{libexec}/bin/duplicity", "python2", "python"
+    inreplace libexec/"bin/duplicity", "python2", "python"
+
+    # We prefer gpg2, so set a default. This can still be overriden by
+    # passing the `--gpg-binary=` command line flag.
+    inreplace libexec/"lib/python2.7/site-packages/duplicity/globals.py",
+              "gpg_binary = None", "gpg_binary = 'gpg2'"
   end
 
   test do

--- a/Formula/git-secret.rb
+++ b/Formula/git-secret.rb
@@ -3,6 +3,8 @@ class GitSecret < Formula
   homepage "https://sobolevn.github.io/git-secret/"
   url "https://github.com/sobolevn/git-secret/archive/v0.2.0.tar.gz"
   sha256 "db4afbc3a453df2527603bf8bfffd9946f00d5595f2dca4f5088cb6bb47cacdf"
+  revision 1
+
   head "https://github.com/sobolevn/git-secret.git"
 
   bottle do
@@ -15,8 +17,18 @@ class GitSecret < Formula
   depends_on :gpg => :recommended
 
   def install
+    # Prefer GPG2 by default.
+    inreplace "src/_utils/_git_secret_tools.sh", ':="gpg"', ':="gpg2"'
     system "make", "build"
     system "bash", "utils/install.sh", prefix
+  end
+
+  def caveats; <<-EOS.undent
+    Homebrew defaults `git-secret` to using `gpg2`. If you
+    wish to use alternative GPG executables you should add:
+      export SECRETS_GPG_COMMAND="gpg"
+    to your shell profile.
+  EOS
   end
 
   test do

--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -13,15 +13,17 @@ class Lbdb < Formula
     sha256 "a82a06c8e00a7188315891f06529f460fc995db9cdb65bf59c4b1a24e3366329" => :mavericks
   end
 
-  depends_on :gpg => :optional
+  depends_on "gnupg" => :optional
   depends_on "abook" => :recommended
+
+  deprecated_option "with-gpg" => "with-gnupg"
 
   def install
     args = %W[
       --prefix=#{prefix}
       --libdir=#{libexec}
     ]
-    args << "--with-gpg" if build.with? "gpg"
+    args << "--with-gpg" if build.with? "gnupg"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/multirust.rb
+++ b/Formula/multirust.rb
@@ -6,6 +6,7 @@ class Multirust < Formula
   url "https://github.com/brson/multirust.git",
     :tag => "0.8.0",
     :revision => "8654d1c07729e961c172425088c451509557ef32"
+  revision 1
 
   head "https://github.com/brson/multirust.git"
 

--- a/Formula/multirust.rb
+++ b/Formula/multirust.rb
@@ -1,7 +1,6 @@
 class Multirust < Formula
-  homepage "https://github.com/brson/multirust"
   desc "Manage multiple Rust installations"
-
+  homepage "https://github.com/brson/multirust"
   # Use the tag instead of the tarball to get submodules
   url "https://github.com/brson/multirust.git",
     :tag => "0.8.0",

--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -3,6 +3,8 @@ class Pass < Formula
   homepage "https://www.passwordstore.org/"
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.6.5.tar.xz"
   sha256 "337a39767e6a8e69b2bcc549f27ff3915efacea57e5334c6068fcb72331d7315"
+  revision 1
+
   head "https://git.zx2c4.com/password-store", :using => :git
 
   bottle do
@@ -16,11 +18,11 @@ class Pass < Formula
   depends_on "pwgen"
   depends_on "tree"
   depends_on "gnu-getopt"
-  depends_on :gpg
+  depends_on :gpg => :run
 
   def install
     system "make", "PREFIX=#{prefix}", "install"
-    share.install "contrib"
+    pkgshare.install "contrib"
     zsh_completion.install "src/completion/pass.zsh-completion" => "_pass"
     bash_completion.install "src/completion/pass.bash-completion" => "password-store"
     fish_completion.install "src/completion/pass.fish-completion" => "pass.fish"

--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -29,6 +29,23 @@ class Pass < Formula
   end
 
   test do
-    system "#{bin}/pass", "--version"
+    # Note that test do is always in temporary path, with HOME captured,
+    # so this doesn't interfere with a user's pre-existing keychain.
+    (testpath/"batchgpg").write <<-EOS.undent
+    Key-Type: RSA
+    Key-Length: 2048
+    Subkey-Type: RSA
+    Subkey-Length: 2048
+    Name-Real: Testing
+    Name-Email: testing@foo.bar
+    Expire-Date: 1d
+    Passphrase: brew
+    %commit
+    EOS
+    system "gpg2", "--batch", "--gen-key", "batchgpg"
+
+    system bin/"pass", "init", "Testing"
+    system bin/"pass", "generate", "Email/testing@foo.bar", "15"
+    assert File.exist?(".password-store/Email/testing@foo.bar.gpg")
   end
 end

--- a/Formula/passpie.rb
+++ b/Formula/passpie.rb
@@ -3,6 +3,8 @@ class Passpie < Formula
   homepage "https://github.com/marcwebbie/passpie"
   url "https://files.pythonhosted.org/packages/6b/d1/e198766fee560af7d6568f213209c7f377376edaa326a7d5802ef5262aa5/passpie-1.4.3.tar.gz"
   sha256 "c6778a65fd7c1e00be94cc39a0468f04509d0c14b3686a1788f2012917b1d2fc"
+  revision 1
+
   head "https://github.com/marcwebbie/passpie.git"
 
   bottle do

--- a/Formula/pius.rb
+++ b/Formula/pius.rb
@@ -3,6 +3,8 @@ class Pius < Formula
   homepage "https://www.phildev.net/pius/"
   url "https://github.com/jaymzh/pius/archive/v2.2.2.tar.gz"
   sha256 "2a3a7f1c4ecaa7df46fa7c791387f2de5ef377a8f769fc325ba067d225ebfc79"
+  revision 1
+
   head "https://github.com/jaymzh/pius.git"
 
   bottle do
@@ -16,19 +18,17 @@ class Pius < Formula
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    # Replace hardcoded gpg path (WONTFIX):
-    # https://sourceforge.net/p/pgpius/bugs/12/
-    # According to the author, the next version of pius should ONLY support gpg2
-    # at which point we should change this to point to gpg2.  See discussion at:
-    # https://github.com/Homebrew/homebrew/pull/44756/files#r41721585
-    inreplace "libpius/constants.py", %r{/usr/bin/gpg2?}, "#{HOMEBREW_PREFIX}/bin/gpg"
+
+    # Note: Upstream are planning to remove gpg1.x support in future.
+    gpg = which("gpg2") || which("gpg")
+    inreplace "libpius/constants.py", %r{/usr/bin/gpg2?}, gpg
     system "python", *Language::Python.setup_install_args(libexec)
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
   def caveats; <<-EOS.undent
-    The path to gpg is hardcoded in pius as #{HOMEBREW_PREFIX}/bin/gpg.
+    The path to gpg is hardcoded in pius at compile time.
     You can specify a different path by editing ~/.pius:
       gpg-path=/path/to/gpg
     EOS

--- a/Formula/weboob.rb
+++ b/Formula/weboob.rb
@@ -3,6 +3,8 @@ class Weboob < Formula
   homepage "http://weboob.org/"
   url "https://symlink.me/attachments/download/324/weboob-1.1.tar.gz"
   sha256 "cbc0d8a88e402ec71a79f0cf09594fd3a969122111f5cd695f4a4ca67961661c"
+  revision 1
+
   head "https://git.symlink.me/pub/weboob/stable.git"
 
   bottle do
@@ -15,8 +17,8 @@ class Weboob < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "libyaml"
-  depends_on :gpg
   depends_on "pyqt"
+  depends_on :gpg => :run
 
   resource "termcolor" do
     url "https://pypi.python.org/packages/source/t/termcolor/termcolor-1.1.0.tar.gz"
@@ -54,7 +56,7 @@ class Weboob < Formula
   end
 
   test do
-    system "#{bin}/weboob-config", "update"
-    system "#{bin}/weboob-config", "applications"
+    system bin/"weboob-config", "update"
+    system bin/"weboob-config", "applications"
   end
 end

--- a/Formula/zero-install.rb
+++ b/Formula/zero-install.rb
@@ -1,8 +1,17 @@
 class ZeroInstall < Formula
   desc "Zero Install is a decentralised software installation system"
   homepage "http://0install.net/"
-  url "https://downloads.sf.net/project/zero-install/0install/2.8/0install-2.8.tar.bz2"
-  sha256 "12de771be748bce9350c90bc4720029a566b078ceabd335af09386ac6a37df2b"
+  # This is a fairly nasty hack to avoid backporting 10k+ lines of
+  # changes in patch format. It should be reverted to use the SF tarball
+  # as pointed to on the upstream website on next release.
+  # One of the resources, lwt, was updated in an incompatible way,
+  # but the older versions of lwt no longer support the ocaml Homebrew
+  # ships since May 5th 2016. Upstream pushed changes to fix this
+  # but those haven't made it into a stable release yet.
+  # There's also a build fix for Ocaml 4.03.0 not in latest release.
+  url "https://github.com/0install/0install.git",
+      :revision => "5ec4a9f55ba8e38b60cceeef5da982847395928c"
+  version "2.11"
 
   bottle do
     cellar :any_skip_relocation
@@ -14,77 +23,75 @@ class ZeroInstall < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ocaml" => :build
+  depends_on "ocamlbuild" => :build
   depends_on "opam" => :build
+  depends_on "camlp4" => :build
   depends_on "gtk+" => :optional
   depends_on :gpg
 
-  # 0install.2.8 resources from https://github.com/ocaml/opam-repository.git
-
   resource "easy-format" do # [required by yojson]
-    url "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
-    sha256 "c2a04ab1084bc5ce1ec52a3aa320c825c22f8be527fb5f82d920a9d92a673cd3"
+    url "https://github.com/mjambon/easy-format/archive/v1.2.0.tar.gz"
+    sha256 "a288fabcdc19c2262e76cf93e0fd987fe1b21493edd13309522fbae405329ffd"
   end
 
   resource "biniou" do # [required by yojson]
-    url "https://opam.ocaml.org/archives/biniou.1.0.9+opam.tar.gz"
-    sha256 "08e6a17a19fbe5e9da4c77d1e8c1bb05333f84ec8a634721a39c6c505ce51e0d"
+    url "http://mjambon.com/releases/biniou/biniou-1.0.9.tar.gz"
+    sha256 "eb47c48f61b169e652629e7f2ee582dfd5965e640ee51bf28fab63b960864392"
   end
 
   resource "cppo" do # [required by yojson]
-    url "https://opam.ocaml.org/archives/cppo.1.1.2+opam.tar.gz"
-    sha256 "8341d5a37d9e9351c1a46bf4d0843bff4fe1690b6329c28f8f41ca3dd189252a"
+    url "https://github.com/mjambon/cppo/archive/v1.3.2.tar.gz"
+    sha256 "c49e3080b3326466c7ddd97100c63bd568301802b3e48cebea3406e1ca76ebc8"
   end
 
   resource "yojson" do
-    url "https://opam.ocaml.org/archives/yojson.1.1.8+opam.tar.gz"
-    sha256 "20ce2c2f752b49695468b0bf66f17cf20219d7bca5a0b71a3fb89af500fb52f1"
+    url "https://github.com/mjambon/yojson/archive/v1.3.2.tar.gz"
+    sha256 "eff510621efd6dcfb86b65eaf1d4d6f3b9b680143d88e652b6f14072523a2351"
   end
 
   resource "xmlm" do
-    url "https://opam.ocaml.org/archives/xmlm.1.2.0+opam.tar.gz"
-    sha256 "a73af14cb2771247311e9130cbf7d10d66970f4725359db0923c92106ba94457"
+    url "http://erratique.ch/software/xmlm/releases/xmlm-1.2.0.tbz"
+    sha256 "d012018af5d1948f65404e1cc811ae0eab563b23006416f79b6ffc627966dccb"
   end
 
   resource "ounit" do
-    url "https://opam.ocaml.org/archives/ounit.2.0.0+opam.tar.gz"
-    sha256 "5a26c6404d9c8701f5a7510a985963f4eae003d58ae5fc3d9b7f1a862e91de71"
+    url "https://forge.ocamlcore.org/frs/download.php/1258/ounit-2.0.0.tar.gz"
+    sha256 "4d4a05b20c39c60d7486fb7a90eb4c5c08e8c9862360b5938b97a09e9bd21d85"
   end
 
   resource "react" do
-    url "https://opam.ocaml.org/archives/react.1.2.0+opam.tar.gz"
-    sha256 "51cab5941511220cd3f51b04cbab58ed34409bf9ec78dfed7611ab169f294499"
+    url "http://erratique.ch/software/react/releases/react-1.2.0.tbz"
+    sha256 "887aaea9191870bc0f37f945c02ec4c90497d949cd4dedc3d565c3fbec7ad04e"
   end
 
   resource "ppx_tools" do # [required by lwt]
-    url "https://opam.ocaml.org/archives/ppx_tools.0.99.2+opam.tar.gz"
-    sha256 "0c5b9802de2005b55717ac78bffcead1ee11dd28f91fb32f7e3518a7d7d8c48a"
+    url "https://github.com/alainfrisch/ppx_tools/archive/5.0+4.03.0.tar.gz"
+    sha256 "2cd990ef36145c35b0fd2cfaadc379cf032dd0987c07bea094d4437277d573e5"
   end
 
   resource "lwt" do
-    url "https://opam.ocaml.org/archives/lwt.2.4.6+opam.tar.gz"
-    sha256 "f0d814e04e4447322b592ee38b2bb634287bc6142c195381da39e28d4a0e9071"
+    url "https://github.com/ocsigen/lwt/archive/2.5.2.tar.gz"
+    sha256 "b319514cf51656780a8f609a63ead08d3052a442546b218530ce146d37bf6331"
   end
 
   resource "extlib" do
-    url "https://opam.ocaml.org/archives/extlib.1.6.1+opam.tar.gz"
-    sha256 "c76176916c39d4ccae82a34c33e694652c0c55d79eec8830dfddadb580b53773"
+    url "https://github.com/ygrek/ocaml-extlib/archive/1.7.0.tar.gz"
+    sha256 "3c9fd159a4ec401559905f96e578317a4933452ced9a7f3a4f89f9c7130d9a63"
   end
 
   resource "ocurl" do
-    url "https://opam.ocaml.org/archives/ocurl.0.7.2+opam.tar.gz"
-    sha256 "669c5142b7f4002521468b75ee254b269f0094c9a22d3381e94a440a6aa2d400"
+    url "http://ygrek.org.ua/p/release/ocurl/ocurl-0.7.7.tar.gz"
+    sha256 "79805776f207ae8e64d63cda63d0bf8c6ee079c70b0d7f3bd2114faba0d5f41c"
   end
 
-  if build.with? "gtk+"
-    resource "lablgtk" do
-      url "https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz"
-      sha256 "f0b7ed0bd85f6cf4b4c5f81966f03763e76bb9f866f5172511ce48cf31fd433c"
-    end
+  resource "lablgtk" do
+    url "https://forge.ocamlcore.org/frs/download.php/1602/lablgtk-2.18.4.tar.gz"
+    sha256 "b316ae0b92e760c1ab0d1bdeaa0a3c2a6ab14face5a0fe2b93445be3a3d013c0"
   end
 
   resource "sha" do
-    url "https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz"
-    sha256 "d3cfda4cd6f79b01c6613219baa3e8548365c309952168b3539e0edce9370b40"
+    url "https://github.com/vincenthz/ocaml-sha/archive/ocaml-sha-v1.9.tar.gz"
+    sha256 "caa1dd9071c2c56ca180061bb8e1824ac3b5e83de8ec4ed197275006c2a088d0"
   end
 
   def install
@@ -95,6 +102,9 @@ class ZeroInstall < Formula
     archives = opamroot/"repo/default/archives"
     modules = []
     resources.each do |r|
+      if build.without? "gtk+"
+        next if r.name == "lablgtk"
+      end
       r.verify_download_integrity(r.fetch)
       original_name = File.basename(r.url)
       cp r.cached_download, archives/original_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Formula sibling of https://github.com/Homebrew/brew/pull/386. This will follow the other in ASAP post-merge.

Eventually the batch generation of a `gpg` key for proper functionality testing will be split into a `Utils` method to call, rather than having to write the whole blob into every formula each time, so that is a temporary measure rather than a permanent thing.

Where the `gpg` requirement is only `:run`, which is the majority of cases, the `revision` bump is designed to get people moved across harmoniously rather than in dribs & drabs

Beside needing to install `gnupg2` instead of `gnupg` _(which will happen automatically for from-bottle installations)_ there should be minimal change noticed by end users given that `gpg` 1.x & `gpg` 2.0 _(which the new requirement is bound to)_ share a mutual keychain and can be swapped in & out without issue.

This will wildly fail until the `brew` PR is merged, for obvious reasons.
