### PR TITLE
imagemagick: build with fontconfig by default

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -30,6 +30,8 @@ class Imagemagick < Formula
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-modules", "Disable support for dynamically loadable modules"
   option "without-threads", "Disable threads support"
+  option "without-freetype", "Disable TrueType support"
+  option "without-fontconfig", "Disable fontconfig support"
 
   depends_on "xz"
   depends_on "libtool" => :run
@@ -39,9 +41,9 @@ class Imagemagick < Formula
   depends_on "libpng" => :recommended
   depends_on "libtiff" => :recommended
   depends_on "freetype" => :recommended
+  depends_on "fontconfig" => :recommended
 
   depends_on :x11 => :optional
-  depends_on "fontconfig" => :optional
   depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
   depends_on "libwmf" => :optional
@@ -68,6 +70,9 @@ class Imagemagick < Formula
       --enable-shared
       --enable-static
     ]
+
+    args << (build.without? "fontconfig") ? "--without-fontconfig" : "--with-fontconfig"
+    args << (build.without? "freetype") ? "--without-freetype" : "--with-freetype"
 
     if build.without? "modules"
       args << "--without-modules"
@@ -107,8 +112,6 @@ class Imagemagick < Formula
     args << "--with-quantum-depth=#{quantum_depth}" if quantum_depth
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-x" if build.without? "x11"
-    args << "--with-fontconfig=yes" if build.with? "fontconfig"
-    args << "--with-freetype=yes" if build.with? "freetype"
     args << "--with-webp=yes" if build.with? "webp"
 
     # versioned stuff in main tree is pointless for us


### PR DESCRIPTION
I would like to suggest we build `imagemagick` with `fontconfig` by default. Currently it does not support any text/annotation/labeling features which is very limiting.

``` sh
curl -O https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/helloworld.svg
convert helloworld.svg out.png 
#>> convert: unable to read font `serif' @ warning/annotate.c/RenderType/927
```

I verified that all of these issues disappear when we build `--with-fontconfig` so perhaps this would be a better default for most users.
