### PR TITLE
luajit: link binaries with necessary flags

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -3,7 +3,7 @@ class Luajit < Formula
   homepage "http://luajit.org/luajit.html"
   url "http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
   sha256 "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
-  revision 2
+  revision 3
 
   head "http://luajit.org/git/luajit-2.0.git"
 
@@ -64,6 +64,8 @@ class Luajit < Formula
               "INSTALL_LMOD=#{HOMEBREW_PREFIX}/share/lua/${abiver}"
       s.gsub! "INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}",
               "INSTALL_CMOD=#{HOMEBREW_PREFIX}/${multilib}/lua/${abiver}"
+      s.gsub! "Libs:",
+              "Libs: -pagezero_size 10000 -image_base 100000000"
     end
 
     # Having an empty Lua dir in lib/share can mess with other Homebrew Luas.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

From install.html:

If you're building a 64 bit application on OSX which links directly or
indirectly against LuaJIT, you need to link your main executable with these
flags:
  -pagezero_size 10000 -image_base 100000000
