### PR TITLE
zsh-syntax-highlighting: from #{share} to #{pkgshare}

### DIFF
--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -35,6 +35,6 @@ class ZshSyntaxHighlighting < Formula
 
   test do
     assert_match "#{version}\n",
-      shell_output("zsh -c '. #{share}/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh && echo $ZSH_HIGHLIGHT_VERSION'")
+      shell_output("zsh -c '. #{pkgshare}/zsh-syntax-highlighting.zsh && echo $ZSH_HIGHLIGHT_VERSION'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online zsh-syntax-highlighting` returns:

``` zsh
zsh-syntax-highlighting:
  * Use #{pkgshare} instead of #{share}/zsh-syntax-highlighting
```
