### PR TITLE
libssh2: have HEAD depends on openssl@1.1

### DIFF
--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -1,8 +1,13 @@
 class Libssh2 < Formula
   desc "C library implementing the SSH2 protocol"
   homepage "https://libssh2.org/"
-  url "https://libssh2.org/download/libssh2-1.7.0.tar.gz"
-  sha256 "e4561fd43a50539a8c2ceb37841691baf03ecb7daf043766da1b112e4280d584"
+
+  stable do
+    url "https://libssh2.org/download/libssh2-1.7.0.tar.gz"
+    sha256 "e4561fd43a50539a8c2ceb37841691baf03ecb7daf043766da1b112e4280d584"
+
+    depends_on "openssl" => :recommended
+  end
 
   bottle do
     cellar :any
@@ -17,11 +22,11 @@ class Libssh2 < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    depends_on "openssl@1.1" => :recommended
   end
 
   option "with-libressl", "build with LibreSSL instead of OpenSSL"
 
-  depends_on "openssl" => :recommended
   depends_on "libressl" => :optional
 
   def install
@@ -38,7 +43,8 @@ class Libssh2 < Formula
     if build.with? "libressl"
       args << "--with-libssl-prefix=#{Formula["libressl"].opt_prefix}"
     else
-      args << "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}"
+      openssl = build.head? ? Formula["openssl@1.1"] : Formula["openssl"]
+      args << "--with-libssl-prefix=#{openssl.opt_prefix}"
     end
 
     system "./buildconf" if build.head?


### PR DESCRIPTION
Credits to @vszakats and @tholberton who bring about OpenSSL 1.1 Compatibility to libssh2.
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
