### PR TITLE
ncmpcpp 0.7.4

### DIFF
--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -1,9 +1,8 @@
 class Ncmpcpp < Formula
   desc "Ncurses-based client for the Music Player Daemon"
   homepage "http://rybczak.net/ncmpcpp/"
-  url "http://rybczak.net/ncmpcpp/stable/ncmpcpp-0.7.3.tar.bz2"
-  sha256 "2c8b29435ca4fd845400cee7c9fd50a731bee215e92fd7e98a7446c84136b212"
-  revision 1
+  url "http://ncmpcpp.rybczak.net/stable/ncmpcpp-0.7.4.tar.bz2"
+  sha256 "d70425f1dfab074a12a206ddd8f37f663bce2bbdc0a20f7ecf290ebe051f1e63"
 
   bottle do
     cellar :any
@@ -34,10 +33,10 @@ class Ncmpcpp < Formula
   depends_on "fftw" if build.with? "visualizer"
 
   if MacOS.version < :mavericks
-    depends_on "boost" => ["with-icu4c", "c++11"]
+    depends_on "boost" => "c++11"
     depends_on "taglib" => "c++11"
   else
-    depends_on "boost" => ["with-icu4c"]
+    depends_on "boost"
     depends_on "taglib"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I have removed the required dependency on ICU, which should be optional. There was a [bug in the configure script for 0.7.x](https://github.com/arybczak/ncmpcpp/issues/127) that forced to use boost with ICU support, but it is fixed on this release.

This ICU dependency was forcing a full compilation of boost just to install ncmpcpp, which it is a pain.
