### PR TITLE
git-annex 6.20160808

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -5,20 +5,9 @@ class GitAnnex < Formula
 
   desc "Manage files with git without checking in file contents"
   homepage "https://git-annex.branchable.com/"
+  url "https://hackage.haskell.org/package/git-annex-6.20160808/git-annex-6.20160808.tar.gz"
+  sha256 "c729decece3dfc05366879b72328b5ebe4a86e77a32f634fcfa4dbebbb8799fd"
   head "git://git-annex.branchable.com/"
-
-  stable do
-    url "https://hackage.haskell.org/package/git-annex-6.20160619/git-annex-6.20160619.tar.gz"
-    sha256 "5acc80dfb86d8f568819256a428f04794bff4c654389692f27a7bf0877ebe12f"
-
-    # Upstream commit "cabal constraints for aws and esqueleto"
-    # Upstream aws issue: https://github.com/aristidb/aws/issues/206
-    # Upstream esqueleto issue: https://github.com/prowdsponsor/esqueleto/issues/137
-    patch do
-      url "https://github.com/joeyh/git-annex/commit/18e458db.patch"
-      sha256 "75c3f7426e492ea48062f9922badae5c7809f2494f128e41f9d3e148fb9daa50"
-    end
-  end
 
   bottle do
     cellar :any
@@ -37,6 +26,13 @@ class GitAnnex < Formula
   depends_on "libmagic"
   depends_on "gnutls"
   depends_on "quvi"
+
+  # Fixes CI timeout by providing a more specific hint for Solver
+  # Reported 9 Aug 2016: "git-annex.cabal: persistent ==2.2.4.1"
+  patch do
+    url "https://github.com/joeyh/git-annex/pull/56.patch"
+    sha256 "62ad81e3019f5c639708c679783e3f93e20996db1dc3577553ce90ab55fac9cf"
+  end
 
   def install
     install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["s3", "webapp"] do


### PR DESCRIPTION
Simplify Solver's task by requesting version 2.2.4.1 of the persistent
package instead of just providing the persistent < 2.5 constraint.
