### PR TITLE
fontconfig: patch for caching bug in 2.12.1 and add head spec

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -1,9 +1,23 @@
 class Fontconfig < Formula
   desc "XML-based font configuration API for X Windows"
   homepage "https://wiki.freedesktop.org/www/Software/fontconfig/"
-  url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.1.tar.bz2"
-  sha256 "b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.1.tar.bz2"
+    sha256 "b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3"
+
+    patch do
+      # Fixes https://bugs.freedesktop.org/show_bug.cgi?id=97546, "fc-cache
+      # failure with /System/Library/Fonts", and #4172.
+      #
+      # Patch from upstream maintainer Akira TAGOH. See
+      #   https://bugs.freedesktop.org/show_bug.cgi?id=97546#c7
+      #   https://bugs.freedesktop.org/attachment.cgi?id=126464
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/3790bcd/fontconfig/patch-2.12.1-fccache.diff"
+      sha256 "e7c074109a367bf3966578034b20d11f7e0b4a611785a040aef1fd11359af04d"
+    end
+  end
 
   # The bottle tooling is too lenient and thinks fontconfig
   # is relocatable, but it has hardcoded paths in the executables.

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -36,6 +36,14 @@ class Fontconfig < Formula
     satisfy { HOMEBREW_PREFIX.to_s == "/usr/local" }
   end
 
+  head do
+    url "https://anongit.freedesktop.org/git/fontconfig", :using => :git
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   keg_only :provided_pre_mountain_lion
 
   option :universal
@@ -45,6 +53,7 @@ class Fontconfig < Formula
 
   def install
     ENV.universal_binary if build.universal?
+    system "autoreconf", "-iv" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--enable-static",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

https://bugs.freedesktop.org/show_bug.cgi?id=97546#c7

Closes #4172 (which is already closed, oh well).
