### PR TITLE
commonmark 0.26.0 and rename to cmark

### DIFF
--- a/Aliases/cmark
+++ b/Aliases/cmark
@@ -1,1 +1,0 @@
-../Formula/commonmark.rb

--- a/Formula/cmark.rb
+++ b/Formula/cmark.rb
@@ -1,4 +1,4 @@
-class Commonmark < Formula
+class Cmark < Formula
   desc "Strongly specified, highly compatible implementation of Markdown"
   homepage "http://commonmark.org"
   url "https://github.com/jgm/cmark/archive/0.26.0.tar.gz"

--- a/Formula/commonmark.rb
+++ b/Formula/commonmark.rb
@@ -1,8 +1,8 @@
 class Commonmark < Formula
   desc "Strongly specified, highly compatible implementation of Markdown"
   homepage "http://commonmark.org"
-  url "https://github.com/jgm/cmark/archive/0.25.2.tar.gz"
-  sha256 "530ae56d81a370ce29ed77fd3a34628c94277320f23657f5efb402283716f29b"
+  url "https://github.com/jgm/cmark/archive/0.26.0.tar.gz"
+  sha256 "7ed32e77966c5d06cd6f010b46894cd4d1f494651d6e0da55cb876436fdac806"
 
   bottle do
     cellar :any

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -2,6 +2,7 @@
   "app-engine-java-sdk": "app-engine-java",
   "beanstalk": "beanstalkd",
   "letsencrypt": "certbot",
+  "commonmark": "cmark",
   "cppformat": "fmt",
   "crystal": "autocode",
   "cv": "progress",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

https://github.com/jgm/cmark/releases/tag/0.26.0.

About the rename: When I created this formula in Jan 2015, it was part of [CommonMark's main repo](github.com/jgm/CommonMark), but the C implementation we were packaging quickly spun off `jgm/CommonMark` to become the standalone [`jgm/cmark`](github.com/jgm/cmark). I wanted to rename the formula to `cmark` at that time, but [the technology wasn't ready](https://github.com/Homebrew/legacy-homebrew/pull/36209#issuecomment-71387071). The formula then went under the misnomer `commonmark` for 10+ releases. I think it's time to correct its name.
