### PR TITLE
Make all go_resource's consistent in indentation style 

### DIFF
--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -69,17 +69,17 @@ class Algernon < Formula
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "5bcd134fee4dd1475da17714aac19c0aa0142e2f"
+        :revision => "5bcd134fee4dd1475da17714aac19c0aa0142e2f"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "c4c3ea71919de159c9e246d7be66deb7f0a39a58"
+        :revision => "c4c3ea71919de159c9e246d7be66deb7f0a39a58"
   end
 
   go_resource "golang.org/x/sys" do
     url "https://go.googlesource.com/sys.git",
-      :revision => "076b546753157f758b316e59bcb51e6807c04057"
+        :revision => "076b546753157f758b316e59bcb51e6807c04057"
   end
 
   def install

--- a/Formula/apache-brooklyn-cli.rb
+++ b/Formula/apache-brooklyn-cli.rb
@@ -17,12 +17,12 @@ class ApacheBrooklynCli < Formula
 
   go_resource "github.com/codegangsta/cli" do
     url "https://github.com/codegangsta/cli.git",
-      :revision => "5db74198dee1cfe60cf06a611d03a420361baad6"
+        :revision => "5db74198dee1cfe60cf06a611d03a420361baad6"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://github.com/golang/crypto.git",
-      :revision => "1f22c0103821b9390939b6776727195525381532"
+        :revision => "1f22c0103821b9390939b6776727195525381532"
   end
 
   def install

--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -18,22 +18,22 @@ class Aptly < Formula
 
   go_resource "github.com/daviddengcn/go-colortext" do
     url "https://github.com/daviddengcn/go-colortext.git",
-    :revision => "511bcaf42ccd42c38aba7427b6673277bf19e2a1"
+        :revision => "511bcaf42ccd42c38aba7427b6673277bf19e2a1"
   end
 
   go_resource "github.com/hashicorp/go-version" do
     url "https://github.com/hashicorp/go-version.git",
-    :revision => "0181db47023708a38c2d20d2fe25a5fa034d5743"
+        :revision => "0181db47023708a38c2d20d2fe25a5fa034d5743"
   end
 
   go_resource "github.com/mattn/gover" do
     url "https://github.com/mattn/gover.git",
-    :revision => "715629d6b57a2104c5221dc72514cfddc992e1de"
+        :revision => "715629d6b57a2104c5221dc72514cfddc992e1de"
   end
 
   go_resource "github.com/mattn/gom" do
     url "https://github.com/mattn/gom.git",
-    :revision => "393e714d663c35e121a47fec32964c44a630219b"
+        :revision => "393e714d663c35e121a47fec32964c44a630219b"
   end
 
   def install

--- a/Formula/cig.rb
+++ b/Formula/cig.rb
@@ -19,11 +19,13 @@ class Cig < Formula
   depends_on "godep" => :build
 
   go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+    url "https://github.com/kr/fs.git",
+        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
   end
 
   go_resource "golang.org/x/tools" do
-    url "https://github.com/golang/tools.git", :revision => "473fd854f8276c0b22f17fb458aa8f1a0e2cf5f5"
+    url "https://github.com/golang/tools.git",
+        :revision => "473fd854f8276c0b22f17fb458aa8f1a0e2cf5f5"
   end
 
   def install

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -27,13 +27,13 @@ class ConsulTemplate < Formula
 
   go_resource "github.com/mitchellh/gox" do
     url "https://github.com/mitchellh/gox.git",
-    :revision => "6e9ee79eab7bb1b84155379b3f94ff9a87b344e4"
+        :revision => "6e9ee79eab7bb1b84155379b3f94ff9a87b344e4"
   end
 
   # gox dependency
   go_resource "github.com/mitchellh/iochan" do
     url "https://github.com/mitchellh/iochan.git",
-    :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
+        :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
   end
 
   def install

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -22,152 +22,152 @@ class Consul < Formula
 
   go_resource "github.com/DataDog/datadog-go" do
     url "https://github.com/DataDog/datadog-go.git",
-      :revision => "bc97e0770ad4edae1c9dc14beb40b79b2dde32f8"
+        :revision => "bc97e0770ad4edae1c9dc14beb40b79b2dde32f8"
   end
 
   go_resource "github.com/armon/circbuf" do
     url "https://github.com/armon/circbuf.git",
-      :revision => "bbbad097214e2918d8543d5201d12bfd7bca254d"
+        :revision => "bbbad097214e2918d8543d5201d12bfd7bca254d"
   end
 
   go_resource "github.com/armon/go-metrics" do
     url "https://github.com/armon/go-metrics.git",
-      :revision => "345426c77237ece5dab0e1605c3e4b35c3f54757"
+        :revision => "345426c77237ece5dab0e1605c3e4b35c3f54757"
   end
 
   go_resource "github.com/armon/go-radix" do
     url "https://github.com/armon/go-radix.git",
-      :revision => "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
+        :revision => "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
   end
 
   go_resource "github.com/boltdb/bolt" do
     url "https://github.com/boltdb/bolt.git",
-      :revision => "ee4a0888a9abe7eefe5a0992ca4cb06864839873"
+        :revision => "ee4a0888a9abe7eefe5a0992ca4cb06864839873"
   end
 
   go_resource "github.com/fsouza/go-dockerclient" do
     url "https://github.com/fsouza/go-dockerclient.git",
-      :revision => "25bc220b299845ae5489fd19bf89c5278864b050"
+        :revision => "25bc220b299845ae5489fd19bf89c5278864b050"
   end
 
   go_resource "github.com/hashicorp/errwrap" do
     url "https://github.com/hashicorp/errwrap.git",
-      :revision => "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+        :revision => "7554cd9344cec97297fa6649b055a8c98c2a1e55"
   end
 
   go_resource "github.com/hashicorp/go-checkpoint" do
     url "https://github.com/hashicorp/go-checkpoint.git",
-      :revision => "e4b2dc34c0f698ee04750bf2035d8b9384233e1b"
+        :revision => "e4b2dc34c0f698ee04750bf2035d8b9384233e1b"
   end
 
   go_resource "github.com/hashicorp/go-cleanhttp" do
     url "https://github.com/hashicorp/go-cleanhttp.git",
-      :revision => "ce617e79981a8fff618bb643d155133a8f38db96"
+        :revision => "ce617e79981a8fff618bb643d155133a8f38db96"
   end
 
   go_resource "github.com/hashicorp/go-immutable-radix" do
     url "https://github.com/hashicorp/go-immutable-radix.git",
-      :revision => "12e90058b2897552deea141eff51bb7a07a09e63"
+        :revision => "12e90058b2897552deea141eff51bb7a07a09e63"
   end
 
   go_resource "github.com/hashicorp/go-memdb" do
     url "https://github.com/hashicorp/go-memdb.git",
-      :revision => "31949d523ade8a236956c6f1761e9dcf902d1638"
+        :revision => "31949d523ade8a236956c6f1761e9dcf902d1638"
   end
 
   go_resource "github.com/hashicorp/go-msgpack" do
     url "https://github.com/hashicorp/go-msgpack.git",
-      :revision => "fa3f63826f7c23912c15263591e65d54d080b458"
+        :revision => "fa3f63826f7c23912c15263591e65d54d080b458"
   end
 
   go_resource "github.com/hashicorp/go-multierror" do
     url "https://github.com/hashicorp/go-multierror.git",
-      :revision => "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
+        :revision => "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
   end
 
   go_resource "github.com/hashicorp/go-syslog" do
     url "https://github.com/hashicorp/go-syslog.git",
-      :revision => "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
+        :revision => "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
   end
 
   go_resource "github.com/hashicorp/golang-lru" do
     url "https://github.com/hashicorp/golang-lru.git",
-      :revision => "5c7531c003d8bf158b0fe5063649a2f41a822146"
+        :revision => "5c7531c003d8bf158b0fe5063649a2f41a822146"
   end
 
   go_resource "github.com/hashicorp/hcl" do
     url "https://github.com/hashicorp/hcl.git",
-      :revision => "578dd9746824a54637686b51a41bad457a56bcef"
+        :revision => "578dd9746824a54637686b51a41bad457a56bcef"
   end
 
   go_resource "github.com/hashicorp/logutils" do
     url "https://github.com/hashicorp/logutils.git",
-      :revision => "0dc08b1671f34c4250ce212759ebd880f743d883"
+        :revision => "0dc08b1671f34c4250ce212759ebd880f743d883"
   end
 
   go_resource "github.com/hashicorp/memberlist" do
     url "https://github.com/hashicorp/memberlist.git",
-      :revision => "9888dc523910e5d22c5be4f6e34520943df21809"
+        :revision => "9888dc523910e5d22c5be4f6e34520943df21809"
   end
 
   go_resource "github.com/hashicorp/net-rpc-msgpackrpc" do
     url "https://github.com/hashicorp/net-rpc-msgpackrpc.git",
-      :revision => "a14192a58a694c123d8fe5481d4a4727d6ae82f3"
+        :revision => "a14192a58a694c123d8fe5481d4a4727d6ae82f3"
   end
 
   go_resource "github.com/hashicorp/raft" do
     url "https://github.com/hashicorp/raft.git",
-      :revision => "057b893fd996696719e98b6c44649ea14968c811"
+        :revision => "057b893fd996696719e98b6c44649ea14968c811"
   end
 
   go_resource "github.com/hashicorp/raft-boltdb" do
     url "https://github.com/hashicorp/raft-boltdb.git",
-      :revision => "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee"
+        :revision => "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee"
   end
 
   go_resource "github.com/hashicorp/scada-client" do
     url "https://github.com/hashicorp/scada-client.git",
-      :revision => "84989fd23ad4cc0e7ad44d6a871fd793eb9beb0a"
+        :revision => "84989fd23ad4cc0e7ad44d6a871fd793eb9beb0a"
   end
 
   go_resource "github.com/hashicorp/serf" do
     url "https://github.com/hashicorp/serf.git",
-      :revision => "64d10e9428bd70dbcd831ad087573b66731c014b"
+        :revision => "64d10e9428bd70dbcd831ad087573b66731c014b"
   end
 
   go_resource "github.com/hashicorp/yamux" do
     url "https://github.com/hashicorp/yamux.git",
-      :revision => "df949784da9ed028ee76df44652e42d37a09d7e4"
+        :revision => "df949784da9ed028ee76df44652e42d37a09d7e4"
   end
 
   go_resource "github.com/inconshreveable/muxado" do
     url "https://github.com/inconshreveable/muxado.git",
-      :revision => "f693c7e88ba316d1a0ae3e205e22a01aa3ec2848"
+        :revision => "f693c7e88ba316d1a0ae3e205e22a01aa3ec2848"
   end
 
   go_resource "github.com/miekg/dns" do
     url "https://github.com/miekg/dns.git",
-      :revision => "c144371d31e35dc0588755ada496462c102c90a6"
+        :revision => "c144371d31e35dc0588755ada496462c102c90a6"
   end
 
   go_resource "github.com/mitchellh/cli" do
     url "https://github.com/mitchellh/cli.git",
-      :revision => "cb6853d606ea4a12a15ac83cc43503df99fd28fb"
+        :revision => "cb6853d606ea4a12a15ac83cc43503df99fd28fb"
   end
 
   go_resource "github.com/mitchellh/mapstructure" do
     url "https://github.com/mitchellh/mapstructure.git",
-      :revision => "281073eb9eb092240d33ef253c404f1cca550309"
+        :revision => "281073eb9eb092240d33ef253c404f1cca550309"
   end
 
   go_resource "github.com/ryanuber/columnize" do
     url "https://github.com/ryanuber/columnize.git",
-      :revision => "983d3a5fab1bf04d1b412465d2d9f8430e2e917e"
+        :revision => "983d3a5fab1bf04d1b412465d2d9f8430e2e917e"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "3760e016850398b85094c4c99e955b8c3dea5711"
+        :revision => "3760e016850398b85094c4c99e955b8c3dea5711"
   end
 
   resource "web-ui" do

--- a/Formula/cosi.rb
+++ b/Formula/cosi.rb
@@ -17,47 +17,47 @@ class Cosi < Formula
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-      :revision => "f0aeabca5a127c4078abb8c8d64298b147264b55"
+        :revision => "f0aeabca5a127c4078abb8c8d64298b147264b55"
   end
 
   go_resource "github.com/daviddengcn/go-colortext" do
     url "https://github.com/daviddengcn/go-colortext.git",
-      :revision => "511bcaf42ccd42c38aba7427b6673277bf19e2a1"
+        :revision => "511bcaf42ccd42c38aba7427b6673277bf19e2a1"
   end
 
   go_resource "github.com/dedis/crypto" do
     url "https://github.com/dedis/crypto.git",
