### PR TITLE
cryptopp: add CXXFLAGS argument to `make` enabling C++11

### DIFF
--- a/Formula/cryptopp.rb
+++ b/Formula/cryptopp.rb
@@ -13,8 +13,12 @@ class Cryptopp < Formula
   option :cxx11
 
   def install
-    ENV.cxx11 if build.cxx11?
-    system "make", "CXX=#{ENV.cxx}"
+    if build.cxx11?
+      ENV.cxx11
+      system "make", "CXX=#{ENV.cxx}", "CXXFLAGS=-std=c++11"
+    else
+      system "make", "CXX=#{ENV.cxx}"
+    end
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
`ENV.cxx11` does not quite cut it in this case – this change builds CryptoPP in C++11 mode correctly
