### PR TITLE
riemann-client 1.9.0

### DIFF
--- a/Formula/riemann-client.rb
+++ b/Formula/riemann-client.rb
@@ -1,8 +1,19 @@
 class RiemannClient < Formula
   desc "C client library for the Riemann monitoring system"
   homepage "https://github.com/algernon/riemann-c-client"
-  url "https://github.com/algernon/riemann-c-client/archive/riemann-c-client-1.3.0.tar.gz"
-  sha256 "64bb7ccdb6d7267110932feddcd8c3149588baf3227b05c330bfef97347be995"
+  head "https://github.com/algernon/riemann-c-client.git"
+
+  stable do
+    url "https://github.com/algernon/riemann-c-client/archive/riemann-c-client-1.9.0.tar.gz"
+    sha256 "9584e8f1f442684a0f9607059874cfe1a1632c3fa5de2997b303ab8859048a3b"
+
+    # Fixes "<inline asm>:1:1: error: unknown directive .symver ..."
+    # Applies upstream commit "HAVE_VERSIONING: use #if not #ifdef"
+    patch do
+      url "https://github.com/algernon/riemann-c-client/commit/e6b49e68.patch"
+      sha256 "7c0949e0719eea014ffb69f03f355b242f0d388907c18af4df90f8a4e3b8d60e"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
had to patch improper use of `#ifdef` where `#if` is needed
