### PR TITLE
Added depends_on gmp to crystal-lang

### DIFF
--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -19,6 +19,7 @@ class CrystalLang < Formula
   depends_on "bdw-gc"
   depends_on "llvm"
   depends_on "pcre"
+  depends_on "gmp"
   depends_on "libyaml" if build.with? "shards"
 
   resource "boot" do


### PR DESCRIPTION
Adding gmp fixes this error when running crystal 0.19.3:

```
$ ./bin/crystal spec ./spec/std/json/**
ld: library not found for -lgmp
```
