### PR TITLE
upx: slap on an el_capitan MaximumMacOSRequirement

### DIFF
--- a/Formula/upx.rb
+++ b/Formula/upx.rb
@@ -17,6 +17,10 @@ class Upx < Formula
 
   depends_on "ucl"
 
+  # https://sourceforge.net/p/upx/bugs/248/
+  # https://github.com/upx/upx/issues/4
+  depends_on MaximumMacOSRequirement => :el_capitan
+
   resource "lzma" do
     url "https://downloads.sourceforge.net/project/sevenzip/LZMA%20SDK/lzma938.7z"
     sha256 "721f4f15378e836686483811d7ea1282463e3dec1932722e1010d3102c5c3b20"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

upx 3.91 is completely broken on Sierra, and there's no easy rescue. Need to wait for the next release, for which no one seems to have an ETA.

See:
- https://sourceforge.net/p/upx/bugs/248/
- https://github.com/upx/upx/issues/4
