### PR TITLE
serval-dna batphone-release-0.93 (new formula)

### DIFF
--- a/Formula/serval-dna.rb
+++ b/Formula/serval-dna.rb
@@ -1,0 +1,23 @@
+class ServalDna < Formula
+  desc "Serval is an open-source, delay-tolerant networking system."
+  homepage "http://www.servalproject.org"
+  url "https://github.com/servalproject/serval-dna/archive/c78ee668d5a08ca4f528a4260de384aaa2a06fed.tar.gz"
+  version "batphone-release-0.93"
+  sha256 "314b50bf0f45c6a4ff118a3f8b0d305e15c234bdb773bf505152689e9428e0b3"
+  head "https://github.com/servalproject/serval-dna.git", :branch => "development"
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+
+  def install
+    system "autoreconf", "-f", "-i", "-I", "m4"
+    system "./configure"
+    File.write("#{buildpath}/VERSION.txt", "#{version}\n")
+    system "make", "servald"
+    bin.install "servald"
+  end
+
+  test do
+    system "#{bin}/servald", "version"
+  end
+end

--- a/Formula/serval-dna.rb
+++ b/Formula/serval-dna.rb
@@ -2,7 +2,7 @@ class ServalDna < Formula
   desc "Serval is an open-source, delay-tolerant networking system."
   homepage "http://www.servalproject.org"
   url "https://github.com/servalproject/serval-dna/archive/c78ee668d5a08ca4f528a4260de384aaa2a06fed.tar.gz"
-  version "batphone-release-0.93"
+  version "0.93"
   sha256 "314b50bf0f45c6a4ff118a3f8b0d305e15c234bdb773bf505152689e9428e0b3"
   head "https://github.com/servalproject/serval-dna.git", :branch => "development"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Serval-dna is the core of servalproject.org, an open-source, delay-tolerant wireless ad-hoc networking system.
This commit contains a formula for both the current released version and the possibility to install the current development head.
