### PR TITLE
qjackctl: fix build errors

### DIFF
--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -19,7 +19,7 @@ class Qjackctl < Formula
   # Fixes varaible length array error with LLVM/Clang
   # Reported upstream: https://github.com/rncbc/qjackctl/issues/17
   patch do
-    url "https://github.com/rncbc/qjackctl/pulls/18.patch"
+    url "https://github.com/rncbc/qjackctl/pull/18.patch"
     sha256 "cbb7cc72e0086b8e6df24c8c3a462dc0e9297f095573adb7a3cf98502a1902d4"
   end
 
@@ -30,7 +30,7 @@ class Qjackctl < Formula
                           "--disable-dbus",
                           "--disable-xunique",
                           "--prefix=#{prefix}",
-                          "--with-qt5=#{Formula["qt5"].prefix}"
+                          "--with-qt5=#{Formula["qt5"].opt_prefix}"
 
     system "make", "install"
     prefix.install bin/"qjackctl.app"

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -19,7 +19,7 @@ class Qjackctl < Formula
   # Fixes varaible length array error with LLVM/Clang
   # Reported upstream: https://github.com/rncbc/qjackctl/issues/17
   patch do
-    url "https://patch-diff.githubusercontent.com/raw/rncbc/qjackctl/pull/18.patch"
+    url "https://github.com/rncbc/qjackctl/pulls/18.patch"
     sha256 "cbb7cc72e0086b8e6df24c8c3a462dc0e9297f095573adb7a3cf98502a1902d4"
   end
 

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -14,6 +14,7 @@ class Qjackctl < Formula
   depends_on "autoconf" => :build
   depends_on "qt5"
   depends_on "jack"
+  depends_on "portaudio" => :linked
 
   # Fixes varaible length array error with LLVM/Clang
   # Reported upstream: https://github.com/rncbc/qjackctl/issues/17

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -15,13 +15,21 @@ class Qjackctl < Formula
   depends_on "qt5"
   depends_on "jack"
 
+  # Fixes varaible length array error with LLVM/Clang
+  # Reported upstream: https://github.com/rncbc/qjackctl/issues/17
+  patch do
+    url "https://patch-diff.githubusercontent.com/raw/rncbc/qjackctl/pull/18.patch"
+    sha256 "cbb7cc72e0086b8e6df24c8c3a462dc0e9297f095573adb7a3cf98502a1902d4"
+  end
+
   def install
     system "./autogen.sh"
     system "./configure", "--disable-debug",
                           "--enable-qt5",
                           "--disable-dbus",
                           "--disable-xunique",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-qt5=#{Formula["qt5"].prefix}"
 
     system "make", "install"
     prefix.install bin/"qjackctl.app"

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -19,7 +19,7 @@ class Qjackctl < Formula
   # Fixes varaible length array error with LLVM/Clang
   # Reported upstream: https://github.com/rncbc/qjackctl/issues/17
   patch do
-    url "https://github.com/rncbc/qjackctl/pull/18.patch"
+    url "https://github.com/rncbc/qjackctl/commit/e92de08f7fd7c62ff1fb4f0330583f321a2a9aae.patch"
     sha256 "cbb7cc72e0086b8e6df24c8c3a462dc0e9297f095573adb7a3cf98502a1902d4"
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

qmake-qt5 cannot be found by the configure script. This is fixed adding
the prefix of the Qt5 installation as a configure option.
Building with LLVM/Clang raises an error related to a variable sized
array. This is fixed by patching a source file to use a dynamically
allocated array instead.

Fixes #3278.
