### PR TITLE
imagemagick: fix option handling

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -18,6 +18,7 @@ class Imagemagick < Formula
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
   option "with-opencl", "Compile with OpenCL support"
+  option "with-openjpeg", "Compile with JPEG 2000 support"
   option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
   option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
@@ -26,7 +27,7 @@ class Imagemagick < Formula
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-modules", "Disable support for dynamically loadable modules"
   option "without-threads", "Disable threads support"
-  option "with-zero-configuration", "Disables depending on XML configuration files"
+  option "with-zero-configuration", "Disable configuration files"
 
   deprecated_option "enable-hdri" => "with-hdri"
   deprecated_option "with-jp2" => "with-openjpeg"
@@ -40,20 +41,20 @@ class Imagemagick < Formula
   depends_on "libtiff" => :recommended
   depends_on "freetype" => :recommended
 
-  depends_on :x11 => :optional
+  depends_on "fftw" => :optional
   depends_on "fontconfig" => :optional
+  depends_on "ghostscript" => :optional
+  depends_on "liblqr" => :optional
+  depends_on "librsvg" => :optional
+  depends_on "libwmf" => :optional
   depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
-  depends_on "libwmf" => :optional
-  depends_on "librsvg" => :optional
-  depends_on "liblqr" => :optional
   depends_on "openexr" => :optional
-  depends_on "ghostscript" => :optional
-  depends_on "webp" => :optional
   depends_on "openjpeg" => :optional
-  depends_on "fftw" => :optional
   depends_on "pango" => :optional
+  depends_on "webp" => :optional
   depends_on :perl => ["5.5", :optional]
+  depends_on :x11 => :optional
 
   needs :openmp if build.with? "openmp"
 
@@ -69,49 +70,44 @@ class Imagemagick < Formula
       --enable-static
     ]
 
-    if build.without? "modules"
-      args << "--without-modules"
-    else
-      args << "--with-modules"
+    %W[hdri opencl openmp zero-configuration].each do |feature|
+      if build.with? feature
+        args << "--enable-#{feature}"
+      else
+        args << "--disable-#{feature}"
+      end
     end
 
-    if build.with? "opencl"
-      args << "--enable-opencl"
-    else
-      args << "--disable-opencl"
+    %W[fftw fontconfig freetype jpeg magick-plus-plus modules openexr pango
+       perl threads webp].each do |feature|
+      if build.with? feature
+        args << "--with-#{feature}"
+      else
+        args << "--without-#{feature}"
+      end
     end
 
-    if build.with? "openmp"
-      args << "--enable-openmp"
-    else
-      args << "--disable-openmp"
+    %W[
+      ghostscript gslib
+      liblqr lqr
+      libpng png
+      librsvg rsvg
+      libtiff tiff
+      libwmf wmf
+      little-cms lcms
+      openjpeg openjp2
+      x11 x
+    ].each_slice(2) do |option, feature|
+      if build.with? option
+        args << "--with-#{feature}"
+      else
+        args << "--without-#{feature}"
+      end
     end
 
-    if build.with? "webp"
-      args << "--with-webp=yes"
-    else
-      args << "--without-webp"
-    end
-
-    if build.with? "openjpeg"
-      args << "--with-openjp2"
-    else
-      args << "--without-openjp2"
-    end
-
-    args << "--without-gslib" if build.without? "ghostscript"
-    args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
-    args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"
-    args << "--without-magick-plus-plus" if build.without? "magick-plus-plus"
-    args << "--enable-hdri=yes" if build.with? "hdri"
-    args << "--without-fftw" if build.without? "fftw"
-    args << "--without-pango" if build.without? "pango"
-    args << "--without-threads" if build.without? "threads"
-    args << "--with-rsvg" if build.with? "librsvg"
-    args << "--without-x" if build.without? "x11"
-    args << "--with-fontconfig=yes" if build.with? "fontconfig"
-    args << "--with-freetype=yes" if build.with? "freetype"
-    args << "--enable-zero-configuration" if build.with? "zero-configuration"
+    gs_font_dir = HOMEBREW_PREFIX/"share/ghostscript/fonts"
+    args << "--with-gs-font-dir=#{gs_font_dir}" if build.with? "ghostscript"
+    args << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
 
     if build.with? "quantum-depth-32"
       quantum_depth = 32
@@ -123,7 +119,8 @@ class Imagemagick < Formula
     args << "--with-quantum-depth=#{quantum_depth}" if quantum_depth
 
     # versioned stuff in main tree is pointless for us
-    inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"
+    inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}",
+                           "${PACKAGE_NAME}"
     system "./configure", *args
     system "make", "install"
   end
@@ -137,7 +134,8 @@ class Imagemagick < Formula
   end
 
   test do
-    assert_match "PNG", shell_output("#{bin}/identify #{test_fixtures("test.png")}")
+    test_image = test_fixtures("test.png")
+    assert_match "PNG", shell_output("#{bin}/identify #{test_image}")
     # Check support for recommended features and delegates.
     features = shell_output("#{bin}/convert -version")
     %W[Modules freetype jpeg png tiff].each do |feature|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Specify `--enable`/`--disable` or `--with`/`--without` for every single feature and delegate to prevent opportunistic linking.

This is necessary for preventing screwups like the 6.9.5-9_2 rebuild #0 bottle, which picked up `libwmflite-0.2.7.dylib` from `libwmf`, which was then missing due to `libwmf` not being a recommended dep. That resulted in the post-launch audit failure in https://travis-ci.org/Homebrew/homebrew-core/jobs/158917006#L2075-L2080 and a subsequent rebuild.
