### PR TITLE
asciidoc: include docs in installation

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -3,10 +3,10 @@ class Asciidoc < Formula
   homepage "http://asciidoc.org/"
   url "https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
   sha256 "78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
-    revision 1
     sha256 "345affbf8e5c86ecb679580c5a0e5f8e97fc732557cb75e7b2ba94d8ecfc2a70" => :el_capitan
     sha256 "6d868af1ee68431d2f17e86cb30839efed396a963c5b7be5df435c0db4ca48c3" => :yosemite
     sha256 "631dd27e65bb68697bda0b6641b753c0a8b6544c32c061ff15a2026b831eddbb" => :mavericks
@@ -30,6 +30,7 @@ class Asciidoc < Formula
     # otherwise OS X's xmllint bails out
     inreplace "Makefile", "-f manpage", "-f manpage -L"
     system "make", "install"
+    system "make", "docs"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Includes the documentation as part of the asciidoc installation. The docs contain useful reference files, and the AsciiDoc user's guide refers to them.
