### PR TITLE
libnotify 0.7.7

### DIFF
--- a/Formula/libnotify.rb
+++ b/Formula/libnotify.rb
@@ -1,8 +1,8 @@
 class Libnotify < Formula
   desc "Library that sends desktop notifications to a notification daemon"
   homepage "https://developer.gnome.org/libnotify"
-  url "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.6.tar.xz"
-  sha256 "0ef61ca400d30e28217979bfa0e73a7406b19c32dd76150654ec5b2bdf47d837"
+  url "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.7.tar.xz"
+  sha256 "9cb4ce315b2655860c524d46b56010874214ec27e854086c1a1d0260137efc04"
 
   bottle do
     sha256 "7b9bbf7af44434aca82465bf7f234d4affb50daeae54c65a7758b9814e113ff5" => :sierra
@@ -12,12 +12,15 @@ class Libnotify < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gtk+3"
+  depends_on "gdk-pixbuf"
+  depends_on "gobject-introspection"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--disable-tests",
+                          "--enable-introspection"
     system "make", "install"
   end
 end


### PR DESCRIPTION
Removed redundant gtk+3 dependency
Added support for gobject-introspection
