### PR TITLE
ansible: update pywinrm

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -437,8 +437,8 @@ class Ansible < Formula
   end
 
   resource "pywinrm" do
-    url "https://pypi.python.org/packages/source/p/pywinrm/pywinrm-0.1.1.tar.gz"
-    sha256 "0230d7e574a5375e8a0b46001a2bce2440aba2b866629342be0360859f8d514d"
+    url "https://github.com/diyan/pywinrm/archive/v0.2.1.tar.gz"
+    sha256 "b919767eb2598944c6437629de6f5da3b79374d6d409c7b99a167f376f1c6c75"
   end
 
   resource "rackspace-auth-openstack" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This updates pywinrm from 0.1.1 to 0.2.1. The reason to the update is that we have seen occasional connection problems with 0.1.1 (`[Errno 54] Connection reset by peer`). We have used 0.2.0 internally for about a month without ever seeing this problem so I believe 0.2.x is much more stable than 0.1.1. I think the change from urllib2 to requests did the trick for us.

There are other nice things added in 0.2.0 such as NTLM auth support, [full changelog](https://github.com/diyan/pywinrm/blob/7115b87bf30563caeb6e7d0a072064b532dab6fa/CHANGELOG.md).

Unfortunately it seems like pywinrm does not publish the `tar.gz` file to pypi anymore, why github is used instead.
