### PR TITLE
PostgreSQL 9.6rc1 (devel)

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -12,9 +12,8 @@ class Postgresql < Formula
   end
 
   devel do
-    url "https://ftp.postgresql.org/pub/source/v9.6beta4/postgresql-9.6beta4.tar.gz"
-    version "9.6beta4"
-    sha256 "6fb1bdade1754f3f29626e8e4cbf3f269e107e0d496ed07e8b693175afc44562"
+    url "https://ftp.postgresql.org/pub/source/v9.6rc1/postgresql-9.6rc1.tar.gz"
+    sha256 "a202c0bfba27f4dd612c01a4a4f6de1f5b42ada27471f8cb6a59df150cfe71c9"
   end
 
   option "32-bit"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

1st September 2016 PostgreSQL have released their first release candidate of upcoming 9.6 version.

See more at official announcement: https://www.postgresql.org/about/news/1693/

Due to `brew audit postgresql` complaints removed explicit version specification.
