### PR TITLE
apr-util: add missing crypto switch

### DIFF
--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -32,6 +32,7 @@ class AprUtil < Formula
       --prefix=#{libexec}
       --with-apr=#{Formula["apr"].opt_prefix}
       --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-crypto
     ]
 
     args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

The crypto switch is missing from the apr-util formula which causes the openssl part not to be included when compiling the software. Since ssl is a dependency I'm assuming this is an oversight that hasn't been discovered until now. This was discovered when troubleshooting  https://github.com/Homebrew/homebrew-apache/issues/138 .
