### PR TITLE
cvsync: use `to_s` over string interpolation

### DIFF
--- a/Formula/cvsync.rb
+++ b/Formula/cvsync.rb
@@ -38,6 +38,6 @@ class Cvsync < Formula
   end
 
   test do
-    assert_match "#{version}", shell_output("#{bin}/cvsync -h 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/cvsync -h 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online cvsync` returns:

``` zsh
cvsync:
  * C: 41: col 18: Prefer `to_s` over string interpolation.
```
