### PR TITLE
tesseract: add serial-num-pack option

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -27,6 +27,7 @@ class Tesseract < Formula
   option "with-all-languages", "Install recognition data for all languages"
   option "with-training-tools", "Install OCR training tools"
   option "with-opencl", "Enable OpenCL support"
+  option "with-serial-num-tools", "Install training tools for serial number recognition"
 
   deprecated_option "all-languages" => "with-all-languages"
 
@@ -62,6 +63,11 @@ class Tesseract < Formula
   resource "osd" do
     url "https://github.com/tesseract-ocr/tessdata/raw/3.04.00/osd.traineddata"
     sha256 "9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff"
+  end
+
+  resource "snum" do
+    url "https://github.com/USCDataScience/counterfeit-electronics-tesseract/blob/master/Training%20Tesseract/snum.traineddata"
+    sha256 "36f772980ff17c66a767f584a0d80bf2302a1afa585c01a226c1863afcea1392"
   end
 
   def install
@@ -103,6 +109,9 @@ class Tesseract < Formula
     else
       resource("eng").stage { mv "eng.traineddata", share/"tessdata" }
       resource("osd").stage { mv "osd.traineddata", share/"tessdata" }
+    end
+    if build.with? "serial-num-tools"
+      resource("snum").stage{ mv "snum.traineddata", share/"tessdata"}
     end
   end
 

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -27,7 +27,7 @@ class Tesseract < Formula
   option "with-all-languages", "Install recognition data for all languages"
   option "with-training-tools", "Install OCR training tools"
   option "with-opencl", "Enable OpenCL support"
-  option "with-serial-num-tools", "Install training tools for serial number recognition"
+  option "with-serial-num-pack", "Install serial number recognition pack"
 
   deprecated_option "all-languages" => "with-all-languages"
 
@@ -66,7 +66,7 @@ class Tesseract < Formula
   end
 
   resource "snum" do
-    url "https://github.com/USCDataScience/counterfeit-electronics-tesseract/blob/master/Training%20Tesseract/snum.traineddata"
+    url "https://github.com/USCDataScience/counterfeit-electronics-tesseract/raw/319a6eeacff181dad5c02f3e7a3aff804eaadeca/Training%20Tesseract/snum.traineddata"
     sha256 "36f772980ff17c66a767f584a0d80bf2302a1afa585c01a226c1863afcea1392"
   end
 
@@ -98,6 +98,9 @@ class Tesseract < Formula
     system "./configure", *args
 
     system "make", "install"
+    if build.with? "serial-num-pack"
+      resource("snum").stage{ mv "snum.traineddata", share/"tessdata" }
+    end
     if build.with? "training-tools"
       system "make", "training"
       system "make", "training-install"
@@ -109,9 +112,6 @@ class Tesseract < Formula
     else
       resource("eng").stage { mv "eng.traineddata", share/"tessdata" }
       resource("osd").stage { mv "osd.traineddata", share/"tessdata" }
-    end
-    if build.with? "serial-num-tools"
-      resource("snum").stage{ mv "snum.traineddata", share/"tessdata"}
     end
   end
 

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -99,7 +99,7 @@ class Tesseract < Formula
 
     system "make", "install"
     if build.with? "serial-num-pack"
-      resource("snum").stage{ mv "snum.traineddata", share/"tessdata" }
+      resource("snum").stage { mv "snum.traineddata", share/"tessdata" }
     end
     if build.with? "training-tools"
       system "make", "training"

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -99,7 +99,7 @@ class Tesseract < Formula
 
     system "make", "install"
     if build.with? "serial-num-pack"
-      resource("snum").stage { mv "snum.traineddata", share/"tessdata" }
+      (pkgshare/"tessdata").install resource("snum")
     end
     if build.with? "training-tools"
       system "make", "training"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Updating formula for Tesseract to include option for installing serial number language pack.
