### PR TITLE
bgrep: closing array brace must be on the same line as the last array

### DIFF
--- a/Formula/bgrep.rb
+++ b/Formula/bgrep.rb
@@ -20,8 +20,7 @@ class Bgrep < Formula
   test do
     path = testpath/"hi.prg"
     path.binwrite [0x00, 0xc0, 0xa9, 0x48, 0x20, 0xd2, 0xff,
-                   0xa9, 0x49, 0x20, 0xd2, 0xff, 0x60
-                  ].pack("C*")
+                   0xa9, 0x49, 0x20, 0xd2, 0xff, 0x60].pack("C*")
 
     assert_equal "#{path}: 00000004\n#{path}: 00000009\n",
                  shell_output("#{bin}/bgrep 20d2ff #{path}")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online bgrep` returns:

``` zsh
bgrep:
  * C: 22: col 19: Closing array brace must be on the same line as the last array element when opening brace is on the same line as the first array element.
```
