### PR TITLE
glib-networking 2.50.0 and libsoup 2.56.0

### DIFF
--- a/Formula/glib-networking.rb
+++ b/Formula/glib-networking.rb
@@ -1,8 +1,8 @@
 class GlibNetworking < Formula
   desc "Network related modules for glib"
   homepage "https://launchpad.net/glib-networking"
-  url "https://download.gnome.org/sources/glib-networking/2.48/glib-networking-2.48.2.tar.xz"
-  sha256 "925c0c49d6b2b8b5695f2e33cd952d1dbb7d18d3f2f796413577719315bb3a84"
+  url "https://download.gnome.org/sources/glib-networking/2.50/glib-networking-2.50.0.tar.xz"
+  sha256 "3f1a442f3c2a734946983532ce59ed49120319fdb10c938447c373d5e5286bee"
 
   bottle do
     sha256 "8d9f25c6ad40d0461faf185e2d82a6b54d2b8df4ef485ebdc6f00129f9302c71" => :sierra

--- a/Formula/libsoup.rb
+++ b/Formula/libsoup.rb
@@ -1,8 +1,8 @@
 class Libsoup < Formula
   desc "HTTP client/server library for GNOME"
   homepage "https://live.gnome.org/LibSoup"
-  url "https://download.gnome.org/sources/libsoup/2.54/libsoup-2.54.1.tar.xz"
-  sha256 "47b42c232034734d66e5f093025843a5d8cc4b2357c011085a2fd04ef02dd633"
+  url "https://download.gnome.org/sources/libsoup/2.56/libsoup-2.56.0.tar.xz"
+  sha256 "d8216b71de8247bc6f274ec054c08547b2e04369c1f8add713e9350c8ef81fe5"
 
   bottle do
     sha256 "0c66d84be8f6026c0994d7d480ec25e36caf8f9ba281915be949349fb08c5ba3" => :sierra


### PR DESCRIPTION
Enabled `p11-kit support`, which also required a modification to the `gnutls` formula.
`libsoup` depends on `glib-networking`, so I added that one too
