### PR TITLE
vegeta 6.1.0

### DIFF
--- a/Formula/vegeta.rb
+++ b/Formula/vegeta.rb
@@ -3,9 +3,8 @@ require "language/go"
 class Vegeta < Formula
   desc "HTTP load testing tool and library"
   homepage "https://github.com/tsenart/vegeta"
-  url "https://github.com/tsenart/vegeta/archive/v6.0.0.tar.gz"
-  sha256 "7933a77eaae1e5269f6490842527a646221d91515eb8e863e831df608e7a0d48"
-  revision 1
+  url "https://github.com/tsenart/vegeta/archive/v6.1.0.tar.gz"
+  sha256 "60d2b6cb51d069ef207f9c9e9a6c437df0f7159939ee10086131620f8e6d3916"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,19 +20,26 @@ class Vegeta < Formula
       :revision => "b0c588724d25ae13f5afb3d90efec0edc636432b"
   end
 
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+      :revision => "7864c9eef811cd4e2387a4d17eaf985e412b5032"
+  end
+
   def install
-    mkdir_p buildpath/"src/github.com/tsenart/"
-    ln_s buildpath, buildpath/"src/github.com/tsenart/vegeta"
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
-    Language::Go.stage_deps resources, buildpath/"src"
 
-    system "go", "build", "-ldflags", "-X main.Version=#{version}", "-o", "vegeta"
-    bin.install "vegeta"
+    (buildpath/"src/github.com/tsenart").mkpath
+    ln_s buildpath, buildpath/"src/github.com/tsenart/vegeta"
+    Language::Go.stage_deps resources, buildpath/"src"
+    system "go", "build", "-ldflags", "-X main.Version=#{version}",
+                          "-o", bin/"vegeta"
   end
 
   test do
-    output = pipe_output("#{bin}/vegeta attack -duration=1s -rate=1", "GET http://localhost/")
-    pipe_output("#{bin}/vegeta report", output)
+    input = "GET https://google.com"
+    output = pipe_output("#{bin}/vegeta attack -duration=1s -rate=1", input, 0)
+    report = pipe_output("#{bin}/vegeta report", output, 0)
+    assert_match /Success +\[ratio\] +100.00%/, report
   end
 end


### PR DESCRIPTION
- new go_resource "golang.org/x/net"
- avoid lines exceeding the eightieth column
- require successful exit statuses and a match in the test
