### PR TITLE
tcptrace: use mirror urls

### DIFF
--- a/Formula/tcptrace.rb
+++ b/Formula/tcptrace.rb
@@ -1,7 +1,8 @@
 class Tcptrace < Formula
   desc "Analyze tcpdump output"
-  homepage "http://www.tcptrace.org/"
-  url "http://www.tcptrace.org/download/tcptrace-6.6.7.tar.gz"
+  homepage "http://www.tcptrace.org/" # site is currently offline
+  url "https://www.mirrorservice.org/sites/distfiles.macports.org/tcptrace/tcptrace-6.6.7.tar.gz"
+  mirror "https://distfiles.macports.org/tcptrace/tcptrace-6.6.7.tar.gz"
   sha256 "63380a4051933ca08979476a9dfc6f959308bc9f60d45255202e388eb56910bd"
 
   bottle do


### PR DESCRIPTION
upstream homepage is down (permanently?)
