### PR TITLE
nuxeo: update sha256 for upstream retag

### DIFF
--- a/Formula/nuxeo.rb
+++ b/Formula/nuxeo.rb
@@ -3,7 +3,7 @@ class Nuxeo < Formula
   homepage "https://nuxeo.github.io/"
   url "https://cdn.nuxeo.com/nuxeo-8.3/nuxeo-cap-8.3-tomcat.zip"
   version "8.3"
-  sha256 "6de18ffa1737d6ef3fb9561f6c35f3200cfeedc7e7693e424ce31396eb42206c"
+  sha256 "69a51ea0f5663723a58448be80b5caf4258f9d1f8df124e4de90676224afac3c"
 
   bottle :unneeded
 

--- a/Formula/nuxeo.rb
+++ b/Formula/nuxeo.rb
@@ -1,7 +1,7 @@
 class Nuxeo < Formula
   desc "Enterprise Content Management"
   homepage "https://nuxeo.github.io/"
-  url "https://cdn.nuxeo.com/nuxeo-8.3/nuxeo-cap-8.3-tomcat.zip"
+  url "https://cdn.nuxeo.com/nuxeo-8.3/nuxeo-server-8.3-tomcat.zip"
   version "8.3"
   sha256 "69a51ea0f5663723a58448be80b5caf4258f9d1f8df124e4de90676224afac3c"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

SHA256 has been updated.
