### PR TITLE
Wireshark: Remove the Qt4 option.

### DIFF
--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -13,10 +13,9 @@ class Wireshark < Formula
     sha256 "54e3add2e9631aa400bca0f06a9952dc16d620a2db3a21f1bb450e94c3f8f493" => :mavericks
   end
 
-  option "with-gtk+3", "Build the wireshark command with gtk+3"
-  option "with-gtk+", "Build the wireshark command with gtk+"
-  option "with-qt", "Build the wireshark-qt command (can be used with or without either GTK option)"
-  option "with-qt5", "Build the wireshark-qt command with qt5 (can be used with or without either GTK option)"
+  option "with-qt", "Build the wireshark command with Qt5 (can be used with or without either GTK option)"
+  option "with-gtk+3", "Build the wireshark-gtk command with gtk+3"
+  option "with-gtk+", "Build the wireshark-gtk command with gtk+"
   option "with-headers", "Install Wireshark library headers for plug-in development"
 
   depends_on "pkg-config" => :build
@@ -31,7 +30,6 @@ class Wireshark < Formula
   depends_on "lua" => :optional
   depends_on "portaudio" => :optional
   depends_on "qt5" => :optional
-  depends_on "qt" => :optional
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
   depends_on "gnome-icon-theme" if build.with? "gtk+3"
@@ -57,10 +55,10 @@ class Wireshark < Formula
     args = std_cmake_args
     args << "-DENABLE_GNUTLS=ON" << "-DENABLE_GCRYPT=ON"
 
-    if build.with?("qt") || build.with?("qt5")
+    if build.with?("qt")
       args << "-DBUILD_wireshark=ON"
       args << "-DENABLE_APPLICATION_BUNDLE=ON"
-      args << "-DENABLE_QT5=" + ((build.with? "qt5") ? "ON" : "OFF")
+      args << "-DENABLE_QT5=ON"
     else
       args << "-DBUILD_wireshark=OFF"
       args << "-DENABLE_APPLICATION_BUNDLE=OFF"
@@ -104,7 +102,7 @@ class Wireshark < Formula
     ENV.deparallelize # parallel install fails
     system "make", "install"
 
-    if build.with?("qt") || build.with?("qt5")
+    if build.with?("qt")
       prefix.install bin/"Wireshark.app"
       bin.install_symlink prefix/"Wireshark.app/Contents/MacOS/Wireshark"
     end


### PR DESCRIPTION
Make --with-qt build with Qt5. Remove support for building with Qt4.
Qt5 has much better support for current versions of macOS than Qt4,
particularly retina displays. We (the Wireshark project) don't build or
test Wireshark+Qt4+macOS and haven't for quite some time. We would very
much appreciate not getting bug reports from Homebrew users who are
having trouble with Qt4.
