### PR TITLE
imagemagick 6.9.5-3

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -4,9 +4,9 @@ class Imagemagick < Formula
   # Please always keep the Homebrew mirror as the primary URL as the
   # ImageMagick site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
-  url "https://dl.bintray.com/homebrew/mirror/imagemagick-6.9.5-2.tar.xz"
-  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.5-2.tar.xz"
-  sha256 "f29e7991fe3d6ce819d99fc35926248f2f109fc826b4e26f3ced5b19f2cd0326"
+  url "https://dl.bintray.com/homebrew/mirror/imagemagick-6.9.5-3.tar.xz"
+  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.5-3.tar.xz"
+  sha256 "6fec9f493bb7434b8c143eb3bba86f3892c68e0b6633ce7eeed970d47c5db4ec"
 
   head "http://git.imagemagick.org/repos/ImageMagick.git"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
  
  My local installation (with options) fails the new undeclared linkage check in https://github.com/Homebrew/brew/commit/0ed673a:
  
  ```
  /usr/local/Library/Taps/homebrew/homebrew-core/Formula/imagemagick.rb: * Formulae are required to declare all linked dependencies.
  Please add all linked dependencies to the formula with:
    depends_on "cairo" => :linked
    depends_on "gdk-pixbuf" => :linked
    depends_on "gettext" => :linked
    depends_on "glib" => :linked
  ```
  
  But that should be due to configure auto detecting extra installed stuff. After all, none of these are in the dep tree:
  
  ```
  $ brew deps --recursive imagemagick
  freetype
  jpeg
  libpng
  libtiff
  libtool
  xz
  ```
  
  Let's see what the test bot has to say.

---
