### PR TITLE
imagemagick: enable fontconfig by default

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -39,9 +39,9 @@ class Imagemagick < Formula
   depends_on "libpng" => :recommended
   depends_on "libtiff" => :recommended
   depends_on "freetype" => :recommended
+  depends_on "fontconfig" => :recommended
 
   depends_on :x11 => :optional
-  depends_on "fontconfig" => :optional
   depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
   depends_on "libwmf" => :optional


### PR DESCRIPTION
I would like to suggest we build `imagemagick` with `fontconfig` by default. Currently it does not support any text/annotation/labeling features which is very limiting.

``` sh
curl -O https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/helloworld.svg
convert helloworld.svg out.png 
#>> convert: unable to read font `serif' @ warning/annotate.c/RenderType/927
```

I verified that all of these issues disappear when we build `--with-fontconfig` so perhaps this would be a better default for most users.

FYI there was some constructive comments by @zmwangx in https://github.com/Homebrew/homebrew-core/pull/3124 which I accidentally closed. Let's blame the heat.
