### PR TITLE
redshift: moved caveats method to before the plist block

### DIFF
--- a/Formula/redshift.rb
+++ b/Formula/redshift.rb
@@ -42,6 +42,14 @@ class Redshift < Formula
     pkgshare.install "redshift.conf.sample"
   end
 
+  def caveats; <<-EOS.undent
+    A sample .conf file has been installed to #{opt_pkgshare}.
+
+    Please note redshift expects to read its configuration file from
+    #{ENV["HOME"]}/.config
+    EOS
+  end
+
   plist_options :manual => "redshift"
 
   def plist; <<-EOS.undent
@@ -65,14 +73,6 @@ class Redshift < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
-  end
-
-  def caveats; <<-EOS.undent
-    A sample .conf file has been installed to #{opt_pkgshare}.
-
-    Please note redshift expects to read its configuration file from
-    #{ENV["HOME"]}/.config
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

initial, slight edit to Redshift formula aligning it to brew audit --strict guidelines with the caveats method running before the plist block. @MikeMcQuaid  
