### PR TITLE
clog: fix homepage url

### DIFF
--- a/Formula/clog.rb
+++ b/Formula/clog.rb
@@ -1,6 +1,6 @@
 class Clog < Formula
   desc "Colorized pattern-matching log tail utility."
-  homepage "https://tasktools.org/projects/clog.html"
+  homepage "https://taskwarrior.org/docs/clog/"
   url "https://tasktools.org/download/clog-1.3.0.tar.gz"
   sha256 "fed44a8d398790ab0cf426c1b006e7246e20f3fcd56c0ec4132d24b05d5d2018"
   head "https://git.tasktools.org/scm/ut/clog.git", :branch => "1.4.0", :shallow => false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The above is not really applicable -- just fixing the broken homepage URL for `brew home` (no source changes, no version bump needed)
