### PR TITLE
new formula for handbrake-cli

### DIFF
--- a/Formula/handbrake.rb
+++ b/Formula/handbrake.rb
@@ -1,0 +1,41 @@
+# Documentation: https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md
+#                http://www.rubydoc.info/github/Homebrew/brew/master/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+
+class Handbrake < Formula
+  desc "HandBrake is an open-source video transcoder available for Linux, Mac, and Windows, licensed under the GNU General Public License (GPL) Version 2."
+  homepage "https://handbrake.fr/"
+  url "https://github.com/HandBrake/HandBrake/archive/0.10.5.tar.gz"
+  sha256 "1e3aab0be004b05129579f1068a8d4664b23f83d55ca2d8c72f9935c319d2e0a"
+  version "0.10.5"
+  head "https://github.com/HandBrake/HandBrake.git"
+
+  depends_on "yasm" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    # ENV.deparallelize  # if your formula fails when building in parallel
+
+    # Remove unrecognized options if warned by configure
+    system "./configure", "--debug=none",
+                          "--prefix=#{prefix}",
+                          "--disable-xcode"
+                          "--disable-gtk"
+    system "make", "install" # if this fails, try separate make/make install steps
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! It's enough to just replace
+    # "false" with the main program this formula installs, but it'd be nice if you
+    # were more thorough. Run the test with `brew test HandBrake`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

I am currently a bit stuck with trying to get it into a compiling state. The error is:

```
compute: project data...Traceback (most recent call last):
  File "./make/configure.py", line 1529, in <module>
    action.run()
  File "./make/configure.py", line 274, in run
    self._action()
  File "./make/configure.py", line 832, in _action
    self.version = repo.date.strftime("%Y%m%d%H%M%S")
ValueError: year=1 is before 1900; the datetime strftime() methods require year >= 1900
```

My brew config looks as follows:

```
HOMEBREW_VERSION: 1.0.7-11-g4a1dddf
ORIGIN: https://github.com/Homebrew/brew.git
HEAD: 4a1dddf5279b605043c5bcb02114aa4f9ee2042b
Last commit: 2 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 01ff79596e4cc2e11a9539770218fb177f76f89e
Core tap last commit: 3 minutes ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_REPOSITORY: /usr/local/Homebrew
HOMEBREW_CELLAR: /usr/local/Cellar
HOMEBREW_BOTTLE_DOMAIN: https://homebrew.bintray.com
CPU: dual-core 64-bit penryn
Homebrew Ruby: 2.0.0-p648
Clang: 8.0 build 800
Git: 2.8.4 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Perl: /usr/bin/perl
Python: /Users/justin/Development_HFS/anaconda3/bin/python => /Users/justin/Development_HFS/anaconda3/bin/python3.4
Ruby: /usr/local/bin/ruby => /usr/local/Cellar/ruby/2.3.1_2/bin/ruby
Java: 1.8.0_66
macOS: 10.11.6-x86_64
Xcode: 8.0
CLT: 7.3.1.0.1.1461711523
X11: N/A
```

When I try to compile handbrake-cli from head via `brew install -i --HEAD handbrake", it doesn't throw this error but I don't want to start with HEAD compiling and rather the stable version first. I looked for similar issues on homebrew and on the internet but wasn't really successfull. Their build documentation for Mac OS X is here: [Building on Mac OS X](https://github.com/HandBrake/HandBrake/blob/master/doc/BUILD-Mac)
