### PR TITLE
qscintilla2 with qt5 support

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -14,7 +14,8 @@ class Qscintilla2 < Formula
   end
 
   option "with-plugin", "Build the Qt Designer plugin"
-  option "without-python", "Skip building the Python bindings"
+  option "with-python", "Build Python bindings"
+  option "without-python3", "Do not build Python3 bindings"
 
   depends_on "qt5"
   depends_on :python3 => :recommended

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -32,9 +32,6 @@ class Qscintilla2 < Formula
   end
 
   def install
-    # Make sure Qt5 is found even if not linked
-    ENV.prepend_path "PATH", Formula["qt5"].bin
-
     spec = ENV.compiler == :clang && MacOS.version >= :mavericks ? "macx-clang" : "macx-g++"
     args = %W[-config release -spec #{spec}]
 
@@ -66,7 +63,6 @@ class Qscintilla2 < Formula
           system python, "configure.py", "-o", lib, "-n", include,
                            "--apidir=#{prefix}/qsci",
                            "--destdir=#{lib}/python#{version}/site-packages/PyQt5",
-                           "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
                            "--qsci-sipdir=#{share}/sip",
                            "--pyqt=PyQt5",
                            "--pyqt-sipdir=#{Formula["pyqt5"].opt_share}/sip/Qt5",

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -3,6 +3,7 @@ class Qscintilla2 < Formula
   homepage "https://www.riverbankcomputing.com/software/qscintilla/intro"
   url "https://downloads.sf.net/project/pyqt/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.tar.gz"
   sha256 "98aab93d73b05635867c2fc757acb383b5856a0b416e3fd7659f1879996ddb7e"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,28 +13,29 @@ class Qscintilla2 < Formula
     sha256 "5a265016e1a21e110bb9c344e7db8fd41b5690df5ffc359394c6e62aad8af494" => :mavericks
   end
 
-  option "without-plugin", "Skip building the Qt Designer plugin"
+  option "with-plugin", "Build the Qt Designer plugin"
   option "without-python", "Skip building the Python bindings"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "qt5"
+  depends_on :python3 => :recommended
+  depends_on :python => :optional
 
-  if build.with? "python3"
-    depends_on "pyqt" => "with-python3"
-  elsif build.with? "python"
-    depends_on "pyqt"
-  else
-    depends_on "qt"
+  if build.with?("python") && build.with?("python3")
+    depends_on "sip" => "with-python3"
+    depends_on "pyqt5" => "with-python"
+  elsif build.with?("python")
+    depends_on "sip"
+    depends_on "pyqt5" => "with-python"
+  elsif build.with?("python3")
+    depends_on "sip" => "with-python3"
+    depends_on "pyqt5"
   end
 
   def install
-    # On Mavericks we want to target libc++, this requires an
-    # unsupported/macx-clang-libc++ flag.
-    if ENV.compiler == :clang && MacOS.version >= :mavericks
-      spec = "unsupported/macx-clang-libc++"
-    else
-      spec = "macx-g++"
-    end
+    # Make sure Qt5 is found even if not linked
+    ENV.prepend_path "PATH", Formula["qt5"].bin
+
+    spec = ENV.compiler == :clang && MacOS.version >= :mavericks ? "macx-clang" : "macx-g++"
     args = %W[-config release -spec #{spec}]
 
     cd "Qt4Qt5" do
@@ -63,10 +65,12 @@ class Qscintilla2 < Formula
           (share/"sip").mkpath
           system python, "configure.py", "-o", lib, "-n", include,
                            "--apidir=#{prefix}/qsci",
-                           "--destdir=#{lib}/python#{version}/site-packages/PyQt4",
-                           "--stubsdir=#{lib}/python#{version}/site-packages/PyQt4",
+                           "--destdir=#{lib}/python#{version}/site-packages/PyQt5",
+                           "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
                            "--qsci-sipdir=#{share}/sip",
-                           "--pyqt-sipdir=#{HOMEBREW_PREFIX}/share/sip",
+                           "--pyqt=PyQt5",
+                           "--pyqt-sipdir=#{Formula["pyqt5"].opt_share}/sip/Qt5",
+                           "--sip-incdir=#{Formula["sip"].opt_include}",
                            "--spec=#{spec}"
           system "make"
           system "make", "install"
@@ -79,7 +83,7 @@ class Qscintilla2 < Formula
       mkpath prefix/"plugins/designer"
       cd "designer-Qt4Qt5" do
         inreplace "designer.pro" do |s|
-          s.sub! "$$[QT_INSTALL_PLUGINS]", "#{lib}/qt4/plugins"
+          s.sub! "$$[QT_INSTALL_PLUGINS]", "#{lib}/qt5/plugins"
           s.sub! "$$[QT_INSTALL_LIBS]", lib
         end
         system "qmake", "designer.pro", *args
@@ -90,9 +94,9 @@ class Qscintilla2 < Formula
   end
 
   test do
-    Pathname("test.py").write <<-EOS.undent
-      import PyQt4.Qsci
-      assert("QsciLexer" in dir(PyQt4.Qsci))
+    (testpath/"test.py").write <<-EOS.undent
+      import PyQt5.Qsci
+      assert("QsciLexer" in dir(PyQt5.Qsci))
     EOS
     Language::Python.each_python(build) do |python, _version|
       system python, "test.py"

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -43,13 +43,11 @@ class Qscintilla2 < Formula
         s.gsub! "$$[QT_INSTALL_TRANSLATIONS]", prefix/"trans"
         s.gsub! "$$[QT_INSTALL_DATA]", prefix/"data"
         s.gsub! "$$[QT_HOST_DATA]", prefix/"data"
-        #s.gsub! "TARGET = qscintilla2", "TARGET = qscintilla2-qt5"
       end
 
       inreplace "features/qscintilla2.prf" do |s|
         s.gsub! "$$[QT_INSTALL_LIBS]", lib
         s.gsub! "$$[QT_INSTALL_HEADERS]", include
-        #s.gsub! "LIBS += -lqscintilla2", "LIBS += -lqscintilla2-qt5"
       end
 
       system "qmake", "qscintilla.pro", *args
@@ -88,7 +86,6 @@ class Qscintilla2 < Formula
         inreplace "designer.pro" do |s|
           s.sub! "$$[QT_INSTALL_PLUGINS]", "#{lib}/qt5/plugins"
           s.sub! "$$[QT_INSTALL_LIBS]", lib
-          #s.sub! "TARGET = qscintillaplugin", "TARGET = qscintillaplugin-qt5"
         end
         system "qmake", "designer.pro", *args
         system "make"

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -43,13 +43,13 @@ class Qscintilla2 < Formula
         s.gsub! "$$[QT_INSTALL_TRANSLATIONS]", prefix/"trans"
         s.gsub! "$$[QT_INSTALL_DATA]", prefix/"data"
         s.gsub! "$$[QT_HOST_DATA]", prefix/"data"
-        s.gsub! "TARGET = qscintilla2", "TARGET = qscintilla2_qt5"
+        #s.gsub! "TARGET = qscintilla2", "TARGET = qscintilla2-qt5"
       end
 
       inreplace "features/qscintilla2.prf" do |s|
         s.gsub! "$$[QT_INSTALL_LIBS]", lib
         s.gsub! "$$[QT_INSTALL_HEADERS]", include
-        s.gsub! "LIBS += -lqscintilla2", "LIBS += -lqscintilla2_qt5"
+        #s.gsub! "LIBS += -lqscintilla2", "LIBS += -lqscintilla2-qt5"
       end
 
       system "qmake", "qscintilla.pro", *args
@@ -88,6 +88,7 @@ class Qscintilla2 < Formula
         inreplace "designer.pro" do |s|
           s.sub! "$$[QT_INSTALL_PLUGINS]", "#{lib}/qt5/plugins"
           s.sub! "$$[QT_INSTALL_LIBS]", lib
+          #s.sub! "TARGET = qscintillaplugin", "TARGET = qscintillaplugin-qt5"
         end
         system "qmake", "designer.pro", *args
         system "make"

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -16,7 +16,6 @@ class Qscintilla2 < Formula
   option "with-plugin", "Build the Qt Designer plugin"
   option "without-python", "Skip building the Python bindings"
 
-  depends_on "qt5"
   depends_on :python3 => :recommended
   depends_on :python => :optional
 
@@ -29,6 +28,8 @@ class Qscintilla2 < Formula
   elsif build.with?("python3")
     depends_on "sip" => "with-python3"
     depends_on "pyqt5"
+  else
+    depends_on "qt5"
   end
 
   def install

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -16,6 +16,7 @@ class Qscintilla2 < Formula
   option "with-plugin", "Build the Qt Designer plugin"
   option "without-python", "Skip building the Python bindings"
 
+  depends_on "qt5"
   depends_on :python3 => :recommended
   depends_on :python => :optional
 
@@ -28,8 +29,6 @@ class Qscintilla2 < Formula
   elsif build.with?("python3")
     depends_on "sip" => "with-python3"
     depends_on "pyqt5"
-  else
-    depends_on "qt5"
   end
 
   def install
@@ -42,11 +41,14 @@ class Qscintilla2 < Formula
         s.gsub! "$$[QT_INSTALL_HEADERS]", include
         s.gsub! "$$[QT_INSTALL_TRANSLATIONS]", prefix/"trans"
         s.gsub! "$$[QT_INSTALL_DATA]", prefix/"data"
+        s.gsub! "$$[QT_HOST_DATA]", prefix/"data"
+        s.gsub! "TARGET = qscintilla2", "TARGET = qscintilla2_qt5"
       end
 
       inreplace "features/qscintilla2.prf" do |s|
         s.gsub! "$$[QT_INSTALL_LIBS]", lib
         s.gsub! "$$[QT_INSTALL_HEADERS]", include
+        s.gsub! "LIBS += -lqscintilla2", "LIBS += -lqscintilla2_qt5"
       end
 
       system "qmake", "qscintilla.pro", *args
@@ -64,7 +66,10 @@ class Qscintilla2 < Formula
           system python, "configure.py", "-o", lib, "-n", include,
                            "--apidir=#{prefix}/qsci",
                            "--destdir=#{lib}/python#{version}/site-packages/PyQt5",
+                           "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
                            "--qsci-sipdir=#{share}/sip",
+                           "--qsci-incdir=#{include}",
+                           "--qsci-libdir=#{lib}",
                            "--pyqt=PyQt5",
                            "--pyqt-sipdir=#{Formula["pyqt5"].opt_share}/sip/Qt5",
                            "--sip-incdir=#{Formula["sip"].opt_include}",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This pull request addresses https://github.com/Homebrew/legacy-homebrew/issues/37591 and https://github.com/Homebrew/legacy-homebrew/issues/41464. This changset als sets python as the default switch for pyqt5 (i.e., not python3) since this seems more consistent with all other formulae.
