### PR TITLE
Remove preprocessor/compiler/linker flags from environment in test blocks

### DIFF
--- a/Formula/atk.rb
+++ b/Formula/atk.rb
@@ -36,8 +36,7 @@ class Atk < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/atkmm.rb
+++ b/Formula/atkmm.rb
@@ -38,8 +38,7 @@ class Atkmm < Formula
     glib = Formula["glib"]
     glibmm = Formula["glibmm"]
     libsigcxx = Formula["libsigc++"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0

--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -80,8 +80,7 @@ class Cairo < Formula
     glib = Formula["glib"]
     libpng = Formula["libpng"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{fontconfig.opt_include}
       -I#{freetype.opt_include}/freetype2
       -I#{gettext.opt_include}

--- a/Formula/cairomm.rb
+++ b/Formula/cairomm.rb
@@ -45,8 +45,7 @@ class Cairomm < Formula
     libpng = Formula["libpng"]
     libsigcxx = Formula["libsigc++"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}
       -I#{freetype.opt_include}/freetype2

--- a/Formula/clutter-gst.rb
+++ b/Formula/clutter-gst.rb
@@ -58,8 +58,7 @@ class ClutterGst < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{clutter.opt_include}/clutter-1.0

--- a/Formula/clutter-gtk.rb
+++ b/Formula/clutter-gtk.rb
@@ -55,8 +55,7 @@ class ClutterGtk < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{clutter.opt_include}/clutter-1.0

--- a/Formula/clutter.rb
+++ b/Formula/clutter.rb
@@ -59,8 +59,7 @@ class Clutter < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{cogl.opt_include}/cogl

--- a/Formula/etl.rb
+++ b/Formula/etl.rb
@@ -27,8 +27,7 @@ class Etl < Formula
         return 6 - rv;
       }
     EOS
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{include}
       -lpthread
     ]

