### PR TITLE
gx-go 1.2.1

### DIFF
--- a/Formula/gx-go.rb
+++ b/Formula/gx-go.rb
@@ -3,9 +3,8 @@ require "language/go"
 class GxGo < Formula
   desc "Tool to use with the gx package manager for packages written in go."
   homepage "https://github.com/whyrusleeping/gx-go"
-  url "https://github.com/whyrusleeping/gx-go.git",
-    :tag => "v1.2.0",
-    :revision => "1fd3e84312ff558b7020a732207910d6c491d5e4"
+  url "https://github.com/whyrusleeping/gx-go/archive/v1.2.1.tar.gz"
+  sha256 "190856a82d4cd79a76e3d366ce015d93c9147ffe581f4fcd6cf9b86ab5955dd3"
   head "https://github.com/whyrusleeping/gx-go.git"
 
   bottle do
@@ -16,57 +15,35 @@ class GxGo < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
-  depends_on "gx"
+
+  go_resource "github.com/anacrolix/missinggo" do
+    url "https://github.com/anacrolix/missinggo.git",
+      :revision => "797fc5dd606f07c7c8af5bed81b61c2a8dccefb0"
+  end
+
+  go_resource "github.com/anacrolix/sync" do
+    url "https://github.com/anacrolix/sync.git",
+      :revision => "812602587b72df6a2a4f6e30536adc75394a374b"
+  end
+
+  go_resource "github.com/anacrolix/utp" do
+    url "https://github.com/anacrolix/utp.git",
+      :revision => "d7ad5aff2b8a5fa415d1c1ed00b71cfd8b4c69e0"
+  end
+
+  go_resource "github.com/bradfitz/iter" do
+    url "https://github.com/bradfitz/iter.git",
+      :revision => "454541ec3da2a73fc34fd049b19ee5777bf19345"
+  end
 
   go_resource "github.com/codegangsta/cli" do
     url "https://github.com/codegangsta/cli.git",
-      :revision => "71f57d300dd6a780ac1856c005c4b518cfd498ec"
-  end
-
-  go_resource "github.com/whyrusleeping/gx-go" do
-    url "https://github.com/whyrusleeping/gx-go.git",
-      :revision => "e5258e8126435420207a15d914c895e076177af4"
-  end
-
-  go_resource "github.com/whyrusleeping/gx" do
-    url "https://github.com/whyrusleeping/gx.git",
-      :revision => "b82b91b0cf30023c277903ab1ed6b158e80d5d23"
-  end
-
-  go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git",
-      :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
-  end
-
-  go_resource "github.com/jbenet/go-multiaddr-net" do
-    url "https://github.com/jbenet/go-multiaddr-net.git",
-      :revision => "4a8bd8f8baf45afcf2bb385bbc17e5208d5d4c71"
-  end
-
-  go_resource "github.com/jbenet/go-multiaddr" do
-    url "https://github.com/jbenet/go-multiaddr.git",
-      :revision => "41d11170520e5b0ea0af2489d7ac5fbdd452e603"
-  end
-
-  go_resource "github.com/jbenet/go-multihash" do
-    url "https://github.com/jbenet/go-multihash.git",
-      :revision => "e8d2374934f16a971d1e94a864514a21ac74bf7f"
-  end
-
-  go_resource "github.com/sabhiram/go-git-ignore" do
-    url "https://github.com/sabhiram/go-git-ignore.git",
-      :revision => "228fcfa2a06e870a3ef238d54c45ea847f492a37"
-  end
-
-  go_resource "github.com/whyrusleeping/stump" do
-    url "https://github.com/whyrusleeping/stump.git",
-      :revision => "bdc01b1f13fc5bed17ffbf4e0ed7ea17fd220ee6"
+      :revision => "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
   end
 
   go_resource "github.com/ipfs/go-ipfs-api" do
     url "https://github.com/ipfs/go-ipfs-api.git",
