### PR TITLE
gradle: correct java dependency to 1.7

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -6,7 +6,7 @@ class Gradle < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.6+"
+  depends_on :java => "1.7+"
 
   def install
     libexec.install %w[bin lib]


### PR DESCRIPTION
The last commit to update to Gradle 3.0 did not include an update to the required Java version as Java 6 is no longer supported for Gradle 3.x.
