### PR TITLE
gdb: add --enable-tui by default

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -41,6 +41,7 @@ class Gdb < Formula
 
   def install
     args = [
+      "--enable-tui",
       "--prefix=#{prefix}",
       "--disable-debug",
       "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Add --enable-tui as a default option in building gdb.
