### PR TITLE
Enable static libraries for imagemagick

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -64,7 +64,7 @@ class Imagemagick < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --enable-shared
-      --disable-static
+      --enable-static
       --with-modules
     ]
 


### PR DESCRIPTION
This enables the the static libraries for `imagemagick` which we need to build self-contained applications. Tested to build without warnings or side effects.

Some [precedents](https://github.com/Homebrew/legacy-homebrew/commits/master?author=jeroenooms) of enabling static libraries. 

Yes we _could_ make static libraries optional, but it would be much nicer if they get bottled by default so that my users don't have to build from source. :blue_heart: :beer:
