### PR TITLE
openshift-cli: only build the client commands

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -27,12 +27,11 @@ class OpenshiftCli < Formula
     # this is necessary to avoid having the version marked as dirty
     (buildpath/".git/info/exclude").atomic_write "/.brew_home"
 
-    system "make", "all", "WHAT=cmd/openshift", "GOFLAGS=-v", "OS_OUTPUT_GOPATH=1"
+    system "make", "all", "WHAT=cmd/oc", "GOFLAGS=-v", "OS_OUTPUT_GOPATH=1"
 
     arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
-    bin.install "_output/local/bin/darwin/#{arch}/openshift"
-    bin.install_symlink "openshift" => "oc"
-    bin.install_symlink "openshift" => "oadm"
+    bin.install "_output/local/bin/darwin/#{arch}/oc"
+    bin.install_symlink "oc" => "oadm"
 
     bash_completion.install Dir["contrib/completions/bash/*"]
   end
@@ -40,6 +39,5 @@ class OpenshiftCli < Formula
   test do
     assert_match /^oc v#{version}$/, shell_output("#{bin}/oc version")
     assert_match /^oadm v#{version}$/, shell_output("#{bin}/oadm version")
-    assert_match /^openshift v#{version}$/, shell_output("#{bin}/openshift version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The `openshift` binary is the server process, which isn't actually useful on non-Linux platforms. We were only building it because the client hadn't yet been fully split into a separate `oc` package. This has since been done, so we can now switch to compiling only the client utilities.
