### PR TITLE
osquery: permit weak imports

### DIFF
--- a/Formula/osquery.rb
+++ b/Formula/osquery.rb
@@ -46,6 +46,8 @@ class Osquery < Formula
   end
 
   def install
+    ENV.permit_weak_imports
+
     # Link dynamically against brew-installed libraries.
     ENV["BUILD_LINK_SHARED"] = "1"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`osquery` uses two private APIs from `/usr/lib/system/libsystem_kernel.dylib` which are always declared as `weak_import`.

https://github.com/facebook/osquery/blob/master/osquery/tables/system/darwin/sip_config.cpp#L50-L51
