### PR TITLE
protobuf 3.0.2 (devel)

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -19,9 +19,8 @@ class Protobuf < Formula
   end
 
   devel do
-    url "https://github.com/google/protobuf/archive/v3.0.0-beta-4.tar.gz"
-    sha256 "132ba7654ee45f5cbbd33fa8f2c9efa25f2193640e42098029bfa993a8360a9c"
-    version "3.0.0-beta-4"
+    url "https://github.com/google/protobuf/archive/v3.0.2.tar.gz"
+    sha256 "b700647e11556b643ccddffd1f41d8cb7704ed02090af54cc517d44d912d11c1"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
Updated location, removed `version` as `audit` insisted.
