### PR TITLE
newlisp: remove devel

### DIFF
--- a/Formula/newlisp.rb
+++ b/Formula/newlisp.rb
@@ -10,11 +10,6 @@ class Newlisp < Formula
     sha256 "dbacba90228024041cbe50efc63959cdaa94c3ca0d30267bcedcd1769dc4c597" => :mavericks
   end
 
-  devel do
-    url "http://www.newlisp.org/downloads/development/inprogress/newlisp-10.7.1.tgz"
-    sha256 "9e019f876f4179601c569e0324dbe2e48f28aa67b1c9e61ee194b700be6c1067"
-  end
-
   depends_on "readline" => :recommended
 
   def install


### PR DESCRIPTION
http://www.newlisp.org/downloads/development/inprogress/readme.txt

"Files in this directory are not official development releases, but work
in progress. Source .tgz packages or files may appear or may be changed
unannounced and with unchanged version numbers or CHANGES files."

So having a devel spec in this formula will just break CI every time
upstream bumps the tarball without changing the version number.
