### PR TITLE
httrack: switch homepage and url back to HTTP

### DIFF
--- a/Formula/httrack.rb
+++ b/Formula/httrack.rb
@@ -1,9 +1,9 @@
 class Httrack < Formula
   desc "Website copier/offline browser"
-  homepage "https://www.httrack.com/"
+  homepage "http://www.httrack.com/"
   # Always use mirror.httrack.com when you link to a new version of HTTrack, as
   # link to download.httrack.com will break on next HTTrack update.
-  url "https://mirror.httrack.com/historical/httrack-3.48.21.tar.gz"
+  url "http://mirror.httrack.com/historical/httrack-3.48.21.tar.gz"
   sha256 "871b60a1e22d7ac217e4e14ad4d562fbad5df7c370e845f1ecf5c0e4917be482"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Their SSL cert expired on September 12, 2016.
