### PR TITLE
pike: revision to remove gdbm linkage

### DIFF
--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -3,7 +3,7 @@ class Pike < Formula
   homepage "https://pike.lysator.liu.se"
   url "https://pike.lysator.liu.se/pub/pike/all/7.8.866/Pike-v7.8.866.tar.gz"
   sha256 "0b12e1a99bd8bdd9c8a2daa46e623ac718bc0737290236a0c8474091359b594e"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "df8e5edbe83a457ee1c204379a5baa08ec93d4e9e3e8d73450e25e2300d2ddc8" => :el_capitan


### PR DESCRIPTION
The current lot of pike bottles are linked against libgdbm.4.dylib, but
gdbm is only an optional dependencies and, at least currently, shouldn't
be present in the CI environment while building.

This should fix the `brew linkage pike` failure when gdbm doesn't happen
to be installed.
