### PR TITLE
kubernetes-cli 1.4.4

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -12,6 +12,12 @@ class KubernetesCli < Formula
     sha256 "dccdacf5c86d6d95d0028b62db543dd6ec286c2d02b6791fce665cb7bf7d0b26" => :yosemite
   end
 
+  devel do
+    url "https://github.com/kubernetes/kubernetes/archive/v1.5.0-alpha.1.tar.gz"
+    sha256 "4b05aa319c394e085c219ab8f7b2170ee137da2f726da51d8acda450e67ceb00"
+    version "1.5.0-alpha.1"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -1,8 +1,8 @@
 class KubernetesCli < Formula
   desc "Kubernetes command-line interface"
   homepage "http://kubernetes.io/"
-  url "https://github.com/kubernetes/kubernetes/archive/v1.4.3.tar.gz"
-  sha256 "abf4e6fcc920a2f307c0dd2df7b039098cc4034072d761a91109bc07691ab118"
+  url "https://github.com/kubernetes/kubernetes/archive/v1.4.4.tar.gz"
+  sha256 "ab6304dbff6e49095d68459da748477ffba231893e1f1dae4e0d60ba2fdb725a"
   head "https://github.com/kubernetes/kubernetes.git"
 
   bottle do


### PR DESCRIPTION
Minor version update for the Kubernetes CLI tool, `kubectl`

I also re-added the `devel` block, which was removed in #5267 because the `stable` version was newer than the `devel` one. The correct way to handle this formula is to keep the devel version up-to-date, not to remove it.
