### PR TITLE
heroku: Update homepage URL

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -1,6 +1,6 @@
 class Heroku < Formula
   desc "Everything you need to get started with Heroku"
-  homepage "https://toolbelt.heroku.com/other"
+  homepage "https://toolbelt.heroku.com/standalone"
   url "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-3.43.3.tgz"
   sha256 "502a62b50867e6d1acc04c75201dac038f0234a14389038a4cbee7bd555f9713"
   head "https://github.com/heroku/heroku.git"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Homepage URL ending in `/other` now redirects to `/standalone`.
