### PR TITLE
ndpi: fix url

### DIFF
--- a/Formula/ndpi.rb
+++ b/Formula/ndpi.rb
@@ -1,8 +1,8 @@
 class Ndpi < Formula
   desc "Deep Packet Inspection (DPI) library"
   homepage "http://www.ntop.org/products/ndpi/"
-  url "https://downloads.sourceforge.net/project/ntop/nDPI/nDPI-1.8.tgz"
-  sha256 "f490137a7387b69d0d55e990f2150b86d7b5eaae870e5326e8c2f18c17412443"
+  url "https://github.com/ntop/nDPI/archive/1.8.tar.gz"
+  sha256 "cea26a7f280301cc3a0e714b560d48b57ae2cf6453b71eb647ceb3fccecb5ba2"
 
   bottle do
     cellar :any
@@ -25,6 +25,6 @@ class Ndpi < Formula
   end
 
   test do
-    system "#{bin}/ndpiReader", "-i", test_fixtures("test.pcap")
+    system bin/"ndpiReader", "-i", test_fixtures("test.pcap")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

nDPI-1.8.tgz disappeared from SF, seemingly replaced by a nDPI-1.8.tar.gz from a later date with a different checksum. I could not verify the identity of this replaced file, so I sought to contact the
upstream and landed on http://www.ntop.org/support/need-help-2/need-help/, which linked me to
https://github.com/ntop. Therefore, apparently the GitHub organization is trustworthy, so let's use the tarball there.
