### PR TITLE
boost and log4cxx --HEAD

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -1,9 +1,26 @@
 class Boost < Formula
   desc "Collection of portable C++ source libraries"
   homepage "https://www.boost.org/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
-  sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
   revision 2
+
+  stable do
+    url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
+    sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
+
+    # Handle compile failure with boost/graph/adjacency_matrix.hpp
+    # https://github.com/Homebrew/homebrew/pull/48262
+    # https://svn.boost.org/trac/boost/ticket/11880
+    # patch derived from https://github.com/boostorg/graph/commit/1d5f43d
+    patch :DATA
+
+    # Fix auto-pointer registration in 1.60
+    # https://github.com/boostorg/python/pull/59
+    # patch derived from https://github.com/boostorg/python/commit/f2c465f
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/9e56b45/boost/boost1_60_0_python_class_metadata.diff"
+      sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
+    end
+  end
 
   head "https://github.com/boostorg/boost.git"
 
@@ -13,20 +30,6 @@ class Boost < Formula
     sha256 "932c8ad1cbf1acef67e8ff18ff6eddd8eb995c2670ba89f1d9525c41517e132b" => :el_capitan
     sha256 "677e37a021fc677f9e6f15c1511ea2ac33f247ec25ea85ac90e5fa11419386db" => :yosemite
     sha256 "fa6ee8ea6a5975fb94235db3d3c18681011289b4d1588ff675259b2088aaff21" => :mavericks
-  end
-
-  # Handle compile failure with boost/graph/adjacency_matrix.hpp
-  # https://github.com/Homebrew/homebrew/pull/48262
-  # https://svn.boost.org/trac/boost/ticket/11880
-  # patch derived from https://github.com/boostorg/graph/commit/1d5f43d
-  patch :DATA
-
-  # Fix auto-pointer registration in 1.60
-  # https://github.com/boostorg/python/pull/59
-  # patch derived from https://github.com/boostorg/python/commit/f2c465f
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/9e56b45/boost/boost1_60_0_python_class_metadata.diff"
-    sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
   end
 
   env :userpaths

--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -1,29 +1,9 @@
 class Log4cxx < Formula
   desc "Library of C++ classes for flexible logging"
   homepage "https://logging.apache.org/log4cxx/index.html"
+  stable do
   url "https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
   sha256 "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
-
-  bottle do
-    cellar :any
-    sha256 "e588ef7c319d3fca76aeb29684ed1ec66f648a04c06d2f4263889b81d3c24067" => :el_capitan
-    sha256 "803d857c115430068d91887a218159dd728b87c94c8a819807225817ff9f2ecb" => :yosemite
-    sha256 "93b74be0ecb9bdb32ab803fbae0836ad58387a9ff1ba9346334e734596da7b6d" => :mavericks
-    sha256 "6b07acbb1e77d8d7edc7e111f57250b9d05c9b9c8aa6f1363f919940695aa1f9" => :mountain_lion
-  end
-
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
-
-  option :universal
-  option :cxx11
-
-  fails_with :llvm do
-    build 2334
-    cause "Fails with 'collect2: ld terminated with signal 11 [Segmentation fault]'"
-  end
-
   # Incorporated upstream, remove on next version update
   # https://issues.apache.org/jira/browse/LOGCXX-400 (r1414037)
   # https://issues.apache.org/jira/browse/LOGCXX-404 (r1414037)
@@ -43,6 +23,30 @@ class Log4cxx < Formula
     url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/f33998566cccf91fb84133e101f5a92a14b31aed/LOGCXX-404---domtestcase.cpp.patch"
     sha256 "3eaf321e1df8e8e4a0a507a96646727180e7e721b2c42af22a5d40962d3dbecc"
   end
+  done
+
+  bottle do
+    cellar :any
+    sha256 "e588ef7c319d3fca76aeb29684ed1ec66f648a04c06d2f4263889b81d3c24067" => :el_capitan
+    sha256 "803d857c115430068d91887a218159dd728b87c94c8a819807225817ff9f2ecb" => :yosemite
+    sha256 "93b74be0ecb9bdb32ab803fbae0836ad58387a9ff1ba9346334e734596da7b6d" => :mavericks
+    sha256 "6b07acbb1e77d8d7edc7e111f57250b9d05c9b9c8aa6f1363f919940695aa1f9" => :mountain_lion
+  end
+
+  head "http://svn.apache.org/repos/asf/incubator/log4cxx/trunk"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  option :universal
+  option :cxx11
+
+  fails_with :llvm do
+    build 2334
+    cause "Fails with 'collect2: ld terminated with signal 11 [Segmentation fault]'"
+  end
+
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
move patches (which are already in upstream, or at least don't apply) under a 'stable' block
