### PR TITLE
fastd: patch for Xcode 8 clock_gettime issue

### DIFF
--- a/Formula/fastd.rb
+++ b/Formula/fastd.rb
@@ -1,11 +1,21 @@
 class Fastd < Formula
   desc "Fast and Secure Tunnelling Daemon"
   homepage "https://projects.universe-factory.net/projects/fastd"
-  url "https://projects.universe-factory.net/attachments/download/86/fastd-18.tar.xz"
-  sha256 "714ff09d7bd75f79783f744f6f8c5af2fe456c8cf876feaa704c205a73e043c9"
-  revision 1
+  revision 2
 
   head "https://git.universe-factory.net/fastd/", :using => :git
+
+  stable do
+    url "https://projects.universe-factory.net/attachments/download/86/fastd-18.tar.xz"
+    sha256 "714ff09d7bd75f79783f744f6f8c5af2fe456c8cf876feaa704c205a73e043c9"
+
+    # https://projects.universe-factory.net/issues/239
+    # https://projects.universe-factory.net/projects/fastd/repository/revisions/2fa2187
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c2c6049/fastd/patch-xcode8-clock_gettime.diff"
+      sha256 "dfa07eccf01a84a6e5eacc82c47c2cd5ba216e1f5032b41d2cef32e0b205ba9c"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Applying the upstream patch.
