### PR TITLE
imagemagick: unrecommend opencl and improve test

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -139,6 +139,11 @@ class Imagemagick < Formula
   end
 
   test do
-    system "#{bin}/identify", test_fixtures("test.png")
+    assert_match "PNG", shell_output("#{bin}/identify #{test_fixtures("test.png")}")
+    # Check support for recommended features and delegates.
+    features = shell_output("#{bin}/convert -version")
+    %W[Modules freetype jpeg png tiff].each do |feature|
+      assert_match feature, features
+    end
   end
 end

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -7,6 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick-6.9.5-9.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.5-9.tar.xz"
   sha256 "9c4f300daae165a6bcf46779876f9361a958076f8cd59fa203d84c70ba5bc183"
+  revision 1
   head "http://git.imagemagick.org/repos/ImageMagick.git"
 
   bottle do
@@ -18,12 +19,12 @@ class Imagemagick < Formula
 
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
+  option "with-opencl", "Compile with OpenCL support"
   option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
   option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
   option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit"
   option "with-quantum-depth-32", "Compile with a quantum depth of 32 bit"
-  option "without-opencl", "Disable OpenCL"
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-modules", "Disable support for dynamically loadable modules"
   option "without-threads", "Disable threads support"
@@ -76,6 +77,12 @@ class Imagemagick < Formula
       args << "--with-modules"
     end
 
+    if build.with? "opencl"
+      args << "--enable-opencl"
+    else
+      args << "--disable-opencl"
+    end
+
     if build.with? "openmp"
       args << "--enable-openmp"
     else
@@ -94,7 +101,6 @@ class Imagemagick < Formula
       args << "--without-openjp2"
     end
 
-    args << "--disable-opencl" if build.without? "opencl"
     args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
     args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I noticed the OpenCL issue back when I was working on #3511. As described in the commit message:

> OpenCL support is something to be --enable'd. We've only been specifying
> --disable-opencl when building --without, meaning that no build
> setting (bottle or source, with or without options) ever supported
> OpenCL since upstream made OpenCL opt-in. Miraculously though, no one
> ever complained, so it's probably safe to unrecommend it.
> 
> Also, from personal testing building with proper OpenCL support actually
> crashes IM. See details below. Might be related:
> https://www.imagemagick.org/discourse-server/viewtopic.php?t=24603.

I'm still in favor of more systematic treatment of build options (as in #3511), but if we only want to address user-reported issues (this PR itself contains a user — that's me — reported issue), this is it. CC @MikeMcQuaid.
## Details about the OpenCL problem (you shouldn't need to care)

More specifically, even when we use IM's default for everything else, building with `--enable-opencl` could lead to crashes in the most basic commands (like `convert <infile> -resize <width>x<height> <outfile>`). Last time I checked I got a segfault. Today the crash had more a helpful message (that's running inside Fusion though, I didn't bother to touch my main installation):

```
Assertion failed: (cache_info->opencl != (OpenCLCacheInfo *) NULL), function GetOpenCLEvents, file magick/cache.c, line 1699.
Abort trap: 6
```

Still. I don't care about OpenCL support (and no one does it seems), so I'm not gonna waste time debugging this.
