### PR TITLE
ffmpeg revision for openjpeg 2.1.1

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,6 +3,8 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-3.1.1.tar.bz2"
   sha256 "a5bca50a90a37b983eaa17c483a387189175f37ca678ae7e51d43e7610b4b3b4"
+  revision 1
+
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

update to openjpeg breaks backwards compat; lib not found at runtime

```
Exception Type:        EXC_BREAKPOINT (SIGTRAP)
Exception Codes:       0x0000000000000002, 0x0000000000000000

Application Specific Information:
dyld: launch, loading dependent libraries

Dyld Error Message:
  Library not loaded: /usr/local/opt/openjpeg/lib/libopenjpeg.5.dylib
  Referenced from: /usr/local/Cellar/ffmpeg/3.1.1/bin/ffmpeg
  Reason: image not found
```

see: https://github.com/Homebrew/homebrew-core/pull/3234
