### PR TITLE
mongodb 3.2.9

### DIFF
--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Mongodb < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.org/"
-  url "https://fastdl.mongodb.org/src/mongodb-src-r3.2.8.tar.gz"
-  sha256 "5501e0e90c9358358e9ee20d4814643e910b847827627ed7ca1a9d90d220c0a7"
+  url "https://fastdl.mongodb.org/src/mongodb-src-r3.2.9.tar.gz"
+  sha256 "25f8817762b784ce870edbeaef14141c7561eb6d7c14cd3197370c2f9790061b"
 
   bottle do
     sha256 "45558113845748b89958ccef0e76c84cbb1075d766fdf0f9f78dd37fd7f88701" => :el_capitan
@@ -23,8 +23,9 @@ class Mongodb < Formula
 
   go_resource "github.com/mongodb/mongo-tools" do
     url "https://github.com/mongodb/mongo-tools.git",
-      :tag => "r3.2.8",
-      :revision => "2214d4d6561574f962c1dc72fefce4fe11843023"
+      :tag => "r3.2.9",
+      :revision => "4a4e7d30773b28cf66f75e45bc289a5d3ca49ddd",
+      :shallow => false
   end
 
   needs :cxx11
@@ -38,9 +39,6 @@ class Mongodb < Formula
     Language::Go.stage_deps resources, buildpath/"src"
 
     cd "src/github.com/mongodb/mongo-tools" do
-      # https://github.com/Homebrew/homebrew/issues/40136
-      inreplace "build.sh", '-ldflags "-X github.com/mongodb/mongo-tools/common/options.Gitspec `git rev-parse HEAD` -X github.com/mongodb/mongo-tools/common/options.VersionStr $(git describe)"', ""
-
       args = %W[]
 
       if build.with? "openssl"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

The mongo tools (such as mongorestore and mongostat) are built incorrectly in Homebrew. The current formula removes compiler flags that provide the tag and revision to the tools to be shown in the `--version` output. Given that the formula already explicitly references the tag and revision of `mongo-tools` in the `go_resource` call, I figured they should be passed in to the compile call.

Output before my change:

```
~ mongodump --version
mongodump version: not-built-with-ldflags
git version: not-built-with-ldflags
```

and after:

```
~ mongodump --version
mongodump version: r3.2.8
git version: 2214d4d6561574f962c1dc72fefce4fe11843023
```

---

Unfortunately this change involves having the tag and git hash repeated inside the formula. I would appreciate some advice on a cleaner way of doing this. I tried using class variables but that failed auditing and suggested using instance variables. I tried instance variables and the auditing script broke.

```
~ brew audit mongodb
Error: undefined method `[]' for nil:NilClass
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/version.rb:176:in `detect'
/usr/local/Library/Homebrew/resource.rb:161:in `detect_version'
/usr/local/Library/Homebrew/resource.rb:148:in `version'
/usr/local/Library/Homebrew/software_spec.rb:56:in `block in owner='
/usr/local/Library/Homebrew/software_spec.rb:54:in `each_value'
/usr/local/Library/Homebrew/software_spec.rb:54:in `owner='
/usr/local/Library/Homebrew/formula.rb:186:in `set_spec'
/usr/local/Library/Homebrew/formula.rb:154:in `initialize'
/usr/local/Library/Homebrew/formulary.rb:78:in `new'
/usr/local/Library/Homebrew/formulary.rb:78:in `get_formula'
/usr/local/Library/Homebrew/formulary.rb:175:in `get_formula'
/usr/local/Library/Homebrew/formulary.rb:215:in `factory'
/usr/local/Library/Homebrew/formulary.rb:242:in `from_keg'
/usr/local/Library/Homebrew/formulary.rb:225:in `from_rack'
/usr/local/Library/Homebrew/extend/ARGV.rb:43:in `block in resolved_formulae'
/usr/local/Library/Homebrew/extend/ARGV.rb:27:in `map'
/usr/local/Library/Homebrew/extend/ARGV.rb:27:in `resolved_formulae'
/usr/local/Library/Homebrew/cmd/audit.rb:62:in `audit'
/usr/local/Library/Homebrew/brew.rb:87:in `<main>'
```
