### PR TITLE
syncthing-inotify sha256 update -- Fixes #5369

### DIFF
--- a/Formula/syncthing-inotify.rb
+++ b/Formula/syncthing-inotify.rb
@@ -2,7 +2,7 @@ class SyncthingInotify < Formula
   desc "File watcher intended for use with Syncthing"
   homepage "https://github.com/syncthing/syncthing-inotify"
   url "https://github.com/syncthing/syncthing-inotify/archive/v0.8.3.tar.gz"
-  sha256 "3bbcce6788b44019472205c000bed2b3255a2ee08c0d20a93a9e7b22c73f3d45"
+  sha256 "2c8ac5152056ec2f106f00f62458db478c3e8cefa11c9f6aadfeb86eccdcb811"
   head "https://github.com/syncthing/syncthing-inotify.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Fixes #5369 by updating sha256.

(PS My RuboCop is broken so `brew audit syncthing-inotify` works but with `--new-formula` it does not work. I think it's a local issue)
