### PR TITLE
mutt 1.7.0

### DIFF
--- a/Formula/mutt.rb
+++ b/Formula/mutt.rb
@@ -11,9 +11,9 @@
 class Mutt < Formula
   desc "Mongrel of mail user agents (part elm, pine, mush, mh, etc.)"
   homepage "http://www.mutt.org/"
-  url "https://bitbucket.org/mutt/mutt/downloads/mutt-1.6.2.tar.gz"
-  mirror "ftp://ftp.mutt.org/pub/mutt/mutt-1.6.2.tar.gz"
-  sha256 "c5d02ef06486cdf04f9eeb9e9d7994890d8dfa7f47e7bfeb53a2a67da2ac1d8e"
+  url "ftp://ftp.mutt.org/pub/mutt/mutt-1.7.0.tar.gz"
+  mirror "http://mirror.meerval.net/pub/mutt/mutt-1.7.0.tar.gz"
+  sha256 "1d3e987433d8c92ef88a604f4dcefdb35a86ce73f3eff0157e2e491e5b55b345"
 
   bottle do
     sha256 "26f5169d2dbfe81a21d06e0a751e7a0b0293ace894235bee289a5c99fd319694" => :el_capitan
@@ -29,9 +29,6 @@ class Mutt < Formula
     end
   end
 
-  conflicts_with "tin",
-    :because => "both install mmdf.5 and mbox.5 man pages"
-
   option "with-debug", "Build with debug option enabled"
   option "with-s-lang", "Build against slang instead of ncurses"
   option "with-confirm-attachment-patch", "Apply confirm attachment patch"
@@ -45,6 +42,9 @@ class Mutt < Formula
   depends_on "gpgme" => :optional
   depends_on "libidn" => :optional
   depends_on "s-lang" => :optional
+
+  conflicts_with "tin",
+    :because => "both install mmdf.5 and mbox.5 man pages"
 
   if build.with? "confirm-attachment-patch"
     patch do
@@ -68,6 +68,7 @@ class Mutt < Formula
       --enable-pop
       --enable-hcache
       --with-tokyocabinet
+      --enable-sidebar
     ]
 
     # This is just a trick to keep 'make install' from trying


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

1.7.0 (2016-08-18):

  ! Improved alignment when using multi-column characters with
    soft-fill (%*X) and right-justified (%>X) format strings.
- The COLUMNS environment variable will be set to the width of the
  pager when invoking display filters.  This can be used in
  copiousoutput mailcap entries to allow their output to match the
  pager width.
- The sidebar patch has been merged.  Please watch for airborne
  bovine.  See the documentation for all the options, or simply
  enable it with 'set sidebar_visible'.
- $mail_check_stats and $mail_check_stats_interval control whether,
  and how often, to scan for unread, flagged, and total message
  counts when checking for new mail in mailboxes.  These statistics
  can be displayed in the sidebar and browser.
- $trash, when set, specifies the path of the folder where mails
  marked for deletion will be moved, instead of being irremediably
  purged.
- The <purge-message> function can be used to delete an entry and
  bypass the trash folder.
- $folder_format has new format strings %m and %n, to display
  total and unread message counts for mailboxes.  Note that
  $mail_check_stats should be enabled to use these.
  ! When browsing IMAP, %N will now display 'N', instead of the unread
    message count.  Please use %n to display unread messages.
