### PR TITLE
emacs devel 25.1-rc2

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -13,9 +13,9 @@ class Emacs < Formula
   end
 
   devel do
-    url "http://alpha.gnu.org/gnu/emacs/pretest/emacs-25.1-rc1.tar.xz"
-    version "25.1-rc1"
-    sha256 "c00c50e66474359d1e24baa2a0703bc64207caffc31d0808d8b4ffa4b3826133"
+    url "http://alpha.gnu.org/gnu/emacs/pretest/emacs-25.1-rc2.tar.xz"
+    version "25.1-rc2"
+    sha256 "5bd45f03bdff90f9d7add7224917fc828ed89716e952b3db8eb98242b7dfcec1"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Announcement: https://lists.gnu.org/archive/html/emacs-devel/2016-08/msg00442.html.
### Note about sandbox violation

`brew install emacs --devel` or `--HEAD` results in a sandbox violation now that `HOMEBREW_SANDBOX=1` for all core formulae:

```
==> ./autogen.sh
Checking whether you have the necessary tools...
(Read INSTALL.REPO for more details on building Emacs)

Checking for autoconf (need at least version 2.65)...
ok
Checking for automake (need at least version 1.11)...
ok
Your system has the required tools.
Running 'autoreconf -fi -I m4' ...
autoreconf: cannot create /Volumes/ramdisk/ar7126.1876: Operation not permitted
 at /usr/local/opt/autoconf/bin/autoreconf line 689.
==> Sandbox log
Aug 22 17:55:08 kernel[0]: Sandbox: mktemp(1879) deny(1) file-write-create /Volumes/ramdisk/areQTL97
Aug 22 17:55:08 kernel[0]: Sandbox: perl5.18(1876) deny(1) file-write-create /Volumes/ramdisk/ar7126.1876
```

`--no-sandbox` works as before.

Personally I think `autoreconf` writing to `$TMPDIR` or `/tmp` is perfectly reasonable. If sandbox violations for these legit uses are to be circumvented, we might need to set `$TMPDIR` to somewhere inside the keg (handled on the brew level, created pre-install and deleted post-install), and even then it's hard to work around writing to `/tmp`, or `/var/folders` which is used by `/usr/bin/mktemp`.
