### PR TITLE
msgpack: add conflicts_with against msgpack

### DIFF
--- a/Formula/fluent-bit.rb
+++ b/Formula/fluent-bit.rb
@@ -15,6 +15,7 @@ class FluentBit < Formula
   depends_on "cmake" => :build
 
   conflicts_with "mbedtls", :because => "fluent-bit includes mbedtls libraries."
+  conflicts_with "msgpack", :because => "fluent-bit includes msgpack libraries."
 
   def install
     system "cmake", ".", "-DWITH_IN_MEM=OFF", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

fluent-bit includes `msgpack` library now.

So, it should add `conflicts_with` for msgpack.
