### PR TITLE
Pango: Add back optional X11 support

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -22,6 +22,7 @@ class Pango < Formula
   option :universal
 
   depends_on "pkg-config" => :build
+  depends_on :x11 => :optional
   depends_on "glib"
   depends_on "cairo"
   depends_on "harfbuzz"
@@ -43,9 +44,14 @@ class Pango < Formula
       --enable-man
       --with-html-dir=#{share}/doc
       --enable-introspection=yes
-      --without-xft
       --enable-static
     ]
+
+    if build.with? "x11"
+      args << "--with-xft"
+    else
+      args << "--without-xft"
+    end
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Closes #4602
