### PR TITLE
Elasticsearch 5.0.0-beta1

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -5,9 +5,9 @@ class Elasticsearch < Formula
   sha256 "3ae01140ae7bcbb91436feef381fbed774e36ef6d1e8e6a3153640db82acf4c9"
 
   devel do
-    url "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.tar.gz"
-    sha256 "4ec8fa57310affa9e0510aa18fb98c8b08f7e7d6f591d29c3e1fffe88d411813"
-    version "5.0.0-alpha5"
+    url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0-beta1.tar.gz"
+    sha256 "4ff6680b2d053c74835db77dcb03e02340555cd70cae8bb73d3b1f94ddf0147d"
+    version "5.0.0-beta1"
   end
 
   head do

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -11,13 +11,13 @@ class Elasticsearch < Formula
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"
-    depends_on :java => "1.8"
+    depends_on java: "1.8"
     depends_on "gradle" => :build
   end
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on java: "1.7+"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -103,7 +103,7 @@ class Elasticsearch < Formula
     s
   end
 
-  plist_options :manual => "elasticsearch"
+  plist_options manual: "elasticsearch"
 
   def plist; <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -7,18 +7,17 @@ class Elasticsearch < Formula
   devel do
     url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0-beta1.tar.gz"
     sha256 "4ff6680b2d053c74835db77dcb03e02340555cd70cae8bb73d3b1f94ddf0147d"
-    version "5.0.0-beta1"
   end
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"
-    depends_on java: "1.8"
+    depends_on :java => "1.8"
     depends_on "gradle" => :build
   end
 
   bottle :unneeded
 
-  depends_on java: "1.7+"
+  depends_on :java => "1.7+"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -104,7 +103,7 @@ class Elasticsearch < Formula
     s
   end
 
-  plist_options manual: "elasticsearch"
+  plist_options :manual => "elasticsearch"
 
   def plist; <<-EOS.undent
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This pull request upgrades the devel release for Elasticsearch from version 5.0.0-alpha5 to 5.0.0-beta1, the [latest pre-release version of the Elasticsearch 5.x series](https://www.elastic.co/blog/elasticsearch-5-0-0-beta1-released) as of 2016-09-21.
