### PR TITLE
elasticsearch: fix plugin script path in caveats

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -88,14 +88,20 @@ class Elasticsearch < Formula
   end
 
   def caveats
-    plugin=(devel? || head?) ? "#{libexec}/bin/elasticsearch-plugin" : "#{libexec}/bin/plugin"
-    <<-EOS.undent
-    Data:    #{var}/elasticsearch/#{cluster_name}/
-    Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
-    Plugins: #{libexec}/plugins/
-    Config:  #{etc}/elasticsearch/
-    plugin script: #{plugin}
+    s = <<-EOS.undent
+      Data:    #{var}/elasticsearch/#{cluster_name}/
+      Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
+      Plugins: #{libexec}/plugins/
+      Config:  #{etc}/elasticsearch/
     EOS
+
+    if stable?
+      s += <<-EOS.undent
+        plugin script: #{libexec}/bin/plugin
+      EOS
+    end
+
+    s
   end
 
   plist_options :manual => "elasticsearch"

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -88,7 +88,7 @@ class Elasticsearch < Formula
   end
 
   def caveats
-    plugin=(devel? || head?) ? "#{libexec}/elasticsearch-plugin" : "#{libexec}/plugin"
+    plugin=(devel? || head?) ? "#{libexec}/bin/elasticsearch-plugin" : "#{libexec}/bin/plugin"
     <<-EOS.undent
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log


### PR DESCRIPTION
ex.
before: `plugin script: /usr/local/Cellar/elasticsearch/2.3.3/libexec/plugin`
after: `plugin script: /usr/local/Cellar/elasticsearch/2.3.3/libexec/bin/plugin`
