### PR TITLE
vim 8.0.0019

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -2,8 +2,8 @@ class Vim < Formula
   desc "Vi \"workalike\" with many additional features"
   homepage "http://www.vim.org/"
   # *** Vim should be updated no more than once every 7 days ***
-  url "https://github.com/vim/vim/archive/v8.0.0013.tar.gz"
-  sha256 "46b509cd0c4d085cfec60b2e8d30daca568908c4d7dbcaa2af586ed897cc8d4b"
+  url "https://github.com/vim/vim/archive/v8.0.0019.tar.gz"
+  sha256 "f13a76504b2f976228edd7169d592870a6af45614d82ae2a9c312fc17ab3d4ad"
   head "https://github.com/vim/vim.git"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

update vim version 8.0013. This version fix the bug"Error detected while processing function youcompleteme#Enable[5]..<snr>66_SetUpP ython:
line 39:
E887: Sorry, this command is disabled, the Python's site module could not be loaded."
when with YouCompleteMe
