### PR TITLE
qt5: link brewed openssl when using postresql or mysql

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -83,6 +83,7 @@ class Qt5 < Formula
   depends_on :macos => :mountain_lion
 
   depends_on "dbus" => :optional
+  depends_on "openssl" if build.with?("mysql") || build.with?("postgresql")
   depends_on :mysql => :optional
   depends_on :postgresql => :optional
   depends_on :xcode => :build
@@ -150,6 +151,14 @@ class Qt5 < Formula
     if build.with? "qtwebkit"
       (buildpath/"qtwebkit").install resource("qt-webkit")
       inreplace ".gitmodules", /.*status = obsolete\n((\s*)project = WebKit\.pro)/, "\\1\n\\2initrepo = true"
+    end
+
+    if build.with?("mysql") || build.with?("postgresql")
+      openssl_opt = Formula["openssl"].opt_prefix
+      args << "-L#{openssl_opt}/lib"
+      args << "-I#{openssl_opt}/include"
+      args << "-openssl-linked"
+      ENV["OPENSSL_LIBS"] = "-L#{openssl_opt}/lib -lssl -lcrypto"
     end
 
     system "./configure", *args


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Fixes #6032.
Fixes #6319.

This fixes a build failure that happens when `--with-mysql` or `--with-postgresql` is specified. Does not affect the default build.

Looks like Qt5 needs to be linked against openssl when compiling in mysql or postgresql support.

This PR conditionally links `qt5` against the brewed `openssl` when mysql or postgresql support is enabled. It does the `-openssl-linked` option to ensure that the brewed openssl is linked at compile time and is always used. (The default is for Qt to detect installed openssl libraries at run time, which may pick up the system openssl instead.)

I'm wondering if we should actually make the `openssl` dependency and linkage unconditional (instead of just when using mysql or postgresql), to avoid the run-time detection possibly picking up the system openssl in other circumstances. (I don't know in what conditions that would actually happen; didn't find enough documentation on it.)

This is something of a followup to #5619, including only the openssl-related code. It differs in that it:
- does `-openssl-linked` as described above
- does not do `-no-opentransport`. I don't think it is necessary, because we don't have a reason to disable OpenTransport and always use OpenSSL instead; we just need to make sure that for the cases which do use OpenSSL, it a) builds, and b) uses the brewed `openssl` instead of the system one.
