### PR TITLE
czmq: fix makecert binary name

### DIFF
--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -52,12 +52,6 @@ class Czmq < Formula
     rm Dir["#{bin}/*.gsl"]
   end
 
-  def caveats; <<-EOS.undent
-      The 'makecert' binary has been installed as 'zmakecert' to avoid a 
-      conflict with the 'mono' formula.
-    EOS
-  end
-
   test do
     (testpath/"test.c").write <<-EOS.undent
       #include <czmq.h>

--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -43,13 +43,18 @@ class Czmq < Formula
     system "make"
     system "(ZSYS_INTERFACE=lo0 && make check-verbose)"
     system "make", "install"
+
+    # Rename to avoid formula conflict.
+    # This change will eventually be incorporated into a future CZMQ release.
+    # See https://github.com/zeromq/czmq/issues/1038 for more details.
     mv bin/"makecert", bin/"zmakecert"
+
     rm Dir["#{bin}/*.gsl"]
   end
 
   def caveats; <<-EOS.undent
-      The 'makecert' binary has been installed as 'zmakecert' to avoid a conflict with the 'mono' formula.
-      This change will eventually be incorporated into a future CZMQ release. See https://github.com/zeromq/czmq/issues/1038 for more details.
+      The 'makecert' binary has been installed as 'zmakecert' to avoid a 
+      conflict with the 'mono' formula.
     EOS
   end
 

--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -26,8 +26,6 @@ class Czmq < Formula
   depends_on "pkg-config" => :build
   depends_on "libsodium" => :recommended
 
-  conflicts_with "mono", :because => "both install `makecert` binaries"
-
   if build.without? "libsodium"
     depends_on "zeromq" => "without-libsodium"
   else
@@ -45,6 +43,7 @@ class Czmq < Formula
     system "make"
     system "(ZSYS_INTERFACE=lo0 && make check-verbose)"
     system "make", "install"
+    mv bin/"makecert", bin/"zmakecert"
     rm Dir["#{bin}/*.gsl"]
   end
 
@@ -76,5 +75,11 @@ class Czmq < Formula
     ]
     system ENV.cc, "-o", "test", "test.c", *flags
     assert_equal "Hello, World!\n", shell_output("./test")
+  end
+
+  def caveats; <<-EOS.undent
+      The 'makecert' binary has been installed as 'zmakecert' to avoid a conflict with the 'mono' formula.
+      This change will eventually be incorporated into a future CZMQ release. See https://github.com/zeromq/czmq/issues/1038 for more details.
+    EOS
   end
 end

--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -47,6 +47,12 @@ class Czmq < Formula
     rm Dir["#{bin}/*.gsl"]
   end
 
+  def caveats; <<-EOS.undent
+      The 'makecert' binary has been installed as 'zmakecert' to avoid a conflict with the 'mono' formula.
+      This change will eventually be incorporated into a future CZMQ release. See https://github.com/zeromq/czmq/issues/1038 for more details.
+    EOS
+  end
+
   test do
     (testpath/"test.c").write <<-EOS.undent
       #include <czmq.h>
@@ -75,11 +81,5 @@ class Czmq < Formula
     ]
     system ENV.cc, "-o", "test", "test.c", *flags
     assert_equal "Hello, World!\n", shell_output("./test")
-  end
-
-  def caveats; <<-EOS.undent
-      The 'makecert' binary has been installed as 'zmakecert' to avoid a conflict with the 'mono' formula.
-      This change will eventually be incorporated into a future CZMQ release. See https://github.com/zeromq/czmq/issues/1038 for more details.
-    EOS
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

It's a known issue that CZMQ and Mono conflict because of the `makecert` binary. In https://github.com/zeromq/czmq/issues/1038 I was told that it won't break anything to rename `makecert` to `zmakecert`, and that in fact this change is already planned for a future release. With that in mind, I'm making this change now to mitigate my own (and hopefully others') frustration, especially since both formulas could be low-devel dependences for a variety of programs.
