### PR TITLE
gtk+3: add recommended dependency on librsvg

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -16,6 +16,10 @@ class Gtkx3 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gdk-pixbuf"
+  # Without this gdk-pixbuf cannot be used to load SVG icons, for example.
+  # Technically librsvg depends on gdk-pixbuf and not the other way around,
+  # because it declares its availability when it's installed.
+  depends_on "librsvg" => :recommended
   depends_on "atk"
   depends_on "gobject-introspection"
   depends_on "libepoxy"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Many GTK+3 apps use SVG icons, for example Builder, Pitivi, etc.

See for example https://packages.debian.org/sid/libgtk-3-0
