### PR TITLE
htmlcleaner: add java 8+ dependency

### DIFF
--- a/Formula/htmlcleaner.rb
+++ b/Formula/htmlcleaner.rb
@@ -12,6 +12,7 @@ class Htmlcleaner < Formula
   end
 
   depends_on "maven" => :build
+  depends_on :java => "1.8+"
 
   def install
     ENV.java_cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

htmlcleaner supports Java 5+ when running, but currently can only be built by Java 8. It uses JDK8-only compiler flags.

I submitted a [bug report](https://sourceforge.net/p/htmlcleaner/bugs/174/) for this in May, but no action to resolve it appears to have been taken. See https://github.com/Linuxbrew/homebrew-core/pull/167
