### PR TITLE
no-more-secrets 0.2.0

### DIFF
--- a/Formula/no-more-secrets.rb
+++ b/Formula/no-more-secrets.rb
@@ -1,8 +1,8 @@
 class NoMoreSecrets < Formula
   desc "Recreates the SETEC ASTRONOMY effect from 'Sneakers'"
   homepage "https://github.com/bartobri/no-more-secrets"
-  url "https://github.com/bartobri/no-more-secrets/archive/v0.1.0.tar.gz"
-  sha256 "9e42f359bda578716d176245d416b5924ed0b321390a28221467301bc10e537b"
+  url "https://github.com/bartobri/no-more-secrets/archive/v0.2.0.tar.gz"
+  sha256 "cc0f588d1c05290027c7b33d4639e9a860122eba1af9475c00db9d3b18ffdcb3"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,13 +11,22 @@ class NoMoreSecrets < Formula
     sha256 "b1efac63c0fafcecc0f2c7ef04820f50e00d99b2e0a8fe46ed889b8042803b6f" => :mavericks
   end
 
+  # upstream commit that fixes version for 0.2.0
+  patch do
+    url "https://github.com/bartobri/no-more-secrets/commit/e07eddae.patch"
+    sha256 "20dce9db7b7164f5529a94dca71c9f21195477980dae7bb8c082eef5d942f911"
+  end
+
   def install
+    # ld: library not found for -lncursesw
+    # Reported 4 Jul 2016: https://github.com/bartobri/no-more-secrets/issues/24
+    inreplace "Makefile", "LDLIBS = -lncursesw", "LDLIBS = -lncurses"
+
     system "make", "all"
-    bin.install "bin/nms", "bin/sneakers"
+    system "make", "prefix=#{prefix}", "install"
   end
 
   test do
-    # nms is an interactive-only program, so we can't do a real test
-    assert (bin/"nms").executable?
+    assert_equal "nms version #{version}", shell_output("#{bin}/nms -v").chomp
   end
 end


### PR DESCRIPTION
- fix -lncursesw regression with inreplace
- apply upstream commit to fix the version
- use make install
- match version in the test using new upstream -v CLI option
