### PR TITLE
Protobuf 3.0

### DIFF
--- a/Formula/ddar.rb
+++ b/Formula/ddar.rb
@@ -3,7 +3,7 @@ class Ddar < Formula
   homepage "https://github.com/basak/ddar"
   url "https://github.com/basak/ddar/archive/v1.0.tar.gz"
   sha256 "b95a11f73aa872a75a6c2cb29d91b542233afa73a8eb00e8826633b8323c9b22"
-  revision 1
+  revision 2
 
   head "https://github.com/basak/ddar.git"
 

--- a/Formula/gjstest.rb
+++ b/Formula/gjstest.rb
@@ -3,7 +3,7 @@ class Gjstest < Formula
   homepage "https://github.com/google/gjstest"
   url "https://github.com/google/gjstest/archive/v1.0.2.tar.gz"
   sha256 "7bf0de1c4b880b771a733c9a5ce07c71b93f073e6acda09bec7e400c91c2057c"
-  revision 4
+  revision 5
 
   head "https://github.com/google/gjstest.git"
 

--- a/Formula/libphonenumber.rb
+++ b/Formula/libphonenumber.rb
@@ -3,6 +3,7 @@ class Libphonenumber < Formula
   homepage "https://github.com/googlei18n/libphonenumber"
   url "https://github.com/googlei18n/libphonenumber/archive/libphonenumber-7.6.1.tar.gz"
   sha256 "2ed406c2b535f496a1ce9ced2ceefaa40c8473ad6dc53bb7e5fe0279f107333f"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -3,6 +3,7 @@ class MobileShell < Formula
   homepage "https://mosh.mit.edu/"
   url "https://mosh.mit.edu/mosh-1.2.6.tar.gz"
   sha256 "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85"
+  revision 1
 
   bottle do
     sha256 "ce0722d44de6a01bb2eeb65e57913ece2e67608220f88ce88313433774b848bd" => :el_capitan

--- a/Formula/nanopb-generator.rb
+++ b/Formula/nanopb-generator.rb
@@ -3,6 +3,7 @@ class NanopbGenerator < Formula
   homepage "https://koti.kapsi.fi/jpa/nanopb/docs/index.html"
   url "https://koti.kapsi.fi/~jpa/nanopb/download/nanopb-0.3.6.tar.gz"
   sha256 "3e6d5d4971dc11845261ddca7e1c67b96eabf95e839327c7d8ed6f07412edab7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,8 +16,13 @@ class NanopbGenerator < Formula
   depends_on "protobuf"
 
   resource "protobuf-python" do
-    url "https://pypi.python.org/packages/source/p/protobuf/protobuf-2.6.0.tar.gz"
-    sha256 "b1556c5e9cca9069143b41312fd45d0d4785ca0cab682b2624195a6bc4ec296f"
+    url "https://pypi.python.org/packages/14/3e/56da1ecfa58f6da0053a523444dff9dfb8a18928c186ad529a24b0e82dec/protobuf-3.0.0.tar.gz"
+    sha256 "ecc40bc30f1183b418fe0ec0c90bc3b53fa1707c4205ee278c6b90479e5b6ff5"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
   end
 
   def install

--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -3,6 +3,7 @@ class Ola < Formula
   homepage "https://www.openlighting.org/ola/"
   url "https://github.com/OpenLightingProject/ola/releases/download/0.10.2/ola-0.10.2.tar.gz"
   sha256 "986e61874bc80db3b23cf201af2dafa39e3412cc50cddf1cd449c869110bfd27"
+  revision 1
 
   bottle do
     sha256 "37dabc62d0ed531c06bdf4bc153858d0a8f30f895b4f3765d6f2b9a69b03e840" => :el_capitan

--- a/Formula/osm-pbf.rb
+++ b/Formula/osm-pbf.rb
@@ -10,6 +10,7 @@ class OsmPbf < Formula
     sha256 "c102e66477bbbb75dfd91e0349659f59781002246a57775f2d7cab5fbf7cae27" => :yosemite
     sha256 "6a9a5fb19889732dbe9d9837e38d417be53277a44df6b8fb2191c8f9f4872b70" => :mavericks
   end
+  revision 1
 
   depends_on "protobuf"
 

--- a/Formula/protobuf-c.rb
+++ b/Formula/protobuf-c.rb
@@ -9,6 +9,7 @@ class ProtobufC < Formula
     sha256 "178f84dfb66628862e08a3bf58c5a0bdb1a6624f4de63d1670832ea394b5c04d" => :yosemite
     sha256 "50c184193ace913ed581c66669418f4755e4ac44428a9383e10d6178022664aa" => :mavericks
   end
