### PR TITLE
berkeley-db 6.2.23

### DIFF
--- a/Formula/bogofilter.rb
+++ b/Formula/bogofilter.rb
@@ -3,6 +3,7 @@ class Bogofilter < Formula
   homepage "http://bogofilter.sourceforge.net"
   url "https://downloads.sourceforge.net/project/bogofilter/bogofilter-1.2.4/bogofilter-1.2.4.tar.bz2"
   sha256 "e10287a58d135feaea26880ce7d4b9fa2841fb114a2154bf7da8da98aab0a6b4"
+  revision 1
 
   bottle do
     sha256 "22cdf81e4f0f6bc9b45f5e46ddcca5262141f726f425724ef3b208138fd6d528" => :el_capitan

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -3,6 +3,7 @@ class Darkice < Formula
   homepage "https://code.google.com/p/darkice/"
   url "https://darkice.googlecode.com/files/darkice-1.2.tar.gz"
   sha256 "b3fba9be2d9c72f36b0659cd9ce0652c8f973b5c6498407f093da9a364fdb254"
+  revision 1
 
   head "http://darkice.googlecode.com/svn/darkice/branches/darkice-macosx"
 

--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -3,6 +3,7 @@ class Dbxml < Formula
   homepage "https://www.oracle.com/us/products/database/berkeley-db/xml/overview/index.html"
   url "http://download.oracle.com/berkeley-db/dbxml-6.0.18.tar.gz"
   sha256 "5851f60a47920718b701752528a449f30b16ddbf5402a2a5e8cde8b4aecfabc8"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/dirt.rb
+++ b/Formula/dirt.rb
@@ -4,6 +4,7 @@ class Dirt < Formula
   url "https://github.com/tidalcycles/Dirt/archive/1.1.tar.gz"
   sha256 "bb1ae52311813d0ea3089bf3837592b885562518b4b44967ce88a24bc10802b6"
   head "https://github.com/tidalcycles/Dirt.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -1,7 +1,7 @@
 class GnuCobol < Formula
   desc "Implements much of the COBOL 85 and COBOL 2002 standards"
   homepage "http://www.opencobol.org/"
-  revision 3
+  revision 4
 
   stable do
     url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/1.1/gnu-cobol-1.1.tar.gz"

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -3,6 +3,7 @@ class Gnuradio < Formula
   homepage "https://gnuradio.squarespace.com/"
   url "https://gnuradio.org/releases/gnuradio/gnuradio-3.7.9.1.tar.gz"
   sha256 "9c06f0f1ec14113203e0486fd526dd46ecef216dfe42f12d78d9b781b1ef967e"
+  revision 1
 
   bottle do
     sha256 "c9fdb8e1a9d96dafe29dd828038bcedc5e03b21612f6cf81843c85238dac9204" => :el_capitan

--- a/Formula/isync.rb
+++ b/Formula/isync.rb
@@ -3,6 +3,7 @@ class Isync < Formula
   homepage "http://isync.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/isync/isync/1.2.1/isync-1.2.1.tar.gz"
   sha256 "e716de28c9a08e624a035caae3902fcf3b511553be5d61517a133e03aa3532ae"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -10,6 +10,7 @@ class Jack < Formula
   homepage "http://jackaudio.org"
   url "http://jackaudio.org/downloads/jack-audio-connection-kit-0.124.1.tar.gz"
   sha256 "eb42df6065576f08feeeb60cb9355dce4eb53874534ad71534d7aa31bae561d6"
+  revision 1
 
   bottle do
     revision 2

--- a/Formula/jigdo.rb
+++ b/Formula/jigdo.rb
@@ -3,7 +3,7 @@ class Jigdo < Formula
   homepage "http://atterer.org/jigdo/"
   url "http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-0.7.3.tar.bz2"
   sha256 "875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
-  revision 2
+  revision 3
 
   bottle do
     revision 2

--- a/Formula/ltc-tools.rb
+++ b/Formula/ltc-tools.rb
@@ -3,6 +3,7 @@ class LtcTools < Formula
   homepage "https://github.com/x42/ltc-tools"
   url "https://github.com/x42/ltc-tools/archive/v0.6.4.tar.gz"
   sha256 "8fc9621df6f43ab24c65752a9fee67bee6625027c19c088e5498d2ea038a22ec"
+  revision 1
   head "https://github.com/x42/ltc-tools.git"
 
   bottle do

--- a/Formula/memcacheq.rb
+++ b/Formula/memcacheq.rb
@@ -3,6 +3,7 @@ class Memcacheq < Formula
   homepage "http://memcachedb.org/memcacheq"
   url "https://memcacheq.googlecode.com/files/memcacheq-0.2.0.tar.gz"
   sha256 "b314c46e1fb80d33d185742afe3b9a4fadee5575155cb1a63292ac2f28393046"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -3,6 +3,7 @@ class Moc < Formula
   homepage "https://moc.daper.net"
   url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.1.tar.bz2"
   sha256 "1b419c75a92a85ff4ee7670c65d660c86fef32032c65e89e868b988f80fac4f2"
