### PR TITLE
nfdump: fix typo

### DIFF
--- a/Formula/nfdump.rb
+++ b/Formula/nfdump.rb
@@ -1,5 +1,5 @@
 class Nfdump < Formula
-  desc "Tools to collect and process netflow data on the command line"
+  desc "Tools to collect and process netflow data on the command-line"
   homepage "http://nfdump.sourceforge.net"
   url "https://downloads.sourceforge.net/project/nfdump/stable/nfdump-1.6.13/nfdump-1.6.13.tar.gz"
   sha256 "251533c316c9fe595312f477cdb051e9c667517f49fb7ac5b432495730e45693"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online nfdump` returns:

```
nfdump:
  * Description should use "command-line" instead of "command line"
```
