### PR TITLE
shibboleth-sp 2.6.0

### DIFF
--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -16,6 +16,7 @@ class Opensaml < Formula
   depends_on "xerces-c"
   depends_on "xml-security-c"
   depends_on "xml-tooling-c"
+  depends_on "openssl"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"

--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -1,8 +1,8 @@
 class Opensaml < Formula
   desc "Library for Security Assertion Markup Language"
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/Home"
-  url "https://shibboleth.net/downloads/c++-opensaml/2.5.3/opensaml-2.5.3.tar.gz"
-  sha256 "1ed6a241b2021def6a1af57d3087b697c98b38842e9195e1f3fae194d55c13fb"
+  url "https://shibboleth.net/downloads/c++-opensaml/2.6.0/opensaml-2.6.0.tar.gz"
+  sha256 "8c8e7d1d7b045cda330dd49ea1972a3306ebefbf42cc65b8f612d66828352179"
 
   bottle do
     cellar :any

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -1,8 +1,8 @@
 class ShibbolethSp < Formula
   desc "Shibboleth 2 Service Provider daemon"
   homepage "https://wiki.shibboleth.net/confluence/display/SHIB2"
-  url "https://shibboleth.net/downloads/service-provider/2.5.6/shibboleth-sp-2.5.6.tar.gz"
-  sha256 "024739a7b5190aebecac913d9445719912c6e4e401bfe256a25ca75ab4e67ad5"
+  url "https://shibboleth.net/downloads/service-provider/2.6.0/shibboleth-sp-2.6.0.tar.gz"
+  sha256 "7f23b8a28e66ae1b0fe525ca1f8b84c4566a071367f5d9a1bd71bd6b29e4d985"
 
   bottle do
     revision 1

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -15,11 +15,12 @@ class ShibbolethSp < Formula
   depends_on :macos => :yosemite
   depends_on "curl" => "with-openssl"
   depends_on "opensaml"
-  depends_on "xml-tooling-c" => "with-openssl"
+  depends_on "xml-tooling-c"
   depends_on "xerces-c"
   depends_on "xml-security-c"
   depends_on "log4shib"
   depends_on "boost"
+  depends_on "unixodbc"
 
   def install
     ENV.O2 # Os breaks the build

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -1,8 +1,8 @@
 class XmlToolingC < Formula
   desc "Provides a higher level interface to XML processing"
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/XMLTooling-C"
-  url "https://shibboleth.net/downloads/c++-opensaml/2.5.3/xmltooling-1.5.3.tar.gz"
-  sha256 "90e453deb738574b04f1f1aa08ed7cc9d8746bcbf93eb59f401a6e38f2ec9574"
+  url "https://shibboleth.net/downloads/c++-opensaml/2.6.0/xmltooling-1.6.0.tar.gz"
+  sha256 "25814c49e27cdc97e17d42ca503e325f7e474ca3558a5a6b476e57a8a3c1a20e"
 
   bottle do
     cellar :any

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -11,14 +11,13 @@ class XmlToolingC < Formula
     sha256 "bd4c05a80dc82e1fac3b4fd68f6a518c45cd19d62f9a682642f23b333302d856" => :mavericks
   end
 
-  option "with-openssl", "Build with OpenSSL instead of Secure Transport"
-
   depends_on "pkg-config" => :build
   depends_on "log4shib"
   depends_on "xerces-c"
   depends_on "xml-security-c"
   depends_on "boost"
-  depends_on "curl" => "with-openssl" if build.with? "openssl"
+  depends_on "openssl"
+  depends_on "curl" => "with-openssl"
 
   def install
     ENV.O2 # Os breaks the build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Upgrades Shibboleth SP to known stable version 2.6.0, includes necessary dependency upgrades.
