### PR TITLE
vifm 0.8.2

### DIFF
--- a/Formula/vifm.rb
+++ b/Formula/vifm.rb
@@ -1,9 +1,8 @@
 class Vifm < Formula
   desc "Ncurses based file manager with vi like keybindings"
   homepage "https://vifm.info/"
-  url "https://downloads.sourceforge.net/project/vifm/vifm/vifm-0.8.1a.tar.bz2"
-  mirror "https://github.com/vifm/vifm/releases/download/v0.8.1a/vifm-0.8.1a.tar.bz2"
-  sha256 "974fb2aa5e32d2c729ceff678c595070c701bd30a6ccc5cb6ca64807a9dd4422"
+  url "https://github.com/vifm/vifm/releases/download/v0.8.2/vifm-0.8.2.tar.bz2"
+  sha256 "8b466d766658a24d07fc2039a26fefc6a018f5653684a6035183ca79f02c211f"
 
   bottle do
     sha256 "46ad2f98c56e9306c00540ead159cbc70f02e4a7947e9f3f80f2408a01752f01" => :el_capitan
@@ -11,24 +10,18 @@ class Vifm < Formula
     sha256 "ba80ce8c6d4762404cfd8f1595823ad1d7e347447dbbe50c1d73ad75a10efdcf" => :mavericks
   end
 
-  head do
-    url "https://github.com/vifm/vifm.git"
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
-  end
-
   def install
-    system "autoreconf", "-ivf" if build.head?
-
-    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-    system "./configure", *args
-
-    ENV.deparallelize
-    system "make", "install"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--without-gtk",
+                          "--without-libmagic",
+                          "--without-X11"
+    system "make"
+    system "make", "check"
+    ENV.deparallelize { system "make", "install" }
   end
 
   test do
-    assert_match /^Version: #{Regexp.escape(version)}/,
-      shell_output("#{bin}/vifm --version")
+    assert_match version.to_s, shell_output("#{bin}/vifm --version")
   end
 end


### PR DESCRIPTION
- use solely the GitHub tarball
- prevent opportunistic linking against libmagic, GTK+, and X11
- run "make check"
- use a string for the substring match in the test
