### PR TITLE
terraform 0.7.2

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -3,9 +3,20 @@ require "language/go"
 class Terraform < Formula
   desc "Tool to build, change, and version infrastructure"
   homepage "https://www.terraform.io/"
-  url "https://github.com/hashicorp/terraform/archive/v0.7.1.tar.gz"
-  sha256 "b6a6b5553755ebbf5362e8104eea801234c127831f5c12792a55fbbc8792ef1d"
   head "https://github.com/hashicorp/terraform.git"
+
+  stable do
+    url "https://github.com/hashicorp/terraform/archive/v0.7.2.tar.gz"
+    sha256 "ccea0fe6948ef801ecd3f000202534e735766bc489f976bec9722fb5daa62a67"
+
+    # so that we don't have to build from the tag
+    # https://github.com/hashicorp/terraform/pull/8481
+    # https://github.com/hashicorp/terraform/issues/8489
+    patch do
+      url "https://github.com/hashicorp/terraform/commit/010f0287.patch"
+      sha256 "f0986afc0ce934315d3aa1e406dddfe598ff4e1df3ca8c65887c59669bef076e"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -47,7 +58,7 @@ class Terraform < Formula
     end
 
     cd "src/golang.org/x/tools/cmd/stringer" do
-      system "go", "build"
+      ENV.deparallelize { system "go", "build" }
       buildpath.install "stringer"
     end
 


### PR DESCRIPTION
deparallelize the build of golang.org/x/tools/cmd/stringer, which seems
to be defective otherwise, causing subsequent failures in the terraform
build, though the exact mechanism by which that occurs isn't yet clear
