### PR TITLE
doxygen: use Qt 5

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -14,19 +14,20 @@ class Doxygen < Formula
   end
 
   option "with-graphviz", "Build with dot command support from Graphviz."
-  option "with-doxywizard", "Build GUI frontend with qt support."
+  option "with-qt5", "Build GUI frontend with Qt support."
   option "with-libclang", "Build with libclang support."
 
   deprecated_option "with-dot" => "with-graphviz"
+  deprecated_option "with-doxywizard" => "with-qt5"
 
   depends_on "cmake" => :build
   depends_on "graphviz" => :optional
-  depends_on "qt" if build.with? "doxywizard"
+  depends_on "qt5" => :optional
   depends_on "llvm" => "with-clang" if build.with? "libclang"
 
   def install
     args = std_cmake_args
-    args << "-Dbuild_wizard=ON" if build.with? "doxywizard"
+    args << "-Dbuild_wizard=ON" if build.with? "qt5"
     args << "-Duse_libclang=ON -DLLVM_CONFIG=#{Formula["llvm"].opt_bin}/llvm-config" if build.with? "libclang"
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Qt 5 works well and unlike Qt 4, properly supports new macOS versions.
