### PR TITLE
gdub: optional gradle dependency

### DIFF
--- a/Formula/gdub.rb
+++ b/Formula/gdub.rb
@@ -6,18 +6,11 @@ class Gdub < Formula
 
   bottle :unneeded
 
-  depends_on "gradle"
-
   def install
     bin.install "bin/gw"
   end
 
   test do
-    ENV.java_cache
-
-    system "gradle", "init"
-    cd "gradle" do
-      system bin/"gw", "tasks"
-    end
+    assert_match "No gradlew set up for this project", pipe_output("#{bin}/gw 2>&1")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Typically with the gw command you're going to want the gradle wrapper to download gradle for you. I would also hazard a guess when you want to start a new project and need a global gradle install most Java developers will be using sdkman.

Thanks!
