### PR TITLE
libspatialite: disable make check

### DIFF
--- a/Formula/libspatialite.rb
+++ b/Formula/libspatialite.rb
@@ -79,7 +79,6 @@ class Libspatialite < Formula
     args << "--enable-geopackage=no" if build.without? "geopackage"
 
     system "./configure", *args
-    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/libspatialite.rb
+++ b/Formula/libspatialite.rb
@@ -33,9 +33,6 @@ class Libspatialite < Formula
   option "without-libxml2", "Disable support for xml parsing (parsing needed by spatialite-gui)"
   option "without-liblwgeom", "Build without additional sanitization/segmentation routines provided by PostGIS 2.0+ library"
   option "without-geopackage", "Build without OGC GeoPackage support"
-  option "without-test", "Do not run `make check` prior to installing"
-
-  deprecated_option "without-check" => "without-test"
 
   depends_on "pkg-config" => :build
   depends_on "proj"
@@ -82,7 +79,7 @@ class Libspatialite < Formula
     args << "--enable-geopackage=no" if build.without? "geopackage"
 
     system "./configure", *args
-    system "make", "check" if build.with? "test"
+    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`--without-test` option has been removed because no one ever use it (or any other option):

![](https://i.imgur.com/ZHy7S8A.png)

As for turning off `make check`: 1 out of 84 checks fails on Sierra, hindering bottling effort. Might as well just ship something "good enough" ™ for now. Disclaimer: blame ILZ for this.

CC @ilovezfs.
