### PR TITLE
mpv 0.18.0

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -1,8 +1,8 @@
 class Mpv < Formula
   desc "Free, open source, and cross-platform media player"
   homepage "https://mpv.io"
-  url "https://github.com/mpv-player/mpv/archive/v0.17.0.tar.gz"
-  sha256 "602cd2b0f5fc7e43473234fbb96e3f7bbb6418f15eb8fa720d9433cce31eba6e"
+  url "https://github.com/mpv-player/mpv/archive/v0.18.0.tar.gz"
+  sha256 "b656638d4f6bce2621baaacb60d8be384aa492fcd86dfd43996aaa2c16fee02b"
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
@@ -11,7 +11,6 @@ class Mpv < Formula
     sha256 "6df154963d1757f6abb2b5255049fd3e91c7585fa72bd8b02834e3448e4117fe" => :mavericks
   end
 
-  option "with-shared", "Build libmpv shared library."
   option "with-bundle", "Enable compilation of the .app bundle."
 
   depends_on "pkg-config" => :build
@@ -25,6 +24,7 @@ class Mpv < Formula
   depends_on "lua" => :recommended
   depends_on "youtube-dl" => :recommended
 
+  depends_on "libarchive" => :optional
   depends_on "libcaca" => :optional
   depends_on "libdvdread" => :optional
   depends_on "libdvdnav" => :optional
@@ -37,12 +37,12 @@ class Mpv < Formula
   depends_on :macos => :mountain_lion
 
   resource "waf" do
-    url "https://waf.io/waf-1.8.12"
-    sha256 "01bf2beab2106d1558800c8709bc2c8e496d3da4a2ca343fe091f22fca60c98b"
+    url "https://waf.io/waf-1.8.21"
+    sha256 "31383a18d183c72be70d251e09b47389a6eb4bebbc94b737cff3187ddd88dff1"
   end
 
   resource "docutils" do
-    url "https://pypi.python.org/packages/source/d/docutils/docutils-0.12.tar.gz"
+    url "https://files.pythonhosted.org/packages/37/38/ceda70135b9144d84884ae2fc5886c6baac4edea39550f28bcd144c1234d/docutils-0.12.tar.gz"
     sha256 "c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"
   end
 
@@ -61,9 +61,17 @@ class Mpv < Formula
     end
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
-    args = ["--prefix=#{prefix}", "--enable-zsh-comp"]
-    args << "--enable-gpl3" if build.stable?
-    args << "--enable-libmpv-shared" if build.with? "shared"
+    args = %W[
+      --prefix=#{prefix}
+      --enable-zsh-comp
+      --enable-libmpv-shared
+      --confdir=#{etc}/mpv
+      --datadir=#{pkgshare}
+      --mandir=#{man}
+      --docdir=#{doc}
+      --zshdir=#{zsh_completion}
+    ]
+    args << "--enable-libarchive" if build.with? "libarchive"
 
     waf = resource("waf")
     buildpath.install waf.files("waf-#{waf.version}" => "waf")
@@ -77,6 +85,6 @@ class Mpv < Formula
   end
 
   test do
-    system "#{bin}/mpv", "--ao=null", test_fixtures("test.wav")
+    system bin/"mpv", "--ao=null", test_fixtures("test.wav")
   end
 end


### PR DESCRIPTION
- always build the shared library
- move "applications" and "icons" to `pkgshare`
- set confdir to `"#{etc}/mpv"`
- gpl3 option no longer exists
- libarchive support
