### PR TITLE
wxmac: patch for Xcode 8 with macOS 10.12 SDK

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -2,7 +2,6 @@ class Wxmac < Formula
   desc "wxWidgets, a cross-platform C++ GUI toolkit (for OS X)"
   homepage "https://www.wxwidgets.org"
   revision 2
-
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   stable do
@@ -20,7 +19,10 @@ class Wxmac < Formula
     # Please keep an eye on http://trac.wxwidgets.org/ticket/16329 as well
     # Theoretically the above linked patch should still be needed, but it isn't.
     # Try to find out why.
-    patch :DATA
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bbf499584062c25390deaef0eb9cd849fc56dac5/wxmac/patch-yosemite.diff"
+      sha256 "02ab6d044ceab85127cad11f2eba2164e7f3fe5c95d6a863e8231a57d1f87d6f"
+    end
 
     # Fails to find QuickTime headers; fixed in 3.1.0 and newer.
     # https://github.com/Homebrew/homebrew-core/issues/1957
@@ -129,65 +131,3 @@ class Wxmac < Formula
     system bin/"wx-config", "--libs"
   end
 end
-
-__END__
-
-diff --git a/include/wx/defs.h b/include/wx/defs.h
-index 397ddd7..d128083 100644
---- a/include/wx/defs.h
-+++ b/include/wx/defs.h
-@@ -3169,12 +3169,20 @@ DECLARE_WXCOCOA_OBJC_CLASS(UIImage);
- DECLARE_WXCOCOA_OBJC_CLASS(UIEvent);
- DECLARE_WXCOCOA_OBJC_CLASS(NSSet);
- DECLARE_WXCOCOA_OBJC_CLASS(EAGLContext);
-+DECLARE_WXCOCOA_OBJC_CLASS(UIWebView);
- 
- typedef WX_UIWindow WXWindow;
- typedef WX_UIView WXWidget;
- typedef WX_EAGLContext WXGLContext;
- typedef WX_NSString* WXGLPixelFormat;
- 
-+typedef WX_UIWebView OSXWebViewPtr;
-+
-+#endif
-+
-+#if wxOSX_USE_COCOA_OR_CARBON
-+DECLARE_WXCOCOA_OBJC_CLASS(WebView);
-+typedef WX_WebView OSXWebViewPtr;
- #endif
- 
- #endif /* __WXMAC__ */
-diff --git a/include/wx/html/webkit.h b/include/wx/html/webkit.h
-index 8700367..f805099 100644
---- a/include/wx/html/webkit.h
-+++ b/include/wx/html/webkit.h
-@@ -18,7 +18,6 @@
- #endif
- 
- #include "wx/control.h"
--DECLARE_WXCOCOA_OBJC_CLASS(WebView); 
- 
- // ----------------------------------------------------------------------------
- // Web Kit Control
-@@ -107,7 +106,7 @@ private:
-     wxString m_currentURL;
-     wxString m_pageTitle;
- 
--    WX_WebView m_webView;
-+    OSXWebViewPtr m_webView;
- 
-     // we may use this later to setup our own mouse events,
-     // so leave it in for now.
-diff --git a/include/wx/osx/webview_webkit.h b/include/wx/osx/webview_webkit.h
-index 803f8b0..438e532 100644
---- a/include/wx/osx/webview_webkit.h
-+++ b/include/wx/osx/webview_webkit.h
-@@ -158,7 +158,7 @@ private:
-     wxWindowID m_windowID;
-     wxString m_pageTitle;
- 
--    wxObjCID m_webView;
-+    OSXWebViewPtr m_webView;
- 
-     // we may use this later to setup our own mouse events,
-     // so leave it in for now.

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,7 +1,7 @@
 class Wxmac < Formula
   desc "wxWidgets, a cross-platform C++ GUI toolkit (for OS X)"
   homepage "https://www.wxwidgets.org"
-  revision 2
+  revision 3
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   stable do
@@ -20,13 +20,17 @@ class Wxmac < Formula
     # Theoretically the above linked patch should still be needed, but it isn't.
     # Try to find out why.
     patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bbf499584062c25390deaef0eb9cd849fc56dac5/wxmac/patch-yosemite.diff"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bbf4995/wxmac/patch-yosemite.diff"
       sha256 "02ab6d044ceab85127cad11f2eba2164e7f3fe5c95d6a863e8231a57d1f87d6f"
     end
 
-    # Fails to find QuickTime headers; fixed in 3.1.0 and newer.
-    # https://github.com/Homebrew/homebrew-core/issues/1957
-    depends_on MaximumMacOSRequirement => :el_capitan
+    # Remove uncenessary <QuickTime/QuickTime.h> includes
+    # Fixes building against Xcode 8 with macOS 10.12 SDK
+    # http://trac.wxwidgets.org/changeset/f6a2d1caef5c6d412c84aa900cb0d3990b350938/git-wxWidgets
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bbf4995/wxmac/patch-quicktime-removal.diff"
+      sha256 "ebddf09877b053a6fafbf61ac52e4a7b511489dc8437110f80f00d5d2b5ff885"
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

`<QuickTime/QuickTime.h>` has been removed in the macOS 10.12 SDK. Remove unnecessary includes that now fail: http://trac.wxwidgets.org/changeset/f6a2d1caef5c6d412c84aa900cb0d3990b350938/git-wxWidgets

This should fix the build on Sierra, so we also remove the maximum macOS requirement.

CC @ilovezfs.
