### PR TITLE
minikube 0.3.0 (new formula)

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -1,0 +1,17 @@
+class Minikube < Formula
+  desc "Tool that provisions and manages local single-node Kubernetes clusters"
+  homepage "https://github.com/kubernetes/minikube"
+  url "https://storage.googleapis.com/minikube/releases/v0.3.0/minikube-darwin-amd64"
+  version "0.3.0"
+  sha256 "cada05315d6643a3d8813b75c36b703773df739f32a576b25b8572a51ca90ee6"
+  head "https://github.com/kubernetes/minikube.git"
+
+  def install
+    mv "minikube-darwin-amd64", "minikube"
+    bin.install "minikube"
+  end
+
+  test do
+    assert_match /^minikube version: v0.3.0/, shell_output("#{bin}/minikube version 2>&1", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Minikube is a CLI tool that provisions and manages single-node Kubernetes clusters optimized for development workflows.
This Homebrew Formula is equivalent to the official Google release installation instructions https://github.com/kubernetes/minikube/releases
