### PR TITLE
Add imgcat

### DIFF
--- a/Formula/imgcat.rb
+++ b/Formula/imgcat.rb
@@ -1,0 +1,18 @@
+class Imgcat < Formula
+  desc "Displays one or more images inline at their full size."
+  homepage "https://www.iterm2.com/documentation-images.html"
+  url "https://raw.githubusercontent.com/gnachman/iTerm2/master/tests/imgcat"
+  version "0.0.1"
+  sha256 "5d471f24d512143796b81de873fb7b6660b0a57bc1c99bb26fd1c9ef8dff64de"
+
+  depends_on "bash" => :run
+
+  def install
+    bin.install "imgcat"
+  end
+
+  test do
+    touch "test.png"
+    system "imgcat", "test.png"
+  end
+end

--- a/Formula/imgcat.rb
+++ b/Formula/imgcat.rb
@@ -5,14 +5,12 @@ class Imgcat < Formula
   version "0.0.1"
   sha256 "5d471f24d512143796b81de873fb7b6660b0a57bc1c99bb26fd1c9ef8dff64de"
 
-  depends_on "bash" => :run
-
   def install
     bin.install "imgcat"
   end
 
   test do
-    touch "test.png"
-    system "imgcat", "test.png"
+    test_fixtures("test.png")
+    system "#{bin}/imgcat", "test.png"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

Displays one or more images inline at their full size.

- I'm not so sure about the dependency on bash as it's often already installed on most user's systems and maybe the users want to keep their native bash
- It seems to not work in all terminal (e.g.: the protocol was created by iTerm2, it's public and well-done, but I'm not sure if it would work on other terminals, and I couldn't find a way to have a recommended dependency on iTerm2's cask)