### PR TITLE
ncmpcpp: fix test when boost was built with icu4c

### DIFF
--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -71,6 +71,7 @@ class Ncmpcpp < Formula
   end
 
   test do
+    ENV.delete("LC_CTYPE")
     assert_match version.to_s, shell_output("#{bin}/ncmpcpp --version")
   end
 end


### PR DESCRIPTION
stdenv sets LC_CTYPE=C, which causes the test to fail with a segfault if
boost was built with icu4c. This commit avoids the bug by just undoing
the intervention in the usual environment that triggers the problem.
Alternatively, setting LC_CTYPE=en_US.UTF-8 works fine, too.
