### PR TITLE
openconnect: make before make install

### DIFF
--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -49,6 +49,7 @@ class Openconnect < Formula
     ]
 
     system "./configure", *args
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Due to the way the makefiles are set up, the `make` command has to be run prior to running `make install`
