### PR TITLE
wine : fix using Hardware::CPU.is_64_bit instead of Hardware.is_64_bit

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -133,7 +133,7 @@ class Wine < Formula
     args << "--enable-win64" if build.with? "win64"
 
     # 64-bit builds of mpg123 are incompatible with 32-bit builds of Wine
-    args << "--without-mpg123" if Hardware.is_64_bit?
+    args << "--without-mpg123" if Hardware::CPU.is_64_bit?
 
     args << "--without-x" if build.without? "x11"
 


### PR DESCRIPTION
- [*] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [*] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [*] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

wine : fix using Hardware::CPU.is_64_bit instead of Hardware.is_64_bit
