### PR TITLE
log4cxx: fix one problem about code position

### DIFF
--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -12,11 +12,12 @@ class Log4cxx < Formula
     sha256 "6b07acbb1e77d8d7edc7e111f57250b9d05c9b9c8aa6f1363f919940695aa1f9" => :mountain_lion
   end
 
+  option :universal
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  option :universal
   option :cxx11
 
   fails_with :llvm do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online log4cxx` returns:

```
log4cxx:
  * `option` (line 19) should be put before `depends_on` (line 15)
Error: 1 problem in 1 formula
```
