### PR TITLE
hopenpgp-tools 0.19.2 (new formula)

### DIFF
--- a/Formula/hopenpgp-tools.rb
+++ b/Formula/hopenpgp-tools.rb
@@ -1,0 +1,33 @@
+require "language/haskell"
+
+class HopenpgpTools < Formula
+  include Language::Haskell::Cabal
+
+  desc "Command-line tools for OpenPGP-related operations"
+  homepage "https://hackage.haskell.org/package/hopenpgp-tools"
+  url "https://hackage.haskell.org/package/hopenpgp-tools/hopenpgp-tools-0.19.2.tar.gz"
+  sha256 "6bcc067bfc2b54c0c47ea7169f3741ec8f64abee9bd8c398191a0b35520fa39c"
+  head "git://anonscm.debian.org/users/clint/hopenpgp-tools.git"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+  depends_on "nettle"
+  depends_on "pkg-config" => :build
+
+  resource "homebrew-key.gpg" do
+    url "https://gist.githubusercontent.com/zmwangx/be307671d11cd78985bd3a96182f15ea/raw/c7e803814efc4ca96cc9a56632aa542ea4ccf5b3/homebrew-key.gpg"
+    sha256 "994744ca074a3662cff1d414e4b8fb3985d82f10cafcaadf1f8342f71f36b233"
+  end
+
+  def install
+    install_cabal_package :using => ["alex", "happy"]
+  end
+
+  test do
+    ENV["TERM"] = "dumb"
+    resource("homebrew-key.gpg").stage do
+      assert_match "Homebrew <security@brew.sh>",
+                   shell_output("#{bin}/hokey lint <homebrew-key.gpg 2>/dev/null")
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

hopenpgp-tools is a suite of command-line tools for OpenPGP-related operations written in Haskell. I mainly use it to audit keys.

A few notes:
- The project might be marginally notable. FWIW it's [available on Debian](https://packages.debian.org/source/sid/haskell-hopenpgp-tools). Not really sure if it's notable enough.
- The project homepage is supposed to be http://floss.scru.org/hopenpgp-tools, but at the time of submission the homepage is down:
  
  ```
  $ nmap scru.org
  
  Starting Nmap 6.40 ( http://nmap.org ) at 2016-08-17 20:53 EDT
  Nmap scan report for scru.org (67.18.186.230)
  Host is up (0.041s latency).
  rDNS record for 67.18.186.230: thumb.scru.org
  Not shown: 990 closed ports
  PORT     STATE SERVICE
  22/tcp   open  ssh
  25/tcp   open  smtp
  53/tcp   open  domain
  80/tcp   open  http
  443/tcp  open  https
  465/tcp  open  smtps
  587/tcp  open  submission
  993/tcp  open  imaps
  5222/tcp open  xmpp-client
  5269/tcp open  xmpp-server
  
  Nmap done: 1 IP address (1 host up) scanned in 4.19 seconds
  $ nmap floss.scru.org
  
  Starting Nmap 6.40 ( http://nmap.org ) at 2016-08-17 20:53 EDT
  Note: Host seems down. If it is really up, but blocking our ping probes, try -Pn
  Nmap done: 1 IP address (0 hosts up) scanned in 3.15 seconds
  ```
  
  Nevertheless, the project is actively developed and maintained, as seen from https://anonscm.debian.org/git/users/clint/hopenpgp-tools.git, especially the fact that the latest release was made a mere six days ago.
  
  I'm using https://hackage.haskell.org/package/hopenpgp-tools for homepage at the moment which seems good enough for me. I guess I could email the maintainer and ask about the status of the home page, since there doesn't seem to be a public issue tracker (or maybe it's just tracked on [Debian](https://bugs.debian.org/cgi-bin/pkgreport.cgi?dist=unstable;package=hopenpgp-tools), since the code is hosted on https://anonscm.debian.org/git/, and the maintainer sports a debian.org email address).
- I'm fetching a resource for testing because I need a key at the very least, which needs to be preexisting as a standalone file, preexisting in a keyring, or fetched on the fly. Of course a resource is the most appropriate.
  
  The key `homebrew-key.gpg` was dearmored from https://keybase.io/homebrew/key.asc. The script that generated the key can be found at https://gist.github.com/zmwangx/be307671d11cd78985bd3a96182f15ea/#file-gen.
