### PR TITLE
pyenv 20160629

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -1,8 +1,8 @@
 class Pyenv < Formula
   desc "Python version management"
   homepage "https://github.com/yyuu/pyenv"
-  url "https://github.com/yyuu/pyenv/archive/v20160628.tar.gz"
-  sha256 "90126dcdb988e0fff006d8dbecfbd0f58ad7ea45654ccd3a7934657355f4be15"
+  url "https://github.com/yyuu/pyenv/archive/v20160629.tar.gz"
+  sha256 "a98f8e738f6f45651d4646aecc8a7c2c6bc5151445e902fb603f33ceb0de0621"
   head "https://github.com/yyuu/pyenv.git"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Last time I had sent a PR for a pyenv version update, I was told to omit the `v` from the version in the commit (Homebrew/legacy-homebrew#50001), but the PR @alex just submitted kept it (#2444). I don't see this specifically mentioned in the contributing guidelines, is that format still preferred?
