### PR TITLE
qwt: port qwt to qt5

### DIFF
--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -1,8 +1,9 @@
 class Qwt < Formula
-  desc "Qt Widgets for Technical Applications (v5.1)"
+  desc "Qt Widgets for Technical Applications"
   homepage "http://qwt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2"
   sha256 "f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733"
+  revision 1
 
   bottle do
     cellar :any
@@ -44,7 +45,7 @@ class Qwt < Formula
       prefix.install "textengines/mathml/qtmmlwidget-license"
     end
 
-    system "qmake", *args
+    system Formula["qt5"].bin/"qmake", *args
     system "make"
     system "make", "install"
   end

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -15,7 +15,7 @@ class Qwt < Formula
   option "with-qwtmathml", "Build the qwtmathml library"
   option "without-plugin", "Skip building the Qt Designer plugin"
 
-  depends_on "qt"
+  depends_on "qt5"
 
   # Update designer plugin linking back to qwt framework/lib after install
   # See: https://sourceforge.net/p/qwt/patches/45/
@@ -26,15 +26,15 @@ class Qwt < Formula
       s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
       s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
 
-      # Install Qt plugin in `lib/qt4/plugins/designer`, not `plugins/designer`.
+      # Install Qt plugin in `lib/qt5/plugins/designer`, not `plugins/designer`.
       s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
-             "\\1/lib/qt4/\\2"
+             "\\1/lib/qt5/\\2"
     end
 
     args = ["-config", "release", "-spec"]
     # On Mavericks we want to target libc++, this requires a unsupported/macx-clang-libc++ flag
     if ENV.compiler == :clang && MacOS.version >= :mavericks
-      args << "unsupported/macx-clang-libc++"
+      args << "macx-clang"
     else
       args << "macx-g++"
     end
@@ -73,10 +73,10 @@ class Qwt < Formula
     EOS
     system ENV.cxx, "test.cpp", "-o", "out",
       "-framework", "qwt", "-framework", "QtCore",
-      "-F#{lib}", "-F#{Formula["qt"].opt_lib}",
+      "-F#{lib}", "-F#{Formula["qt5"].opt_lib}",
       "-I#{lib}/qwt.framework/Headers",
-      "-I#{Formula["qt"].opt_lib}/QtCore.framework/Headers",
-      "-I#{Formula["qt"].opt_lib}/QtGui.framework/Headers"
+      "-I#{Formula["qt5"].opt_lib}/QtCore.framework/Versions/5/Headers",
+      "-I#{Formula["qt5"].opt_lib}/QtGui.framework/Versions/5/Headers"
     system "./out"
   end
 end

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -72,6 +72,7 @@ class Qwt < Formula
         return (curve1 == NULL);
       }
     EOS
+    ENV.cxx11
     system ENV.cxx, "test.cpp", "-o", "out",
       "-framework", "qwt", "-framework", "QtCore",
       "-F#{lib}", "-F#{Formula["qt5"].opt_lib}",

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -72,8 +72,8 @@ class Qwt < Formula
         return (curve1 == NULL);
       }
     EOS
-    ENV.cxx11
     system ENV.cxx, "test.cpp", "-o", "out",
+      "-std=c++11",
       "-framework", "qwt", "-framework", "QtCore",
       "-F#{lib}", "-F#{Formula["qt5"].opt_lib}",
       "-I#{lib}/qwt.framework/Headers",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I was able to compile `qwt` using `qt5` (related to #1705) on my ElCapitan machine with this set of changes. `brew test` also finished just fine. I was able to compile `gnuradio` (revdep) using this modified version but I'm unsure that the commands that I run from gnuradio really tests loading and runtime so please feel free to propose an application (or gnuradio command) to test that runtime is fine.

Thanks.
