### PR TITLE
apr-util: Update 1.5.4 bottle

### DIFF
--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -3,7 +3,7 @@ class AprUtil < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.5.4.tar.bz2"
   sha256 "a6cf327189ca0df2fb9d5633d7326c460fe2b61684745fd7963e79a6dd0dc82e"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "befef73518b6503d4e6d24c8b7de4f9c30c985dedb85251cf580ccf53378c7ad" => :sierra


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?

---

Currently the bottle is linked to the previous revision bottle in the apr formula causing the httpd24 (and most likely anything else dependent on apr-util) package to fail when compiling.
