### PR TITLE
zsh-syntax-highlighting: fix install with --git

### DIFF
--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -1,7 +1,9 @@
 class ZshSyntaxHighlighting < Formula
   desc "Fish shell like syntax highlighting for zsh"
   homepage "https://github.com/zsh-users/zsh-syntax-highlighting"
-  url "https://github.com/zsh-users/zsh-syntax-highlighting.git", tag: "0.4.1"
+  url "https://github.com/zsh-users/zsh-syntax-highlighting.git",
+    :tag => "0.4.1",
+    :revision => "c19ee583138ebab416b0d2efafbad7dc9f3f7c4f"
   sha256 "971b9c1e881a8d60442e40003c9e4c98bd1d5243a32fdf386a217c4cd7815197"
   head "https://github.com/zsh-users/zsh-syntax-highlighting.git"
 

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -1,7 +1,7 @@
 class ZshSyntaxHighlighting < Formula
   desc "Fish shell like syntax highlighting for zsh"
   homepage "https://github.com/zsh-users/zsh-syntax-highlighting"
-  url "https://github.com/zsh-users/zsh-syntax-highlighting/archive/0.4.1.tar.gz"
+  url "https://github.com/zsh-users/zsh-syntax-highlighting.git", tag: "0.4.1"
   sha256 "971b9c1e881a8d60442e40003c9e4c98bd1d5243a32fdf386a217c4cd7815197"
   head "https://github.com/zsh-users/zsh-syntax-highlighting.git"
 
@@ -13,14 +13,6 @@ class ZshSyntaxHighlighting < Formula
   end
 
   def install
-    inreplace "Makefile" do |s|
-      # Fix for `brew install --git zsh-syntax-highlighting`.
-      # Without this, the git repository with no HEAD would cause
-      # `git rev-parse` to fail and abort the installation.
-      s.gsub! "git rev-parse HEAD",
-        "git rev-parse --verify HEAD 2> /dev/null || cat .revision-hash"
-    end
-
     system "make", "install", "PREFIX=#{prefix}"
   end
 

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -13,6 +13,14 @@ class ZshSyntaxHighlighting < Formula
   end
 
   def install
+    inreplace "Makefile" do |s|
+      # Fix for `brew install --git zsh-syntax-highlighting`.
+      # Without this, the git repository with no HEAD would cause
+      # `git rev-parse` to fail and abort the installation.
+      s.gsub! "git rev-parse HEAD",
+        "git rev-parse --verify HEAD 2> /dev/null || cat .revision-hash"
+    end
+
     system "make", "install", "PREFIX=#{prefix}"
   end
 

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -4,7 +4,6 @@ class ZshSyntaxHighlighting < Formula
   url "https://github.com/zsh-users/zsh-syntax-highlighting.git",
     :tag => "0.4.1",
     :revision => "c19ee583138ebab416b0d2efafbad7dc9f3f7c4f"
-  sha256 "971b9c1e881a8d60442e40003c9e4c98bd1d5243a32fdf386a217c4cd7815197"
   head "https://github.com/zsh-users/zsh-syntax-highlighting.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

See zsh-users/zsh-syntax-highlighting#357 for a description of the issue this fixes.

The maintainers of zsh-syntax-highlighting [decided](https://github.com/zsh-users/zsh-syntax-highlighting/issues/357#issuecomment-243836555) this would be better as a Homebrew patch than being implemented in zsh-syntax-highlighting itself.
