### PR TITLE
zmap: remove extra space inside brackets

### DIFF
--- a/Formula/zmap.rb
+++ b/Formula/zmap.rb
@@ -25,7 +25,7 @@ class Zmap < Formula
   depends_on "mongo-c" => :optional
 
   def install
-    inreplace ["conf/zmap.conf", "src/zmap.c", "src/zopt.ggo.in" ], "/etc", etc
+    inreplace ["conf/zmap.conf", "src/zmap.c", "src/zopt.ggo.in"], "/etc", etc
 
     args = std_cmake_args
     args << "-DENABLE_DEVELOPMENT=OFF"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online zmap` returns:

``` zsh
zmap:
  * C: 28: col 65: Space inside square brackets detected.
```
