### PR TITLE
newt: always build --with-python

### DIFF
--- a/Formula/byobu.rb
+++ b/Formula/byobu.rb
@@ -23,7 +23,7 @@ class Byobu < Formula
   depends_on "coreutils"
   depends_on "gnu-sed" # fails with BSD sed
   depends_on "tmux"
-  depends_on "newt" => "with-python"
+  depends_on "newt"
 
   def install
     if build.head?

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -43,4 +43,18 @@ class Newt < Formula
     system "./configure", *args
     system "make", "install"
   end
+
+  test do
+    ENV["TERM"] = "xterm"
+    system "python", "-c", "import snack"
+    (testpath/"test.c").write <<-EOS.undent
+      #import <newt.h>
+      int main() {
+        newtInit();
+        newtFinished();
+      }
+    EOS
+    system ENV.cc, testpath/"test.c", "-o", testpath/"newt_test", "-lnewt"
+    system testpath/"newt_test"
+  end
 end

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -3,6 +3,7 @@ class Newt < Formula
   homepage "https://fedorahosted.org/newt/"
   url "https://fedorahosted.org/releases/n/e/newt/newt-0.52.18.tar.gz"
   sha256 "771b0e634ede56ae6a6acd910728bb5832ac13ddb0d1d27919d2498dab70c91e"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,6 @@ class Newt < Formula
   depends_on "gettext"
   depends_on "popt"
   depends_on "s-lang"
-  depends_on :python => :optional
 
   # build dylibs with -dynamiclib; version libraries
   # Patch via MacPorts
@@ -26,7 +26,6 @@ class Newt < Formula
 
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]
-    args << "--without-python" if build.without? "python"
 
     inreplace "Makefile.in" do |s|
       # name libraries correctly


### PR DESCRIPTION
Newt is almost never installed without python (cf http://rpubs.com/tdsmith/198233, bottom figure, second row.)
