### PR TITLE
consul: fix missing web-ui resource

### DIFF
--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -20,6 +20,11 @@ class Consul < Formula
 
   depends_on "go" => :build
 
+  resource "web-ui" do
+    url "https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip"
+    sha256 "42212089c228a73a0881a5835079c8df58a4f31b5060a3b4ffd4c2497abe3aa8"
+  end
+
   def install
     contents = Dir["{*,.git,.gitignore}"]
     gopath = buildpath/"gopath"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

After the update to Consul 0.7.0 (pull request #4834) , running `brew install consul --with-web-ui` no longer works. 

This PR re-instates the web-ui resource, updated to 0.7.0. 
