### PR TITLE
platformio 2.11.0

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -1,8 +1,8 @@
 class Platformio < Formula
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/b7/a3/1d3a9d7bae91df1b607e0f31549ec3e0006f29484cc6a1431b3fe3c5b02e/platformio-2.10.3.tar.gz"
-  sha256 "f3a646871f9baed05f336a32576edaab90abf0737d8adb54f2acb7bcad42a65f"
+  url "https://pypi.python.org/packages/71/76/05dd805502dc5f9adadc7cdfd91f89320f505038884d97d0c05024a98e0f/platformio-2.11.0.tar.gz"
+  sha256 "11775c303fc3cb82fd353574bd2258b4ec6504855dcde6c557624a963a88fe08"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
## 2.11.0 (2016-06-28)
-   New ESP8266-based boards: Generic ESP8285 Module, Phoenix 1.0 & 2.0, WifInfo
-   Added support for Arduino M0 Pro board ([issue #472](https://github.com/platformio/platformio/issues/472))
-   Added support for Arduino MKR1000 board ([issue #620](https://github.com/platformio/platformio/issues/620))
-   Added support for Adafruit Feather M0, SparkFun SAMD21 and SparkFun SAMD21 Mini Breakout boards ([issue #520](https://github.com/platformio/platformio/issues/520))
-   Updated Arduino ESP8266 core for Espressif platform to 2.3.0
-   Better removing unnecessary flags using `build_unflags` option ([issue #698](https://github.com/platformio/platformio/issues/698))
-   Fixed issue with `platformio init --ide` command for Python 2.6
