### PR TITLE
emacs: disable --with-file-notification=gfile on devel and head

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -42,6 +42,8 @@ class Emacs < Formula
   depends_on "librsvg" => :recommended
   depends_on "imagemagick" => :optional
   depends_on "mailutils" => :optional
+  # Remove this option and the --with-file-notification=gfile line below once
+  # Emacs 25 is stable (#4048)
   depends_on "glib" => :optional
 
   def install
@@ -54,7 +56,7 @@ class Emacs < Formula
       --without-x
     ]
 
-    args << "--with-file-notification=gfile" if build.with? "glib"
+    args << "--with-file-notification=gfile" if build.stable? && build.with?("glib")
 
     if build.with? "libxml2"
       args << "--with-xml2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`--with-file-notification=gfile` support on OS X has been removed in Emacs 25 (supplanted by `kqueue(2)` support), and even leads to a configure error since https://github.com/emacs-mirror/emacs/commit/21ad7279e47f0bc33acf36f0ac27f92808232dbd.

Even when there's no error, which is the case for the latest devel (25.1-rc1), `--with-file-notification=gfile` is simply ignored thanks to a check in https://github.com/emacs-mirror/emacs/commit/e3354e2265bc442e4c7b84b806be482db88581a2.

The `--with-glib` option should be entirely removed once Emacs 25 is stable.

Fixes #4048.
