### PR TITLE
httpstat 1.1.2 (new formula)

### DIFF
--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -1,10 +1,11 @@
 class Httpstat < Formula
   desc "Curl statistics made simple"
   homepage "https://github.com/reorx/httpstat"
-  url "https://github.com/reorx/httpstat/archive/v1.1.2.tar.gz"
-  sha256 "0468abebfbae9ff7ea35d577b60ff9af9db3ff67ffd81b11ac005c4e9602919b"
+  url "https://github.com/reorx/httpstat/archive/v1.1.3.tar.gz"
+  sha256 "8ba3a8f0550468a634dce45d45dc03375e5dcdedea4c8edc8c26a326d929af04"
 
   depends_on :python if MacOS.version <= :snow_leopard
+  bottle :unneeded
 
   def install
     bin.install "httpstat.py" => "httpstat"

--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -2,14 +2,13 @@ class Httpstat < Formula
   desc "curl statistics made simple"
   homepage "https://github.com/reorx/httpstat"
   url "https://github.com/reorx/httpstat/archive/v1.1.2.tar.gz"
-  version "1.1.2"
   sha256 "0468abebfbae9ff7ea35d577b60ff9af9db3ff67ffd81b11ac005c4e9602919b"
 
   bottle :unneeded
 
   def install
-      bin.install "httpstat.py"
-      mv bin/"httpstat.py", bin/"httpstat"
+    bin.install "httpstat.py"
+    mv bin/"httpstat.py", bin/"httpstat"
   end
 
   test do

--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -11,6 +11,6 @@ class Httpstat < Formula
   end
 
   test do
-    assert_match "HTTP/1.1", shell_output("#{bin}/httpstat https://github.com")
+    assert_match "HTTP", shell_output("#{bin}/httpstat https://github.com")
   end
 end

--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -1,17 +1,16 @@
 class Httpstat < Formula
-  desc "curl statistics made simple"
+  desc "Curl statistics made simple"
   homepage "https://github.com/reorx/httpstat"
   url "https://github.com/reorx/httpstat/archive/v1.1.2.tar.gz"
   sha256 "0468abebfbae9ff7ea35d577b60ff9af9db3ff67ffd81b11ac005c4e9602919b"
 
-  bottle :unneeded
+  depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    bin.install "httpstat.py"
-    mv bin/"httpstat.py", bin/"httpstat"
+    bin.install "httpstat.py" => "httpstat"
   end
 
   test do
-    system "#{bin}/httpstat", "https://github.com"
+    assert_match "HTTP/1.1", shell_output("#{bin}/httpstat https://github.com")
   end
 end

--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -1,0 +1,18 @@
+class Httpstat < Formula
+  desc "curl statistics made simple"
+  homepage "https://github.com/reorx/httpstat"
+  url "https://github.com/reorx/httpstat/archive/v1.1.2.tar.gz"
+  version "1.1.2"
+  sha256 "0468abebfbae9ff7ea35d577b60ff9af9db3ff67ffd81b11ac005c4e9602919b"
+
+  bottle :unneeded
+
+  def install
+      bin.install "httpstat.py"
+      mv bin/"httpstat.py", bin/"httpstat"
+  end
+
+  test do
+    system "#{bin}/httpstat", "https://github.com"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?
  
  Not exactly, according to the Brew Cookbook, `brew audit --strict --online $FORMULA` test passed, however `brew audit --new-formula <formula>` didn't pass with the following:
  
  ```
  httpstat:
  * GitHub repository too new (<30 days old)
  Error: 1 problem in 1 formula
  ```
  
  which seems not a problem for submitting this pull request.

---
