### PR TITLE
various formulae: remove golang requirement

### DIFF
--- a/Formula/assh.rb
+++ b/Formula/assh.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Assh < Formula
   desc "Advanced SSH config - Regex, aliases, gateways, includes and dynamic hosts"
   homepage "https://github.com/moul/advanced-ssh-config"

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class DockerMachineDriverXhyve < Formula
   desc "Docker Machine driver for xhyve"
   homepage "https://github.com/zchee/docker-machine-driver-xhyve"

--- a/Formula/emp.rb
+++ b/Formula/emp.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Emp < Formula
   desc "CLI for Empire."
   homepage "https://github.com/remind101/empire"

--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -1,3 +1,6 @@
+require "socket"
+require "timeout"
+
 class Fabio < Formula
   desc "Zero-conf load balancing HTTP(S) router."
   homepage "https://github.com/eBay/fabio"

--- a/Formula/noti.rb
+++ b/Formula/noti.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Noti < Formula
   desc "Trigger notifications when a process completes"
   homepage "https://github.com/variadico/noti"

--- a/Formula/path-extractor.rb
+++ b/Formula/path-extractor.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class PathExtractor < Formula
   desc "unix filter which outputs the filepaths found in stdin"
   homepage "https://github.com/edi9999/path-extractor"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

These commits address the `brew audit` warning:
`require "language/go" is unnecessary unless using `go_resource`s`.
