### PR TITLE
libbdplus 0.1.2 (new formula)

### DIFF
--- a/Formula/libbdplus.rb
+++ b/Formula/libbdplus.rb
@@ -13,7 +13,6 @@ class Libbdplus < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "bison" => :build
   depends_on "libgcrypt"
 
   def install

--- a/Formula/libbdplus.rb
+++ b/Formula/libbdplus.rb
@@ -23,5 +23,17 @@ class Libbdplus < Formula
   end
 
   test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <libbdplus/bdplus.h>
+      int main() {
+        int major = -1;
+        int minor = -1;
+        int micro = -1;
+        bdplus_get_version(&major, &minor, &micro);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lbdplus", "-o", "test"
+    system "./test"
   end
 end

--- a/Formula/libbdplus.rb
+++ b/Formula/libbdplus.rb
@@ -1,0 +1,28 @@
+class Libbdplus < Formula
+  desc "Implements the BD+ System Specifications"
+  homepage "https://www.videolan.org/developers/libbdplus.html"
+  url "https://download.videolan.org/pub/videolan/libbdplus/0.1.2/libbdplus-0.1.2.tar.bz2"
+  mirror "http://videolan-nyc.defaultroute.com/libbdplus/0.1.2/libbdplus-0.1.2.tar.bz2"
+  sha256 "a631cae3cd34bf054db040b64edbfc8430936e762eb433b1789358ac3d3dc80a"
+
+  head do
+    url "https://git.videolan.org/git/libbdplus.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "bison" => :build
+  depends_on "libgcrypt"
+
+  def install
+    system "./bootstrap" if build.head?
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

libbdplus implements the Blu-Ray BD+ specification for VLC and other open source players.

This is useful when using VLC to play Blu-Ray discs.
