### PR TITLE
protobuf-swift: fix build with protobuf 3.1.0

### DIFF
--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -18,6 +18,10 @@ class ProtobufSwift < Formula
   depends_on "protobuf"
 
   def install
+    system "protoc", "-Iplugin/compiler",
+                     "plugin/compiler/google/protobuf/descriptor.proto",
+                     "plugin/compiler/google/protobuf/swift-descriptor.proto",
+                     "--cpp_out=plugin/compiler"
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
There are generated files checked into upstream's SCM that need to be
regenerated due to the new version of protobuf. THe next release of
protobuf-swift will obviate the need to regerate them in the formula.