--- a/Formula/gdl.rb
+++ b/Formula/gdl.rb
@@ -45,8 +45,7 @@ class Gdl < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/geany.rb
+++ b/Formula/geany.rb
@@ -44,8 +44,7 @@ class Geany < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gedit.rb
+++ b/Formula/gedit.rb
@@ -68,8 +68,7 @@ class Gedit < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/geocode-glib.rb
+++ b/Formula/geocode-glib.rb
@@ -46,8 +46,7 @@ class GeocodeGlib < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/gerbv.rb
+++ b/Formula/gerbv.rb
@@ -47,8 +47,7 @@ class Gerbv < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -74,8 +74,7 @@ class Gitg < Formula
     pango = Formula["pango"]
     pixman = Formula["pixman"]
     webkitgtk = Formula["webkitgtk"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/glade.rb
+++ b/Formula/glade.rb
@@ -61,8 +61,7 @@ class Glade < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/glibmm.rb
+++ b/Formula/glibmm.rb
@@ -36,8 +36,7 @@ class Glibmm < Formula
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     libsigcxx = Formula["libsigc++"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/gom.rb
+++ b/Formula/gom.rb
@@ -34,8 +34,7 @@ class Gom < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/graphene.rb
+++ b/Formula/graphene.rb
@@ -36,8 +36,7 @@ class Graphene < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/gspell.rb
+++ b/Formula/gspell.rb
@@ -56,8 +56,7 @@ class Gspell < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{enchant.opt_include}/enchant

--- a/Formula/gssdp.rb
+++ b/Formula/gssdp.rb
@@ -33,8 +33,7 @@ class Gssdp < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/gstreamermm.rb
+++ b/Formula/gstreamermm.rb
@@ -43,8 +43,7 @@ class Gstreamermm < Formula
     gst_plugins_base = Formula["gst-plugins-base"]
     gstreamer = Formula["gstreamer"]
     libsigcxx = Formula["libsigc++"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -88,8 +88,7 @@ class Gtkx < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -92,8 +92,7 @@ class Gtkx3 < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtk-mac-integration.rb
+++ b/Formula/gtk-mac-integration.rb
@@ -52,8 +52,7 @@ class GtkMacIntegration < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtkdatabox.rb
+++ b/Formula/gtkdatabox.rb
@@ -47,8 +47,7 @@ class Gtkdatabox < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtkextra.rb
+++ b/Formula/gtkextra.rb
@@ -44,8 +44,7 @@ class Gtkextra < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtkglext.rb
+++ b/Formula/gtkglext.rb
@@ -99,8 +99,7 @@ class Gtkglext < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -53,8 +53,7 @@ class Gtkmm < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/gtkmm3.rb
+++ b/Formula/gtkmm3.rb
@@ -51,8 +51,7 @@ class Gtkmm3 < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/gtksourceview.rb
+++ b/Formula/gtksourceview.rb
@@ -52,8 +52,7 @@ class Gtksourceview < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtksourceview3.rb
+++ b/Formula/gtksourceview3.rb
@@ -43,8 +43,7 @@ class Gtksourceview3 < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/gtksourceviewmm.rb
+++ b/Formula/gtksourceviewmm.rb
@@ -52,8 +52,7 @@ class Gtksourceviewmm < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/gtksourceviewmm3.rb
+++ b/Formula/gtksourceviewmm3.rb
@@ -52,7 +52,7 @@ class Gtksourceviewmm3 < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split + %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/gtkspell3.rb
+++ b/Formula/gtkspell3.rb
@@ -43,8 +43,7 @@ class Gtkspell3 < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{enchant.opt_include}/enchant

--- a/Formula/gwyddion.rb
+++ b/Formula/gwyddion.rb
@@ -54,8 +54,7 @@ class Gwyddion < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fftw.opt_include}

--- a/Formula/gxml.rb
+++ b/Formula/gxml.rb
@@ -52,8 +52,7 @@ class Gxml < Formula
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     libgee = Formula["libgee"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/json-glib.rb
+++ b/Formula/json-glib.rb
@@ -33,8 +33,7 @@ class JsonGlib < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libchamplain.rb
+++ b/Formula/libchamplain.rb
@@ -53,8 +53,7 @@ class Libchamplain < Formula
     libsoup = Formula["libsoup"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{clutter.opt_include}/clutter-1.0

--- a/Formula/libgdata.rb
+++ b/Formula/libgdata.rb
@@ -45,8 +45,7 @@ class Libgdata < Formula
     json_glib = Formula["json-glib"]
     liboauth = Formula["liboauth"]
     libsoup = Formula["libsoup"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libgee.rb
+++ b/Formula/libgee.rb
@@ -41,8 +41,7 @@ class Libgee < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -52,8 +52,7 @@ class Libgit2 < Formula
       }
     EOS
     libssh2 = Formula["libssh2"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{include}
       -I#{libssh2.opt_include}
       -L#{lib}

--- a/Formula/libglade.rb
+++ b/Formula/libglade.rb
@@ -44,8 +44,7 @@ class Libglade < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/libglademm.rb
+++ b/Formula/libglademm.rb
@@ -57,8 +57,7 @@ class Libglademm < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/libgnomecanvas.rb
+++ b/Formula/libgnomecanvas.rb
@@ -50,8 +50,7 @@ class Libgnomecanvas < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/libgnomecanvasmm.rb
+++ b/Formula/libgnomecanvasmm.rb
@@ -53,8 +53,7 @@ class Libgnomecanvasmm < Formula
     pango = Formula["pango"]
     pangomm = Formula["pangomm"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{atkmm.opt_include}/atkmm-1.6
       -I#{cairo.opt_include}/cairo

--- a/Formula/libgtop.rb
+++ b/Formula/libgtop.rb
@@ -34,8 +34,7 @@ class Libgtop < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libgweather.rb
+++ b/Formula/libgweather.rb
@@ -58,8 +58,7 @@ class Libgweather < Formula
     libsoup = Formula["libsoup"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/libical-glib.rb
+++ b/Formula/libical-glib.rb
@@ -34,8 +34,7 @@ class LibicalGlib < Formula
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     libical = Formula["libical"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libinfinity.rb
+++ b/Formula/libinfinity.rb
@@ -47,8 +47,7 @@ class Libinfinity < Formula
     gsasl = Formula["gsasl"]
     libtasn1 = Formula["libtasn1"]
     nettle = Formula["nettle"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -39,8 +39,7 @@ class Libpeas < Formula
     glib = Formula["glib"]
     gobject_introspection = Formula["gobject-introspection"]
     libffi = Formula["libffi"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/librest.rb
+++ b/Formula/librest.rb
@@ -40,8 +40,7 @@ class Librest < Formula
     EOS
     glib = Formula["glib"]
     libsoup = Formula["libsoup"]
-    flags = (ENV.cflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{libsoup.opt_include}/libsoup-2.4
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -68,8 +68,7 @@ class Librsvg < Formula
     glib = Formula["glib"]
     libpng = Formula["libpng"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}
       -I#{freetype.opt_include}/freetype2

--- a/Formula/libsoup.rb
+++ b/Formula/libsoup.rb
@@ -49,8 +49,7 @@ class Libsoup < Formula
     ENV.libxml2
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libspectre.rb
+++ b/Formula/libspectre.rb
@@ -36,8 +36,7 @@ class Libspectre < Formula
         return 0;
       }
     EOS
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{include}
       -L#{lib}
       -lspectre

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -41,8 +41,7 @@ class Libxmlxx < Formula
     glib = Formula["glib"]
     glibmm = Formula["glibmm"]
     libsigcxx = Formula["libsigc++"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -41,8 +41,7 @@ class Libxmlxx3 < Formula
     glib = Formula["glib"]
     glibmm = Formula["glibmm"]
     libsigcxx = Formula["libsigc++"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -68,8 +68,12 @@ class OpenMesh < Formula
     }
 
     EOS
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[ -I#{include} -L#{lib} -lOpenMeshCore -lOpenMeshTools]
+    flags = %W[
+      -I#{include}
+      -L#{lib}
+      -lOpenMeshCore
+      -lOpenMeshTools
+    ]
     system ENV.cxx, "test.cpp", "-o", "test", *flags
     system "./test"
   end

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -75,8 +75,7 @@ class Pango < Formula
     glib = Formula["glib"]
     libpng = Formula["libpng"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}
       -I#{freetype.opt_include}/freetype2

--- a/Formula/pangomm.rb
+++ b/Formula/pangomm.rb
@@ -44,8 +44,7 @@ class Pangomm < Formula
     libsigcxx = Formula["libsigc++"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{cairo.opt_include}/cairo
       -I#{cairomm.opt_include}/cairomm-1.0
       -I#{cairomm.opt_lib}/cairomm-1.0/include

--- a/Formula/pangox-compat.rb
+++ b/Formula/pangox-compat.rb
@@ -32,8 +32,7 @@ class PangoxCompat < Formula
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     pango = Formula["pango"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include

--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -49,8 +49,7 @@ class Pixman < Formula
         return 0;
       }
     EOS
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{include}/pixman-1
       -L#{lib}
       -lpixman-1

--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -49,8 +49,7 @@ class Plplot < Formula
         return 0;
       }
     EOS
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{include}/plplot
       -L#{lib}
       -lcsirocsa

--- a/Formula/synfig.rb
+++ b/Formula/synfig.rb
@@ -69,8 +69,7 @@ class Synfig < Formula
     mlt = Formula["mlt"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{cairo.opt_include}/cairo
       -I#{etl.opt_include}
       -I#{fontconfig.opt_include}

--- a/Formula/vte.rb
+++ b/Formula/vte.rb
@@ -55,8 +55,7 @@ class Vte < Formula
     libpng = Formula["libpng"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/vte3.rb
+++ b/Formula/vte3.rb
@@ -55,8 +55,7 @@ class Vte3 < Formula
     nettle = Formula["nettle"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}

--- a/Formula/webkitgtk.rb
+++ b/Formula/webkitgtk.rb
@@ -72,8 +72,7 @@ class Webkitgtk < Formula
     libsoup = Formula["libsoup"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
-    flags += %W[
+    flags = %W[
       -I#{atk.opt_include}/atk-1.0
       -I#{cairo.opt_include}/cairo
       -I#{fontconfig.opt_include}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] **Too many of them.** Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] **Too many of them.** Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This PR attempts to remove

``` ruby
flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
```

from test blocks en masse, which is useless as discussed in https://github.com/Homebrew/homebrew-core/pull/2944#discussion_r70846681. [According to Mike](https://github.com/Homebrew/homebrew-core/pull/2944#discussion_r71087380)

> I don't think it is necessary; I think it was some sort of early "handle superenv if we ever port tests to that" or something. I don't think there's any need for it, really.

CC @apjanke @MikeMcQuaid.
