### PR TITLE
libftdi 1.3

### DIFF
--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -1,8 +1,8 @@
 class Libftdi < Formula
   desc "Library to talk to FTDI chips"
   homepage "https://www.intra2net.com/en/developer/libftdi"
-  url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.2.tar.bz2"
-  sha256 "a6ea795c829219015eb372b03008351cee3fb39f684bff3bf8a4620b558488d6"
+  url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.3.tar.bz2"
+  sha256 "9a8c95c94bfbcf36584a0a58a6e2003d9b133213d9202b76aec76302ffaa81f4"
 
   bottle do
     cellar :any
@@ -15,6 +15,7 @@ class Libftdi < Formula
   depends_on "pkg-config" => :build
   depends_on "libusb"
   depends_on "boost" => :optional
+  depends_on "confuse" => :optional
 
   def install
     mkdir "libftdi-build" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I'm getting this error from `brew audit`:

```
libftdi:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/Cellar/libftdi/1.3/lib/python2.7/site-packages/_ftdi1.so
Error: 1 problem in 1 formula
```

Can someone please give me a hint on how to solve this?
I came across http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/, but I'm not sure how to make this patch in the formula.
