### PR TITLE
x264 r2699

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -2,9 +2,8 @@ class X264 < Formula
   desc "H.264/AVC encoder"
   homepage "https://www.videolan.org/developers/x264.html"
   # the latest commit on the stable branch
-  url "https://git.videolan.org/git/x264.git", :revision => "fd2c324731c2199e502ded9eff723d29c6eafe0b"
-  version "r2668"
-
+  url "https://git.videolan.org/git/x264.git", :revision => "a5e06b9a435852f0125de4ecb198ad47340483fa"
+  version "r2699"
   head "https://git.videolan.org/git/x264.git"
 
   bottle do
@@ -17,21 +16,17 @@ class X264 < Formula
 
   devel do
     # the latest commit on the master branch
-    url "https://git.videolan.org/git/x264.git", :revision => "3b70645597bea052d2398005bc723212aeea6875"
-    version "r2694"
+    url "https://git.videolan.org/git/x264.git", :revision => "3f5ed56d4105f68c01b86f94f41bb9bbefa3433b"
+    version "r2705"
   end
 
   option "with-10-bit", "Build a 10-bit x264 (default: 8-bit)"
-  option "with-mp4=", "Select mp4 output: none (default), l-smash or gpac"
+  option "with-l-smash", "Build CLI with l-smash mp4 output"
 
   depends_on "yasm" => :build
+  depends_on "l-smash" => :optional
 
   deprecated_option "10-bit" => "with-10-bit"
-
-  case ARGV.value "with-mp4"
-  when "l-smash" then depends_on "l-smash"
-  when "gpac" then depends_on "gpac"
-  end
 
   def install
     args = %W[
@@ -40,11 +35,7 @@ class X264 < Formula
       --enable-static
       --enable-strip
     ]
-    if Formula["l-smash"].installed?
-      args << "--disable-gpac"
-    elsif Formula["gpac"].installed?
-      args << "--disable-lsmash"
-    end
+    args << "--disable-lsmash" if build.without? "l-smash"
     args << "--bit-depth=10" if build.with? "10-bit"
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

update stable to r2699, devel to r2705;
remove option to build gpac mp4 output:
non-functional & would require static build of gpac (impractical);
formula reconfigured and cleaned up to reflect this

---

I felt it would simply be better to remove the `gpac` build option because x264 currently requires `libgpac_static` which seemingly needs to be built directly from a git repo source, otherwise it fails.

If it becomes/is possible to simply modify the `gpac` formula to build the static lib as a configuration option, then it might make sense to reenable the `gpac` mp4 output.

Also, the formula no longer automatically builds against an installation of `l-smash` unless the option is explicitly enabled when building from source.
