### PR TITLE
pure-ftpd: safer defaults + add missing dependency

### DIFF
--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -13,6 +13,7 @@ class PureFtpd < Formula
     sha256 "c97aa32a237cdfb02780d6808a42507ec8fa97345ef4f3332cfcfb6cce91ff1a" => :mavericks
   end
 
+  depends_on "libsodium"
   depends_on "openssl"
   depends_on :postgresql => :optional
   depends_on :mysql => :optional

--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -23,23 +23,15 @@ class PureFtpd < Formula
       --prefix=#{prefix}
       --mandir=#{man}
       --sysconfdir=#{etc}
+      --with-everything
       --with-pam
-      --with-altlog
-      --with-puredb
-      --with-throttling
-      --with-ratios
-      --with-quotas
-      --with-ftpwho
-      --with-virtualhosts
-      --with-virtualchroot
-      --with-diraliases
-      --with-peruserlimits
       --with-tls
       --with-bonjour
     ]
 
     args << "--with-pgsql" if build.with? "postgresql"
     args << "--with-mysql" if build.with? "mysql"
+    args << "--with-virtualchroot" if build.with? "virtualchroot"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -13,6 +13,8 @@ class PureFtpd < Formula
     sha256 "c97aa32a237cdfb02780d6808a42507ec8fa97345ef4f3332cfcfb6cce91ff1a" => :mavericks
   end
 
+  option "with-virtualchroot", "Follow symbolic links even for chrooted accounts"
+
   depends_on "libsodium"
   depends_on "openssl"
   depends_on :postgresql => :optional


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This simplify autoconf options, makes `virtualchroot` optional and disabled by default, and makes virtual users actually work on macOS by adding `libsodium` as a dependency.
