### PR TITLE
Set `gdk-pixbuf` environment variables in non-/usr/local installs

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -32,6 +32,18 @@ class GdkPixbuf < Formula
     sha256 "c38cbf14bee68a15a12edb55a5fa39e36a8dc3d82b4160e9cefea921eda6a13d"
   end
 
+  # gdk-pixbuf has an internal version number separate from the overall
+  # version number that specifies the location of its module and cache
+  # files, this will need to be updated if that internal version number
+  # is ever changed (as evidenced by the location no longer existing)
+  def gdk_so_ver
+    "2.0"
+  end
+
+  def gdk_module_ver
+    "2.10.0"
+  end
+
   def install
     ENV.universal_binary if build.universal?
     ENV.append_to_cflags "-DGDK_PIXBUF_LIBDIR=\\\"#{HOMEBREW_PREFIX}/lib\\\""
@@ -54,29 +66,29 @@ class GdkPixbuf < Formula
 
     # Other packages should use the top-level modules directory
     # rather than dumping their files into the gdk-pixbuf keg.
-    inreplace lib/"pkgconfig/gdk-pixbuf-2.0.pc" do |s|
+    inreplace lib/"pkgconfig/gdk-pixbuf-#{gdk_so_ver}.pc" do |s|
       libv = s.get_make_var "gdk_pixbuf_binary_version"
       s.change_make_var! "gdk_pixbuf_binarydir",
-        HOMEBREW_PREFIX/"lib/gdk-pixbuf-2.0"/libv
+        HOMEBREW_PREFIX/"lib/gdk-pixbuf-#{gdk_so_ver}"/libv
     end
 
     # Remove the cache. We will regenerate it in post_install
-    (lib/"gdk-pixbuf-2.0/2.10.0/loaders.cache").unlink
+    (lib/"gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache").unlink
   end
 
   def post_install
     # Change the version directory below with any future update
     if build.with?("relocations") || HOMEBREW_PREFIX.to_s != "/usr/local"
-      ENV["GDK_PIXBUF_MODULE_FILE"]="#{lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-      ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+      ENV["GDK_PIXBUF_MODULE_FILE"]="#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
+      ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
     end
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
   end
 
   def caveats; <<-EOS.undent
     Programs that require this module need to set the environment variable
-      export GDK_PIXBUF_MODULE_FILE="#{lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-      export GDK_PIXBUF_MODULEDIR="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+      export GDK_PIXBUF_MODULE_FILE="#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
+      export GDK_PIXBUF_MODULEDIR="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
     If you need to manually update the query loader cache, set these variables then run
       #{bin}/gdk-pixbuf-query-loaders --update-cache
     EOS

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -66,7 +66,7 @@ class GdkPixbuf < Formula
 
   def post_install
     # Change the version directory below with any future update
-    if build.with?("relocations")
+    if build.with?("relocations") || HOMEBREW_PREFIX.to_s != "/usr/local"
       ENV["GDK_PIXBUF_MODULE_FILE"]="#{lib}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
       ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
     end
@@ -80,7 +80,7 @@ class GdkPixbuf < Formula
     If you need to manually update the query loader cache, set these variables then run
       #{bin}/gdk-pixbuf-query-loaders --update-cache
     EOS
-  end if build.with?("relocations")
+  end if build.with?("relocations") || HOMEBREW_PREFIX.to_s != "/usr/local"
 
   test do
     system bin/"gdk-pixbuf-csource", test_fixtures("test.png")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

When running `gdk-pixbuf` binaries in a non-`/usr/local` cellar location, we must set the proper environment variables, or the commands will fail, regardless of whether `with-relocations` is enabled or not.

Note that this doesn't quite pass `brew audit --strict --online gdk-pixbuf`, as it complains about `gettext` not being declared as a `:linked` dependency.

I have tested this on both a `/usr/local`-based `brew` installation, and a non-`/usr/local`-based `brew` installation, and the `postinstall` step completes successfully for both.
