### PR TITLE
unpaper: vendor libav instead of using ffmpeg

### DIFF
--- a/Formula/unpaper.rb
+++ b/Formula/unpaper.rb
@@ -1,9 +1,17 @@
 class Unpaper < Formula
   desc "Post-processing for scanned/photocopied books"
   homepage "https://www.flameeyes.eu/projects/unpaper"
-  url "https://www.flameeyes.eu/files/unpaper-6.1.tar.xz"
-  sha256 "237c84f5da544b3f7709827f9f12c37c346cdf029b1128fb4633f9bafa5cb930"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://www.flameeyes.eu/files/unpaper-6.1.tar.xz"
+    sha256 "237c84f5da544b3f7709827f9f12c37c346cdf029b1128fb4633f9bafa5cb930"
+
+    resource "libav" do
+      url "https://libav.org/releases/libav-11.7.tar.xz"
+      sha256 "8c9a75c89c6df58dd5e3f6f735d1ba5448680e23013fd66a51b50b4f49913c46"
+    end
+  end
 
   bottle do
     cellar :any
@@ -16,12 +24,25 @@ class Unpaper < Formula
     url "https://github.com/Flameeyes/unpaper.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
+
+    resource "libav" do
+      url "https://github.com/libav/libav.git"
+    end
   end
 
   depends_on "pkg-config" => :build
-  depends_on "ffmpeg"
+  depends_on "yasm" => :build
 
   def install
+    resource("libav").stage do
+      system "./configure", "--prefix=#{libexec}", "--enable-shared"
+      system "make", "install"
+    end
+
+    ENV.append "CFLAGS", "-I#{libexec}/include"
+    ENV.append "LDFLAGS", "-L#{libexec}/lib"
+    ENV.append_path "PKG_CONFIG_PATH", "#{libexec}/lib/pkgconfig"
+
     system "autoreconf", "-i" if build.head?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Upstream actually develops against libav not ffmpeg. Since enabling
shared libraries on libav would result in a conflict between ffmpeg
and libav, we can either vendor libav with unpaper or make libav
`keg_only`. This commit pursues the vendoring option but I certainly
wouldn't object to making libav `keg_only` instead if that's acceptable
to others.

The impetus for this change is an unaddressed (by either upstream)
incompatibility between ffmpeg 3.1 and unpaper 6.1. See https://github.com/Homebrew/homebrew-core/pull/2416.
