### PR TITLE
Elasticsearch 2.3.4 and Logstash 2.3.4

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.3/elasticsearch-2.3.3.tar.gz"
-  sha256 "5fe0a6887432bb8a8d3de2e79c9b81c83cfa241e6440f0f0379a686657789165"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.4/elasticsearch-2.3.4.tar.gz"
+  sha256 "371e0c5f4ded0a8548f1cce55faff3efebcfd5f895c2c816f220146521f6f06e"
 
   devel do
     url "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha4/elasticsearch-5.0.0-alpha4.tar.gz"

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -3,8 +3,8 @@ class Logstash < Formula
   homepage "https://www.elastic.co/products/logstash"
 
   stable do
-    url "https://download.elastic.co/logstash/logstash/logstash-2.3.3.tar.gz"
-    sha256 "51a20fbfe2aa0c5ea49ceda8278a4667289fd1871cf7be4ba1c32bd6cbc71d74"
+    url "https://download.elastic.co/logstash/logstash/logstash-2.3.4.tar.gz"
+    sha256 "7f62a03ddc3972e33c343e982ada1796b18284f43ed9c0089a2efee78b239583"
     depends_on :java => "1.7+"
   end
 


### PR DESCRIPTION
This pull request updates the Elasticsearch and Logstah formulae from
version 2.3.3 to version 2.3.4, the latest stable versions as of
2016-07-07.
