### PR TITLE
Pyinvoke

### DIFF
--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -5,7 +5,6 @@ class Pyinvoke < Formula
   homepage "http://pyinvoke.org/"
   url "https://github.com/pyinvoke/invoke/archive/0.13.0.tar.gz"
   sha256 "4942aa901618f99afa70271d7b15fd018da0f174178fbca4048354c785e7736a"
-
   head "https://github.com/pyinvoke/invoke.git"
 
   depends_on :python if MacOS.version <= :snow_leopard
@@ -26,8 +25,8 @@ class Pyinvoke < Formula
           for pattern in patterns:
               run("rm -rf {}".format(pattern))
     EOS
-    mkdir_p testpath/"foo"/"bar"
-    mkdir_p testpath/"baz"
+    (testpath/"foo"/"bar").mkpath
+    (testpath/"baz").mkpath
     system bin/"invoke", "clean"
     assert !File.exist?(testpath/"foo"), "\"pyinvoke clean\" should have deleted \"foo\""
     assert File.exist?(testpath/"baz"), "pyinvoke should have left \"baz\""

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -1,0 +1,38 @@
+class Pyinvoke < Formula
+  include Language::Python::Virtualenv
+
+  desc "Pythonic task management & command execution"
+  homepage "http://pyinvoke.org/"
+  url "https://github.com/pyinvoke/invoke/archive/0.12.2.tar.gz"
+  sha256 "dfc9892a0731456c785bd9d515fe761767729d32155cfd77bd0f042bd6228187"
+
+  head "https://github.com/pyinvoke/invoke.git"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"tasks.py").write <<-EOS.undent
+      from invoke import run, task
+
+      @task
+      def clean(extra=''):
+          patterns = ['foo']
+          if extra:
+              patterns.append(extra)
+          for pattern in patterns:
+              run("rm -rf {}".format(pattern))
+    EOS
+    mkdir_p testpath/"foo"/"bar"
+    mkdir_p testpath/"baz"
+    system bin/"invoke", "clean"
+    assert !File.exist?(testpath/"foo"), "\"pyinvoke clean\" should have deleted \"foo\""
+    assert File.exist?(testpath/"baz"), "pyinvoke should have left \"baz\""
+    system bin/"invoke", "clean", "--extra=baz"
+    assert !File.exist?(testpath/"foo"), "\"pyinvoke clean-extra\" should have still deleted \"foo\""
+    assert !File.exist?(testpath/"baz"), "pyinvoke clean-extra should have deleted \"baz\""
+  end
+end

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -3,8 +3,8 @@ class Pyinvoke < Formula
 
   desc "Pythonic task management & command execution"
   homepage "http://pyinvoke.org/"
-  url "https://github.com/pyinvoke/invoke/archive/0.12.2.tar.gz"
-  sha256 "dfc9892a0731456c785bd9d515fe761767729d32155cfd77bd0f042bd6228187"
+  url "https://github.com/pyinvoke/invoke/archive/0.13.0.tar.gz"
+  sha256 "4942aa901618f99afa70271d7b15fd018da0f174178fbca4048354c785e7736a"
 
   head "https://github.com/pyinvoke/invoke.git"
 
@@ -19,7 +19,7 @@ class Pyinvoke < Formula
       from invoke import run, task
 
       @task
-      def clean(extra=''):
+      def clean(ctx, extra=''):
           patterns = ['foo']
           if extra:
               patterns.append(extra)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)? (well, yes, modulo issue 5249)

---

This formula started life at version 0.12.2 because that was the specific version required to build another piece of software. However, 0.12 is not the latest version; that is 0.13.0 and is the one at the head of this PR. But I thought it would be useful to leave 0.12.2 in the history in case someone also wishes to build using the older version of pyinvoke

As you might suspect, I purposefully did not call the formula "invoke", however, I had mixed feelings about leaving their `inv` and `invoke` on the `$PATH`, so if you have guidance around that I'd welcome it.
