### PR TITLE
eigen 3.2.10

### DIFF
--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -1,8 +1,8 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
   homepage "https://eigen.tuxfamily.org/"
-  url "https://bitbucket.org/eigen/eigen/get/3.2.9.tar.bz2"
-  sha256 "4d1e036ec1ed4f4805d5c6752b76072d67538889f4003fadf2f6e00a825845ff"
+  url "https://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2"
+  sha256 "760e6656426fde71cc48586c971390816f456d30f0b5d7d4ad5274d8d2cb0a6d"
   head "https://bitbucket.org/eigen/eigen", :using => :hg
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?
  Returns 

```
eigen:
  * C: 6: col 45: Use the new Ruby 1.9 hash syntax
```

But I believe that is caused by https://github.com/Homebrew/brew/issues/1149
