### PR TITLE
gvp 0.3.0

### DIFF
--- a/Formula/gvp.rb
+++ b/Formula/gvp.rb
@@ -1,8 +1,8 @@
 class Gvp < Formula
   desc "Go versioning packager"
   homepage "https://github.com/pote/gvp"
-  url "https://github.com/pote/gvp/archive/v0.2.0.tar.gz"
-  sha256 "ede10a32889cf284eaa4c4a9ed4e6bc0a85e0663246bf2fb7c1cf3965db661ea"
+  url "https://github.com/pote/gvp/archive/v0.3.0.tar.gz"
+  sha256 "e1fccefa76495293350d47d197352a63cae6a014d8d28ebdedb785d4304ee338"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,13 +12,19 @@ class Gvp < Formula
     sha256 "d940a179bae92e734b725f27e766abe525cd82c98599e52ae201f4be2bd1787f" => :mountain_lion
   end
 
+  # Upstream fix for "syntax error near unexpected token `;'"
+  patch do
+    url "https://github.com/pote/gvp/commit/11c4cefd.patch"
+    sha256 "59379b52fc13d79ea03de453cd58df98ad5ddd49ba3ba5d784b8bee7649e9cd7"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/gvp", "init"
+    system bin/"gvp", "in"
     assert File.directory? ".godeps/src"
   end
 end


### PR DESCRIPTION
- apply upstream patch for syntax error in switch operator
- subcommand used in the test changed from "init" to "in"