-      :revision => "1e3445c6574212ffd7d5536e5ec77713debe1f32"
+      :revision => "b683f180dcbe2241e95502f2315622f0bcbb5848"
   end
 
   go_resource "github.com/jbenet/go-base58" do
@@ -74,9 +51,39 @@ class GxGo < Formula
       :revision => "6237cf65f3a6f7111cd8a42be3590df99a66bc7d"
   end
 
-  go_resource "golang.org/x/crypto" do
-    url "https://go.googlesource.com/crypto.git",
-    :revision => "3fbbcd23f1cb824e69491a5930cfeff09b12f4d2"
+  go_resource "github.com/jbenet/go-multiaddr" do
+    url "https://github.com/jbenet/go-multiaddr.git",
+      :revision => "f3dff105e44513821be8fbe91c89ef15eff1b4d4"
+  end
+
+  go_resource "github.com/jbenet/go-multiaddr-net" do
+    url "https://github.com/jbenet/go-multiaddr-net.git",
+      :revision => "d4cfd691db9f50e430528f682ca603237b0eaae0"
+  end
+
+  go_resource "github.com/jbenet/go-multihash" do
+    url "https://github.com/jbenet/go-multihash.git",
+      :revision => "dfd3350f10a27ba2cfcd0e5e2d12c43a69f6e408"
+  end
+
+  go_resource "github.com/jbenet/go-os-rename" do
+    url "https://github.com/jbenet/go-os-rename.git",
+      :revision => "3ac97f61ef67a6b87b95c1282f6c317ed0e693c2"
+  end
+
+  go_resource "github.com/kr/fs" do
+    url "https://github.com/kr/fs.git",
+      :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+  end
+
+  go_resource "github.com/mitchellh/go-homedir" do
+    url "https://github.com/mitchellh/go-homedir.git",
+      :revision => "756f7b183b7ab78acdbbee5c7f392838ed459dda"
+  end
+
+  go_resource "github.com/sabhiram/go-git-ignore" do
+    url "https://github.com/sabhiram/go-git-ignore.git",
+      :revision => "228fcfa2a06e870a3ef238d54c45ea847f492a37"
   end
 
   go_resource "github.com/whyrusleeping/go-multipart-files" do
@@ -84,20 +91,35 @@ class GxGo < Formula
       :revision => "3be93d9f6b618f2b8564bfb1d22f1e744eabbae2"
   end
 
+  go_resource "github.com/whyrusleeping/gx" do
+    url "https://github.com/whyrusleeping/gx.git",
+      :revision => "267eb7e2912e08e656dc50136a716793adb61ca4"
+  end
+
+  go_resource "github.com/whyrusleeping/stump" do
+    url "https://github.com/whyrusleeping/stump.git",
+      :revision => "206f8f13aae1697a6fc1f4a55799faf955971fc5"
+  end
+
   go_resource "github.com/whyrusleeping/tar-utils" do
     url "https://github.com/whyrusleeping/tar-utils.git",
       :revision => "beab27159606f5a7c978268dd1c3b12a0f1de8a7"
   end
 
+  go_resource "golang.org/x/crypto" do
+    url "https://go.googlesource.com/crypto.git",
+      :revision => "c2f4947f41766b144bb09066e919466da5eddeae"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
+    mkdir_p "src/github.com/whyrusleeping"
+    ln_s buildpath, "src/github.com/whyrusleeping/gx-go"
     Language::Go.stage_deps resources, buildpath/"src"
-
-    system "go", "build", "-o", "gx-go"
-    bin.install "gx-go"
+    system "go", "build", "-o", bin/"gx-go"
   end
 
   test do
-    system "#{bin}/gx-go", "help"
+    system bin/"gx-go", "help"
   end
 end


### PR DESCRIPTION
- switch to tarball
- indent :revision in go_resource blocks two spaces beyond the url
- remove godep and gx dependencies
