### PR TITLE
rtags: fix to use brew version of llvm

### DIFF
--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -22,7 +22,7 @@ class Rtags < Formula
     ENV.append("LDFLAGS", "-lc++abi")
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DRTAGS_NO_BUILD_CLANG=ON", *std_cmake_args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This fixes build from head, as described [here](https://github.com/Andersbakken/rtags/commit/42688252e0c45db76088934fb7a3d76f49217b1a).
