### PR TITLE
wego 2.0 (new formula)

### DIFF
--- a/Formula/wego.rb
+++ b/Formula/wego.rb
@@ -1,0 +1,39 @@
+require "language/go"
+
+class Wego < Formula
+  desc "Weather app for the terminal"
+  homepage "https://github.com/schachmat/wego"
+  url "https://github.com/schachmat/wego/archive/2.0.tar.gz"
+  sha256 "d63d79520b385c4ed921c7decc37a0b85c40af66600f8a5733514e04d3048075"
+  head "https://github.com/schachmat/wego.git"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/mattn/go-colorable" do
+    url "https://github.com/mattn/go-colorable.git",
+        :revision => "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
+  end
+
+  go_resource "github.com/mattn/go-runewidth" do
+    url "https://github.com/mattn/go-runewidth.git",
+        :revision => "d6bea18f789704b5f83375793155289da36a3c7f"
+  end
+
+  go_resource "github.com/schachmat/ingo" do
+    url "https://github.com/schachmat/ingo.git",
+        :revision => "b1887f863beaeb31b3924e839dfed3cf3a981ea8"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/schachmat").mkpath
+    ln_sf buildpath, buildpath/"src/github.com/schachmat/wego"
+    Language::Go.stage_deps resources, buildpath/"src"
+    system "go", "build", "-o", bin/"wego"
+  end
+
+  test do
+    ENV["WEGORC"] = testpath/".wegorc"
+    assert_match /No .*API key specified./, shell_output("#{bin}/wego 2>&1", 1)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The test is currently written to detect the "No API key specified." error in `wego`'s output. In order to have it do anything useful one has to donate a forecast.io or Worldweatheronline API key, which is probably not a good idea to include as clear text in a public formula.

By the way, maybe the process for creating formulae in languages like Go, Haskell and <s>Python</s> (I forgot Python is [documented](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Python-for-Formula-Authors.md)) could be documented somewhere? I personally have very limited experience with Go, and had to sift through the issue tracker to find out how the `go_resources` could be generated automatically (fortunately I've read some of the relevant discussions before and thus had some keywords in mind to search), then model the `install` block on existing `language/go`-using formulae (and they are quite inconsistent 😓 ).
