### PR TITLE
agda: raise emacs requirement to 23.4

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -44,7 +44,7 @@ class Agda < Formula
   end
 
   depends_on "gmp"
-  depends_on :emacs => ["21.1", :recommended]
+  depends_on :emacs => ["23.4", :recommended]
 
   def install
     # install Agda core


### PR DESCRIPTION
Fixes "agda-mode compile" so that it doesn't error out with
  Symbol's function definition is void: byte-compile-disable-warning
  Unable to compile the following Emacs Lisp files:
    etc.

See
  https://github.com/Homebrew/homebrew-core/issues/3168
  https://github.com/agda/agda/issues/1945
  https://github.com/Homebrew/legacy-homebrew/pull/45327
