### PR TITLE
collectd: depend on Homebrew net-snmp

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -32,7 +32,7 @@ class Collectd < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf-c" => :optional
   depends_on :java => :optional
-  depends_on "openssl"
+  depends_on "net-snmp"
 
   fails_with :clang do
     build 318


### PR DESCRIPTION
Avoid linking to system openssl.

Closes #4442.
