### PR TITLE
libsoxr: remove conflicts with sox

### DIFF
--- a/Formula/libsoxr.rb
+++ b/Formula/libsoxr.rb
@@ -14,8 +14,6 @@ class Libsoxr < Formula
 
   depends_on "cmake" => :build
 
-  conflicts_with "sox", :because => "Sox contains soxr. Soxr is purely the resampler."
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

`libsoxr` and `sox` install completely different sets of binaries, headers and libraries, and thus they do not conflict at all. In fact, usage cases of them do differ. `libsoxr` acts as the dependency of `ffmpeg` which provides the functionality of resampling. On the other hand, `sox` provides a binary named `sox` which enables users to perform some manipulation on audio files like generating a spectrogram.

@DomT4 This `conflicts_with` mark was originally added by you. Can you provide some comments? Thanks.
