### PR TITLE
Add explicit Python support for collectd

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -24,6 +24,7 @@ class Collectd < Formula
   end
 
   option "with-java", "Enable Java support"
+  option "with-python", "Enable Python support"
   option "with-protobuf-c", "Enable write_riemann via protobuf-c support"
   option "with-debug", "Enable debug support"
 
@@ -33,6 +34,7 @@ class Collectd < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf-c" => :optional
   depends_on :java => :optional
+  depends_on :python => :optional
   depends_on "net-snmp"
 
   fails_with :clang do
@@ -53,6 +55,7 @@ class Collectd < Formula
 
     args << "--disable-embedded-perl" if MacOS.version <= :leopard
     args << "--disable-java" if build.without? "java"
+    args << "--enable-python" if build.with? "python"
     args << "--enable-write_riemann" if build.with? "protobuf-c"
     args << "--enable-debug" if build.with? "debug"
 


### PR DESCRIPTION
The default configure script tries to guess if Python is present, but
links with the wrong one if the flag is not specified, which ends up not
working:

Unhandled python exception in importing module:
ImportError:
dlopen(/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/lib-dynload/_io.so,
2): Symbol not found: __PyCodecInfo_GetIncrementalDecoder

Adding an explicit dependency and flag at compile time make sure it
works properly.
