### PR TITLE
libgcrypt: build static library too

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -33,6 +33,7 @@ class Libgcrypt < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--enable-static",
                           "--prefix=#{prefix}",
                           "--disable-asm",
                           "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}"


### PR DESCRIPTION
I'm not sure why this is not on by default in upstream libgcrypt. I think when you install a library, you come to expect getting a static library. I know I do, when I want to link against it.
