### PR TITLE
ngspice: add option to build shared library.

### DIFF
--- a/Formula/ngspice.rb
+++ b/Formula/ngspice.rb
@@ -11,6 +11,7 @@ class Ngspice < Formula
   end
 
   option "without-xspice", "Build without x-spice extensions"
+  option "with-shared", "Build shared library"
 
   deprecated_option "with-x" => "with-x11"
 
@@ -28,6 +29,19 @@ class Ngspice < Formula
       args << "--without-x"
     end
     args << "--enable-xspice" if build.with? "xspice"
+
+    if build.with? "shared"
+      # The build system cannot build both the executable and the shared
+      # library in one sequence, see
+      # https://sourceforge.net/p/ngspice/support-requests/19 .
+      # But we can build the shared library first, clean up, and then build
+      # the executable.
+      args << "--with-ngshared"
+      system "./configure", *args
+      system "make", "install"
+      system "make", "clean"
+      args.pop
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Add --with-shared option to ngspice.  It might look a little hacky, but
it only works this way, i.e. build two times in a row, with different
configure args.  Arch Linux does it the same way.
