### PR TITLE
ssh-agent-filter 0.4.2 (new formula)

### DIFF
--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -1,0 +1,62 @@
+class SshAgentFilter < Formula
+  desc "filtering proxy for ssh-agent"
+  homepage "https://github.com/tiwe-de/ssh-agent-filter"
+  url "https://github.com/tiwe-de/ssh-agent-filter/archive/0.4.2.tar.gz"
+  sha256 "5586e40da34f4afd873d7ff30f115c4a1b9455c1b81f3c4679c995db7615b080"
+
+  depends_on "help2man" => :build
+  depends_on "boost"
+  depends_on "nettle"
+
+  patch :DATA
+
+  def install
+    ENV.deparallelize
+    system "make", "ssh-agent-filter.1"
+    man1.install "ssh-agent-filter.1"
+    bin.install "ssh-agent-filter"
+    bin.install "afssh"
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! It's enough to just replace
+    # "false" with the main program this formula installs, but it'd be nice if you
+    # were more thorough. Run the test with `brew test ssh-agent-filter`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "#{bin}/ssh-agent-filter", "-V"
+  end
+end
+__END__
+Fix afssh https://github.com/tiwe-de/ssh-agent-filter/pull/5#issuecomment-242216945
+Fix man page generation due to missing perl Locale::gettext
+diff --git a/afssh b/afssh
+index c482aea..6c2fbdf 100755
+--- a/afssh
++++ b/afssh
+@@ -52,7 +52,7 @@ fi
+ declare -a agent_filter_args
+ 
+ if [ -x "${BASH_SOURCE%/*}/ssh-agent-filter" ]; then
+-	SAF=$(readlink -f "${BASH_SOURCE%/*}/ssh-agent-filter")
++	SAF=$(realpath "${BASH_SOURCE%/*}/ssh-agent-filter")
+ else
+ 	SAF=$(which ssh-agent-filter)
+ fi
+diff --git a/Makefile b/Makefile
+index b2e05ec..30b3e9f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -28,7 +28,7 @@ all: ssh-agent-filter.1 afssh.1 ssh-askpass-noinput.1
+ 	pandoc -s -w man $< -o $@
+ 
+ %.1: %.help2man %
+-	help2man -i $< -o $@ -N -L C.UTF-8 $(*D)/$(*F)
++	help2man -i $< -o $@ -N $(*D)/$(*F)
+ 
+ ssh-agent-filter: ssh-agent-filter.o
+ 

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -31,10 +31,9 @@ class SshAgentFilter < Formula
 
   test do
     (testpath/"test.sh").write <<-EOS.undent
-      mydir=$(pwd)
       cd $(mktemp -d)
-      ssh-keygen -q -N '' -f keyA
-      ssh-keygen -q -N '' -f keyB
+      ssh-keygen -q -N '' -t ed25519 -C keyA -f keyA
+      ssh-keygen -q -N '' -t ed25519 -C keyB -f keyB
       eval $(ssh-agent)
       pid=$SSH_AGENT_PID
       ssh-add keyA
@@ -43,7 +42,7 @@ class SshAgentFilter < Formula
       eval $(ssh-agent-filter -c keyA)
       sha2=$(ssh-add -l | awk '{print $2}')
       kill $SSH_AGENT_PID $pid 
-      test "$sha1" == "$sha2"
+      test "$sha1" = "$sha2"
     EOS
     system "sh", "test.sh"
   end

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -18,15 +18,13 @@ class SshAgentFilter < Formula
   patch do
     # https://github.com/tiwe-de/ssh-agent-filter/pull/6
     url "https://patch-diff.githubusercontent.com/raw/tiwe-de/ssh-agent-filter/pull/6.diff"
-    sha256 "e64c93daed3a0b696dd5325a60a8a5d65a267c28607e29b886eb8901ec6e7da7"
+    sha256 "5bd81db7cbfaf04e681f343ef6742061eaf6c9ead7d30c3fe6bf98eb8690c32f"
   end
 
   patch :DATA
 
   def install
-    system "mkdir", "-p", "#{prefix}/bin"
-    system "mkdir", "-p", "#{prefix}/man/man1"
-    system "make", "install", "PREFIX=#{prefix}"
+   system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -18,11 +18,9 @@ class SshAgentFilter < Formula
   patch :DATA
 
   def install
-    ENV.deparallelize
-    system "make", "ssh-agent-filter.1"
-    man1.install "ssh-agent-filter.1"
-    bin.install "ssh-agent-filter"
-    bin.install "afssh"
+    system "mkdir", "-p", "#{prefix}/bin"
+    system "mkdir", "-p", "#{prefix}/man/man1"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -19,15 +19,6 @@ class SshAgentFilter < Formula
   end
 
   test do
