### PR TITLE
passenger: fix building on Sierra

### DIFF
--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -18,9 +18,23 @@ class Passenger < Formula
   depends_on "openssl"
   depends_on :macos => :lion
 
+  # macOS Sierra ships the APR libraries & headers, but has removed the
+  # apr-1-config & apu-1-config executables which are used to find
+  # those elements. We may need to adopt a broader solution if this problem
+  # expands, but currently subversion & passenger are the only breakage as a result.
+  if MacOS.version >= :sierra
+    depends_on "apr-util" => :build
+    depends_on "apr" => :build
+  end
+
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")
+
+    if MacOS.version >= :sierra
+      ENV["APU_CONFIG"] = Formula["apr-util"].opt_bin/"apu-1-config"
+      ENV["APR_CONFIG"] = Formula["apr"].opt_bin/"apr-1-config"
+    end
 
     rake "apache2" if build.with? "apache2-module"
     rake "nginx"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I found that I needed `apr` & `apu` for both Xcode & CLT builds, not sure about the upgrade situation as I'm using a VM for Sierra stuff for now so I only have a clean install to play with.
