### PR TITLE
openssl@1.1: increment version_scheme

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -4,6 +4,7 @@ class OpensslAT11 < Formula
   url "https://www.openssl.org/source/openssl-1.1.0a.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.0a.tar.gz"
   sha256 "c2e696e34296cde2c9ec5dcdad9e4f042cd703932591d395c389de488302442b"
+  version_scheme 1
 
   bottle do
     sha256 "d43a620410465b82af3bb4057156cfc81c4eff2a7afd2ee5ce05b8d366ac3e70" => :sierra


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Remember the old bug we have with OpenSSL versioning where each new branch we never update people from the x.x.0 release to the x.x.0a release because we read `a` as less than a stable release? It still exists! Le sigh.
