### PR TITLE
tldr 1.3.0 (new formula)

### DIFF
--- a/Formula/tldr.rb
+++ b/Formula/tldr.rb
@@ -1,0 +1,18 @@
+class Tldr < Formula
+  desc "Simplified and community-driven man pages"
+  homepage "https://tldr-pages.github.io"
+  url "https://github.com/tldr-pages/tldr-cpp-client/archive/v1.3.0.tar.gz"
+  sha256 "6210ece3f5d8f8e55b404e2f6c84be50bfdde9f0d194a271bce751a3ed6141be"
+  head "https://github.com/tldr-pages/tldr-cpp-client.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "libzip"
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  test do
+    assert_match "brew", shell_output("#{bin}/tldr brew")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The formula doesn't pass audit because the tldr-cpp-client doesn't have enough users.

```
$ brew audit --new-formula tldr
tldr:
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
Error: 1 problem in 1 formula
```

A similar PR was rejected in https://github.com/Homebrew/legacy-homebrew/pull/47867 because it doesn't have enough users. At first glance, this Formula would seem to have the same problem. 

However the main repo which has the users, contributions, and attention is https://github.com/tldr-pages/tldr. From that repo, you can install an NPM plugin which provides tldr results. However that has obvious issues, the biggest for me is that npm is not homebrew. That is the reasoning for adding this formula instead.

This formula was taken from https://github.com/tldr-pages/homebrew-tldr.
