### PR TITLE
erlang: fix compilation on macOS Sierra

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -96,8 +96,10 @@ class Erlang < Formula
     end
 
     system "./configure", *args
+    # Install is not thread-safe; can try to create folder twice and fail
+    # Reported 8 Sep 2016 https://bugs.erlang.org/browse/ERL-250
+    ENV.deparallelize
     system "make"
-    ENV.j1 # Install is not thread-safe; can try to create folder twice and fail
     system "make", "install"
 
     if build.with? "docs"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The `erlang` formula fails consistently in the `make` step of compilation on macOS Sierra Public Beta Build 16A313a with the following error messages in `~/Library/Logs/Homebrew/erlang/03.make`, starting at line 3833:

```
=== Leaving application hipe
echo "OTP built" > /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/make/otp_built
sed -e 's;%SYS_VSN%;19;' \
            -e 's;%ERTS_VSN%;8.0.2;' \
            -e 's;%KERNEL_VSN%;5.0;' \
            -e 's;%STDLIB_VSN%;3.0.1;' \
          /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_clean.rel.src > /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_clean.rel
sed -e 's;%SYS_VSN%;19;' \
            -e 's;%ERTS_VSN%;8.0.2;' \
            -e 's;%KERNEL_VSN%;5.0;' \
            -e 's;%STDLIB_VSN%;3.0.1;' \
            -e 's;%SASL_VSN%;3.0;' \
          /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_sasl.rel.src > /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_sasl.rel
sed -e 's;%SYS_VSN%;19;' \
            -e 's;%ERTS_VSN%;8.0.2;' \
            -e 's;%KERNEL_VSN%;5.0;' \
            -e 's;%STDLIB_VSN%;3.0.1;' \
            -e 's;%SASL_VSN%;3.0;' \
            -e 's;%OS_MON_VSN%;2.4.1;' \
            -e 's;%MNESIA_VSN%;4.14;' \
            -e 's;%SNMP_VSN%;;' \
            -e 's;%INETS_VSN%;6.3.1;' \
          /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_all_example.rel.src > /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_all_example.rel
sed -e 's;%SYS_VSN%;19;' \
            -e 's;%ERTS_VSN%;8.0.2;' \
            -e 's;%KERNEL_VSN%;5.0;' \
            -e 's;%STDLIB_VSN%;3.0.1;' \
          /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/no_dot_erlang.rel.src > /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/no_dot_erlang.rel
/usr/bin/install -c -d /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/tmp
/usr/bin/install -c -d /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/tmp
install: mkdir /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/tmp: File exists
make[2]: *** [/private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_clean.boot] Error 71
make[2]: *** Waiting for unfinished jobs....
( cd /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/tmp && \
    erlc -W   -I/private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/lib/kernel/ebin -I/private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/lib/stdlib/ebin -I/private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/lib/sasl/ebin +no_warn_sasl -o /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/start_clean.rel )
make[1]: *** [local_setup] Error 2
make: *** [local_setup] Error 2
```

Interestingly this line invoking `install` is there twice:

```
/usr/bin/install -c -d /private/tmp/erlang-20160902-36780-1v4kxuu/otp-OTP-19.0.2/erts/start_scripts/tmp
```

So it fails the second time when the `tmp` directory already exists.

The formula has a helpful comment that hints at a thread safety issue with `install`:

```
ENV.j1 # Install is not thread-safe; can try to create folder twice and fail
system "make", "install"
```

Since `install` is not only called in the `make install` phase but but already in the `make` phase and causes issues there, moving `ENV.j1` up one line, above the `make`, solves this issue for me.

I cannot say for sure whether this issue is specific to macOS Sierra or I just run into it because there are no bottles available yet for Sierra.

I installed the formula with the `--without-wxmac` option since it is currently not supported on Sierra.
