### PR TITLE
Remove inreplace do block

### DIFF
--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -57,9 +57,7 @@ class Flac < Formula
     ENV["OBJ_FORMAT"] = "macho"
 
     # adds universal flags to the generated libtool script
-    inreplace "libtool" do |s|
-      s.gsub! ":$verstring\"", ":$verstring -arch #{Hardware::CPU.arch_32_bit} -arch #{Hardware::CPU.arch_64_bit}\""
-    end
+    inreplace "libtool", ":$verstring\"", ":$verstring -arch #{Hardware::CPU.arch_32_bit} -arch #{Hardware::CPU.arch_64_bit}\""
 
     system "make", "install"
   end

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -17,9 +17,7 @@ class Genstats < Formula
     # Tried to make this a patch.  Applying the patch hunk would
     # fail, even though I used "git diff | pbcopy".  Tried messing
     # with whitespace, # lines, etc.  Ugh.
-    inreplace "br.cpp" do |s|
-      s.gsub! /if \(_XOPEN_VERSION >= 600\)/, "if (_XOPEN_VERSION >= 600) && !__APPLE__"
-    end
+    inreplace "br.cpp", /if \(_XOPEN_VERSION >= 600\)/, "if (_XOPEN_VERSION >= 600) && !__APPLE__"
 
     system "make"
     bin.install("genstats")

--- a/Formula/pev.rb
+++ b/Formula/pev.rb
@@ -25,9 +25,7 @@ class Pev < Formula
       s.change_make_var! "MANDIR", man
     end
 
-    inreplace "lib/libpe/Makefile" do |s|
-      s.gsub! "/usr", prefix
-    end
+    inreplace "lib/libpe/Makefile", "/usr", prefix
 
     system "make", "CC=#{ENV.cc}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This change addresses the following warning for a few formulae:
`* 'inreplace ... do' was used for a single substitution (use the non-block form instead).`
