### PR TITLE
amap: fix openssl build

### DIFF
--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -3,7 +3,7 @@ class Amap < Formula
   homepage "https://www.thc.org/thc-amap/"
   url "https://www.thc.org/releases/amap-5.4.tar.gz"
   sha256 "a75ea58de75034de6b10b0de0065ec88e32f9e9af11c7d69edbffc4da9a5b059"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,11 +16,28 @@ class Amap < Formula
   depends_on "openssl"
 
   def install
+    # Last release was 2011 & there's nowhere supported to report this.
+    openssl = Formula["openssl"]
+    inreplace "configure" do |s|
+      s.gsub! 'SSL_IPATH=""', "SSL_IPATH=\"#{openssl.opt_include}/openssl\""
+      s.gsub! 'SSL_PATH=""', "SSL_PATH=\"#{openssl.opt_lib}\""
+      s.gsub! 'CRYPTO_PATH=""', "CRYPTO_PATH=\"#{openssl.opt_lib}\""
+    end
+
     system "./configure", "--prefix=#{prefix}"
     system "make"
 
     # --prefix doesn't work as we want it to so install manually
     bin.install "amap", "amap6", "amapcrap"
+    etc.install "appdefs.resp", "appdefs.rpc", "appdefs.trig"
     man1.install "amap.1"
+  end
+
+  test do
+    output = shell_output("otool -L #{bin}/amap")
+    assert_match Formula["openssl"].opt_lib.to_s, output
+    # We can do more than this, but unsure how polite it is to port-scan
+    # someone's domain every time this goes through CI.
+    assert_match version.to_s, shell_output("#{bin}/amap", 255)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

If it can't link to OpenSSL, it silently skips over it. This seems to have been linking to the system OpenSSL on Yosemite and below, and skipping over SSL support for El Cap & above. We might want to just boneyard instead given this is unsupported.

Also: Install required files in etc, add linking/version tests.
