### PR TITLE
gitless 0.8.3 initial submission

### DIFF
--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -1,0 +1,19 @@
+class Gitless < Formula
+  desc "Gitless: a version control system"
+  homepage "http://gitless.com/"
+  url "https://github.com/sdg-mit/gitless/releases/download/v0.8.3/gl-v0.8.3-darwin-x86_64.tar.gz"
+  version "0.8.3"
+  sha256 "4b5cdc00da5fe93a12904c9992a332484201b979687ce9cce5160576c7cb2048"
+
+  def install
+    # The tarball is already compiled.
+    # No need to do anything but move it.
+    bin.install "gl"
+  end
+
+  test do
+    # The output of `gl init` has non-ascii characters and will
+    # cause the test to fail, so we revert to `gl version`.
+    system "#{bin}/gl" " --version"
+  end
+end


### PR DESCRIPTION
I have read the submission guidelines and tried to ensure the pull request follows code style guidelines and passes tests.

I have checked to see that no one else has submitted a pull request for gitless.

The formula seems to install properly and passes tests.

The formula has passed audits using the flags `new-formula`, `online`, and `strict`.

Please let me know if there is anything else I can do to help get this merged.
## Thanks!

gitless is a CLI that wraps git and provides an alternative
workflow without the concept of a staging area.

This formula downloads an already compiled binary and simply moves it
to the bin directory.
