### PR TITLE
crosstool-ng: fix coreutils dependency.

### DIFF
--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -3,6 +3,7 @@ class CrosstoolNg < Formula
   homepage "http://crosstool-ng.org"
   url "http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.xz"
   sha256 "a8b50ddb6e651c3eec990de54bd191f7b8eb88cd4f88be9338f7ae01639b3fba"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,8 +15,8 @@ class CrosstoolNg < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "coreutils" => :build
   depends_on "help2man" => :build
+  depends_on "coreutils"
   depends_on "wget"
   depends_on "gnu-sed"
   depends_on "gawk"
@@ -28,17 +29,18 @@ class CrosstoolNg < Formula
   env :std
 
   def install
-    args = ["--prefix=#{prefix}",
-            "--exec-prefix=#{prefix}",
-            "--with-objcopy=gobjcopy",
-            "--with-objdump=gobjdump",
-            "--with-readelf=greadelf",
-            "--with-libtool=glibtool",
-            "--with-libtoolize=glibtoolize",
-            "--with-install=ginstall",
-            "--with-sed=gsed",
-            "--with-awk=gawk",
-           ]
+    args = [
+      "--prefix=#{prefix}",
+      "--exec-prefix=#{prefix}",
+      "--with-objcopy=gobjcopy",
+      "--with-objdump=gobjdump",
+      "--with-readelf=greadelf",
+      "--with-libtool=glibtool",
+      "--with-libtoolize=glibtoolize",
+      "--with-install=ginstall",
+      "--with-sed=gsed",
+      "--with-awk=gawk",
+    ]
 
     args << "--with-grep=ggrep" if build.with? "grep"
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

A basic "ct-ng build" requires ginstall, which is provided by coreutils.
