### PR TITLE
cpmtools: add optional libdsk support

### DIFF
--- a/Formula/cpmtools.rb
+++ b/Formula/cpmtools.rb
@@ -11,8 +11,16 @@ class Cpmtools < Formula
     sha256 "b810122c220af6b36ab9316deec811adca68313d4371f8a0121239c40b94a015" => :mavericks
   end
 
+  depends_on "libdsk" => :optional
+
   def install
-    system "./configure", "--prefix=#{prefix}"
+    args = %W[
+      --prefix=#{prefix}
+    ]
+
+    args << "--with-libdsk" if build.with? "libdsk"
+
+    system "./configure", *args
 
     bin.mkpath
     man1.mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This patch adds a `--with-libdsk` option to build `cpmtools` with libdsk support. The behaviour with libdsk support enabled is slightly different - empty images with no directory entries seem to require an explicit libdsk type to avoid _file not found_ errors, so the tests are adjusted accordingly.
