### PR TITLE
libsoundio 1.1.0

### DIFF
--- a/Formula/libsoundio.rb
+++ b/Formula/libsoundio.rb
@@ -1,8 +1,8 @@
 class Libsoundio < Formula
   desc "Cross-platform audio input and output"
   homepage "http://libsound.io"
-  url "https://github.com/andrewrk/libsoundio/archive/1.0.3.tar.gz"
-  sha256 "a2b9fb88ad44cb97bab03e8955b444d824182c12a3957a5e4f5a52aee45b1bc3"
+  url "https://github.com/andrewrk/libsoundio/archive/1.1.0.tar.gz"
+  sha256 "ba0b21397cb3e29dc8f51ed213ae27625f05398c01aefcfbaa860fab42a84281"
 
   bottle do
     cellar :any
@@ -10,6 +10,9 @@ class Libsoundio < Formula
     sha256 "b0e334a48e59b046b2fe798dc020424c4ddf82928303de72330c142f2128206e" => :yosemite
     sha256 "bc45824227f9e1c37a26064bf2a146917fa2ad19f82051240865e53028846f2d" => :mavericks
   end
+
+  # fatal error: 'stdatomic.h' file not found
+  depends_on :macos => :yosemite
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
needs to be restricted to >= Yosemite due to stdatomic.h, which
Mavericks and below don't have
