### PR TITLE
pdftoedn v0.32.0

### DIFF
--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -18,7 +18,7 @@ class Pdftoedn < Formula
     ENV.cxx11
 
     system "autoreconf", "-i"
-    system "./configure", "--with-openssl=#{Formula['openssl'].opt_prefix}", "--prefix=#{prefix}"
+    system "./configure", "--with-openssl=#{Formula["openssl"].opt_prefix}", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -1,0 +1,35 @@
+class Pdftoedn < Formula
+  desc "Extract PDF document data and save the output in EDN format"
+  homepage "https://github.com/edporras/pdftoedn"
+  url "https://github.com/edporras/pdftoedn/archive/v0.32.0.tar.gz"
+  sha256 "90406cb6954d01514dcea2fb6e857437afd3e8d067b81a2362a7ef6e383919bc"
+
+  bottle do
+    cellar :any
+  end
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "freetype"
+  depends_on "libpng"
+  depends_on "poppler"
+  depends_on "boost"
+  depends_on "leptonica"
+  depends_on "openssl"
+  depends_on "rapidjson"
+
+  def install
+    ENV.cxx11 if MacOS.version < :mavericks
+
+    system "autoreconf", "-i"
+    system "./configure", "--with-openssl=/usr/local/opt/openssl/", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    # working on converting my ruby-based test suite but all the docs
+    # are private. Need to find a public set I can use.
+    system "#{bin}/pdftoedn", "-h"
+  end
+end

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -24,6 +24,6 @@ class Pdftoedn < Formula
   end
 
   test do
-    system "make", "check"
+    system "#{bin}/pdftoedn", "-o", "test.edn", test_fixtures("test.pdf")
   end
 end

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -1,12 +1,8 @@
 class Pdftoedn < Formula
   desc "Extract PDF document data and save the output in EDN format"
   homepage "https://github.com/edporras/pdftoedn"
-  url "https://github.com/edporras/pdftoedn/archive/v0.32.0.tar.gz"
-  sha256 "90406cb6954d01514dcea2fb6e857437afd3e8d067b81a2362a7ef6e383919bc"
-
-  bottle do
-    cellar :any
-  end
+  url "https://github.com/edporras/pdftoedn/archive/v0.32.1.tar.gz"
+  sha256 "7b56e404710c0d835e8b693660a6e4e98e2d37ab7329a4f67010a10c34235e85"
 
   depends_on "automake" => :build
   depends_on "autoconf" => :build
@@ -19,17 +15,15 @@ class Pdftoedn < Formula
   depends_on "rapidjson"
 
   def install
-    ENV.cxx11 if MacOS.version < :mavericks
+    ENV.cxx11
 
     system "autoreconf", "-i"
-    system "./configure", "--with-openssl=/usr/local/opt/openssl/", "--prefix=#{prefix}"
+    system "./configure", "--with-openssl=#{Formula['openssl'].opt_prefix}", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end
 
   test do
-    # working on converting my ruby-based test suite but all the docs
-    # are private. Need to find a public set I can use.
-    system "#{bin}/pdftoedn", "-h"
+    system "make", "check"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Initial public release of a PDF to EDN conversion tool. 

Formerly an internal ruby gem (w/ c++ extension), we have switched to a standalone binary for greater efficiency and speed. We are using this tool on runs to process tens of thousands of documents with Starcluster. I started working on it in 2012 and it is the reason I've been submitting formula updates for new releases of poppler and leptonica.

I understand you frown upon authors submitting their own non-popular work but we've open-sourced this tool because we feel people have been looking for something like it for some time. Most existing PDF processing tools do direct conversion to a specific output format. This tool allows extraction and storage of document data which can be opened via any language with an EDN reader to extract specific document elements. For example, you can get all text spans with font and position information for each character allowing assembly of the entire document's text content for splitting and/or merging with related external documents. We also have an internal `edntosvg` tool that reproduces output that matches the source PDF amazingly well.

I'd appreciate any suggestions to get the Formula accepted. Thank you for your consideration.
