### PR TITLE
Ansible: fix add gnu-tar dependency

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -17,6 +17,7 @@ class Ansible < Formula
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "libyaml"
   depends_on "openssl"
+  depends_on "gnu-tar"
 
   #
   # ansible (core dependencies)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Ansible's unarchive module requires GNU tar. ref: ansible/ansible-modules-core#4390
