### PR TITLE
mobile-shell 1.2.6

### DIFF
--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -1,15 +1,8 @@
 class MobileShell < Formula
   desc "Remote terminal application"
   homepage "https://mosh.mit.edu/"
-
-  stable do
-    url "https://mosh.mit.edu/mosh-1.2.5.tar.gz"
-    sha256 "1af809e5d747c333a852fbf7acdbf4d354dc4bbc2839e3afe5cf798190074be3"
-
-    # Upstream switched to defaulting to CommonCrypto as of
-    # https://github.com/mobile-shell/mosh/commit/0eb614809a7ea
-    depends_on "openssl"
-  end
+  url "https://mosh.mit.edu/mosh-1.2.6.tar.gz"
+  sha256 "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85"
 
   bottle do
     sha256 "046b0c48cd1c573d57500e683122e3152a00556ad960938c6caa962b0c2ef460" => :el_capitan
@@ -18,19 +11,11 @@ class MobileShell < Formula
     sha256 "5a244c07094d5d3d30a95888a7bb0df6051fd81cfec7fd35ac861090f1897d6e" => :mountain_lion
   end
 
-  devel do
-    url "https://github.com/mobile-shell/mosh/releases/download/mosh-1.2.5.95rc1/mosh-1.2.5.95rc1.tar.gz"
-    sha256 "a2697c41cfc8c92dc7a743dd101849a7a508c6986b24d6f44711d8533d18fcf5"
-
-    depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
-  end
-
   head do
     url "https://github.com/mobile-shell/mosh.git", :shallow => false
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
   end
 
   option "without-test", "Run build-time tests"
@@ -39,6 +24,7 @@ class MobileShell < Formula
 
   depends_on "pkg-config" => :build
   depends_on "protobuf"
+  depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
 
   def install
     # teach mosh to locate mosh-client without referring


### PR DESCRIPTION
verified new version still builds with protobuf 3
