### PR TITLE
gnuradio: make python optional

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -20,7 +20,7 @@ class Gnuradio < Formula
     sha256 "9e1c612f0f4063d387d85517cc420f050f49c7903d36fab45b72e8d828549e3c"
   end
 
-  option "without-python", "Build without python support"
+  option "with-python", "Build with python support"
   option "with-documentation", "Build with documentation"
   option :universal
 


### PR DESCRIPTION
to avoid qt4 being a default dependency
