### PR TITLE
x264: try to fix test on Sierra CI

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -64,7 +64,12 @@ class X264 < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "-lx264", "test.c", "-o", "test"
+    flags = %W[
+      -I#{include}
+      -L#{lib}
+      -lx264
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Specify header search path and library search path.

The previous version was causing library not found error on Sierra CI.
