### PR TITLE
zbackup: fix brew audit --strict warnings

### DIFF
--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -30,10 +30,21 @@ class Zbackup < Formula
 
   def install
     # Avoid collision with protobuf 3.x CHECK macro
-    inreplace ["backup_creator.cc", "check.hh", "chunk_id.cc", "chunk_storage.cc",
-      "compression.cc", "encrypted_file.cc", "encryption.cc", "encryption_key.cc", "mt.cc",
-      "tests/bundle/test_bundle.cc", "tests/encrypted_file/test_encrypted_file.cc",
-      "unbuffered_file.cc", ], /\bCHECK\b/, "ZBCHECK"
+    inreplace [
+      "backup_creator.cc",
+      "check.hh",
+      "chunk_id.cc",
+      "chunk_storage.cc",
+      "compression.cc",
+      "encrypted_file.cc",
+      "encryption.cc",
+      "encryption_key.cc",
+      "mt.cc",
+      "tests/bundle/test_bundle.cc",
+      "tests/encrypted_file/test_encrypted_file.cc",
+      "unbuffered_file.cc",
+    ],
+    /\bCHECK\b/, "ZBCHECK"
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This change addresses warnings returned by `brew audit --strict`. ⚡ 
