### PR TITLE
fix pango 1.40.2 install issue on OSX 10.6.x

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -10,7 +10,8 @@ class Pango < Formula
     sha256 "861f6ad2e6c8c06b7072a238dca831cbf5a09eb9125a015150f3d522dbe7d7a7" => :yosemite
     sha256 "1e9be870617caba7603eb1b8953eed684a863035ae2becabe0dd86b9f96a540a" => :mavericks
   end
-
+  
+  # upstream bug report - https://bugzilla.gnome.org/show_bug.cgi?id=770729
   patch :p1, :DATA
 
   head do

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -11,6 +11,8 @@ class Pango < Formula
     sha256 "1e9be870617caba7603eb1b8953eed684a863035ae2becabe0dd86b9f96a540a" => :mavericks
   end
 
+  patch :p1, :DATA
+
   head do
     url "https://git.gnome.org/browse/pango.git"
 
@@ -102,3 +104,21 @@ class Pango < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/pango/pangocoretext-fontmap.c b/pango/pangocoretext-fontmap.c
+index 0d7d793..05d1fd0 100644
+--- a/pango/pangocoretext-fontmap.c
++++ b/pango/pangocoretext-fontmap.c
+@@ -110,8 +110,8 @@ typedef struct
+     PangoWeight pango_weight;
+ } PangoCTWeight;
+
+-const float ct_weight_min = -0.7f;
+-const float ct_weight_max = 0.8f;
++#define ct_weight_min -0.7
++#define ct_weight_max 0.8
+
+ /* This map is based on empirical data from analyzing a large collection of
+  * fonts and comparing the opentype value with the value that OSX returns.
+

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -10,7 +10,7 @@ class Pango < Formula
     sha256 "861f6ad2e6c8c06b7072a238dca831cbf5a09eb9125a015150f3d522dbe7d7a7" => :yosemite
     sha256 "1e9be870617caba7603eb1b8953eed684a863035ae2becabe0dd86b9f96a540a" => :mavericks
   end
-  
+
   # upstream bug report - https://bugzilla.gnome.org/show_bug.cgi?id=770729
   patch :p1, :DATA
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

pango 1.40.2 fails to install on OSX 10.6.x with the following compilation errors -

```
pangocoretext-fontmap.c:122: error: initializer element is not constant
pangocoretext-fontmap.c:122: error: (near initialization for ‘ct_weight_map[0].ct_weight’)
pangocoretext-fontmap.c:131: error: initializer element is not constant
pangocoretext-fontmap.c:131: error: (near initialization for ‘ct_weight_map[9].ct_weight’)
make[4]: *** [pangocoretext-fontmap.lo] Error 1
```

This pull request fixes these compilation errors.
