### PR TITLE
Add comment about Yarn URL

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -4,7 +4,7 @@ class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
   url "https://yarnpkg.com/downloads/0.15.0/yarn-v0.15.0.tar.gz"
-  sha256 "93A8083BD4989D3F7C05FCF57DFE232E00A35A09E48354B9316D2BC43F74B51B"
+  sha256 "93a8083bd4989d3f7c05fcf57dfe232e00a35a09e48354b9316d2bc43f74b51b"
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,8 +3,13 @@ require "language/node"
 class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://yarnpkg.com/downloads/0.15.0/yarn-v0.15.0.tar.gz"
-  sha256 "93a8083bd4989d3f7c05fcf57dfe232e00a35a09e48354b9316d2bc43f74b51b"
+  # Note: If updating this to a newer version, please change the URL to the official 
+  # yarnpkg.com download URL:
+  # url "https://yarnpkg.com/downloads/0.15.0/yarn-v0.15.0.tar.gz"
+  # This was not updated yet as Yarn 0.15.1 was an npm-specific release and is not available
+  # as a standalone tarball.
+  url "https://registry.npmjs.org/yarn/-/yarn-0.15.1.tgz"
+  sha256 "f99fd587e84987909d5f9e918b8fe524349fdc548e5bc5c380c8f8c0a70c6b87"
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://registry.npmjs.org/yarn/-/yarn-0.15.1.tgz"
-  sha256 "f99fd587e84987909d5f9e918b8fe524349fdc548e5bc5c380c8f8c0a70c6b87"
+  url "https://yarnpkg.com/downloads/0.15.0/yarn-v0.15.0.tar.gz"
+  sha256 "93A8083BD4989D3F7C05FCF57DFE232E00A35A09E48354B9316D2BC43F74B51B"
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
-  # Note: If updating this to a newer version, please change the URL to the official 
+  # Note: If updating this to a newer version, please change the URL to the official
   # yarnpkg.com download URL:
   # url "https://yarnpkg.com/downloads/0.15.0/yarn-v0.15.0.tar.gz"
   # This was not updated yet as Yarn 0.15.1 was an npm-specific release and is not available


### PR DESCRIPTION
Hi!

The tarball for Yarn should be downloaded from its official website rather than from npm. Additionally, our current official release is 0.15.0... 0.15.1 was just a patch to the npm package and is not a "real" release (it's just specific to npm)

Unfortunately I don't have a Mac so I can't test this myself.

@rudineirk 
