### PR TITLE
oniguruma: Fix wrong uchar type in headers

### DIFF
--- a/Formula/oniguruma.rb
+++ b/Formula/oniguruma.rb
@@ -3,6 +3,7 @@ class Oniguruma < Formula
   homepage "https://github.com/kkos/oniguruma/"
   url "https://github.com/kkos/oniguruma/releases/download/v6.1.1/onig-6.1.1.tar.gz"
   sha256 "b9cf2eefef5105820c97f94a2ccd12ed8aa274a576ccdaaed3c632a2aa0d0f04"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,6 +12,10 @@ class Oniguruma < Formula
     sha256 "775764a099ba44167efdb9ad76e6d082c772100a3c92e060ec6dd0102ceb2e04" => :yosemite
     sha256 "3714187af50dfaa7106796167bb604a73f84a69e9daef725a4df1f2b06fec992" => :mavericks
   end
+
+  # Fix wrong usage of UChar instead of OnigUChar in oniguruma.h
+  # Patch is from develop branch of kkos/oniguruma and can be dropped in next release.
+  patch :DATA
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
@@ -21,3 +26,26 @@ class Oniguruma < Formula
     assert_match /#{prefix}/, shell_output("#{bin}/onig-config --prefix")
   end
 end
+
+__END__
+diff --git a/src/oniguruma.h b/src/oniguruma.h
+--- a/src/oniguruma.h
++++ b/src/oniguruma.h
+@@ -364,7 +364,7 @@ int onigenc_strlen_null P_((OnigEncoding enc, const OnigUChar* p));
+ ONIG_EXTERN
+ int onigenc_str_bytelen_null P_((OnigEncoding enc, const OnigUChar* p));
+ ONIG_EXTERN
+-int onigenc_is_valid_mbc_string P_((OnigEncoding enc, const UChar* s, const UChar* end));
++int onigenc_is_valid_mbc_string P_((OnigEncoding enc, const OnigUChar* s, const OnigUChar* end));
+ 
+ 
+ 
+@@ -742,7 +742,7 @@ void onig_free P_((OnigRegex));
+ ONIG_EXTERN
+ void onig_free_body P_((OnigRegex));
+ ONIG_EXTERN
+-int onig_scan(regex_t* reg, const UChar* str, const UChar* end, OnigRegion* region, OnigOptionType option, int (*scan_callback)(int, int, OnigRegion*, void*), void* callback_arg);
++int onig_scan(regex_t* reg, const OnigUChar* str, const OnigUChar* end, OnigRegion* region, OnigOptionType option, int (*scan_callback)(int, int, OnigRegion*, void*), void* callback_arg);
+ ONIG_EXTERN
+ int onig_search P_((OnigRegex, const OnigUChar* str, const OnigUChar* end, const OnigUChar* start, const OnigUChar* range, OnigRegion* region, OnigOptionType option));
+ ONIG_EXTERN


### PR DESCRIPTION
This backports two fixes from the kkos/oniguruma#develop branch that are
required to successfully compile hhvm from the hhvm/homebrew-hhvm tap.

The fixes are discussed in hhvm/homebrew-hhvm#50 and in the commit
comments of the broken code:
- kkos/oniguruma@c4be742
- kkos/oniguruma@f5fe5a3

The fixes are taken from:
- kkos/oniguruma@b38e7b0
- kkos/oniguruma@220d62a

The patch can be dropped when the next upstream version is released.