-      :revision => "d9272cb478c0942e1d60049e6df219cba2067fcd"
+        :revision => "d9272cb478c0942e1d60049e6df219cba2067fcd"
   end
 
   go_resource "github.com/dedis/protobuf" do
     url "https://github.com/dedis/protobuf.git",
-      :revision => "6948fbd96a0f1e4e96582003261cf647dc66c831"
+        :revision => "6948fbd96a0f1e4e96582003261cf647dc66c831"
   end
 
   go_resource "github.com/montanaflynn/stats" do
     url "https://github.com/montanaflynn/stats.git",
-      :revision => "60dcacf48f43d6dd654d0ed94120ff5806c5ca5c"
+        :revision => "60dcacf48f43d6dd654d0ed94120ff5806c5ca5c"
   end
 
   go_resource "github.com/satori/go.uuid" do
     url "https://github.com/satori/go.uuid.git",
-      :revision => "f9ab0dce87d815821e221626b772e3475a0d2749"
+        :revision => "f9ab0dce87d815821e221626b772e3475a0d2749"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "0c607074acd38c5f23d1344dfe74c977464d1257"
+        :revision => "0c607074acd38c5f23d1344dfe74c977464d1257"
   end
 
   go_resource "gopkg.in/codegangsta/cli.v1" do
     url "https://gopkg.in/codegangsta/cli.v1.git",
-      :revision => "01857ac33766ce0c93856370626f9799281c14f4"
+        :revision => "01857ac33766ce0c93856370626f9799281c14f4"
   end
 
   go_resource "gopkg.in/dedis/cothority.v0" do
     url "https://gopkg.in/dedis/cothority.v0.git",
-      :revision => "e5eb384290e5fd98b8cb150a1348661aa2d49e2a"
+        :revision => "e5eb384290e5fd98b8cb150a1348661aa2d49e2a"
   end
 
   def install

--- a/Formula/dockviz.rb
+++ b/Formula/dockviz.rb
@@ -19,47 +19,47 @@ class Dockviz < Formula
 
   go_resource "github.com/Sirupsen/logrus" do
     url "https://github.com/Sirupsen/logrus.git",
-    :revision => "f3cfb454f4c209e6668c95216c4744b8fddb2356"
+        :revision => "f3cfb454f4c209e6668c95216c4744b8fddb2356"
   end
 
   go_resource "github.com/docker/docker" do
     url "https://github.com/docker/docker.git",
-    :revision => "1704914d7cf8318a69ba9712f664cd031b6e61f6"
+        :revision => "1704914d7cf8318a69ba9712f664cd031b6e61f6"
   end
 
   go_resource "github.com/docker/engine-api" do
     url "https://github.com/docker/engine-api.git",
-    :revision => "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
+        :revision => "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
   end
 
   go_resource "github.com/docker/go-units" do
     url "https://github.com/docker/go-units.git",
-    :revision => "f2d77a61e3c169b43402a0a1e84f06daf29b8190"
+        :revision => "f2d77a61e3c169b43402a0a1e84f06daf29b8190"
   end
 
   go_resource "github.com/fsouza/go-dockerclient" do
     url "https://github.com/fsouza/go-dockerclient.git",
-    :revision => "3c8f092cb1e9d1e18a07c1d05d993e69a6676097"
+        :revision => "3c8f092cb1e9d1e18a07c1d05d993e69a6676097"
   end
 
   go_resource "github.com/hashicorp/go-cleanhttp" do
     url "https://github.com/hashicorp/go-cleanhttp.git",
-    :revision => "ad28ea4487f05916463e2423a55166280e8254b5"
+        :revision => "ad28ea4487f05916463e2423a55166280e8254b5"
   end
 
   go_resource "github.com/jessevdk/go-flags" do
     url "https://github.com/jessevdk/go-flags.git",
-    :revision => "b9b882a3990882b05e02765f5df2cd3ad02874ee"
+        :revision => "b9b882a3990882b05e02765f5df2cd3ad02874ee"
   end
 
   go_resource "github.com/opencontainers/runc" do
     url "https://github.com/opencontainers/runc.git",
-    :revision => "42dfd606437b538ffde4f0640d433916bee928e3"
+        :revision => "42dfd606437b538ffde4f0640d433916bee928e3"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-    :revsion => "3f122ce3dbbe488b7e6a8bdb26f41edec852a40b"
+        :revsion => "3f122ce3dbbe488b7e6a8bdb26f41edec852a40b"
   end
 
   def install

--- a/Formula/dockward.rb
+++ b/Formula/dockward.rb
@@ -19,27 +19,27 @@ class Dockward < Formula
 
   go_resource "github.com/Sirupsen/logrus" do
     url "https://github.com/Sirupsen/logrus.git",
-      :revision => "a26f43589d737684363ff856c5a0f9f24b946510"
+        :revision => "a26f43589d737684363ff856c5a0f9f24b946510"
   end
 
   go_resource "github.com/docker/engine-api" do
     url "https://github.com/docker/engine-api.git",
-      :revision => "fba5dc8922bbc5098a0da24704c04ae3c4bf8b4a"
+        :revision => "fba5dc8922bbc5098a0da24704c04ae3c4bf8b4a"
   end
 
   go_resource "github.com/docker/go-connections" do
     url "https://github.com/docker/go-connections.git",
-      :revision => "f549a9393d05688dff0992ef3efd8bbe6c628aeb"
+        :revision => "f549a9393d05688dff0992ef3efd8bbe6c628aeb"
   end
 
   go_resource "github.com/docker/go-units" do
     url "https://github.com/docker/go-units.git",
-      :revision => "5d2041e26a699eaca682e2ea41c8f891e1060444"
+        :revision => "5d2041e26a699eaca682e2ea41c8f891e1060444"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "042ba42fa6633b34205efc66ba5719cd3afd8d38"
+        :revision => "042ba42fa6633b34205efc66ba5719cd3afd8d38"
   end
 
   def install

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -18,12 +18,12 @@ class Fzf < Formula
 
   go_resource "github.com/junegunn/go-shellwords" do
     url "https://github.com/junegunn/go-shellwords.git",
-      :revision => "35d512af75e283aae4ca1fc3d44b159ed66189a4"
+        :revision => "35d512af75e283aae4ca1fc3d44b159ed66189a4"
   end
 
   go_resource "github.com/junegunn/go-runewidth" do
     url "https://github.com/junegunn/go-runewidth.git",
-      :revision => "63c378b851290989b19ca955468386485f118c65"
+        :revision => "63c378b851290989b19ca955468386485f118c65"
   end
 
   def install

--- a/Formula/gauge.rb
+++ b/Formula/gauge.rb
@@ -19,7 +19,7 @@ class Gauge < Formula
 
   go_resource "github.com/getgauge/gauge_screenshot" do
     url "https://github.com/getgauge/gauge_screenshot.git",
-    :revision => "d04c2acc873b408211df8408f0217d4eafd327fe"
+        :revision => "d04c2acc873b408211df8408f0217d4eafd327fe"
   end
 
   def install

--- a/Formula/ghq.rb
+++ b/Formula/ghq.rb
@@ -10,7 +10,7 @@ class Ghq < Formula
 
     go_resource "github.com/codegangsta/cli" do
       url "https://github.com/codegangsta/cli.git",
-      :revision => "aca5b047ed14d17224157c3434ea93bf6cdaadee"
+          :revision => "aca5b047ed14d17224157c3434ea93bf6cdaadee"
     end
   end
 
@@ -27,7 +27,7 @@ class Ghq < Formula
 
     go_resource "github.com/codegangsta/cli" do
       url "https://github.com/codegangsta/cli.git",
-      :revision => "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
+          :revision => "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
     end
   end
 
@@ -37,17 +37,17 @@ class Ghq < Formula
 
   go_resource "github.com/mitchellh/go-homedir" do
     url "https://github.com/mitchellh/go-homedir.git",
-    :revision => "981ab348d865cf048eb7d17e78ac7192632d8415"
+        :revision => "981ab348d865cf048eb7d17e78ac7192632d8415"
   end
 
   go_resource "github.com/motemen/go-colorine" do
     url "https://github.com/motemen/go-colorine.git",
-    :revision => "49ff36b8fa42db28092361cd20dcefd0b03b1472"
+        :revision => "49ff36b8fa42db28092361cd20dcefd0b03b1472"
   end
 
   go_resource "github.com/daviddengcn/go-colortext" do
     url "https://github.com/daviddengcn/go-colortext.git",
-    :revision => "3b18c8575a432453d41fdafb340099fff5bba2f7"
+        :revision => "3b18c8575a432453d41fdafb340099fff5bba2f7"
   end
 
   def install

--- a/Formula/github-markdown-toc.rb
+++ b/Formula/github-markdown-toc.rb
@@ -17,17 +17,17 @@ class GithubMarkdownToc < Formula
 
   go_resource "github.com/alecthomas/template" do
     url "https://github.com/alecthomas/template.git",
-      :revision => "14fd436dd20c3cc65242a9f396b61bfc8a3926fc"
+        :revision => "14fd436dd20c3cc65242a9f396b61bfc8a3926fc"
   end
 
   go_resource "github.com/alecthomas/units" do
     url "https://github.com/alecthomas/units.git",
-      :revision => "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
+        :revision => "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
   end
 
   go_resource "gopkg.in/alecthomas/kingpin.v2" do
     url "https://github.com/alecthomas/kingpin.git",
-      :revision => "v2.1.11"
+        :revision => "v2.1.11"
   end
 
   def install

--- a/Formula/gitlab-ci-multi-runner.rb
+++ b/Formula/gitlab-ci-multi-runner.rb
@@ -20,7 +20,7 @@ class GitlabCiMultiRunner < Formula
 
   go_resource "github.com/jteeuwen/go-bindata" do
     url "https://github.com/jteeuwen/go-bindata.git",
-      :revision => "a0ff2567cfb70903282db057e799fd826784d41d"
+        :revision => "a0ff2567cfb70903282db057e799fd826784d41d"
   end
 
   resource "prebuilt-x86_64.tar.xz" do

--- a/Formula/gost.rb
+++ b/Formula/gost.rb
@@ -16,27 +16,33 @@ class Gost < Formula
   depends_on "go" => :build
 
   go_resource "golang.org/x/oauth2" do
-    url "https://go.googlesource.com/oauth2.git", :revision => "8434495902bd0900797016affe4ca35c55babb3f"
+    url "https://go.googlesource.com/oauth2.git",
+        :revision => "8434495902bd0900797016affe4ca35c55babb3f"
   end
 
   go_resource "golang.org/x/net" do
-    url "https://go.googlesource.com/net.git", :revision => "35ec611a141ee705590b9eb64d673f9e6dfeb1ac"
+    url "https://go.googlesource.com/net.git",
+        :revision => "35ec611a141ee705590b9eb64d673f9e6dfeb1ac"
   end
 
   go_resource "github.com/atotto/clipboard" do
-    url "https://github.com/atotto/clipboard.git", :revision => "bb272b845f1112e10117e3e45ce39f690c0001ad"
+    url "https://github.com/atotto/clipboard.git",
+        :revision => "bb272b845f1112e10117e3e45ce39f690c0001ad"
   end
 
   go_resource "github.com/docopt/docopt.go" do
-    url "https://github.com/docopt/docopt.go.git", :revision => "784ddc588536785e7299f7272f39101f7faccc3f"
+    url "https://github.com/docopt/docopt.go.git",
+        :revision => "784ddc588536785e7299f7272f39101f7faccc3f"
   end
 
   go_resource "github.com/google/go-github" do
-    url "https://github.com/google/go-github.git", :revision => "842c551fdeae14c97c04ef490f601ae4d849a00c"
+    url "https://github.com/google/go-github.git",
+        :revision => "842c551fdeae14c97c04ef490f601ae4d849a00c"
   end
 
   go_resource "github.com/google/go-querystring" do
-    url "https://github.com/google/go-querystring.git", :revision => "9235644dd9e52eeae6fa48efd539fdc351a0af53"
+    url "https://github.com/google/go-querystring.git",
+        :revision => "9235644dd9e52eeae6fa48efd539fdc351a0af53"
   end
 
   def install

--- a/Formula/gron.rb
+++ b/Formula/gron.rb
@@ -19,27 +19,27 @@ class Gron < Formula
 
   go_resource "github.com/fatih/color" do
     url "https://github.com/fatih/color.git",
-    :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
+        :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
   end
 
   go_resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
-    :revision => "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
+        :revision => "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
   end
 
   go_resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
-    :revision => "3a115632dcd687f9c8cd01679c83a06a0e21c1f3"
+        :revision => "3a115632dcd687f9c8cd01679c83a06a0e21c1f3"
   end
 
   go_resource "github.com/nwidger/jsoncolor" do
     url "https://github.com/nwidger/jsoncolor.git",
