### PR TITLE
juju 2.0.0

### DIFF
--- a/Aliases/juju
+++ b/Aliases/juju
@@ -1,0 +1,1 @@
+../Formula/juju@2.0.rb

--- a/Formula/juju@1.25.rb
+++ b/Formula/juju@1.25.rb
@@ -1,4 +1,4 @@
-class Juju < Formula
+class JujuAT125 < Formula
   desc "DevOps management tool"
   homepage "https://jujucharms.com/"
   url "https://launchpad.net/juju-core/1.25/1.25.6/+download/juju-core_1.25.6.tar.gz"
@@ -12,6 +12,7 @@ class Juju < Formula
   end
 
   depends_on "go" => :build
+  conflicts_with "juju@2.0", :because => "juju 1 and 2 cannot be installed simultaneously."
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Formula/juju@1.25.rb
+++ b/Formula/juju@1.25.rb
@@ -1,8 +1,8 @@
 class JujuAT125 < Formula
   desc "DevOps management tool"
   homepage "https://jujucharms.com/"
-  url "https://launchpad.net/juju-core/1.25/1.25.6/+download/juju-core_1.25.6.tar.gz"
-  sha256 "b826cbc4085fe3b3cf5413ef5dc20ece1fb69d36fa6c0dda711aeaaca19ff7fa"
+  url "https://launchpad.net/juju-core/1.25/1.25.8/+download/juju-core_1.25.8.tar.gz"
+  sha256 "7866cf4195d7fe87463bc7501cece12b4d0c3d08b8983f66cecf54f6f8b28267"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/juju@2.0.rb
+++ b/Formula/juju@2.0.rb
@@ -1,0 +1,28 @@
+class JujuAT20 < Formula
+  desc "DevOps management tool"
+  homepage "https://jujucharms.com/"
+  url "https://launchpad.net/juju/2.0/2.0.0/+download/juju-core_2.0.0.tar.gz"
+  sha256 "dac0b59ac670ba922cfbe7dc29652a07f4166c927c0fdba2f0b5760035b1fe18"
+
+  depends_on "go" => :build
+  conflicts_with "juju@1.25", :because => "juju 1 and 2 cannot be installed simultaneously."
+
+  # The juju client wants to know that MacOS Sierra is supported.
+  # https://bugs.launchpad.net/juju/+bug/1633495
+  patch do
+    url "https://raw.githubusercontent.com/sinzui/patches/master/homebrew-juju-sierra.patch"
+    sha256 "363bbf23437e07805e0fafd54a758e37ff135c5a529344e53841ae453ad1c39a"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    system "go", "build", "github.com/juju/juju/cmd/juju"
+    system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
+    bin.install "juju", "juju-metadata"
+    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
+  end
+
+  test do
+    system "#{bin}/juju", "version"
+  end
+end

--- a/Formula/juju@2.0.rb
+++ b/Formula/juju@2.0.rb
@@ -1,18 +1,11 @@
 class JujuAT20 < Formula
   desc "DevOps management tool"
   homepage "https://jujucharms.com/"
-  url "https://launchpad.net/juju/2.0/2.0.0/+download/juju-core_2.0.0.tar.gz"
-  sha256 "dac0b59ac670ba922cfbe7dc29652a07f4166c927c0fdba2f0b5760035b1fe18"
+  url "https://launchpad.net/juju/2.0/2.0.1/+download/juju-core_2.0.1.tar.gz"
+  sha256 "af5d59f4b4508c3f81b15fe052fe377876f5de845885d6d41d054f4ac605b9e9"
 
   depends_on "go" => :build
   conflicts_with "juju@1.25", :because => "juju 1 and 2 cannot be installed simultaneously."
-
-  # The juju client wants to know that MacOS Sierra is supported.
-  # https://bugs.launchpad.net/juju/+bug/1633495
-  patch do
-    url "https://raw.githubusercontent.com/sinzui/patches/master/homebrew-juju-sierra.patch"
-    sha256 "363bbf23437e07805e0fafd54a758e37ff135c5a529344e53841ae453ad1c39a"
-  end
 
   def install
     ENV["GOPATH"] = buildpath

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -16,6 +16,7 @@
   "hamsterdb": "upscaledb",
   "heroku-toolbelt": "heroku",
   "kotlin-compiler": "kotlin",
+  "juju": "juju@2.0",
   "letsencrypt": "certbot",
   "libcppa": "caf",
   "mpich2": "mpich",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -16,7 +16,7 @@
   "hamsterdb": "upscaledb",
   "heroku-toolbelt": "heroku",
   "kotlin-compiler": "kotlin",
-  "juju": "juju@2.0",
+  "juju": "juju@1.25",
   "letsencrypt": "certbot",
   "libcppa": "caf",
   "mpich2": "mpich",


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This update switches the default juju formula to juju 2.0 and allows juju 1.25 to continue.

Per the conversation at https://github.com/Homebrew/homebrew-core/pull/5076
Juju 2 and Juju 1 clients are not compatible. Users with juju 1 with existing deployments need to use the juju@1.25 client to continue maintaining them. Juju 1.25 will be getting incremental bug fixes over the next 18 months.

I suggest that Juju 2 be the default because it is the current stable release. Juju 2 supports the current features of many clouds unlike juju 1.

I include a patch that adds support for MacOS Sierra. Juju's utils library supports it, but juju 2.0.0 was released without the fix. 2.0.1 will include the fix and the patch can be removed.
