### PR TITLE
pcap_dnsproxy 0.4.7.0

### DIFF
--- a/Formula/pcap_dnsproxy.rb
+++ b/Formula/pcap_dnsproxy.rb
@@ -1,8 +1,8 @@
 class PcapDnsproxy < Formula
   desc "Powerful DNS proxy designed to anti DNS spoofing"
   homepage "https://github.com/chengr28/Pcap_DNSProxy"
-  url "https://github.com/chengr28/Pcap_DNSProxy/archive/v0.4.6.0.tar.gz"
-  sha256 "f48ac6575f84ab838044d278e0ba7f748dd4b453a40d73eb17e8d6e400373485"
+  url "https://github.com/chengr28/Pcap_DNSProxy/archive/v0.4.7.0.tar.gz"
+  sha256 "48e92a3c9073047140e6b171c2b2d2bdc50af6b308ade0a131e233cfe8d12e8e"
   head "https://github.com/chengr28/Pcap_DNSProxy.git"
 
   bottle do
@@ -15,12 +15,7 @@ class PcapDnsproxy < Formula
   depends_on :xcode => :build
 
   def install
-    xcodebuild "-project", "./Source/KeyPairGenerator.xcodeproj", "-target", "KeyPairGenerator", "-configuration", "Release", "SYMROOT=build"
-    xcodebuild "-project", "./Source/FileHash.xcodeproj", "-target", "FileHash", "-configuration", "Release", "SYMROOT=build"
     xcodebuild "-project", "./Source/Pcap_DNSProxy.xcodeproj", "-target", "Pcap_DNSProxy", "-configuration", "Release", "SYMROOT=build"
-
-    bin.install "Source/build/Release/KeyPairGenerator"
-    bin.install "Source/build/Release/FileHash"
     bin.install "Source/build/Release/Pcap_DNSProxy"
     (etc/"pcap_DNSproxy").install Dir["Source/ExampleConfig/*.{ini,txt}"]
   end
@@ -50,16 +45,16 @@ class PcapDnsproxy < Formula
   end
 
   test do
-    (testpath/"pcap_dnsproxy").mkpath
-    cp Dir[etc/"pcap_dnsproxy/*"], testpath/"pcap_dnsproxy/"
+    (testpath/"pcap_DNSproxy").mkpath
+    cp Dir[etc/"pcap_DNSproxy/*"], testpath/"pcap_DNSproxy/"
 
-    inreplace testpath/"pcap_dnsproxy/Config.ini" do |s|
+    inreplace testpath/"pcap_DNSproxy/Config.ini" do |s|
       s.gsub! /^Direct Request.*/, "Direct Request = IPv4 + IPv6"
       s.gsub! /^Operation Mode.*/, "Operation Mode = Proxy"
       s.gsub! /^Listen Port.*/, "Listen Port = 9999"
     end
 
-    pid = fork { exec bin/"Pcap_DNSProxy", "-c", testpath/"pcap_dnsproxy/" }
+    pid = fork { exec bin/"Pcap_DNSProxy", "-c", testpath/"pcap_DNSproxy/" }
     begin
       system "dig", "google.com", "@127.0.0.1", "-p", "9999", "+short"
     ensure


### PR DESCRIPTION
remove the two xcode projects that were merged into the third
(thanks to Daniel Zeng for the fix)

case sensitivity fix in the test
