### PR TITLE
tbb: add optional python library

### DIFF
--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -17,6 +17,8 @@ class Tbb < Formula
   # requires malloc features first introduced in Lion
   # https://github.com/Homebrew/homebrew/issues/32274
   depends_on :macos => :lion
+  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "swig" => :build
 
   def install
     # Intel sets varying O levels on each compile command.
@@ -32,6 +34,11 @@ class Tbb < Formula
     system "make", *args
     lib.install Dir["build/BUILDPREFIX_release/*.dylib"]
     include.install "include/tbb"
+
+    cd "python" do
+      ENV["TBBROOT"] = prefix
+      system "python", *Language::Python.setup_install_args(prefix)
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This adds an option to build TBB's new python library that monkey-patches multiprocessing.Pool.

https://software.intel.com/en-us/blogs/2016/04/04/unleash-parallel-performance-of-python-programs