+  revision 1
 
   option :universal
 

--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -3,18 +3,12 @@ class ProtobufSwift < Formula
   homepage "https://github.com/alexeyxo/protobuf-swift"
   url "https://github.com/alexeyxo/protobuf-swift/archive/2.4.4.tar.gz"
   sha256 "c5960def4f9d48d4933f1a1ff1ac403ca278c0502ee048c6c8704d769b0ae7c5"
-
-  bottle do
-    cellar :any
-    sha256 "17cf44adc252e062bc9e63cdf2c110066c6b0ad0c994be7feaa1f35fe7b56831" => :el_capitan
-    sha256 "6346f4a7adda25f013c60e3d9bc0e158d571a6007d0dca6d1467525248b41345" => :yosemite
-    sha256 "a7eddb2d6c52a560242b8cb8ed819d9e028f52029df6fdff2f77e50eea1f449a" => :mavericks
-  end
+  revision 1
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "protobuf"
+  depends_on "protobuf" => "2.6.1"
 
   def install
     system "./autogen.sh"

--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -1,14 +1,13 @@
 class ProtobufSwift < Formula
   desc "Implementation of Protocol Buffers in Apple Swift."
   homepage "https://github.com/alexeyxo/protobuf-swift"
-  url "https://github.com/alexeyxo/protobuf-swift/archive/2.4.4.tar.gz"
-  sha256 "c5960def4f9d48d4933f1a1ff1ac403ca278c0502ee048c6c8704d769b0ae7c5"
-  revision 1
+  url "https://github.com/alexeyxo/protobuf-swift/archive/3.0.0.tar.gz"
+  sha256 "3e93f410844049673a164698589f1cb2c8f8ee1e4169b6cee3c6c32f8f5c4edb"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "protobuf" => "2.6.1"
+  depends_on "protobuf"
 
   def install
     system "./autogen.sh"
@@ -19,14 +18,15 @@ class ProtobufSwift < Formula
 
   test do
     testdata = <<-EOS.undent
-       enum Flavor{
-         CHOCOLATE = 1;
-          VANILLA = 2;
-        }
-        message IceCreamCone {
-          optional int32 scoops = 1;
-          optional Flavor flavor = 2;
-        }
+      syntax = "proto3";
+      enum Flavor {
+        CHOCOLATE = 0;
+        VANILLA = 1;
+      }
+      message IceCreamCone {
+        int32 scoops = 1;
+        Flavor flavor = 2;
+      }
     EOS
     (testpath/"test.proto").write(testdata)
     system "protoc", "test.proto", "--swift_out=."

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -3,37 +3,12 @@ class Protobuf < Formula
   homepage "https://github.com/google/protobuf/"
 
   stable do
-    url "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2"
-    sha256 "ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910"
-
-    # Fixes the unexpected identifier error when compiling software against protobuf:
-    # https://github.com/google/protobuf/issues/549
-    patch :p1, :DATA
-  end
-
-  bottle do
-    revision 5
-    sha256 "b1a6c4508ec66e706929e3e34a5b57b3c881c5ac1e3d0fc7c4b3598f97902c7f" => :el_capitan
-    sha256 "5c21d50d1d3ca2dc2906bba174bfb4ec0d55c0f16bac5541abf3180e68f885c2" => :yosemite
-    sha256 "6f6a30044450bb3e2d420fea3435d0c84594b197ea0d3a54bca473e3b4c855b5" => :mavericks
-  end
-
-  devel do
-    url "https://github.com/google/protobuf/archive/v3.0.0-beta-4.tar.gz"
-    sha256 "132ba7654ee45f5cbbd33fa8f2c9efa25f2193640e42098029bfa993a8360a9c"
-    version "3.0.0-beta-4"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
+    url "https://github.com/google/protobuf/archive/v3.0.0.tar.gz"
+    sha256 "f5b3563f118f1d3d6e001705fa7082e8fc3bda50038ac3dff787650795734146"
   end
 
   head do
     url "https://github.com/google/protobuf.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
   end
 
   # this will double the build time approximately if enabled
@@ -44,6 +19,11 @@ class Protobuf < Formula
   option :cxx11
 
   option "without-python", "Build without python support"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
 
   fails_with :llvm do
@@ -51,8 +31,8 @@ class Protobuf < Formula
   end
 
   resource "setuptools" do
