### PR TITLE
ffmpeg 3.1.2

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -1,9 +1,8 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-3.1.1.tar.bz2"
-  sha256 "a5bca50a90a37b983eaa17c483a387189175f37ca678ae7e51d43e7610b4b3b4"
-  revision 1
+  url "https://ffmpeg.org/releases/ffmpeg-3.1.2.tar.bz2"
+  sha256 "62eb8d810b93c1ffc23739c0824a91eabfe5e7be81fab34ce740736a110b70f7"
 
   head "https://github.com/FFmpeg/FFmpeg.git"
 

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,6 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.18.1.tar.gz"
   sha256 "e413d57fec4ad43b9f9b848f38d13fb921313fc9a4a64bf1e906c8d0f7a46329"
+  revision 1
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

I'm bumping mpv because as of 0.18.1, mpv is not supposed to run against a version of FFmpeg other than the one it was compiled with. To quote the [release notes](https://github.com/mpv-player/mpv/releases/tag/v0.18.1):

> Note: Running mpv with different versions of the FFmpeg/Libav libraries than
> it was compiled with is no longer supported. Even supposedly ABI-compatible
> versions have been a source of trouble, and it creates far too much
> complexity with little to no benefit, coupled with absurd and unusable FFmpeg
> API artifacts.

I tried my old mpv installation (compiled with FFmpeg 3.1.1) with FFmpeg 3.1.2 and it actually runs without problems, but let's bump just to be safe.
