### PR TITLE
sqlite: add regexp extension support

### DIFF
--- a/Formula/sqlite.rb
+++ b/Formula/sqlite.rb
@@ -84,9 +84,9 @@ class Sqlite < Formula
       system ENV.cc, "-fno-common",
                      "-dynamiclib",
                      "extension-functions.c",
-                     "-o", "libsqlitefunctions.dylib",
+                     "-o", "libfunctions.dylib",
                      *ENV.cflags.to_s.split
-      lib.install "libsqlitefunctions.dylib"
+      lib.install "libfunctions.dylib"
     end
 
     if build.with? "regexp"
@@ -117,7 +117,7 @@ class Sqlite < Formula
 
         If the program is built so that loading extensions is permitted,
         the following will work:
-         sqlite> SELECT load_extension('#{lib}/libsqlitefunctions.dylib');
+         sqlite> SELECT load_extension('#{lib}/libfunctions.dylib');
          sqlite> select cos(radians(45));
          0.707106781186548
          sqlite> SELECT load_extension('#{lib}/libregexp.dylib');


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

@plumbojumbo @vszakats @twexler @DomT4 @bfontaine

Hello recent sqlite maintainers,

I am working on this PR for sqlite regex support. However I ran into some
strange problems and I could use your advice.
1. The build uses `sqlite-autoconf-3130000` instead of `sqlite-src-3100200`.
   This combined / mashed-up copy of the code does not include
   `ext/misc/regexp.c`. So I tried to follow the pattern of the `functions`
   support which downloads the extra file.
2. The Fossil SCM repository seems to prevent direct-linking to the latest
   version of the file... the interface it uses for file downloads is totally
   bizarre:
   
   Default (Hardcoded) URL:
   `http://www.sqlite.org/src/raw/ext/misc/regexp.c?name=a68d25c659bd2d893cd1215667bbf75ecb9dc7d4`
   
   Other Failed Attempts:
   `http://www.sqlite.org/src/raw/ext/misc/regexp.c`: returns repo homepage
   `http://www.sqlite.org/src/raw/ext/misc/regexp.c?name=trunk`: returns some bogus internal SCM file
   
   Can I fix this issue, or should I host the file elsewhere? Right now I
   cheated and used a local webserver as a POC to get feedback first.
3. Something kind of bad has changed about the extension library and extension
   function naming. Loading failed when the extensions were named
   `libsqlitefunctions.dylib` and `libsqliteregexp.dylib`. Loading succeeds after
   I rename them to `libfunctions.dylib` and `libregexp.dylib`. However I was
   concerned this could cause some kind of unexpected breakage if these `SONAMES`
   are too common. Note this also means the upstream `functions` feature is
   broken as-is. I fixed it here temporarily but I am not sure if I did it right.

Sincerely,
@megahall