-    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-20.9.0.tar.gz"
-    sha256 "2a360c782e067f84840315bcdcb5ed6c7c841cdedf6444f3232ab4a8b3204ac1"
+    url "https://pypi.python.org/packages/df/c3/4265eb901f9db8c0ea5bdfb344084d85bc96c1a9b883f70430254b5491f6/setuptools-26.1.0.tar.gz"
+    sha256 "64a2f7676cd026b64e46d179ed26b365e2f92f26c7fe04228ddd86d0436b797f"
   end
 
   resource "six" do
@@ -61,18 +41,18 @@ class Protobuf < Formula
   end
 
   resource "python-dateutil" do
-    url "https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.5.2.tar.gz"
-    sha256 "063907ef47f6e187b8fe0728952e4effb587a34f2dc356888646f9b71fbb2e4b"
+    url "https://pypi.python.org/packages/3e/f5/aad82824b369332a676a90a8c0d1e608b17e740bbb6aeeebca726f17b902/python-dateutil-2.5.3.tar.gz"
+    sha256 "1408fdb07c6a1fa9997567ce3fcee6a337b39a503d80699e0f213de4aa4b32ed"
   end
 
   resource "pytz" do
-    url "https://pypi.python.org/packages/source/p/pytz/pytz-2016.3.tar.bz2"
-    sha256 "c193dfa167ac32c8cb96f26cbcd92972591b22bda0bac3effdbdb04de6cc55d6"
+    url "https://pypi.python.org/packages/f7/c7/08e54702c74baf9d8f92d0bc331ecabf6d66a56f6d36370f0a672fc6a535/pytz-2016.6.1.tar.bz2"
+    sha256 "b5aff44126cf828537581e534cc94299b223b945a2bb3b5434d37bf8c7f3a10c"
   end
 
   resource "python-gflags" do
-    url "https://pypi.python.org/packages/source/p/python-gflags/python-gflags-2.0.tar.gz"
-    sha256 "0dff6360423f3ec08cbe3bfaf37b339461a54a21d13be0dd5d9c9999ce531078"
+    url "https://pypi.python.org/packages/91/97/84778286b3a1c0d52533a35a0b70a477050df2b83229f56e99c7a0f2d9d6/python-gflags-3.0.6.tar.gz"
+    sha256 "e904b251cb1d70ddd3a1fd152bd4b3674a95981dcac497450efd1311ff2b9b5a"
   end
 
   resource "google-apputils" do
@@ -80,7 +60,7 @@ class Protobuf < Formula
     sha256 "47959d0651c32102c10ad919b8a0ffe0ae85f44b8457ddcf2bdc0358fb03dc29"
   end
 
-  # Upstream's autogen script fetches this for devel/head if not present
+  # Upstream's autogen script fetches this if not present
   # but does no integrity verification & mandates being online to install.
   resource "gmock" do
     url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/googlemock/gmock-1.7.0.zip"
@@ -96,10 +76,8 @@ class Protobuf < Formula
     ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?
 
-    if build.devel? || build.head?
-      (buildpath/"gmock").install resource("gmock")
-      system "./autogen.sh"
-    end
+    (buildpath/"gmock").install resource("gmock")
+    system "./autogen.sh"
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-zlib"
@@ -141,7 +119,7 @@ class Protobuf < Formula
   end
 
   test do
-    testdata = if devel?
+    testdata =
       <<-EOS.undent
         syntax = "proto3";
         package test;
@@ -152,35 +130,8 @@ class Protobuf < Formula
           repeated TestCase case = 1;
         }
         EOS
-    else
-      <<-EOS.undent
-        package test;
-        message TestCase {
-          required string name = 4;
-        }
-        message Test {
-          repeated TestCase case = 1;
-        }
-        EOS
-    end
     (testpath/"test.proto").write testdata
     system bin/"protoc", "test.proto", "--cpp_out=."
     system "python", "-c", "import google.protobuf" if build.with? "python"
   end
 end
