### PR TITLE
gnutls: fix the build on 10.11 with Xcode 8

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -27,6 +27,12 @@ class Gnutls < Formula
   end
 
   def install
+    # Fix "dyld: lazy symbol binding failed: Symbol not found: _getentropy"
+    # Reported 18 Oct 2016 https://gitlab.com/gnutls/gnutls/issues/142
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      inreplace "configure", "getentropy(0, 0);", "undefinedgibberish(0, 0);"
+    end
+
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules


### PR DESCRIPTION
gnutls uses some customized Autotools tests, so the general superenv
workaround in https://github.com/Homebrew/brew/pull/970 is insufficient
