### PR TITLE
mobile-shell: improve the test

### DIFF
--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -41,6 +41,7 @@ class MobileShell < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    system "#{bin}/mosh-client", "-c"
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    system bin/"mosh", "--local", "127.0.0.1", "true"
   end
 end


### PR DESCRIPTION
Change recommended by upstream:

>  For the test method, you could now do mosh --local 127.0.0.1 true or
> mosh --local ::1 true. Those will start a session without using ssh
> and test much more functionality.
