### PR TITLE
jemalloc: revision, make Sierra patches unconditional

### DIFF
--- a/Formula/jemalloc.rb
+++ b/Formula/jemalloc.rb
@@ -3,6 +3,7 @@ class Jemalloc < Formula
   homepage "http://www.canonware.com/jemalloc/"
   url "https://github.com/jemalloc/jemalloc/releases/download/4.2.1/jemalloc-4.2.1.tar.bz2"
   sha256 "5630650d5c1caab95d2f0898de4fe5ab8519dc680b04963b38bb425ef6a42d57"
+  revision 1
   head "https://github.com/jemalloc/jemalloc.git"
 
   bottle do
@@ -16,16 +17,14 @@ class Jemalloc < Formula
 
   # https://github.com/jemalloc/jemalloc/issues/420
   # Should be in the next release, but please check.
-  if MacOS.version >= :sierra
-    patch do
-      url "https://github.com/jemalloc/jemalloc/commit/4abaee5d13.patch"
-      sha256 "05c754089098c4275b460b90d1f4b94e32a2c819496187e5378e460c9398a65f"
-    end
+  patch do
+    url "https://github.com/jemalloc/jemalloc/commit/4abaee5d13.patch"
+    sha256 "05c754089098c4275b460b90d1f4b94e32a2c819496187e5378e460c9398a65f"
+  end
 
-    patch do
-      url "https://github.com/jemalloc/jemalloc/commit/19c9a3e828.patch"
-      sha256 "b736dab20d2688d4b21b4ba4755fd19b68145b2d9ae299a1ae154e8553d9261d"
-    end
+  patch do
+    url "https://github.com/jemalloc/jemalloc/commit/19c9a3e828.patch"
+    sha256 "b736dab20d2688d4b21b4ba4755fd19b68145b2d9ae299a1ae154e8553d9261d"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The Sierra patches only affects Sierra, but the bug is a particularly severe one that can be hard to diagnose. I've encountered a number of users who upgraded from previous versions of Sierra and then didn't have the ability to figure out what broke, or that jemalloc specifically was what they needed to reinstall. Since we usually tell users that they don't need to reinstall all their packages after upgrading to Sierra, a lot of users have broken jemallocs after the OS upgrade.

Since these patches are upstream already, I'd like to just include them unconditionally and bump the revision so that people on older OSs get them before they upgrade.