-    # `test do` will create, run in and delete a temporary directory.
-    #
-    # This test will fail and we won't accept that! It's enough to just replace
-    # "false" with the main program this formula installs, but it'd be nice if you
-    # were more thorough. Run the test with `brew test ssh-agent-filter`. Options passed
-    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-    #
-    # The installed folder is not in the path, so use the entire path to any
-    # executables being tested: `system "#{bin}/program", "do", "something"`.
     system "#{bin}/ssh-agent-filter", "-V"
   end
 end

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -36,8 +36,7 @@ class SshAgentFilter < Formula
       ssh-keygen -q -N '' -t ed25519 -C keyB -f keyB
       eval $(ssh-agent)
       pid=$SSH_AGENT_PID
-      ssh-add keyA
-      ssh-add keyB
+      ssh-add keyA keyB
       sha1=$(ssh-add -l | awk '/keyA/{print $2}')
       eval $(ssh-agent-filter -c keyA)
       sha2=$(ssh-add -l | awk '{print $2}')

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -12,7 +12,7 @@ class SshAgentFilter < Formula
     # upstream didn't want this because realpath isn't included in coreutils for Debian wheezy.
     # see https://github.com/tiwe-de/ssh-agent-filter/pull/5
     url "https://patch-diff.githubusercontent.com/raw/tiwe-de/ssh-agent-filter/pull/5.diff"
-    sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
+    sha256 "307ccd6e872a3f3b999d8a4368d152dfbd3a7e43b4cff0cacbc0390c78b2976b"
   end
 
   patch do

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -15,6 +15,12 @@ class SshAgentFilter < Formula
     sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
   end
 
+  patch do
+    # https://github.com/tiwe-de/ssh-agent-filter/pull/6
+    url "https://patch-diff.githubusercontent.com/raw/tiwe-de/ssh-agent-filter/pull/6.diff"
+    sha256 "e64c93daed3a0b696dd5325a60a8a5d65a267c28607e29b886eb8901ec6e7da7"
+  end
+
   patch :DATA
 
   def install

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -8,6 +8,13 @@ class SshAgentFilter < Formula
   depends_on "boost"
   depends_on "nettle"
 
+  patch do
+    # upstream didn't want this because realpath isn't included in coreutils for Debian wheezy.
+    # see https://github.com/tiwe-de/ssh-agent-filter/pull/5
+    url "https://patch-diff.githubusercontent.com/raw/tiwe-de/ssh-agent-filter/pull/5.diff"
+    sha256 "85cc828a96735bdafcf29eb6291ca91bac846579bcef7308536e0c875d6c81d7"
+  end
+
   patch :DATA
 
   def install
@@ -38,21 +45,7 @@ class SshAgentFilter < Formula
   end
 end
 __END__
-Fix afssh https://github.com/tiwe-de/ssh-agent-filter/pull/5#issuecomment-242216945
 Fix man page generation due to missing perl Locale::gettext
-diff --git a/afssh b/afssh
-index c482aea..6c2fbdf 100755
---- a/afssh
-+++ b/afssh
-@@ -52,7 +52,7 @@ fi
- declare -a agent_filter_args
- 
- if [ -x "${BASH_SOURCE%/*}/ssh-agent-filter" ]; then
--	SAF=$(readlink -f "${BASH_SOURCE%/*}/ssh-agent-filter")
-+	SAF=$(realpath "${BASH_SOURCE%/*}/ssh-agent-filter")
- else
- 	SAF=$(which ssh-agent-filter)
- fi
 diff --git a/Makefile b/Makefile
 index b2e05ec..30b3e9f 100644
 --- a/Makefile

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -10,8 +10,7 @@ class SshAgentFilter < Formula
   depends_on "nettle"
 
   patch do
-    # https://github.com/tiwe-de/ssh-agent-filter/pull/6
-    url "https://patch-diff.githubusercontent.com/raw/tiwe-de/ssh-agent-filter/pull/6.diff"
+    url "https://github.com/tiwe-de/ssh-agent-filter/pull/6.diff"
     sha256 "073b6d45694b547c6067403d4f657d4dfa2819926c386ecea131a1499403dd30"
   end
 
@@ -33,6 +32,7 @@ class SshAgentFilter < Formula
     system *gencmd, "-C", "keyA", "-f", "keyA"
     system *gencmd, "-C", "keyB", "-f", "keyB"
     (testpath/"test.sh").write <<-EOS.undent
+      set -ex
       eval $(ssh-agent)
       pid=$SSH_AGENT_PID
       ssh-add keyA keyB

--- a/Formula/ssh-agent-filter.rb
+++ b/Formula/ssh-agent-filter.rb
@@ -6,6 +6,7 @@ class SshAgentFilter < Formula
 
   depends_on "help2man" => :build
   depends_on "pandoc" => :build 
+  depends_on "gettext" => :build 
   depends_on "boost"
   depends_on "nettle"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

```
ssh-agent-filter:
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
```

However this [package is in debian stable](https://packages.debian.org/jessie/net/ssh-agent-filter)  since [2013](https://tracker.debian.org/pkg/ssh-agent-filter) and it's [popularity is growing](https://qa.debian.org/popcon.php?package=ssh-agent-filter).
