### PR TITLE
charm 2.1.2

### DIFF
--- a/Formula/charm.rb
+++ b/Formula/charm.rb
@@ -1,8 +1,10 @@
+require "language/go"
+
 class Charm < Formula
   desc "Tool for managing Juju Charms"
   homepage "https://github.com/juju/charmstore-client"
-  url "https://github.com/juju/charmstore-client/releases/download/2.1.1/charm_2.1.1.orig.tar.gz"
-  sha256 "bddf10c43eb0fa85da575d39d46f2041b2396c63351cce2cf8e2d6c271c7cc47"
+  url "https://github.com/juju/charmstore-client/archive/2.1.2.tar.gz"
+  sha256 "09928a60bb4f7d8af3573ce269996417d6000e8e2bc769e4a7e6f451d264fc45"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,11 +14,32 @@ class Charm < Formula
   end
 
   depends_on "go" => :build
+  depends_on "bazaar" => :build
+
+  go_resource "github.com/kisielk/gotool" do
+    url "https://github.com/kisielk/gotool.git",
+        :revision => "94d5dba705240ba73ce5d65d83ce44adc749b440"
+  end
+
+  go_resource "github.com/rogpeppe/godeps" do
+    url "https://github.com/rogpeppe/godeps.git",
+        :revision => "c00f01a737f4f06e397ca86f67341cc345507221"
+  end
 
   def install
     ENV["GOPATH"] = buildpath
-    system "go", "build", "github.com/juju/charmstore-client/cmd/charm"
-    bin.install "charm"
+    dir = buildpath/"src/github.com/juju/charmstore-client"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    Language::Go.stage_deps resources, buildpath/"src"
+    cd("src/github.com/rogpeppe/godeps") { system "go", "install" }
+
+    cd dir do
+      system "godeps", "-x", "-u", "dependencies.tsv"
+      system "go", "build", "github.com/juju/charmstore-client/cmd/charm"
+      bin.install "charm"
+      prefix.install_metafiles
+    end
   end
 
   test do


### PR DESCRIPTION
use upstream `godeps` vendoring

Note: github.com/rogpeppe/godeps not the usual github.com/tools/godep
