### PR TITLE
Bump shairport-sync to 2.8.5, remove merged patch upstream

### DIFF
--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -1,8 +1,8 @@
 class ShairportSync < Formula
   desc "AirTunes emulator. Shairport Sync adds multi-room capability."
   homepage "https://github.com/mikebrady/shairport-sync"
-  url "https://github.com/mikebrady/shairport-sync/archive/2.8.4.tar.gz"
-  sha256 "80dd94c5f37b43e9b157dd5335f8edaf11109859d0144e0046c7b86fe88f6547"
+  url "https://github.com/mikebrady/shairport-sync/archive/2.8.5.tar.gz"
+  sha256 "d19f6cd3d53f5010abcf24cc20a301934372b41efc3ff2a2e4e7d8fa49200cdc"
   head "https://github.com/mikebrady/shairport-sync.git", :branch => "development"
 
   bottle do
@@ -10,11 +10,6 @@ class ShairportSync < Formula
     sha256 "80d1b7c943952fd4633647dc035be8a7e130f73e7fbcd2cef9ea2e847a10f500" => :el_capitan
     sha256 "2153ee8053718e023fa1321235a583674b40a24ebcd72cbd6599c342095a47ba" => :yosemite
     sha256 "b36d3dff2c4b471edc53731daea183c057b7bec10fe39ae348be0f3849b2f2dd" => :mavericks
-  end
-
-  devel do
-    url "https://github.com/mikebrady/shairport-sync/archive/2.8.4.4.tar.gz"
-    sha256 "a25e85386b3c0e32de1e01350d835e11414a42b87a136953d2d09e4ed45e1209"
   end
 
   depends_on "pkg-config" => :build
@@ -26,12 +21,6 @@ class ShairportSync < Formula
   depends_on "libao"
   depends_on "libdaemon"
   depends_on "libconfig"
-
-  # opened PR 12 Aug 2016: "use sysconfdir not $(DESTDIR)/etc for config files"
-  patch do
-    url "https://github.com/mikebrady/shairport-sync/pull/355.patch"
-    sha256 "1e5909c43f8e2e7c729f6884be121b06cd201220e3159804fd845be412046f9b"
-  end
 
   def install
     system "autoreconf", "-fvi"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

This should also fix the sierra bottle issue #5488 for this formula.
