### PR TITLE
mariadb 10.1.15

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -1,14 +1,18 @@
 class Mariadb < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "http://ftp.osuosl.org/pub/mariadb/mariadb-10.1.14/source/mariadb-10.1.14.tar.gz"
-  sha256 "18e71974a059a268a3f28281599607344d548714ade823d575576121f76ada13"
+  url "http://ftp.osuosl.org/pub/mariadb/mariadb-10.1.15/source/mariadb-10.1.15.tar.gz"
+  sha256 "7cc0e55eec64e9ef48345288abe67cf36e72dd2da30d52e4726332ad2a5fea0f"
 
   bottle do
     sha256 "7d1ec840153e4921f2db498afba1809aa117ea51ca154fc43b384704f88fb773" => :el_capitan
     sha256 "2b82f99cb3e318906b358157f76e2474ec2b68386f5d6fb4738d666bf75c406b" => :yosemite
     sha256 "fa09ca1ec1a6557099eafe2b0955a78ec4841a795194400b321914f84aab99fe" => :mavericks
   end
+
+  # upstream fix for compilation error, marked fixed for 10.1.16
+  # https://jira.mariadb.org/browse/MDEV-10322
+  patch :DATA
 
   option :universal
   option "with-test", "Keep test when installing"
@@ -199,3 +203,17 @@ class Mariadb < Formula
     end
   end
 end
+__END__
+diff --git a/storage/connect/jdbconn.cpp b/storage/connect/jdbconn.cpp
+index 9b47927..7c0582d 100644
+--- a/storage/connect/jdbconn.cpp
++++ b/storage/connect/jdbconn.cpp
+@@ -270,7 +270,7 @@ PQRYRES JDBCColumns(PGLOBAL g, char *db, char *table, char *colpat,
+ 		return NULL;
+
+ 	// Colpat cannot be null or empty for some drivers
+-	cap->Pat = (colpat && *colpat) ? colpat : "%";
++	cap->Pat = (colpat && *colpat) ? colpat : PlugDup(g, "%");
+
+ 	/************************************************************************/
+ 	/*  Now get the results into blocks.                                    */


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Two things here.

First, this version required a fix for an compilation error (https://jira.mariadb.org/browse/MDEV-10322).

Second, `brew audit --strict --online mariadb` returns the following message.

```
$ brew audit --strict --online mariadb
mariadb:
  * 'inreplace ... do' was used for a single substitution (use the non-block form instead).
Error: 1 problem in 1 formula
```

I'm not knowledgable enough in ruby to immediately fix this, and as there are several places in the formula I don't know which one is the culprit. Maybe even all places? And what about `gsub!` and `change_make_var!`?
