### PR TITLE
avro-c: support Snappy and LZMA codecs

### DIFF
--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -3,6 +3,7 @@ class AvroC < Formula
   homepage "https://avro.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=avro/avro-1.8.1/c/avro-c-1.8.1.tar.gz"
   sha256 "e5042088fa47e1aa2860c5cfed0bd061d81f9e96628f8b4d87a24d9b8c5e4ecc"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,9 +12,14 @@ class AvroC < Formula
     sha256 "ba3f6ab12df1ad13ec5aa04a038f4e4d4823c671bfb0f65b50d7015488db346e" => :mavericks
   end
 
+  option "with-snappy", "Build with Snappy codec support"
+  option "with-xz", "Build with LZMA codec support"
+
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
-  depends_on "jansson" => :build
+  depends_on "jansson"
+  depends_on "snappy" => :optional
+  depends_on "xz" => :optional
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
When running `avrocat` on an Avro file compressed with `snappy` or `lzma` codec, I get the following error:

```
avrocat file.avro 
Error opening file.avro:
  File header contains an unknown codec
```

Proposed patch add optional support for those two official codecs:

```
brew install avro-c --with-snappy --with-xz
```

Also when installing `avro-c` from a bottle and `jansson` is not installed, I get the following error:

```
$ brew install avro-c
==> Downloading https://homebrew.bintray.com/bottles/avro-c-1.8.1.el_capitan.bottle.tar.gz
Already downloaded: /Users/.../Library/Caches/Homebrew/avro-c-1.8.1.el_capitan.bottle.tar.gz
==> Pouring avro-c-1.8.1.el_capitan.bottle.tar.gz
🍺  /usr/local/Cellar/avro-c/1.8.1: 31 files, 1.3M
$ otool -L /usr/local/bin/avrocat 
$ /usr/local/bin/avrocat 
dyld: Library not loaded: /usr/local/opt/jansson/lib/libjansson.4.dylib
  Referenced from: /usr/local/bin/avrocat
  Reason: image not found
Trace/BPT trap: 5
$ otool -L /usr/local/bin/avrocat 
/usr/local/bin/avrocat:
    /usr/local/opt/jansson/lib/libjansson.4.dylib (compatibility version 12.0.0, current version 12.0.0)
    /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.5)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

Workaround consists of installing the jansson manually:

```
brew install jansson
```

`avro-c` formula changes:
- add support for Snappy codec
- add support for LZMA codec through XZ Utils
- fix jansson dependency that is required at runtime
