### PR TITLE
cfitsio 3.390

### DIFF
--- a/Formula/cfitsio.rb
+++ b/Formula/cfitsio.rb
@@ -1,10 +1,10 @@
 class Cfitsio < Formula
   desc "C access to FITS data files with optional Fortran wrappers"
   homepage "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html"
-  url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3370.tar.gz"
-  mirror "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3370.tar.gz"
-  version "3.370"
-  sha256 "092897c6dae4dfe42d91d35a738e45e8236aa3d8f9b3ffc7f0e6545b8319c63a"
+  url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3390.tar.gz"
+  mirror "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3390.tar.gz"
+  version "3.390"
+  sha256 "62d3d8f38890275cc7a78f5e9a4b85d7053e75ae43e988f1e2390e539ba7f409"
 
   bottle do
     cellar :any
@@ -18,14 +18,15 @@ class Cfitsio < Formula
 
   resource "examples" do
     url "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/cexamples/cexamples.zip"
-    version "2014.01.23"
-    sha256 "85b2deecbd40dc2d4311124758784b1ff11db1dd93ac8e7a29f3d6cda5f8aa3d"
+    version "2016.04.06"
+    sha256 "ed17b6d0f2a3d9858d6b19a073b2479823b37e501b7fd0ef9fa08988ad7ab8fc"
   end
 
   def install
     system "./configure", "--prefix=#{prefix}", "--enable-reentrant"
     system "make", "shared"
     system "make", "install"
+    (pkgshare/"testprog").install Dir["testprog*"]
 
     if build.with? "examples"
       system "make", "fpack", "funpack"
@@ -38,5 +39,18 @@ class Cfitsio < Formula
         end
       end
     end
+  end
+
+  test do
+    cp Dir["#{pkgshare}/testprog/testprog*"], testpath
+    flags = %W[
+      -I#{include}
+      -L#{lib}
+      -lcfitsio
+    ]
+    system ENV.cc, "testprog.c", "-o", "testprog", *flags
+    system "./testprog > testprog.lis"
+    cmp "testprog.lis", "testprog.out"
+    cmp "testprog.fit", "testprog.std"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I saw #2782, so I'm doing a drive-by update.
- Updated the examples resource;
- Added a test block (now installing `testprog*` to `share/cfitsio/testprog/` so that we can test it later).

Another thought: maybe this formula could be migrated to homebrew/science, because `cfitsio` deals with FITS images used only in astronomy (AFAIK)? Plus `ccfits`, its C++ wrapper, is in homebrew/science.
