### PR TITLE
irrtoolset: audit fix

### DIFF
--- a/Formula/irrtoolset.rb
+++ b/Formula/irrtoolset.rb
@@ -1,6 +1,6 @@
 class Irrtoolset < Formula
   desc "Tools to work with Internet routing policies"
-  homepage "http://irrtoolset.isc.org/"
+  homepage "https://github.com/irrtoolset/irrtoolset"
   url "https://ftp.isc.org/isc/IRRToolSet/IRRToolSet-5.0.1/irrtoolset-5.0.1.tar.gz"
   sha256 "c044e4e009bf82db84f6a4f4d5ad563b07357f2d0e9f0bbaaf867e9b33fa5e80"
 
@@ -24,7 +24,7 @@ class Irrtoolset < Formula
   def install
     if build.head?
       system "glibtoolize"
-      system "autoreconf -i"
+      system "autoreconf", "-i"
     end
 
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`brew audit --strict --online irrtoolset` returns:

``` zsh
irrtoolset:
  * The homepage is not reachable (curl exit code 6)
  * Use `system "autoreconf", "-i"` instead of `system "autoreconf -i"`
```
