### PR TITLE
curl: enable HTTP/2 support by default

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -20,7 +20,7 @@ class Curl < Formula
   option "with-gssapi", "Build with GSSAPI/Kerberos authentication support."
   option "with-libmetalink", "Build with libmetalink support."
   option "with-libressl", "Build with LibreSSL instead of Secure Transport or OpenSSL"
-  option "with-nghttp2", "Build with HTTP/2 support (requires OpenSSL or LibreSSL)"
+  option "without-nghttp2", "Build without HTTP/2 support (for optional Secure Transport support)"
 
   deprecated_option "with-idn" => "with-libidn"
   deprecated_option "with-rtmp" => "with-rtmpdump"
@@ -43,7 +43,7 @@ class Curl < Formula
   depends_on "c-ares" => :optional
   depends_on "libmetalink" => :optional
   depends_on "libressl" => :optional
-  depends_on "nghttp2" => :optional
+  depends_on "nghttp2" => :recommended
 
   def install
     # Fail if someone tries to use both SSL choices.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`nghttp2` is a mature/stable component by now, and it makes it for a better experience having HTTP/2 enabled in curl by default. It also means that curl will be built against OpenSSL instead of Secure Transport by default. OpenSSL uses its own root certificate bundle, instead the OS-wide one used by Secure Transport &mdash; which might be a reason why this step wasn't made so far. 

Anyhow, please feel free to discuss/reject this. [Couldn't find past discussions about this. In case there was any and this one is redundant, my apologies.]

Related read: https://daniel.haxx.se/blog/2016/08/01/curl-and-h2-on-mac/

Even though I've been installing curl with this option enabled since a good while, I haven't tested this mod locally &ndash; besides the usual audit check. I'll be watching the bot for reporting any breakage.
