### PR TITLE
freetype: in `freetype-config` and `freetype2.pc`, replace `prefix` with `opt_prefix`

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -34,6 +34,9 @@ class Freetype < Formula
     system "./configure", "--prefix=#{prefix}", "--without-harfbuzz"
     system "make"
     system "make", "install"
+
+    inreplace [bin/"freetype-config", lib/"pkgconfig/freetype2.pc"],
+      prefix, opt_prefix
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This fixes https://github.com/Homebrew/legacy-homebrew/pull/44587#issuecomment-145355908.
