### PR TITLE
Require LLVM 3.8 for ponyc

### DIFF
--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -12,7 +12,7 @@ class Ponyc < Formula
   end
 
   depends_on :macos => :yosemite
-  depends_on "llvm"
+  depends_on "homebrew/versions/llvm38"
   depends_on "libressl"
   depends_on "pcre2"
   needs :cxx11


### PR DESCRIPTION
- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

We are finding that users who install ponyc via homebrew without
having llvm 3.8 are installed because by default ponyc is built
with Link Time Optimizations on. This means they need to have the
same version of LLVM installed that was used when building ponyc.

This commit requires LLVM 3.8 specifically rather than the general
LLVM formula that could result in different versions. We believe
this should fix the issue but are unsure as building from source
on the user's machine always solves the problem and it is only
once this has been merged and a bottle created that we can test
whether the fix was successful.

If you have any advice on another way to test, we would appreciate
that.
