### PR TITLE
cocoapods: patch for avoiding activesupport 5

### DIFF
--- a/Formula/cocoapods.rb
+++ b/Formula/cocoapods.rb
@@ -1,14 +1,31 @@
 class Cocoapods < Formula
   desc "The Cocoa Dependency Manager."
   homepage "https://cocoapods.org/"
-  url "https://github.com/CocoaPods/CocoaPods/archive/1.0.1.tar.gz"
-  sha256 "5ff282d8400a773ffcdf12af45a5cef98cac78a87aea7e0ce3818ab767597da2"
+
+  stable do
+    url "https://github.com/CocoaPods/CocoaPods/archive/1.0.1.tar.gz"
+    sha256 "5ff282d8400a773ffcdf12af45a5cef98cac78a87aea7e0ce3818ab767597da2"
+
+    patch do
+      # Avoid use of activesupport version 5 (which requires Ruby >= 2.2.2)
+      # https://github.com/CocoaPods/CocoaPods/pull/5602
+      # https://github.com/CocoaPods/CocoaPods/commit/c6e557b
+      url "https://raw.githubusercontent.com/zmwangx/patches/4cb8f3cbcf9caf1056e7ddbddb2e114ed2b18536/cocoapods/patch-activesupport-4.x.diff"
+      sha256 "4448552b4c2ea952a9a30d15be50e09c2eca73f29ff6029db215afe244aa7bc9"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation
     sha256 "736b65d17ed27bac64e14c7e932c1b3959d57d652d5d72a335c17494b9c5e2ad" => :el_capitan
     sha256 "df75ba653f028491ea817cc21d1993adfa39090d24575226404fe5220da90082" => :yosemite
     sha256 "0e60242bb181b9a0b66bdbe3b105780330c737da4bb0dea9bd6408f2093aa96a" => :mavericks
+  end
+
+  devel do
+    url "https://github.com/CocoaPods/CocoaPods/archive/1.1.0.rc.2.tar.gz"
+    version "1.1.0.rc.2"
+    sha256 "f2bc2108daa1e49816dd8af433d282968bb8af68bf691999144e598d9f67f50e"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

activesupport 5 requires Ruby >= 2.2.2, a requirement not met by macOS's system Ruby. This cherrypicked upstream patch pins activesupport to 4.x. See
- https://github.com/CocoaPods/CocoaPods/pull/5602
- https://github.com/CocoaPods/CocoaPods/commit/c6e557b

(The commit doesn't apply cleanly, but the working patch is very straightforward.)

Also add devel spec where the issue has already been fixed.
