### PR TITLE
trace2html 2016-09-08

### DIFF
--- a/Formula/trace2html.rb
+++ b/Formula/trace2html.rb
@@ -1,8 +1,9 @@
 class Trace2html < Formula
   desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
-  homepage "https://github.com/google/trace-viewer"
-  url "https://github.com/google/trace-viewer/archive/2015-06-23.tar.gz"
-  sha256 "97ad0ca9c07a50c53a3d881b69b6b6f7424d6b0f4d9e9fb531c2d9273e413f19"
+  homepage "https://github.com/catapult-project/catapult"
+  url "https://github.com/catapult-project/catapult/archive/328391fbc1e3f931caf93d1e3f50d1643e624560.tar.gz"
+  version "2016-09-08"
+  sha256 "4439ba9037cd1328c7dcc4723537e02dfd99efad36363e025e06ab42c0b99c71"
 
   bottle :unneeded
 
@@ -10,7 +11,7 @@ class Trace2html < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"trace2html"
+    bin.install_symlink libexec/"tracing/bin/trace2html"
   end
 
   test do


### PR DESCRIPTION
Pulled from latest master, update to fix Chrome compatibility when viewing trace and pull in this patch that fixes Homebrew symlinks:
https://codereview.chromium.org/2134613003/

The repo moved from trace-viewer to catapult which does not have tags / releases, which is why I am pulling directly from the latest commit. The fixes upstream and in this formula should make it trivial to update to a newer version of catapult in the future.
