### PR TITLE
quassel: use Qt 5

### DIFF
--- a/Formula/quassel.rb
+++ b/Formula/quassel.rb
@@ -23,11 +23,7 @@ class Quassel < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-
-  # Official binary packages upstream now built against qt5 by default. But source
-  # packages default to qt4 *for now*, and Homebrew prioritises qt5 in PATH due to keg_only.
-  depends_on "qt5" => :optional
-  depends_on "qt" => :recommended
+  depends_on "qt5" => :recommended
 
   needs :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Qt 5 works well and unlike Qt 4, properly supports new macOS versions.
