### PR TITLE
lolcode: fix description and code position

### DIFF
--- a/Formula/lolcode.rb
+++ b/Formula/lolcode.rb
@@ -1,6 +1,7 @@
 class Lolcode < Formula
-  desc "LOLCODE interpreter"
+  desc "An esoteric programming language"
   homepage "http://lolcode.org"
+  sha256 "cb1065936d3a7463928dcddfc345a8d7d8602678394efc0e54981f9dd98c27d2"
   head "https://github.com/justinmeza/lolcode.git"
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +13,6 @@ class Lolcode < Formula
 
   # note: 0.10.* releases are stable versions, 0.11.* are dev ones
   url "https://github.com/justinmeza/lci/archive/v0.11.2.tar.gz"
-  sha256 "cb1065936d3a7463928dcddfc345a8d7d8602678394efc0e54981f9dd98c27d2"
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online lolcode` returns:

```
lolcode:
  * `checksum` (line 15) should be put before `head` (line 4)
  * Description shouldn't include the formula name
Error: 2 problems in 1 formula
```
