### PR TITLE
bazel: patch bazel for macOS 10.12 Sierra

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -1,9 +1,18 @@
 class Bazel < Formula
   desc "Google's own build tool"
   homepage "https://www.bazel.io/"
-  url "https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz"
-  sha256 "52beafc9d78fc315115226f31425e21df1714d96c7dfcdeeb02306e2fe028dd8"
   head "https://github.com/bazelbuild/bazel.git"
+
+  stable do
+    url "https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz"
+    sha256 "52beafc9d78fc315115226f31425e21df1714d96c7dfcdeeb02306e2fe028dd8"
+
+    # Fix build on macOS 10.12 Sierra
+    patch do
+      url "https://github.com/bazelbuild/bazel/commit/fefd2329f4812bcb513294fdf417fc726a86ddfd.diff"
+      sha256 "73455ede4acb9e40923838cb66750a5baacc6b6f8eaaeed72df02dbca38bbe73"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
- Use nanosleep(2) instead of poll(2) to sleep
- See
  https://github.com/bazelbuild/bazel/commit/fefd2329f4812bcb513294fdf417fc726a86ddfd

---

Referenced:
- https://github.com/Homebrew/homebrew-core/issues/4841
- https://github.com/bazelbuild/bazel/issues/1767
- https://github.com/Homebrew/homebrew-core/pull/5041
- https://github.com/bazelbuild/bazel/commit/fefd2329f4812bcb513294fdf417fc726a86ddfd
