### PR TITLE
zbackup: work around CHECK macro collision

### DIFF
--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -29,6 +29,11 @@ class Zbackup < Formula
   end
 
   def install
+    # Avoid collision with protobuf 3.x CHECK macro
+    inreplace ["backup_creator.cc", "check.hh", "chunk_id.cc", "chunk_storage.cc",
+      "compression.cc", "encrypted_file.cc", "encryption.cc", "encryption_key.cc", "mt.cc",
+      "tests/bundle/test_bundle.cc", "tests/encrypted_file/test_encrypted_file.cc",
+      "unbuffered_file.cc", ], /\bCHECK\b/, "ZBCHECK"
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
This locally renames the `CHECK` macro to `ZBCHECK` to avoid collisions with other `CHECK` macros. This is required for compatibility with protobuf 3.x

Blocks #3415
