### PR TITLE
gdk-pixbuf: expose additional configure flags

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -13,6 +13,8 @@ class GdkPixbuf < Formula
 
   option :universal
   option "with-relocations", "Build with relocation support for bundles"
+  option "without-modules", "Disable dynamic module loading"
+  option "with-included-loaders=", "Build the specified loaders into gdk-pixbuf"
 
   depends_on "pkg-config" => :build
   depends_on "glib"
@@ -52,6 +54,10 @@ class GdkPixbuf < Formula
     ]
 
     args << "--enable-relocations" if build.with?("relocations")
+    args << "--disable-modules" if build.without?("modules")
+
+    included_loaders = ARGV.value("with-included-loaders")
+    args << "--with-included-loaders=#{included_loaders}" if included_loaders
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Hello, this PR exposes a couple of gdk-pixbuf's existing and useful configure flags:
- `--without-modules`, mapped to the underlying `--disable-modules` flag, to prevent the use dynamically-loaded image format modules at runtime.
- `--with-included-loaders=`, a comma separated list of image format loaders to "statically" include in the dylib, e.g. `--with-included-loaders="png,jpeg"`.
