### PR TITLE
no-more-secrets 0.2.1

### DIFF
--- a/Formula/no-more-secrets.rb
+++ b/Formula/no-more-secrets.rb
@@ -1,8 +1,8 @@
 class NoMoreSecrets < Formula
   desc "Recreates the SETEC ASTRONOMY effect from 'Sneakers'"
   homepage "https://github.com/bartobri/no-more-secrets"
-  url "https://github.com/bartobri/no-more-secrets/archive/v0.2.0.tar.gz"
-  sha256 "cc0f588d1c05290027c7b33d4639e9a860122eba1af9475c00db9d3b18ffdcb3"
+  url "https://github.com/bartobri/no-more-secrets/archive/v0.2.1.tar.gz"
+  sha256 "b5e899a318c64f2f18c85fce6e5a434d604b80f0fd41a3a5a3338f195b8a41c4"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,17 +11,7 @@ class NoMoreSecrets < Formula
     sha256 "e6969faff5484a728a6b339b4c6448e4b801313253c4eea874d8f705f8f3b6fe" => :mavericks
   end
 
-  # upstream commit that fixes version for 0.2.0
-  patch do
-    url "https://github.com/bartobri/no-more-secrets/commit/e07eddae.patch"
-    sha256 "20dce9db7b7164f5529a94dca71c9f21195477980dae7bb8c082eef5d942f911"
-  end
-
   def install
-    # ld: library not found for -lncursesw
-    # Reported 4 Jul 2016: https://github.com/bartobri/no-more-secrets/issues/24
-    inreplace "Makefile", "LDLIBS = -lncursesw", "LDLIBS = -lncurses"
-
     system "make", "all"
     system "make", "prefix=#{prefix}", "install"
   end


### PR DESCRIPTION
- remove version correction patch, which is now stale
- remove ncurses workaround since issue was fixed upstream
