### PR TITLE
Added optional python bindings to unbound

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -14,6 +14,9 @@ class Unbound < Formula
   depends_on "openssl"
   depends_on "libevent"
 
+  depends_on :python => :optional
+  depends_on "swig" if build.with?("python")
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -21,6 +24,14 @@ class Unbound < Formula
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-ssl=#{Formula["openssl"].opt_prefix}
     ]
+
+    if build.with? "python"
+      ENV.prepend "LDFLAGS", `python-config --ldflags`.chomp
+
+      args << "--with-pyunbound"
+      args << "--with-pythonmodule"
+    end
+
     args << "--with-libexpat=#{MacOS.sdk_path}/usr" unless MacOS::CLT.installed?
     system "./configure", *args
 

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -30,12 +30,14 @@ class Unbound < Formula
 
       args << "--with-pyunbound"
       args << "--with-pythonmodule"
+      args << "PYTHON_SITE_PKG=#{lib}/python2.7/site-packages"
     end
 
     args << "--with-libexpat=#{MacOS.sdk_path}/usr" unless MacOS::CLT.installed?
     system "./configure", *args
 
     inreplace "doc/example.conf", 'username: "unbound"', 'username: "@@HOMEBREW-UNBOUND-USER@@"'
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Audit shows one problem, but I can not solve this:

unbound:
- python modules have explicit framework links
  These python extension modules were linked directly to a Python
  framework binary. They should be linked with -undefined dynamic_lookup
  instead of -lpython or -framework Python.
    /usr/local/Cellar/unbound/1.5.10/lib/python2.7/site-packages/_unbound.so
  Error: 1 problem in 1 formula

If you think that this needs be fixed, please help me with a hint on a solution.

A short python test shows that the module gets loaded.
