### PR TITLE
openssl@1.1: remove unnecessary build option

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -37,6 +37,9 @@ class OpensslAT11 < Formula
   def configure_args; %W[
     --prefix=#{prefix}
     --openssldir=#{openssldir}
+    no-ssl3
+    no-ssl3-method
+    no-zlib
   ]
   end
 

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -37,10 +37,6 @@ class OpensslAT11 < Formula
   def configure_args; %W[
     --prefix=#{prefix}
     --openssldir=#{openssldir}
-    no-ssl3
-    no-ssl3-method
-    no-zlib
-    enable-cms
   ]
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
- `enable-cms` is a no-op and the feature is enabled by default
