### PR TITLE
remctl 3.13

### DIFF
--- a/Formula/remctl.rb
+++ b/Formula/remctl.rb
@@ -1,21 +1,13 @@
 class Remctl < Formula
   desc "Client/server application for remote execution of tasks"
   homepage "https://www.eyrie.org/~eagle/software/remctl/"
-  url "https://archives.eyrie.org/software/kerberos/remctl-3.10.tar.xz"
-  sha256 "6a206dc3d5149fe4a40fb47850fd55619de03c165c843caf61f84b840c623a93"
-
-  bottle do
-    sha256 "b509ae099d9f39a5c9beecec9397ca5edd55e632bc4a94f5e896fb27016f2621" => :el_capitan
-    sha256 "766b3a13fdc77e8a98fb1989fb549f068475b80d675ab1341d993b9294d66010" => :yosemite
-    sha256 "5035361df688340431fbce01ea01d9ae0e5945a46d4ae4e0f0d059037fb8ed5f" => :mavericks
-  end
+  url "https://archives.eyrie.org/software/kerberos/remctl-3.13.tar.xz"
+  sha256 "e8f249c5ef54d5cff95ae503278d262615b3e7ebe13dfb368a1576ef36ee9109"
 
   depends_on "pcre"
   depends_on "libevent"
 
   def install
-    # needed for gss_oid_equal()
-    ENV.append "LDFLAGS", "-framework GSS"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-pcre=#{HOMEBREW_PREFIX}"

--- a/Formula/remctl.rb
+++ b/Formula/remctl.rb
@@ -4,6 +4,12 @@ class Remctl < Formula
   url "https://archives.eyrie.org/software/kerberos/remctl-3.13.tar.xz"
   sha256 "e8f249c5ef54d5cff95ae503278d262615b3e7ebe13dfb368a1576ef36ee9109"
 
+  bottle do
+    sha256 "b509ae099d9f39a5c9beecec9397ca5edd55e632bc4a94f5e896fb27016f2621" => :el_capitan
+    sha256 "766b3a13fdc77e8a98fb1989fb549f068475b80d675ab1341d993b9294d66010" => :yosemite
+    sha256 "5035361df688340431fbce01ea01d9ae0e5945a46d4ae4e0f0d059037fb8ed5f" => :mavericks
+  end
+
   depends_on "pcre"
   depends_on "libevent"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

From: Russ Allbery eagle@eyrie.org
To: kerberos@mit.edu
Subject: remctl 3.13 released
Date: Mon, 10 Oct 2016 20:20:37 -0700

I'm pleased to announce release 3.13 of remctl.

remctl is a client/server application that supports remote execution of
specific commands, using Kerberos GSS-API for authentication.
Authorization is controlled by a configuration file and ACL files and can
be set separately for each command, unlike with rsh.  remctl is like a
Kerberos-authenticated simple CGI server, or a combination of Kerberos rsh
and sudo without most of the features and complexity of either.

Changes from previous release:

```
remctl-shell now also supports being run as a forced command from
authorized_keys (or other methods).  This may be preferrable to using
it as a shell since it doesn't require setting non-standard sshd
options.

The summary configuration option is now allowed for commands with
subcommands other than ALL.  When generating a help summary (done in
response to the command "help" with no arguments), command lines with
a subcommand and a summary option will be run with two arguments: the
value of the summary option and then the subcommand.  This allows
proper generation of command summaries even for users who only have
access to a few subcommands of a command.  Patch from Remi Ferrand.

The build system now supports new REMCTL_PROGRAM_CFLAGS and
REMCTL_PROGRAM_LDFLAGS variables that can be set at build time to pass
in additional arguments when compiling and linking programs (like
remctl and remctld) but not libraries and, more importantly, language
bindings.  This can be used in distribution builds to pass in -fPIE
for additional binary hardening.  (CFLAGS and LDFLAGS cannot be used
since -fPIE breaks the builds of the dynamic modules for langauges
like Perl.)

Update to rra-c-util 6.1:

* Correct return-value checks for snprintf.
* Adjust Test::RRA::Config for new load path behavior in Perl 5.22.2.
```

You can download it from:

```
<http://www.eyrie.org/~eagle/software/remctl/>
```

This package is maintained using Git; see the instructions on the above
page to access the Git repository.

Debian packages have been uploaded to Debian unstable.

Please let me know of any problems or feature requests not already listed
in the TODO file.
## 

Russ Allbery (eagle@eyrie.org)              http://www.eyrie.org/~eagle/

---

Kerberos mailing list           Kerberos@mit.edu
https://mailman.mit.edu/mailman/listinfo/kerberos

Signed-off-by: Eugene Lee leee@mit.edu

---

This pull request follows the announcement of remctl 3.13 by Russ Allbery on the MIT Kerberos mailing list and its' package upload to Debian unstable.

This also resolves issue #5092 although we are skipping straight from 3.10 to 3.13.

I'm not sure where the `ENV.append` came from, but `remctl 3.13` builds and works just fine for both Heimdal Kerberos (provided as is in OS X) and with MIT Kerberos, available via homebrew/dupes/krb5, without it.
