### PR TITLE
mobile-shell:  enable complete tests under 'make check'

### DIFF
--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -3,7 +3,7 @@ class MobileShell < Formula
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.2.6.tar.gz"
   sha256 "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "bc1a1ce96af199e577ee7eecd75688f43aaa6bddec09a7973c487f8d4233e60f" => :sierra
@@ -25,6 +25,7 @@ class MobileShell < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf"
   depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
+  depends_on "tmux" => :build if build.with?("test") || build.bottle?
 
   def install
     # Fix for 'dyld: lazy symbol binding failed: Symbol not found: _clock_gettime' issue

--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -18,7 +18,7 @@ class MobileShell < Formula
     depends_on "automake" => :build
   end
 
-  option "without-test", "Run build-time tests"
+  option "with-test", "Run build-time tests"
 
   deprecated_option "without-check" => "without-test"
 

--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -3,7 +3,7 @@ class MobileShell < Formula
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.2.6.tar.gz"
   sha256 "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85"
-  revision 4
+  revision 3
 
   bottle do
     sha256 "bc1a1ce96af199e577ee7eecd75688f43aaa6bddec09a7973c487f8d4233e60f" => :sierra


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

'make check' will use tmux to run complete tests if
available, including running the executables.

This likely would have caught #5220 and #5247.

This runs the tests at build time, rendering the smoke test in the `test` block irrelevant-- what's the proper way to handle this?
(We tried to improve that before in #3880)
