### PR TITLE
ironssh 0.9.1 (new formula)

### DIFF
--- a/Formula/ironssh.rb
+++ b/Formula/ironssh.rb
@@ -1,0 +1,27 @@
+class Ironssh < Formula
+  desc "Fork of OpenSSH adding transparent E2E encryption to file transfers"
+  homepage "https://github.com/ironcorelabs/ironssh"
+  url "https://github.com/IronCoreLabs/ironssh/archive/0.9.1.tar.gz"
+  sha256 "6b2f78244dd836afdf6da561fda73d16fe42477b7f4034b1aeb09d75f23aff47"
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "openssl"
+  depends_on "libsodium"
+
+  def install
+    system "autoreconf"
+
+    system "./configure",
+                          "--with-ssl-dir=#{Formula["openssl"].opt_prefix}",
+                          "--with-libedit=/usr",
+                          "--prefix=#{prefix}"
+
+    system "make", "SSH_PROGRAM=/usr/bin/ssh", "ironsftp"
+    system "make", "install"
+  end
+
+  test do
+    system "make", "iron-tests"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [No - see below] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Hello,

IronSSH is an alternative to sftp and scp that keeps files encrypted after they're uploaded and allows sharing of files with cryptographic enforcement. 

This fails the following two `--new-formula` tests:
- GitHub fork (not canonical repository)
- GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)

To the first: this is a fork of openssh, but it does not install anything that conflicts with openssh. At present it installs only `ironsftp` and the related man page. It will eventually also install `ironscp`. This is a complementary project to openssh that shares a code base. Please waive the fork requirement given the unusual reason for the fork.  https://github.com/ironcorelabs/ironssh is the base repo for this project.

To the second point: this project has just had its first release. Packages are available via rpm and deb for Linux platforms. We'd like to make it easy to install for Mac users as well.  Please consider an exception to the popularity requirement. 
