### PR TITLE
libplist: fixed Cython resource with updated PyPI link

### DIFF
--- a/Formula/libplist.rb
+++ b/Formula/libplist.rb
@@ -27,8 +27,8 @@ class Libplist < Formula
   depends_on :python => :optional
 
   resource "cython" do
-    url "http://cython.org/release/Cython-0.21.tar.gz"
-    sha256 "0cd5787fb3f1eaf8326b21bdfcb90aabd3eca7c214c5b7b503fbb82da97bbaa0"
+    url "https://pypi.python.org/packages/c6/fe/97319581905de40f1be7015a0ea1bd336a756f6249914b148a17eefa75dc/Cython-0.24.1.tar.gz#md5=890b494a12951f1d6228c416a5789554"
+    sha256 "84808fda00508757928e1feadcf41c9f78e9a9b7167b6649ab0933b76f75e7b9"
   end
 
   def install


### PR DESCRIPTION
Cython is no longer distributed via cython.org – q.v. download directions therein at http://cython.org/#download – and official release source tarballs may be had through PyPI. This update points the Cython resource at a valid PyPI link for Cython 0.24.1 (the current stable version) and updates the `sha256` value accordingly; `brew install libplist --with-python` will work thereafter with these changes.
