### PR TITLE
open-mpi 2.0.0

### DIFF
--- a/Formula/konoha.rb
+++ b/Formula/konoha.rb
@@ -3,6 +3,7 @@ class Konoha < Formula
   homepage "https://github.com/konoha-project/konoha3"
   url "https://github.com/konoha-project/konoha3/archive/v0.1.tar.gz"
   sha256 "e7d222808029515fe229b0ce1c4e84d0a35b59fce8603124a8df1aeba06114d3"
+  revision 1
 
   bottle do
     sha256 "85ae184ec6d34407588f31830e5669ee0a69be8d36ce2d9ef7074eb01b8831bf" => :el_capitan

--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -1,8 +1,8 @@
 class OpenMpi < Formula
   desc "High performance message passing library"
   homepage "https://www.open-mpi.org/"
-  url "https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.3.tar.bz2"
-  sha256 "7484bb664312082fd12edc2445b42362089b53b17fb5fce12efd4fe452cc254d"
+  url "https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.0.tar.bz2"
+  sha256 "08b64cf8e3e5f50a50b4e5655f2b83b54653787bd549b72607d9312be44c18e0"
 
   bottle do
     sha256 "9c16c39c8f018b2388d18ea22ca896a852304d319768561968af3ea9fa6162fd" => :el_capitan
@@ -22,6 +22,7 @@ class OpenMpi < Formula
 
   option "with-mpi-thread-multiple", "Enable MPI_THREAD_MULTIPLE"
   option :cxx11
+  option "with-cxx-bindings", "Enable C++ MPI bindings (deprecated as of MPI-3.0)"
 
   depends_on :fortran => :recommended
   depends_on :java => :optional
@@ -45,6 +46,7 @@ class OpenMpi < Formula
     args << "--disable-mpi-fortran" if build.without? "fortran"
     args << "--enable-mpi-thread-multiple" if build.with? "mpi-thread-multiple"
     args << "--enable-mpi-java" if build.with? "java"
+    args << "--enable-mpi-cxx" if build.with? "cxx-bindings"
 
     system "./autogen.pl" if build.head?
     system "./configure", *args
@@ -56,12 +58,6 @@ class OpenMpi < Formula
     # (Fortran header) in `lib` that need to be moved to `include`.
     if build.with? "fortran"
       include.install Dir["#{lib}/*.mod"]
-    end
-
-    if build.stable?
-      # Move vtsetup.jar from bin to libexec.
-      libexec.install bin/"vtsetup.jar"
-      inreplace bin/"vtsetup", "$bindir/vtsetup.jar", "$prefix/libexec/vtsetup.jar"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
- Update OpenMPI to version 2.0.0.
- Add --with-cxx-bindings option because MPI C++ bindings are
  deprecated by the MPI-3.0 standard and are no longer installed by
  default.
- Remove code that moves "vtsetup.jar" because that file no longer
  exists when OpenMPI 2.0.0 is built.
