### PR TITLE
libimobiledevice, libplist: Add support for Python 3 bindings

### DIFF
--- a/Formula/ideviceinstaller.rb
+++ b/Formula/ideviceinstaller.rb
@@ -20,6 +20,7 @@ class Ideviceinstaller < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libplist"
   depends_on "libimobiledevice"
   depends_on "libzip"
 

--- a/Formula/libplist.rb
+++ b/Formula/libplist.rb
@@ -13,39 +13,54 @@ class Libplist < Formula
   end
 
   head do
-    url "http://git.sukimashita.com/libplist.git"
-
+    url "https://git.libimobiledevice.org/libplist.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
     depends_on "libtool" => :build
   end
 
   option "with-python", "Enable Cython Python bindings"
+  option "with-python3", "Enable Cython Python3 bindings"
 
   depends_on "pkg-config" => :build
   depends_on "libxml2"
   depends_on :python => :optional
+  depends_on :python3 => :optional
 
   resource "cython" do
     url "https://pypi.python.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz#md5=890b494a12951f1d6228c416a5789554"
     sha256 "84808fda00508757928e1feadcf41c9f78e9a9b7167b6649ab0933b76f75e7b9"
   end
 
+  if build.with?("python") && build.with?("python3")
+    raise "Either python or python3 bindings can be installed at the same time."
+  end
+
   def install
-    ENV.deparallelize
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
     ]
 
-    if build.with? "python"
+    if build.with? "python3"
+      version = Language::Python.major_minor_version "python3"
       resource("cython").stage do
-        ENV.prepend_create_path "PYTHONPATH", buildpath+"lib/python2.7/site-packages"
-        system "python", "setup.py", "build", "install", "--prefix=#{buildpath}",
-                 "--single-version-externally-managed", "--record=installed.txt"
+        ENV.prepend_create_path "PYTHONPATH", buildpath/"lib/python#{version}/site-packages"
+        system "python3", *Language::Python.setup_install_args(buildpath)
       end
-      ENV.prepend_path "PATH", "#{buildpath}/bin"
+      ENV.prepend_path "PATH", buildpath/"bin"
+
+      args << "PYTHON=python3"
+      args << "PYTHON_LDFLAGS=-undefined dynamic_lookup"
+    elsif build.with? "python"
+      version = Language::Python.major_minor_version "python3"
+
+      resource("cython").stage do
+        ENV.prepend_create_path "PYTHONPATH", buildpath/"lib/python#{version}/site-packages"
+        system "python", *Language::Python.setup_install_args(buildpath)
+      end
+      ENV.prepend_path "PATH", buildpath/"bin"
     else
       args << "--without-cython"
     end
@@ -53,5 +68,11 @@ class Libplist < Formula
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make", "install", "PYTHON_LDFLAGS=-undefined dynamic_lookup"
+
+    (include/"plist/cython").install Dir["cython/*"]
+  end
+
+  test do
+    system "#{bin}/plistutil"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Current problem with `brew audit  --strict --online <formula>`:

```
libimobiledevice:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/Cellar/libimobiledevice/1.2.0/lib/python3.5/site-packages/imobiledevice.so
Error: 1 problem in 1 formula
```

Can anyone tell me how to fix this?

The corresponding PR for fixing the inreplace and patch is here: libimobiledevice/libimobiledevice#335
