### PR TITLE
ffmpeg 3.1.3

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -1,9 +1,8 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-3.1.2.tar.bz2"
-  sha256 "62eb8d810b93c1ffc23739c0824a91eabfe5e7be81fab34ce740736a110b70f7"
-
+  url "https://ffmpeg.org/releases/ffmpeg-3.1.3.tar.bz2"
+  sha256 "58bc89c65dd114d874efbf76f76368d03b5e407f0a3f42d5b40801c280968a38"
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,6 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.19.0.tar.gz"
   sha256 "3df5811942cd1d71f48eb4720092fdafec11885bf6dd6d1d3e6413f32e5d67e2"
+  revision 1
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Still no libopenh264 1.6 support (no https://github.com/FFmpeg/FFmpeg/commit/293676c476733e81d7b596736add6cd510eb6960 in https://github.com/FFmpeg/FFmpeg/commits/n3.1.3/libavcodec/libopenh264enc.c). I guess we'll wait till 3.2 or something.