-    :revision => "f344a1ffbe51794516e9cf2c4d58b203863d3070"
+        :revision => "f344a1ffbe51794516e9cf2c4d58b203863d3070"
   end
 
   go_resource "github.com/pkg/errors" do
     url "https://github.com/pkg/errors.git",
-    :revision => "17b591df37844cde689f4d5813e5cea0927d8dd2"
+        :revision => "17b591df37844cde689f4d5813e5cea0927d8dd2"
   end
 
   def install

--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -18,177 +18,177 @@ class Hugo < Formula
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-    :revision => "f0aeabca5a127c4078abb8c8d64298b147264b55"
+        :revision => "f0aeabca5a127c4078abb8c8d64298b147264b55"
   end
 
   go_resource "github.com/PuerkitoBio/purell" do
     url "https://github.com/PuerkitoBio/purell.git",
-    :revision => "d69616f51cdfcd7514d6a380847a152dfc2a749d"
+        :revision => "d69616f51cdfcd7514d6a380847a152dfc2a749d"
   end
 
   go_resource "github.com/bep/inflect" do
     url "https://github.com/bep/inflect.git",
-    :revision => "b896c45f5af983b1f416bdf3bb89c4f1f0926f69"
+        :revision => "b896c45f5af983b1f416bdf3bb89c4f1f0926f69"
   end
 
   go_resource "github.com/cpuguy83/go-md2man" do
     url "https://github.com/cpuguy83/go-md2man.git",
-    :revision => "2724a9c9051aa62e9cca11304e7dd518e9e41599"
+        :revision => "2724a9c9051aa62e9cca11304e7dd518e9e41599"
   end
 
   go_resource "github.com/dchest/cssmin" do
     url "https://github.com/dchest/cssmin.git",
-    :revision => "fb8d9b44afdc258bfff6052d3667521babcb2239"
+        :revision => "fb8d9b44afdc258bfff6052d3667521babcb2239"
   end
 
   go_resource "github.com/eknkc/amber" do
     url "https://github.com/eknkc/amber.git",
-    :revision => "91774f050c1453128146169b626489e60108ec03"
+        :revision => "91774f050c1453128146169b626489e60108ec03"
   end
 
   go_resource "github.com/fsnotify/fsnotify" do
     url "https://github.com/fsnotify/fsnotify.git",
-    :revision => "30411dbcefb7a1da7e84f75530ad3abe4011b4f8"
+        :revision => "30411dbcefb7a1da7e84f75530ad3abe4011b4f8"
   end
 
   go_resource "github.com/gorilla/websocket" do
     url "https://github.com/gorilla/websocket.git",
-    :revision => "a68708917c6a4f06314ab4e52493cc61359c9d42"
+        :revision => "a68708917c6a4f06314ab4e52493cc61359c9d42"
   end
 
   go_resource "github.com/hashicorp/hcl" do
     url "https://github.com/hashicorp/hcl.git",
-    :revision => "9a905a34e6280ce905da1a32344b25e81011197a"
+        :revision => "9a905a34e6280ce905da1a32344b25e81011197a"
   end
 
   go_resource "github.com/kardianos/osext" do
     url "https://github.com/kardianos/osext.git",
-    :revision => "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"
+        :revision => "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"
   end
 
   go_resource "github.com/kr/fs" do
     url "https://github.com/kr/fs.git",
-    :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
   end
 
   go_resource "github.com/kyokomi/emoji" do
     url "https://github.com/kyokomi/emoji.git",
-    :revision => "17c5e7085c9d59630aa578df67f4469481fbe7a9"
+        :revision => "17c5e7085c9d59630aa578df67f4469481fbe7a9"
   end
 
   go_resource "github.com/magiconair/properties" do
     url "https://github.com/magiconair/properties.git",
-    :revision => "c265cfa48dda6474e208715ca93e987829f572f8"
+        :revision => "c265cfa48dda6474e208715ca93e987829f572f8"
   end
 
   go_resource "github.com/miekg/mmark" do
     url "https://github.com/miekg/mmark.git",
-    :revision => "1cc81181240610a61032c944355759771a652f71"
+        :revision => "1cc81181240610a61032c944355759771a652f71"
   end
 
   go_resource "github.com/mitchellh/mapstructure" do
     url "https://github.com/mitchellh/mapstructure.git",
-    :revision => "d2dd0262208475919e1a362f675cfc0e7c10e905"
+        :revision => "d2dd0262208475919e1a362f675cfc0e7c10e905"
   end
 
   go_resource "github.com/opennota/urlesc" do
     url "https://github.com/opennota/urlesc.git",
-    :revision => "5fa9ff0392746aeae1c4b37fcc42c65afa7a9587"
+        :revision => "5fa9ff0392746aeae1c4b37fcc42c65afa7a9587"
   end
 
   go_resource "github.com/pkg/errors" do
     url "https://github.com/pkg/errors.git",
-    :revision => "f45f2b7903d2db989402601ad8ec27eff5c1dc9d"
+        :revision => "f45f2b7903d2db989402601ad8ec27eff5c1dc9d"
   end
 
   go_resource "github.com/pkg/sftp" do
     url "https://github.com/pkg/sftp.git",
-    :revision => "526cf9b2b38d2f3675e34e473f2cef38e1e0565b"
+        :revision => "526cf9b2b38d2f3675e34e473f2cef38e1e0565b"
   end
 
   go_resource "github.com/russross/blackfriday" do
     url "https://github.com/russross/blackfriday.git",
-    :revision => "1d6b8e9301e720b08a8938b8c25c018285885438"
+        :revision => "1d6b8e9301e720b08a8938b8c25c018285885438"
   end
 
   go_resource "github.com/shurcooL/sanitized_anchor_name" do
     url "https://github.com/shurcooL/sanitized_anchor_name.git",
-    :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
+        :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
   end
 
   go_resource "github.com/spf13/afero" do
     url "https://github.com/spf13/afero.git",
-    :revision => "1a8ecf8b9da1fb5306e149e83128fc447957d2a8"
+        :revision => "1a8ecf8b9da1fb5306e149e83128fc447957d2a8"
   end
 
   go_resource "github.com/spf13/cast" do
     url "https://github.com/spf13/cast.git",
-    :revision => "27b586b42e29bec072fe7379259cc719e1289da6"
+        :revision => "27b586b42e29bec072fe7379259cc719e1289da6"
   end
 
   go_resource "github.com/spf13/cobra" do
     url "https://github.com/spf13/cobra.git",
-    :revision => "f447048345b64b3247b29a679a14bd0da12c7f2f"
+        :revision => "f447048345b64b3247b29a679a14bd0da12c7f2f"
   end
 
   go_resource "github.com/spf13/fsync" do
     url "https://github.com/spf13/fsync.git",
-    :revision => "eefee59ad7de621617d4ff085cf768aab4b919b1"
+        :revision => "eefee59ad7de621617d4ff085cf768aab4b919b1"
   end
 
   go_resource "github.com/spf13/hugo" do
     url "https://github.com/spf13/hugo.git",
-    :revision => "48ebd598a9da395ae1ba39376b35fdd1105472ce"
+        :revision => "48ebd598a9da395ae1ba39376b35fdd1105472ce"
   end
 
   go_resource "github.com/spf13/jwalterweatherman" do
     url "https://github.com/spf13/jwalterweatherman.git",
-    :revision => "33c24e77fb80341fe7130ee7c594256ff08ccc46"
+        :revision => "33c24e77fb80341fe7130ee7c594256ff08ccc46"
   end
 
   go_resource "github.com/spf13/nitro" do
     url "https://github.com/spf13/nitro.git",
-    :revision => "24d7ef30a12da0bdc5e2eb370a79c659ddccf0e8"
+        :revision => "24d7ef30a12da0bdc5e2eb370a79c659ddccf0e8"
   end
 
   go_resource "github.com/spf13/pflag" do
     url "https://github.com/spf13/pflag.git",
-    :revision => "cb88ea77998c3f024757528e3305022ab50b43be"
+        :revision => "cb88ea77998c3f024757528e3305022ab50b43be"
   end
 
   go_resource "github.com/spf13/viper" do
     url "https://github.com/spf13/viper.git",
-    :revision => "c1ccc378a054ea8d4e38d8c67f6938d4760b53dd"
+        :revision => "c1ccc378a054ea8d4e38d8c67f6938d4760b53dd"
   end
 
   go_resource "github.com/stretchr/testify" do
     url "https://github.com/stretchr/testify.git",
-    :revision => "8d64eb7173c7753d6419fd4a9caf057398611364"
+        :revision => "8d64eb7173c7753d6419fd4a9caf057398611364"
   end
 
   go_resource "github.com/yosssi/ace" do
     url "https://github.com/yosssi/ace.git",
-    :revision => "71afeb714739f9d5f7e1849bcd4a0a5938e1a70d"
+        :revision => "71afeb714739f9d5f7e1849bcd4a0a5938e1a70d"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "89d9e62992539701a49a19c52ebb33e84cbbe80f"
+        :revision => "89d9e62992539701a49a19c52ebb33e84cbbe80f"
   end
 
   go_resource "golang.org/x/sys" do
     url "https://go.googlesource.com/sys.git",
-    :revision => "076b546753157f758b316e59bcb51e6807c04057"
+        :revision => "076b546753157f758b316e59bcb51e6807c04057"
   end
 
   go_resource "golang.org/x/text" do
     url "https://go.googlesource.com/text.git",
-    :revision => "a4d77b4813ec88686efd8caedc113322933f9891"
+        :revision => "a4d77b4813ec88686efd8caedc113322933f9891"
   end
 
   go_resource "gopkg.in/yaml.v2" do
     url "https://gopkg.in/yaml.v2.git",
-    :revision => "a83829b6f1293c91addabc89d0571c246397bbf4"
+        :revision => "a83829b6f1293c91addabc89d0571c246397bbf4"
   end
 
   def install

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -11,7 +11,7 @@ class Influxdb < Formula
 
     go_resource "github.com/dgrijalva/jwt-go" do
       url "https://github.com/dgrijalva/jwt-go.git",
-      :revision => "9b486c879bab3fde556ce8c27d9a2bb05d5b2c60"
+          :revision => "9b486c879bab3fde556ce8c27d9a2bb05d5b2c60"
     end
   end
 
@@ -28,7 +28,7 @@ class Influxdb < Formula
 
     go_resource "github.com/dgrijalva/jwt-go" do
       url "https://github.com/dgrijalva/jwt-go.git",
-      :revision => "63734eae1ef55eaac06fdc0f312615f2e321e273"
+          :revision => "63734eae1ef55eaac06fdc0f312615f2e321e273"
     end
   end
 
@@ -36,87 +36,87 @@ class Influxdb < Formula
 
   go_resource "collectd.org" do
     url "https://github.com/collectd/go-collectd.git",
-    :revision => "9fc824c70f713ea0f058a07b49a4c563ef2a3b98"
+        :revision => "9fc824c70f713ea0f058a07b49a4c563ef2a3b98"
   end
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-    :revision => "99064174e013895bbd9b025c31100bd1d9b590ca"
+        :revision => "99064174e013895bbd9b025c31100bd1d9b590ca"
   end
 
   go_resource "github.com/bmizerany/pat" do
     url "https://github.com/bmizerany/pat.git",
-    :revision => "c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c"
+        :revision => "c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c"
   end
 
   go_resource "github.com/boltdb/bolt" do
     url "https://github.com/boltdb/bolt.git",
-    :revision => "5cc10bbbc5c141029940133bb33c9e969512a698"
+        :revision => "5cc10bbbc5c141029940133bb33c9e969512a698"
   end
 
   go_resource "github.com/davecgh/go-spew" do
     url "https://github.com/davecgh/go-spew.git",
-    :revision => "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+        :revision => "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
   end
 
   go_resource "github.com/dgryski/go-bits" do
     url "https://github.com/dgryski/go-bits.git",
-    :revision => "2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef"
+        :revision => "2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef"
   end
 
   go_resource "github.com/dgryski/go-bitstream" do
     url "https://github.com/dgryski/go-bitstream.git",
-    :revision => "7d46cd22db7004f0cceb6f7975824b560cf0e486"
+        :revision => "7d46cd22db7004f0cceb6f7975824b560cf0e486"
   end
 
   go_resource "github.com/gogo/protobuf" do
     url "https://github.com/gogo/protobuf.git",
-    :revision => "6abcf94fd4c97dcb423fdafd42fe9f96ca7e421b"
+        :revision => "6abcf94fd4c97dcb423fdafd42fe9f96ca7e421b"
   end
 
   go_resource "github.com/golang/snappy" do
     url "https://github.com/golang/snappy.git",
