### PR TITLE
pkg-config: default HOMEBREW_REPOSITORY changed.

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -4,7 +4,7 @@ class PkgConfig < Formula
   url "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.1.tar.gz"
   mirror "https://fossies.org/linux/misc/pkg-config-0.29.1.tar.gz"
   sha256 "beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "236a2aa2b7f414ac36279cf5b11b9f64429c5224d8e765224a6315061f39bbaa" => :sierra


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

So bump the `revision`. Blocked on https://github.com/Homebrew/brew/pull/1015, https://github.com/Homebrew/brew/pull/1011 and then being rebuilt.
