### PR TITLE
Mbedtls: fixed --HEAD and added a patch for current stable

### DIFF
--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -1,16 +1,29 @@
 class Mbedtls < Formula
   desc "Cryptographic & SSL/TLS library"
   homepage "https://tls.mbed.org/"
-  url "https://tls.mbed.org/download/mbedtls-2.3.0-apache.tgz"
-  sha256 "590734c8bc8b3ac48e9123d44bf03562e91f8dce0d1ac2615c318c077f3215b2"
   head "https://github.com/ARMmbed/mbedtls.git", :branch => "development"
 
   stable do
+    url "https://tls.mbed.org/download/mbedtls-2.3.0-apache.tgz"
+    sha256 "590734c8bc8b3ac48e9123d44bf03562e91f8dce0d1ac2615c318c077f3215b2"
+
+    # https://github.com/ARMmbed/mbedtls/issues/522
+    # They are commits already applied to the upstream.
     patch do
-      # https://github.com/ARMmbed/mbedtls/issues/522
-      # It is a commit already applied to the upstream.
       url "https://github.com/ARMmbed/mbedtls/commit/7247f99b3e068a2b90b7776a2cdd438fddb7a38b.patch"
       sha256 "071830f9b1870ed319fcc65e34ce6d6f9b3476e81f0a204d474635e59ac08687"
+    end
+    patch do
+      url "https://github.com/ARMmbed/mbedtls/commit/b5b6af2663fdb7f57c30494607bade90810f6844.patch"
+      sha256 "859ffed5d6e4dfb386c0ee3b9f00efa904d0ee8977272def4bd787e1c9efda82"
+    end
+    patch do
+      url "https://github.com/ARMmbed/mbedtls/commit/b92834324f29768a5bf39c58c674c5f3c09b6763.patch"
+      sha256 "f48b42e10ed0462945391ac2c7eb737ed39d377d91960baeaf91fe1325b38c96"
+    end
+    patch do
+      url "https://github.com/ARMmbed/mbedtls/commit/23e9778684ba734dbfba1445e145b04dd6b59e76.patch"
+      sha256 "5f642020d7706660778a14547425c5cb5a8c99b56b92ed46514b7a43823487b7"
     end
   end
 

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -3,7 +3,7 @@ class Mbedtls < Formula
   homepage "https://tls.mbed.org/"
   url "https://tls.mbed.org/download/mbedtls-2.3.0-apache.tgz"
   sha256 "590734c8bc8b3ac48e9123d44bf03562e91f8dce0d1ac2615c318c077f3215b2"
-  head "https://github.com/ARMmbed/mbedtls.git"
+  head "https://github.com/ARMmbed/mbedtls.git", :branch => "development"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -2,6 +2,7 @@ class Mbedtls < Formula
   desc "Cryptographic & SSL/TLS library"
   homepage "https://tls.mbed.org/"
   head "https://github.com/ARMmbed/mbedtls.git", :branch => "development"
+  revision 1
 
   stable do
     url "https://tls.mbed.org/download/mbedtls-2.3.0-apache.tgz"

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -5,6 +5,15 @@ class Mbedtls < Formula
   sha256 "590734c8bc8b3ac48e9123d44bf03562e91f8dce0d1ac2615c318c077f3215b2"
   head "https://github.com/ARMmbed/mbedtls.git", :branch => "development"
 
+  stable do
+    patch do
+      # https://github.com/ARMmbed/mbedtls/issues/522
+      # It is a commit already applied to the upstream.
+      url "https://github.com/ARMmbed/mbedtls/commit/7247f99b3e068a2b90b7776a2cdd438fddb7a38b.patch"
+      sha256 "071830f9b1870ed319fcc65e34ce6d6f9b3476e81f0a204d474635e59ac08687"
+    end
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "bd0d1b53b53dc6ed0018315c45523911530c50ad12ee38754f2cde22ba81f180" => :el_capitan


### PR DESCRIPTION
2 changes to the mbedtls formula:
- head branch is "development"
- added a patch from upstream that fixes `brew install neko --HEAD`