-    :revision => "d9eb7a3d35ec988b8585d4a0068e462c27d28380"
+        :revision => "d9eb7a3d35ec988b8585d4a0068e462c27d28380"
   end
 
   go_resource "github.com/influxdata/usage-client" do
     url "https://github.com/influxdata/usage-client.git",
-    :revision => "475977e68d79883d9c8d67131c84e4241523f452"
+        :revision => "475977e68d79883d9c8d67131c84e4241523f452"
   end
 
   go_resource "github.com/jwilder/encoding" do
     url "https://github.com/jwilder/encoding.git",
-    :revision => "ac74639f65b2180a2e5eb5ff197f0c122441aed0"
+        :revision => "ac74639f65b2180a2e5eb5ff197f0c122441aed0"
   end
 
   go_resource "github.com/kimor79/gollectd" do
     url "https://github.com/kimor79/gollectd.git",
-    :revision => "61d0deeb4ffcc167b2a1baa8efd72365692811bc"
+        :revision => "61d0deeb4ffcc167b2a1baa8efd72365692811bc"
   end
 
   go_resource "github.com/paulbellamy/ratecounter" do
     url "https://github.com/paulbellamy/ratecounter.git",
-    :revision => "5a11f585a31379765c190c033b6ad39956584447"
+        :revision => "5a11f585a31379765c190c033b6ad39956584447"
   end
 
   go_resource "github.com/peterh/liner" do
     url "https://github.com/peterh/liner.git",
-    :revision => "8975875355a81d612fafb9f5a6037bdcc2d9b073"
+        :revision => "8975875355a81d612fafb9f5a6037bdcc2d9b073"
   end
 
   go_resource "github.com/rakyll/statik" do
     url "https://github.com/rakyll/statik.git",
-    :revision => "274df120e9065bdd08eb1120e0375e3dc1ae8465"
+        :revision => "274df120e9065bdd08eb1120e0375e3dc1ae8465"
   end
 
   go_resource "github.com/retailnext/hllpp" do
     url "https://github.com/retailnext/hllpp.git",
-    :revision => "38a7bb71b483e855d35010808143beaf05b67f9d"
+        :revision => "38a7bb71b483e855d35010808143beaf05b67f9d"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6"
+        :revision => "c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6"
   end
 
   def install

--- a/Formula/jvgrep.rb
+++ b/Formula/jvgrep.rb
@@ -18,27 +18,27 @@ class Jvgrep < Formula
 
   go_resource "github.com/k-takata/go-iscygpty" do
     url "https://github.com/k-takata/go-iscygpty.git",
-    :revision => "f91f8810106213f01bd64933dc10d849bd9137ac"
+        :revision => "f91f8810106213f01bd64933dc10d849bd9137ac"
   end
 
   go_resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
-    :revision => "9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59"
+        :revision => "9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59"
   end
 
   go_resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
-    :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
+        :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-    :revision => "e445b19913b9d40fdbdfe19ac5e3d314aafd6f63"
+        :revision => "e445b19913b9d40fdbdfe19ac5e3d314aafd6f63"
   end
 
   go_resource "golang.org/x/text" do
     url "https://go.googlesource.com/text.git",
-    :revision => "4440cd4f4c2ea31e1872e00de675a86d0c19006c"
+        :revision => "4440cd4f4c2ea31e1872e00de675a86d0c19006c"
   end
 
   def install

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -21,107 +21,107 @@ class Kapacitor < Formula
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-    :revision => "bbd5bb678321a0d6e58f1099321dfa73391c1b6f"
+        :revision => "bbd5bb678321a0d6e58f1099321dfa73391c1b6f"
   end
 
   go_resource "github.com/boltdb/bolt" do
     url "https://github.com/boltdb/bolt.git",
-    :revision => "144418e1475d8bf7abbdc48583500f1a20c62ea7"
+        :revision => "144418e1475d8bf7abbdc48583500f1a20c62ea7"
   end
 
   go_resource "github.com/cenkalti/backoff" do
     url "https://github.com/cenkalti/backoff.git",
-    :revision => "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
+        :revision => "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
   end
 
   go_resource "github.com/dustin/go-humanize" do
     url "https://github.com/dustin/go-humanize.git",
-    :revision => "8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"
+        :revision => "8929fe90cee4b2cb9deb468b51fb34eba64d1bf0"
   end
 
   go_resource "github.com/gogo/protobuf" do
     url "https://github.com/gogo/protobuf.git",
-    :revision => "4365f750fe246471f2a03ef5da5231c3565c5628"
+        :revision => "4365f750fe246471f2a03ef5da5231c3565c5628"
   end
 
   go_resource "github.com/gorhill/cronexpr" do
     url "https://github.com/gorhill/cronexpr.git",
-    :revision => "f0984319b44273e83de132089ae42b1810f4933b"
+        :revision => "f0984319b44273e83de132089ae42b1810f4933b"
   end
 
   go_resource "github.com/influxdata/influxdb" do
     url "https://github.com/influxdata/influxdb.git",
-    :revision => "f232c0548611371929e8a2cc082e29ae2d4a4326"
+        :revision => "f232c0548611371929e8a2cc082e29ae2d4a4326"
   end
 
   go_resource "github.com/influxdb/usage-client" do
     url "https://github.com/influxdb/usage-client.git",
-    :revision => "475977e68d79883d9c8d67131c84e4241523f452"
+        :revision => "475977e68d79883d9c8d67131c84e4241523f452"
   end
 
   go_resource "github.com/kimor79/gollectd" do
     url "https://github.com/kimor79/gollectd.git",
-    :revision => "b5dddb1667dcc1e6355b9305e2c1608a2db6983c"
+        :revision => "b5dddb1667dcc1e6355b9305e2c1608a2db6983c"
   end
 
   go_resource "github.com/mattn/go-runewidth" do
     url "https://github.com/mattn/go-runewidth.git",
-    :revision => "d6bea18f789704b5f83375793155289da36a3c7f"
+        :revision => "d6bea18f789704b5f83375793155289da36a3c7f"
   end
 
   go_resource "github.com/naoina/go-stringutil" do
     url "https://github.com/naoina/go-stringutil.git",
-    :revision => "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b"
+        :revision => "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b"
   end
 
   go_resource "github.com/naoina/toml" do
     url "https://github.com/naoina/toml.git",
-    :revision => "751171607256bb66e64c9f0220c00662420c38e9"
+        :revision => "751171607256bb66e64c9f0220c00662420c38e9"
   end
 
   go_resource "github.com/russross/blackfriday" do
     url "https://github.com/russross/blackfriday.git",
-    :revision => "b43df972fb5fdf3af8d2e90f38a69d374fe26dd0"
+        :revision => "b43df972fb5fdf3af8d2e90f38a69d374fe26dd0"
   end
 
   go_resource "github.com/serenize/snaker" do
     url "https://github.com/serenize/snaker.git",
-    :revision => "8824b61eca66d308fcb2d515287d3d7a28dba8d6"
+        :revision => "8824b61eca66d308fcb2d515287d3d7a28dba8d6"
   end
 
   go_resource "github.com/shurcooL/go" do
     url "https://github.com/shurcooL/go.git",
-    :revision => "377921096a5b956ff0a2cd207bf03a385a3af745"
+        :revision => "377921096a5b956ff0a2cd207bf03a385a3af745"
   end
 
   go_resource "github.com/shurcooL/markdownfmt" do
     url "https://github.com/shurcooL/markdownfmt.git",
-    :revision => "45e6ea2c4705675a93a32b5f548dbb7997826875"
+        :revision => "45e6ea2c4705675a93a32b5f548dbb7997826875"
   end
 
   go_resource "github.com/shurcooL/sanitized_anchor_name" do
     url "https://github.com/shurcooL/sanitized_anchor_name.git",
-    :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
+        :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
   end
 
   go_resource "github.com/stretchr/testify" do
     url "https://github.com/stretchr/testify.git",
-    :revision => "1f4a1643a57e798696635ea4c126e9127adb7d3c"
+        :revision => "1f4a1643a57e798696635ea4c126e9127adb7d3c"
   end
 
   go_resource "github.com/twinj/uuid" do
     url "https://github.com/twinj/uuid.git",
-    :revision => "89173bcdda19db0eb88aef1e1cb1cb2505561d31"
+        :revision => "89173bcdda19db0eb88aef1e1cb1cb2505561d31"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "b8a0f4bb4040f8d884435cff35b9691e362cf00c"
+        :revision => "b8a0f4bb4040f8d884435cff35b9691e362cf00c"
   end
 
   go_resource "gopkg.in/gomail.v2" do
     url "https://gopkg.in/gomail.v2.git",
-    :revision => "42916101524810bd3aed9a8b25e6bb58d8e3af82"
+        :revision => "42916101524810bd3aed9a8b25e6bb58d8e3af82"
   end
 
   def install

--- a/Formula/leaps.rb
+++ b/Formula/leaps.rb
@@ -20,7 +20,7 @@ class Leaps < Formula
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "db8e4de5b2d6653f66aea53094624468caad15d2"
+        :revision => "db8e4de5b2d6653f66aea53094624468caad15d2"
   end
 
   def install

--- a/Formula/lego.rb
+++ b/Formula/lego.rb
@@ -17,72 +17,72 @@ class Lego < Formula
 
   go_resource "cloud.google.com/go" do
     url "https://code.googlesource.com/gocloud.git",
-      :revision => "49467e5deee2b3e98455bb834e029afc067d04f5"
+        :revision => "49467e5deee2b3e98455bb834e029afc067d04f5"
   end
 
   go_resource "github.com/JamesClonk/vultr" do
     url "https://github.com/JamesClonk/vultr.git",
-      :revision => "42d4701246e48d1b81b80471e418ea0d1cc99586"
+        :revision => "42d4701246e48d1b81b80471e418ea0d1cc99586"
   end
 
   go_resource "github.com/aws/aws-sdk-go" do
     url "https://github.com/aws/aws-sdk-go.git",
-      :revision => "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e"
+        :revision => "00e2bf9d1518c2b7d8a97eb05b5d2a9afd1dd34e"
   end
 
   go_resource "github.com/juju/ratelimit" do
     url "https://github.com/juju/ratelimit.git",
-      :revision => "77ed1c8a01217656d2080ad51981f6e99adaa177"
+        :revision => "77ed1c8a01217656d2080ad51981f6e99adaa177"
   end
 
   go_resource "github.com/miekg/dns" do
     url "https://github.com/miekg/dns.git",
-      :revision => "db96a2b759cdef4f11a34506a42eb8d1290c598e"
+        :revision => "db96a2b759cdef4f11a34506a42eb8d1290c598e"
   end
 
   go_resource "github.com/ovh/go-ovh" do
     url "https://github.com/ovh/go-ovh.git",
-      :revision => "d2b2eae2511fa5fcd0bdef9f1790ea3979fa35d4"
+        :revision => "d2b2eae2511fa5fcd0bdef9f1790ea3979fa35d4"
   end
 
   go_resource "github.com/codegangsta/cli" do
     url "https://github.com/urfave/cli.git",
-      :revision => "168c95418e66e019fe17b8f4f5c45aa62ff80e23"
+        :revision => "168c95418e66e019fe17b8f4f5c45aa62ff80e23"
   end
 
   go_resource "github.com/weppos/dnsimple-go" do
     url "https://github.com/weppos/dnsimple-go.git",
-      :revision => "65c1ca73cb19baf0f8b2b33219b7f57595a3ccb0"
+        :revision => "65c1ca73cb19baf0f8b2b33219b7f57595a3ccb0"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "611beeb3d5df450a45f4b67f9e25235f54beda72"
+        :revision => "611beeb3d5df450a45f4b67f9e25235f54beda72"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "57bfaa875b96fb91b4766077f34470528d4b03e9"
+        :revision => "57bfaa875b96fb91b4766077f34470528d4b03e9"
   end
 
   go_resource "golang.org/x/oauth2" do
     url "https://go.googlesource.com/oauth2.git",
-      :revision => "04e1573abc896e70388bd387a69753c378d46466"
+        :revision => "04e1573abc896e70388bd387a69753c378d46466"
   end
 
   go_resource "google.golang.org/api" do
     url "https://code.googlesource.com/google-api-go-client.git",
-      :revision => "593853e2d377362656ee40abf6df5cd3030c736b"
+        :revision => "593853e2d377362656ee40abf6df5cd3030c736b"
   end
 
   go_resource "gopkg.in/ini.v1" do
     url "https://gopkg.in/ini.v1.git",
-      :revision => "cf53f9204df4fbdd7ec4164b57fa6184ba168292"
+        :revision => "cf53f9204df4fbdd7ec4164b57fa6184ba168292"
   end
 
   go_resource "gopkg.in/square/go-jose.v1" do
     url "https://gopkg.in/square/go-jose.v1.git",
