### PR TITLE
libtorrent-rasterbar 1.1.1

### DIFF
--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -1,8 +1,8 @@
 class LibtorrentRasterbar < Formula
   desc "C++ bittorrent library by Rasterbar Software"
   homepage "http://www.libtorrent.org/"
-  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1/libtorrent-rasterbar-1.1.0.tar.gz"
-  sha256 "2713df7da4aec5263ac11b6626ea966f368a5a8081103fd8f2f2ed97b5cd731d"
+  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1_1/libtorrent-rasterbar-1.1.1.tar.gz"
+  sha256 "f70c82367b0980460ef95aff3e117fd4a174477892d529beec434f74d615b31f"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

Hi!
This PR upgrades libtorrent-rasterbar from version 1.1.0 to 1.1.1
changelog: https://github.com/arvidn/libtorrent/releases/tag/libtorrent-1_1_1
