### PR TITLE
platformio 2.11.1

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -1,8 +1,8 @@
 class Platformio < Formula
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/71/76/05dd805502dc5f9adadc7cdfd91f89320f505038884d97d0c05024a98e0f/platformio-2.11.0.tar.gz"
-  sha256 "11775c303fc3cb82fd353574bd2258b4ec6504855dcde6c557624a963a88fe08"
+  url "https://pypi.python.org/packages/31/d9/9d06e2b531028772650dc3a79dd770fcc12e1265d877b9de0ad455217f1c/platformio-2.11.1.tar.gz"
+  sha256 "26e64cf0aed9fef2b6a7be6e907a0f347885b7610da80244c6fc63e72671ab89"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---
## 2.11.1 (2016-07-12)
-   Added support for Arduino M0, M0 Pro and Tian boards ([issue #472](https://github.com/platformio/platformio/issues/472))
-   Added support for Microchip chipKIT Lenny board
-   Updated Microchip PIC32 Arduino framework to v1.2.1
-   Documented [uploading of EEPROM data](http://docs.platformio.org/en/latest/platforms/atmelavr.html#upload-eeprom-data) (from EEMEM directive)
-   Added `Rebuild C/C++ Project Index` target to CLion and Eclipse IDEs
-   Improved project generator for [CLion IDE](http://docs.platformio.org/en/latest/ide/clion.html)
-   Added `udev` rules for OpenOCD CMSIS-DAP adapters ([issue #718](https://github.com/platformio/platformio/issues/718))
-   Auto-remove project cache when PlatformIO is upgraded
-   Keep user changes for `.gitignore` file when re-generate/update project data
-   Ignore `[platformio]` section from custom project configuration file when [platformio ci –project-conf](http://docs.platformio.org/en/latest/userguide/cmd_ci.html) command is used
-   Fixed missed `--boot` flag for the firmware uploader for ATSAM3X8E Cortex-M3 MCU based boards (Arduino Due, etc) ([issue #710](https://github.com/platformio/platformio/issues/710))
-   Fixed missing trailing `\` for the source files list when generate project for [Qt Creator IDE](http://docs.platformio.org/en/latest/ide/qtcreator.html) ([issue #711](https://github.com/platformio/platformio/issues/711))
-   Split source files to `HEADERS` and `SOURCES` when generate project for [Qt Creator IDE](http://docs.platformio.org/en/latest/ide/qtcreator.html) ([issue #713](https://github.com/platformio/platformio/issues/713))
