### PR TITLE
wireguard-tools 0.0.20160722 (new formula)

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -1,0 +1,17 @@
+class WireguardTools < Formula
+  desc "Tools for the WireGuard secure network tunnel"
+  homepage "https://www.wireguard.io/"
+  # Despite the experimental tag the tools themselves are stable.
+  # Please only update version when the tools have been modified/updated.
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-experimental-0.0.20160722.tar.xz"
+  sha256 "0dcda97b6bb4e962f731a863df9b4291c1c453b01f4faba78be4aaa13a594242"
+  head "https://git.zx2c4.com/WireGuard", :using => :git
+
+  def install
+    system "make", "PREFIX=#{prefix}", "-C", "src/tools", "install"
+  end
+
+  test do
+    system "#{bin}/wg", "help"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Hello,

This is a formula for the `wg(8)` tool, for [WireGuard](https://www.wireguard.io/). I'm the author of `pass`, which is already in here as `pass.rb`, so I'm somewhat familiar with brew maintenance. As part of the effort to make userspace implementations of WireGuard for OS X, getting the wireguard-tools package running smoothly on Homebrew is quite important. I expect for this package to become popular overtime. It has packages currently for Debian, Arch, OpenWRT, Gentoo, and OpenSUSE, with more on their way. The package ships with a man page as well, accessible at `man wg`.

Here's a screenshot after a successful brew installation:
![wireguard-osx](https://cloud.githubusercontent.com/assets/10643/17018882/23b0e02a-4f3a-11e6-8b05-e89b46f17566.png)

Looking forward,
Jason
