### PR TITLE
xtitle: Change test assert_equal to assert_match

### DIFF
--- a/Formula/xtitle.rb
+++ b/Formula/xtitle.rb
@@ -13,6 +13,6 @@ class Xtitle < Formula
   end
 
   test do
-    assert_equal "#{version}", shell_output("#{bin}/xtitle -V").chomp
+    assert_match version.to_s, shell_output("#{bin}/xtitle --version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Altered test block to use assert_equal & to_s instead of string interpolation.
