### PR TITLE
libswiften: revision for boost

### DIFF
--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -1,15 +1,13 @@
 class Libswiften < Formula
   desc "C++ library for implementing XMPP applications"
   homepage "https://swift.im/swiften"
+  url "https://swift.im/downloads/releases/swift-3.0/swift-3.0.tar.gz"
+  sha256 "8aa490431190294e62a9fc18b69ccc63dd0f561858d7d0b05c9c65f4d6ba5397"
+  revision 1
 
-  stable do
-    url "https://swift.im/downloads/releases/swift-3.0/swift-3.0.tar.gz"
-    sha256 "8aa490431190294e62a9fc18b69ccc63dd0f561858d7d0b05c9c65f4d6ba5397"
-
-    # Patch to fix build error of dynamic library with Apple's Secure Transport API
-    # Fixed upstream: https://swift.im/git/swift/commit/?id=1d545a4a7fb877f021508094b88c1f17b30d8b4e
-    patch :DATA
-  end
+  # Patch to fix build error of dynamic library with Apple's Secure Transport API
+  # Fixed upstream: https://swift.im/git/swift/commit/?id=1d545a4a7fb877f021508094b88c1f17b30d8b4e
+  patch :DATA
 
   bottle do
     revision 1


### PR DESCRIPTION
broken by boost 1.61.0 (https://github.com/Homebrew/homebrew-core/pull/3488)

needs >= 1.61.0_1: https://github.com/Homebrew/homebrew-core/pull/3875
