### PR TITLE
dbus: Update HEAD build

### DIFF
--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -19,6 +19,12 @@ class Dbus < Formula
     sha256 "474de2afde8087adbd26b3fc5cbf6ec45559763c75b21981169a9a1fbac256c9"
   end
 
+  head do
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
   patch do
@@ -30,6 +36,7 @@ class Dbus < Formula
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
 
+    system "./autogen.sh", "--no-configure" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",


### PR DESCRIPTION
./autogen took the place of ./configure. This updates that command and adds necessary depends_on.
