### PR TITLE
willgit: import from head-only

### DIFF
--- a/Formula/willgit.rb
+++ b/Formula/willgit.rb
@@ -1,0 +1,20 @@
+class Willgit < Formula
+  desc "William's miscellaneous git tools"
+  homepage "http://git-wt-commit.rubyforge.org"
+  url "https://github.com/DanielVartanov/willgit/archive/1.0.0.tar.gz"
+  sha256 "3bb99d6ec2614a90f40962311daf51f393b3d0abfdb0f9e0a14ba7340b33a2c8"
+  head "https://github.com/DanielVartanov/willgit.git"
+
+  def install
+    prefix.install "bin"
+  end
+
+  test do
+    system "git", "init"
+    (testpath/"README.md").write "# My Awesome Project"
+    system "git", "add", "README.md"
+    system "git", "commit", "-m", "init"
+    assert_equal "Local branch: master",
+      shell_output("git wtf").chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

See https://github.com/Homebrew/homebrew-head-only/pull/243. I removed the reference to the original repository; it’s not down anymore but it’s read-only so there’s no point pulling from it given that the stable tag is more recent than the latest commit.
