### PR TITLE
Qu1j0t3 add vasm formula

### DIFF
--- a/Formula/vasm.rb
+++ b/Formula/vasm.rb
@@ -36,7 +36,7 @@ class Vasm < Formula
     cpu_options.each do |cpu|
       syntax_options.each do |syntax|
         prog = "vasm#{cpu}_#{syntax}"
-        system "make", prog, "CPU="+cpu, "SYNTAX="+syntax
+        system "make", prog, "CPU=#{cpu}", "SYNTAX=#{syntax}"
         bin.install prog
       end
     end

--- a/Formula/vasm.rb
+++ b/Formula/vasm.rb
@@ -10,7 +10,7 @@ class Vasm < Formula
   option "with-arm", "Enable ARM CPU target (binary vasmarm_SYNTAX)"
   option "with-c16x", "Enable c16x/st10 microcontroller target (binary vasmc16x_SYNTAX)"
   option "with-jagrisc", "Enable Atari Jaguar GPU/DSP RISC target (binary vasmjagrisc_SYNTAX)"
-  option "with-m68k", "Enable Motorola 68K CPU target (binary vasmm68k_SYNTAX)"
+  option "with-m68k", "Enable Motorola 68K CPU target (binary vasmm68k_SYNTAX) (default)"
   option "with-ppc", "Enable PowerPC CPU target (binary vasmppc_SYNTAX)"
   option "with-tr3200", "Enable Trillek TR3200 CPU target (binary vasmtr3200_SYNTAX)"
   option "with-vidcore", "Enable VideoCore IV CPU target (binary vasmvidcore_SYNTAX)"
@@ -23,7 +23,8 @@ class Vasm < Formula
   option "with-oldstyle", "Enable oldstyle (8-bit) syntax (binary vasmCPU_oldstyle)"
 
   def cpu_options
-    %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }
+    opts = %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }
+    opts.empty? ? ["m68k"] : opts
   end
 
   def syntax_options
@@ -32,20 +33,21 @@ class Vasm < Formula
   end
 
   def install
-    configs = 0
     cpu_options.each do |cpu|
       syntax_options.each do |syntax|
         prog = "vasm#{cpu}_#{syntax}"
         system "make", prog, "CPU="+cpu, "SYNTAX="+syntax
         bin.install prog
-        configs += 1
       end
     end
 
-    odie "Please specify at least one cpu with --with-<cpu>" unless configs > 0
-
     system "make", "vobjdump"
     bin.install "vobjdump"
+  end
+
+  def caveats
+    opts = %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }
+    "No target CPU was specified with --with-<cpu>, so #{cpu_options} has been chosen by default." if opts.empty?
   end
 
   test do

--- a/Formula/vasm.rb
+++ b/Formula/vasm.rb
@@ -1,0 +1,60 @@
+class Vasm < Formula
+  desc "Portable and retargetable assembler"
+  homepage "http://sun.hasenbraten.de/vasm/"
+  url "http://server.owl.de/~frank/tags/vasm1_7e.tar.gz"
+  version "1.7e"
+  sha256 "2878c9c62bd7b33379111a66649f6de7f9267568946c097ffb7c08f0acd0df92"
+
+  # target options
+  option "with-6502", "Enable 6502 CPU target (binary vasm6502_SYNTAX)"
+  option "with-6800", "Enable Motorola 6800 CPU target (binary vasm6800_SYNTAX)"
+  option "with-arm", "Enable ARM CPU target (binary vasmarm_SYNTAX)"
+  option "with-c16x", "Enable c16x/st10 microcontroller target (binary vasmc16x_SYNTAX)"
+  option "with-jagrisc", "Enable Atari Jaguar GPU/DSP RISC target (binary vasmjagrisc_SYNTAX)"
+  option "with-m68k", "Enable Motorola 68K CPU target (binary vasmm68k_SYNTAX)"
+  option "with-ppc", "Enable PowerPC CPU target (binary vasmppc_SYNTAX)"
+  option "with-tr3200", "Enable Trillek TR3200 CPU target (binary vasmtr3200_SYNTAX)"
+  option "with-vidcore", "Enable VideoCore IV CPU target (binary vasmvidcore_SYNTAX)"
+  option "with-x86", "Enable Intel x86 CPU target (binary vasmx86_SYNTAX)"
+  option "with-z80", "Enable Zilog Z80 CPU target (binary vasmz80_SYNTAX)"
+
+  # syntax options
+  option "with-std", "Enable standard syntax (binary vasmCPU_std)"
+  option "with-madmac", "Enable MadMac (Atari) syntax (binary vasmCPU_madmac)"
+  option "with-mot", "Enable Motorola syntax (binary vasmCPU_mot)"
+  option "with-oldstyle", "Enable oldstyle (8-bit) syntax (binary vasmCPU_oldstyle)"
+
+  def install
+    configs = 0
+    %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }.each do |cpu|
+      %w[std madmac mot oldstyle].select { |s| build.with? s }.each do |syntax|
+        prog = "vasm#{cpu}_#{syntax}"
+        system "make", prog, "CPU="+cpu, "SYNTAX="+syntax
+        bin.install prog
+        configs += 1
+      end
+    end
+
+    odie "Please specify at least one cpu with --with-<cpu> and at least one syntax with --with-<syntax>" unless configs > 0
+
+    system "make", "vobjdump"
+    bin.install "vobjdump"
+  end
+
+  test do
+    (testpath/"std.asm").write 'foo: .ascii "bar"'
+    (testpath/"madmac.asm").write 'foo: dc.b "bar"'
+    (testpath/"mot.asm").write 'foo: dc.b "bar"'
+    (testpath/"oldstyle.asm").write 'foo: ascii "bar"'
+
+    %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }.each do |cpu|
+      %w[std madmac mot oldstyle].select { |s| build.with? s }.each do |syntax|
+        prog = "vasm#{cpu}_#{syntax}"
+        system bin/prog, "-o", "vasm.out", "#{syntax}.asm"
+        system "grep", "62 61 72", "vasm.out"
+        system bin/prog, "-Fvobj", "-o", "vasm.obj", "#{syntax}.asm"
+      end
+    end
+    system bin/"vobjdump", "vasm.obj"
+  end
+end

