### PR TITLE
homeshick: Corrected .bash_rc to .bashrc in caveats

### DIFF
--- a/Formula/homeshick.rb
+++ b/Formula/homeshick.rb
@@ -30,7 +30,7 @@ class Homeshick < Formula
       `export HOMESHICK_DIR=#{opt_prefix}`
       and
       `source "#{opt_prefix}/homeshick.sh"`
-      in your $HOME/.bash_rc
+      in your $HOME/.bashrc
     EOS
     if build.with? "fish"
       s += <<-EOS.undent


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

As per https://github.com/andsens/homeshick/issues/158#issuecomment-249033127 the caveat to modify the .bash_rc should be instead to modify the .bashrc.
