### PR TITLE
fdupes: bump version_scheme

### DIFF
--- a/Formula/fdupes.rb
+++ b/Formula/fdupes.rb
@@ -3,6 +3,7 @@ class Fdupes < Formula
   homepage "https://github.com/adrianlopezroche/fdupes"
   url "https://github.com/adrianlopezroche/fdupes/archive/v1.6.1.tar.gz"
   sha256 "9d6b6fdb0b8419815b4df3bdfd0aebc135b8276c90bbbe78ebe6af0b88ba49ea"
+  version_scheme 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

26c531a bumped fdupes from version 1.51 to 1.6.1, which requires a
version_scheme bump.