--- a/Formula/vasm.rb
+++ b/Formula/vasm.rb
@@ -5,7 +5,6 @@ class Vasm < Formula
   version "1.7e"
   sha256 "2878c9c62bd7b33379111a66649f6de7f9267568946c097ffb7c08f0acd0df92"
 
-  # target options
   option "with-6502", "Enable 6502 CPU target (binary vasm6502_SYNTAX)"
   option "with-6800", "Enable Motorola 6800 CPU target (binary vasm6800_SYNTAX)"
   option "with-arm", "Enable ARM CPU target (binary vasmarm_SYNTAX)"
@@ -18,7 +17,6 @@ class Vasm < Formula
   option "with-x86", "Enable Intel x86 CPU target (binary vasmx86_SYNTAX)"
   option "with-z80", "Enable Zilog Z80 CPU target (binary vasmz80_SYNTAX)"
 
-  # syntax options
   option "with-std", "Enable standard syntax (binary vasmCPU_std) (default)"
   option "with-madmac", "Enable MadMac (Atari) syntax (binary vasmCPU_madmac)"
   option "with-mot", "Enable Motorola syntax (binary vasmCPU_mot)"

--- a/Formula/vasm.rb
+++ b/Formula/vasm.rb
@@ -22,6 +22,21 @@ class Vasm < Formula
   option "with-mot", "Enable Motorola syntax (binary vasmCPU_mot)"
   option "with-oldstyle", "Enable oldstyle (8-bit) syntax (binary vasmCPU_oldstyle)"
 
+  # These defaults come from Frank Wille, vasm upstream.
+  def cpu_syntax
+    { "6502"    => ["oldstyle"],
+      "6800"    => ["oldstyle"],
+      "arm"     => ["std"],
+      "c16x"    => ["std"],
+      "jagrisc" => ["madmac"],
+      "m68k"    => ["mot"],
+      "ppc"     => ["std"],
+      "tr3200"  => ["std"],
+      "vidcore" => ["std"],
+      "x86"     => ["std"],
+      "z80"     => ["oldstyle"] }
+  end
+
   def cpu_options
     opts = %w[6502 6800 arm c16x jagrisc m68k ppc tr3200 vidcore x86 z80].select { |c| build.with? c }
     opts.empty? ? ["m68k"] : opts
@@ -29,7 +44,7 @@ class Vasm < Formula
 
   def syntax_options
     opts = %w[std madmac mot oldstyle].select { |s| build.with? s }
-    opts.empty? ? ["std"] : opts
+    opts.empty? ? cpu_options.flat_map { |cpu| cpu_syntax[cpu] } : opts
   end
 
   def install


### PR DESCRIPTION
- [Y] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [Y] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [Y] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Unfortunately I erroneously deleted my original fork of Homebrew for this old PR: https://github.com/Homebrew/homebrew-core/pull/1703

I'm reopening with advice from upstream on setting default "syntaxes" for the set of CPUs supported by this assembler. It's therefore not usually necessary specify _both_ CPU and syntax, although any combination can be built by specifying the options.

Re-reading the old PR, it seems that the concern was mainly CI coverage? In which case we'd need to build more CPUs by default? I have a problem with that in that most users would have a particular CPU in mind and don't need to install anything else. 

I'm reopening a PR to see if we can reach an accommodation. Frank Wille (upstream author) provided this info:

> Also some CPU backends are less mature and rarely used. I would concentrate
> on one or two CPUs, where you need a cross-assembler for.
> M68k, PPC and Z80 are the most mature and frequently used backends (in this
> order).
