### PR TITLE
rsync 3.1.2 (new formula)

### DIFF
--- a/Formula/rsync.rb
+++ b/Formula/rsync.rb
@@ -1,0 +1,18 @@
+class Rsync < Formula
+  desc "Fast incremental file transfer"
+  homepage "https://rsync.samba.org/"
+  url "https://download.samba.org/pub/rsync/src/rsync-3.1.2.tar.gz"
+  sha256 "ecfa62a7fa3c4c18b9eccd8c16eaddee4bd308a76ea50b5c02a5840f09c0a1c2"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    rsync --version
+  end
+end


### PR DESCRIPTION
- [ ✔] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ✔] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ✔] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✔] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Did not see a Homebrew formula for rsync. This is the latest
version from December 2015. The last several versions of Mac OS X
have included version 2.6.9 (probably because v3+ is GPLv3).
The newer version is better in many ways, including having
the ability to copy extended attributes and ACLs.
