### PR TITLE
shairport-sync: add stdout and pipe audio outputs

### DIFF
--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -28,6 +28,8 @@ class ShairportSync < Formula
       --with-ssl=openssl
       --with-dns_sd
       --with-ao
+      --with-stdout
+      --with-pipe
       --with-soxr
       --with-configfiles=no
       --with-piddir=#{prefix}
@@ -40,6 +42,6 @@ class ShairportSync < Formula
 
   test do
     test_cmd = "#{bin}/shairport-sync -V"
-    assert_match(/openssl-ao-soxr/, shell_output(test_cmd, 1))
+    assert_match(/openssl-ao-stdout-pipe-soxr/, shell_output(test_cmd, 1))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Note: fails `brew audit --strict --online <formula>` with `GitHub fork (not canonical repository)` but it did before this change as well.

The `stdout` and `pipe` backends are very useful for streaming airplay audio to other devices rather than playing locally. They require no extra dependencies.
