### PR TITLE
erlang: remove ENV.deparallelize, fixed upstream

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -101,9 +101,6 @@ class Erlang < Formula
     end
 
     system "./configure", *args
-    # Install is not thread-safe; can try to create folder twice and fail
-    # Reported 8 Sep 2016 https://bugs.erlang.org/browse/ERL-250
-    ENV.deparallelize
     system "make"
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Remove the `ENV.deparallelize` introduced in #4440, since the issue with parallel make was fixed upstream in erlang/otp#1166.

The updated formula builds fine here with `brew install --build-from-source --verbose --debug erlang`.

I did not introduce a new `revision` since this is only a small build optimisation and a forced rebuild is not desirable.
