### PR TITLE
hubflow: specify revision in addition to tag

### DIFF
--- a/Formula/hubflow.rb
+++ b/Formula/hubflow.rb
@@ -2,7 +2,9 @@
 class Hubflow < Formula
   desc "GitFlow for GitHub"
   homepage "https://datasift.github.io/gitflow/"
-  url "https://github.com/datasift/gitflow.git", :tag => "1.5.2"
+  url "https://github.com/datasift/gitflow.git",
+    :tag => "1.5.2",
+    :revision => "8bb7890b39f782864d55cfca5a156c926fa53c0d"
   head "https://github.com/datasift/gitflow.git"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Turns out there's only one formula with this problem so I figured I'd just make the PR.

This pull request adds a `:revision` to the hubflow `url` stanza so the tag can't be swapped out maliciously.
