### PR TITLE
apr: revision for internal libtool SED

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -3,6 +3,7 @@ class Apr < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.2.tar.bz2"
   sha256 "7d03ed29c22a7152be45b8e50431063736df9e1daa1ddf93f6a547ba7a28f67a"
+  revision 1
 
   bottle do
     sha256 "ce60ca59b86b7e0bba92bd04b91a0667a4c9e2061358d728da7aa8b7053b0541" => :el_capitan
@@ -29,6 +30,6 @@ class Apr < Formula
   end
 
   test do
-    system "#{bin}/apr-1-config", "--link-libtool", "--libs"
+    system bin/"apr-1-config", "--link-libtool", "--libs"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Same problem we had with the `libtool` formula itself after the ENV path move. Forgot `apr` has its own internal `libtool`.
