### PR TITLE
jsdoc3: remove outdated conflict

### DIFF
--- a/Formula/jsdoc3.rb
+++ b/Formula/jsdoc3.rb
@@ -16,8 +16,6 @@ class Jsdoc3 < Formula
 
   depends_on "node"
 
-  conflicts_with "jsdoc-toolkit", :because => "both install jsdoc"
-
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
#6011 moved jsdoc-toolkit to the boneyard, but jsdoc3 still had a `conflicts_with` for it.
