### PR TITLE
libwandevent: remove Formula name from description

### DIFF
--- a/Formula/libwandevent.rb
+++ b/Formula/libwandevent.rb
@@ -1,5 +1,5 @@
 class Libwandevent < Formula
-  desc "Libwandevent provides an API for developing event-driven programs"
+  desc "API for developing event-driven programs"
   homepage "http://research.wand.net.nz/software/libwandevent.php"
   url "http://research.wand.net.nz/software/libwandevent/libwandevent-3.0.1.tar.gz"
   sha256 "317b2cc39f912f8e5875b9dd05658cd48ead98bf20a1d89855e5a435381bee24"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online libwandevent` returns:

``` zsh
libwandevent:
  * Description shouldn't include the formula name
```
