### PR TITLE
Add `etc/telegraf.d` directory to `telegraf` formula and startup script

### DIFF
--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -373,6 +373,11 @@ class Telegraf < Formula
     etc.install telegraf_path/"etc/telegraf.conf" => "telegraf.conf"
   end
 
+  def post_install
+    # Create directory for additional user configurations
+    (etc/"telegraf.d").mkpath
+  end
+
   plist_options :manual => "telegraf -config #{HOMEBREW_PREFIX}/etc/telegraf.conf"
 
   def plist; <<-EOS.undent
@@ -391,7 +396,9 @@ class Telegraf < Formula
         <array>
           <string>#{opt_bin}/telegraf</string>
           <string>-config</string>
-          <string>#{HOMEBREW_PREFIX}/etc/telegraf.conf</string>
+          <string>#{etc}/telegraf.conf</string>
+          <string>-config-directory</string>
+          <string>#{etc}/telegraf.d</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This change allows users to place configuration files into `etc/telegraf.d` as well as edit `etc/telegraf.conf`, as is common with software such as this.
