### PR TITLE
purescript: switch to upstream fix

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -5,9 +5,20 @@ class Purescript < Formula
 
   desc "Strongly typed programming language that compiles to JavaScript"
   homepage "http://www.purescript.org"
-  url "https://github.com/purescript/purescript/archive/v0.9.2.tar.gz"
-  sha256 "f02e5b39764346aa83103ef40cfd90e5aeea6958793ec64ab0eac37293b8df2f"
   head "https://github.com/purescript/purescript.git"
+  revision 1
+
+  stable do
+    url "https://github.com/purescript/purescript/archive/v0.9.2.tar.gz"
+    sha256 "f02e5b39764346aa83103ef40cfd90e5aeea6958793ec64ab0eac37293b8df2f"
+
+    # "ambiguous occurrence" errors for fromStrict, decodeUtf8, and encodeUtf8
+    # upstream commit "protolude 0.1.6: fix ambiguous occurrences"
+    patch do
+      url "https://github.com/purescript/purescript/commit/15c466f1.patch"
+      sha256 "dbba6a25b0aea7c67423e58c1c44b87cd43884b1948c8ae1b9f0f4d28b7ddbb5"
+    end
+  end
 
   bottle do
     sha256 "9e77153298a0c2d1cf511701cfdf3a7404eaefcd9865ea56d688dffdf1a4e8c7" => :el_capitan
@@ -19,10 +30,6 @@ class Purescript < Formula
   depends_on "cabal-install" => :build
 
   def install
-    # "ambiguous occurrence" errors for fromStrict, decodeUtf8, and encodeUtf8
-    # protlude 0.1.6 issue reported 11 Jul 2016: purescript/purescript#2225
-    inreplace "purescript.cabal", "protolude >= 0.1.5,", "protolude == 0.1.5,"
-
     install_cabal_package :using => ["alex", "happy"]
   end
 


### PR DESCRIPTION
upstream accepted the PR upgrading the Protolude version, so apply that
commit as a patch in lieu of the inreplace workaround
