### PR TITLE
psqlodbc: add support for libiodbc

### DIFF
--- a/Formula/psqlodbc.rb
+++ b/Formula/psqlodbc.rb
@@ -19,13 +19,24 @@ class Psqlodbc < Formula
   end
 
   depends_on "openssl"
-  depends_on "unixodbc"
   depends_on :postgresql
+  depends_on "unixodbc" => :recommended
+  depends_on "libiodbc" => :optional
 
   def install
+    if build.with?("libiodbc") && build.with?("unixodbc")
+      odie "psqlodbc: --without-unixodbc must be specified when using --with-libiodbc"
+    end
+
+    args = %W[
+      --prefix=#{prefix}
+    ]
+
+    args << "--with-iodbc=#{Formula["libiodbc"].opt_prefix}" if build.with?("libiodbc")
+    args << "--with-unixodbc=#{Formula["unixodbc"].opt_prefix}" if build.with?("unixodbc")
+
     system "./bootstrap" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--with-unixodbc=#{Formula["unixodbc"].opt_prefix}"
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The previous formula supported only compiling with unixodbc, this adds
support for libiodbc as well. It ensures only one or the other can be
linked to the psqlodbc driver.
