### PR TITLE
newt: update homepage and url

### DIFF
--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -1,7 +1,7 @@
 class Newt < Formula
   desc "Library for color text mode, widget based user interfaces"
-  homepage "https://fedorahosted.org/newt/"
-  url "https://fedorahosted.org/releases/n/e/newt/newt-0.52.18.tar.gz"
+  homepage "https://pagure.io/newt"
+  url "https://pagure.io/releases/newt/newt-0.52.18.tar.gz"
   sha256 "771b0e634ede56ae6a6acd910728bb5832ac13ddb0d1d27919d2498dab70c91e"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

https://fedorahosted.org/newt/ redirects to https://pagure.io/newt. Releases are also redirected.

There's also a 0.52.19 release, but I'm in the mood of refreshing the patch.

Fixes #5787.
