### PR TITLE
Fixed Ace formula for macOS 10.12 SDK

### DIFF
--- a/Formula/ace.rb
+++ b/Formula/ace.rb
@@ -3,6 +3,9 @@ class Ace < Formula
   homepage "https://www.dre.vanderbilt.edu/~schmidt/ACE.html"
   url "http://download.dre.vanderbilt.edu/previous_versions/ACE-6.4.0.tar.bz2"
   sha256 "6a7fd5f23f6a004bb21978767df4e36adea078cd344e45bab50266213586c001"
+  revision 1
+
+  depends_on "openssl" => :build
 
   bottle do
     cellar :any
@@ -10,6 +13,9 @@ class Ace < Formula
     sha256 "d3e7e45197f7d7643d675ff84057df769947f6c0a9185388d23b2a28375760f0" => :yosemite
     sha256 "72f21357797c350fe547a7978f402e564cf328c3662a0e321d1ec293f4899139" => :mavericks
   end
+
+  # this patch backports new files for macOS Sierra and possibility to compile with Xcode 8 on El Capitan
+  patch :DATA
 
   def install
     # Figure out the names of the header and makefile for this version
@@ -42,3 +48,50 @@ class Ace < Formula
     system "./test_callback"
   end
 end
+
+__END__
+
+diff --git a/ace/config-macosx-sierra.h b/ace/config-macosx-sierra.h
+new file mode 100644
+index 0000000..7cad7ce
+--- /dev/null
++++ b/ace/config-macosx-sierra.h
+@@ -0,0 +1,6 @@
++#ifndef ACE_CONFIG_MACOSX_SIERRA_H
++#define ACE_CONFIG_MACOSX_SIERRA_H
++
++#include "ace/config-macosx-elcapitan.h"
++
++#endif // ACE_CONFIG_MACOSX_SIERRA_H
+diff --git a/include/makeinclude/platform_macosx_sierra.GNU b/include/makeinclude/platform_macosx_sierra.GNU
+new file mode 100644
+index 0000000..2ed4cc3
+--- /dev/null
++++ b/include/makeinclude/platform_macosx_sierra.GNU
+@@ -0,0 +1,3 @@
++
++include $(ACE_ROOT)/include/makeinclude/platform_macosx_elcapitan.GNU
++
+
+diff --git a/ace/config-macosx-leopard.h b/ace/config-macosx-leopard.h
+index 1b9b90d..cadb1a2 100644
+--- a/ace/config-macosx-leopard.h
++++ b/ace/config-macosx-leopard.h
+@@ -4,6 +4,8 @@
+ #ifndef ACE_CONFIG_MACOSX_LEOPARD_H
+ #define ACE_CONFIG_MACOSX_LEOPARD_H
+ 
++#include <Availability.h>
++
+ #define ACE_HAS_MAC_OSX
+ #define ACE_HAS_NET_IF_DL_H
+ 
+@@ -205,9 +207,11 @@
+ #endif
+ 
+ #define ACE_LACKS_CONDATTR_SETCLOCK
++#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+ #define ACE_LACKS_CLOCKID_T
+ #define ACE_LACKS_CLOCK_MONOTONIC
+ #define ACE_LACKS_CLOCK_REALTIME
++#endif

--- a/Formula/ace.rb
+++ b/Formula/ace.rb
@@ -95,3 +95,4 @@ index 1b9b90d..cadb1a2 100644
  #define ACE_LACKS_CLOCK_MONOTONIC
  #define ACE_LACKS_CLOCK_REALTIME
 +#endif
+


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

See https://github.com/Homebrew/homebrew-core/issues/3639

This PR solves compilation issue on El Capitan with Xcode 8.0
This should also solve the same issue on macOS Sierra, but I am unable to test it.

This is a temporary workaround while waiting for a new release by ACE (https://github.com/DOCGroup/ACE_TAO) as they already fixed the problem upstream.

Unfortunately `brew audit` does not pass with the following output

```
$ brew audit ace
ace:
  * The installation was broken.
    Broken dylib links found:
      libExport_Lib.dylib
        libIPC_Tests_Server.dylib
        libTimer.dylib
        libtqtd.dylib
Error: 1 problem in 1 formula
```

which are built in the example phase of the formula.

Note that I had to add a build dependency on `openssl` as macOS 10.11 does not ship anymore the headers of the system openssl. Binary packages do not need this as the system version is taken.
