### PR TITLE
Add trash patch option to mutt Formula.

### DIFF
--- a/Formula/mutt.rb
+++ b/Formula/mutt.rb
@@ -35,6 +35,7 @@ class Mutt < Formula
   option "with-debug", "Build with debug option enabled"
   option "with-s-lang", "Build against slang instead of ncurses"
   option "with-confirm-attachment-patch", "Apply confirm attachment patch"
+  option "with-trash-patch", "Apply trash folder patch"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -45,6 +46,13 @@ class Mutt < Formula
   depends_on "gpgme" => :optional
   depends_on "libidn" => :optional
   depends_on "s-lang" => :optional
+
+  if build.with? "trash-patch"
+    patch do
+      url "https://raw.githubusercontent.com/emmanuelbernard/homebrew-mutt/master/patchs/trashfolder-1.6.0.diff.gz"
+      sha256 "b779c6df61a77f3069139aad8562b4a47c8eed8ab5b8f5681742a1c2eaa190b8"
+    end
+  end
 
   if build.with? "confirm-attachment-patch"
     patch do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The patch has been taken from https://github.com/emmanuelbernard/homebrew-mutt. Emmanuel Bernard has also defined other compiling options that may be interesting to integrate.
