### PR TITLE
lua/luajit: ensure module persistence

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -60,10 +60,9 @@ class Lua < Formula
     ENV.universal_binary if build.universal?
 
     # Subtitute formula prefix in `src/Makefile` for install name (dylib ID).
-    inreplace "src/Makefile", "@LUA_PREFIX@", prefix
-
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
+      s.gsub! "@LUA_PREFIX@", prefix
       s.remove_make_var! "CC"
       s.change_make_var! "CFLAGS", "#{ENV.cflags} -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
@@ -98,7 +97,7 @@ class Lua < Formula
         system "make", "build"
         system "make", "install"
 
-        (share/"lua/5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
+        (pkgshare/"5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
         bin.install_symlink libexec/"bin/luarocks-5.2"
         bin.install_symlink libexec/"bin/luarocks-admin-5.2"
         bin.install_symlink libexec/"bin/luarocks"

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -3,7 +3,7 @@ class Lua < Formula
   homepage "https://www.lua.org/"
   url "https://www.lua.org/ftp/lua-5.2.4.tar.gz"
   sha256 "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -75,7 +75,7 @@ class Lua < Formula
     # We ship our own pkg-config file as Lua no longer provide them upstream.
     system "make", "macosx", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
     system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
-    (lib+"pkgconfig/lua.pc").write pc_file
+    (lib/"pkgconfig/lua.pc").write pc_file
 
     # Fix some software potentially hunting for different pc names.
     bin.install_symlink "lua" => "lua5.2"
@@ -98,7 +98,7 @@ class Lua < Formula
         system "make", "build"
         system "make", "install"
 
-        (share+"lua/5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
+        (share/"lua/5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
         bin.install_symlink libexec/"bin/luarocks-5.2"
         bin.install_symlink libexec/"bin/luarocks-admin-5.2"
         bin.install_symlink libexec/"bin/luarocks"
@@ -118,13 +118,13 @@ class Lua < Formula
   def pc_file; <<-EOS.undent
     V= 5.2
     R= 5.2.4
-    prefix=#{prefix}
+    prefix=#{opt_prefix}
     INSTALL_BIN= ${prefix}/bin
     INSTALL_INC= ${prefix}/include
     INSTALL_LIB= ${prefix}/lib
     INSTALL_MAN= ${prefix}/share/man/man1
-    INSTALL_LMOD= ${prefix}/share/lua/${V}
-    INSTALL_CMOD= ${prefix}/lib/lua/${V}
+    INSTALL_LMOD= #{HOMEBREW_PREFIX}/share/lua/${V}
+    INSTALL_CMOD= #{HOMEBREW_PREFIX}/lib/lua/${V}
     exec_prefix=${prefix}
     libdir=${exec_prefix}/lib
     includedir=${prefix}/include

--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -3,7 +3,7 @@ class Luajit < Formula
   homepage "http://luajit.org/luajit.html"
   url "http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
   sha256 "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
-  revision 1
+  revision 2
 
   head "http://luajit.org/git/luajit-2.0.git"
 
@@ -56,6 +56,15 @@ class Luajit < Formula
     # https://github.com/Homebrew/homebrew/issues/45854.
     lib.install_symlink lib/"libluajit-5.1.dylib" => "libluajit.dylib"
     lib.install_symlink lib/"libluajit-5.1.a" => "libluajit.a"
+
+    # Fix path in pkg-config so modules are installed
+    # to permanent location rather than inside the Cellar.
+    inreplace lib/"pkgconfig/luajit.pc" do |s|
+      s.gsub! "INSTALL_LMOD=${prefix}/share/lua/${abiver}",
+              "INSTALL_LMOD=#{HOMEBREW_PREFIX}/share/lua/${abiver}"
+      s.gsub! "INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}",
+              "INSTALL_CMOD=#{HOMEBREW_PREFIX}/${multilib}/lua/${abiver}"
+    end
 
     # Having an empty Lua dir in lib/share can mess with other Homebrew Luas.
     %W[ #{lib}/lua #{share}/lua ].each { |d| rm_rf d }

--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -67,7 +67,7 @@ class Luajit < Formula
     end
 
     # Having an empty Lua dir in lib/share can mess with other Homebrew Luas.
-    %W[ #{lib}/lua #{share}/lua ].each { |d| rm_rf d }
+    %W[#{lib}/lua #{share}/lua].each { |d| rm_rf d }
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

A loose comparison would be to say LMOD/CMOD are representative of Python's site-packages setup & how we handle that. It isn't expected to point to a transient location.

Note that `lua51` isn't impacted because we've been rewriting the `pkg-config` file there to point to `HOMEBREW_PREFIX` as the `prefix` variable, which means the rest of the paths are automatically correct.

Ref: https://github.com/Homebrew/homebrew-core/pull/2665.
