### PR TITLE
ffmpeg 3.2

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -1,26 +1,9 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-
-  stable do
-    url "https://ffmpeg.org/releases/ffmpeg-3.1.5.tar.bz2"
-    sha256 "2400882a2c7795c74f0abebc28d267f2796510fb69ba324b0e9f16cc8dbb0d2b"
-
-    option "with-sdl", "Enable FFplay media player"
-    option "with-openh264", "Enable OpenH264 library"
-    deprecated_option "with-ffplay" => "with-sdl"
-
-    depends_on "sdl" => :optional
-    depends_on "nasm" => :build if build.with? "openh264"
-
-    # Remove when ffmpeg has support for openh264 1.6.0
-    # See https://github.com/cisco/openh264/issues/2505
-    # Master now has support, but not the 3.1.x branch
-    resource "openh264-1.5.0" do
-      url "https://github.com/cisco/openh264/archive/v1.5.0.tar.gz"
-      sha256 "98077bd5d113c183ce02b678733b0cada2cf36750370579534c4d70f0b6c27b5"
-    end
-  end
+  url "https://ffmpeg.org/releases/ffmpeg-3.2.tar.bz2"
+  sha256 "76d6cd9f5e64463a5b9940736da8a515c990bcbbe506a722e2040916cb366d74"
+  head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
     sha256 "201c11c27d3c4d2c65593d1f95ecbc93194da5c3d0d88193313df1d81db6d69d" => :sierra
@@ -28,84 +11,77 @@ class Ffmpeg < Formula
     sha256 "4b4e684b3a89fdbc9d9c6858814da26f67004fdd06ec4a19268d1034ea9b87d0" => :yosemite
   end
 
-  head do
-    url "https://github.com/FFmpeg/FFmpeg.git"
-
-    # Support for SDL1 has been removed from master
-    option "with-sdl2", "Enable FFplay media player"
-    deprecated_option "with-ffplay" => "with-sdl2"
-
-    depends_on "sdl2" => :optional
-    depends_on "openh264" => :optional
-  end
-
-  option "without-x264", "Disable H.264 encoder"
-  option "without-lame", "Disable MP3 encoder"
-  option "without-xvid", "Disable Xvid MPEG-4 video encoder"
-  option "without-qtkit", "Disable deprecated QuickTime framework"
-
-  option "with-rtmpdump", "Enable RTMP protocol"
+  option "with-fdk-aac", "Enable the Fraunhofer FDK AAC library"
   option "with-libass", "Enable ASS/SSA subtitle format"
+  option "with-libebur128", "Enable using libebur128 for EBU R128 loudness measurement"
+  option "with-libsoxr", "Enable the soxr resample library"
+  option "with-libssh", "Enable SFTP protocol via libssh"
+  option "with-libtesseract", "Enable the tesseract OCR engine"
+  option "with-libvidstab", "Enable vid.stab support for video stabilization"
   option "with-opencore-amr", "Enable Opencore AMR NR/WB audio format"
+  option "with-openh264", "Enable OpenH264 library"
   option "with-openjpeg", "Enable JPEG 2000 image format"
   option "with-openssl", "Enable SSL support"
-  option "with-libssh", "Enable SFTP protocol via libssh"
-  option "with-schroedinger", "Enable Dirac video format"
-  option "with-tools", "Enable additional FFmpeg tools"
-  option "with-fdk-aac", "Enable the Fraunhofer FDK AAC library"
-  option "with-libvidstab", "Enable vid.stab support for video stabilization"
-  option "with-x265", "Enable x265 encoder"
-  option "with-libsoxr", "Enable the soxr resample library"
-  option "with-webp", "Enable using libwebp to encode WEBP images"
-  option "with-zeromq", "Enable using libzeromq to receive commands sent through a libzeromq client"
-  option "with-snappy", "Enable Snappy library"
+  option "with-rtmpdump", "Enable RTMP protocol"
   option "with-rubberband", "Enable rubberband library"
-  option "with-zimg", "Enable z.lib zimg library"
+  option "with-schroedinger", "Enable Dirac video format"
+  option "with-sdl2", "Enable FFplay media player"
+  option "with-snappy", "Enable Snappy library"
+  option "with-tools", "Enable additional FFmpeg tools"
+  option "with-webp", "Enable using libwebp to encode WEBP images"
+  option "with-x265", "Enable x265 encoder"
   option "with-xz", "Enable decoding of LZMA-compressed TIFF files"
-  option "with-libebur128", "Enable using libebur128 for EBU R128 loudness measurement"
-  option "with-libtesseract", "Enable the tesseract OCR engine"
+  option "with-zeromq", "Enable using libzeromq to receive commands sent through a libzeromq client"
+  option "with-zimg", "Enable z.lib zimg library"
+  option "without-lame", "Disable MP3 encoder"
+  option "without-qtkit", "Disable deprecated QuickTime framework"
+  option "without-x264", "Disable H.264 encoder"
+  option "without-xvid", "Disable Xvid MPEG-4 video encoder"
+
+  deprecated_option "with-ffplay" => "with-sdl2"
+  deprecated_option "with-sdl" => "with-sdl2"
 
   depends_on "pkg-config" => :build
