### PR TITLE
predictionio: redirect homepage

### DIFF
--- a/Formula/predictionio.rb
+++ b/Formula/predictionio.rb
@@ -1,6 +1,6 @@
 class Predictionio < Formula
   desc "Source machine learning server"
-  homepage "https://prediction.io/"
+  homepage "http://predictionio.incubator.apache.org/"
   url "http://download.prediction.io/PredictionIO-0.9.6.tar.gz"
   sha256 "d64ee99f50094b36accac4deae1008372c15f2cbc6112f6a7d8094842cf57e86"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

https://prediction.io/ now redirects to http://predictionio.incubator.apache.org/.

Note that they do serve an HTTPS version, but the fact that
1. They use a SHA-1 cert which is no longer considered secure;
2. They don't redirect to the HTTPS version;
3. We had to downgrade the download URL to HTTP recently;

makes it clear that they are not SSL ready.
