### PR TITLE
tesseract: fix snum installation location (Fixes #2899)

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -99,7 +99,7 @@ class Tesseract < Formula
 
     system "make", "install"
     if build.with? "serial-num-pack"
-      (pkgshare/"tessdata").install resource("snum")
+      resource("snum").stage { mv "snum.traineddata", share/"tessdata" }
     end
     if build.with? "training-tools"
       system "make", "training"


### PR DESCRIPTION
Puts the serial number training data in the /tessdata share.
