### PR TITLE
hg-fast-export: fix test

### DIFF
--- a/Formula/hg-fast-export.rb
+++ b/Formula/hg-fast-export.rb
@@ -15,6 +15,6 @@ class HgFastExport < Formula
   end
 
   test do
-    system bin/"hg-reset.sh", "--help"
+    system bin/"hg-fast-export.sh", "--help"
   end
 end


### PR DESCRIPTION
The `hg-reset.sh` command will fail if run from outside a git repo, even if you're just doing 'hg-reset.sh --help'. This breaks the current test for `hg-fast-export`. We missed it when [initially adding the formula](https://github.com/Homebrew/homebrew-core/pull/4112) because the build skipped bottling for some reason, and apparently this also skipped the test.

This PR fixes the test by switching to using `hg-fast-export.sh --help`, which apparently is happy to run outside a git repo.
