### PR TITLE
(devel) add selenium-server-standalone 3.0-beta4 

### DIFF
--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -4,6 +4,11 @@ class SeleniumServerStandalone < Formula
   url "https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar"
   sha256 "1cce6d3a5ca5b2e32be18ca5107d4f21bddaa9a18700e3b117768f13040b7cf8"
 
+  devel do
+    url "http://selenium-release.storage.googleapis.com/3.0-beta4/selenium-server-standalone-3.0.0-beta4.jar"
+    sha256 "7ed927c83d953a05b84794f6e1fb2b699c3c26b04e2379027f72930c679cd76a"
+  end
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
The 3.0 beta is needed for the new safaridriver included in Safari 10.
- [ x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ x ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---
