### PR TITLE
kubernetes-cli: have kubectl generate completions

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -27,7 +27,7 @@ class KubernetesCli < Formula
 
     dir = "_output/local/bin/darwin/#{arch}"
     bin.install "#{dir}/kubectl"
-    (bash_completion/"kubectl").write Utils.popen_read("#{bin}/kubectl completion bash")
+    (bash_completion/"kubectl").write "source <(kubectl completion bash)"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

There's no real need to pre-compile the bash completion at installation time when we can have it generate it at runtime. ~~This also adds zsh completion using the same trick.~~

Signed-off-by: Eli Young elyscape@gmail.com
