### PR TITLE
cppcheck: use Qt 5

### DIFF
--- a/Formula/cppcheck.rb
+++ b/Formula/cppcheck.rb
@@ -12,12 +12,13 @@ class Cppcheck < Formula
   end
 
   option "without-rules", "Build without rules (no pcre dependency)"
-  option "with-gui", "Build the cppcheck gui (requires Qt)"
+  option "with-qt5", "Build the cppcheck GUI (requires Qt)"
 
   deprecated_option "no-rules" => "without-rules"
+  deprecated_option "with-gui" => "with-qt5"
 
   depends_on "pcre" if build.with? "rules"
-  depends_on "qt" if build.with? "gui"
+  depends_on "qt5" => :optional
 
   needs :cxx11
 
@@ -39,10 +40,12 @@ class Cppcheck < Formula
     # Move the python addons to the cppcheck pkgshare folder
     (pkgshare/"addons").install Dir.glob(bin/"*.py")
 
-    if build.with? "gui"
+    if build.with? "qt5"
       cd "gui" do
         if build.with? "rules"
-          system "qmake", "HAVE_RULES=yes"
+          system "qmake", "HAVE_RULES=yes",
+                          "INCLUDEPATH+=#{Formula["pcre"].opt_include}",
+                          "LIBS+=-L#{Formula["pcre"].opt_lib}"
         else
           system "qmake", "HAVE_RULES=no"
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Qt 5 works well and unlike Qt 4, properly supports new macOS versions.
