### PR TITLE
GHC: Build documentation add option to build without

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -12,10 +12,12 @@ class Ghc < Formula
   end
 
   option "with-test", "Verify the build using the testsuite"
+  option "without-docs", "Do not build documentation (including man page)"
   deprecated_option "tests" => "with-test"
   deprecated_option "with-tests" => "with-test"
 
   depends_on :macos => :lion
+  depends_on "sphinx-doc" => :build if build.with? "docs"
 
   resource "gmp" do
     url "https://ftpmirror.gnu.org/gmp/gmp-6.1.0.tar.bz2"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
  - I've audited, but installing from source is taking an eternity. I've installed from source before (with and without Homebrew and `sphinx-doc`), but for some reason, I'm now experiencing huge compile times (and I really haven't changed anything that would warrant this, not on the formula at least). _This PR is not ready to merge, and I am simply making it to take advantage of the CI so I can know if I'm on a dead end with the strategy I'm using_.
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  - I am unable to install the formula due to huge compile times, but the audit passes before install.
