### PR TITLE
xapian 1.4.0

### DIFF
--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -28,8 +28,7 @@ class Xapian < Formula
   deprecated_option "ruby" => "with-ruby"
 
   depends_on :python => :optional
-  depends_on "sphinx-doc" if build.with? "python" => :build
-  depends_on "php56" if build.with? "php"
+  depends_on "sphinx-doc" => :build if build.with? "python"
   depends_on :ruby => "2.1"
 
   skip_clean :la
@@ -49,7 +48,7 @@ class Xapian < Formula
           XAPIAN_CONFIG=#{bin}/xapian-config
           --without-csharp
           --without-tcl
-          SPHINX_BUILD=/usr/local/bin/sphinx-build
+          SPHINX_BUILD=#{Formula["sphinx-doc"].opt_bin}/sphinx-build
         ]
 
         if build.with? "java"

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -3,12 +3,12 @@ class Xapian < Formula
   homepage "https://xapian.org/"
 
   stable do
-    url "http://oligarchy.co.uk/xapian/1.2.23/xapian-core-1.2.23.tar.xz"
-    sha256 "9783aeae4e1a6d06e5636b270db4b458a7d0804a31da158269f57fa5dc86347d"
+    url "http://oligarchy.co.uk/xapian/1.4.0/xapian-core-1.4.0.tar.xz"
+    sha256 "10584f57112aa5e9c0e8a89e251aecbf7c582097638bfee79c1fe39a8b6a6477"
 
     resource "bindings" do
-      url "http://oligarchy.co.uk/xapian/1.2.23/xapian-bindings-1.2.23.tar.xz"
-      sha256 "19b4b56c74863c51733d8c2567272ef7f004b898cf44016711ae25bc524b2215"
+      url "http://oligarchy.co.uk/xapian/1.4.0/xapian-bindings-1.4.0.tar.xz"
+      sha256 "3aec7a009d0bf0b95968420bf68683176c05d63140eaf1cf265d39afe8fa6253"
     end
   end
 
@@ -17,17 +17,6 @@ class Xapian < Formula
     sha256 "08232fd96069f4d80cf947a22d40a729bb9a65169e0c60eb59091041da987722" => :el_capitan
     sha256 "a076ee6fbab9f6eb3171171d9d54d68f2b6ffcabf88016d028b16bc68cfeafdf" => :yosemite
     sha256 "f881021eee674478fbd70179414d27e502a1de2751e8d4454f933551052b06fb" => :mavericks
-  end
-
-  devel do
-    url "http://oligarchy.co.uk/xapian/1.3.5/xapian-core-1.3.5.tar.xz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/x/xapian-core/xapian-core_1.3.5.orig.tar.xz"
-    sha256 "3ad99ff4e91a4ff997fd576377e7c8f0134ceb3695c49e8f7d78ebf3c19b70ad"
-
-    resource "bindings" do
-      url "http://oligarchy.co.uk/xapian/1.3.5/xapian-bindings-1.3.5.tar.xz"
-      sha256 "4b5b9089d39b2a725651349127f64d24fe66db46572bdd92f39b8483bca400c3"
-    end
   end
 
   option "with-java", "Java bindings"
@@ -39,6 +28,9 @@ class Xapian < Formula
   deprecated_option "ruby" => "with-ruby"
 
   depends_on :python => :optional
+  depends_on "sphinx-doc" if build.with? "python" => :build
+  depends_on "php56" if build.with? "php"
+  depends_on :ruby => "2.1"
 
   skip_clean :la
 
@@ -57,6 +49,7 @@ class Xapian < Formula
           XAPIAN_CONFIG=#{bin}/xapian-config
           --without-csharp
           --without-tcl
+          SPHINX_BUILD=/usr/local/bin/sphinx-build
         ]
 
         if build.with? "java"
@@ -79,8 +72,6 @@ class Xapian < Formula
 
           (lib/"python2.7/site-packages").mkpath
           ENV["PYTHON_LIB"] = lib/"python2.7/site-packages"
-          # configure looks for python2 and system python doesn't install one
-          ENV["PYTHON"] = which "python"
           args << "--with-python"
         else
           args << "--without-python"
@@ -101,6 +92,13 @@ class Xapian < Formula
   end
 
   def caveats
+    if build.with? "python"
+      <<-EOS.undent
+        You may need to add the following to your PYTHONPATH:
+          #{HOMEBREW_PREFIX}/lib/python2.7/site-packages/xapian
+
+      EOS
+    end
     if build.with? "ruby"
       <<-EOS.undent
         You may need to add the Ruby bindings to your RUBYLIB from:
@@ -111,7 +109,6 @@ class Xapian < Formula
   end
 
   test do
-    suffix = devel? ? "-1.3" : ""
-    system bin/"xapian-config#{suffix}", "--libs"
+    system bin/"xapian-config", "--libs"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

However:
- [ ] Is this actually ready to merge?

because it contains a hard-coded path based on where my copy of brew puts stuff. This is covered further down.

---
- there isn't a development version of Xapian at the moment (perhaps adding a `--head` would be useful in future)
- 1.4.0 now falls back to checking python if it can't find python2, so we don't need to cater for that in the formula
- the python caveat doesn't seem to show, so I've probably done something silly here
- brew test isn't testing the bindings, which it probably should do; or perhaps the bindings should be in their own formula(e)
- I'm unconvinced `--with-java` does anything useful, because of how Java libraries work; but I'm also unconvinced that brew should bother supporting it anyway. If brew has a standard for where to put Java libraries, I could probably make this usable.
- the python bindings require sphinx-build (to build their documentation), but because the `PATH` during builds is sanitised, I don't know how to use the one from brew `sphinx-doc`. I've included a change which shows how to specify the path to it (you set `SPHINX_BUILD` to the bindings configure run), but my ruby isn't sufficient to make that dynamic, even if I knew how to get the path to the brew one. I also don't know how this is supposed to work for system python, where you'd have to `pip install` sphinx (but it then would work).
- is making `php56` a dependency the right thing to do here? While it's possible that you could install with the system PHP, that way almost certainly lies terror. (Also, because it's `php56` I haven't made it `:optional` because the option should remain `--with-php`. This may not be the neatest approach.)
