### PR TITLE
llvm: Change URL for HEAD resource libunwind

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -108,7 +108,7 @@ class Llvm < Formula
     end
 
     resource "libunwind" do
-      url "git://git.sv.gnu.org/libunwind.git"
+      url "http://llvm.org/git/libunwind.git"
     end
 
     resource "lld" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The old URL pointed to the GNU libunwind repository. Unfortunately,
placing the GNU version in the "projects" folder results in CMake being
unable to find the libunwind headers when building with libc++abi,
resulting in a CMake error. The build appears to work fine with the
LLVM version of the library.
