### PR TITLE
graphviz: Support building with ghostscript>=9.16

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -1,9 +1,19 @@
 class Graphviz < Formula
   desc "Graph visualization software from AT&T and Bell Labs"
   homepage "http://graphviz.org/"
-  url "http://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/graphviz/graphviz_2.38.0.orig.tar.gz"
-  sha256 "81aa238d9d4a010afa73a9d2a704fc3221c731e1e06577c2ab3496bdef67859e"
+
+  stable do
+    url "http://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz"
+    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/graphviz/graphviz_2.38.0.orig.tar.gz"
+    sha256 "81aa238d9d4a010afa73a9d2a704fc3221c731e1e06577c2ab3496bdef67859e"
+
+    # https://github.com/ellson/graphviz/commit/f97c86e
+    # Support either version of ghostcript's error prefixes
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/6a6a1a3/graphviz/patch-gvloadimage_gs.c.diff"
+      sha256 "bcc0758dd9e0ac17bd1cde63a55a613124814002b470ac4a7a0c421c83a253ab"
+    end
+  end
 
   bottle do
     rebuild 1

--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -1,6 +1,7 @@
 class Graphviz < Formula
   desc "Graph visualization software from AT&T and Bell Labs"
   homepage "http://graphviz.org/"
+  revision 1
 
   stable do
     url "http://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz"


### PR DESCRIPTION
Using preexisting patch from graphviz’s repo: https://github.com/ellson/graphviz/commit/f97c86e975aa472272d0a5b5a042b96eb77ebbc0
