### PR TITLE
skinny 2.2.0

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.1.2/skinny-2.1.2.tar.gz"
-  sha256 "8a201a98d27128ef3d191186757899350311df96c6b28e8cee97c5daa5d04b8b"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.2.0/skinny-2.2.0.tar.gz"
+  sha256 "5abcbd183a4066b43feef3e6fdae70dc82ede3a00bcac311c7ae27f8bb0ee1c1"
 
   bottle :unneeded
 


### PR DESCRIPTION
Skinny Framework 2.2.0 is out. Thanks as always. Please take a look at  an update on our Formula corresponding the release. https://github.com/skinny-framework/skinny-framework/releases/tag/2.2.0
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

```
$ brew install Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.2.0/skinny-2.2.0.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/9586e108-5247-11e6-97fd-f3c892ede4d3.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F2
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.2.0: 772 files, 99.7M, built in 11 minutes 38 seconds

$ brew audit --strict --online Formula/skinny.rb
$
```