-      :revision => "e3f973b66b91445ec816dd7411ad1b6495a5a2fc"
+        :revision => "e3f973b66b91445ec816dd7411ad1b6495a5a2fc"
   end
 
   def install

--- a/Formula/megacmd.rb
+++ b/Formula/megacmd.rb
@@ -20,17 +20,17 @@ class Megacmd < Formula
 
   go_resource "github.com/t3rm1n4l/go-humanize" do
     url "https://github.com/t3rm1n4l/go-humanize.git",
-    :revision => "e7ed15be05eb554fbaa83ac9b335556d6390fb9f"
+        :revision => "e7ed15be05eb554fbaa83ac9b335556d6390fb9f"
   end
 
   go_resource "github.com/t3rm1n4l/go-mega" do
     url "https://github.com/t3rm1n4l/go-mega.git",
-    :revision => "551abb8f1c87053be3f24282d198a6614c0ca14f"
+        :revision => "551abb8f1c87053be3f24282d198a6614c0ca14f"
   end
 
   go_resource "github.com/t3rm1n4l/megacmd" do
     url "https://github.com/t3rm1n4l/megacmd.git",
-    :revision => "d7f3f3a2427cc52b71cad90b26889e2a33fc3565"
+        :revision => "d7f3f3a2427cc52b71cad90b26889e2a33fc3565"
   end
 
   def install

--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -23,9 +23,9 @@ class Mongodb < Formula
 
   go_resource "github.com/mongodb/mongo-tools" do
     url "https://github.com/mongodb/mongo-tools.git",
-      :tag => "r3.2.9",
-      :revision => "4a4e7d30773b28cf66f75e45bc289a5d3ca49ddd",
-      :shallow => false
+        :tag => "r3.2.9",
+        :revision => "4a4e7d30773b28cf66f75e45bc289a5d3ca49ddd",
+        :shallow => false
   end
 
   needs :cxx11

--- a/Formula/mpdviz.rb
+++ b/Formula/mpdviz.rb
@@ -18,22 +18,22 @@ class Mpdviz < Formula
 
   go_resource "github.com/lucy/go-fftw" do
     url "https://github.com/lucy/go-fftw.git",
-      :revision => "37bfa0d3053b133f7067e9524611a7a963294124"
+        :revision => "37bfa0d3053b133f7067e9524611a7a963294124"
   end
 
   go_resource "github.com/lucy/pflag" do
     url "https://github.com/lucy/pflag.git",
-      :revision => "20db95b725d76759ba16e25ae6ae2ec67bf45216"
+        :revision => "20db95b725d76759ba16e25ae6ae2ec67bf45216"
   end
 
   go_resource "github.com/lucy/termbox-go" do
     url "https://github.com/lucy/termbox-go.git",
-      :revision => "a09edf97f26bd0a461d4660b5322236ecf9d4397"
+        :revision => "a09edf97f26bd0a461d4660b5322236ecf9d4397"
   end
 
   go_resource "github.com/mattn/go-runewidth" do
     url "https://github.com/mattn/go-runewidth.git",
-      :revision => "36f63b8223e701c16f36010094fb6e84ffbaf8e0"
+        :revision => "36f63b8223e701c16f36010094fb6e84ffbaf8e0"
   end
 
   def install

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -18,57 +18,57 @@ class Nsq < Formula
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-    :revision => "2dff11163ee667d51dcc066660925a92ce138deb"
+        :revision => "2dff11163ee667d51dcc066660925a92ce138deb"
   end
 
   go_resource "github.com/bitly/go-hostpool" do
     url "https://github.com/bitly/go-hostpool.git",
-    :revision => "58b95b10d6ca26723a7f46017b348653b825a8d6"
+        :revision => "58b95b10d6ca26723a7f46017b348653b825a8d6"
   end
 
   go_resource "github.com/nsqio/go-nsq" do
     url "https://github.com/nsqio/go-nsq.git",
-    :revision => "642a3f9935f12cb3b747294318d730f56f4c34b4"
+        :revision => "642a3f9935f12cb3b747294318d730f56f4c34b4"
   end
 
   go_resource "github.com/bitly/go-simplejson" do
     url "https://github.com/bitly/go-simplejson.git",
-    :revision => "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a"
+        :revision => "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a"
   end
 
   go_resource "github.com/bmizerany/perks" do
     url "https://github.com/bmizerany/perks.git",
-    :revision => "6cb9d9d729303ee2628580d9aec5db968da3a607"
+        :revision => "6cb9d9d729303ee2628580d9aec5db968da3a607"
   end
 
   go_resource "github.com/mreiferson/go-options" do
     url "https://github.com/mreiferson/go-options.git",
-    :revision => "7ae3226d3e1fa6a0548f73089c72c96c141f3b95"
+        :revision => "7ae3226d3e1fa6a0548f73089c72c96c141f3b95"
   end
 
   go_resource "github.com/mreiferson/go-snappystream" do
     url "https://github.com/mreiferson/go-snappystream.git",
-    :revision => "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504"
+        :revision => "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504"
   end
 
   go_resource "github.com/bitly/timer_metrics" do
     url "https://github.com/bitly/timer_metrics.git",
-    :revision => "afad1794bb13e2a094720aeb27c088aa64564895"
+        :revision => "afad1794bb13e2a094720aeb27c088aa64564895"
   end
 
   go_resource "github.com/blang/semver" do
     url "https://github.com/blang/semver.git",
-    :revision => "9bf7bff48b0388cb75991e58c6df7d13e982f1f2"
+        :revision => "9bf7bff48b0388cb75991e58c6df7d13e982f1f2"
   end
 
   go_resource "github.com/julienschmidt/httprouter" do
     url "https://github.com/julienschmidt/httprouter.git",
-    :revision => "6aacfd5ab513e34f7e64ea9627ab9670371b34e7"
+        :revision => "6aacfd5ab513e34f7e64ea9627ab9670371b34e7"
   end
 
   go_resource "github.com/judwhite/go-svc" do
     url "https://github.com/judwhite/go-svc.git",
-    :revision => "63c12402f579f0bdf022653c821a1aa5d7544f01"
+        :revision => "63c12402f579f0bdf022653c821a1aa5d7544f01"
   end
 
   def install

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -20,22 +20,22 @@ class Oauth2Proxy < Formula
 
   go_resource "github.com/BurntSushi/toml" do
     url "https://github.com/BurntSushi/toml.git",
-      :revision => "056c9bc7be7190eaa7715723883caffa5f8fa3e4"
+        :revision => "056c9bc7be7190eaa7715723883caffa5f8fa3e4"
   end
 
   go_resource "github.com/bitly/go-simplejson" do
     url "https://github.com/bitly/go-simplejson.git",
-      :revision => "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a"
+        :revision => "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a"
   end
 
   go_resource "github.com/mreiferson/go-options" do
     url "https://github.com/mreiferson/go-options.git",
-      :revision => "7c174072188d0cfbe6f01bb457626abb22bdff52"
+        :revision => "7c174072188d0cfbe6f01bb457626abb22bdff52"
   end
 
   go_resource "gopkg.in/fsnotify.v1" do
     url "https://gopkg.in/fsnotify.v1.git",
-      :revision => "96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0"
+        :revision => "96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0"
   end
 
   def install

--- a/Formula/otto.rb
+++ b/Formula/otto.rb
@@ -64,12 +64,12 @@ class Otto < Formula
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "803f01ea27e23d998825ec085f0d153cac01c828"
+        :revision => "803f01ea27e23d998825ec085f0d153cac01c828"
   end
 
   go_resource "golang.org/x/tools" do
     url "https://go.googlesource.com/tools.git",
-      :revision => "4ad533583d0194672e7d3bc6fb8b67c8e905d853"
+        :revision => "4ad533583d0194672e7d3bc6fb8b67c8e905d853"
   end
 
   def install

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -20,17 +20,17 @@ class Packer < Formula
 
   go_resource "github.com/mitchellh/gox" do
     url "https://github.com/mitchellh/gox.git",
-      :revision => "6e9ee79eab7bb1b84155379b3f94ff9a87b344e4"
+        :revision => "6e9ee79eab7bb1b84155379b3f94ff9a87b344e4"
   end
 
   go_resource "github.com/mitchellh/iochan" do
     url "https://github.com/mitchellh/iochan.git",
-      :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
+        :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
   end
 
   go_resource "golang.org/x/tools" do
     url "https://go.googlesource.com/tools.git",
-      :revision => "8b3828f1c8f7c67e5ebb863a4c632937778eaaae"
+        :revision => "8b3828f1c8f7c67e5ebb863a4c632937778eaaae"
   end
 
   def install

--- a/Formula/pond.rb
+++ b/Formula/pond.rb
@@ -28,32 +28,32 @@ class Pond < Formula
 
   go_resource "github.com/agl/ed25519" do
     url "https://github.com/agl/ed25519.git",
-    :revision => "278e1ec8e8a6e017cd07577924d6766039146ced"
+        :revision => "278e1ec8e8a6e017cd07577924d6766039146ced"
   end
 
   go_resource "github.com/agl/pond" do
     url "https://github.com/agl/pond.git",
-    :revision => "bce6e0dc61803c23699c749e29a83f81da3c41b2"
+        :revision => "bce6e0dc61803c23699c749e29a83f81da3c41b2"
   end
 
   go_resource "github.com/golang/protobuf" do
     url "https://github.com/golang/protobuf.git",
-    :revision => "68415e7123da32b07eab49c96d2c4d6158360e9b"
+        :revision => "68415e7123da32b07eab49c96d2c4d6158360e9b"
   end
 
   go_resource "github.com/agl/go-gtk" do
     url "https://github.com/agl/go-gtk.git",
-    :revision => "91c1edb38c241d73129e6b098ca1c9fa83abfc15"
+        :revision => "91c1edb38c241d73129e6b098ca1c9fa83abfc15"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "7b85b097bf7527677d54d3220065e966a0e3b613"
+        :revision => "7b85b097bf7527677d54d3220065e966a0e3b613"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-    :revision => "72b0708b72ac7a531f8e89f370e6214aad23ee2e"
+        :revision => "72b0708b72ac7a531f8e89f370e6214aad23ee2e"
   end
 
   def install

--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -17,142 +17,142 @@ class Rclone < Formula
 
   go_resource "golang.org/x/oauth2" do
     url "https://go.googlesource.com/oauth2.git",
-     :revision => "1364adb2c63445016c5ed4518fc71f6a3cda6169"
+        :revision => "1364adb2c63445016c5ed4518fc71f6a3cda6169"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "6a513affb38dc9788b449d59ffed099b8de18fa0"
+        :revision => "6a513affb38dc9788b449d59ffed099b8de18fa0"
   end
 
   go_resource "golang.org/x/tools" do
     url "https://go.googlesource.com/tools.git",
-      :revision => "9e7459099f9afd6a15464d69d93c6eed49bb545d"
+        :revision => "9e7459099f9afd6a15464d69d93c6eed49bb545d"
   end
 
   go_resource "google.golang.org/api" do
     url "https://code.googlesource.com/google-api-go-client.git",
-      :revision => "fa0566afd4c8fdae644725fdf9b57b5851a20742"
+        :revision => "fa0566afd4c8fdae644725fdf9b57b5851a20742"
   end
 
   go_resource "google.golang.org/cloud" do
     url "https://code.googlesource.com/gocloud.git",
-      :revision => "30fab6304c9888af49f1884cf4eddad7027e2e7b"
+        :revision => "30fab6304c9888af49f1884cf4eddad7027e2e7b"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-      :revision => "bc89c496413265e715159bdc8478ee9a92fdc265"
+        :revision => "bc89c496413265e715159bdc8478ee9a92fdc265"
   end
 
   go_resource "golang.org/x/text" do
     url "https://go.googlesource.com/text.git",
-      :revision => "2910a502d2bf9e43193af9d68ca516529614eed3"
+        :revision => "2910a502d2bf9e43193af9d68ca516529614eed3"
   end
 
   go_resource "github.com/kisielk/errcheck" do
     url "https://github.com/kisielk/errcheck.git",
-     :revision => "50ffcb6f3595daac70aff9e63afe8b8b277b1a1a"
+        :revision => "50ffcb6f3595daac70aff9e63afe8b8b277b1a1a"
   end
 
   go_resource "github.com/golang/lint" do
     url "https://github.com/golang/lint.git",
-      :revision => "c7bacac2b21ca01afa1dee0acf64df3ce047c28f"
+        :revision => "c7bacac2b21ca01afa1dee0acf64df3ce047c28f"
   end
 
   go_resource "github.com/tsenart/tb" do
     url "https://github.com/tsenart/tb.git",
-      :revision => "19f4c3d79d2bd67d0911b2e310b999eeea4454c1"
+        :revision => "19f4c3d79d2bd67d0911b2e310b999eeea4454c1"
   end
 
   go_resource "github.com/stacktic/dropbox" do
     url "https://github.com/stacktic/dropbox.git",
