### PR TITLE
OpenCSG 1.4.2

### DIFF
--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -1,8 +1,8 @@
 class Opencsg < Formula
   desc "The CSG rendering library"
   homepage "http://www.opencsg.org"
-  url "http://www.opencsg.org/OpenCSG-1.4.1.tar.gz"
-  sha256 "48182c8233e6f89cd6752679bde44ef6cc9eda4c06f4db845ec7de2cae2bb07a"
+  url "http://www.opencsg.org/OpenCSG-1.4.2.tar.gz"
+  sha256 "d952ec5d3a2e46a30019c210963fcddff66813efc9c29603b72f9553adff4afb"
 
   bottle do
     cellar :any

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -6,6 +6,9 @@ class Opencsg < Formula
 
   bottle do
     cellar :any
+    sha256 "577e6777db3c9ee1010577e9dd29f7d86cff106273ef650bf58b08b20020a751" => :el_capitan
+    sha256 "d6e5913457b310b32a3dd9673a248793fd53bc6d2863f55b3d3334be7665c544" => :yosemite
+    sha256 "26098d8c2d4e89f2a0389c470f8b094a805e97c959defa3381ab0cd8c8d8ec9e" => :mavericks
   end
 
   depends_on "qt5" => :build

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -18,6 +18,7 @@ class Opencsg < Formula
     system "qmake", "-r", "INSTALLDIR=#{prefix}",
       "INCLUDEPATH+=#{Formula["glew"].opt_include}",
       "LIBS+=-L#{Formula["glew"].opt_lib} -lGLEW"
+    system "cat", "src/Makefile"
     system "make", "install"
   end
 

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -20,7 +20,7 @@ class Opencsg < Formula
     sha256 "12cc799a6352eda4a18706eeefea059d14e23605a627dc12ed2a809f65328d69"
   end
 
-def install
+  def install
     system "qmake", "-r", "INSTALLDIR=#{prefix}",
       "INCLUDEPATH+=#{Formula["glew"].opt_include}",
       "LIBS+=-L#{Formula["glew"].opt_lib} -lGLEW"

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -24,7 +24,6 @@ class Opencsg < Formula
     system "qmake", "-r", "INSTALLDIR=#{prefix}",
       "INCLUDEPATH+=#{Formula["glew"].opt_include}",
       "LIBS+=-L#{Formula["glew"].opt_lib} -lGLEW"
-    system "cat", "src/Makefile"
     system "make", "install"
   end
 

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -16,7 +16,7 @@ class Opencsg < Formula
 
   # This patch disabling building examples
   patch do
-    url "https://raw.githubusercontent.com/openscad/formula-patches/d6fea2cf509a6feca48f498c167bce4970b16356/opencsg/patch-build.diff"
+    url "https://raw.githubusercontent.com/openscad/formula-patches/4e9b9aabcc89dff597f14ba64542e87d750bced6/opencsg/disable-examples.diff"
     sha256 "12cc799a6352eda4a18706eeefea059d14e23605a627dc12ed2a809f65328d69"
   end
 

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -1,28 +1,12 @@
 class Opencsg < Formula
   desc "The CSG rendering library"
   homepage "http://www.opencsg.org"
-  url "http://www.opencsg.org/OpenCSG-1.4.0.tar.gz"
-  sha256 "ecb46be54cfb8a338d2a9b62dec90ec8da6c769078c076f58147d4a6ba1c878d"
+  url "http://www.opencsg.org/OpenCSG-1.4.1.tar.gz"
+  sha256 "48182c8233e6f89cd6752679bde44ef6cc9eda4c06f4db845ec7de2cae2bb07a"
   revision 1
-
-  bottle do
-    cellar :any
-    sha256 "577e6777db3c9ee1010577e9dd29f7d86cff106273ef650bf58b08b20020a751" => :el_capitan
-    sha256 "d6e5913457b310b32a3dd9673a248793fd53bc6d2863f55b3d3334be7665c544" => :yosemite
-    sha256 "26098d8c2d4e89f2a0389c470f8b094a805e97c959defa3381ab0cd8c8d8ec9e" => :mavericks
-  end
 
   depends_on "qt5" => :build
   depends_on "glew"
-
-  # This patch adds support for specifying INSTALLDIR
-  # It has been submitted upstream and accepted 20160709, through private email
-  # (as that's how submissions are done)
-  # Should be in the next release (> 1.4.0)
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/814a29d3ce4c6e7e919cd2fcd64bf45d421e821b/opencsg/patch-build.diff"
-    sha256 "9d710cf6c2d5495ca5ba51c0319785cefc21477c85fa3aacb9ccd3473fee54f3"
-  end
 
   def install
     system "qmake", "-r", "INSTALLDIR=#{prefix}",

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -3,7 +3,10 @@ class Opencsg < Formula
   homepage "http://www.opencsg.org"
   url "http://www.opencsg.org/OpenCSG-1.4.1.tar.gz"
   sha256 "48182c8233e6f89cd6752679bde44ef6cc9eda4c06f4db845ec7de2cae2bb07a"
-  revision 1
+
+  bottle do
+    cellar :any
+  end
 
   depends_on "qt5" => :build
   depends_on "glew"

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -16,7 +16,7 @@ class Opencsg < Formula
 
   # This patch disabling building examples
   patch do
-    url "https://raw.githubusercontent.com/openscad/formula-patches/4e9b9aabcc89dff597f14ba64542e87d750bced6/opencsg/disable-examples.diff"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/990b9bb/opencsg/disable-examples.diff"
     sha256 "12cc799a6352eda4a18706eeefea059d14e23605a627dc12ed2a809f65328d69"
   end
 

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -14,7 +14,13 @@ class Opencsg < Formula
   depends_on "qt5" => :build
   depends_on "glew"
 
-  def install
+  # This patch disabling building examples
+  patch do
+    url "https://raw.githubusercontent.com/openscad/formula-patches/d6fea2cf509a6feca48f498c167bce4970b16356/opencsg/patch-build.diff"
+    sha256 "12cc799a6352eda4a18706eeefea059d14e23605a627dc12ed2a809f65328d69"
+  end
+
+def install
     system "qmake", "-r", "INSTALLDIR=#{prefix}",
       "INCLUDEPATH+=#{Formula["glew"].opt_include}",
       "LIBS+=-L#{Formula["glew"].opt_lib} -lGLEW"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The build currently fails with this error:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: symbols referenced by indirect symbol table entries that can't be stripped in: /usr/local/Cellar/opencsg/1.4.1/lib/libopencsg.1.4.1.dylib
```

Notes:
- The currently deployed version also fails with the same error, but the error is ignored. This is most probably due to the generated makefile (`src/Makefile`) prefixes the strip command with a '-' to ignore errors.
- I'm unable to reproduce this build error locally - my makefiles end up containing the '-' prefix and thus ignoring any strip errors. (@kintel)

Link to OpenCSG-1.4.0 built on the CI: https://bot.brew.sh/view/Testing/job/Homebrew%20Testing/1092/

-> the issue turned out to be triggered by building the OpenCSG examples.
