### PR TITLE
watch: fix brew audit --strict warnings

### DIFF
--- a/Formula/watch.rb
+++ b/Formula/watch.rb
@@ -25,13 +25,13 @@ class Watch < Formula
   end
 
   depends_on "autoconf" => :build
-  conflicts_with "visionmedia-watch"
-
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
   depends_on "gettext"
+
+  conflicts_with "visionmedia-watch"
 
   def install
     # Prevents undefined symbol errors for _libintl_gettext, etc.

--- a/Formula/watch.rb
+++ b/Formula/watch.rb
@@ -24,9 +24,9 @@ class Watch < Formula
     sha256 "f4e6ab66a65524de9fcca757afd95d1178f21ef87be1b04f56beec25e8cb191f" => :mavericks
   end
 
+  depends_on "autoconf" => :build
   conflicts_with "visionmedia-watch"
 
-  depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [ X ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ X ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This change addresses the warning from "brew audit --strict"
