### PR TITLE
juju 1.26-alpha3 (devel)

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -12,9 +12,9 @@ class Juju < Formula
   end
 
   devel do
-    url "https://launchpad.net/juju-core/trunk/2.0-beta9/+download/juju-core_2.0-beta9.tar.gz"
-    sha256 "0f201909de0c77be21097f7749a32c131606e86a4b5940484d2fe668c108c22b"
-    version "2.0-beta9"
+    url "https://launchpad.net/juju-core/1.26/1.26-alpha3/+download/juju-core_1.26-alpha3.tar.gz"
+    sha256 "505e995082c3dff885ec6096dd3cdf2f69c177d0eba44b01bae8e84c37033a13"
+    version "1.26-alpha3"
   end
 
   depends_on "go" => :build
@@ -24,11 +24,7 @@ class Juju < Formula
     system "go", "build", "github.com/juju/juju/cmd/juju"
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
     bin.install "juju", "juju-metadata"
-    if build.stable?
-      bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-core"
-    else
-      bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju2"
-    end
+    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-core"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Per discussion with @sinzui in #2369, pulling back from 2.x to keep juju as juju 1.x series. Juju 2.x is so radically different (and incompatible with setups made on 1.x) that it should be a separate formula, and Homebrew/homebrew-devel-only#47 will resolve that.

It was a mistake to have 2.x be a --devel release on juju.
