### PR TITLE
qt5 5.6.1-1

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -14,9 +14,9 @@ end
 class Qt5 < Formula
   desc "Version 5 of the Qt framework"
   homepage "https://www.qt.io/"
-  url "https://download.qt.io/official_releases/qt/5.6/5.6.1/single/qt-everywhere-opensource-src-5.6.1.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.6/5.6.1/single/qt-everywhere-opensource-src-5.6.1.tar.xz"
-  sha256 "0d3cc75d2368ad988c9ec6bcbed6362dbaa8e03fdfd04e679284f4b9af91e565"
+  url "https://download.qt.io/official_releases/qt/5.6/5.6.1-1/single/qt-everywhere-opensource-src-5.6.1-1.tar.xz"
+  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.6/5.6.1-1/single/qt-everywhere-opensource-src-5.6.1-1.tar.xz"
+  sha256 "ce08a7eb54661705f55fb283d895a089b267c688fabe017062bd71b9231736db"
 
   head "https://code.qt.io/qt/qt5.git", :branch => "5.6", :shallow => false
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Replace 5.6.1 that has been completely pulled from all download servers due to a somewhat important fix in the `qtdeclarative` module. For details: http://blog.qt.io/blog/2016/06/22/qt-5-6-1-1-released/

(Would be obsolete if #2087 was ready, but have to restore the `qt5` formula to a working condition in the mean time, particularly for users building from source.)
