### PR TITLE
ISSUE_TEMPLATE: improve bug report instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,9 @@ _You can erase any parts of this template not applicable to your Issue._
 
 ### Bug reports:
 
-Please replace this line with a brief summary of your issue **AND** if reporting a build issue include the link from:
+Please replace this section with a summary of your issue. Always include **exact commands that resulted in errors**, **exact error messages**, and ideally full transcripts of such commands.
+
+ If reporting a build issue, please also include the link from:
 
 `brew gist-logs <formula>`
 (where `<formula>` is the name of the formula that failed to build).


### PR DESCRIPTION
As ridiculous as it sounds, we get way too many issues that don't include what command errored out. They basically contain "foo doesn't work" plus sometimes the last few lines of the transcript plus sometimes a gist-logs link. And occasionally the gist-logs link is totally misleading because the user was running into run-time issues (sometimes having nothing to do with brew), so we're sent on a wild-goose chase and waste quite some time before realizing the issue at hand has nothing to do with the logs. This is ridiculous and I think from now on we should refuse to support and instead point to the template when no failing command and no exact error message are given (of course this should be judged on a case to case basis).

I'm also tempted to always ask for `brew config`, but I want to have people's opinions on this.
