### PR TITLE
libbladerf: fix missing head repository

### DIFF
--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -3,6 +3,7 @@ class Libbladerf < Formula
   homepage "https://nuand.com/"
   url "https://github.com/Nuand/bladeRF/archive/2015.07.tar.gz"
   sha256 "9e15911ab39ba1eb4aa1bcbf518a0eac5396207fc4a58c32b2550fe0a65f9d22"
+  head "https://github.com/Nuand/bladeRF.git"
 
   bottle do
     sha256 "a0f5f3a24237452816c8d25caf2d615d00bf54b1f5f1afaac3aeed3db24dfb06" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Adds the git repository to libbladerf to allow installing the latest in-development version with `brew install --HEAD libbladerf`
