### PR TITLE
gcc: backport memory consumption fix

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -21,11 +21,26 @@ class Gcc < Formula
 
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org"
-  url "https://ftpmirror.gnu.org/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
-  sha256 "09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351"
+  revision 1
 
   head "svn://gcc.gnu.org/svn/gcc/trunk"
+
+  stable do
+    url "https://ftpmirror.gnu.org/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
+    mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
+    sha256 "09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351"
+
+    # 6.1.0 contains a bug that in certain circumstances causes GCC to consume
+    # all available memory very quickly & effectively crash systems.
+    # This should be safe to remove on the next stable release.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70977
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70824
+    # https://github.com/gcc-mirror/gcc/commit/75e7d6607
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c963247c6b/gcc/gcc-6.1.0_infinite_memory_snacking.patch"
+      sha256 "636394ab2024ab026ead265b13b4c2a24e44c20ddfeab43a9be6e78e824de4f2"
+    end
+  end
 
   bottle do
     sha256 "af4822329b0673723b16c7237495ee86e099f5170d6ff28f17934d4c0681b515" => :el_capitan


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Backporting this since the bug is pretty vicious, easy to stumble into and crashes more or less everything on the system in the space of 120 seconds.
