### PR TITLE
Remove manual `TERM` setting in test blocks

### DIFF
--- a/Formula/browser.rb
+++ b/Formula/browser.rb
@@ -14,7 +14,6 @@ class Browser < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     system "#{bin}/browser"
   end
 end

--- a/Formula/bvi.rb
+++ b/Formula/bvi.rb
@@ -17,7 +17,6 @@ class Bvi < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     system "#{bin}/bvi", "-c", "q"
   end
 end

--- a/Formula/clipsafe.rb
+++ b/Formula/clipsafe.rb
@@ -57,7 +57,6 @@ class Clipsafe < Formula
   end
 
   test do
-    ENV["TERM"] = "dumb"
-    system "#{bin}/clipsafe", "--help"
+    system bin/"clipsafe", "--help"
   end
 end

--- a/Formula/diff-so-fancy.rb
+++ b/Formula/diff-so-fancy.rb
@@ -22,7 +22,19 @@ class DiffSoFancy < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
-    system bin/"diff-so-fancy"
+    diff = <<-EOS.undent
+      diff --git a/hello.c b/hello.c
+      index 8c15c31..0a9c78f 100644
+      --- a/hello.c
+      +++ b/hello.c
+      @@ -1,5 +1,5 @@
+       #include <stdio.h>
+
+       int main(int argc, char **argv) {
+      -    printf("Hello, world!\n");
+      +    printf("Hello, Homebrew!\n");
+       }
+    EOS
+    assert_match "modified: hello.c", pipe_output(bin/"diff-so-fancy", diff, 0)
   end
 end

--- a/Formula/dshb.rb
+++ b/Formula/dshb.rb
@@ -19,7 +19,6 @@ class Dshb < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     pipe_output("#{bin}/dshb", "q", 0)
   end
 end

--- a/Formula/git-test.rb
+++ b/Formula/git-test.rb
@@ -20,6 +20,8 @@ class GitTest < Formula
   end
 
   test do
+    ENV["XDG_CONFIG_HOME"] = testpath/".config"
+    ENV["GIT_CONFIG_NOSYSTEM"] = "1"
     system "git", "init"
     ln_s bin/"git-test", testpath
     cp pkgshare/"test.sh", testpath

--- a/Formula/hopenpgp-tools.rb
+++ b/Formula/hopenpgp-tools.rb
@@ -31,7 +31,6 @@ class HopenpgpTools < Formula
   end
 
   test do
-    ENV["TERM"] = "dumb"
     resource("homebrew-key.gpg").stage do
       linter_output = shell_output("#{bin}/hokey lint <homebrew-key.gpg 2>/dev/null")
       assert_match "Homebrew <security@brew.sh>", linter_output

--- a/Formula/htop-osx.rb
+++ b/Formula/htop-osx.rb
@@ -35,7 +35,6 @@ class HtopOsx < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     pipe_output("#{bin}/htop", "q", 0)
   end
 end

--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -39,7 +39,6 @@ class Htop < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     pipe_output("#{bin}/htop", "q", 0)
   end
 end


### PR DESCRIPTION
Goes with https://github.com/Homebrew/brew/pull/982.

I haven't converted everything yet because I don't want to overload the CI in one job. I would do the rest in another PR or two.

Note that some tests do require `TERM` set to `xterm` to work, e.g. `ee`, `eg` and `git-test`, and that's fine — if `TERM` is not explicitly set to `xterm` then Homebrew/brew#982 makes them fail hard locally instead of only failing mysteriously on the CI.

Also, `asciiquarium` passes on CI but fails locally even when `TERM` is set to `xterm`, not sure why. But then, when I manually invoke `asciiquarium` (poured) it segfaults... I don't intend to investigate.
