### PR TITLE
fish: Version independent config dirs for fish. Fixes completion support.

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -1,9 +1,17 @@
 class Fish < Formula
   desc "User-friendly command-line shell for UNIX-like operating systems"
   homepage "https://fishshell.com"
-  url "https://fishshell.com/files/2.3.1/fish-2.3.1.tar.gz"
-  mirror "https://github.com/fish-shell/fish-shell/releases/download/2.3.1/fish-2.3.1.tar.gz"
-  sha256 "328acad35d131c94118c1e187ff3689300ba757c4469c8cc1eaa994789b98664"
+
+  stable do
+    url "https://fishshell.com/files/2.3.1/fish-2.3.1.tar.gz"
+    mirror "https://github.com/fish-shell/fish-shell/releases/download/2.3.1/fish-2.3.1.tar.gz"
+    sha256 "328acad35d131c94118c1e187ff3689300ba757c4469c8cc1eaa994789b98664"
+
+    # Skip extra dirs creation during install phase patch for current stable. To be removed on the next fish release.
+    # As discussed in https://github.com/Homebrew/homebrew-core/pull/2813
+    # Use part of https://github.com/fish-shell/fish-shell/commit/9abbc5f upstream commit and patch the makefile.
+    patch :DATA
+  end
 
   bottle do
     sha256 "99462c8b9fc844882b8877f2b016823ce7c9e54dd89d532e13ce9e3af90558d4" => :el_capitan
@@ -22,9 +30,17 @@ class Fish < Formula
 
   def install
     system "autoconf" if build.head? || build.devel?
+
     # In Homebrew's 'superenv' sed's path will be incompatible, so
     # the correct path is passed into configure here.
-    system "./configure", "--prefix=#{prefix}", "SED=/usr/bin/sed"
+    args = %W[
+      --prefix=#{prefix}
+      --with-extra-functionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_functions.d
+      --with-extra-completionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
+      --with-extra-confdir=#{HOMEBREW_PREFIX}/share/fish/vendor_conf.d
+      SED=/usr/bin/sed
+    ]
+    system "./configure", *args
     system "make", "install"
   end
 
@@ -39,7 +55,30 @@ class Fish < Formula
     EOS
   end
 
+  def post_install
+    (pkgshare/"vendor_functions.d").mkpath
+    (pkgshare/"vendor_completions.d").mkpath
+    (pkgshare/"vendor_conf.d").mkpath
+  end
+
   test do
     system "#{bin}/fish", "-c", "echo"
   end
 end
+
+__END__
+As discussed in https://github.com/Homebrew/homebrew-core/pull/2813
+Grab part of https://github.com/fish-shell/fish-shell/commit/9abbc5f upstream commit and patch the makefile.
+--- a/Makefile.in
++++ b/Makefile.in@@ -664,5 +664,5 @@ install-force: all install-translations
+@@ -664,5 +664,5 @@ install-force: all install-translations
+ 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/completions
+-	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_completionsdir)
+-	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_functionsdir)
+-	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_confdir)
++	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_completionsdir); true
++	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_functionsdir); true
++	$(INSTALL) -m 755 -d $(DESTDIR)$(extra_confdir); true
+ 	$(INSTALL) -m 755 -d $(DESTDIR)$(datadir)/fish/functions
+
+


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This fixes https://github.com/Homebrew/legacy-homebrew/issues/45124 by using 3 extra dirs.

```
 #{HOMEBREW_PREFIX}/share/fish/vendor_functions.d
 #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
 #{HOMEBREW_PREFIX}/share/fish/vendor_conf.d
```

all Formulae using `fish_completion.install` will just work now as it installes files to 
_#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d_
(there are 8 in core tap, I tested on youtube-dl formula)

other 2 dirs are for 3-rd party fish shell extensions like this one https://github.com/fisherman/homebrew-tap

It's my first contribution, please let me know if something is wrong.
