### PR TITLE
dovecot 2.2.25, with dovecot-pigeonhole 0.4.15

### DIFF
--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -5,6 +5,12 @@ class Dovecot < Formula
   mirror "https://fossies.org/linux/misc/dovecot-2.2.25.tar.gz"
   sha256 "d8d9f32c846397f7c22749a84c5cf6f59c55ff7ded3dc9f07749a255182f9667"
 
+  bottle do
+    sha256 "6ce8e803e9928bbaa63f5e1a5bc86e035138b02fd5b8c9337eab860ed1344fb8" => :el_capitan
+    sha256 "a7edbef68eff6834c88719ff4c86c576e7267214b813f2ec7c0ca102a2ca46f4" => :yosemite
+    sha256 "9cc3b02b610622cf9fffa4c882b0731e1d9e3e4e08fc62ba788463f23dd61858" => :mavericks
+  end
+
   option "with-pam", "Build with PAM support"
   option "with-pigeonhole", "Add Sieve addon for Dovecot mailserver"
   option "with-pigeonhole-unfinished-features", "Build unfinished new Sieve addon features/extensions"

--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -1,15 +1,9 @@
 class Dovecot < Formula
   desc "IMAP/POP3 server"
   homepage "http://dovecot.org/"
-  url "http://dovecot.org/releases/2.2/dovecot-2.2.24.tar.gz"
-  mirror "https://fossies.org/linux/misc/dovecot-2.2.24.tar.gz"
-  sha256 "71c86891ea8deb5703d3dbbc3ea31ce2cbf7638f1aa395d9e8794d3ff7aebeb7"
-
-  bottle do
-    sha256 "6ce8e803e9928bbaa63f5e1a5bc86e035138b02fd5b8c9337eab860ed1344fb8" => :el_capitan
-    sha256 "a7edbef68eff6834c88719ff4c86c576e7267214b813f2ec7c0ca102a2ca46f4" => :yosemite
-    sha256 "9cc3b02b610622cf9fffa4c882b0731e1d9e3e4e08fc62ba788463f23dd61858" => :mavericks
-  end
+  url "http://dovecot.org/releases/2.2/dovecot-2.2.25.tar.gz"
+  mirror "https://fossies.org/linux/misc/dovecot-2.2.25.tar.gz"
+  sha256 "d8d9f32c846397f7c22749a84c5cf6f59c55ff7ded3dc9f07749a255182f9667"
 
   option "with-pam", "Build with PAM support"
   option "with-pigeonhole", "Add Sieve addon for Dovecot mailserver"
@@ -20,8 +14,8 @@ class Dovecot < Formula
   depends_on "clucene" => :optional
 
   resource "pigeonhole" do
-    url "http://pigeonhole.dovecot.org/releases/2.2/dovecot-2.2-pigeonhole-0.4.13.tar.gz"
-    sha256 "7fd187b8393a5048b302f90ad84adc7bf6e73bf79fd8d22a1c1aaa71f836a910"
+    url "http://pigeonhole.dovecot.org/releases/2.2/dovecot-2.2-pigeonhole-0.4.15.tar.gz"
+    sha256 "c99ace6ead310c6c3b639922da618f90d846307da4fe252d994e5e51bf8a3de3"
   end
 
   resource "stemmer" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Attached diff updates to 2.2.25, and dovecot-pigeonhole to 0.4.15
