### PR TITLE
glm 0.9.8.0

### DIFF
--- a/Formula/glm.rb
+++ b/Formula/glm.rb
@@ -1,8 +1,8 @@
 class Glm < Formula
   desc "C++ mathematics library for graphics software"
   homepage "https://glm.g-truc.net/"
-  url "https://github.com/g-truc/glm/releases/download/0.9.7.4/glm-0.9.7.4.zip"
-  sha256 "d48a0d732776b0fbfd17f01c830a08b50f07a3226f0cab95fcca5591982a43f2"
+  url "https://github.com/g-truc/glm/releases/download/0.9.8.0/glm-0.9.8.0.zip"
+  sha256 "ce084bb133639e83eb94358ce52c28694c551501c2c778373c29612bb5e5dda8"
 
   head "https://github.com/g-truc/glm.git"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

GLM 0.9.8.0 version update

```
glm:
  * GitHub fork (not canonical repository)
```

It is true that the [GLM GitHub repo](https://github.com/g-truc/glm) is technically a fork, but it is a fork by the original owner that deprecated the old one, and it has seen all development since October, 2012. The official site for the project also only references [g-truc/glm](https://github.com/g-truc/glm) for releases and the like, with no mention of [Groovounet/glm-deprecated](https://github.com/Groovounet/glm-deprecated). The deprecated repo even links to the new repo directly.
