### PR TITLE
ykclient: various fix and improvements

### DIFF
--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -1,7 +1,7 @@
 class Ykclient < Formula
   desc "Library to validate YubiKey OTPs against YubiCloud"
-  homepage "https://yubico.github.io/yubico-c-client/"
-  url "https://yubico.github.io/yubico-c-client/releases/ykclient-2.15.tar.gz"
+  homepage "https://developers.yubico.com/yubico-c-client/"
+  url "https://developers.yubico.com/yubico-c-client/Releases/ykclient-2.15.tar.gz"
   sha256 "f461cdefe7955d58bbd09d0eb7a15b36cb3576b88adbd68008f40ea978ea5016"
 
   bottle do

--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -11,6 +11,14 @@ class Ykclient < Formula
     sha256 "c051e1c30bc2cb34907e5d91e1addb572d2bfa2011c75e13c167712d93fefb47" => :mavericks
   end
 
+  head do
+    url "https://github.com/Yubico/yubico-c-client.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   option :universal
 
   depends_on "pkg-config" => :build
@@ -18,9 +26,13 @@ class Ykclient < Formula
 
   def install
     ENV.universal_binary if build.universal?
+    # https://github.com/Yubico/yubico-c-client/issues/38
+    ENV.deparallelize if build.head?
 
+    system "autoreconf", "-iv" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+    system "make", "check"
   end
 
   test do

--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -24,6 +24,6 @@ class Ykclient < Formula
   end
 
   test do
-    system "#{bin}/ykclient", "--version"
+    assert_equal version.to_s, shell_output("#{bin}/ykclient --version").chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`ykclient`, or actually `yubico-c-client`, has moved to https://developers.yubico.com/yubico-c-client/.

I'm adding the head build along the way. Note I'm using `ENV.deparallelize`: the Makefile in current master seems to be suffering from a race condition where `help2man` is called on the `ykclient` executable before it is even generated. I don't bother to report a bug at this point; hope they'll sort this out if they ever release another version.
