### PR TITLE
lsyncd: fix installation with xnu headers for Sierra

### DIFF
--- a/Formula/lsyncd.rb
+++ b/Formula/lsyncd.rb
@@ -37,13 +37,16 @@ class Lsyncd < Formula
     "10.10.1"  => ["xnu-2782.1.97.tar.gz",   "18fd93155c53fa66c48c2c876313311bba55cff260ea10e7b67dd7ed1f4b945c"],
     "10.10.2"  => ["xnu-2782.10.72.tar.gz",  "0725dfc77ce245e37b57d226445217c17d0a7750db099d3ca69a4ad1c7f39356"],
     "10.10.3"  => ["xnu-2782.20.48.tar.gz",  "d1d7cfdf282b6b651415d5adb7f591f3d7ee0e0ccdd29db664c0ec3f9f827146"],
-    "10.10.4"  => ["xnu-2782.30.5.tar.gz",  "16fbd88fb5833fdfb6d8169b7c330d344c12b6a644678a1eb68f27c318b8811d"],
-    "10.10.5"  => ["xnu-2782.40.9.tar.gz",  "f9f2524124edebe81bb1ead2f69c3daeed1f37641aef68ac4df5bcffd2ab0898"],
+    "10.10.4"  => ["xnu-2782.30.5.tar.gz",   "16fbd88fb5833fdfb6d8169b7c330d344c12b6a644678a1eb68f27c318b8811d"],
+    "10.10.5"  => ["xnu-2782.40.9.tar.gz",   "f9f2524124edebe81bb1ead2f69c3daeed1f37641aef68ac4df5bcffd2ab0898"],
     "10.11"    => ["xnu-3247.1.106.tar.gz",  "660f8f107d284fe797675b0a266c63016876aa5bb4add99d88ffb9cd9001d84f"],
     "10.11.1"  => ["xnu-3247.10.11.tar.gz",  "66ff554039e3b8351fdb2103c4dfb6bf8015c6f9a219f70c057b839cb10b1640"],
     "10.11.2"  => ["xnu-3248.20.55.tar.gz",  "10c3acf0da74d6f4684d6a870b425546fc9c9dcb9c39541556f47cba2440a2ab"],
-    "10.11.3"  => ["xnu-3248.20.55.tar.gz",  "10c3acf0da74d6f4684d6a870b425546fc9c9dcb9c39541556f47cba2440a2ab"],
-    "10.11.4"  => ["xnu-3248.20.55.tar.gz",  "10c3acf0da74d6f4684d6a870b425546fc9c9dcb9c39541556f47cba2440a2ab"],
+    "10.11.3"  => ["xnu-3248.30.4.tar.gz",   "106a8a3a9e01bd73b06298f81b397fe3d772428e0a650edb24b340315a4d0e84"],
+    "10.11.4"  => ["xnu-3248.40.184.tar.gz", "a9e1b03ae9cde203f83602260ea1994822cb4e38c81b99e74797a124f6cd10ab"],
+    "10.11.5"  => ["xnu-3248.50.21.tar.gz",  "e1daa3666c7cdf35d7d320a0b0dae8b7d03ea35c7383ea681371e0543fb5d4b5"],
+    "10.11.6"  => ["xnu-3248.60.10.tar.gz",  "295b69cee59f2a7419eab3d95744595fa8cd614716fb6ddc958b61dc088e1f7a"],
+    "10.12"    => ["xnu-3248.60.10.tar.gz",  "295b69cee59f2a7419eab3d95744595fa8cd614716fb6ddc958b61dc088e1f7a"],
   }
 
   if xnu_headers.key? MacOS.full_version


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Should fix this error installing `lsyncd` on Sierra

```
==> Installing lsyncd
==> Using the sandbox
==> Downloading https://github.com/axkibe/lsyncd/archive/release-2.1.6.tar.gz
==> Downloading from https://codeload.github.com/axkibe/lsyncd/tar.gz/release-2.1.6
######################################################################## 100.0%
Error: lsyncd does not define resource "xnu"
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Homebrew/Library/Homebrew/software_spec.rb:106:in `block in resource'
/usr/local/Homebrew/Library/Homebrew/software_spec.rb:106:in `fetch'
/usr/local/Homebrew/Library/Homebrew/software_spec.rb:106:in `resource'
/usr/local/Homebrew/Library/Homebrew/formula.rb:391:in `resource'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/lsyncd.rb:59:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:135:in `block in install'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1083:in `block in brew'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1815:in `block in stage'
/usr/local/Homebrew/Library/Homebrew/resource.rb:98:in `block in unpack'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:14:in `block in mktemp'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `block in run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:13:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/resource.rb:94:in `unpack'
/usr/local/Homebrew/Library/Homebrew/resource.rb:86:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1802:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1078:in `brew'
/usr/local/Homebrew/Library/Homebrew/build.rb:112:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:187:in `<main>'
```
