### PR TITLE
plantuml v8046

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -1,8 +1,8 @@
 class Plantuml < Formula
   desc "Draw UML diagrams"
   homepage "http://plantuml.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/plantuml/plantuml.8041.jar"
-  sha256 "8964b8ea316e37492d9a4533a57338c46f629cdd920d48ddae53e2b62f5b6c8d"
+  url "https://downloads.sourceforge.net/project/plantuml/plantuml.8046.jar"
+  sha256 "136997cd0d5c40b71b5cf9f45b5f1e93d3dbfa6c67b57a3679a628183c6f236e"
 
   bottle :unneeded
 


### PR DESCRIPTION
Per http://plantuml.com/changes.html, changes are:
## V8046
- Salt fails when there is an empty line between @startuml and salt keywords
- Marking class diagram if is public, private, or protected
- Problem with a while inside a fork
- Apply skinparam defaultTextAlignment to other items
- Need a way to color and number different routes on an activity diagram
## V8045
- Set background color for one note
- Database modeling
- Does PlantUML support references between class/component members
- Ability to hide packages
- Tooltip issue on sequence diagram
- Param to center text in activity
- Why do strange symbols appear on an eps printout, but not on the screen
- Package style erase Partition style
- Notes on conditionnal elements
## V8043
- Arrow's thickness in sequence diagrams and skins
- Arrow marker`s background color is incorrect in v. 8042
- Leak in TranscoderUtil
