### PR TITLE
python3: Fix regular expression in xy function.

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -275,7 +275,7 @@ class Python3 < Formula
   end
 
   def xy
-    version.to_s.slice(/(3.\d)/) || "3.6"
+    version.to_s.slice(/(3\.\d)/) || "3.6"
   end
 
   def sitecustomize


### PR DESCRIPTION
## This fixes `brew install --HEAD python3`

Fixes #4083.
