### PR TITLE
gcc 6.2.0

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -21,25 +21,13 @@ class Gcc < Formula
 
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org"
-  revision 1
 
   head "svn://gcc.gnu.org/svn/gcc/trunk"
 
   stable do
-    url "https://ftpmirror.gnu.org/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
-    mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.1.0/gcc-6.1.0.tar.bz2"
-    sha256 "09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351"
-
-    # 6.1.0 contains a bug that in certain circumstances causes GCC to consume
-    # all available memory very quickly & effectively crash systems.
-    # This should be safe to remove on the next stable release.
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70977
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70824
-    # https://github.com/gcc-mirror/gcc/commit/75e7d6607
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c963247c6b/gcc/gcc-6.1.0_infinite_memory_snacking.patch"
-      sha256 "636394ab2024ab026ead265b13b4c2a24e44c20ddfeab43a9be6e78e824de4f2"
-    end
+    url "https://ftpmirror.gnu.org/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+    mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+    sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Update gcc to version 6.2.0

Removed patch [https://github.com/Homebrew/formula-patches/blob/master/gcc/gcc-6.1.0_infinite_memory_snacking.patch](https://github.com/Homebrew/formula-patches/blob/master/gcc/gcc-6.1.0_infinite_memory_snacking.patch) since the issue is fixed in 6.2.0, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70824
