### PR TITLE
ppl: give full path to GMP

### DIFF
--- a/Formula/ppl.rb
+++ b/Formula/ppl.rb
@@ -16,6 +16,7 @@ class Ppl < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--with-gmp=#{Formula["gmp"].opt_prefix}",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
This fix is necessary to build ppl on my laptop (probably because my homebrew is under $HOME/Homebrew).
