### PR TITLE
kubernetes-cli - Add zsh completion

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -27,7 +27,15 @@ class KubernetesCli < Formula
 
     dir = "_output/local/bin/darwin/#{arch}"
     bin.install "#{dir}/kubectl"
+
     (bash_completion/"kubectl").write Utils.popen_read("#{bin}/kubectl completion bash")
+    (zsh_completion/"_kubectl").write Utils.popen_read("#{bin}/kubectl completion zsh")
+  end
+
+  def caveats; <<-EOS.undent
+    Add the following to ~/.zshrc to enable zsh completion:
+      source #{HOMEBREW_PREFIX}/share/zsh/site-functions/_kubectl
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Follow up to the previous PR from another contributor, this time for zsh completion.

I also added a note in the _caveats_ to let people know they have the enable zsh completion explicitly. That's because the resultion completion script is missing a `#compdef` header.
