### PR TITLE
libxml2: fix --with-python option

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -40,7 +40,7 @@ class Libxml2 < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--without-python",
+                          ((build.with? "python") ? "--with-python" : "--without-python"),
                           "--without-lzma"
     system "make"
     ENV.deparallelize


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Just a minor fix: even when the formula receives the `--with-python` option, it passes `--without-python` to `configure`.

Fix this by using a conditional expression that yields the `--with-python` option for `configure` when the `--with-python` option is passed to the formula.
