### PR TITLE
python & python3: fix sqlite3 on sierra

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -140,7 +140,7 @@ class Python < Formula
 
     # Allow sqlite3 module to load extensions:
     # https://docs.python.org/library/sqlite3.html#f1
-    if build.with? "sqlite"
+    if MacOS.version < :sierra && build.with?("sqlite")
       inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "")
     end
 

--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -150,7 +150,9 @@ class Python3 < Formula
     end
 
     # Allow sqlite3 module to load extensions: https://docs.python.org/library/sqlite3.html#f1
-    inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "pass") if build.with? "sqlite"
+    if MacOS.version < :sierra && build.with?("sqlite")
+      inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "pass")
+    end
 
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Steps to reproduce: On a MacOS sierra system without this patch, open the `python` or `python3` binary compiled by homebrew and run `import _sqlite3`.

Expected output (no errors):

```
$ python
Python 2.7.12 (default, Jul 19 2016, 15:02:58)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.33.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import _sqlite3
>>>

$ python3
Python 3.5.2 (default, Jul 19 2016, 15:09:52)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.33.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import _sqlite3
>>>
```
