### PR TITLE
swift: fix pod2man build failure

### DIFF
--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -1,6 +1,7 @@
 class Swift < Formula
   desc "High-performance system programming language"
   homepage "https://github.com/apple/swift"
+  revision 1
 
   stable do
     url "https://github.com/apple/swift/archive/swift-2.2.1-RELEASE.tar.gz"
@@ -20,6 +21,12 @@ class Swift < Formula
     resource "llvm" do
       url "https://github.com/apple/swift-llvm/archive/#{swift_tag}.tar.gz"
       sha256 "f7977e5bb275494b5dac4490afc5d634f894ba5f209f3b2dbd5b7e520fa5fce2"
+    end
+
+    # Fixes build error against certain pod2man versions. Already merged in upstream HEAD.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/abef20e/swift/swift-2.2.1-pod2man.patch"
+      sha256 "bb8fefc664b248737e127cced2418372dc3a1398a85d13ff19f5aa5668d6fa20"
     end
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Fixes #5306.

Backports upstream patch from https://github.com/apple/swift/commit/4e291f0b09d8bb86c91d608c1f52d741fd971527. This fixes an incorrect `pod2man` invocation which breaks with some `pod2man` versions.

I'm bumping the revision because even though the changes in the resulting files are minor, it does change the contents of the `swift` man page, which is part of the file set included in the keg and bottle.
