### PR TITLE
qt5: fix build with mysql/postgresql of openssl and add pch support

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -131,13 +131,10 @@ class Qt5 < Formula
 
     if build.with? "mysql"
       args << "-plugin-sql-mysql"
-      inreplace "qtbase/configure", /(QT_LFLAGS_MYSQL_R|QT_LFLAGS_MYSQL)=\`(.*)\`/, "\\1=\`\\2 | sed \"s|-lssl|-L#{openssl_lib} -lssl|\"\`"
+      inreplace "qtbase/configure", /(QT_LFLAGS_MYSQL_R|QT_LFLAGS_MYSQL)=\`(.*)\`/, "\\1=\`\\2 | sed \"s/-lssl -lcrypto//\"\`"
     end
 
-    if build.with? "postgresql"
-      args << "-plugin-sql-psql"
-      inreplace "qtbase/configure", /QT_LFLAGS_PSQL=\`(.*)\`/, "QT_LFLAGS_PSQL=\`\\1 | sed \"s|-lssl|-L#{openssl_lib} -lssl|\"\`"
-    end
+    args << "-plugin-sql-psql" if build.with? "postgresql"
 
     if build.with? "dbus"
       dbus_opt = Formula["dbus"].opt_prefix

--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -121,7 +121,6 @@ class Qt5 < Formula
       -qt-pcre
       -nomake tests
       -no-rpath
-      -system-proxies
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"

--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -121,14 +121,11 @@ class Qt5 < Formula
       -qt-pcre
       -nomake tests
       -no-rpath
-      -pch
       -system-proxies
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"
     
-    openssl_lib = Formula["openssl"].opt_lib
-
     if build.with? "mysql"
       args << "-plugin-sql-mysql"
       inreplace "qtbase/configure", /(QT_LFLAGS_MYSQL_R|QT_LFLAGS_MYSQL)=\`(.*)\`/, "\\1=\`\\2 | sed \"s/-lssl -lcrypto//\"\`"

--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -121,12 +121,23 @@ class Qt5 < Formula
       -qt-pcre
       -nomake tests
       -no-rpath
+      -pch
+      -system-proxies
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"
+    
+    openssl_lib = Formula["openssl"].opt_lib
 
-    args << "-plugin-sql-mysql" if build.with? "mysql"
-    args << "-plugin-sql-psql" if build.with? "postgresql"
+    if build.with? "mysql"
+      args << "-plugin-sql-mysql"
+      inreplace "qtbase/configure", /(QT_LFLAGS_MYSQL_R|QT_LFLAGS_MYSQL)=\`(.*)\`/, "\\1=\`\\2 | sed \"s|-lssl|-L#{openssl_lib} -lssl|\"\`"
+    end
+
+    if build.with? "postgresql"
+      args << "-plugin-sql-psql"
+      inreplace "qtbase/configure", /QT_LFLAGS_PSQL=\`(.*)\`/, "QT_LFLAGS_PSQL=\`\\1 | sed \"s|-lssl|-L#{openssl_lib} -lssl|\"\`"
+    end
 
     if build.with? "dbus"
       dbus_opt = Formula["dbus"].opt_prefix

--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -125,7 +125,7 @@ class Qt5 < Formula
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"
-    
+
     if build.with? "mysql"
       args << "-plugin-sql-mysql"
       inreplace "qtbase/configure", /(QT_LFLAGS_MYSQL_R|QT_LFLAGS_MYSQL)=\`(.*)\`/, "\\1=\`\\2 | sed \"s/-lssl -lcrypto//\"\`"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

I know there is another PR about this. The only reason that mysql/postgresql failed to build is there is no `libssl.dynlib` to find when build mysql/postgresql. 

In my previous PR, I added `-L/usr/local/opt/openssl/lib` to global LFLAGS, this will cause all library will have this link flags, for example, if you only link QtCore, there will be this option exists and does nothing.

Qt's configure script need `mysql_config` and `pg_config` to give the link flags, but default flags of `mysql_config --libs` gives the result of `-L/usr/local/Cellar/mariadb/10.1.18/lib  -lmysqlclient -lz -lssl -lcrypto`, but the libssl and libcrypto is not placed on /usr/local/lib, so link will fail because linker have no idea where to find the libssl.

and I really don't know how can I change the result of `mysql_config`, so seems the only solution is to patch the configure script to manually add openssl's lib folder.

as to another option in my previous PR, to build plugins into QtSql is trivial, so I decided no to include those changes, and that is purely my own personal favorite ways of building qt.

also I added the pch option, I think this won't have any other effects but to speed up the compile time.

Fixes #6032.
Fixes #6319.
Fixes #6309.