### PR TITLE
valgrind: patch for Xcode 8

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -40,6 +40,9 @@ class Valgrind < Formula
   depends_on "libtool" => :build
 
   depends_on :macos => :snow_leopard
+  # See currently supported platforms: http://valgrind.org/info/platforms.html
+  # Also dev comment: https://bugs.kde.org/show_bug.cgi?id=366138#c5
+  depends_on MaximumMacOSRequirement => :el_capitan
 
   # Valgrind needs vcpreload_core-*-darwin.so to have execute permissions.
   # See #2150 for more information.

--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -2,6 +2,7 @@ class Valgrind < Formula
   desc "Dynamic analysis tools (memory, debug, profiling)"
   homepage "http://www.valgrind.org/"
   revision 1
+  head "svn://svn.valgrind.org/valgrind/trunk"
 
   stable do
     url "http://valgrind.org/downloads/valgrind-3.11.0.tar.bz2"
@@ -14,6 +15,14 @@ class Valgrind < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/cc0e461/valgrind/10.11_assertion.diff"
       sha256 "c4b73d50069f59ad2bcbddd5934b7068318bb2ba31f702ca21fb42d558addff4"
     end
+
+    # Add support for Xcode 8 (svn r15949)
+    # https://bugs.kde.org/show_bug.cgi?id=366138#c5
+    # https://github.com/liquid-mirror/valgrind/commit/16ff0e684bd44acc2e6d3a369876fe0c331e641d
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/b42540f/valgrind/xcode-8.diff"
+      sha256 "1191a728fa6df5de3520be57238a265815156d48062cdd12d2d6517fbdc8443f"
+    end
   end
 
   bottle do
@@ -22,13 +31,13 @@ class Valgrind < Formula
     sha256 "13b4586d3781bc50bcc2cd14ed05d19333ef85b91ef4b2b21b4c1438dba163b5" => :mavericks
   end
 
-  head do
-    url "svn://svn.valgrind.org/valgrind/trunk"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  # These should normally be head-only deps, but we're patching stable's
+  # configure.ac for Xcode 8 compatibility, so we always have to run
+  # autogen.sh. Restore head-only status when the next stable release comes
+  # out.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   depends_on :macos => :snow_leopard
 
@@ -47,7 +56,9 @@ class Valgrind < Formula
       args << "--enable-only32bit"
     end
 
-    system "./autogen.sh" if build.head?
+    # Always run autogen.sh due to us patching stable's configure.ac.
+    # Restore "if build.head?" when the next stable release comes out.
+    system "./autogen.sh"
 
     # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
     unless MacOS::CLT.installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Note: This PR currently contains another commit which is already in #4878. I just want to throw it out here and get some sleep. When I wake up the CI should have tested this, and I'll rebase and hopefully merge.

---

What's in this PR:
1. A patch to add Xcode 8 support (trivial), tested locally on 10.11.6 with Xcode 8.0 and CLT 7.3.1.0.1.1461711523 (note CI is still on Xcode 7.3).
2. Set `MaximumMacOSRequirement` to El Cap. This is because Valgrind simply doesn't support Sierra at the moment, both seen from http://valgrind.org/info/platforms.html and [a very recent dev comment](https://bugs.kde.org/show_bug.cgi?id=366138#c5) (by the way, if my experience with Valgrind on OS X years ago still has any value, Valgrind is typically really slow at picking up new OS support, and even when the thing compiles, it's usually almost unusable until way later).
