### PR TITLE
curl: migrate to openssl@1.1

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -3,6 +3,7 @@ class Curl < Formula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.50.2.tar.bz2"
   sha256 "0c72105df4e9575d68bcf43aea1751056c1d29b1040df6194a49c5ac08f8e233"
+  revision 1
 
   bottle do
     cellar :any
@@ -31,10 +32,10 @@ class Curl < Formula
   # HTTP/2 support requires OpenSSL 1.0.2+ or LibreSSL 2.1.3+ for ALPN Support
   # which is currently not supported by Secure Transport (DarwinSSL).
   if MacOS.version < :mountain_lion || (build.with?("nghttp2") && build.without?("libressl"))
-    depends_on "openssl"
+    depends_on "openssl@1.1"
   else
     option "with-openssl", "Build with OpenSSL instead of Secure Transport"
-    depends_on "openssl" => :optional
+    depends_on "openssl@1.1" => :optional
   end
 
   depends_on "pkg-config" => :build
@@ -71,9 +72,9 @@ class Curl < Formula
       args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
       args << "--with-ca-bundle=#{etc}/libressl/cert.pem"
     elsif MacOS.version < :mountain_lion || build.with?("openssl") || build.with?("nghttp2")
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl"].opt_lib}/pkgconfig"
-      args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
-      args << "--with-ca-bundle=#{etc}/openssl/cert.pem"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl@1.1"].opt_lib}/pkgconfig"
+      args << "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+      args << "--with-ca-bundle=#{etc}/openssl@1.1/cert.pem"
     else
       args << "--with-darwinssl"
     end


### PR DESCRIPTION
Migrate curl openssl dependency to 1.1. I built locally and passed the brew test. If anything depends both on curl and OpenSSL, will there be any conflicts between curl's linked OpenSSL and the other?

By the way, `#{etc}/openssl@1.1/cert.pem` usage makes me a little bit awkward, we don't have anything like `Formula["openssl@1.1"].etc_prefix`?

I am also not sure whether I should add revision since OpenSSL is only an optional dependency. I could not find any related guidelines on [here](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md#formulae-revisions).

It looks more complicated than I thought, see [here](https://github.com/Homebrew/homebrew-core/issues/4543), maybe we shall wait for other upstream to adapt to OpenSSL before upgrading curl's OpenSSL dependency?

---
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
