### PR TITLE
qjackctl 0.4.3

### DIFF
--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -1,8 +1,8 @@
 class Qjackctl < Formula
   desc "simple Qt application to control the JACK sound server daemon"
   homepage "http://qjackctl.sourceforge.net"
-  url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.4.2.tar.gz"
-  sha256 "cf1c4aff22f8410feba9122e447b1e28c8fa2c71b12cfc0551755d351f9eaf5e"
+  url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.4.3.tar.gz"
+  sha256 "6bfdc3452f3c48d1ce40bd4164be0caa1c716474fbd3fb408d3308dfadf79e07"
   head "http://git.code.sf.net/p/qjackctl/code.git"
 
   bottle do
@@ -13,24 +13,17 @@ class Qjackctl < Formula
     sha256 "1b12ec7026cf50ed6b29726c60731f4bb1f22e39e62efe1569547dcb0f2b239a" => :mavericks
   end
 
-  depends_on "autoconf" => :build
   depends_on "qt5"
   depends_on "jack"
 
-  # Fixes varaible length array error with LLVM/Clang
-  # Reported upstream: https://github.com/rncbc/qjackctl/issues/17
-  patch do
-    url "https://github.com/rncbc/qjackctl/commit/e92de08f7fd7c62ff1fb4f0330583f321a2a9aae.patch"
-    sha256 "cbb7cc72e0086b8e6df24c8c3a462dc0e9297f095573adb7a3cf98502a1902d4"
-  end
-
   def install
-    system "./autogen.sh"
     system "./configure", "--disable-debug",
                           "--enable-qt5",
                           "--disable-dbus",
+                          "--disable-portaudio",
                           "--disable-xunique",
                           "--prefix=#{prefix}",
+                          "--with-jack=#{Formula["jack"].opt_prefix}",
                           "--with-qt5=#{Formula["qt5"].opt_prefix}"
 
     system "make", "install"
@@ -39,7 +32,6 @@ class Qjackctl < Formula
   end
 
   test do
-    output = shell_output("#{bin}/qjackctl --version 2>&1", 1)
-    assert_match version.to_s, output
+    assert_match version.to_s, shell_output("#{bin}/qjackctl --version 2>&1", 1)
   end
 end


### PR DESCRIPTION
prevent opportunistic linking to portaudio
remove upstreamed patch
don't needlessly run autogen
