### PR TITLE
qemu: Disable cocoa UI when SDL/GTK+ are enabled.

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -49,14 +49,15 @@ class Qemu < Formula
       --disable-guest-agent
     ]
 
-    # Cocoa and SDL UIs cannot both be enabled at once.
-    if build.with? "sdl"
-      args << "--enable-sdl" << "--disable-cocoa"
+    # Cocoa and SDL/GTK+ UIs cannot both be enabled at once.
+    if build.with?("sdl") || build.with?("gtk+")
+      args << "--disable-cocoa"
     else
-      args << "--enable-cocoa" << "--disable-sdl"
+      args << "--enable-cocoa"
     end
 
     args << (build.with?("vde") ? "--enable-vde" : "--disable-vde")
+    args << (build.with?("sdl") ? "--enable-sdl" : "--disable-sdl")
     args << (build.with?("gtk+") ? "--enable-gtk" : "--disable-gtk")
     args << (build.with?("libssh2") ? "--enable-libssh2" : "--disable-libssh2")
 


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-core/issues/4707, avoids build error found in http://git.qemu-project.org/?p=qemu.git;a=blob;f=configure;h=4b808f9d17f640347bb8ffd4033461464eb0b8bb;hb=1dc33ed90bf1fe1c2014dffa0d9e863c520d953a#l1702.
