### PR TITLE
mercurial: bottle against Homebrew python

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -13,6 +13,13 @@ class Mercurial < Formula
     sha256 "8934a8fc26c36e56f017d99ac43a0ebe9d6922f8276c1dfccd9ccb980ae05e45" => :mavericks
   end
 
+  if MacOS.version <= :snow_leopard
+    depends_on :python
+  else
+    option "without-python", "Use system Python (will not support TLS 1.1)"
+    depends_on :python => :recommended
+  end
+
   def install
     ENV.minimal_optimization if MacOS.version <= :snow_leopard
 

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -36,8 +36,8 @@ class Mercurial < Formula
   end
 
   def caveats
-    return unless (bin/"hg").exist?
-    cacerts_configured = `#{bin}/hg config web.cacerts`.strip
+    return unless (opt_bin/"hg").exist?
+    cacerts_configured = `#{opt_bin}/hg config web.cacerts`.strip
     return if cacerts_configured == ""
     <<-EOS.undent
       Mercurial is configured to use a certificate bundle file as its trust

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -14,8 +14,7 @@ class Mercurial < Formula
     sha256 "8934a8fc26c36e56f017d99ac43a0ebe9d6922f8276c1dfccd9ccb980ae05e45" => :mavericks
   end
 
-  option "with-custom-python", "Install against the python in PATH instead of "\
-                               "Homebrew's python"
+  option "with-custom-python", "Install against the python in PATH instead of Homebrew's python"
   if build.with? "custom-python"
     depends_on :python
   else
@@ -38,7 +37,7 @@ class Mercurial < Formula
   def caveats
     return unless (opt_bin/"hg").exist?
     cacerts_configured = `#{opt_bin}/hg config web.cacerts`.strip
-    return if cacerts_configured == ""
+    return if cacerts_configured.empty?
     <<-EOS.undent
       Mercurial is configured to use a certificate bundle file as its trust
       store for TLS connections instead of using the default OpenSSL store.

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -39,11 +39,11 @@ class Mercurial < Formula
     cacerts_configured = `#{opt_bin}/hg config web.cacerts`.strip
     return if cacerts_configured.empty?
     <<-EOS.undent
-      Mercurial is configured to use a certificate bundle file as its trust
-      store for TLS connections instead of using the default OpenSSL store.
-      If you have trouble connecting to remote repositories, consider unsetting
-      the `web.cacerts` property. You can determine where the property is being
-      set by running:
+      Homebrew has detected that Mercurial is configured to use a certificate
+      bundle file as its trust store for TLS connections instead of using the
+      default OpenSSL store. If you have trouble connecting to remote
+      repositories, consider unsetting the `web.cacerts` property. You can
+      determine where the property is being set by running:
         hg config --debug web.cacerts
     EOS
   end

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -5,6 +5,7 @@ class Mercurial < Formula
   homepage "https://mercurial-scm.org/"
   url "https://mercurial-scm.org/release/mercurial-3.9.tar.gz"
   sha256 "834f25dcff44994198fb8a7ba161a6e24204dbd63c8e6270577e06e6cedbdabc"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,11 +14,12 @@ class Mercurial < Formula
     sha256 "8934a8fc26c36e56f017d99ac43a0ebe9d6922f8276c1dfccd9ccb980ae05e45" => :mavericks
   end
 
-  if MacOS.version <= :snow_leopard
+  option "with-custom-python", "Install against the python in PATH instead of "\
+                               "Homebrew's python"
+  if build.with? "custom-python"
     depends_on :python
   else
-    option "without-python", "Use system Python (will not support TLS 1.1)"
-    depends_on :python => :recommended
+    depends_on "python"
   end
 
   def install
@@ -31,6 +33,20 @@ class Mercurial < Formula
     # install the completion scripts
     bash_completion.install "contrib/bash_completion" => "hg-completion.bash"
     zsh_completion.install "contrib/zsh_completion" => "_hg"
+  end
+
+  def caveats
+    return unless (bin/"hg").exist?
+    cacerts_configured = `#{bin}/hg config web.cacerts`.strip
+    return if cacerts_configured == ""
+    <<-EOS.undent
+      Mercurial is configured to use a certificate bundle file as its trust
+      store for TLS connections instead of using the default OpenSSL store.
+      If you have trouble connecting to remote repositories, consider unsetting
+      the `web.cacerts` property. You can determine where the property is being
+      set by running:
+        hg config --debug web.cacerts
+    EOS
   end
 
   test do


### PR DESCRIPTION
Hg uses the python ssl module, which is linked to OpenSSL 0.9.8 on OS X ≤ 10.11, which lacks TLS 1.1 support.

`--install-from-source` will use the Python in PATH (which may be system python!); `--without-python` will use system python.
