### PR TITLE
ibex 2.3.1

### DIFF
--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -1,8 +1,8 @@
 class Ibex < Formula
   desc "C++ library for constraint processing over real numbers."
   homepage "http://www.ibex-lib.org/"
-  url "https://github.com/ibex-team/ibex-lib/archive/ibex-2.3.0.tar.gz"
-  sha256 "637cd0d3bdae5f72867264fa9349a4f86023ac34b6d01ca0bec3618bc38d4a79"
+  url "https://github.com/ibex-team/ibex-lib/archive/ibex-2.3.1.tar.gz"
+  sha256 "a5aa561e485229dc58100673d0b10df5c0e7c3661b57530ed68a4d84cdfe3940"
   head "https://github.com/ibex-team/ibex-lib.git"
 
   bottle do
@@ -14,7 +14,6 @@ class Ibex < Formula
 
   option "with-java", "Enable Java bindings for CHOCO solver."
   option "with-ampl", "Use AMPL file loader plugin"
-
   option "without-ensta-robotics", "Don't build the Contractors for robotics (SLAM) plugin"
   option "without-param-estim", "Don't build the Parameter Estimation (enhanced Q-intersection algorithm) plugin"
 
@@ -24,14 +23,6 @@ class Ibex < Formula
   depends_on "pkg-config" => :build
 
   def install
-    # Test failure "uncaught exception of type ibex::DimException"
-    # Same as upstream fix https://github.com/ibex-team/ibex-lib/commit/1c882ef2
-    if build.stable?
-      inreplace "examples/slam/slam1.cpp",
-        "x,dist(x[t],beacons[b])=d[t][b]);",
-        "x,dist(transpose(x[t]),beacons[b])=d[t][b]);"
-    end
-
     if build.with?("java") && build.with?("ampl")
       odie "Cannot set options --with-java and --with-ampl simultaneously for now."
     end
@@ -51,16 +42,6 @@ class Ibex < Formula
     system "./waf", "configure", *args
     system "./waf", "install"
 
-    cd "examples" do
-      ENV["PKG_CONFIG_PATH"] = "#{share}/pkgconfig"
-      # Build Ibex examples
-      system "make", *%w[ctc01 ctc02 symb01 solver01 solver02]
-      # Build SLAM examples
-      cd "slam" do
-        system "make", *%w[slam1 slam2 slam3]
-      end
-    end
-
     pkgshare.install %w[examples benchs]
     (pkgshare/"examples/symb01.txt").write <<-EOS.undent
       function f(x)
@@ -70,16 +51,21 @@ class Ibex < Formula
   end
 
   test do
-    cp_r "#{pkgshare}/examples/.", testpath
+    cp_r (pkgshare/"examples").children, testpath
+    cp pkgshare/"benchs/cyclohexan3D.bch", testpath/"c3D.bch"
 
-    # Base Ibex examples
-    %w[ctc01 ctc02 symb01].each { |a| system "./#{a}" }
-    # Ibex solver examples
-    cp "#{pkgshare}/benchs/cyclohexan3D.bch", testpath
-    %w[solver01 solver02].each { |a| system "./#{a}", "cyclohexan3D.bch", "1e-05", "10" }
-    # Slam example (base Ibex)
-    cd "slam" do
-      %w[slam1 slam2 slam3].each { |a| system "./#{a}" }
+    # so that pkg-config can remain a build-time only dependency
+    inreplace %w[makefile slam/makefile] do |s|
+      s.gsub! /CXXFLAGS.*pkg-config --cflags ibex./,
+              "CXXFLAGS := -ffloat-store -I#{include} -I#{include}/ibex"
+      s.gsub! /LIBS.*pkg-config --libs  ibex./,
+              "LIBS := -L#{lib} -libex -lprim -lClp -lCoinUtils -lm"
     end
+
+    system "make", *%w[ctc01 ctc02 symb01 solver01 solver02]
+    system "make", "-C", "slam", *%w[slam1 slam2 slam3]
+    %w[ctc01 ctc02 symb01].each { |a| system "./#{a}" }
+    %w[solver01 solver02].each { |a| system "./#{a}", "c3D.bch", "1e-05", "10" }
+    %w[slam1 slam2 slam3].each { |a| system "./slam/#{a}" }
   end
 end


### PR DESCRIPTION
remove upstreamed patch
defer building the examples until the test to fix linkage audit error
