### PR TITLE
Elasticsearch 5.0.0-alpha4

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -5,9 +5,9 @@ class Elasticsearch < Formula
   sha256 "5fe0a6887432bb8a8d3de2e79c9b81c83cfa241e6440f0f0379a686657789165"
 
   devel do
-    url "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha3/elasticsearch-5.0.0-alpha3.tar.gz"
-    sha256 "8fc606d56bdec83dc5219b5ad2346f2fe7c95feec9ad1d92c2bc1268323885e5"
-    version "5.0.0-alpha3"
+    url "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha4/elasticsearch-5.0.0-alpha4.tar.gz"
+    sha256 "088ca4a5bd34b3c46c910bfe8948b1bc77bbb2a06a92e6aa161f3552c0afd46c"
+    version "5.0.0-alpha4"
   end
 
   head do


### PR DESCRIPTION
This commit updates the devel build for the Elasticsearch formula to
install the 5.0.0-alpha4 release of Elasticsearch, the latest
pre-release version of Elasticsearch as of 2016-06-30.
