### PR TITLE
python: fix --universall on macOS 10.12 Sierra

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -68,6 +68,11 @@ class Python < Formula
     sha256 "c075353337f9ff3ccf8091693d278782fcdff62c113245d8de43c5c7acc57daf"
   end
 
+  patch do
+    url "https://bugs.python.org/file44699/issue27806_v3.patch"
+    sha256 "fff60cbdb9ff344cd84ea776ea16e940147419c303ab378fb5c7fb3e9053ef0a"
+  end
+
   def lib_cellar
     prefix/"Frameworks/Python.framework/Versions/2.7/lib/python2.7"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Applies the patch on [Issue 27806: 2.7 32-bit builds fail on macOS 10.12 Sierra due to dependency on deleted header file QuickTime/QuickTime.h](https://bugs.python.org/issue27806) that is committed for release on `2.7.13`.
