### PR TITLE
w-calc: fix code position

### DIFF
--- a/Formula/w-calc.rb
+++ b/Formula/w-calc.rb
@@ -1,5 +1,9 @@
 class WCalc < Formula
+  desc "Very capable calculator"
+  homepage "http://w-calc.sourceforge.net"
   url "https://downloads.sourceforge.net/w-calc/wcalc-2.5.tar.bz2"
+  sha256 "0e2c17c20f935328dcdc6cb4c06250a6732f9ee78adf7a55c01133960d6d28ee"
+
   bottle do
     cellar :any
     sha256 "67160a91e50ae33f723ead45c4150750b62b3bd45ec009eb4b493e138d2a908d" => :el_capitan
@@ -7,10 +11,6 @@ class WCalc < Formula
     sha256 "14bcdc8bb396d6c3890a7a7719d6619911ffe92e8949278865b256eb5f74682e" => :mavericks
     sha256 "0eb8fb2e15ee8274ec673850eb5004654e3f7c3d3a835597b5809e87420db08f" => :mountain_lion
   end
-
-  desc "Very capable calculator"
-  homepage "http://w-calc.sourceforge.net"
-  sha256 "0e2c17c20f935328dcdc6cb4c06250a6732f9ee78adf7a55c01133960d6d28ee"
 
   depends_on "gmp"
   depends_on "mpfr"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online w-calc` returns:

``` zsh
w-calc:
  * `homepage` (line 12) should be put before `url` (line 2)
  * `checksum` (line 13) should be put before `bottle block` (line 3)
Error: 2 problems in 1 formulae
```
