### PR TITLE
net-snmp: swap `keg_only` and `dependes_on`. Futhermore, added a comma after the last item of a multiline array

### DIFF
--- a/Formula/net-snmp.rb
+++ b/Formula/net-snmp.rb
@@ -12,10 +12,10 @@ class NetSnmp < Formula
     sha256 "f2c4102f61ee8d6ad151bdbe6da97a5fc5127e84e7939f5e1672f81414a28873" => :mountain_lion
   end
 
+  keg_only :provided_by_osx
+
   depends_on "openssl"
   depends_on :python => :optional
-
-  keg_only :provided_by_osx
 
   def install
     args = [
@@ -29,7 +29,7 @@ class NetSnmp < Formula
       "--without-rpm",
       "--without-kmem-usage",
       "--disable-embedded-perl",
-      "--without-perl-modules"
+      "--without-perl-modules",
     ]
 
     if build.with? "python"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online net-snmp` returns:

```
net-snmp:
  * `keg_only` (line 18) should be put before `depends_on` (line 15)
  * A `test do` test block should be added
  * C: 32: col 7: Put a comma after the last item of a multiline array.
Error: 3 problem in 1 formula
```
