### PR TITLE
p11-kit:  Versioning fixes.

### DIFF
--- a/Formula/p11-kit.rb
+++ b/Formula/p11-kit.rb
@@ -1,13 +1,21 @@
 class P11Kit < Formula
   desc "Library to load and enumerate PKCS#11 modules"
   homepage "https://p11-glue.freedesktop.org"
-  url "https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz"
-  sha256 "ba726ea8303c97467a33fca50ee79b7b35212964be808ecf9b145e9042fdfaf0"
+
+  stable do
+    url "https://p11-glue.freedesktop.org/releases/p11-kit-0.22.1.tar.gz"
+    sha256 "ef3a339fcf6aa0e32c8c23f79ba7191e57312be2bda8b24e6d121c2670539a5c"
+  end
 
   bottle do
     sha256 "f8a576f0e0c58aeb43d0973c689d2de5d959febb86082d5f9505661402217946" => :sierra
     sha256 "056f262ed1ed5fa665885f577e5b2463429c255ff2a987c4f2af67f4f23e0a54" => :el_capitan
     sha256 "f82755ab85440b64ec4db85ecaee5c0185ba751a08d693fffd98f8f80c92afb5" => :yosemite
+  end
+
+  devel do
+    url "https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz"
+    sha256 "ba726ea8303c97467a33fca50ee79b7b35212964be808ecf9b145e9042fdfaf0"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] ~~Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?~~  (N/A:  This is a formula _revision_.)  

---

Moves v0.23.2 of p11-kit to `devel` status and (correctly) gives v0.22.1 of the software `stable` status.
