### PR TITLE
castxml 0.1+git20160706

### DIFF
--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -1,10 +1,10 @@
 class Castxml < Formula
   desc "C-family Abstract Syntax Tree XML Output"
   homepage "https://github.com/CastXML/CastXML"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160412.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160412.orig.tar.gz"
-  version "0.1+git20160412"
-  sha256 "d65a4e447e1315021c8230f806100c4a812edeff48b8ce564998066315599c86"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20160706.orig.tar.xz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20160706.orig.tar.xz"
+  version "0.1+git20160706"
+  sha256 "28e7df5f9cc4de6222339d135a7b1583ae0c20aa0d18e47fa202939b81a7dada"
 
   head "https://github.com/CastXML/castxml.git"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Notes:
#4579 also updates castxml, but I am not sure we should wait until llvm 3.9.0 is merged.

Also, the current URLS are broken as the debian mirrors removed old versions, so that the current formula is broken.
#5488 Needs Sierra bottles. I built the current castxml on Sierra so this should be good to go.
