### PR TITLE
darcs 2.12.2

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -5,8 +5,8 @@ class Darcs < Formula
 
   desc "Distributed version control system that tracks changes, via Haskell"
   homepage "http://darcs.net/"
-  url "https://hackage.haskell.org/package/darcs-2.12.0/darcs-2.12.0.tar.gz"
-  sha256 "17318d1b49ca4b1aa00a4bffc2ab30a448e7440ce1945eed9bf382d77582308d"
+  url "https://hackage.haskell.org/package/darcs-2.12.2/darcs-2.12.2.tar.gz"
+  sha256 "20b2eb292854c89036bae74330e71f1f3b253a369610916ddcc44f0d49f38bdd"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,14 +21,6 @@ class Darcs < Formula
   depends_on "gmp"
 
   def install
-    # GHC 8 compat
-    # Fixes the build error:
-    #   checking whether to use -liconv...
-    #   dist/dist-sandbox-296ea86f/setup/setup.hs:149:15-41: Irrefutable pattern
-    #   failed for pattern Just lib
-    # Reported 26 May 2016: http://bugs.darcs.net/issue2498
-    (buildpath/"cabal.config").write("allow-newer: base\n")
-
     install_cabal_package
   end
 


### PR DESCRIPTION
GHC 8 patch is no longer needed.
