### PR TITLE
duti: add 10.12 support

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -15,11 +15,12 @@ class Duti < Formula
 
   depends_on "autoconf" => :build
 
-  # Add hardcoded SDK path for El Capitan. See https://github.com/moretension/duti/pull/13
-  if MacOS.version == :el_capitan
+  # Add hardcoded SDK path for El Capitan or later.
+  # See https://github.com/moretension/duti/pull/20.
+  if MacOS.version >= :el_capitan
     patch do
-      url "https://github.com/moretension/duti/pull/13.patch"
-      sha256 "5e2d482fe73fe95aea23c25417fdc3815f14724e96e4ac60e5a329424a735388"
+      url "https://github.com/moretension/duti/pull/20.patch"
+      sha256 "8fab50d10242f8ebc4be10e9a9e11d3daf91331d438d06f692fb6ebd6cbec2f8"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Another year, another Darwin version, [another patch](https://github.com/moretension/duti/pull/20). Upstream has abandoned the project — last year's patch hasn't been merged yet; but after applying the patch in this PR, `duti` still compiles and runs perfectly fine on 10.12 PB1.

It is also worth mentioning that `duti` is reasonably popular — [286 bottle downloads within the last month alone](https://bintray.com/homebrew/bottles/duti/view#statistics) — so I don't think it should be boneyarded.
