### PR TITLE
ponyc: only pour bottle when user has Xcode 8

### DIFF
--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -17,6 +17,15 @@ class Ponyc < Formula
   depends_on "pcre2"
   needs :cxx11
 
+  # https://github.com/ponylang/ponyc/issues/1274
+  # https://github.com/Homebrew/homebrew-core/issues/5346
+  pour_bottle? do
+    reason <<-EOS.undent
+      The bottle requires Xcode/CLT 8.0 or later to work properly.
+    EOS
+    satisfy { DevelopmentTools.clang_build_version >= 800 }
+  end
+
   def install
     ENV.cxx11
     ENV["LLVM_CONFIG"]="#{Formula["llvm"].opt_bin}/llvm-config"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

See https://github.com/ponylang/ponyc/issues/1274 and https://github.com/Homebrew/homebrew-core/issues/5346.

TL;DR: `ponyc` 4.0 bottle doesn't work on systems with Xcode 7.3, but building from source on such systems is fine.

Fixes #5346.
