### PR TITLE
Speed up nvm loading when open a new shell

### DIFF
--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -25,7 +25,7 @@ class Nvm < Formula
     configuration file:
 
       export NVM_DIR="$HOME/.nvm"
-      . "$(brew --prefix nvm)/nvm.sh"
+      . "#{opt_prefix}/nvm.sh"
 
     You can set $NVM_DIR to any location, but leaving it unchanged from
     #{prefix} will destroy any nvm-installed Node installations


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Because `brew --prefix nvm` is too slow and the result is usually a
fixed value. So run this command everytime will waste a lot of time to
get the path.
