### PR TITLE
Update upx: real "HEAD" should refer devel branch

### DIFF
--- a/Formula/upx.rb
+++ b/Formula/upx.rb
@@ -4,7 +4,7 @@ class Upx < Formula
   url "https://github.com/upx/upx/releases/download/v3.91/upx-3.91-src.tar.bz2"
   mirror "https://fossies.org/linux/privat/upx-3.91-src.tar.bz2"
   sha256 "527ce757429841f51675352b1f9f6fc8ad97b18002080d7bf8672c466d8c6a3c"
-  head "https://github.com/upx/upx.git"
+  head "https://github.com/upx/upx.git", :branch => :devel
   revision 1
 
   bottle do


### PR DESCRIPTION
- [✓] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [✓] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Note that currently the devel branch is required for working upx-compressed-binaries.
