### PR TITLE
Fix Calling Hardware.is_32_bit? is deprecated! Issues

### DIFF
--- a/Formula/avidemux.rb
+++ b/Formula/avidemux.rb
@@ -65,7 +65,7 @@ class Avidemux < Formula
 
     # For 32-bit compilation under gcc 4.2, see:
     # https://trac.macports.org/ticket/20938#comment:22
-    if MacOS.version <= :leopard || (Hardware.is_32_bit? && Hardware::CPU.intel? && ENV.compiler == :clang)
+    if MacOS.version <= :leopard || (Hardware::CPU.is_32_bit? && Hardware::CPU.intel? && ENV.compiler == :clang)
       inreplace "cmake/admFFmpegBuild.cmake",
         "${CMAKE_INSTALL_PREFIX})",
         "${CMAKE_INSTALL_PREFIX} --extra-cflags=-mdynamic-no-pic)"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -179,7 +179,7 @@ class Ffmpeg < Formula
 
     # For 32-bit compilation under gcc 4.2, see:
     # https://trac.macports.org/ticket/20938#comment:22
-    ENV.append_to_cflags "-mdynamic-no-pic" if Hardware.is_32_bit? && Hardware::CPU.intel? && ENV.compiler == :clang
+    ENV.append_to_cflags "-mdynamic-no-pic" if Hardware::CPU.is_32_bit? && Hardware::CPU.intel? && ENV.compiler == :clang
 
     system "./configure", *args
 

--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -48,7 +48,7 @@ class Flac < Formula
       --enable-static
     ]
 
-    args << "--disable-asm-optimizations" if build.universal? || Hardware.is_32_bit?
+    args << "--disable-asm-optimizations" if build.universal? || Hardware::CPU.is_32_bit?
     args << "--without-ogg" if build.without? "libogg"
 
     system "./autogen.sh" if build.head?

--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -34,7 +34,7 @@ class Libvpx < Formula
 
     # configure misdetects 32-bit 10.6
     # https://code.google.com/p/webm/issues/detail?id=401
-    if MacOS.version == "10.6" && Hardware.is_32_bit?
+    if MacOS.version == "10.6" && Hardware::CPU.is_32_bit?
       args << "--target=x86-darwin10-gcc"
     end
 

--- a/Formula/nspr.rb
+++ b/Formula/nspr.rb
@@ -23,7 +23,7 @@ class Nspr < Formula
     cd "nspr" do
       # Fixes a bug with linking against CoreFoundation, needed to work with SpiderMonkey
       # See: https://openradar.appspot.com/7209349
-      target_frameworks = (Hardware.is_32_bit? || MacOS.version <= :leopard) ? "-framework Carbon" : ""
+      target_frameworks = (Hardware::CPU.is_32_bit? || MacOS.version <= :leopard) ? "-framework Carbon" : ""
       inreplace "pr/src/Makefile.in", "-framework CoreServices -framework CoreFoundation", target_frameworks
 
       args = %W[

--- a/Formula/rdiff-backup.rb
+++ b/Formula/rdiff-backup.rb
@@ -31,7 +31,7 @@ class RdiffBackup < Formula
     # We remove 'ppc' support, so we can pass Intel-optimized CFLAGS.
     archs = archs_for_command("python")
     archs.remove_ppc!
-    archs.delete :x86_64 if Hardware.is_32_bit?
+    archs.delete :x86_64 if Hardware::CPU.is_32_bit?
     ENV["ARCHFLAGS"] = archs.as_arch_flags
     system "python", "setup.py", "--librsync-dir=#{prefix}", "build"
     libexec.install Dir["build/lib.macosx*/rdiff_backup"]

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -58,7 +58,7 @@ class Zookeeper < Formula
 
   def install
     # Don't try to build extensions for PPC
-    if Hardware.is_32_bit?
+    if Hardware::CPU.is_32_bit?
       ENV["ARCHFLAGS"] = "-arch #{Hardware::CPU.arch_32_bit}"
     else
       ENV["ARCHFLAGS"] = Hardware::CPU.universal_archs.as_arch_flags


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Updates: `avidemux`, `ffmpeg`, `flac`, `libvpx`, `nspr`, `rdiff-backup`, `zookeeper`.

This is to fix the `Fix Calling Hardware.is_32_bit? is deprecated!` issues with these formulae so they install and don't cancel out bulk updates.

Only `avidemux` seems to be [changing](https://github.com/Homebrew/homebrew-core/pull/3328) type to `cask` but that hasn't been pulled in yet, and this is still otherwise broken without this fix.

`libvpx`, `nspr`, `rdiff-backup`, and `zookeeper` all fail audit due to missing tests, but I don't feel qualified to be writing those.
