### PR TITLE
duti: changes homepage to github repo

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -1,6 +1,6 @@
 class Duti < Formula
   desc "Select default apps for documents and URL schemes on OS X"
-  homepage "http://duti.org/"
+  homepage "https://github.com/moretension/duti/"
   url "https://github.com/moretension/duti/archive/duti-1.5.3.tar.gz"
   sha256 "0e71b7398e01aedf9dde0ffe7fd5389cfe82aafae38c078240780e12a445b9fa"
   head "https://github.com/moretension/duti.git"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Current site is dead (expired domain):
![image](https://cloud.githubusercontent.com/assets/1699443/17711632/779898f8-63ea-11e6-9f46-99fae81c2b85.png)

Since it hasn’t gotten an update since Dec 4, 2014, it seems unlikely the site will be back up.
