### PR TITLE
pypy: fix compilation on macOS sierra

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -37,6 +37,8 @@ class Pypy < Formula
     sha256 "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732"
   end
 
+  patch :p0, :DATA if MacOS.version >= :sierra
+
   # https://bugs.launchpad.net/ubuntu/+source/gcc-4.2/+bug/187391
   fails_with :gcc
 
@@ -159,3 +161,20 @@ class Pypy < Formula
     system scripts_folder/"pip", "list"
   end
 end
+
+__END__
+--- rpython/rlib/rtime.py	2016-09-06 05:46:10.000000000 -0500
++++ rpython/rlib/rtime.py	2016-09-28 15:56:54.000000000 -0500
+@@ -163,11 +163,9 @@
+     globals().update(rffi_platform.configure(CConfigForClockGetTime))
+     TIMESPEC = TIMESPEC
+     CLOCK_PROCESS_CPUTIME_ID = CLOCK_PROCESS_CPUTIME_ID
+-    eci_with_lrt = eci.merge(ExternalCompilationInfo(libraries=['rt']))
+     c_clock_gettime = external('clock_gettime',
+                                [lltype.Signed, lltype.Ptr(TIMESPEC)],
+-                               rffi.INT, releasegil=False,
+-                               compilation_info=eci_with_lrt)
++                               rffi.INT, releasegil=False)
+ if need_rusage:
+     RUSAGE = RUSAGE
+     RUSAGE_SELF = RUSAGE_SELF or 0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Per discussion in https://bitbucket.org/pypy/pypy/issues/2407/pypy-541-fails-to-build-on-macos-sierra, it seems a 5.4.2 may not be forthcoming. 5.3 (or later) releases will contain an upstream fix for compilation on sierra, but in the meantime, this allows people to use PyPy on Sierra.

Fixes #5093
