### PR TITLE
Update gdal.rb

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -3,7 +3,6 @@ class Gdal < Formula
   homepage "http://www.gdal.org/"
   url "http://download.osgeo.org/gdal/1.11.3/gdal-1.11.3.tar.gz"
   sha256 "561588bdfd9ca91919d4679a77a2b44214b158934ee8b425295ca5be33a1014d"
-  revision 1
 
   bottle do
     sha256 "768d5ee34e959628f630ea7f8ba1933b5936c82da5cfbae9f4eb6b90bf0bbc25" => :el_capitan


### PR DESCRIPTION
- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Last update to the 1.x branch. Bug fixes to goal.

`brew test gdal` is fine.
`brew audit --strict --online gdal` yields "C: 1: col 1: Missing frozen string literal comment." which may be something related to changes in ruby 2.3, if I understand some of what I'm finding online correctly. Not quite sure where to add the appropriate line in the code, if it's needed. New version seems to work for me.
