### PR TITLE
emacs: Add option to enable dynamic modules.

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -28,6 +28,7 @@ class Emacs < Formula
   option "with-cocoa", "Build a Cocoa version of emacs"
   option "with-ctags", "Don't remove the ctags executable that emacs provides"
   option "without-libxml2", "Don't build with libxml2 support"
+  option "with-modules", "Build with dynamic module support (devel/HEAD only)"
 
   deprecated_option "cocoa" => "with-cocoa"
   deprecated_option "keep-ctags" => "with-ctags"
@@ -86,6 +87,14 @@ class Emacs < Formula
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--with-imagemagick" if build.with? "imagemagick"
     args << "--without-popmail" if build.with? "mailutils"
+
+    if build.with? "modules"
+      if build.head? || build.devel?
+        args << "--with-modules"
+      else
+        opoo "Dynamic module support is only available in devel/HEAD. Ignoring..."
+      end
+    end
 
     system "./autogen.sh" if build.head? || build.devel?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

As of version 25.0.95 Emacs supports dynamic (native code) modules, but they are disabled by default. The `--with-modules` option must be passed to the `./configure` script to enable them. This PR adds
this option to the formula, and warns the user if they try to use it for pre-25.0.95 builds.

Note that when Emacs 25 is released, this option will be available to all builds, and the formula will need to be updated.
