### PR TITLE
carina: fix 1.5.0 ref

### DIFF
--- a/Formula/carina.rb
+++ b/Formula/carina.rb
@@ -3,7 +3,7 @@ class Carina < Formula
   homepage "https://github.com/getcarina/carina"
   url "https://github.com/getcarina/carina.git",
         tag: "v1.5.0",
-        revision: "621b6ecc9d34bad00b016a9829210b33fd4f2355"
+        revision: "2d7f5c0afe28a3e9e794c99ce5024be283979e71"
   head "https://github.com/getcarina/carina.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Apparently another commit came out on this tag and I can only assume, the tag was force pushed: https://github.com/getcarina/carina/commits/v1.5.0
