### PR TITLE
openmesh version bump

### DIFF
--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -1,8 +1,8 @@
 class OpenMesh < Formula
   desc "Generic data structure to represent and manipulate polygonal meshes"
   homepage "https://openmesh.org/"
-  url "https://www.openmesh.org/media/Releases/5.1/OpenMesh-5.1.tar.gz"
-  sha256 "643262dec62d1c2527950286739613a5b8d450943c601ecc42a817738556e6f7"
+  url "https://www.openmesh.org/media/Releases/6.2/OpenMesh-6.2.tar.gz"
+  sha256 "570b5b2d3b949050d9628367268c495e87b3dc59f18a07c8037449356fe40374"
   head "http://openmesh.org/svnrepo/OpenMesh/trunk/", :using => :svn
 
   bottle do
@@ -15,6 +15,9 @@ class OpenMesh < Formula
   depends_on "cmake" => :build
   depends_on "qt" => :optional
 
+  option "without-python", "Build without python 2 support"
+  depends_on "boost-python"
+
   def install
     mkdir "build" do
       args = std_cmake_args
@@ -24,6 +27,14 @@ class OpenMesh < Formula
       else
         args << "-DBUILD_APPS=OFF"
       end
+
+      if build.without? "python"
+        args << "-DOPENMESH_BUILD_PYTHON_BINDINGS=OFF"
+      else
+        args << "-DOPENMESH_BUILD_PYTHON_BINDINGS=ON"
+      end
+
+      inreplace "#{buildpath}/src/Python/CMakeLists.txt", "${ACG_PROJECT_LIBDIR}/python", "${ACG_PROJECT_LIBDIR}/python2.7/site-packages"
 
       system "cmake", "..", *args
       system "make", "install"
@@ -76,5 +87,6 @@ class OpenMesh < Formula
     ]
     system ENV.cxx, "test.cpp", "-o", "test", *flags
     system "./test"
+    system "python -c 'import openmesh;'"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

It reports the following problem which I really do not known how to remove.

```
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/Cellar/open-mesh/6.2/lib/python2.7/site-packages/openmesh.so
```

I checked the cmake file: it finds python by cmake ---- will that be troublesome?

Hope someone could fix the problem based on my P.R.

---
1. upgrade to version 6.2;
2. add python binding
