### PR TITLE
file-roller: fix test crash without window server

### DIFF
--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -53,6 +53,6 @@ class FileRoller < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/file-roller --version 2>&1")
+    system bin/"file-roller", "--help"
   end
 end


### PR DESCRIPTION
`file-roller --version` dies when not logged into the macOS GUI with

```
  *** -[__NSArray0 objectAtIndex:]: index 0 beyond bounds for empty
  NSArray
```

So use `--help` instead.
