### PR TITLE
kestrel: fix broken links to homepage and url

### DIFF
--- a/Formula/kestrel.rb
+++ b/Formula/kestrel.rb
@@ -1,7 +1,7 @@
 class Kestrel < Formula
   desc "Distributed message queue"
-  homepage "https://twitter.github.io/kestrel/"
-  url "https://twitter.github.io/kestrel/download/kestrel-2.4.1.zip"
+  homepage "https://twitter-archive.github.io/kestrel/"
+  url "https://twitter-archive.github.io/kestrel/download/kestrel-2.4.1.zip"
   sha256 "5d72a301737cc6cc3908483ce73d4bdb6e96521f3f8c96f93b732d740aaea80c"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I get an `Error: Broken pipe` when I run `brew audit --strict --online <any formula>`... It does work without the `--online` flag.