-
-  # manpages won't be built without texi2html
   depends_on "texi2html" => :build
   depends_on "yasm" => :build
 
-  depends_on "x264" => :recommended
   depends_on "lame" => :recommended
+  depends_on "x264" => :recommended
   depends_on "xvid" => :recommended
 
   depends_on "faac" => :optional
+  depends_on "fdk-aac" => :optional
   depends_on "fontconfig" => :optional
   depends_on "freetype" => :optional
-  depends_on "theora" => :optional
+  depends_on "frei0r" => :optional
+  depends_on "libass" => :optional
+  depends_on "libbluray" => :optional
+  depends_on "libbs2b" => :optional
+  depends_on "libcaca" => :optional
+  depends_on "libebur128" => :optional
+  depends_on "libsoxr" => :optional
+  depends_on "libssh" => :optional
+  depends_on "libvidstab" => :optional
   depends_on "libvorbis" => :optional
   depends_on "libvpx" => :optional
-  depends_on "rtmpdump" => :optional
   depends_on "opencore-amr" => :optional
-  depends_on "libass" => :optional
+  depends_on "openh264" => :optional
   depends_on "openjpeg" => :optional
+  depends_on "openssl" => :optional
+  depends_on "opus" => :optional
+  depends_on "rtmpdump" => :optional
+  depends_on "rubberband" => :optional
+  depends_on "schroedinger" => :optional
+  depends_on "sdl2" => :optional
   depends_on "snappy" => :optional
   depends_on "speex" => :optional
-  depends_on "schroedinger" => :optional
-  depends_on "fdk-aac" => :optional
-  depends_on "opus" => :optional
-  depends_on "frei0r" => :optional
-  depends_on "libcaca" => :optional
-  depends_on "libbluray" => :optional
-  depends_on "libsoxr" => :optional
-  depends_on "libvidstab" => :optional
-  depends_on "x265" => :optional
-  depends_on "openssl" => :optional
-  depends_on "libssh" => :optional
-  depends_on "webp" => :optional
-  depends_on "zeromq" => :optional
-  depends_on "libbs2b" => :optional
-  depends_on "rubberband" => :optional
-  depends_on "zimg" => :optional
-  depends_on "xz" => :optional
-  depends_on "libebur128" => :optional
   depends_on "tesseract" => :optional
+  depends_on "theora" => :optional
+  depends_on "webp" => :optional
+  depends_on "x265" => :optional
+  depends_on "xz" => :optional
+  depends_on "zeromq" => :optional
+  depends_on "zimg" => :optional
 
   def install
     # Fixes "dyld: lazy symbol binding failed: Symbol not found: _clock_gettime"
@@ -127,52 +103,41 @@ class Ffmpeg < Formula
       --host-ldflags=#{ENV.ldflags}
     ]
 
-    if build.with? "openh264"
-      if build.stable?
-        resource("openh264-1.5.0").stage do
-          system "make", "install-shared", "PREFIX=#{libexec}/openh264-1.5.0"
-        end
-        ENV.prepend_path "PKG_CONFIG_PATH", libexec/"openh264-1.5.0/lib/pkgconfig"
-      end
-      args << "--enable-libopenh264"
-    end
-
-    args << "--enable-opencl" if MacOS.version > :lion
-
-    args << "--enable-libx264" if build.with? "x264"
-    args << "--enable-libmp3lame" if build.with? "lame"
-    args << "--enable-libxvid" if build.with? "xvid"
-    args << "--enable-libsnappy" if build.with? "snappy"
-
+    args << "--disable-indev=qtkit" if build.without? "qtkit"
+    args << "--enable-ffplay" if build.with? "sdl2"
+    args << "--enable-frei0r" if build.with? "frei0r"
+    args << "--enable-libass" if build.with? "libass"
+    args << "--enable-libbs2b" if build.with? "libbs2b"
+    args << "--enable-libcaca" if build.with? "libcaca"
+    args << "--enable-libebur128" if build.with? "libebur128"
+    args << "--enable-libfaac" if build.with? "faac"
+    args << "--enable-libfdk-aac" if build.with? "fdk-aac"
     args << "--enable-libfontconfig" if build.with? "fontconfig"
     args << "--enable-libfreetype" if build.with? "freetype"
+    args << "--enable-libmp3lame" if build.with? "lame"
+    args << "--enable-libopencore-amrnb" << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
+    args << "--enable-libopenh264" if build.with? "openh264"
+    args << "--enable-libopus" if build.with? "opus"
+    args << "--enable-librtmp" if build.with? "rtmpdump"
+    args << "--enable-librubberband" if build.with? "rubberband"
+    args << "--enable-libschroedinger" if build.with? "schroedinger"
+    args << "--enable-libsnappy" if build.with? "snappy"
+    args << "--enable-libsoxr" if build.with? "libsoxr"
+    args << "--enable-libspeex" if build.with? "speex"
+    args << "--enable-libssh" if build.with? "libssh"
+    args << "--enable-libtesseract" if build.with? "tesseract"
     args << "--enable-libtheora" if build.with? "theora"
