### PR TITLE
qscintilla2: fix configure.py command to include --stubsdir

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -63,6 +63,7 @@ class Qscintilla2 < Formula
           system python, "configure.py", "-o", lib, "-n", include,
                            "--apidir=#{prefix}/qsci",
                            "--destdir=#{lib}/python#{version}/site-packages/PyQt4",
+                           "--stubsdir=#{lib}/python#{version}/site-packages/PyQt4",
                            "--qsci-sipdir=#{share}/sip",
                            "--pyqt-sipdir=#{HOMEBREW_PREFIX}/share/sip",
                            "--spec=#{spec}"


### PR DESCRIPTION
Pass in `--stubsdir` option to match `--destdir`. Without this the stubs try to install themselves to `/Library/Python/2.7/site-packages/PyQt4`
