### PR TITLE
pypy: add head spec

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -3,6 +3,7 @@ class Pypy < Formula
   homepage "http://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.1-src.tar.bz2"
   sha256 "45dbc50c81498f6f1067201b8fc887074b43b84ee32cc47f15e7db17571e9352"
+  head "https://bitbucket.org/pypy/pypy", :using => :hg
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Add head spec to facilitate testing, specifically https://bitbucket.org/pypy/pypy/issues/2407/pypy-541-fails-to-build-on-macos-sierra. (If anyone could help test `brew isntall pypy --HEAD` on 10.9 and 10.11 it would be nice.)
