### PR TITLE
logstash 2.4.0

### DIFF
--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -3,8 +3,8 @@ class Logstash < Formula
   homepage "https://www.elastic.co/products/logstash"
 
   stable do
-    url "https://download.elastic.co/logstash/logstash/logstash-2.3.4.tar.gz"
-    sha256 "7f62a03ddc3972e33c343e982ada1796b18284f43ed9c0089a2efee78b239583"
+    url "https://download.elastic.co/logstash/logstash/logstash-2.4.0.tar.gz"
+    sha256 "622c435c5c0f40e205fd4d9411eb409cc52992cf62dde4c7cd46e480cd8247cc"
     depends_on :java => "1.7+"
   end
 


### PR DESCRIPTION
This pull requests updates the Logstash formula from version 2.3.4 to version 2.4.0, [the latest stable release as-of 2016-08-31](https://www.elastic.co/blog/logstash-2-4-0-released).
