### PR TITLE
convox 20160623185456

### DIFF
--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -1,7 +1,8 @@
 class Convox < Formula
   desc "The convox AWS PaaS CLI tool"
   homepage "https://convox.com/"
-  url "https://github.com/convox/rack/archive/20160623185456.tar.gz"
+  version "20160623185456"
+  url "https://github.com/convox/rack/archive/#{version}.tar.gz"
   sha256 "0ff842a5ac3d21f8b3b7d40b36f6286e389ccebfb3befdf6786c0bf808c09e13"
 
   bottle do
@@ -16,7 +17,7 @@ class Convox < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/convox/rack").install Dir["*"]
-    system "go", "build", "-ldflags=-X main.Version=20160623185456", "-o", "#{bin}/convox", "-v", "github.com/convox/rack/cmd/convox"
+    system "go", "build", "-ldflags=-X main.Version=#{version}", "-o", "#{bin}/convox", "-v", "github.com/convox/rack/cmd/convox"
   end
 
   test do

--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -1,8 +1,8 @@
 class Convox < Formula
   desc "The convox AWS PaaS CLI tool"
   homepage "https://convox.com/"
-  url "https://github.com/convox/rack/archive/20160615213630.tar.gz"
-  sha256 "f09b6adda368d67efa87b097299d9cdae1852d1a0c255f6740ff990f0064d937"
+  url "https://github.com/convox/rack/archive/20160623185456.tar.gz"
+  sha256 "0ff842a5ac3d21f8b3b7d40b36f6286e389ccebfb3befdf6786c0bf808c09e13"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,7 @@ class Convox < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/convox/rack").install Dir["*"]
-    system "go", "build", "-o", "#{bin}/convox", "-v", "github.com/convox/rack/cmd/convox"
+    system "go", "build", "-ldflags=-X main.Version=20160623185456", "-o", "#{bin}/convox", "-v", "github.com/convox/rack/cmd/convox"
   end
 
   test do

--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -1,8 +1,7 @@
 class Convox < Formula
   desc "The convox AWS PaaS CLI tool"
   homepage "https://convox.com/"
-  version "20160623185456"
-  url "https://github.com/convox/rack/archive/#{version}.tar.gz"
+  url "https://github.com/convox/rack/archive/20160623185456.tar.gz"
   sha256 "0ff842a5ac3d21f8b3b7d40b36f6286e389ccebfb3befdf6786c0bf808c09e13"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
- Update convox to 20160623185456
- Add version flag to build command to fix `convox -v` output after install

---
### Before

```
$ convox -v
client: dev
server: 20160610201355 (console.convox.com)
```
### After

```
$ convox -v
client: 20160623185456
server: 20160610201355 (console.convox.com)
```
