### PR TITLE
ansible: fix openssl failures by using brewed python at all times

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -17,7 +17,7 @@ class Ansible < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on :python
   depends_on "libyaml"
   depends_on "openssl"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

native Apple Python & OpenSSL combo does not handle gracefully situations
where SSLv3 and lower are disabled by the remote end. By using brewed
Python, we use the much newer brewed OpenSSL and we have support for
session negotation, without cryptic failures.

NB this is not related to https://github.com/Homebrew/homebrew-core/pull/4539 despite the surface similarity. One questions
the wisdom of having multiple versions of OpenSSL available to python.
