### PR TITLE
Remove manual `TERM` setting in test blocks

### DIFF
--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -27,8 +27,6 @@ class Jp2a < Formula
   end
 
   test do
-    # the test fails if this is not set
-    ENV["TERM"] = "xterm-256color"
-    system "#{bin}/jp2a", test_fixtures("test.jpg")
+    system bin/"jp2a", test_fixtures("test.jpg")
   end
 end

--- a/Formula/le.rb
+++ b/Formula/le.rb
@@ -20,7 +20,6 @@ class Le < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     assert_match "Usage", shell_output("#{bin}/le --help", 1)
   end
 end

--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -42,7 +42,6 @@ class MobileShell < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
-    system "#{bin}/mosh-client", "-c"
+    system bin/"mosh-client", "-c"
   end
 end

--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -20,8 +20,6 @@ class Multitail < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
-    assert_match "multitail #{version}",
-      shell_output("#{bin}/multitail -h 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/multitail -h 2>&1", 1)
   end
 end

--- a/Formula/ne.rb
+++ b/Formula/ne.rb
@@ -18,9 +18,21 @@ class Ne < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    (testpath/"test.txt").write("This is a test document.\n")
-    (testpath/"test_ne").write("GotoLine 2\nInsertString line 2\nExit\n")
-    system "script", "-q", "/dev/null", "#{bin}/ne", "--macro", ((testpath/"test_ne")).to_s, ((testpath/"test.txt")).to_s
-    assert_equal "This is a test document.\nline 2", File.read("#{testpath}/test.txt")
+    document = testpath/"test.txt"
+    macros = testpath/"macros"
+    document.write <<-EOS.undent
+      This is a test document.
+    EOS
+    macros.write <<-EOS.undent
+      GotoLine 2
+      InsertString line 2
+      InsertLine
+      Exit
+    EOS
+    system "script", "-q", "/dev/null", bin/"ne", "--macro", macros, document
+    assert_equal <<-EOS.undent, document.read
+      This is a test document.
+      line 2
+    EOS
   end
 end

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -54,7 +54,7 @@ class Newt < Formula
         newtFinished();
       }
     EOS
-    system ENV.cc, testpath/"test.c", "-o", testpath/"newt_test", "-lnewt"
-    system testpath/"newt_test"
+    system ENV.cc, "test.c", "-o", "test", "-lnewt"
+    system "./test"
   end
 end

--- a/Formula/pwntools.rb
+++ b/Formula/pwntools.rb
@@ -146,8 +146,7 @@ class Pwntools < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     assert_equal "686f6d6562726577696e7374616c6c636f6d706c657465",
-      shell_output("#{bin}/hex homebrewinstallcomplete").strip
+                 shell_output("#{bin}/hex homebrewinstallcomplete").strip
   end
 end

--- a/Formula/slrn.rb
+++ b/Formula/slrn.rb
@@ -34,6 +34,6 @@ class Slrn < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    system bin/"slrn", "--show-config"
+    assert_match version.to_s, shell_output("#{bin}/slrn --show-config")
   end
 end

--- a/Formula/sngrep.rb
+++ b/Formula/sngrep.rb
@@ -26,7 +26,6 @@ class Sngrep < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     pipe_output("#{bin}/sngrep -I #{test_fixtures("test.pcap")}", "Q\n", 0)
   end
 end

--- a/Formula/tnote.rb
+++ b/Formula/tnote.rb
@@ -22,8 +22,7 @@ class Tnote < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
-    ENV["EDITOR"] = `which cat`.chomp
-    system "#{bin}/tnote", "--nocol", "-a", "test"
+    ENV["EDITOR"] = "/bin/cat"
+    system bin/"tnote", "--nocol", "-a", "test"
   end
 end

--- a/Formula/watch.rb
+++ b/Formula/watch.rb
@@ -45,7 +45,6 @@ class Watch < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     system bin/"watch", "--errexit", "--chgexit", "--interval", "1", "date"
   end
 end

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -59,7 +59,6 @@ class Weechat < Formula
   end
 
   test do
-    ENV["TERM"] = "xterm"
     system "weechat", "-r", "/quit"
   end
 end


### PR DESCRIPTION
Follow up of #4933. The remaining formulae.
