### PR TITLE
liquibase 3.5.1

### DIFF
--- a/Formula/liquibase.rb
+++ b/Formula/liquibase.rb
@@ -1,8 +1,8 @@
 class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "http://liquibase.org"
-  url "https://github.com/liquibase/liquibase/releases/download/liquibase-parent-3.5.2/liquibase-3.5.2-bin.tar.gz"
-  sha256 "15b0284e29a2661440d1c577478ec18eda2bafd3f90c583ce0a200ec3971beba"
+  url "https://github.com/liquibase/liquibase/releases/download/liquibase-parent-3.5.1/liquibase-3.5.1-bin.tar.gz"
+  sha256 "b99870efec8c779b4e279a8b0c730273f837d4b6dffd037176737ecc0641ab6b"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [✅ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [✅ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [✅ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Author has published a [blog post](http://www.liquibase.org/2016/09/liquibase-3-5-2-pulled.html) advising that the 3.5.2 has been pulled and users use 3.5.1.
