### PR TITLE
es: fix readline default

### DIFF
--- a/Formula/es.rb
+++ b/Formula/es.rb
@@ -3,6 +3,7 @@ class Es < Formula
   homepage "https://wryun.github.io/es-shell/"
   url "https://github.com/wryun/es-shell/releases/download/v0.9.1/es-0.9.1.tar.gz"
   sha256 "b0b41fce99b122a173a06b899a4d92e5bd3cc48b227b2736159f596a58fff4ba"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,8 +19,14 @@ class Es < Formula
   conflicts_with "kes", :because => "both install 'es' binary"
 
   def install
-    args = ["--prefix=#{prefix}"]
-    args << "--with-readline" if build.with? "readline"
+    args = %W[--prefix=#{prefix}]
+
+    if build.with? "readline"
+      args << "--with-readline"
+    else
+      args << "--with-editline"
+    end
+
     system "./configure", *args
     system "make"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

It's linking to `readline` regardless because that's the upstream default. Nudge it to actually link to the correct thing based on given option.
