### PR TITLE
git-integration (0.4)

### DIFF
--- a/Formula/git-integration.rb
+++ b/Formula/git-integration.rb
@@ -14,8 +14,8 @@ end
 class GitIntegration < Formula
   desc "Manage git integration branches"
   homepage "https://johnkeeping.github.io/git-integration/"
-  url "https://github.com/johnkeeping/git-integration/archive/v0.3.tar.gz"
-  sha256 "7fb0a4ed4e4c23b7fa9334abfd1894ed5821b73be144d56d67d926e3cd7a1eb5"
+  url "https://github.com/johnkeeping/git-integration/archive/v0.4.tar.gz"
+  sha256 "b0259e90dca29c71f6afec4bfdea41fe9c08825e740ce18409cfdbd34289cc02"
   head "https://github.com/johnkeeping/git-integration.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This formula fails `brew audit --strict --online` because the GitHub repository is not popular enough!  Since there are no other failures, and I'm merely updating an existing formula that already “passed muster” in a prior version, I feel like the notability error is spurious here.
