### PR TITLE
go: fix installation of external tools with Go 1.7

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -14,10 +14,13 @@ class Go < Formula
     sha256 "0cf1ef52a5ac93b20b5f8cce1d7f2fd470fd0af9ac70d5ecea77ec7a87dee92c" => :mavericks
   end
 
+  go_version = "1.6"
+
   devel do
     url "https://storage.googleapis.com/golang/go1.7rc1.src.tar.gz"
     version "1.7rc1"
     sha256 "f26b42ea8d3de92efda5e2f7172b22d59e19676f23bbcf64412b32b4f4a5ff58"
+  go_version = "1.7"
   end
 
   option "without-cgo", "Build without cgo"
@@ -25,7 +28,6 @@ class Go < Formula
   option "without-vet", "vet will not be installed for you"
   option "without-race", "Build without race detector"
 
-  go_version = "1.6"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
@@ -87,7 +89,9 @@ class Go < Formula
         bin.install_symlink libexec/"bin/godoc"
       end
 
-      if build.with? "vet"
+      # go vet is now part of the standard Go toolchain. Remove this block
+      # and the option once Go 1.7 is released
+      if build.with? "vet" && File.exist?("src/golang.org/x/tools/cmd/vet/")
         cd "src/golang.org/x/tools/cmd/vet/" do
           system "go", "build"
           # This is where Go puts vet natively; not in the bin.

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -20,14 +20,13 @@ class Go < Formula
     url "https://storage.googleapis.com/golang/go1.7rc1.src.tar.gz"
     version "1.7rc1"
     sha256 "f26b42ea8d3de92efda5e2f7172b22d59e19676f23bbcf64412b32b4f4a5ff58"
-  go_version = "1.7"
+    go_version = "1.7"
   end
 
   option "without-cgo", "Build without cgo"
   option "without-godoc", "godoc will not be installed for you"
   option "without-vet", "vet will not be installed for you"
   option "without-race", "Build without race detector"
-
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
@@ -91,7 +90,7 @@ class Go < Formula
 
       # go vet is now part of the standard Go toolchain. Remove this block
       # and the option once Go 1.7 is released
-      if build.with? "vet" && File.exist?("src/golang.org/x/tools/cmd/vet/")
+      if build.with?("vet") && File.exist?("src/golang.org/x/tools/cmd/vet/")
         cd "src/golang.org/x/tools/cmd/vet/" do
           system "go", "build"
           # This is where Go puts vet natively; not in the bin.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Go 1.7 integrated `go vet` in the standard toolchain, so it's not part of the external tools repo anymore. This PR fixes two related bugs in the formula:
- Make sure that we checkout the correct tools branch when building devel; previously, it would always build the branch of the stable version. This is a potential bug because you can't use old tools (aligned with a previous version) with a newer Go version and expect them to work. See for instance https://github.com/golang/go/issues/16044 (that is fixed by this patch).
- Add a workaround to avoid failing when trying to install `go vet` from the tools directory. Once Go 1.7 is released and the whole formula cleaned up, the whole codeblock can just be removed.
