### PR TITLE
ffmpeg: fix rtmpdump nonfree

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -146,7 +146,7 @@ class Ffmpeg < Formula
 
     # These librares are GPL-incompatible, and require ffmpeg be built with
     # the "--enable-nonfree" flag, which produces unredistributable libraries
-    if %w[faac fdk-aac openssl].any? { |f| build.with? f }
+    if %w[faac fdk-aac openssl rtmpdump].any? { |f| build.with? f }
       args << "--enable-nonfree"
     end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

--with-rtmpdump causes explicit linking against openssl ;
solution: same behavior as if openssl enabled directly

This may be me being overly picky, however compiling ffmpeg with rtmpdump enabled causes ffmpeg to link to openssl directly. Currently, building with openssl enabled triggers the --enable-nonfree arg as a work-around for openssl's non-GPLv3 compatible license. At least in my mind, since rtmpdump causes similar linkage, the formula should act as if openssl had been configured, because for all intents and purposes it has.

Specifically, on my machine, ffmpeg is linked to /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib and /usr/local/opt/openssl/lib/libssl.1.0.0.dylib, in addition to /usr/local/opt/rtmpdump/lib/librtmp.1.dylib
