### PR TITLE
libosinfo: formula tweaks

### DIFF
--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -10,22 +10,19 @@ class Libosinfo < Formula
     sha256 "f39179801faa67e260672bcaa07406bad710283894d50e26838bb57c5a58b12a" => :mavericks
   end
 
-  depends_on "check"
-  depends_on "glib"
   depends_on "intltool" => :build
-  depends_on "libsoup"
-  depends_on "libxml2"
-  depends_on "libxslt"
   depends_on "pkg-config" => :build
-  depends_on "pygobject3"
   depends_on "wget" => :build
 
-  depends_on "gobject-introspection" => :optional
-  depends_on "vala" => :optional
+  depends_on "check"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "libsoup"
+  depends_on "libxml2"
+  depends_on "pygobject3"
 
-  # work around "ld: unknown option: --no-undefined"
-  # upstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=1305016
-  patch :DATA
+  depends_on "gobject-introspection" => :recommended
+  depends_on "vala" => :optional
 
   def install
     args = %W[
@@ -38,7 +35,7 @@ class Libosinfo < Formula
       --enable-tests
     ]
 
-    args << "--enable-introspection" if build.with? "gobject-introspection"
+    args << "--disable-introspection" if build.without? "gobject-introspection"
     args << "--enable-vala" if build.with? "vala"
 
     system "./configure", *args
@@ -50,50 +47,38 @@ class Libosinfo < Formula
 
   test do
     (testpath/"test.py").write <<-EOS.undent
-    from gi.repository import Libosinfo as osinfo;
+      import gi
+      gi.require_version('Libosinfo', '1.0')
+      from gi.repository import Libosinfo as osinfo;
 
-    loader = osinfo.Loader()
-    loader.process_path("./")
+      loader = osinfo.Loader()
+      loader.process_path("./")
 
-    db = loader.get_db()
+      db = loader.get_db()
 
-    devs = db.get_device_list()
-    print "All device IDs"
-    for dev in devs.get_elements():
-      print ("  Device " + dev.get_id())
+      devs = db.get_device_list()
+      print "All device IDs"
+      for dev in devs.get_elements():
+        print ("  Device " + dev.get_id())
 
-    names = db.unique_values_for_property_in_device("name")
-    print "All device names"
-    for name in names:
-      print ("  Name " + name)
+      names = db.unique_values_for_property_in_device("name")
+      print "All device names"
+      for name in names:
+        print ("  Name " + name)
 
-    osnames = db.unique_values_for_property_in_os("short-id")
-    osnames.sort()
-    print "All OS short IDs"
-    for name in osnames:
-      print ("  OS short id " + name)
+      osnames = db.unique_values_for_property_in_os("short-id")
+      osnames.sort()
+      print "All OS short IDs"
+      for name in osnames:
+        print ("  OS short id " + name)
 
-    hvnames = db.unique_values_for_property_in_platform("short-id")
-    hvnames.sort()
-    print "All HV short IDs"
-    for name in hvnames:
-      print ("  HV short id " + name)
+      hvnames = db.unique_values_for_property_in_platform("short-id")
+      hvnames.sort()
+      print "All HV short IDs"
+      for name in hvnames:
+        print ("  HV short id " + name)
     EOS
 
     system "python", "test.py"
   end
 end
-
-__END__
-diff -Nu a/osinfo/Makefile.in b/osinfo/Makefile.in
---- a/osinfo/Makefile.in	2016-02-05 18:49:24.000000000 +0800
-+++ b/osinfo/Makefile.in	2016-02-05 18:50:09.000000000 +0800
-@@ -353,7 +353,7 @@
- MSGMERGE = @MSGMERGE@
- NM = @NM@
- NMEDIT = @NMEDIT@
--NO_UNDEFINED_FLAGS = @NO_UNDEFINED_FLAGS@
-+NO_UNDEFINED_FLAGS =
- OBJDUMP = @OBJDUMP@
- OBJEXT = @OBJEXT@
- OTOOL = @OTOOL@


### PR DESCRIPTION
- sort build dependencies to the top
- add linked library dependency gettext
- make gobject-introspection recommended instead of optional since it will be installed anyway
- remove the patch for "ld: unknown option" since it's been upstreamed
- fix indentation of the heredoc in the test
