### PR TITLE
dirt: fix URLs and SHA-256 checksum

### DIFF
--- a/Formula/dirt.rb
+++ b/Formula/dirt.rb
@@ -1,9 +1,9 @@
 class Dirt < Formula
   desc "Experimental sample playback"
-  homepage "https://github.com/yaxu/Dirt"
-  url "https://github.com/yaxu/Dirt/archive/1.0.tar.gz"
-  sha256 "c7c51ea3f279c048e84d988978455f075fd8ae063b2ad7378fc9b8369218f8fb"
-  head "https://github.com/yaxu/Dirt.git"
+  homepage "https://github.com/tidalcycles/Dirt"
+  url "https://github.com/tidalcycles/Dirt/archive/1.0.tar.gz"
+  sha256 "4a79a3c8650e8852907beb2d40af0f9bc2824adcffc91041fe62edd55c23ecdc"
+  head "https://github.com/tidalcycles/Dirt.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Upstream retag? (Update: See https://github.com/Homebrew/homebrew-core/pull/2552#issuecomment-230071624.)

Discovered when bumping for berkeley-db update (#2549).
