### PR TITLE
sile 0.9.4

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "http://www.sile-typesetter.org/"
-  url "https://github.com/simoncozens/sile/releases/download/v0.9.3/sile-0.9.3.tar.bz2"
-  sha256 "30dfce5dca517280f3c41c34d52e7983080f880f22aca6ddca471d541a2d3f49"
+  url "https://github.com/simoncozens/sile/releases/download/v0.9.4/sile-0.9.4.tar.bz2"
+  sha256 "1c696679e5243d0448705db86227eec57a000846f02a964f882b7978c46954d5"
 
   head do
     url "https://github.com/simoncozens/sile.git"
@@ -17,8 +17,8 @@ class Sile < Formula
   depends_on "harfbuzz"
   depends_on "fontconfig"
   depends_on "libpng"
-  depends_on "freetype"
   depends_on "lua"
+  depends_on "icu4c"
 
   depends_on "lpeg" => :lua
   depends_on "luaexpat" => :lua


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I'm trying to update the [Sile](http://sile-typesetter.org/) package to the [latest release](https://github.com/simoncozens/sile/releases/tag/v0.9.4). One of the changes in this version is a new dependency on ICU. Adding this with `depends_on` seems to go fine and the program installs and runs. However `brew audit` shows the following errors:

```
❯❯❯ brew audit Formula/sile.rb
sile:
  * The installation was broken.
    Broken dylib links found:
      /usr/local/opt/icu4c/lib/libicuio.56.dylib
      /usr/local/opt/icu4c/lib/libicui18n.56.dylib
      /usr/local/opt/icu4c/lib/libicuuc.56.dylib
      /usr/local/opt/icu4c/lib/libicudata.56.1.dylib
      /usr/local/lib/libthai.0.dylib
      /usr/local/lib/libdatrie.1.dylib
Error: 1 problem in 1 formula
```

How is this  supposed to be fixed?
