### PR TITLE
selenium-server-standalone 3.0.1

### DIFF
--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -1,8 +1,8 @@
 class SeleniumServerStandalone < Formula
   desc "Browser automation for testing purposes"
   homepage "http://seleniumhq.org/"
-  url "https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar"
-  sha256 "1cce6d3a5ca5b2e32be18ca5107d4f21bddaa9a18700e3b117768f13040b7cf8"
+  url "https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar"
+  sha256 "b4f6d2401e88170355f409d4cc70dd2cbcebdd8bd0f730f18581558c283533a1"
 
   devel do
     url "https://selenium-release.storage.googleapis.com/3.0-beta4/selenium-server-standalone-3.0.0-beta4.jar"

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -1,8 +1,8 @@
 class SeleniumServerStandalone < Formula
   desc "Browser automation for testing purposes"
   homepage "http://seleniumhq.org/"
-  url "https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar"
-  sha256 "b4f6d2401e88170355f409d4cc70dd2cbcebdd8bd0f730f18581558c283533a1"
+  url "https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar"
+  sha256 "1537b6d1b259191ed51586378791bc62b38b0cb18ae5ba1433009dc365e9f26b"
 
   bottle :unneeded
 
@@ -44,7 +44,7 @@ class SeleniumServerStandalone < Formula
   end
 
   test do
-    selenium_version = shell_output("unzip -p #{libexec}/selenium-server-standalone-3.0.0.jar META-INF/MANIFEST.MF | sed -nEe '/Selenium-Version:/p'")
+    selenium_version = shell_output("unzip -p #{libexec}/selenium-server-standalone-#{version}.jar META-INF/MANIFEST.MF | sed -nEe '/Selenium-Version:/p'")
     assert_equal "Selenium-Version: #{version}", selenium_version.strip
   end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -44,7 +44,7 @@ class SeleniumServerStandalone < Formula
   end
 
   test do
-    selenium_version = shell_output("unzip -p #{path}/selenium-server-standalone-3.0.0.jar META-INF/MANIFEST.MF | sed -nEe '/Selenium-Version:/p'")
-    assert_equal "Selenium-Version: #{version}", selenium_version
+    selenium_version = shell_output("unzip -p #{libexec}/selenium-server-standalone-3.0.0.jar META-INF/MANIFEST.MF | sed -nEe '/Selenium-Version:/p'")
+    assert_equal "Selenium-Version: #{version}", selenium_version.strip
   end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -42,4 +42,9 @@ class SeleniumServerStandalone < Formula
     </plist>
     EOS
   end
+
+  test do
+    selenium_version = shell_output("unzip -p #{path}/selenium-server-standalone-3.0.0.jar META-INF/MANIFEST.MF | sed -nEe '/Selenium-Version:/p'")
+    assert_equal "Selenium-Version: #{version}", selenium_version
+  end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -4,11 +4,6 @@ class SeleniumServerStandalone < Formula
   url "https://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.0.jar"
   sha256 "b4f6d2401e88170355f409d4cc70dd2cbcebdd8bd0f730f18581558c283533a1"
 
-  devel do
-    url "https://selenium-release.storage.googleapis.com/3.0-beta4/selenium-server-standalone-3.0.0-beta4.jar"
-    sha256 "7ed927c83d953a05b84794f6e1fb2b699c3c26b04e2379027f72930c679cd76a"
-  end
-
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Update `selenium-server-standalone` to 3.0.0 released on 2016-10-13.
There are two errors from `brew audit`. The first, missing test, I am
leaving as is out of ignorance, however I am open to test suggestions.
The second issue is `devel version ... older than stable version....`
which I am leaving because presently there is no new devel version.

Selenium release index:
  http://selenium-release.storage.googleapis.com/index.html

Audit output:

```
$ brew audit --strict selenium-server-standalone
...
selenium-server-standalone:
  * A `test do` test block should be added
  * devel version 3.0.0-beta4 is older than stable version 3.0.0
Error: 2 problems in 1 formula
```
