### PR TITLE
wildfly-as: add launchd plist.

### DIFF
--- a/Formula/wildfly-as.rb
+++ b/Formula/wildfly-as.rb
@@ -6,14 +6,17 @@ class WildflyAs < Formula
 
   bottle :unneeded
 
+  depends_on :java => "1.8+"
+
   def install
     rm_f Dir["bin/*.bat"]
     rm_f Dir["bin/*.ps1"]
     libexec.install Dir["*"]
+    mkdir_p libexec/"standalone/log"
   end
 
   def caveats; <<-EOS.undent
-    The home of WildFly Application Server 10 is:
+    The home of WildFly Application Server #{version} is:
       #{opt_libexec}
     You may want to add the following to your .bash_profile:
       export JBOSS_HOME=#{opt_libexec}
@@ -21,7 +24,41 @@ class WildflyAs < Formula
     EOS
   end
 
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/wildfly-as/libexec/bin/standalone.sh --server-config=standalone.xml"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>KeepAlive</key>
+      <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+      </dict>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_libexec}/bin/standalone.sh</string>
+        <string>--server-config=standalone.xml</string>
+      </array>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>JBOSS_HOME</key>
+        <string>#{opt_libexec}</string>
+        <key>WILDFLY_HOME</key>
+        <string>#{opt_libexec}</string>
+      </dict>
+    </dict>
+    </plist>
+    EOS
+  end
+
   test do
+    ENV["JBOSS_HOME"] = opt_libexec
     system "#{opt_libexec}/bin/standalone.sh --version | grep #{version}"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
- Adds a launchd plist for the wildfly-as formula.
- Clarifies the dependency on Java 8.
- Fixes a test gotcha with `$JBOSS_HOME`.
