### PR TITLE
macvim: bump revision for Python 2.7.12_1

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -5,6 +5,8 @@ class Macvim < Formula
   url "https://github.com/macvim-dev/macvim/archive/snapshot-110.tar.gz"
   version "8.0-110"
   sha256 "a3437a0edbe0d2229def37e342b746ce22028bd604a738f5ee0cc978c7996336"
+  revision 1
+
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This has happened before (https://github.com/Homebrew/brew/issues/463)
Bumping revision so the embedded python framework path is updated. And a couple stylistic changes to appease `brew audit`