+  revision 1
   head "svn://daper.net/moc/trunk"
 
   bottle do

--- a/Formula/nvi.rb
+++ b/Formula/nvi.rb
@@ -4,7 +4,7 @@ class Nvi < Formula
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   sha256 "8bc348889159a34cf268f80720b26f459dbd723b5616107d36739d007e4c978d"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/open-cobol.rb
+++ b/Formula/open-cobol.rb
@@ -3,6 +3,7 @@ class OpenCobol < Formula
   homepage "http://www.opencobol.org/"
   url "https://downloads.sourceforge.net/project/open-cobol/open-cobol/1.1/open-cobol-1.1.tar.gz"
   sha256 "6ae7c02eb8622c4ad55097990e9b1688a151254407943f246631d02655aec320"
+  revision 1
 
   bottle do
     sha256 "31b5e3af55285483f2e73463aa58cf35afae5a5ee675b7622703d62c34bbe529" => :el_capitan

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -4,6 +4,7 @@ class Qjackctl < Formula
   url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.4.2.tar.gz"
   sha256 "cf1c4aff22f8410feba9122e447b1e28c8fa2c71b12cfc0551755d351f9eaf5e"
   head "http://git.code.sf.net/p/qjackctl/code", :using => :git
+  revision 1
 
   bottle do
     sha256 "881297bbb05a0367be914b6c696a1fd38b1591906dfd08077a827f6c28dda692" => :el_capitan

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -18,6 +18,7 @@ class Rpm < Formula
       :using => RpmDownloadStrategy
   version "5.4.15"
   sha256 "d4ae5e9ed5df8ab9931b660f491418d20ab5c4d72eb17ed9055b80b71ef6c4ee"
+  revision 1
 
   bottle do
     sha256 "29c05e064c80738733182e6688a82cef3a2c933b40acbeb43d3a842693ca91f4" => :el_capitan

--- a/Formula/webalizer.rb
+++ b/Formula/webalizer.rb
@@ -4,6 +4,7 @@ class Webalizer < Formula
   url "ftp://ftp.mrunix.net/pub/webalizer/webalizer-2.23-08-src.tgz"
   mirror "https://mirrors.kernel.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
   sha256 "edaddb5aa41cc4a081a1500e3fa96615d4b41bc12086bcedf9938018ce79ed8d"
+  revision 1
 
   bottle do
     sha256 "b49462177a945b9a9bd3d8fc9004c35b2150d1206a5967a5231a5da3f609d956" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I happened to notice that Berkeley DB is outdated (when I was reading [this](http://arstechnica.com/information-technology/2016/07/how-oracles-business-as-usual-is-threatening-to-kill-java/) 😜), so I'm submitting this PR. Since it is only a drive-by update, I might not commit to fixing potential failures of dependents.

I also added a test, but am having some trouble with the sandbox:

```
$ brew test --no-sandbox berkeley-db
Testing berkeley-db
==> /usr/bin/clang++ test.cpp -o test -Os -w -pipe -march=native -mmacosx-version-min=10.11 -F/usr/local/Frameworks -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names -I/usr/local/Cellar/berkeley-db/6.2.23/include -L/usr/local/Cellar/berkeley-db/6.2.23/lib -ldb_cxx
==> ./test
```

```
$ brew test --sandbox berkeley-db
Testing berkeley-db
==> Using the sandbox
/usr/bin/sandbox-exec -f /tmp/homebrew20160701-46650-1dnexye.sb /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby -W0 -I /usr/local/Library/Homebrew -- /usr/local/Library/Homebrew/test.rb /usr/local/Library/Taps/homebrew/homebrew-core/Formula/berkeley-db.rb --sandbox
==> /usr/bin/clang++ test.cpp -o test -Os -w -pipe -march=native -mmacosx-version-min=10.11 -F/usr/local/Frameworks -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names -I/usr/local/Cellar/berkeley-db/6.2.23/include -L/usr/local/Cellar/berkeley-db/6.2.23/lib -ldb_cxx
error: unable to open output file '/Volumes/ramdisk/test-061f1e.o': 'Operation not permitted'
1 error generated.
==> Sandbox log
Jul  1 22:16:38 sandboxd[138]: clang(46660) deny file-write-create /Volumes/ramdisk/test-061f1e.o-4900d519
Jul  1 22:16:38 sandboxd[138]: clang(46660) deny file-write-create /Volumes/ramdisk/test-061f1e.o
Error: berkeley-db: failed
Failed executing: /usr/bin/clang++ test.cpp -o test -Os -w -pipe -march=native -mmacosx-version-min=10.11 -F/usr/local/Frameworks -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names -I/usr/local/Cellar/berkeley-db/6.2.23/include -L/usr/local/Cellar/berkeley-db/6.2.23/lib -ldb_cxx
...
```

Apparently, without a tempfile redirection option like `-save-temps`, clang insists on writing to `$TMPDIR` which is outside `testpath`. I looked at some other existing formulae like `etl` and got the same error, so I'm kind of confused now. Do I need to do something to make `sandbox-exec` happy?
