### PR TITLE
spatialindex: add test to formula

### DIFF
--- a/Formula/spatialindex.rb
+++ b/Formula/spatialindex.rb
@@ -17,4 +17,59 @@ class Spatialindex < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    # write out a small program which inserts a fixed box into an rtree
+    # and verifies that it can query it
+    (testpath/"test.cpp").write <<-EOS.undent
+    #include <spatialindex/SpatialIndex.h>
+
+    using namespace std;
+    using namespace SpatialIndex;
+
+    class MyVisitor : public IVisitor {
+    public:
+        vector<id_type> matches;
+
+        void visitNode(const INode& n) {}
+        void visitData(const IData& d) {
+            matches.push_back(d.getIdentifier());
+        }
+        void visitData(std::vector<const IData*>& v) {}
+    };
+
+
+    int main(int argc, char** argv) {
+        IStorageManager* memory = StorageManager::createNewMemoryStorageManager();
+        id_type indexIdentifier;
+        RTree::RTreeVariant variant = RTree::RV_RSTAR;
+        ISpatialIndex* tree = RTree::createNewRTree(
+            *memory, 0.5, 100, 10, 2,
+            variant, indexIdentifier
+        );
+        /* insert a box from (0, 5) to (0, 10) */
+        double plow[2] = { 0.0, 0.0 };
+        double phigh[2] = { 5.0, 10.0 };
+        Region r = Region(plow, phigh, 2);
+
+        std::string data = "a value";
+
+        id_type id = 1;
+
+        tree->insertData(data.size() + 1, reinterpret_cast<const byte*>(data.c_str()), r, id);
+
+        /* ensure that (2, 2) is in that box */
+        double qplow[2] = { 2.0, 2.0 };
+        double qphigh[2] = { 2.0, 2.0 };
+        Region qr = Region(qplow, qphigh, 2);
+        MyVisitor q_vis;
+
+        tree->intersectsWithQuery(qr, q_vis);
+
+        return (q_vis.matches.size() == 1) ? 0 : 1;
+    }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lspatialindex", "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I was debugging something and was surprised to find that there wasn't a simple test for `spatialindex` in the formula. This adds one. It's kind of long for a test block, but `libspatialindex` requires a lot of boilerplate to actually do anything.
