### PR TITLE
boost: Remove check preventing single-threaded builds --with-mpi

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -39,15 +39,6 @@ class Boost < Formula
   needs :cxx11 if build.cxx11?
 
   def install
-    # https://svn.boost.org/trac/boost/ticket/8841
-    if build.with?("mpi") && build.with?("single")
-      raise <<-EOS.undent
-        Building MPI support for both single and multi-threaded flavors
-        is not supported.  Please use "--with-mpi" together with
-        "--without-single".
-      EOS
-    end
-
     ENV.universal_binary if build.universal?
 
     # Force boost to compile with the desired compiler


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Looks like boost can now build both multi- and single-threaded variants
of its libraries --with-mpi. Not sure when exactly this occurred.
