### PR TITLE
peco: fix `glide install` permissions error

### DIFF
--- a/Formula/peco.rb
+++ b/Formula/peco.rb
@@ -18,9 +18,14 @@ class Peco < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/peco/peco").install buildpath.children
     cd "src/github.com/peco/peco" do
-      system "glide", "install"
-      system "go", "build", "-o", bin/"peco", "cmd/peco/peco.go"
-      prefix.install_metafiles
+      # default $GLIDE_HOME doesn't work
+      Dir.mktmpdir do |tmpdir|
+        ENV["GLIDE_HOME"] = tmpdir
+
+        system "glide", "install"
+        system "go", "build", "-o", bin/"peco", "cmd/peco/peco.go"
+        prefix.install_metafiles
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Fixes #4412.  #4413 also fixes the same problem; I would have no objection to that fix being merged instead of this one.
