### PR TITLE
transmission: fix download URL

### DIFF
--- a/Formula/transmission.rb
+++ b/Formula/transmission.rb
@@ -1,7 +1,7 @@
 class Transmission < Formula
   desc "Lightweight BitTorrent client"
   homepage "https://www.transmissionbt.com/"
-  url "https://download.transmissionbt.com/files/transmission-2.92.tar.xz"
+  url "https://github.com/transmission/transmission-releases/raw/094777d/transmission-2.92.tar.xz"
   sha256 "3a8d045c306ad9acb7bf81126939b9594553a388482efa0ec1bfb67b22acd35f"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

https://transmissionbt.com/download/ now links to https://github.com/transmission/transmission-releases/raw/master/transmission-2.92.tar.xz. download.transmissionbt.com doesn't even resolve now.

Fixes https://github.com/Homebrew/brew/issues/975.

(Remark: Hosting on GitHub is great, but dumping all release tarballs into a repo...)
