### PR TITLE
Install gdk-pixbuf `loaders.cache` file to proper location

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -77,12 +77,14 @@ class GdkPixbuf < Formula
   end
 
   def post_install
-    # Change the version directory below with any future update
-    if build.with?("relocations") || HOMEBREW_PREFIX.to_s != "/usr/local"
-      ENV["GDK_PIXBUF_MODULE_FILE"]="#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
-      ENV["GDK_PIXBUF_MODULEDIR"]="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
-    end
+    # loaders.cache should be placed into Keg-specific lib directory
+    module_file = "#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
+    module_dir = "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
+    ENV["GDK_PIXBUF_MODULE_FILE"] = module_file
+    ENV["GDK_PIXBUF_MODULEDIR"] = module_dir
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
+    # Link newly created module_file into global gdk-pixbuf directory
+    system "ln", "-sf", module_file, "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/"
   end
 
   def caveats; <<-EOS.undent

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -84,7 +84,7 @@ class GdkPixbuf < Formula
     ENV["GDK_PIXBUF_MODULEDIR"] = module_dir
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
     # Link newly created module_file into global gdk-pixbuf directory
-    system "ln", "-sf", module_file, "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/"
+    ln_sf module_file, "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/"
   end
 
   def caveats; <<-EOS.undent

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -76,21 +76,30 @@ class GdkPixbuf < Formula
     (lib/"gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache").unlink
   end
 
+  # Where we want to store the loaders.cache file, which should be in a
+  # Keg-specific lib directory, not in the global Homebrew lib directory
+  def module_file
+    "#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
+  end
+
+  # The directory that loaders.cache gets linked into, also has the "loaders"
+  # directory that is scanned by gdk-pixbuf-query-loaders in the first place
+  def module_dir
+    "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}"
+  end
+
   def post_install
-    # loaders.cache should be placed into Keg-specific lib directory
-    module_file = "#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
-    module_dir = "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
     ENV["GDK_PIXBUF_MODULE_FILE"] = module_file
-    ENV["GDK_PIXBUF_MODULEDIR"] = module_dir
+    ENV["GDK_PIXBUF_MODULEDIR"] = "#{module_dir}/loaders"
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
     # Link newly created module_file into global gdk-pixbuf directory
-    ln_sf module_file, "#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/"
+    ln_sf module_file, module_dir
   end
 
   def caveats; <<-EOS.undent
     Programs that require this module need to set the environment variable
-      export GDK_PIXBUF_MODULE_FILE="#{lib}/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders.cache"
-      export GDK_PIXBUF_MODULEDIR="#{HOMEBREW_PREFIX}/lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
+      export GDK_PIXBUF_MODULE_FILE="#{module_file}"
+      export GDK_PIXBUF_MODULEDIR="#{module_dir}/loaders"
     If you need to manually update the query loader cache, set these variables then run
       #{bin}/gdk-pixbuf-query-loaders --update-cache
     EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`brew audit --new-formula` gives the following errors:

```
$ brew audit --new-formula ./gdk-pixbuf.rb
gdk-pixbuf:
  * Use the `ln` Ruby method instead of `system "ln"`
  * Formulae are required to declare all linked dependencies.
    Please add all linked dependencies to the formula with:
      depends_on "gettext" => :linked
Error: 2 problems in 1 formula
```
- I am not using the `ln` ruby method because I didn't know how to make it overwrite existing files (which it must if you run `postinstall` twice, or if you have previously installed `gdk-pixbuf` through Homebrew).  I saw [this comment](https://github.com/Homebrew/brew/blob/f4fb655aaa907e8ec642469ae21ca03e6cef2e21/Library/Homebrew/cmd/linkapps.rb#L44-L46) in the Homebrew codebase and decided to follow suit.
- I was previously told not to add the `"gettext" -> :linked` dependency, so I am holding off on that for now.

The rationale behind this change is explored in detail in [this thread](https://github.com/Homebrew/homebrew-core/pull/3279), but I'll quote the most relevant parts here:

> as it stands right now, in a "normal" /usr/local Homebrew installation, the loaders.cache file is not a symlink to the currently-installed gdk-pixbuf keg, it is a normal file. This (theoretically) doesn't allow for things like quick switching from version to version through unlinking different kegs of the same formula, just plain doesn't work properly on non-/usr/local Homebrew installations, and in general breaks Homebrew encapsulation.
> 
> On a non-/usr/local Homebrew installation, the environment variables are defined properly and the loaders.cache file is created in the proper place, but no symlink is created because post_install is invoked after link.
