### PR TITLE
jetty 9.3.12.v20160915

### DIFF
--- a/Formula/jetty.rb
+++ b/Formula/jetty.rb
@@ -1,9 +1,9 @@
 class Jetty < Formula
   desc "Java servlet engine and webserver"
   homepage "https://www.eclipse.org/jetty/"
-  url "http://download.eclipse.org/jetty/9.3.10.v20160621/dist/jetty-distribution-9.3.10.v20160621.tar.gz"
-  version "9.3.10.v20160621"
-  sha256 "7f7de08bc395a8973c4de5fda57e91fa511b52f4131c55677c254581ee3a1b77"
+  url "https://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-distribution/9.3.12.v20160915/jetty-distribution-9.3.12.v20160915.tar.gz"
+  version "9.3.12.v20160915"
+  sha256 "adc709d63718f017112e69c2d1fb82d7f79cacf01da7caedf4aee2a9b0064920"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

`brew audit --new-formula jetty` fails with

```
Error: type mismatch: String given
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:153:in `=~'
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:153:in `block in search_tap'
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:153:in `select'
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:153:in `search_tap'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:346:in `block (2 levels) in audit_formula_name'
```

---

Old download link (which is lacking the latest version) changed to link from download page (http://www.eclipse.org/jetty/download.html -> rep1.maven.org/[..]), which was then changed to the one suggested by `brew audit`.
