### PR TITLE
embulk: support Mac OS 10.9 using the same exec script with digdag

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -8,12 +8,10 @@ class Embulk < Formula
 
   depends_on :java
 
-  skip_clean "libexec"
-
   def install
-    (libexec/"bin").install "embulk-#{version}.jar" => "embulk"
-    chmod 0755, libexec/"bin/embulk"
-    bin.write_exec_script libexec/"bin/embulk"
+    # Execute through /bin/bash to be compatible with OS X 10.9.
+    libexec.install "embulk-#{version}.jar" => "embulk.jar"
+    (bin/"embulk").write "#!/bin/bash\nexec /bin/bash \"#{libexec/"embulk.jar"}\" \"$@\"\n"
   end
 
   test do

--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -6,12 +6,15 @@ class Embulk < Formula
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.7+"
 
   def install
     # Execute through /bin/bash to be compatible with OS X 10.9.
     libexec.install "embulk-#{version}.jar" => "embulk.jar"
-    (bin/"embulk").write "#!/bin/bash\nexec /bin/bash \"#{libexec/"embulk.jar"}\" \"$@\"\n"
+    (bin/"embulk").write <<-EOS.undent
+      #!/bin/bash
+      exec /bin/bash "#{libexec/"embulk.jar"}" "$@"
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This PR improves exec script of embulk using the same strategy discussed at #2012 and treasure-data/digdag#125.
Embulk and Digdag use the same hack to make it executable (because creator is same).
