### PR TITLE
flex: fix enable shared libs

### DIFF
--- a/Formula/flex.rb
+++ b/Formula/flex.rb
@@ -17,7 +17,7 @@ class Flex < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--disable-shared",
+                          "--enable-shared",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [✓] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [✓] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

Update flex Formula to add `--enable-shared` to the configuration.

Adds:
- lib/libfl.2.dylib
- lib/libfl.dylib (symlink to lib/libfl.2.dylib)
- lib/libfl_pic.2.dylib
- lib/libfl_pic.dylib (symlink to lib/libfl_pic.2.dylib)
