### PR TITLE
erlang: unrecommend wxmac

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -4,6 +4,7 @@
 class Erlang < Formula
   desc "Programming language for highly scalable real-time systems"
   homepage "https://www.erlang.org/"
+  revision 1
   head "https://github.com/erlang/otp.git"
 
   stable do
@@ -34,7 +35,7 @@ class Erlang < Formula
   depends_on "openssl"
   depends_on "fop" => :optional # enables building PDF docs
   depends_on :java => :optional
-  depends_on "wxmac" => :recommended # for GUI apps like observer
+  depends_on "wxmac" => :optional # for GUI apps like observer
 
   fails_with :llvm
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`wxmac` stable does not work on Sierra yet, we cannot recommend it.

**Update.** We'll just unrecommend it across the board. See discussion below.

This should resolve our bottling problem for both `erlang` and `elixir`.
