### PR TITLE
chromedriver 2.23 64-bit fix for 404 on removed chromedriver 32

### DIFF
--- a/Formula/chromedriver.rb
+++ b/Formula/chromedriver.rb
@@ -1,9 +1,9 @@
 class Chromedriver < Formula
   desc "Tool for automated testing of webapps across many browsers"
   homepage "https://sites.google.com/a/chromium.org/chromedriver/"
-  url "https://chromedriver.storage.googleapis.com/2.23/chromedriver_mac32.zip"
+  url "https://chromedriver.storage.googleapis.com/2.23/chromedriver_mac64.zip"
   version "2.23"
-  sha256 "ea2a182066395dceb43d0bbbf5122193de8509e69af9649e0cbde708b2412568"
+  sha256 "47a8caec6ce251f2dbaa9005e4dc783cb1fa6c09ecd76afafa41eab540a32e86"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [yes] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [yes] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [yes] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The formula for chromedriver was broken because the link was to chromedriver_mac32.zip, which no longer exists. The new link points to chromedriver_mac64.zip for version 2.23 and I have tested and confirmed it works perfectly with the brew installed selenium-server.
