### PR TITLE
wine: move sierra patch to stable block, fixed in devel; add trivial test

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -25,6 +25,15 @@ class Wine < Formula
       url "https://github.com/wine-mirror/wine/commit/cac226200d88b7454747b5ee1016f06b89ce4aa6.patch"
       sha256 "ad5dd3aff4dd03aa6dd9e00162a52ad335dbd9ddb5a4472ad8533efb677fb479"
     end
+
+    # Fixes a CUPS-related build failure
+    # https://bugs.winehq.org/show_bug.cgi?id=40851
+    if MacOS.version >= :sierra
+      patch do
+        url "https://bugs.winehq.org/attachment.cgi?id=54854"
+        sha256 "07da01c4141052d274dbe39d45a13568265cbdcbc9de4f6e80f4eeb08aad9ff8"
+      end
+    end
   end
 
   bottle do
@@ -65,15 +74,6 @@ class Wine < Formula
   patch do
     url "https://bugs.winehq.org/attachment.cgi?id=52384"
     sha256 "30766403f5064a115f61de8cacba1defddffe2dd898b59557956400470adc699"
-  end
-
-  # Fixes a CUPS-related build failure; should be in the next devel.
-  # https://bugs.winehq.org/show_bug.cgi?id=40851
-  if MacOS.version >= :sierra
-    patch do
-      url "https://bugs.winehq.org/attachment.cgi?id=54854"
-      sha256 "07da01c4141052d274dbe39d45a13568265cbdcbc9de4f6e80f4eeb08aad9ff8"
-    end
   end
 
   # This option is currently disabled because Apple clang currently doesn't
@@ -187,5 +187,9 @@ class Wine < Formula
       EOS
     end
     s
+  end
+
+  test do
+    system "#{bin}/wine", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

add trivial test to satisfy audit
