### PR TITLE
yasm: fix cython resource url & audit errors

### DIFF
--- a/Formula/yasm.rb
+++ b/Formula/yasm.rb
@@ -21,12 +21,12 @@ class Yasm < Formula
     depends_on "gettext"
   end
 
-  resource "cython" do
-	url "https://files.pythonhosted.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz"
-	sha256 "84808fda00508757928e1feadcf41c9f78e9a9b7167b6649ab0933b76f75e7b9"
-  end 
-
   depends_on :python => :optional
+
+  resource "cython" do
+    url "https://files.pythonhosted.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz"
+    sha256 "84808fda00508757928e1feadcf41c9f78e9a9b7167b6649ab0933b76f75e7b9"
+  end
 
   def install
     args = %W[

--- a/Formula/yasm.rb
+++ b/Formula/yasm.rb
@@ -22,9 +22,9 @@ class Yasm < Formula
   end
 
   resource "cython" do
-    url "http://cython.org/release/Cython-0.20.2.tar.gz"
-    sha256 "ed13b606a2aeb5bd6c235f8ed6c9988c99d01a033d0d21d56137c13d5c7be63f"
-  end
+	url "https://files.pythonhosted.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz"
+	sha256 "84808fda00508757928e1feadcf41c9f78e9a9b7167b6649ab0933b76f75e7b9"
+  end 
 
   depends_on :python => :optional
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

cython is no longer available for download from http://cython.org/release. Updated cython resource
