### PR TITLE
mfterm 1.0.7 (new formula)

### DIFF
--- a/Formula/mfterm.rb
+++ b/Formula/mfterm.rb
@@ -1,9 +1,9 @@
 class Mfterm < Formula
   desc "Terminal for working with Mifare Classic 1-4k Tags"
   homepage "https://github.com/4ZM/mfterm"
-  url "https://github.com/4ZM/mfterm/archive/v1.0.6.tar.gz"
-  version "1.0.6"
-  sha256 "19adfe858cfa5c672aa543b1c6b439384597cb21f880ed74c9b26e5164006221"
+  url "https://github.com/4ZM/mfterm/releases/download/v1.0.7/mfterm-1.0.7.tar.gz"
+  version "1.0.7"
+  sha256 "b6bb74a7ec1f12314dee42973eb5f458055b66b1b41316ae0c5380292b86b248"
 
   head do
     url "https://github.com/4ZM/mfterm.git"

--- a/Formula/mfterm.rb
+++ b/Formula/mfterm.rb
@@ -2,7 +2,6 @@ class Mfterm < Formula
   desc "Terminal for working with Mifare Classic 1-4k Tags"
   homepage "https://github.com/4ZM/mfterm"
   url "https://github.com/4ZM/mfterm/releases/download/v1.0.7/mfterm-1.0.7.tar.gz"
-  version "1.0.7"
   sha256 "b6bb74a7ec1f12314dee42973eb5f458055b66b1b41316ae0c5380292b86b248"
 
   head do

--- a/Formula/mfterm.rb
+++ b/Formula/mfterm.rb
@@ -1,0 +1,34 @@
+class Mfterm < Formula
+  desc "Terminal for working with Mifare Classic 1-4k Tags"
+  homepage "https://github.com/4ZM/mfterm"
+  url "https://github.com/4ZM/mfterm/archive/v1.0.6.tar.gz"
+  version "1.0.6"
+  sha256 "19adfe858cfa5c672aa543b1c6b439384597cb21f880ed74c9b26e5164006221"
+
+  head do
+    url "https://github.com/4ZM/mfterm.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
+  depends_on "libnfc"
+  depends_on "libusb"
+  depends_on "openssl"
+
+  def install
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib}"
+
+    if build.head?
+      chmod 0755, "./autogen.sh"
+      system "./autogen.sh"
+    end
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/mfterm", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Adding this to make complete toolset for working with Mifare cards.
Related to [mfoc](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mfoc.rb) and [mfcuk](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mfcuk.rb) that already in brew.

mfterm is packaged in [Kali Linux](http://tools.kali.org/wireless-attacks/mfterm). 

Maybe Dominyk @DomT4 can endorse it.

It has not enough stars for pass audit.
