### PR TITLE
lepton 1.2.1 (new formula)

### DIFF
--- a/Formula/lepton.rb
+++ b/Formula/lepton.rb
@@ -1,0 +1,21 @@
+class Lepton < Formula
+  desc "Tool and file format for losslessly compressing JPEGs"
+  homepage "https://github.com/dropbox/lepton"
+  url "https://github.com/dropbox/lepton/archive/1.2.1.tar.gz"
+  sha256 "c4612dbbc88527be2e27fddf53aadf1bfc117e744db67e373ef8940449cdec97"
+  head "https://github.com/dropbox/lepton.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    cp test_fixtures("test.jpg"), "test.jpg"
+    system "#{bin}/lepton", "test.jpg", "compressed.lep"
+    system "#{bin}/lepton", "compressed.lep", "test_restored.jpg"
+    cmp "test.jpg", "test_restored.jpg"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] **See explanation below**. Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This file format and tool is newly open sourced. See
https://blogs.dropbox.com/tech/2016/07/lepton-image-compression-saving-22-losslessly-from-images-at-15mbs/.

It doesn't pass audit at the moment because the GitHub repo is too new, but the code base itself is by no means new — [initial commit](https://github.com/dropbox/lepton/commit/9a448a49ecfcbf962be8c5f14ee712664e49d061) dates back to June 2015. And Dropbox being Dropbox this repo is quickly gaining traction (500+ stars at time of writing, < 1 day after the blog post).

If the formula isn't acceptable at this point, I'll just leave it around and bump it in a month.
