### PR TITLE
mpv: Make python3 a build dependency.

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -17,7 +17,7 @@ class Mpv < Formula
 
   depends_on "pkg-config" => :build
   depends_on "docutils" => :build
-  depends_on :python3
+  depends_on :python3 => :build
 
   depends_on "libass"
   depends_on "ffmpeg"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Change python3 to a build dependency to avoid install unnecessary packages when installing from a bottle.
