### PR TITLE
pandoc-crossref 0.2.2.1

### DIFF
--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -5,9 +5,8 @@ class PandocCrossref < Formula
 
   desc "Pandoc filter for numbering and cross-referencing."
   homepage "https://github.com/lierdakil/pandoc-crossref"
-  url "https://hackage.haskell.org/package/pandoc-crossref-0.2.1.3/pandoc-crossref-0.2.1.3.tar.gz"
-  sha256 "d14b78972c48a722b7e53d12fb601e4379d5384f9a58c8ce46ab42b058125471"
-  revision 1
+  url "https://hackage.haskell.org/package/pandoc-crossref-0.2.2.1/pandoc-crossref-0.2.2.1.tar.gz"
+  sha256 "85da5dff663b578367ed75dcd71d8273a9cd92e8ae4a907ff0b83694d8417abd"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,39 +20,9 @@ class PandocCrossref < Formula
   depends_on "pandoc" => :run
 
   def install
-    cabal_sandbox do
-      # GHC 8 compat
-      # Reported upstream 26 May 2016: https://github.com/lierdakil/pandoc-crossref/issues/69
-      # For specifics regarding the API changes, see
-      # https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#template-haskell-2.11.0.0
-      # https://git.haskell.org/ghc.git/commitdiff/575abf42e218925e456bf765abb14f069ac048a0
-      inreplace "lib/Text/Pandoc/CrossRef/Util/Settings/Template.hs" do |s|
-        s.gsub! "DataD _ _ params cons' _", "DataD _ _ params _ cons' _"
-        s.gsub! "NewtypeD _ _ params con' _", "NewtypeD _ _ params _ con' _"
-        s.gsub! "VarI _ t' _ _ <- reify accName", "VarI _ t' _ <- reify accName"
-      end
-      (buildpath/"cabal.config").write <<-EOS.undent
-        allow-newer: base,time
-        constraints: data-accessor-template ==0.2.1.12
-      EOS
-      system "cabal", "get", "data-accessor-template"
-      cd "data-accessor-template-0.2.1.12" do
-        inreplace "data-accessor-template.cabal",
-          "Build-Depends:  template-haskell >=2.4 && <2.11",
-          "Build-Depends:  template-haskell >=2.4 && <2.12"
-        inreplace "src-5/Data/Accessor/Template.hs" do |s|
-          s.gsub! "DataD _ _ params cons' _ -> return (params, cons')",
-            "DataD _ _ params _ cons' _ -> return (params, cons')"
-          s.gsub! "NewtypeD _ _ params con' _ -> return (params, [con'])",
-            "NewtypeD _ _ params _ con' _ -> return (params, [con'])"
-        end
-      end
-      cabal_sandbox_add_source "data-accessor-template-0.2.1.12"
-
-      args = []
-      args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
-      install_cabal_package *args
-    end
+    args = []
+    args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
+    install_cabal_package *args
   end
 
   test do


### PR DESCRIPTION
now builds with GHC 8 out of the box, so remove the upstreamed fixes
