### PR TITLE
update the sha256 for cli53

### DIFF
--- a/Formula/cli53.rb
+++ b/Formula/cli53.rb
@@ -2,7 +2,7 @@ class Cli53 < Formula
   desc "command-line tool for Amazon Route 53"
   homepage "https://github.com/barnybug/cli53"
   url "https://github.com/barnybug/cli53/archive/0.8.0.tar.gz"
-  sha256 "1efd7b951a74ccc31b3392e19955eaa8c336b35815e24118103155c5b4a9a4a2"
+  sha256 "0a87de05110d9bba851ba3522a1072494256e31fa653f59331313bff21d5c160"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Was getting this

```
Error: SHA256 mismatch
Expected: 1efd7b951a74ccc31b3392e19955eaa8c336b35815e24118103155c5b4a9a4a2
Actual: 0a87de05110d9bba851ba3522a1072494256e31fa653f59331313bff21d5c160
Archive: /Users/tom/Library/Caches/Homebrew/cli53-0.8.0.tar.gz
```