+    args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libvorbis" if build.with? "libvorbis"
     args << "--enable-libvpx" if build.with? "libvpx"
-    args << "--enable-librtmp" if build.with? "rtmpdump"
-    args << "--enable-libopencore-amrnb" << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
-    args << "--enable-libfaac" if build.with? "faac"
-    args << "--enable-libass" if build.with? "libass"
-    args << "--enable-ffplay" if build.with? "ffplay"
-    args << "--enable-libssh" if build.with? "libssh"
-    args << "--enable-libspeex" if build.with? "speex"
-    args << "--enable-libschroedinger" if build.with? "schroedinger"
-    args << "--enable-libfdk-aac" if build.with? "fdk-aac"
-    args << "--enable-openssl" if build.with? "openssl"
-    args << "--enable-libopus" if build.with? "opus"
-    args << "--enable-frei0r" if build.with? "frei0r"
-    args << "--enable-libcaca" if build.with? "libcaca"
-    args << "--enable-libsoxr" if build.with? "libsoxr"
-    args << "--enable-libvidstab" if build.with? "libvidstab"
-    args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
-    args << "--enable-libzmq" if build.with? "zeromq"
-    args << "--enable-libbs2b" if build.with? "libbs2b"
-    args << "--enable-librubberband" if build.with? "rubberband"
+    args << "--enable-libx264" if build.with? "x264"
+    args << "--enable-libx265" if build.with? "x265"
+    args << "--enable-libxvid" if build.with? "xvid"
     args << "--enable-libzimg" if build.with? "zimg"
-    args << "--disable-indev=qtkit" if build.without? "qtkit"
-    args << "--enable-libebur128" if build.with? "libebur128"
-    args << "--enable-libtesseract" if build.with? "tesseract"
+    args << "--enable-libzmq" if build.with? "zeromq"
+    args << "--enable-opencl" if MacOS.version > :lion
+    args << "--enable-openssl" if build.with? "openssl"
 
     if build.with? "xz"
       args << "--enable-lzma"
@@ -225,27 +190,10 @@ class Ffmpeg < Formula
     end
   end
 
-  def caveats
-    if build.without? "faac" then <<-EOS.undent
-      The native FFmpeg AAC encoder has been stable since FFmpeg 3.0. If you
-      were using libvo-aacenc or libaacplus, both of which have been dropped in
-      FFmpeg 3.0, please consider switching to the native encoder (-c:a aac),
-      fdk-aac (-c:a libfdk_aac, ffmpeg needs to be installed with the
-      --with-fdk-aac option), or faac (-c:a libfaac, ffmpeg needs to be
-      installed with the --with-faac option).
-
-      See the announcement
-      https://ffmpeg.org/index.html#removing_external_aac_encoders for details,
-      and https://trac.ffmpeg.org/wiki/Encode/AAC on best practices of encoding
-      AAC with FFmpeg.
-      EOS
-    end
-  end
-
   test do
     # Create an example mp4 file
-    system "#{bin}/ffmpeg", "-y", "-filter_complex",
-        "testsrc=rate=1:duration=1", "#{testpath}/video.mp4"
-    assert (testpath/"video.mp4").exist?
+    mp4out = testpath/"video.mp4"
+    system bin/"ffmpeg", "-filter_complex", "testsrc=rate=1:duration=1", mp4out
+    assert mp4out.exist?
   end
 end

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,7 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.21.0.tar.gz"
   sha256 "d05f8ece859c500ef1649cdfea911ec1529df1898b8fda3e217766dc28dc9bd3"
-  revision 1
+  revision 2
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

See https://github.com/FFmpeg/FFmpeg/blob/n3.2/Changelog.
- `openh264` 1.6 support added (FFmpeg/FFmpeg@293676c); drop vendored `openh264` 1.5.
- <s>Restore the `--with-ffplay` option and deprecate `--with-sdl`/`--with-sdl2` (recently added).  Whatever backend `ffplay` uses is just an implementation detail, users should not need to know it (and most don't), and using the dependency name in the option name not only causes user confusion (especially after years of `--with-ffplay` which is the only name that makes sense), it's also a headache when upstream switches backend, as is happening with this release.</s>
- Deprecate `--with-sdl` in favor of `--with-sdl2`, and point `--with-ffplay` to `--with-sdl2` too. FFplay now uses `sdl2` as its backend.
- Drop the AAC encoding caveats specific to the FFmpeg 3.0 release. It's been out for the better part of a year and shouldn't be news anymore. Users concerned with this caveat should have migrated already.
- Sort options and optional dependencies. They're a mess and I didn't even know where to insert options and dependencies.

More revision bumps are probably necessary. Let's see what the bot has to say.
