### PR TITLE
fon-flash-cli 1.9.1

### DIFF
--- a/Formula/fon-flash-cli.rb
+++ b/Formula/fon-flash-cli.rb
@@ -1,10 +1,9 @@
 class FonFlashCli < Formula
   desc "Flash La Fonera and Atheros chipset compatible devices"
   homepage "https://www.gargoyle-router.com/wiki/doku.php?id=fon_flash"
-  url "https://www.gargoyle-router.com/downloads/src/gargoyle_1.8.0-src.tar.gz"
-  version "1.8.0"
-  sha256 "89493cfedbe38800121fbe5e281e0542df4026f76de242ef664120649900772a"
-
+  url "https://www.gargoyle-router.com/downloads/src/gargoyle_1.9.1-src.tar.gz"
+  version "1.9.1"
+  sha256 "02f3fd919079d3d085a82bc9f5c5f2b5687345df47c439601b2b2568043a0f1f"
   head "https://github.com/ericpaulbishop/gargoyle.git"
 
   bottle do
@@ -14,6 +13,9 @@ class FonFlashCli < Formula
     sha256 "6d9553416c6ee3357c1c160b2f77bcea950a9c326c659011c11ea039200d3384" => :mavericks
     sha256 "0e2e7ff173495f9e9d908be176ad95589637da5f4849ce4702ee82ee410f3308" => :mountain_lion
   end
+
+  # requires at least the 10.11 SDK
+  depends_on :macos => :yosemite
 
   def install
     cd "fon-flash" do


### PR DESCRIPTION
restrict to >= Yosemite since at least the 10.11 SDK is required
