### PR TITLE
rtags: fix the build on 10.11 with Xcode 8

### DIFF
--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -22,8 +22,15 @@ class Rtags < Formula
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
     ENV.append("LDFLAGS", "-lc++abi")
 
+    args = std_cmake_args << "-DRTAGS_NO_BUILD_CLANG=ON"
+
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      args << "-DHAVE_CLOCK_MONOTONIC_RAW:INTERNAL=0"
+      args << "-DHAVE_CLOCK_MONOTONIC:INTERNAL=0"
+    end
+
     mkdir "build" do
-      system "cmake", "..", "-DRTAGS_NO_BUILD_CLANG=ON", *std_cmake_args
+      system "cmake", "..", *args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
rtags decides whether clock_gettime is supported by checking time.h for
definitions of HAVE_CLOCK_MONOTONIC or HAVE_CLOCK_MONOTONIC_RAW, but as
of Xcode 8 that leads to a false positive on 10.11
