### PR TITLE
c-kermit: fix test, fix code style issues

### DIFF
--- a/Formula/c-kermit.rb
+++ b/Formula/c-kermit.rb
@@ -24,6 +24,7 @@ class CKermit < Formula
   end
 
   test do
-    assert_equal "#{testpath}", shell_output("#{bin}/kermit -C PWD,exit").chomp
+    assert_match "C-Kermit #{version}",
+                 shell_output("#{bin}/kermit -C VERSION,exit")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Testing with the `PWD` command turns out to be problematic because it prints the real path, but `testpath` is the logical path, resulting in:

```
==> /usr/local/Cellar/c-kermit/9.0.302/bin/kermit -C PWD,exit
Error: c-kermit: failed
<"/tmp/c-kermit-test-20160711-81517-1v46fdo"> expected but was
<"/private/tmp/c-kermit-test-20160711-81517-1v46fdo">.
```