-      :revision => "58f839b21094d5e0af7caf613599830589233d20"
+        :revision => "58f839b21094d5e0af7caf613599830589233d20"
   end
 
   go_resource "github.com/spf13/pflag" do
     url "https://github.com/spf13/pflag.git",
-      :revision => "1560c1005499d61b80f865c04d39ca7505bf7f0b"
+        :revision => "1560c1005499d61b80f865c04d39ca7505bf7f0b"
   end
 
   go_resource "github.com/skratchdot/open-golang" do
     url "https://github.com/skratchdot/open-golang.git",
-      :revision => "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
+        :revision => "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
   end
 
   go_resource "github.com/Unknwon/goconfig" do
     url "https://github.com/Unknwon/goconfig.git",
-      :revision => "5f601ca6ef4d5cea8d52be2f8b3a420ee4b574a5"
+        :revision => "5f601ca6ef4d5cea8d52be2f8b3a420ee4b574a5"
   end
 
   go_resource "github.com/VividCortex/ewma" do
     url "https://github.com/VividCortex/ewma.git",
-      :revision => "8b9f1311551e712ea8a06b494238b8a2351e1c33"
+        :revision => "8b9f1311551e712ea8a06b494238b8a2351e1c33"
   end
 
   go_resource "github.com/aws/aws-sdk-go" do
     url "https://github.com/aws/aws-sdk-go.git",
-      :revision => "3b8c171554fc7d4fc53b87e25d4926a9e7495c2e"
+        :revision => "3b8c171554fc7d4fc53b87e25d4926a9e7495c2e"
   end
 
   go_resource "github.com/mreiferson/go-httpclient" do
     url "https://github.com/mreiferson/go-httpclient.git",
-      :revision => "31f0106b4474f14bc441575c19d3a5fa21aa1f6c"
+        :revision => "31f0106b4474f14bc441575c19d3a5fa21aa1f6c"
   end
 
   go_resource "github.com/ncw/go-acd" do
     url "https://github.com/ncw/go-acd.git",
-      :revision => "0bd73ce86fffd8afeafe4e46f419f1a8ce6324b9"
+        :revision => "0bd73ce86fffd8afeafe4e46f419f1a8ce6324b9"
   end
 
   go_resource "github.com/ncw/swift" do
     url "https://github.com/ncw/swift.git",
-      :revision => "b964f2ca856aac39885e258ad25aec08d5f64ee6"
+        :revision => "b964f2ca856aac39885e258ad25aec08d5f64ee6"
   end
 
   go_resource "github.com/pkg/errors" do
     url "https://github.com/pkg/errors.git",
-      :revision => "1d2e60385a13aaa66134984235061c2f9302520e"
+        :revision => "1d2e60385a13aaa66134984235061c2f9302520e"
   end
 
   go_resource "github.com/google/go-querystring" do
     url "https://github.com/google/go-querystring.git",
-      :revision => "9235644dd9e52eeae6fa48efd539fdc351a0af53"
+        :revision => "9235644dd9e52eeae6fa48efd539fdc351a0af53"
   end
 
   go_resource "bazil.org/fuse" do
     url "https://github.com/bazil/fuse.git",
-      :revision => "371fbbdaa8987b715bdd21d6adc4c9b20155f748"
+        :revision => "371fbbdaa8987b715bdd21d6adc4c9b20155f748"
   end
 
   go_resource "github.com/ogier/pflag" do
     url "https://github.com/ogier/pflag.git",
-      :revision => "45c278ab3607870051a2ea9040bb85fcb8557481"
+        :revision => "45c278ab3607870051a2ea9040bb85fcb8557481"
   end
 
   go_resource "github.com/rfjakob/eme" do
     url "https://github.com/rfjakob/eme.git",
-      :revision => "601d0e278ceda9aa2085a61c9265f6e690ef5255"
+        :revision => "601d0e278ceda9aa2085a61c9265f6e690ef5255"
   end
 
   go_resource "github.com/spf13/cobra" do
     url "https://github.com/spf13/cobra.git",
-      :revision => "37c3f8060359192150945916cbc2d72bce804b4d"
+        :revision => "37c3f8060359192150945916cbc2d72bce804b4d"
   end
 
   go_resource "github.com/cpuguy83/go-md2man" do
     url "https://github.com/cpuguy83/go-md2man.git",
-      :revision => "2724a9c9051aa62e9cca11304e7dd518e9e41599"
+        :revision => "2724a9c9051aa62e9cca11304e7dd518e9e41599"
   end
 
   go_resource "github.com/russross/blackfriday" do
     url "https://github.com/russross/blackfriday.git",
-      :revision => "93622da34e54fb6529bfb7c57e710f37a8d9cbd8"
+        :revision => "93622da34e54fb6529bfb7c57e710f37a8d9cbd8"
   end
 
   go_resource "github.com/shurcooL/sanitized_anchor_name" do
     url "https://github.com/shurcooL/sanitized_anchor_name.git",
-      :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
+        :revision => "10ef21a441db47d8b13ebcc5fd2310f636973c77"
   end
 
   def install

--- a/Formula/serf.rb
+++ b/Formula/serf.rb
@@ -25,77 +25,77 @@ class Serf < Formula
 
   go_resource "github.com/armon/circbuf" do
     url "https://github.com/armon/circbuf.git",
-      :revision => "bbbad097214e2918d8543d5201d12bfd7bca254d"
+        :revision => "bbbad097214e2918d8543d5201d12bfd7bca254d"
   end
 
   go_resource "github.com/armon/go-metrics" do
     url "https://github.com/armon/go-metrics.git",
-      :revision => "345426c77237ece5dab0e1605c3e4b35c3f54757"
+        :revision => "345426c77237ece5dab0e1605c3e4b35c3f54757"
   end
 
   go_resource "github.com/armon/go-radix" do
     url "https://github.com/armon/go-radix.git",
-      :revision => "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
+        :revision => "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
   end
 
   go_resource "github.com/bgentry/speakeasy" do
     url "https://github.com/bgentry/speakeasy.git",
-      :revision => "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
+        :revision => "36e9cfdd690967f4f690c6edcc9ffacd006014a0"
   end
 
   go_resource "github.com/hashicorp/go-msgpack" do
     url "https://github.com/hashicorp/go-msgpack.git",
-      :revision => "fa3f63826f7c23912c15263591e65d54d080b458"
+        :revision => "fa3f63826f7c23912c15263591e65d54d080b458"
   end
 
   go_resource "github.com/hashicorp/go-syslog" do
     url "https://github.com/hashicorp/go-syslog.git",
-      :revision => "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
+        :revision => "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
   end
 
   go_resource "github.com/hashicorp/go.net" do
     url "https://github.com/hashicorp/go.net.git",
-      :revision => "104dcad90073cd8d1e6828b2af19185b60cf3e29"
+        :revision => "104dcad90073cd8d1e6828b2af19185b60cf3e29"
   end
 
   go_resource "github.com/hashicorp/logutils" do
     url "https://github.com/hashicorp/logutils.git",
-      :revision => "0dc08b1671f34c4250ce212759ebd880f743d883"
+        :revision => "0dc08b1671f34c4250ce212759ebd880f743d883"
   end
 
   go_resource "github.com/hashicorp/mdns" do
     url "https://github.com/hashicorp/mdns.git",
-      :revision => "9d85cf22f9f8d53cb5c81c1b2749f438b2ee333f"
+        :revision => "9d85cf22f9f8d53cb5c81c1b2749f438b2ee333f"
   end
 
   go_resource "github.com/hashicorp/memberlist" do
     url "https://github.com/hashicorp/memberlist.git",
-      :revision => "9888dc523910e5d22c5be4f6e34520943df21809"
+        :revision => "9888dc523910e5d22c5be4f6e34520943df21809"
   end
 
   go_resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
-      :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
+        :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
   end
 
   go_resource "github.com/miekg/dns" do
     url "https://github.com/miekg/dns.git",
-      :revision => "4687536c727745d43759e8baae72cccf716f813a"
+        :revision => "4687536c727745d43759e8baae72cccf716f813a"
   end
 
   go_resource "github.com/mitchellh/cli" do
     url "https://github.com/mitchellh/cli.git",
-      :revision => "cb6853d606ea4a12a15ac83cc43503df99fd28fb"
+        :revision => "cb6853d606ea4a12a15ac83cc43503df99fd28fb"
   end
 
   go_resource "github.com/mitchellh/mapstructure" do
     url "https://github.com/mitchellh/mapstructure.git",
-      :revision => "281073eb9eb092240d33ef253c404f1cca550309"
+        :revision => "281073eb9eb092240d33ef253c404f1cca550309"
   end
 
   go_resource "github.com/ryanuber/columnize" do
     url "https://github.com/ryanuber/columnize.git",
-      :revision => "983d3a5fab1bf04d1b412465d2d9f8430e2e917e"
+        :revision => "983d3a5fab1bf04d1b412465d2d9f8430e2e917e"
   end
 
   def install

--- a/Formula/sift.rb
+++ b/Formula/sift.rb
@@ -17,22 +17,22 @@ class Sift < Formula
 
   go_resource "github.com/svent/go-flags" do
     url "https://github.com/svent/go-flags.git",
-    :revision => "4bcbad344f0318adaf7aabc16929701459009aa3"
+        :revision => "4bcbad344f0318adaf7aabc16929701459009aa3"
   end
 
   go_resource "github.com/svent/go-nbreader" do
     url "https://github.com/svent/go-nbreader.git",
-    :revision => "7cef48da76dca6a496faa7fe63e39ed665cbd219"
+        :revision => "7cef48da76dca6a496faa7fe63e39ed665cbd219"
   end
 
   go_resource "github.com/svent/sift" do
     url "https://github.com/svent/sift.git",
-    :revision => "2d175c4137cad933fa40e0af69020bd658ef5fb3"
+        :revision => "2d175c4137cad933fa40e0af69020bd658ef5fb3"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "1f22c0103821b9390939b6776727195525381532"
+        :revision => "1f22c0103821b9390939b6776727195525381532"
   end
 
   def install

--- a/Formula/slackcat.rb
+++ b/Formula/slackcat.rb
@@ -17,32 +17,32 @@ class Slackcat < Formula
 
   go_resource "github.com/bluele/slack" do
     url "https://github.com/bluele/slack.git",
-      :revision => "ffdcd19858d03d5ebabba5bead2b5dfb18b2c73f"
+        :revision => "ffdcd19858d03d5ebabba5bead2b5dfb18b2c73f"
   end
 
   go_resource "github.com/codegangsta/cli" do
     url "https://github.com/codegangsta/cli.git",
-      :revision => "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
+        :revision => "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
   end
 
   go_resource "github.com/fatih/color" do
     url "https://github.com/fatih/color.git",
-      :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
+        :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
   end
 
   go_resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
-      :revision => "9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59"
+        :revision => "9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59"
   end
 
   go_resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
-      :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
+        :revision => "56b76bdf51f7708750eac80fa38b952bb9f32639"
   end
 
   go_resource "github.com/skratchdot/open-golang" do
     url "https://github.com/skratchdot/open-golang.git",
-      :revision => "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
+        :revision => "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c"
   end
 
   def install

--- a/Formula/srclib.rb
+++ b/Formula/srclib.rb
@@ -192,7 +192,7 @@ class Srclib < Formula
   # For test
   resource "srclib-sample" do
     url "https://github.com/sourcegraph/srclib-sample.git",
-      :revision => "e753b113784bf383f627394e86e4936629a3b588"
+        :revision => "e753b113784bf383f627394e86e4936629a3b588"
   end
 
   test do

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -11,22 +11,22 @@ class Telegraf < Formula
 
     go_resource "github.com/aerospike/aerospike-client-go" do
       url "https://github.com/aerospike/aerospike-client-go.git",
-      :revision => "45863b7fd8640dc12f7fdd397104d97e1986f25a"
+          :revision => "45863b7fd8640dc12f7fdd397104d97e1986f25a"
     end
 
     go_resource "github.com/nats-io/nats" do
       url "https://github.com/nats-io/nats.git",
-      :revision => "b13fc9d12b0b123ebc374e6b808c6228ae4234a3"
+          :revision => "b13fc9d12b0b123ebc374e6b808c6228ae4234a3"
     end
 
     go_resource "github.com/nats-io/nuid" do
       url "https://github.com/nats-io/nuid.git",
-      :revision => "4f84f5f3b2786224e336af2e13dba0a0a80b76fa"
+          :revision => "4f84f5f3b2786224e336af2e13dba0a0a80b76fa"
     end
 
     go_resource "github.com/sparrc/aerospike-client-go" do
       url "https://github.com/sparrc/aerospike-client-go.git",
