### PR TITLE
nginx: remove --with-ipv6 option as is now assumed

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -81,10 +81,7 @@ class Nginx < Formula
       args << "--add-module=#{nginx_ext}"
     end
 
-    if build.stable?
-      args << "--with-ipv6"
-    end
-
+    args << "--with-ipv6" if build.stable?
     args << "--with-http_dav_module" if build.with? "webdav"
     args << "--with-debug" if build.with? "debug"
     args << "--with-http_gunzip_module" if build.with? "gunzip"

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -60,7 +60,6 @@ class Nginx < Formula
       --prefix=#{prefix}
       --with-http_ssl_module
       --with-pcre
-      --with-ipv6
       --sbin-path=#{bin}/nginx
       --with-cc-opt=#{cc_opt}
       --with-ld-opt=#{ld_opt}
@@ -80,6 +79,10 @@ class Nginx < Formula
     if build.with? "passenger"
       nginx_ext = `#{Formula["passenger"].opt_bin}/passenger-config --nginx-addon-dir`.chomp
       args << "--add-module=#{nginx_ext}"
+    end
+
+    if build.stable?
+      args << "--with-ipv6"
     end
 
     args << "--with-http_dav_module" if build.with? "webdav"


### PR DESCRIPTION
As of nginx 1.11.5 IPv6 functionality is compiled by default, and the `--with-ipv6` configure option has been removed. However we still need to add it for the 1.10 stable build

---
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

There was a problem with the audit, but it related to a part of the formula I haven’t edited, the use of `deprecated_option`. Simply running `brew audit nginx` passes.
