### PR TITLE
Add libresolv to work around weechat HEAD building errors.

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -29,6 +29,9 @@ class Weechat < Formula
   depends_on "curl" => :optional
 
   def install
+    # Get around res_init() errors on 10.11
+    ENV.append "LDFLAGS", "-lresolv"
+
     args = std_cmake_args
     if build.with? "debug"
       args -= %w[-DCMAKE_BUILD_TYPE=Release]


### PR DESCRIPTION
This makes compiling HEAD weechat work on OSX, which was broken due to
libc not containing res_init() and it needing libresolv add to ldflags.

After upgrading OSX 10.11, I found weechat HEAD wouldn't compile due to:
    Undefined symbols for architecture x86_64:
      "_res_9_init", referenced from:
          _xfer_resolve_addr in xfer.o

From http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html I
found that this is due to libc in OSX not having res_init() and it being
in libresolv instead.
