### PR TITLE
scriptcs 0.16.1

### DIFF
--- a/Formula/scriptcs.rb
+++ b/Formula/scriptcs.rb
@@ -1,8 +1,8 @@
 class Scriptcs < Formula
   desc "Tools to write and execute C#"
   homepage "https://github.com/scriptcs/scriptcs"
-  url "https://github.com/scriptcs/scriptcs/archive/0.16.0.tar.gz"
-  sha256 "e51060406606010f1ea67ae2573fcd7bc75b40ebe990ba546c7b646f6b4bdaba"
+  url "https://github.com/scriptcs/scriptcs/archive/v0.16.1.tar.gz"
+  sha256 "80d7e5b92a2aa9a2c6fc3409bc7b4793f27ca4bf945413618e01ac96cd8e8827"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,9 +13,17 @@ class Scriptcs < Formula
 
   depends_on "mono" => :recommended
 
+  # Upstream commit "Adding brew build script (#1178)"
+  # See https://github.com/scriptcs/scriptcs/issues/1172
+  # Remove for scriptcs > 0.16.1
+  patch do
+    url "https://github.com/scriptcs/scriptcs/commit/cff8f5d.patch"
+    sha256 "d99e18eee3dd1f545c79155b82c2db23b0315e4124ea54e93060ae284746bba2"
+  end
+
   def install
     script_file = "scriptcs.sh"
-    system "./build.sh"
+    system "sh", "./build_brew.sh"
     libexec.install Dir["src/ScriptCs/bin/Release/*"]
     (libexec/script_file).write <<-EOS.undent
       #!/bin/bash


### PR DESCRIPTION
use upstream's build_brew.sh to work around an incompatibility between
their test framework and mono 4.4.x
