### PR TITLE
presto 0.150 (new formula)

### DIFF
--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -45,9 +45,7 @@ class Presto < Formula
 
     (libexec/"etc/log.properties").write "com.facebook.presto=INFO"
 
-    (libexec/"etc/catalog/jmx.properties").write <<-EOS.undent
-      connector.name=jmx
-    EOS
+    (libexec/"etc/catalog/jmx.properties").write "connector.name=jmx"
 
     (bin/"presto-server").write <<-EOS.undent
       #!/bin/bash

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -4,6 +4,11 @@ class Presto < Formula
   url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.150/presto-server-0.150.tar.gz"
   sha256 "a3249691c16dc49395fb0effe1d407501cf54caf0db8d8596eab575e1867b30b"
 
+  resource "presto-cli" do
+    url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/0.150/presto-cli-0.150-executable.jar"
+    sha256 "cf7032e820e88cce76e2cc92710a5bf82c459588c2d628165d084438e18a35ff"
+  end
+
   bottle :unneeded
 
   depends_on :java => "1.8+"
@@ -50,6 +55,10 @@ class Presto < Formula
       #!/bin/bash
       exec "#{libexec}/bin/launcher" "$@"
     EOS
+
+    resource("presto-cli").stage do |s|
+      cp s.resource.cached_download, bin/"presto"
+    end
   end
 
   def caveats; <<-EOS.undent

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -11,8 +11,6 @@ class Presto < Formula
   def install
     libexec.install Dir["*"]
 
-    mkdir "#{libexec}/etc"
-
     (libexec/"etc/node.properties").write <<-EOS.undent
       node.environment=production
       node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
@@ -44,9 +42,19 @@ class Presto < Formula
       com.facebook.presto=INFO
     EOS
 
+    (libexec/"etc/catalog/jmx.properties").write <<-EOS.undent
+      connector.name=jmx
+    EOS
+
     (bin/"presto-server").write <<-EOS.undent
       #!/bin/bash
       exec "#{libexec}/bin/launcher" "$@"
+    EOS
+  end
+
+  def caveats; <<-EOS.undent
+    Add connectors to #{libexec}/presto/catalog/. See:
+    https://prestodb.io/docs/current/connector.html
     EOS
   end
 
@@ -77,6 +85,6 @@ class Presto < Formula
   end
 
   test do
-    system "#{bin}/presto-server", "run", "--help"
+    system bin/"presto-server", "run", "--help"
   end
 end

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -4,14 +4,14 @@ class Presto < Formula
   url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.150/presto-server-0.150.tar.gz"
   sha256 "a3249691c16dc49395fb0effe1d407501cf54caf0db8d8596eab575e1867b30b"
 
-  resource "presto-cli" do
-    url "https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/0.150/presto-cli-0.150-executable.jar"
-    sha256 "cf7032e820e88cce76e2cc92710a5bf82c459588c2d628165d084438e18a35ff"
-  end
-
   bottle :unneeded
 
   depends_on :java => "1.8+"
+
+  resource "presto-cli" do
+    url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.150/presto-cli-0.150-executable.jar"
+    sha256 "cf7032e820e88cce76e2cc92710a5bf82c459588c2d628165d084438e18a35ff"
+  end
 
   def install
     libexec.install Dir["*"]

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -56,8 +56,8 @@ class Presto < Formula
       exec "#{libexec}/bin/launcher" "$@"
     EOS
 
-    resource("presto-cli").stage do |s|
-      cp s.resource.cached_download, bin/"presto"
+    resource("presto-cli").stage do
+      bin.install "presto-cli-#{version}-executable.jar" => "presto"
     end
   end
 

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -1,0 +1,82 @@
+class Presto < Formula
+  desc "Distributed SQL query engine for big data"
+  homepage "https://prestodb.io"
+  url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.150/presto-server-0.150.tar.gz"
+  sha256 "a3249691c16dc49395fb0effe1d407501cf54caf0db8d8596eab575e1867b30b"
+
+  bottle :unneeded
+
+  depends_on :java => "1.8+"
+
+  def install
+    libexec.install Dir["*"]
+
+    mkdir "#{libexec}/etc"
+
+    (libexec/"etc/node.properties").write <<-EOS.undent
+      node.environment=production
+      node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
+      node.data-dir=#{var}/presto/data
+    EOS
+
+    (libexec/"etc/jvm.config").write <<-EOS.undent
+      -server
+      -Xmx16G
+      -XX:+UseG1GC
+      -XX:G1HeapRegionSize=32M
+      -XX:+UseGCOverheadLimit
+      -XX:+ExplicitGCInvokesConcurrent
+      -XX:+HeapDumpOnOutOfMemoryError
+      -XX:OnOutOfMemoryError=kill -9 %p
+    EOS
+
+    (libexec/"etc/config.properties").write <<-EOS.undent
+      coordinator=true
+      node-scheduler.include-coordinator=true
+      http-server.http.port=8080
+      query.max-memory=5GB
+      query.max-memory-per-node=1GB
+      discovery-server.enabled=true
+      discovery.uri=http://localhost:8080
+    EOS
+
+    (libexec/"etc/log.properties").write <<-EOS.undent
+      com.facebook.presto=INFO
+    EOS
+
+    (bin/"presto-server").write <<-EOS.undent
+      #!/bin/bash
+      exec "#{libexec}/bin/launcher" "$@"
+    EOS
+  end
+
+  plist_options :manual => "presto-server run"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>AbandonProcessGroup</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{opt_libexec}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/presto-server</string>
+          <string>run</string>
+        </array>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/presto-server", "run", "--help"
+  end
+end

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -62,7 +62,7 @@ class Presto < Formula
   end
 
   def caveats; <<-EOS.undent
-    Add connectors to #{libexec}/presto/catalog/. See:
+    Add connectors to #{libexec}/etc/catalog/. See:
     https://prestodb.io/docs/current/connector.html
     EOS
   end

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -43,9 +43,7 @@ class Presto < Formula
       discovery.uri=http://localhost:8080
     EOS
 
-    (libexec/"etc/log.properties").write <<-EOS.undent
-      com.facebook.presto=INFO
-    EOS
+    (libexec/"etc/log.properties").write "com.facebook.presto=INFO"
 
     (libexec/"etc/catalog/jmx.properties").write <<-EOS.undent
       connector.name=jmx
@@ -59,6 +57,10 @@ class Presto < Formula
     resource("presto-cli").stage do
       bin.install "presto-cli-#{version}-executable.jar" => "presto"
     end
+  end
+
+  def post_install
+    (var/"presto/data").mkpath
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

First off, thanks for all the great work on Homebrew!

This adds Facebook's [Presto](https://prestodb.io/). I renamed the bin file `presto-server` (from `launcher`) to keep `presto` available for the [CLI](https://prestodb.io/docs/current/installation/cli.html), but happy to change if needed.

Official Presto [setup instructions here](https://prestodb.io/docs/current/installation/deployment.html)
