### PR TITLE
coq: fix emacs caveat

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -40,7 +40,7 @@ class Coq < Formula
                           "-coqide", "no",
                           "-with-doc", "no"
     system "make", "world"
-    system "make", "install"
+    ENV.deparallelize { system "make", "install" }
   end
 
   test do

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -43,13 +43,6 @@ class Coq < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
-    To use the Coq Emacs mode, add the following to your init file:
-      (setq auto-mode-alist (cons '("\\\\.v$" . coq-mode) auto-mode-alist))
-      (autoload 'coq-mode "coq" "Major mode for editing Coq vernacular." t)
-    EOS
-  end
-
   test do
     (testpath/"testing.v").write <<-EOS.undent
       Inductive nat : Set :=


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The emacs major mode bundled with Coq is called `gallina.el`, not `coq.el` file, so the current caveat doesn't work.

From the [Coq Reference Manual](https://coq.inria.fr/refman/Reference-Manual017.html) section 15.6.1:

> Coq comes with a Major mode for GNU Emacs, `gallina.el`.
> Add the following lines to your .emacs file:
> 
> ```
> (setq auto-mode-alist (cons '("\\.v$" . coq-mode) auto-mode-alist))
> (autoload 'coq-mode "gallina" "Major mode for editing Coq vernacular." t)
> ```
