### PR TITLE
zsh: add --with-texi2html option to build HTML docs

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -1,9 +1,17 @@
 class Zsh < Formula
   desc "UNIX shell (command interpreter)"
   homepage "http://www.zsh.org/"
-  url "https://downloads.sourceforge.net/project/zsh/zsh/5.2/zsh-5.2.tar.gz"
-  mirror "http://www.zsh.org/pub/zsh-5.2.tar.gz"
-  sha256 "fa924c534c6633c219dcffdcd7da9399dabfb63347f88ce6ddcd5bb441215937"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/zsh/zsh/5.2/zsh-5.2.tar.gz"
+    mirror "http://www.zsh.org/pub/zsh-5.2.tar.gz"
+    sha256 "fa924c534c6633c219dcffdcd7da9399dabfb63347f88ce6ddcd5bb441215937"
+
+    # We cannot build HTML doc on HEAD, because yodl which is required for
+    # building zsh.texi is not available.
+    option "with-texi2html", "Build HTML documentation"
+    depends_on "texi2html" => [:build, :optional]
+  end
 
   bottle do
     revision 1
@@ -61,6 +69,7 @@ class Zsh < Formula
     else
       system "make", "install"
       system "make", "install.info"
+      system "make", "install.html" if build.with? "texi2html"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Zsh's HTML documentation is somewhat more comprehensive, or at least better organized than its man pages — for instance, the indexes covering concepts, variables, options, functions are very useful. The HTML docs are hosted at http://zsh.sourceforge.net/Doc/Release/, but sometimes the user is offline and sometimes the site is offline — for instance, zsh.sourceforget.net was offline for two weeks last July when SF infrastructure failed. It's good to have the docs locally.

One complication here is that we can't build HTML docs on head, again due to yodl headache. Currently I have `--with-texi2html` as a non-head option.

Another option is to install HTML docs unconditionally for stable. The docs themselves only take ~3.6M of disk space, but they do introduce additional deps: `xz`, `gettext` and `texi2html`.

**EDIT.** Actually, since `texi2html` is a buildtime dependency, bottle users won't need the additional deps.
