### PR TITLE
mongoose 6.4

### DIFF
--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -1,8 +1,8 @@
 class Mongoose < Formula
   desc "Web server build on top of Libmongoose embedded library"
   homepage "https://github.com/cesanta/mongoose"
-  url "https://github.com/cesanta/mongoose/archive/5.6.tar.gz"
-  sha256 "cc2557c7cf9f15e1e691f285a4c6c705cc7e56cb70c64cb49703a428a0677065"
+  url "https://github.com/cesanta/mongoose/archive/6.4.tar.gz"
+  sha256 "4691ade3ca645e568e0f6049953ac13cabcb289a734fb0f245a6ddce12f97d41"
 
   bottle do
     cellar :any
@@ -19,12 +19,9 @@ class Mongoose < Formula
     # No Makefile but is an expectation upstream of binary creation
     # https://github.com/cesanta/mongoose/blob/master/docs/Usage.md
     # https://github.com/cesanta/mongoose/issues/326
-    cd "examples/web_server" do
-      args = []
-      args << "openssl" if build.with? "openssl"
-
-      system "make", *args
-      bin.install "web_server" => "mongoose"
+    cd "examples/simplest_web_server" do
+      system "make"
+      bin.install "simplest_web_server" => "mongoose"
     end
 
     system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib"
@@ -42,18 +39,15 @@ class Mongoose < Formula
           <title>Homebrew</title>
         </head>
         <body>
-          <p>Hello World!</p>
+          <p>Hi!</p>
         </body>
       </html>
     EOS
 
-    pid = fork do
-      exec "#{bin}/mongoose -document_root #{testpath} -index_files hello.html"
-    end
-    sleep 2
-
     begin
-      assert_match /Hello World!/, shell_output("curl localhost:8080")
+      pid = fork { exec "#{bin}/mongoose" }
+      sleep 2
+      assert_match "Hi!", shell_output("curl http://localhost:8000/hello.html")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)


### PR DESCRIPTION
"web_server" example was removed upstream, so use "simplest_web_server"
