### PR TITLE
gst-plugins-bad: add libvo-aacenc optional dependency

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -42,6 +42,7 @@ class GstPluginsBad < Formula
   depends_on "schroedinger" => :optional
   depends_on "sound-touch" => :optional
   depends_on "srtp" => :optional
+  depends_on "libvo-aacenc" => :optional
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
