### PR TITLE
owfs 3.1p2

### DIFF
--- a/Formula/owfs.rb
+++ b/Formula/owfs.rb
@@ -1,10 +1,9 @@
 class Owfs < Formula
   desc "Monitor and control physical environment using Dallas/Maxim 1-wire system"
   homepage "http://owfs.org/"
-  url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p1/owfs-3.1p1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/owfs/owfs_3.1p1.orig.tar.gz"
-  version "3.1p1"
-  sha256 "e69421ae534565c1f8530a2447f583401f4d0d4b1cf3cb8cf399a57133ed7f81"
+  url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p2/owfs-3.1p2.tar.gz"
+  version "3.1p2"
+  sha256 "82ddc4c40d32d4f4f4b09fd57711d0892281680d9cb3e9cfa96927acd593cfe3"
 
   bottle do
     cellar :any
@@ -13,11 +12,25 @@ class Owfs < Formula
     sha256 "6462c010b2307c488678673bec8772466baf7aafcb8917732f0606889ccadd90" => :mavericks
   end
 
-  depends_on "libusb-compat"
+  depends_on "libusb"
+
+  # "libusb.h" and "ow_ftdi.h" are missing from the release tarball
+  # install them as a resource to avoid building from the tag with Autotools
+  # Reported 8 Aug 2016: https://sourceforge.net/p/owfs/bugs/70/
+  resource "missing_includes" do
+    url "git://git.code.sf.net/p/owfs/code",
+        :tag => "v3.1p2",
+        :revision => "eb05fc0fd388b2de0d501022a1d1e66e1167991a"
+  end
 
   def install
-    # Fix include of getline and strsep to avoid crash
-    inreplace "configure", "-D_POSIX_C_SOURCE=200112L", ""
+    resource("missing_includes").stage do
+      missing = Dir["module/owlib/src/include/{libusb.h,ow_ftdi.h}"]
+      cp missing, buildpath/"module/owlib/src/include"
+
+      # prevent automake from being triggered
+      touch missing, :mtime => (buildpath/"module/owlib/src").mtime
+    end
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -27,11 +40,12 @@ class Owfs < Formula
                           "--disable-zero",
                           "--disable-owpython",
                           "--disable-owperl",
+                          "--disable-ftdi",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/owserver", "--version"
+    system bin/"owserver", "--version"
   end
 end


### PR DESCRIPTION
- pluck missing header files from upstream git repository
- D_POSIX_C_SOURCE inreplace isn't needed with current configure
  options, though the underlying bug is still not fixed
- switch dependency to libusb since that's what it currently links to
- avoid opportunistically enabling ftdi
