### PR TITLE
owfs 3.1p3

### DIFF
--- a/Formula/owfs.rb
+++ b/Formula/owfs.rb
@@ -1,10 +1,9 @@
 class Owfs < Formula
   desc "Monitor and control physical environment using Dallas/Maxim 1-wire system"
   homepage "http://owfs.org/"
-  url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p1/owfs-3.1p1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/owfs/owfs_3.1p1.orig.tar.gz"
-  version "3.1p1"
-  sha256 "e69421ae534565c1f8530a2447f583401f4d0d4b1cf3cb8cf399a57133ed7f81"
+  url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p3/owfs-3.1p3.tar.gz"
+  version "3.1p3"
+  sha256 "81460ae8aab4a5cf2ff59bc416819baeacdeb1b753bc06fd09d6e47cef799be4"
 
   bottle do
     cellar :any
@@ -13,12 +12,7 @@ class Owfs < Formula
     sha256 "6462c010b2307c488678673bec8772466baf7aafcb8917732f0606889ccadd90" => :mavericks
   end
 
-  depends_on "libusb-compat"
-
   def install
-    # Fix include of getline and strsep to avoid crash
-    inreplace "configure", "-D_POSIX_C_SOURCE=200112L", ""
-
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-swig",
@@ -27,11 +21,12 @@ class Owfs < Formula
                           "--disable-zero",
                           "--disable-owpython",
                           "--disable-owperl",
+                          "--disable-ftdi",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/owserver", "--version"
+    system bin/"owserver", "--version"
   end
 end


### PR DESCRIPTION
- D_POSIX_C_SOURCE inreplace isn't needed with current configure options, though the underlying bug is still not fixed
- drop dependency on libusb since it's not used with current configure options
