### PR TITLE
mailhog: references to specific dependency revisions removed.

### DIFF
--- a/Formula/mailhog.rb
+++ b/Formula/mailhog.rb
@@ -18,113 +18,92 @@ class Mailhog < Formula
   depends_on "go" => :build
 
   go_resource "github.com/gorilla/context" do
-    url "https://github.com/gorilla/context.git",
-      :revision => "1c83b3eabd45b6d76072b66b746c20815fb2872d"
+    url "https://github.com/gorilla/context.git"
   end
 
   go_resource "github.com/gorilla/mux" do
-    url "https://github.com/gorilla/mux.git",
-      :revision => "ad4d7a5882b961e07e2626045eb995c022ac6664"
+    url "https://github.com/gorilla/mux.git"
   end
 
   go_resource "github.com/gorilla/pat" do
-    url "https://github.com/gorilla/pat.git",
-      :revision => "e3ceaad21981965be815a74ec833802d74e52947"
+    url "https://github.com/gorilla/pat.git"
+  end
+
+  go_resource "github.com/gorilla/websocket" do
+    url "https://github.com/gorilla/websocket.git"
   end
 
   go_resource "github.com/ian-kent/envconf" do
-    url "https://github.com/ian-kent/envconf.git",
-      :revision => "c19809918c02ab33dc8635d68c77649313185275"
+    url "https://github.com/ian-kent/envconf.git"
   end
 
   go_resource "github.com/ian-kent/go-log" do
-    url "https://github.com/ian-kent/go-log.git",
-      :revision => "0d363706e0041a0431fbfa482d655738f7820db8"
+    url "https://github.com/ian-kent/go-log.git"
   end
 
   go_resource "github.com/ian-kent/goose" do
-    url "https://github.com/ian-kent/goose.git",
-      :revision => "c3541ea826ad9e0f8a4a8c15ca831e8b0adde58c"
+    url "https://github.com/ian-kent/goose.git"
   end
 
   go_resource "github.com/ian-kent/linkio" do
-    url "https://github.com/ian-kent/linkio.git",
-      :revision => "77fb4b01842cb4b019137c0227df9a8f9779d0bd"
-  end
-
-  go_resource "github.com/jteeuwen/go-bindata" do
-    url "https://github.com/jteeuwen/go-bindata.git",
-      :revision => "1c1928d3b62dc79f5b35c32ae372a5fe69e9b4f1"
+    url "https://github.com/ian-kent/linkio.git"
   end
 
   go_resource "github.com/mailhog/data" do
-    url "https://github.com/mailhog/data.git",
-      :revision => "36077cc82f0e00c479943a06173a600dedefd7a0"
+    url "https://github.com/mailhog/data.git"
   end
 
   go_resource "github.com/mailhog/http" do
-    url "https://github.com/mailhog/http.git",
-      :revision => "066a2dfd9d8bf7a94a2df4e1b4b9db3556b56bbb"
+    url "https://github.com/mailhog/http.git"
   end
 
   go_resource "github.com/mailhog/mhsendmail" do
-    url "https://github.com/mailhog/mhsendmail.git",
-      :revision => "0bba7051c64d8af0b436d0c47774d12a8684a3e1"
+    url "https://github.com/mailhog/mhsendmail.git"
   end
 
   go_resource "github.com/mailhog/smtp" do
-    url "https://github.com/mailhog/smtp.git",
-      :revision => "8c087763ca1b9208b0890dab7aacd487c07ba06a"
+    url "https://github.com/mailhog/smtp.git"
   end
 
   go_resource "github.com/mailhog/storage" do
-    url "https://github.com/mailhog/storage.git",
-      :revision => "33a9b882525652a3e4b74b03716e0225de010ba4"
+    url "https://github.com/mailhog/storage.git"
   end
 
   go_resource "github.com/mailhog/MailHog-Server" do
-    url "https://github.com/mailhog/MailHog-Server.git",
-      :revision => "1dfb973b724a309c18474fe032b1458c0d8654fc"
+    url "https://github.com/mailhog/MailHog-Server.git"
   end
 
   go_resource "github.com/mailhog/MailHog-UI" do
-    url "https://github.com/mailhog/MailHog-UI.git",
-      :revision => "ebdfa0f91fac40169ca376953d7c13f9d83cd01a"
+    url "https://github.com/mailhog/MailHog-UI.git"
   end
 
   go_resource "github.com/mailhog/MailHog" do
-    url "https://github.com/mailhog/MailHog.git",
-      :revision => "91a9d8afe119dc96a6c9acfa94c997765c824908"
+    url "https://github.com/mailhog/MailHog.git"
   end
 
-  go_resource "github.com/ogier/pflag" do
-    url "https://github.com/ogier/pflag.git",
-      :revision => "6f7159c3154e7cd4ab30f6cc9c58fa3fd0f22325"
+  go_resource "github.com/spf13/pflag" do
+    url "https://github.com/spf13/pflag.git"
   end
 
   go_resource "github.com/t-k/fluent-logger-golang" do
-    url "https://github.com/t-k/fluent-logger-golang.git",
-      :revision => "0f8ec08f2057a61574b6943e75045fffbeae894e"
+    url "https://github.com/t-k/fluent-logger-golang.git"
   end
 
   go_resource "github.com/tinylib/msgp" do
-    url "https://github.com/tinylib/msgp.git",
-      :revision => "c46fbee0675f25770e5f340dc9bc22bf4a108ad4"
+    url "https://github.com/tinylib/msgp.git"
   end
 
   go_resource "golang.org/x/crypto" do
-    url "https://github.com/golang/crypto.git",
-      :revision => "c8b9e6388ef638d5a8a9d865c634befdc46a6784"
+    url "https://github.com/golang/crypto.git"
   end
 
   go_resource "github.com/philhofer/fwd" do
-    url "https://github.com/philhofer/fwd.git",
-      :revision => "8fd9a4b75098b2125fe442e48a3ffbf738254e13"
+    url "https://github.com/philhofer/fwd.git"
   end
 
-  go_resource "labix.org/v2/mgo" do
+  go_resource "gopkg.in/mgo.v2" do
     url "https://github.com/go-mgo/mgo.git",
-      :revision => "2e26580ebcca4eca6533535f2dd062cd6bff44ac"
+      :branch => "v2"
   end
 
   def install
@@ -136,6 +115,8 @@ class Mailhog < Formula
     system "go", "build", "-o", "MailHog"
     bin.install "MailHog"
   end
+
+  plist_options :manual => "MailHog"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This PR removes references to specific dependency revisions and makes sure that, if built from source, MailHog is using the latest versions of its dependencies. This issue was originally mentioned by @swrobel in #2501.
