### PR TITLE
ptex 2.1.28

### DIFF
--- a/Formula/ptex.rb
+++ b/Formula/ptex.rb
@@ -1,8 +1,8 @@
 class Ptex < Formula
   desc "Texture mapping system"
   homepage "http://ptex.us"
-  url "https://github.com/wdas/ptex/archive/v2.1.10.tar.gz"
-  sha256 "0fb978e57f5e287c34b74896e3a9564a202d8806c75a18dd83855ba6d7c02122"
+  url "https://github.com/wdas/ptex/archive/v2.1.28.tar.gz"
+  sha256 "919af3cc56a7617079757bac5c0202f4375acf21861a3990e313739e56a6142c"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This formula fails the audit check due to a missing `test do` block, but that's always been the case.

This version update lets things actually use the includes from this package as it was previously missing a `PtexVersion.h` header from the installation.
