### PR TITLE
openshift-cli: fix add socat dependency

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -16,12 +16,12 @@ class OpenshiftCli < Formula
   end
 
   devel do
-    depends_on "socat"
-
     url "https://github.com/openshift/origin.git",
       :tag => "v1.3.0-alpha.3",
       :revision => "7998ae49782d89d17c78104d07a98d2aea704ae3"
     version "1.3.0-alpha.3"
+    
+    depends_on "socat"
   end
 
   depends_on "go" => :build

--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -16,6 +16,8 @@ class OpenshiftCli < Formula
   end
 
   devel do
+    depends_on "socat"
+
     url "https://github.com/openshift/origin.git",
       :tag => "v1.3.0-alpha.3",
       :revision => "7998ae49782d89d17c78104d07a98d2aea704ae3"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

In context of [this post](http://blog.switchbit.io/openshift-cluster-up-with-docker-for-mac/#missingcat), add [`socat`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/socat.rb) dependency to prevent `Error: exec: "socat": executable file not found in $PATH` when doing `oc cluster up` with [development version](https://github.com/Homebrew/homebrew-core/blob/master/Formula/openshift-cli.rb#L19).
