### PR TITLE
proof-general: update homepage to github site

### DIFF
--- a/Formula/proof-general.rb
+++ b/Formula/proof-general.rb
@@ -1,6 +1,6 @@
 class ProofGeneral < Formula
   desc "Emacs-based generic interface for theorem provers"
-  homepage "http://proofgeneral.inf.ed.ac.uk"
+  homepage "https://proofgeneral.github.io"
   url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
   sha256 "3567b68077798396ccd55c501b7ea7bd2c4d6300e4c74ff609dc19837d050b27"
   head "https://github.com/ProofGeneral/PG.git"


### PR DESCRIPTION
The old website http://proofgeneral.inf.ed.ac.uk now even redirects there.
