### PR TITLE
codequery: transition to qt5

### DIFF
--- a/Formula/codequery.rb
+++ b/Formula/codequery.rb
@@ -3,7 +3,7 @@ class Codequery < Formula
   homepage "https://github.com/ruben2020/codequery"
   url "https://github.com/ruben2020/codequery/archive/v0.16.0.tar.gz"
   sha256 "4896435a8aa35dbdca43cba769aece9731f647ac9422a92c3209c2955d2e7101"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -13,13 +13,17 @@ class Codequery < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt5"
   depends_on "qscintilla2"
 
   def install
+    args = std_cmake_args
+    args << "-DBUILD_QT5=ON"
+    args << "-DQT5QSCINTILLA_LIBRARY=#{Formula["qscintilla2"].opt_lib}/libqscintilla2.dylib"
+
     share.install "test"
     mkdir "build" do
-      system "cmake", "..", "-G", "Unix Makefiles", *std_cmake_args
+      system "cmake", "..", "-G", "Unix Makefiles", *args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

transition codequery to build using Qt 5

---

In its current state this is a bit rough, with a somewhat hard-coded path for `qscintilla2`'s library in order for cmake to find it and use it. 

This is due to the fact that codequery's [FindQt5QScintilla.cmake](https://github.com/ruben2020/codequery/blob/v0.16.0/cmakefind/FindQt5QScintilla.cmake) looks for `NAMES qt5scintilla2 qscintilla2-qt5` whereas the dyld homebrew builds is `libqscintilla2.dylib`.

If anyone can think of a way to do this more neatly I would love any suggestions/guidance.

I suppose that this is part of the larger effort being chronicled in https://github.com/Homebrew/homebrew-core/issues/1705

_(I hope the build bot doesn't choke on this for some strange reason)_

**EDIT:**
this is just an idea I am throwing out there, and it may not be really practical, but `qscintilla2`'s formula could simply be modified to create a `qscintilla2-qt5.dyld` sym since it is now only being built with `qt5` after all.
