### PR TITLE
libtiff: remove now defunct mirror

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -2,7 +2,6 @@ class Libtiff < Formula
   desc "TIFF library and utilities"
   homepage "http://www.remotesensing.org/libtiff/"
   url "http://download.osgeo.org/libtiff/tiff-4.0.6.tar.gz"
-  mirror "ftp://ftp.remotesensing.org/pub/libtiff/tiff-4.0.6.tar.gz"
   sha256 "4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c"
   revision 2
 

--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -2,6 +2,7 @@ class Libtiff < Formula
   desc "TIFF library and utilities"
   homepage "http://www.remotesensing.org/libtiff/"
   url "http://download.osgeo.org/libtiff/tiff-4.0.6.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.6.orig.tar.gz"
   sha256 "4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c"
   revision 2
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

libtiff has been removed from remotesensing.org. No authoritative word on where it will be hosted next, so not updating the homepage yet.

http://www.asmail.be/msg0054883490.html

CC @mistydemeo @DomT4
