### PR TITLE
docker-machine-driver-xhyve: Update to v0.2.3 and Fix build flags

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -2,8 +2,8 @@ class DockerMachineDriverXhyve < Formula
   desc "Docker Machine driver for xhyve"
   homepage "https://github.com/zchee/docker-machine-driver-xhyve"
   url "https://github.com/zchee/docker-machine-driver-xhyve.git",
-    :tag => "v0.2.2",
-    :revision => "7a7e30b80a9ee444e5e67fd1839422e201a1b328"
+    :tag => "v0.2.3",
+    :revision => "45426155af2998e9cf8a5eca12158fcf4d1acfd3"
 
   head "https://github.com/zchee/docker-machine-driver-xhyve.git"
 
@@ -27,11 +27,11 @@ class DockerMachineDriverXhyve < Formula
       if build.head?
         git_hash = `git rev-parse --short HEAD --quiet`.chomp
         git_hash = "HEAD-#{git_hash}"
-        ENV["CGO_LDFLAGS"] = "#{build_root}/vendor/build/lib9p/lib9p.a -L#{build_root}/vendor/lib9p"
-        ENV["CGO_CFLAGS"] = "-I#{build_root}/vendor/lib9p"
-        system "make", "lib9p"
       end
-      system "go", "build", "-x", "-o", bin/"docker-machine-driver-xhyve",
+      ENV["CGO_LDFLAGS"] = "#{build_root}/vendor/build/lib9p/lib9p.a -L#{build_root}/vendor/lib9p"
+      ENV["CGO_CFLAGS"] = "-I#{build_root}/vendor/lib9p"
+      system "make", "lib9p"
+      system "go", "build", "-tags", "lib9p", "-x", "-o", bin/"docker-machine-driver-xhyve",
       "-ldflags",
       "'-w -s'",
       "-ldflags",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Related of https://github.com/Homebrew/homebrew-core/pull/3638, Update to v0.2.3 and fix build some of flags. Thanks @ilovezfs !

But I can't `brew install` and `brew audit` test because I use Sierra Dev (maybe related to Sierra `gettimeofday` syscall?)
Do you have any workaround? It' just only waits for buildbot results?

Edit: Oh, pull request needs checks complete? Just in case, update checklist.
