### PR TITLE
mpd: test for crash on HEAD builds

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -132,6 +132,7 @@ class Mpd < Formula
 
     begin
       assert_match "OK MPD", shell_output("curl localhost:6600")
+      assert_match "ACK", shell_output("(sleep 1; echo playid foo) | nc localhost 6600")
     ensure
       Process.kill "SIGINT", pid
       Process.wait pid


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

As of homebrew-core 69acd35e30dbf14ec798f41c879d426e1f4ea014 and
mpd 2777a23672dcea12f1b9abf2c137eab987660ece I have a reproducable
crashing bug that occurs only when I `brew install mpd --HEAD` but
not if I do `brew install mpd`. This commit adds a test that makes
MPD crash after being compiled from source at HEAD on my system.
