### PR TITLE
upscaledb: bump vendored libuv

### DIFF
--- a/Formula/upscaledb.rb
+++ b/Formula/upscaledb.rb
@@ -3,6 +3,7 @@ class Upscaledb < Formula
   homepage "https://upscaledb.com/"
   url "http://files.upscaledb.com/dl/upscaledb-2.2.0.tar.gz"
   sha256 "7d0d1ace47847a0f95a9138637fcaaf78b897ef682053e405e2c0865ecfd253e"
+  revision 1
 
   bottle do
     cellar :any
@@ -29,8 +30,8 @@ class Upscaledb < Formula
   depends_on "protobuf" if build.with? "remote"
 
   resource "libuv" do
-    url "https://github.com/libuv/libuv/archive/v0.10.36.tar.gz"
-    sha256 "421087044cab642f038c190f180d96d6a1157be89adb4630881930495b8f5228"
+    url "https://github.com/libuv/libuv/archive/v0.10.37.tar.gz"
+    sha256 "4c12bed4936dc16a20117adfc5bc18889fa73be8b6b083993862628469a1e931"
   end
 
   fails_with :clang do


### PR DESCRIPTION
Created as an adjunct to the protobuf 3.0 upgrade in #4145.
