### PR TITLE
gtk+3: Fix typo that breaks the gstgtk plugin

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -59,6 +59,9 @@ class Gtkx3 < Formula
 
     args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
+    # TODO: Remove when it fails. See https://git.gnome.org/browse/gtk+/commit/?id=74bd3f3810133d44f333aa5f8d02ae3de19a6834
+    inreplace "gdk/quartz/gdkeventloop-quartz.c", "g_string_appendi", "g_string_append"
+
     system "./configure", *args
     # necessary to avoid gtk-update-icon-cache not being found during make install
     bin.mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

When building gst-plugins-bad --with-gtk+3, running gst-inspect-1.0 fails:
dlopen(/usr/local/lib/gstreamer-1.0/libgstgtksink.so, 2): Symbol not found: _g_string_appendi

This problem became visible due to 9d2746020aeaa61d69e08c42801383acd90ba5cb
