### PR TITLE
owfs: enable debug, usb, ftdi

### DIFF
--- a/Formula/owfs.rb
+++ b/Formula/owfs.rb
@@ -4,6 +4,7 @@ class Owfs < Formula
   url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p3/owfs-3.1p3.tar.gz"
   version "3.1p3"
   sha256 "81460ae8aab4a5cf2ff59bc416819baeacdeb1b753bc06fd09d6e47cef799be4"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,16 +13,20 @@ class Owfs < Formula
     sha256 "d7464e56d0d362d4dff9a301959a2f07a0618aab91ac89074805c42fa69b013a" => :mavericks
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "libftdi"
+  depends_on "libusb"
+
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--disable-swig",
-                          "--disable-owfs",
                           "--disable-owtcl",
                           "--disable-zero",
                           "--disable-owpython",
                           "--disable-owperl",
-                          "--disable-ftdi",
+                          "--disable-swig",
+                          "--enable-ftdi",
+                          "--enable-usb",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
upstream requested not to pass --disable-debug:

>  Don't do --disable-debug. There is the runtime switch --debug which
>  enables debug. Only if the small time for testing that switch bothers
>  you (unlikely), you can --disable-debug. Don't do that! Reason is we
>  have no chance to debug any user problems if you --disable-debug.

Also, enable usb and ftdi support as upstream confirmed this is working
on macOS.
