### PR TITLE
go-formulae: tweak flag passing

### DIFF
--- a/Formula/forego.rb
+++ b/Formula/forego.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Forego < Formula
   desc "Foreman in Go"
   homepage "https://github.com/ddollar/forego"
@@ -19,26 +17,13 @@ class Forego < Formula
   depends_on "go" => :build
   depends_on "godep" => :build
 
-  go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git",
-        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
-  end
-
-  go_resource "golang.org/x/tools" do
-    url "https://go.googlesource.com/tools",
-        :using => :git,
-        :revision => "b1aed1a596ad02d2aa2eb5c5af431a7ba2f6afc4"
-  end
-
   def install
     ENV["GOPATH"] = buildpath
     mkdir_p buildpath/"src/github.com/ddollar/"
     ln_sf buildpath, buildpath/"src/github.com/ddollar/forego"
-    Language::Go.stage_deps resources, buildpath/"src"
 
-    ldflags = "-X main.Version #{version} -X main.allowUpdate false"
-    system "godep", "go", "build", "-ldflags", ldflags, "-o", "forego"
-    bin.install "forego"
+    ldflags = "-X main.Version=#{version} -X main.allowUpdate=false"
+    system "godep", "go", "build", "-ldflags", ldflags, "-o", bin/"forego"
   end
 
   test do

--- a/Formula/ghq.rb
+++ b/Formula/ghq.rb
@@ -50,14 +50,13 @@ class Ghq < Formula
   end
 
   def install
-    mkdir_p "#{buildpath}/src/github.com/motemen/"
-    ln_s buildpath, "#{buildpath}/src/github.com/motemen/ghq"
+    mkdir_p buildpath/"src/github.com/motemen/"
+    ln_s buildpath, buildpath/"src/github.com/motemen/ghq"
     ENV["GOPATH"] = buildpath
-    ENV.append_path "PATH", "#{ENV["GOPATH"]}/bin"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    system "go", "build", "-ldflags", "-X main.Version #{version}", "-o", "ghq"
-    bin.install "ghq"
+    system "go", "build", "-ldflags", "-X main.Version=#{version}",
+                          "-o", bin/"ghq"
     zsh_completion.install "zsh/_ghq" if build.with? "completions"
   end
 

--- a/Formula/websocketd.rb
+++ b/Formula/websocketd.rb
@@ -26,15 +26,14 @@ class Websocketd < Formula
   end
 
   def install
-    ENV["GOBIN"] = bin
     ENV["GOPATH"] = buildpath
-    ENV["GOHOME"] = buildpath
 
     mkdir_p buildpath/"src/github.com/joewalnes/"
     ln_sf buildpath, buildpath/"src/github.com/joewalnes/websocketd"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    system "go", "build", "-ldflags", "-X main.version #{version}", "-o", bin/"websocketd", "main.go", "config.go", "help.go", "version.go"
+    system "go", "build", "-ldflags", "-X main.version=#{version}", "-o", bin/"websocketd",
+                          "main.go", "config.go", "help.go", "version.go"
     man1.install "release/websocketd.man" => "websocketd.1"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Go is getting increasingly grumpy about not having `=` between `main.version` and the version, for example. Want to start fixing these before Go inevitably cuts a major release that manages to break every Go-using formulae in Homebrew.
