### PR TITLE
tin 2.4.0

### DIFF
--- a/Formula/tin.rb
+++ b/Formula/tin.rb
@@ -1,8 +1,8 @@
 class Tin < Formula
   desc "Threaded, NNTP-, and spool-based UseNet newsreader"
   homepage "http://www.tin.org"
-  url "http://ftp.cuhk.edu.hk/pub/packages/news/tin/v2.2/tin-2.2.1.tar.gz"
-  sha256 "cf588884bbe4711498b807311e53d82a1b6ca343f4c85e53001c90e8c0e456ac"
+  url "http://ftp.cuhk.edu.hk/pub/packages/news/tin/v2.4/tin-2.4.0.tar.gz"
+  sha256 "26ee20980c88308f225c0bae55b6db12365ced3398dbea0621992dff0e74cbb6"
 
   bottle do
     sha256 "299d98d164fd4a1aba5e66ff4f1bc75d415acfad49555183a793ec9e44323ecf" => :sierra
@@ -10,11 +10,6 @@ class Tin < Formula
     sha256 "1444c2fa1a3f63f4f8f8330b69d6c255c70c4732d13673a4beab2d621d753d3e" => :yosemite
     sha256 "11505b2e7b9953370a54fab8dc3460e28d3aabc1e02d2d713d514e4a78eb68d7" => :mavericks
     sha256 "231470502b1e124011bd79c44d84740d068ccc32aad86a5599e7006755e7a200" => :mountain_lion
-  end
-
-  devel do
-    url "http://ftp.cuhk.edu.hk/pub/packages/news/tin/v2.3/tin-2.3.1.tar.gz"
-    sha256 "d53ee03850988c96162f2a30a24f63a6976612f04fc049fd1e0c17d0d4567083"
   end
 
   conflicts_with "mutt", :because => "both install mmdf.5 and mbox.5 man pages"


### PR DESCRIPTION
Update `tin` to 2.4.0

Not sure what to do with `devel` version. `brew audit` complains, since it's lower than 2.4.
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
