### PR TITLE
bind: enable +sigchase in dig

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -21,6 +21,9 @@ class Bind < Formula
     # libxml2 appends one inc dir to CPPFLAGS but bind ignores CPPFLAGS
     ENV.append "CFLAGS", ENV.cppflags
 
+    # enable DNSSEC signature chasing in dig
+    ENV["STD_CDEFINES"] = "-DDIG_SIGCHASE=1"
+
     json = build.with?("json-c") ? "yes" : "no"
     system "./configure", "--prefix=#{prefix}",
                           "--enable-threads",


### PR DESCRIPTION
Allows dig to perform DNSSEC validation.
