### PR TITLE
selenium-server-standalone 2.53.1

### DIFF
--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -1,8 +1,8 @@
 class SeleniumServerStandalone < Formula
   desc "Browser automation for testing purposes"
   homepage "http://seleniumhq.org/"
-  url "https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar"
-  sha256 "67b88cbfd3b130de6ff3770948f56cc485fd1abb5b7a769397d9050a59b1e036"
+  url "https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar"
+  sha256 "1cce6d3a5ca5b2e32be18ca5107d4f21bddaa9a18700e3b117768f13040b7cf8"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The patch upgrade makes Selenium work with Firefox 47.0.1 (no Selenium works with Firefox 47.0.0, hence the 47.0.1 release). `brew audit` fails, but the failure is unrelated to this upgrade.