-      :revision => "d4bb42d2c2d39dae68e054116f4538af189e05d5"
+          :revision => "d4bb42d2c2d39dae68e054116f4538af189e05d5"
     end
   end
 
@@ -43,17 +43,17 @@ class Telegraf < Formula
 
     go_resource "github.com/aerospike/aerospike-client-go" do
       url "https://github.com/aerospike/aerospike-client-go.git",
-      :revision => "7f3a312c3b2a60ac083ec6da296091c52c795c63"
+          :revision => "7f3a312c3b2a60ac083ec6da296091c52c795c63"
     end
 
     go_resource "github.com/nats-io/nats" do
       url "https://github.com/nats-io/nats.git",
-      :revision => "ea8b4fd12ebb823073c0004b9f09ac8748f4f165"
+          :revision => "ea8b4fd12ebb823073c0004b9f09ac8748f4f165"
     end
 
     go_resource "github.com/nats-io/nuid" do
       url "https://github.com/nats-io/nuid.git",
-      :revision => "a5152d67cf63cbfb5d992a395458722a45194715"
+          :revision => "a5152d67cf63cbfb5d992a395458722a45194715"
     end
   end
 
@@ -61,307 +61,307 @@ class Telegraf < Formula
 
   go_resource "github.com/Shopify/sarama" do
     url "https://github.com/Shopify/sarama.git",
-    :revision => "8aadb476e66ca998f2f6bb3c993e9a2daa3666b9"
+        :revision => "8aadb476e66ca998f2f6bb3c993e9a2daa3666b9"
   end
 
   go_resource "github.com/Sirupsen/logrus" do
     url "https://github.com/Sirupsen/logrus.git",
-    :revision => "219c8cb75c258c552e999735be6df753ffc7afdc"
+        :revision => "219c8cb75c258c552e999735be6df753ffc7afdc"
   end
 
   go_resource "github.com/amir/raidman" do
     url "https://github.com/amir/raidman.git",
-    :revision => "53c1b967405155bfc8758557863bf2e14f814687"
+        :revision => "53c1b967405155bfc8758557863bf2e14f814687"
   end
 
   go_resource "github.com/aws/aws-sdk-go" do
     url "https://github.com/aws/aws-sdk-go.git",
-    :revision => "13a12060f716145019378a10e2806c174356b857"
+        :revision => "13a12060f716145019378a10e2806c174356b857"
   end
 
   go_resource "github.com/beorn7/perks" do
     url "https://github.com/beorn7/perks.git",
-    :revision => "3ac7bf7a47d159a033b107610db8a1b6575507a4"
+        :revision => "3ac7bf7a47d159a033b107610db8a1b6575507a4"
   end
 
   go_resource "github.com/cenkalti/backoff" do
     url "https://github.com/cenkalti/backoff.git",
-    :revision => "4dc77674aceaabba2c7e3da25d4c823edfb73f99"
+        :revision => "4dc77674aceaabba2c7e3da25d4c823edfb73f99"
   end
 
   go_resource "github.com/couchbase/go-couchbase" do
     url "https://github.com/couchbase/go-couchbase.git",
-    :revision => "cb664315a324d87d19c879d9cc67fda6be8c2ac1"
+        :revision => "cb664315a324d87d19c879d9cc67fda6be8c2ac1"
   end
 
   go_resource "github.com/couchbase/gomemcached" do
     url "https://github.com/couchbase/gomemcached.git",
-    :revision => "a5ea6356f648fec6ab89add00edd09151455b4b2"
+        :revision => "a5ea6356f648fec6ab89add00edd09151455b4b2"
   end
 
   go_resource "github.com/couchbase/goutils" do
     url "https://github.com/couchbase/goutils.git",
-    :revision => "5823a0cbaaa9008406021dc5daf80125ea30bba6"
+        :revision => "5823a0cbaaa9008406021dc5daf80125ea30bba6"
   end
 
   go_resource "github.com/dancannon/gorethink" do
     url "https://github.com/dancannon/gorethink.git",
-    :revision => "e7cac92ea2bc52638791a021f212145acfedb1fc"
+        :revision => "e7cac92ea2bc52638791a021f212145acfedb1fc"
   end
 
   go_resource "github.com/davecgh/go-spew" do
     url "https://github.com/davecgh/go-spew.git",
-    :revision => "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+        :revision => "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
   end
 
   go_resource "github.com/docker/engine-api" do
     url "https://github.com/docker/engine-api.git",
-    :revision => "8924d6900370b4c7e7984be5adc61f50a80d7537"
+        :revision => "8924d6900370b4c7e7984be5adc61f50a80d7537"
   end
 
   go_resource "github.com/docker/go-connections" do
     url "https://github.com/docker/go-connections.git",
-    :revision => "f549a9393d05688dff0992ef3efd8bbe6c628aeb"
+        :revision => "f549a9393d05688dff0992ef3efd8bbe6c628aeb"
   end
 
   go_resource "github.com/docker/go-units" do
     url "https://github.com/docker/go-units.git",
-    :revision => "5d2041e26a699eaca682e2ea41c8f891e1060444"
+        :revision => "5d2041e26a699eaca682e2ea41c8f891e1060444"
   end
 
   go_resource "github.com/eapache/go-resiliency" do
     url "https://github.com/eapache/go-resiliency.git",
-    :revision => "b86b1ec0dd4209a588dc1285cdd471e73525c0b3"
+        :revision => "b86b1ec0dd4209a588dc1285cdd471e73525c0b3"
   end
 
   go_resource "github.com/eapache/queue" do
     url "https://github.com/eapache/queue.git",
-    :revision => "ded5959c0d4e360646dc9e9908cff48666781367"
+        :revision => "ded5959c0d4e360646dc9e9908cff48666781367"
   end
 
   go_resource "github.com/eclipse/paho.mqtt.golang" do
     url "https://github.com/eclipse/paho.mqtt.golang.git",
-    :revision => "0f7a459f04f13a41b7ed752d47944528d4bf9a86"
+        :revision => "0f7a459f04f13a41b7ed752d47944528d4bf9a86"
   end
 
   go_resource "github.com/go-sql-driver/mysql" do
     url "https://github.com/go-sql-driver/mysql.git",
-    :revision => "1fca743146605a172a266e1654e01e5cd5669bee"
+        :revision => "1fca743146605a172a266e1654e01e5cd5669bee"
   end
 
   go_resource "github.com/gobwas/glob" do
     url "https://github.com/gobwas/glob.git",
-    :revision => "49571a1557cd20e6a2410adc6421f85b66c730b5"
+        :revision => "49571a1557cd20e6a2410adc6421f85b66c730b5"
   end
 
   go_resource "github.com/golang/protobuf" do
     url "https://github.com/golang/protobuf.git",
-    :revision => "552c7b9542c194800fd493123b3798ef0a832032"
+        :revision => "552c7b9542c194800fd493123b3798ef0a832032"
   end
 
   go_resource "github.com/golang/snappy" do
     url "https://github.com/golang/snappy.git",
-    :revision => "427fb6fc07997f43afa32f35e850833760e489a7"
+        :revision => "427fb6fc07997f43afa32f35e850833760e489a7"
   end
 
   go_resource "github.com/gonuts/go-shellquote" do
     url "https://github.com/gonuts/go-shellquote.git",
-    :revision => "e842a11b24c6abfb3dd27af69a17f482e4b483c2"
+        :revision => "e842a11b24c6abfb3dd27af69a17f482e4b483c2"
   end
 
   go_resource "github.com/gorilla/context" do
     url "https://github.com/gorilla/context.git",
-    :revision => "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+        :revision => "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   end
 
   go_resource "github.com/gorilla/mux" do
     url "https://github.com/gorilla/mux.git",
-    :revision => "c9e326e2bdec29039a3761c07bece13133863e1e"
+        :revision => "c9e326e2bdec29039a3761c07bece13133863e1e"
   end
 
   go_resource "github.com/hailocab/go-hostpool" do
     url "https://github.com/hailocab/go-hostpool.git",
-    :revision => "e80d13ce29ede4452c43dea11e79b9bc8a15b478"
+        :revision => "e80d13ce29ede4452c43dea11e79b9bc8a15b478"
   end
 
   go_resource "github.com/hashicorp/consul" do
     url "https://github.com/hashicorp/consul.git",
-    :revision => "5aa90455ce78d4d41578bafc86305e6e6b28d7d2"
+        :revision => "5aa90455ce78d4d41578bafc86305e6e6b28d7d2"
   end
 
   go_resource "github.com/hpcloud/tail" do
     url "https://github.com/hpcloud/tail.git",
-    :revision => "b2940955ab8b26e19d43a43c4da0475dd81bdb56"
+        :revision => "b2940955ab8b26e19d43a43c4da0475dd81bdb56"
   end
 
   go_resource "github.com/influxdata/config" do
     url "https://github.com/influxdata/config.git",
-    :revision => "b79f6829346b8d6e78ba73544b1e1038f1f1c9da"
+        :revision => "b79f6829346b8d6e78ba73544b1e1038f1f1c9da"
   end
 
   go_resource "github.com/influxdata/influxdb" do
     url "https://github.com/influxdata/influxdb.git",
-    :revision => "e094138084855d444195b252314dfee9eae34cab"
+        :revision => "e094138084855d444195b252314dfee9eae34cab"
   end
 
   go_resource "github.com/influxdata/toml" do
     url "https://github.com/influxdata/toml.git",
-    :revision => "af4df43894b16e3fd2b788d01bd27ad0776ef2d0"
+        :revision => "af4df43894b16e3fd2b788d01bd27ad0776ef2d0"
   end
 
   go_resource "github.com/kardianos/osext" do
     url "https://github.com/kardianos/osext.git",
-    :revision => "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"
+        :revision => "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"
   end
 
   go_resource "github.com/kardianos/service" do
     url "https://github.com/kardianos/service.git",
-    :revision => "5e335590050d6d00f3aa270217d288dda1c94d0a"
+        :revision => "5e335590050d6d00f3aa270217d288dda1c94d0a"
   end
 
   go_resource "github.com/klauspost/crc32" do
     url "https://github.com/klauspost/crc32.git",
-    :revision => "19b0b332c9e4516a6370a0456e6182c3b5036720"
+        :revision => "19b0b332c9e4516a6370a0456e6182c3b5036720"
   end
 
   go_resource "github.com/lib/pq" do
     url "https://github.com/lib/pq.git",
-    :revision => "e182dc4027e2ded4b19396d638610f2653295f36"
+        :revision => "e182dc4027e2ded4b19396d638610f2653295f36"
   end
 
   go_resource "github.com/matttproud/golang_protobuf_extensions" do
     url "https://github.com/matttproud/golang_protobuf_extensions.git",
-    :revision => "d0c3fe89de86839aecf2e0579c40ba3bb336a453"
+        :revision => "d0c3fe89de86839aecf2e0579c40ba3bb336a453"
   end
 
   go_resource "github.com/miekg/dns" do
     url "https://github.com/miekg/dns.git",
-    :revision => "cce6c130cdb92c752850880fd285bea1d64439dd"
+        :revision => "cce6c130cdb92c752850880fd285bea1d64439dd"
   end
 
   go_resource "github.com/mreiferson/go-snappystream" do
     url "https://github.com/mreiferson/go-snappystream.git",
-    :revision => "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504"
+        :revision => "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504"
   end
 
   go_resource "github.com/naoina/go-stringutil" do
     url "https://github.com/naoina/go-stringutil.git",
-    :revision => "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b"
+        :revision => "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b"
   end
 
   go_resource "github.com/nsqio/go-nsq" do
     url "https://github.com/nsqio/go-nsq.git",
-    :revision => "0b80d6f05e15ca1930e0c5e1d540ed627e299980"
+        :revision => "0b80d6f05e15ca1930e0c5e1d540ed627e299980"
   end
 
   go_resource "github.com/opencontainers/runc" do
     url "https://github.com/opencontainers/runc.git",
-    :revision => "89ab7f2ccc1e45ddf6485eaa802c35dcf321dfc8"
+        :revision => "89ab7f2ccc1e45ddf6485eaa802c35dcf321dfc8"
   end
 
   go_resource "github.com/prometheus/client_golang" do
     url "https://github.com/prometheus/client_golang.git",
-    :revision => "18acf9993a863f4c4b40612e19cdd243e7c86831"
+        :revision => "18acf9993a863f4c4b40612e19cdd243e7c86831"
   end
 
   go_resource "github.com/prometheus/client_model" do
     url "https://github.com/prometheus/client_model.git",
-    :revision => "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+        :revision => "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
   end
 
   go_resource "github.com/prometheus/common" do
     url "https://github.com/prometheus/common.git",
