### PR TITLE
sqlitebrowser: use Qt 5

### DIFF
--- a/Formula/sqlitebrowser.rb
+++ b/Formula/sqlitebrowser.rb
@@ -13,12 +13,16 @@ class Sqlitebrowser < Formula
     sha256 "bdb49155b98d84480159b291c51ae01f47c0626ca56f66fc5f0d45756d36846f" => :mavericks
   end
 
-  depends_on "qt"
+  depends_on "qt5"
   depends_on "cmake" => :build
   depends_on "sqlite" => "with-functions"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", "-DUSE_QT5=TRUE", *std_cmake_args
     system "make", "install"
+  end
+
+  test do
+    system "#{bin}/sqlitebrowser", "-h"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Qt 5 works well and unlike Qt 4, properly supports new macOS versions.
