### PR TITLE
Fix ctail build by adding dependency on apr and apr-util

### DIFF
--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -16,18 +16,22 @@ class Ctail < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "apr" => :build
-  depends_on "apr-util" => :build
+  depends_on "apr"
+  depends_on "apr-util"
 
   conflicts_with "byobu", :because => "both install `ctail` binaries"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--with-apr=#{Formula["apr"].bin}", "--with-apr-util=#{Formula["apr-util"].bin}"
+    system "./configure",
+        "--prefix=#{prefix}",
+        "--disable-debug",
+        "--with-apr=#{Formula["apr"].opt_bin}",
+        "--with-apr-util=#{Formula["apr-util"].opt_bin}"
     system "make", "LIBTOOL=glibtool --tag=CC"
     system "make", "install"
   end
 
   test do
-    system "ctail", "-h"
+    system "#{bin}/ctail", "-h"
   end
 end

--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -3,6 +3,7 @@ class Ctail < Formula
   homepage "https://github.com/pquerna/ctail"
   url "https://github.com/pquerna/ctail/archive/ctail-0.1.0.tar.gz"
   sha256 "864efb235a5d076167277c9f7812ad5678b477ff9a2e927549ffc19ed95fa911"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,15 +13,21 @@ class Ctail < Formula
     sha256 "dfab40d65950327c679bde97a335779526c58e99f5679f32f95e517a7249e332" => :mountain_lion
   end
 
-  conflicts_with "byobu", :because => "both install `ctail` binaries"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "apr" => :build
+  depends_on "apr-util" => :build
+
+  conflicts_with "byobu", :because => "both install `ctail` binaries"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug"
+    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--with-apr=#{Formula["apr"].bin}", "--with-apr-util=#{Formula["apr-util"].bin}"
     system "make", "LIBTOOL=glibtool --tag=CC"
     system "make", "install"
+  end
+
+  test do
+    system "ctail", "-h"
   end
 end

--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -16,8 +16,7 @@ class Ctail < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "apr"
-  depends_on "apr-util"
+  depends_on :apr
 
   conflicts_with "byobu", :because => "both install `ctail` binaries"
 

--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -3,7 +3,6 @@ class Ctail < Formula
   homepage "https://github.com/pquerna/ctail"
   url "https://github.com/pquerna/ctail/archive/ctail-0.1.0.tar.gz"
   sha256 "864efb235a5d076167277c9f7812ad5678b477ff9a2e927549ffc19ed95fa911"
-  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -15,7 +15,8 @@ class Ctail < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on :apr
+  depends_on "apr"
+  depends_on "apr-util"
 
   conflicts_with "byobu", :because => "both install `ctail` binaries"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)? -- It fails as not being notable enough, however the formula was already into Homebrew.

---
- Add dependency on `apr` and `apr-util`
- Add their path to the configure flags
- Add a test
