### PR TITLE
OpenH264 1.6.0 retag fix

### DIFF
--- a/Formula/openh264.rb
+++ b/Formula/openh264.rb
@@ -2,7 +2,7 @@ class Openh264 < Formula
   desc "H.264 codec from Cisco"
   homepage "http://www.openh264.org"
   url "https://github.com/cisco/openh264/archive/v1.6.0.tar.gz"
-  sha256 "951109b86cf82be7d2aa65e7542edf4bdf26ae9ec93674c638d28c02a9d1a59a"
+  sha256 "65d307bf312543ad6e98ec02abb7c27d8fd2c9740fd069d7249844612674a2c7"
   head "https://github.com/cisco/openh264.git"
 
   bottle do

--- a/Formula/openh264.rb
+++ b/Formula/openh264.rb
@@ -3,6 +3,8 @@ class Openh264 < Formula
   homepage "http://www.openh264.org"
   url "https://github.com/cisco/openh264/archive/v1.6.0.tar.gz"
   sha256 "65d307bf312543ad6e98ec02abb7c27d8fd2c9740fd069d7249844612674a2c7"
+  revision 1
+
   head "https://github.com/cisco/openh264.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Fix sha256 mismatch likely due to release retagging
