### PR TITLE
libngspice 26 (new formula)

### DIFF
--- a/Formula/libngspice.rb
+++ b/Formula/libngspice.rb
@@ -19,22 +19,11 @@ class Libngspice < Formula
     patch :DATA
   end
 
-  option "without-cider", "Build without CIDER numerical device simulator"
-  option "without-xspice", "Build without XSPICE extensions"
-
   def install
     system "./autogen.sh" if build.head?
-
-    args = %W[
-      --disable-debug
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --with-ngshared
-    ]
-    args << "--enable-cider" if build.with? "cider"
-    args << "--enable-xspice" if build.with? "xspice"
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--disable-debug",
+      "--disable-dependency-tracking", "--with-ngshared", "--enable-cider",
+      "--enable-xspice"
     system "make", "install"
 
     # To avoid rerunning autogen.sh for stable builds, work around the

--- a/Formula/libngspice.rb
+++ b/Formula/libngspice.rb
@@ -1,0 +1,79 @@
+class Libngspice < Formula
+  desc "Spice circuit simulator as shared library"
+  homepage "http://ngspice.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/26/ngspice-26.tar.gz"
+  sha256 "51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108"
+
+  head do
+    url "git://git.code.sf.net/p/ngspice/ngspice"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+    depends_on "libtool" => :build
+
+    # Currently, headers don't get installed to include/*.
+    # There is a patch upstream that addresses this for HEAD.
+    # Upstream ticket: https://sourceforge.net/p/ngspice/bugs/327
+    patch :DATA
+  end
+
+  option "without-cider", "Build without CIDER numerical device simulator"
+  option "without-xspice", "Build without XSPICE extensions"
+
+  def install
+    system "./autogen.sh" if build.head?
+
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --with-ngshared
+    ]
+    args << "--enable-cider" if build.with? "cider"
+    args << "--enable-xspice" if build.with? "xspice"
+
+    system "./configure", *args
+    system "make", "install"
+
+    # To avoid rerunning autogen.sh for stable builds, work around the
+    # includedir bug by symlinking.  Upstream ticket:
+    # https://sourceforge.net/p/ngspice/bugs/327
+    include.install_symlink Dir[share/"ngspice/include/*"] if build.stable?
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <cstdlib>
+      #include <ngspice/sharedspice.h>
+      int ng_exit(int status, bool immediate, bool quitexit, int ident, void *userdata) {
+        return status;
+      }
+      int main() {
+        return ngSpice_Init(NULL, NULL, ng_exit, NULL, NULL, NULL, NULL);
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lngspice", "-o", "test"
+    system "./test"
+  end
+end
+__END__
+diff --git a/src/include/ngspice/Makefile.am b/src/include/ngspice/Makefile.am
+index 216816e..fd7fec0 100644
+--- a/src/include/ngspice/Makefile.am
++++ b/src/include/ngspice/Makefile.am
+@@ -1,11 +1,9 @@
+ ## Process this file with automake to produce Makefile.in
+
+-includedir = $(pkgdatadir)/include/ngspice
+-
+-nodist_include_HEADERS = \
++nodist_pkginclude_HEADERS = \
+	config.h
+
+-include_HEADERS = \
++pkginclude_HEADERS = \
+	tclspice.h	\
+	acdefs.h	\
+	bdrydefs.h	\


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

ngspice can be build as a shared library, but their build system does
not allow building the executable and the library in one go without
interfering with Homebrew's formula guidelines.  A pull request [1](https://github.com/Homebrew/homebrew-core/pull/3367)
trying this in the existing ngspice formula has been disapproved.

During the discussion in [1](https://github.com/Homebrew/homebrew-core/pull/3367) it was suggested that, in this case, a
separate formula building _only_ the shared library might be a solution.
This is what this formula is for.
