### PR TITLE
libuvc: add missing build dep.

### DIFF
--- a/Formula/libuvc.rb
+++ b/Formula/libuvc.rb
@@ -15,6 +15,7 @@ class Libuvc < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "libusb"
   depends_on "jpeg" => :optional
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?
  no - it fails with "\* A `test do` test block should be added", which was a preexisting problem.
  -----

The following commit added a dependency on pkg-config:
https://github.com/ktossell/libuvc/commit/c3b412fe77889e21fccf8baa535a51a259990791
