### PR TITLE
sonarqube: renamed from sonar

### DIFF
--- a/Aliases/sonarqube
+++ b/Aliases/sonarqube
@@ -1,1 +1,0 @@
-../Formula/sonar.rb

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -4,9 +4,9 @@ class Sonarqube < Formula
   url "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.0.zip"
   sha256 "2256e0b44629632d9528911c8d5916ce246c7abe2be65a6a59a94dee504d62a6"
 
-  depends_on :java => "1.8+"
-
   bottle :unneeded
+
+  depends_on :java => "1.8+"
 
   def install
     # Delete native bin directories for other systems

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -1,4 +1,4 @@
-class Sonar < Formula
+class Sonarqube < Formula
   desc "Manage code quality"
   homepage "http://www.sonarqube.org/"
   url "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-6.0.zip"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -26,5 +26,6 @@
   "polarssl": "mbedtls",
   "racket": "minimal-racket",
   "screenbrightness": "brightness",
+  "sonar": "sonarqube",
   "wires": "geckodriver"
 }


### PR DESCRIPTION
Sonar has been renamed into SonarQube 3 years ago - http://www.sonarsource.com/company/news/sonarsource-news/sonar-becomes-the-sonarqube-platform/ 
