### PR TITLE
minio: update to 20161024212347 - regression fix on OS X 10.12

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -2,9 +2,9 @@ class Minio < Formula
   desc "Amazon S3 compatible object storage server"
   homepage "https://github.com/minio/minio"
   url "https://github.com/minio/minio.git",
-    :tag => "RELEASE.2016-10-22T00-50-41Z",
-    :revision => "d1331ecc5cc4abc7304157cc26be64618821a77c"
-  version "20161022005041"
+    :tag => "RELEASE.2016-10-24T21-23-47Z",
+    :revision => "048af5e5cdc1344e83231c09079828a3d289e6df"
+  version "20161024212347"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
