### PR TITLE
zsh-git-prompt 0.5 (new formula)

### DIFF
--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -1,0 +1,25 @@
+class ZshGitPrompt < Formula
+  desc "Informative git prompt for zsh"
+  homepage "https://github.com/olivierverdier/zsh-git-prompt"
+  url "https://github.com/olivierverdier/zsh-git-prompt/archive/v0.5.tar.gz"
+  sha256 "87e5a908369f402e975426ffd61a8800f1c04c0a293f1d4015a6fb1f4408e77d"
+
+  bottle :unneeded
+
+  def install
+    inreplace "README.md", "path/to", opt_prefix
+    prefix.install Dir["*.{sh,py}"]
+  end
+
+  def caveats; <<-EOS.undent
+    For setup instructions:
+      less "#{opt_prefix}/README.md"
+    EOS
+  end
+
+  test do
+    system "git", "init"
+    assert_equal "(%{\e[01;35m%}master%{\e[00m%}|%{…%G%}%{\e[00m%}%{\e[00m%})",
+      shell_output("zsh -c '. #{opt_prefix}/zshrc.sh && git_super_status'").chomp
+  end
+end

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -12,8 +12,11 @@ class ZshGitPrompt < Formula
   end
 
   def caveats; <<-EOS.undent
-    For setup instructions:
-      less "#{opt_prefix}/README.md"
+    First, make sure zsh-git-prompt is loaded from your zshrc:
+      source "#{opt_prefix}/zshrc.sh"
+
+    Then include $(git_super_status) in your PROMPT or RPROMPT, e.g.:
+      PROMPT='%B%m%~%b$(git_super_status) %# '
     EOS
   end
 

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -11,7 +11,7 @@ class ZshGitPrompt < Formula
   end
 
   def caveats; <<-EOS.undent
-    First, make sure zsh-git-prompt is loaded from your zshrc:
+    First, make sure zsh-git-prompt is loaded from your .zshrc:
       source "#{opt_prefix}/zshrc.sh"
 
     Then include $(git_super_status) in your PROMPT or RPROMPT, e.g.:

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -7,7 +7,6 @@ class ZshGitPrompt < Formula
   bottle :unneeded
 
   def install
-    inreplace "README.md", "path/to", opt_prefix
     prefix.install Dir["*.{sh,py}"]
   end
 

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -19,7 +19,7 @@ class ZshGitPrompt < Formula
 
   test do
     system "git", "init"
-    assert_equal "(%{\e[01;35m%}master%{\e[00m%}|%{…%G%}%{\e[00m%}%{\e[00m%})",
-      shell_output("zsh -c '. #{opt_prefix}/zshrc.sh && git_super_status'").chomp
+    zsh_command = ". #{opt_prefix}/zshrc.sh && git_super_status"
+    assert_match "master", shell_output("zsh -c '#{zsh_command}'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Note: this formula installs the Python implementation of zsh-git-prompt, not the alternative Haskell implementation. I thought about adding this as a build option, but getting it to build was rather difficult so I decided to drop it for now.

I based this formula on existing zsh library formulae, but I'm not sure if the `prefix.install` I saw them use is actually necessary. Seems like there's not really a need for them to be in the main prefix when they can just be loaded from the installation path itself?
