### PR TITLE
freetds: add support for libiodbc

### DIFF
--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -33,9 +33,14 @@ class Freetds < Formula
 
   depends_on "pkg-config" => :build
   depends_on "unixodbc" => :optional
+  depends_on "libiodbc" => :optional
   depends_on "openssl" => :recommended
 
   def install
+    if build.with?("unixodbc") && build.with?("libiodbc")
+      odie "freetds: --without-libiodbc must be specified when using --with-unixodbc"
+    end
+
     args = %W[
       --prefix=#{prefix}
       --with-tdsver=7.3
@@ -48,6 +53,10 @@ class Freetds < Formula
 
     if build.with? "unixodbc"
       args << "--with-unixodbc=#{Formula["unixodbc"].opt_prefix}"
+    end
+
+    if build.with? "libiodbc"
+      args << "--with-libiodbc=#{Formula["libiodbc"].opt_prefix}"
     end
 
     # Translate formula's "--with" options to configuration script's "--enable"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

In previous formula, only unixodbc is supported, however, freetds can be built with either unixodbc or libiodbc. This patch adds support of libiodbc to the formula.

The changes are based on #4211
