### PR TITLE
shyaml 0.4.1 (new formula)

### DIFF
--- a/Formula/shyaml.rb
+++ b/Formula/shyaml.rb
@@ -1,0 +1,32 @@
+class Shyaml < Formula
+  include Language::Python::Virtualenv
+
+  desc "Command-line YAML parser"
+  homepage "https://github.com/0k/shyaml"
+  url "https://files.pythonhosted.org/packages/67/70/1133a5817bc62ff4e7ceee59edb95d127092db9385cc7cda5fcac93c494a/shyaml-0.4.1.tar.gz"
+  sha256 "a1535c25bf0058563e03ea8cbad8c4dc755ed231e6a9f3f584982994f19eae59"
+
+  depends_on :python3
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"
+    sha256 "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab"
+  end
+
+  def install
+    virtualenv_create(libexec, "python3")
+    virtualenv_install_with_resources
+  end
+
+  test do
+    yaml = <<-EOS.undent
+      key: val
+      arr:
+        - 1st
+        - 2nd
+    EOS
+    assert_equal "val", pipe_output("shyaml get-value key", yaml, 0)
+    assert_equal "1st", pipe_output("shyaml get-value arr.0", yaml, 0)
+    assert_equal "2nd", pipe_output("shyaml get-value arr.-1", yaml, 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Just now I needed to parse YAML from a shell script and a quick Google search convinced me that this is the only legit and notable player around 😃 And writing the formula was a breeze thanks to Tim's poet 🎉 

Note that `shyaml` does work with Python 2.7, but I'm just not too confident with Python 2.7 (or rather, developers writing Python 2.7) when it comes to dealing with Unicode text, especially in a shared code base. A Python 2 Unicode bug was [squashed](https://github.com/0k/shyaml/commit/8e2c13086e82127219321527f49656e77bef2432) in `shyaml` just two weeks ago.

Maintainers: please let me know if you detest the idea of depending on Python 3 when the code works with Python 2 already.
