### PR TITLE
gcc: Use stable version number + 1 as version number for --HEAD builds

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -73,7 +73,11 @@ class Gcc < Formula
   end
 
   def version_suffix
-    version.to_s.slice(/\d/)
+    if build.head?
+      ("#{stable.version}".slice(/\d/).to_i + 1).to_s
+    else
+      version.to_s.slice(/\d/)
+    end
   end
 
   # Fix for libgccjit.so linkage on Darwin

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -74,7 +74,7 @@ class Gcc < Formula
 
   def version_suffix
     if build.head?
-      ("#{stable.version}".slice(/\d/).to_i + 1).to_s
+      (stable.version.to_s.slice(/\d/).to_i + 1).to_s
     else
       version.to_s.slice(/\d/)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Before, the version string would be empty, resulting in names like gcc-
and g++-, which tripped up brew when looking for a gcc install. This,
coupled with a tweak to brew to allow HEAD as a gcc version string,
should allow HEAD builds to be recognized
