### PR TITLE
tinyproxy: fix inreplace paths

### DIFF
--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -43,8 +43,8 @@ class Tinyproxy < Formula
 
     # Fix broken XML lint
     # See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154624
-    inreplace %w[docs/man5/Makefile docs/man8/Makefile"], "-f manpage",
-                                                          "-f manpage \\\n  -L"
+    inreplace %w[docs/man5/Makefile docs/man8/Makefile], "-f manpage",
+                                                         "-f manpage \\\n  -L"
 
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

A find/replace on `inreplace` usage in https://github.com/Homebrew/homebrew-core/commit/81a388329079f64936f374ef0732fd25dcf6ee3a broke the tinyproxy formula by leaving a quote in a filename when it should've been stripped.
