### PR TITLE
qscintilla2: add symlinks *-qt5.dylib

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -64,6 +64,12 @@ class Qscintilla2 < Formula
       system "make", "install"
     end
 
+    # create symlinks to lib*-qt5.dylib because some configure scripts expect it
+    Pathname.glob("#{lib}/*.dylib") do |file|
+      newfile = File.dirname(file)+"/"+File.basename(file, ".dylib")+"-qt5.dylib"
+      ln_s file, newfile
+    end
+
     # Add qscintilla2 features search path, since it is not installed in Qt keg's mkspecs/features/
     ENV["QMAKEFEATURES"] = prefix/"data/mkspecs/features"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

I suggest to add symlinks from `lib/libqsci*.dylib` to `lib/libqsci*-qt5.dylib` because some configure scripts are looking for `-qt5` (since most linux distributions ship qt4 and qt5 versions).