-
-__END__
-diff --git a/src/google/protobuf/descriptor.h b/src/google/protobuf/descriptor.h
-index 67afc77..504d5fe 100644
---- a/src/google/protobuf/descriptor.h
-+++ b/src/google/protobuf/descriptor.h
-@@ -59,6 +59,9 @@
- #include <vector>
- #include <google/protobuf/stubs/common.h>
-
-+#ifdef TYPE_BOOL
-+#undef TYPE_BOOL
-+#endif
-
- namespace google {
- namespace protobuf {

--- a/Formula/supersonic.rb
+++ b/Formula/supersonic.rb
@@ -5,8 +5,6 @@ class Supersonic < Formula
   sha256 "1592dfd2dc73f0b97298e0d25e51528dc9a94e9e7f4ab525569f63db0442d769"
   revision 1
 
-  depends_on "gflags" => :linked
-
   if MacOS.version < :mavericks
     depends_on "protobuf" => "c++11"
     depends_on "boost" => "c++11"
@@ -17,6 +15,7 @@ class Supersonic < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glog"
+  depends_on "gflags"
 
   needs :cxx11
 

--- a/Formula/supersonic.rb
+++ b/Formula/supersonic.rb
@@ -3,14 +3,9 @@ class Supersonic < Formula
   homepage "https://code.google.com/archive/p/supersonic/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/supersonic/supersonic-0.9.4.tar.gz"
   sha256 "1592dfd2dc73f0b97298e0d25e51528dc9a94e9e7f4ab525569f63db0442d769"
+  revision 1
 
-  bottle do
-    revision 1
-    sha256 "cd76e23c748ec6cfb520800a1890e691680921efa4e6e1bf1dd991b0557e6d33" => :el_capitan
-    sha256 "75c8903d7d637aa495c83eb3a3569b627fbdf9799e907a7d0fff536cf3ddb155" => :yosemite
-    sha256 "c72cb21c7f1efc5a790be376e55dcc4a1edc76cda6686c2ba7d3d7f8c2937321" => :mavericks
-    sha256 "2869dba7bb685f7f6e4df504b87e01a7dda685afc3f27fa1c6010c150982317f" => :mountain_lion
-  end
+  depends_on "gflags" => :linked
 
   if MacOS.version < :mavericks
     depends_on "protobuf" => "c++11"

--- a/Formula/szl.rb
+++ b/Formula/szl.rb
@@ -3,7 +3,6 @@ class Szl < Formula
   homepage "https://code.google.com/archive/p/szl/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/szl/szl-1.0.tar.gz"
   sha256 "af5c647276fd0dea658eae6016957b7ad09ac68efe13ae2a3c867043b5889f87"
-  revision 7
 
   bottle do
     cellar :any
@@ -11,6 +10,7 @@ class Szl < Formula
     sha256 "e06d0ff32258281931e49c1b1eb3e1ed03cde553ffbc7975180149e0d5ef2b31" => :yosemite
     sha256 "3cae7aa8a919c987ce0402f02e966fc6c01bd43f02763ae9994c58d3139e2dbf" => :mavericks
   end
+  revision 8
 
   depends_on :macos => :mavericks
 

--- a/Formula/upscaledb.rb
+++ b/Formula/upscaledb.rb
@@ -3,7 +3,7 @@ class Upscaledb < Formula
   homepage "https://upscaledb.com/"
   url "http://files.upscaledb.com/dl/upscaledb-2.2.0.tar.gz"
   sha256 "7d0d1ace47847a0f95a9138637fcaaf78b897ef682053e405e2c0865ecfd253e"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -44,6 +44,12 @@ class Upscaledb < Formula
   end
 
   def install
+    # Fix collision with isset() in <sys/params.h>
+    # See https://github.com/Homebrew/homebrew-core/pull/4145
+    inreplace "./src/5upscaledb/upscaledb.cc",
+      "#  include \"2protobuf/protocol.h\"",
+      "#  include \"2protobuf/protocol.h\"\n#define isset(f, b)       (((f) & (b)) == (b))"
+
     system "./bootstrap.sh" if build.head?
 
     args = %W[

--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -10,6 +10,7 @@ class Zbackup < Formula
     sha256 "31810ae9ab799eaa715815973d64229f29f6847e9f7608d475c1c1c63f4988e4" => :yosemite
     sha256 "5f98bc19b226d88e2cd3e68edc9286779fa082251d0a587d5d5ffb6210b43133" => :mavericks
   end
+  revision 1
 
   depends_on "cmake" => :build
   depends_on "openssl"


### PR DESCRIPTION
Protobuf major version upgrade to 3.x.

This is an updated version of #3415, preserving original author credit.
- Reorders and squashes a couple commits for a tidy commit history
- Incorporates a compatibility fix for zbackup and removed the bogus version-specific dependency

Closes #3415 
Closes #3803 
## Stuff still broken
- [X] nanopb-generator is broken
- [ ] upscaledb is failing in the test; looks like it's crashing
