### PR TITLE
yaws: fix checksum, use release tarball

### DIFF
--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -1,9 +1,8 @@
 class Yaws < Formula
   desc "Webserver for dynamic content (written in Erlang)"
   homepage "http://yaws.hyber.org"
-  url "https://github.com/klacke/yaws/archive/yaws-2.0.3.tar.gz"
-  sha256 "fbe54fe64455b447d0d44aed4d51402f42c81743ad5e1f1a09d888f2ef54de07"
-  head "https://github.com/klacke/yaws.git"
+  url "http://yaws.hyber.org/download/yaws-2.0.3.tar.gz"
+  sha256 "450a4b2b2750a6feb34238c0b38bc9801de80b228188a22d85dccbb4b4e049f6"
 
   bottle do
     sha256 "1ee10be2188e6dc7c2e01def77e2e8201d4ebf4adf6ac8321569e12b6e1aa0c6" => :el_capitan
@@ -11,12 +10,17 @@ class Yaws < Formula
     sha256 "696fe509205bbc64331c3d6c83894d1b39ee996a42e5157b7a8a50bb10470458" => :mavericks
   end
 
+  head do
+    url "https://github.com/klacke/yaws.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   option "without-yapp", "Omit yaws applications"
   option "32-bit"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "erlang"
 
   # the default config expects these folders to exist
@@ -29,7 +33,7 @@ class Yaws < Formula
       ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
     end
 
-    system "autoreconf", "-fvi"
+    system "autoreconf", "-fvi" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           # Ensure pam headers are found on Xcode-only installs
                           "--with-extrainclude=#{MacOS.sdk_path}/usr/include/security"
@@ -45,7 +49,9 @@ class Yaws < Formula
     # the default config expects these folders to exist
     (lib/"yaws/examples/ebin").mkpath
     (lib/"yaws/examples/include").mkpath
+  end
 
+  def post_install
     (var/"log/yaws").mkpath
     (var/"yaws/www").mkpath
   end


### PR DESCRIPTION
The original PR jumped the gun on the 2.0.3, which wasn't announced
until a couple days later, by which time it had been retagged. Upstream
website cites the same commit as the current GitHub tarball.
