### PR TITLE
jfrog-cli-go 1.4.0

### DIFF
--- a/Formula/jfrog-cli-go.rb
+++ b/Formula/jfrog-cli-go.rb
@@ -1,10 +1,8 @@
-require "language/go"
-
 class JfrogCliGo < Formula
   desc "command-line interface for Jfrog Artifactory and Bintray"
   homepage "https://github.com/JFrogDev/jfrog-cli-go"
-  url "https://github.com/JFrogDev/jfrog-cli-go/archive/1.3.2.tar.gz"
-  sha256 "aac1e592d694996f1ff86e68245cd6e470a82ffafb3bd472f76523860023ac80"
+  url "https://github.com/JFrogDev/jfrog-cli-go/archive/1.4.0.tar.gz"
+  sha256 "c303147e7286f719e958a68d816cd455919b79bf312ac9cc8f32f9c0f1403ce4"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,21 +13,16 @@ class JfrogCliGo < Formula
 
   depends_on "go" => :build
 
-  go_resource "golang.org/x/crypto" do
-    url "https://go.googlesource.com/crypto.git",
-    :revision => "c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6"
-  end
-
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/JFrogDev/").mkpath
-    ln_sf buildpath, buildpath/"src/github.com/JFrogDev/jfrog-cli-go"
-    Language::Go.stage_deps resources, buildpath/"src"
-
-    system "go", "build", "-o", "#{bin}/jfrog", "github.com/jfrogdev/jfrog-cli-go/jfrog"
+    (buildpath/"src/github.com/jfrogdev/jfrog-cli-go").install Dir["*"]
+    cd "src/github.com/jfrogdev/jfrog-cli-go" do
+      system "go", "build", "-o", bin/"jfrog", "jfrog/main.go"
+      prefix.install_metafiles
+    end
   end
 
   test do
-    assert_equal "jfrog version #{version}", shell_output("#{bin}/jfrog -v").chomp
+    assert_match version.to_s, shell_output("#{bin}/jfrog -v")
   end
 end


### PR DESCRIPTION
remove remaining go_resource in favor of upstream vendor directory
