### PR TITLE
nginx: have head depends on openssl@1.1

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -28,9 +28,8 @@ class Nginx < Formula
   deprecated_option "with-spdy" => "with-http2"
 
   depends_on "pcre"
+  depends_on "openssl"
   depends_on "passenger" => :optional
-  depends_on "openssl" => :recommended
-  depends_on "libressl" => :optional
 
   def install
     # Changes default port to 8080
@@ -41,19 +40,13 @@ class Nginx < Formula
 
     pcre = Formula["pcre"]
     openssl = Formula["openssl"]
-    libressl = Formula["libressl"]
 
     if build.head?
       openssl = Formula["openssl@1.1"]
     end
 
-    if build.with? "libressl"
-      cc_opt = "-I#{pcre.include} -I#{libressl.include}"
-      ld_opt = "-L#{pcre.lib} -L#{libressl.lib}"
-    else
-      cc_opt = "-I#{pcre.include} -I#{openssl.include}"
-      ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"
-    end
+    cc_opt = "-I#{pcre.include} -I#{openssl.include}"
+    ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -43,6 +43,10 @@ class Nginx < Formula
     openssl = Formula["openssl"]
     libressl = Formula["libressl"]
 
+    if build.head?
+      openssl = Formula["openssl@1.1"]
+    end
+
     if build.with? "libressl"
       cc_opt = "-I#{pcre.include} -I#{libressl.include}"
       ld_opt = "-L#{pcre.lib} -L#{libressl.lib}"

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -1,9 +1,13 @@
 class Nginx < Formula
   desc "HTTP(S) server and reverse proxy, and IMAP/POP3 proxy server"
   homepage "https://nginx.org/"
-  url "https://nginx.org/download/nginx-1.10.1.tar.gz"
-  sha256 "1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801"
-  head "http://hg.nginx.org/nginx/", :using => :hg
+
+  stable do
+    url "https://nginx.org/download/nginx-1.10.1.tar.gz"
+    sha256 "1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801"
+
+    depends_on "openssl"
+  end
 
   bottle do
     sha256 "2b67c86454cc67bdeb2a637d9872ae471a810d8a2dae40b6a0c1dad7b253d30d" => :el_capitan
@@ -14,6 +18,14 @@ class Nginx < Formula
   devel do
     url "https://nginx.org/download/nginx-1.11.3.tar.gz"
     sha256 "4a667f40f9f3917069db1dea1f2d5baa612f1fa19378aadf71502e846a424610"
+
+    depends_on "openssl"
+  end
+
+  head do
+    url "http://hg.nginx.org/nginx/", :using => :hg
+
+    depends_on "openssl@1.1"
   end
 
   # Before submitting more options to this formula please check they aren't
@@ -28,7 +40,6 @@ class Nginx < Formula
   deprecated_option "with-spdy" => "with-http2"
 
   depends_on "pcre"
-  depends_on "openssl"
   depends_on "passenger" => :optional
 
   def install
@@ -39,11 +50,7 @@ class Nginx < Formula
     end
 
     pcre = Formula["pcre"]
-    openssl = Formula["openssl"]
-
-    if build.head?
-      openssl = Formula["openssl@1.1"]
-    end
+    openssl = build.head? ? Formula["openssl@1.1"] : Formula["openssl"]
 
     cc_opt = "-I#{pcre.include} -I#{openssl.include}"
     ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"


### PR DESCRIPTION
Add build with openssl@1.1 support, there will be an option parsed as `--with-openssl@1.1` on `brew info nginx`. It looks a little bit creepy but I don't know how to customize the parsed option.

Now it can only be built on `--HEAD`, so one can looking forward to build on 1.11.4.
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
