### PR TITLE
xdelta: make lzma secondary compression optional

### DIFF
--- a/Formula/xdelta.rb
+++ b/Formula/xdelta.rb
@@ -11,15 +11,29 @@ class Xdelta < Formula
     sha256 "a0801a8bd9796d03d8c031905e28a6e5f50b155da3102337070ec787ccb5cee9" => :mavericks
   end
 
+  option "without-xz", "Disable LZMA secondary compression"
+
   depends_on "libtool" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "xz"
+
+  depends_on "xz" => :recommended
 
   def install
     cd "xdelta3" do
+      args = %W[
+        --disable-dependency-tracking
+        --prefix=#{prefix}
+      ]
+
+      if build.with? "xz"
+        args << "--with-liblzma"
+      else
+        args << "--with-liblzma=no"
+      end
+
       system "autoreconf", "--install"
-      system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+      system "./configure", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?
