### PR TITLE
llvm: tie exception handling to RTTI

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -129,7 +129,7 @@ class Llvm < Formula
   option "without-lld", "Do not build LLD linker"
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build bindings against custom Python"
-  option "without-rtti", "Build without C++ RTTI"
+  option "without-rtti", "Build without C++ RTTI or exception handling"
   option "without-utils", "Do not install utility binaries"
   option "without-polly", "Do not build Polly optimizer"
   option "with-test", "Build LLVM unit tests"
@@ -211,7 +211,6 @@ class Llvm < Formula
 
     args = %w[
       -DLLVM_OPTIMIZED_TABLEGEN=ON
-      -DLLVM_ENABLE_EH=ON
     ]
     args << "-DLLVM_TARGETS_TO_BUILD=#{build.with?("all-targets") ? "all" : "AMDGPU;ARM;NVPTX;X86"}"
     args << "-DLIBOMP_ARCH=x86_64"
@@ -229,7 +228,11 @@ class Llvm < Formula
       args << "-DLLVM_BUILD_TESTS=ON"
       args << "-DLLVM_ABI_BREAKING_CHECKS=WITH_ASSERTS"
     end
-    args << "-DLLVM_ENABLE_RTTI=ON" if build.with? "rtti"
+
+    if build.with? "rtti"
+      args << "-DLLVM_ENABLE_RTTI=ON"
+      args << "-DLLVM_ENABLE_EH=ON"
+    end
     args << "-DLLVM_INSTALL_UTILS=ON" if build.with? "utils"
     args << "-DLLVM_ENABLE_LIBCXX=ON" if build_libcxx?
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Prevents --without-rtti from breaking the build, since EH depends on
RTTI.

Fixes #4400.
