### PR TITLE
p2mirror 1.1 (new formula)

### DIFF
--- a/Formula/p2mirror.rb
+++ b/Formula/p2mirror.rb
@@ -1,0 +1,22 @@
+class P2mirror < Formula
+  desc "Standalone Mirror Application for P2 (Eclipse) Repositories"
+  homepage "https://github.com/rebaze/p2mirror.tool"
+  url "https://ci.rebaze.io/nexus/content/repositories/releases/com/rebaze/eclipse/p2mirror/com.rebaze.eclipse.p2mirror.tool/1.1.0.RELEASE/com.rebaze.eclipse.p2mirror.tool-1.1.0.RELEASE-macosx.cocoa.x86_64.tar.gz"
+  version "1.1"
+  sha256 "39e9ed9ff0bb6218ff2d84c70a640709cd2670545a0831e45fe41d32aecd332c"
+  depends_on :java => "1.7+"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/Contents/MacOS/p2mirror" => "p2mirror"
+    ohai "Usage Artifact Mirror : p2mirror -verbose -application org.eclipse.equinox.p2.metadata.repository.mirrorApplication -source https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/p2 -destination file:/tmp/out"
+    ohai "Usage Metadata Mirror : p2mirror -verbose -application org.eclipse.equinox.p2.artifact.repository.mirrorApplication -source https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/p2 -destination file:/tmp/out"
+  end
+
+  test do
+    ENV.java_cache
+    cp_r Dir["#{libexec}/*"], testpath
+    assert_match "", shell_output("#{testpath}/Contents/MacOS/p2mirror -application org.eclipse.equinox.p2.metadata.repository.mirrorApplication -source https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/p2 -destination file:#{testpath}/out -configuration #{testpath}/work/config", 0)
+    File.exist? testpath/"out/content.jar"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This formula makes p2mirror available as a system command.
The tool allows servers and desktops to mirror p2 repositories efficiently.
It repackages the director app from eclipse into a smaller, standalone utility.
