### PR TITLE
phantomjs: remove build.py path for OpenSSL

### DIFF
--- a/Formula/phantomjs.rb
+++ b/Formula/phantomjs.rb
@@ -1,10 +1,20 @@
 class Phantomjs < Formula
   desc "Headless WebKit scriptable with a JavaScript API"
   homepage "http://phantomjs.org/"
-  url "https://github.com/ariya/phantomjs.git",
-      :tag => "2.1.1",
-      :revision => "d9cda3dcd26b0e463533c5cc96e39c0f39fc32c1"
   head "https://github.com/ariya/phantomjs.git"
+
+  stable do
+    url "https://github.com/ariya/phantomjs.git",
+        :tag => "2.1.1",
+        :revision => "d9cda3dcd26b0e463533c5cc96e39c0f39fc32c1"
+
+    # Fixes build.py for non-standard Homebrew prefixes.  Applied
+    # upstream, can be removed in next release.
+    patch do
+      url "https://github.com/ariya/phantomjs/commit/6090f5457d2051ab374264efa18f655fa3e15e79.diff"
+      sha256 "43c7d2c76db434aa845c0504209052af6011a20d1295b203c3bee881071aa471"
+    end
+  end
 
   bottle do
     cellar :any
@@ -18,7 +28,7 @@ class Phantomjs < Formula
   depends_on "openssl"
 
   def install
-    inreplace "build.py", "/usr/local", HOMEBREW_PREFIX
+    ENV["OPENSSL"] = Formula["openssl"].opt_prefix
     system "./build.py", "--confirm", "--jobs", ENV.make_jobs
     bin.install "bin/phantomjs"
     pkgshare.install "examples"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Use now-implemented env variable for locating OpenSSL in non-standard
prefixes.
