### PR TITLE
fix head urls that are meant to refer to git repos

### DIFF
--- a/Formula/itpp.rb
+++ b/Formula/itpp.rb
@@ -1,9 +1,9 @@
 class Itpp < Formula
   desc "Library of math, signal, and communication classes and functions"
   homepage "http://itpp.sourceforge.net"
-  head "http://git.code.sf.net/p/itpp/git"
   url "https://downloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2"
   sha256 "50717621c5dfb5ed22f8492f8af32b17776e6e06641dfe3a3a8f82c8d353b877"
+  head "http://git.code.sf.net/p/itpp/git.git"
 
   bottle do
     cellar :any

--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -3,8 +3,8 @@ class Lensfun < Formula
   homepage "http://lensfun.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/lensfun/0.3.1/lensfun-0.3.1.tar.gz"
   sha256 "216c23754212e051c8b834437e46af3812533bd770c09714e8c06c9d91cdb535"
-  head "http://git.code.sf.net/p/lensfun/code"
   revision 1
+  head "http://git.code.sf.net/p/lensfun/code.git"
 
   bottle do
     sha256 "572180649db883ce40823a4e2b6de1f2771e9422572093db1a6b4481071b7ba3" => :el_capitan

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -3,7 +3,7 @@ class Qjackctl < Formula
   homepage "http://qjackctl.sourceforge.net"
   url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.4.2.tar.gz"
   sha256 "cf1c4aff22f8410feba9122e447b1e28c8fa2c71b12cfc0551755d351f9eaf5e"
-  head "http://git.code.sf.net/p/qjackctl/code", :using => :git
+  head "http://git.code.sf.net/p/qjackctl/code.git"
 
   bottle do
     revision 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The shortest way is to use `git:` protocol, but the http protocol is a better standard (thinking about firewalls, proxying), which also has some prospect for supporting encryption in the future.
