### PR TITLE
sdl2 2.0.5

### DIFF
--- a/Formula/mal4s.rb
+++ b/Formula/mal4s.rb
@@ -52,7 +52,7 @@ class Mal4s < Formula
       pid = fork do
         exec bin/"mal4s", "-t", "2", "-o", "out", pkgshare/"sample--newns.mal4s"
       end
-      sleep 1
+      sleep 2
       assert File.exist?("out"), "Failed to output PPM stream!"
     ensure
       Process.kill("TERM", pid)

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -1,8 +1,8 @@
 class Sdl2 < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
   homepage "https://www.libsdl.org/"
-  url "https://libsdl.org/release/SDL2-2.0.4.tar.gz"
-  sha256 "da55e540bf6331824153805d58b590a29c39d2d506c6d02fa409aedeab21174b"
+  url "https://libsdl.org/release/SDL2-2.0.5.tar.gz"
+  sha256 "442038cf55965969f2ff06d976031813de643af9c9edc9e331bd761c242e8785"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

I have also verified that the GPG signature of the tarball matches the one from GPG Keychain's default key server.

I have only tested the formula on macOS 10.11.6, so I have no idea if the pre-Lion patches are still functional.
