### PR TITLE
enable --with-debug for nghttp2

### DIFF
--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -21,6 +21,7 @@ class Nghttp2 < Formula
   option "with-examples", "Compile and install example programs"
   option "without-docs", "Don't build man pages"
   option "with-python3", "Build python3 bindings"
+  option "with-debug", "Emit verbose HTTP/2 debugging output"
 
   depends_on :python3 => :optional
   depends_on "sphinx-doc" => :build if build.with? "docs"


### PR DESCRIPTION
Debugging failing HTTP/2 connections requires that nghttp2 is build configured `--with-debug`, see here: https://github.com/curl/curl/issues/674#issuecomment-187181546
