### PR TITLE
juju2 2.0-rc1

### DIFF
--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -1,0 +1,21 @@
+class Juju2 < Formula
+  desc "DevOps management tool"
+  homepage "https://jujucharms.com/"
+  url "https://launchpad.net/juju/2.0/2.0-rc1/+download/juju-core_2.0-rc1.tar.gz"
+  sha256 "bef47f4d4e929a71c0934a782043fecc409a76ca4e73fbe3406415226077f745"
+
+  depends_on "go" => :build
+  conflicts_with "juju", because: "juju and juju2 cannot be installed simultaneously, and juju environments aren't compatible with juju2"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    system "go", "build", "github.com/juju/juju/cmd/juju"
+    system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
+    bin.install "juju", "juju-metadata"
+    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
+  end
+
+  test do
+    system "#{bin}/juju", "version"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I propose that juju2 is now stable enough to enter homebrew-core. I want to remove it from homebrew-devel-only

Juju 2.0-rc1 guarantees API and command line compatibility with future release of the clients and the cloud agents. Users will be able to deploy applications today, and upgrade juju with the next release. The Juju team will support upgrades to other RC versions if they are released, upgrades to Juju 2.0.0 and greater are supported.
