### PR TITLE
clang-format: set CMAKE_OSX_SYSROOT=/ for CLT only

### DIFF
--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -46,6 +46,7 @@ class ClangFormat < Formula
 
     mkdir "build" do
       args = std_cmake_args
+      args << "-DCMAKE_OSX_SYSROOT=/" unless MacOS::Xcode.installed?
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << ".."
       system "cmake", "-G", "Ninja", *args


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-core/issues/3347.
