### PR TITLE
apr/apr-util: rewrite config scripts to use opt_xyz

### DIFF
--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -3,7 +3,7 @@ class AprUtil < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
   sha256 "a6cf327189ca0df2fb9d5633d7326c460fe2b61684745fd7963e79a6dd0dc82e"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "554fcbcfe8247cbb3fea43679eaaf085b9dc8d5d39476db7c5e4b1fa6957316c" => :el_capitan
@@ -49,9 +49,12 @@ class AprUtil < Formula
     system "make"
     system "make", "install"
     bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    # No need for this to point to the versioned path.
+    inreplace libexec/"bin/apu-1-config", libexec, opt_libexec
   end
 
   test do
-    system "#{bin}/apu-1-config", "--link-libtool", "--libs"
+    assert_match opt_libexec.to_s, shell_output("#{bin}/apu-1-config --prefix")
   end
 end

--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -3,7 +3,7 @@ class Apr < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.2.tar.bz2"
   sha256 "7d03ed29c22a7152be45b8e50431063736df9e1daa1ddf93f6a547ba7a28f67a"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -27,9 +27,12 @@ class Apr < Formula
     system "./configure", "--prefix=#{libexec}"
     system "make", "install"
     bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    # No need for this to point to the versioned path.
+    inreplace libexec/"bin/apr-1-config", libexec, opt_libexec
   end
 
   test do
-    system bin/"apr-1-config", "--link-libtool", "--libs"
+    assert_match opt_libexec.to_s, shell_output("#{bin}/apr-1-config --prefix")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Much like the config scripts of `libgcrypt`, etc that we ended up fixing because it caused more trouble than anything, same situation here. There's no need for them to refer to the versioned path rather than the `opt_libexec`, so let's just fix the darn thing.