-    :revision => "e8eabff8812b05acf522b45fdcd725a785188e37"
+        :revision => "e8eabff8812b05acf522b45fdcd725a785188e37"
   end
 
   go_resource "github.com/prometheus/procfs" do
     url "https://github.com/prometheus/procfs.git",
-    :revision => "406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8"
+        :revision => "406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8"
   end
 
   go_resource "github.com/samuel/go-zookeeper" do
     url "https://github.com/samuel/go-zookeeper.git",
-    :revision => "218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f"
+        :revision => "218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f"
   end
 
   go_resource "github.com/shirou/gopsutil" do
     url "https://github.com/shirou/gopsutil.git",
-    :revision => "4d0c402af66c78735c5ccf820dc2ca7de5e4ff08"
+        :revision => "4d0c402af66c78735c5ccf820dc2ca7de5e4ff08"
   end
 
   go_resource "github.com/soniah/gosnmp" do
     url "https://github.com/soniah/gosnmp.git",
-    :revision => "eb32571c2410868d85849ad67d1e51d01273eb84"
+        :revision => "eb32571c2410868d85849ad67d1e51d01273eb84"
   end
 
   go_resource "github.com/streadway/amqp" do
     url "https://github.com/streadway/amqp.git",
-    :revision => "b4f3ceab0337f013208d31348b578d83c0064744"
+        :revision => "b4f3ceab0337f013208d31348b578d83c0064744"
   end
 
   go_resource "github.com/stretchr/testify" do
     url "https://github.com/stretchr/testify.git",
-    :revision => "1f4a1643a57e798696635ea4c126e9127adb7d3c"
+        :revision => "1f4a1643a57e798696635ea4c126e9127adb7d3c"
   end
 
   go_resource "github.com/vjeantet/grok" do
     url "https://github.com/vjeantet/grok.git",
-    :revision => "83bfdfdfd1a8146795b28e547a8e3c8b28a466c2"
+        :revision => "83bfdfdfd1a8146795b28e547a8e3c8b28a466c2"
   end
 
   go_resource "github.com/wvanbergen/kafka" do
     url "https://github.com/wvanbergen/kafka.git",
-    :revision => "46f9a1cf3f670edec492029fadded9c2d9e18866"
+        :revision => "46f9a1cf3f670edec492029fadded9c2d9e18866"
   end
 
   go_resource "github.com/wvanbergen/kazoo-go" do
     url "https://github.com/wvanbergen/kazoo-go.git",
-    :revision => "0f768712ae6f76454f987c3356177e138df258f8"
+        :revision => "0f768712ae6f76454f987c3356177e138df258f8"
   end
 
   go_resource "github.com/yuin/gopher-lua" do
     url "https://github.com/yuin/gopher-lua.git",
-    :revision => "bf3808abd44b1e55143a2d7f08571aaa80db1808"
+        :revision => "bf3808abd44b1e55143a2d7f08571aaa80db1808"
   end
 
   go_resource "github.com/zensqlmonitor/go-mssqldb" do
     url "https://github.com/zensqlmonitor/go-mssqldb.git",
-    :revision => "ffe5510c6fa5e15e6d983210ab501c815b56b363"
+        :revision => "ffe5510c6fa5e15e6d983210ab501c815b56b363"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3"
+        :revision => "5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-    :revision => "6acef71eb69611914f7a30939ea9f6e194c78172"
+        :revision => "6acef71eb69611914f7a30939ea9f6e194c78172"
   end
 
   go_resource "golang.org/x/text" do
     url "https://go.googlesource.com/text.git",
-    :revision => "a71fd10341b064c10f4a81ceac72bcf70f26ea34"
+        :revision => "a71fd10341b064c10f4a81ceac72bcf70f26ea34"
   end
 
   go_resource "gopkg.in/dancannon/gorethink.v1" do
     url "https://gopkg.in/dancannon/gorethink.v1.git",
-    :revision => "7d1af5be49cb5ecc7b177bf387d232050299d6ef"
+        :revision => "7d1af5be49cb5ecc7b177bf387d232050299d6ef"
   end
 
   go_resource "gopkg.in/fatih/pool.v2" do
     url "https://gopkg.in/fatih/pool.v2.git",
-    :revision => "cba550ebf9bce999a02e963296d4bc7a486cb715"
+        :revision => "cba550ebf9bce999a02e963296d4bc7a486cb715"
   end
 
   go_resource "gopkg.in/mgo.v2" do
     url "https://gopkg.in/mgo.v2.git",
-    :revision => "d90005c5262a3463800497ea5a89aed5fe22c886"
+        :revision => "d90005c5262a3463800497ea5a89aed5fe22c886"
   end
 
   go_resource "gopkg.in/yaml.v2" do
     url "https://gopkg.in/yaml.v2.git",
-    :revision => "a83829b6f1293c91addabc89d0571c246397bbf4"
+        :revision => "a83829b6f1293c91addabc89d0571c246397bbf4"
   end
 
   def install

--- a/Formula/termshare.rb
+++ b/Formula/termshare.rb
@@ -21,22 +21,22 @@ class Termshare < Formula
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-    :revision => "7553b97266dcbbf78298bd1a2b12d9c9aaae5f40"
+        :revision => "7553b97266dcbbf78298bd1a2b12d9c9aaae5f40"
   end
 
   go_resource "github.com/heroku/hk" do
     url "https://github.com/heroku/hk.git",
-    :revision => "406190e9c93802fb0a49b5c09611790aee05c491"
+        :revision => "406190e9c93802fb0a49b5c09611790aee05c491"
   end
 
   go_resource "github.com/kr/pty" do
     url "https://github.com/kr/pty.git",
-    :revision => "f7ee69f31298ecbe5d2b349c711e2547a617d398"
+        :revision => "f7ee69f31298ecbe5d2b349c711e2547a617d398"
   end
 
   go_resource "github.com/nu7hatch/gouuid" do
     url "https://github.com/nu7hatch/gouuid.git",
-    :revision => "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
+        :revision => "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
   end
 
   def install

--- a/Formula/terraform-inventory.rb
+++ b/Formula/terraform-inventory.rb
@@ -18,7 +18,7 @@ class TerraformInventory < Formula
 
   go_resource "github.com/stretchr/testify" do
     url "https://github.com/stretchr/testify.git",
-    :revision => "f390dcf405f7b83c997eac1b06768bb9f44dec18"
+        :revision => "f390dcf405f7b83c997eac1b06768bb9f44dec18"
   end
 
   def install

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -28,7 +28,8 @@ class Terraform < Formula
   end
 
   go_resource "golang.org/x/tools" do
-    url "https://go.googlesource.com/tools.git", :revision => "977844c7af2aa555048a19d28e9fe6c392e7b8e9"
+    url "https://go.googlesource.com/tools.git",
+        :revision => "977844c7af2aa555048a19d28e9fe6c392e7b8e9"
   end
 
   def install

--- a/Formula/textql.rb
+++ b/Formula/textql.rb
@@ -17,7 +17,7 @@ class Textql < Formula
 
   go_resource "github.com/mattn/go-sqlite3" do
     url "https://github.com/mattn/go-sqlite3.git",
-      :revision => "8897bf145272af4dd0305518cfb725a5b6d0541c"
+        :revision => "8897bf145272af4dd0305518cfb725a5b6d0541c"
   end
 
   def install

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -22,12 +22,12 @@ class Vault < Formula
 
   go_resource "github.com/mitchellh/iochan" do
     url "https://github.com/mitchellh/iochan.git",
-    :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
+        :revision => "87b45ffd0e9581375c491fef3d32130bb15c5bd7"
   end
 
   go_resource "github.com/mitchellh/gox" do
     url "https://github.com/mitchellh/gox.git",
-    :revision => "c9740af9c6574448fd48eb30a71f964014c7a837"
+        :revision => "c9740af9c6574448fd48eb30a71f964014c7a837"
   end
 
   def install

--- a/Formula/vaulted.rb
+++ b/Formula/vaulted.rb
@@ -19,42 +19,42 @@ class Vaulted < Formula
 
   go_resource "github.com/aws/aws-sdk-go" do
     url "https://github.com/aws/aws-sdk-go.git",
-    :revision => "94673f7d41219ea3e94e4b1edc01315f14268f72"
+        :revision => "94673f7d41219ea3e94e4b1edc01315f14268f72"
   end
 
   go_resource "github.com/fatih/color" do
     url "https://github.com/fatih/color.git",
-    :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
+        :revision => "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
   end
 
   go_resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
-    :revision => "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
+        :revision => "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
   end
 
   go_resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
-    :revision => "3a115632dcd687f9c8cd01679c83a06a0e21c1f3"
+        :revision => "3a115632dcd687f9c8cd01679c83a06a0e21c1f3"
   end
 
   go_resource "github.com/miquella/ask" do
     url "https://github.com/miquella/ask.git",
-    :revision => "486a722fa4cdb033d35a501d54116b645e139ef3"
+        :revision => "486a722fa4cdb033d35a501d54116b645e139ef3"
   end
 
   go_resource "github.com/miquella/xdg" do
     url "https://github.com/miquella/xdg.git",
-    :revision => "1ee6df0d556245ee71d26d54f9dbfea1f84d136a"
+        :revision => "1ee6df0d556245ee71d26d54f9dbfea1f84d136a"
   end
 
   go_resource "github.com/spf13/pflag" do
     url "https://github.com/spf13/pflag.git",
-    :revision => "4f9190456aed1c2113ca51ea9b89219747458dc1"
+        :revision => "4f9190456aed1c2113ca51ea9b89219747458dc1"
   end
 
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
-    :revision => "9fbab14f903f89e23047b5971369b86380230e56"
+        :revision => "9fbab14f903f89e23047b5971369b86380230e56"
   end
 
   def install

--- a/Formula/vultr.rb
+++ b/Formula/vultr.rb
@@ -19,15 +19,18 @@ class Vultr < Formula
   depends_on "godep" => :build
 
   go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs.git", :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+    url "https://github.com/kr/fs.git",
+        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
   end
 
   go_resource "golang.org/x/tools" do
-    url "https://github.com/golang/tools.git", :revision => "fbb6674a7495706ad1ba2d7cca18ca9d804ccdca"
+    url "https://github.com/golang/tools.git",
+        :revision => "fbb6674a7495706ad1ba2d7cca18ca9d804ccdca"
   end
 
   go_resource "golang.org/x/crypto" do
-    url "https://github.com/golang/crypto.git", :revision => "91ab96ae987aef3e74ab78b3aaf026109d206148"
+    url "https://github.com/golang/crypto.git",
+        :revision => "91ab96ae987aef3e74ab78b3aaf026109d206148"
   end
 
   def install

--- a/Formula/websocketd.rb
+++ b/Formula/websocketd.rb
@@ -18,12 +18,12 @@ class Websocketd < Formula
 
   go_resource "github.com/joewalnes/websocketd" do
     url "https://github.com/joewalnes/websocketd.git",
-      :revision => "709c49912b0d8575e9e9d4035aa0b07183bd879e"
+        :revision => "709c49912b0d8575e9e9d4035aa0b07183bd879e"
   end
 
   go_resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
-      :revision => "30db96677b74e24b967e23f911eb3364fc61a011"
+        :revision => "30db96677b74e24b967e23f911eb3364fc61a011"
   end
 
   def install

--- a/Formula/wellington.rb
+++ b/Formula/wellington.rb
@@ -39,12 +39,12 @@ class Wellington < Formula
 
   go_resource "github.com/kr/fs" do
     url "https://github.com/kr/fs.git",
-      :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
   end
 
   go_resource "golang.org/x/tools" do
     url "https://github.com/golang/tools.git",
-      :revision => "ea5101579e09ace53571c8a5bae6ebb896f8d5e4"
+        :revision => "ea5101579e09ace53571c8a5bae6ebb896f8d5e4"
   end
 
   def install

--- a/Formula/wiki.rb
+++ b/Formula/wiki.rb
@@ -19,7 +19,7 @@ class Wiki < Formula
 
   go_resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
-      :revision => "40e4aedc8fabf8c23e040057540867186712faa5"
+        :revision => "40e4aedc8fabf8c23e040057540867186712faa5"
   end
 
   def install


### PR DESCRIPTION
Massive PR to correct the `:revision` line of all `go_resources` into the following indentation style, which allegedly is the current standard:

``` ruby
   go_resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
         :revision => "5bcd134fee4dd1475da17714aac19c0aa0142e2f"
   end
```

No more frigging arguments, no more begging contributors to update the style, whitespace nazis and OCD sufferers (there is indeed a considerable overlap between these two demographics) rejoice.

Note that there are still other places with inconsistent styles, most notably `:revision` after a formula's `url`. But we can at least settle the `go_resource` problem first.

Maintainers: please kill the CI build for me if you come across it.
