### PR TITLE
micropython 1.8.2

### DIFF
--- a/Formula/micropython.rb
+++ b/Formula/micropython.rb
@@ -1,8 +1,9 @@
 class Micropython < Formula
   desc "Python implementation for microcontrollers and constrained systems"
   homepage "https://www.micropython.org/"
-  url "https://github.com/micropython/micropython/archive/v1.8.tar.gz"
-  sha256 "0890bc0250cb212e0bd8aec4b2d4f83428e5a031bbb0bb92882f5c8a3e7a092e"
+  url "https://github.com/micropython/micropython.git",
+    :tag => "v1.8.2",
+    :revision => "1459a8d5c9b29c78da2cf5c7cf3c37ab03b34b8e"
 
   bottle do
     cellar :any
@@ -15,7 +16,17 @@ class Micropython < Formula
   depends_on "libffi" # Requires libffi v3 closure API; OS X version is too old
 
   def install
+    # Equivalent to upstream fix for "fatal error: 'endian.h' file not found"
+    # https://github.com/pfalcon/axtls/commit/3e1b4909a2ddd76c5797f241f2ed56ef699a7e91
+    # Should be removed at the next version bump (MicroPython > 1.8.2)
+    inreplace "lib/axtls/crypto/os_int.h", "#include <endian.h>", ""
+
     cd "unix" do
+      # Works around undefined symbol error for "mp_thread_get_state"
+      # Reported 11 Jul 2016: https://github.com/micropython/micropython/issues/2233
+      inreplace "mpconfigport.mk", "MICROPY_PY_THREAD = 1",
+                                   "MICROPY_PY_THREAD = 0"
+      system "make", "axtls"
       system "make", "install", "PREFIX=#{prefix}", "V=1"
     end
   end
@@ -30,6 +41,6 @@ class Micropython < Formula
       printf("Hello!\\n")
     EOS
 
-    system "#{bin}/micropython", "ffi-hello.py"
+    system bin/"micropython", "ffi-hello.py"
   end
 end


### PR DESCRIPTION
- switch to using the tag since micropython now has git submodules
- use inreplace to work around an #include bug in the axTLS submodule
- use inreplace to work around undefined symbol "mp_thread_get_state"
- add "make axtls" to the install method
