### PR TITLE
scons: add return 0 line to test

### DIFF
--- a/Formula/scons.rb
+++ b/Formula/scons.rb
@@ -37,6 +37,7 @@ class Scons < Formula
       int main()
       {
         printf("Homebrew");
+        return 0;
       }
     EOS
     (testpath/"SConstruct").write "Program('test.c')"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`brew test scons` may fail because the return value of `test` is undefined. Add a `return 0` line to prevent this.
