### PR TITLE
Add a flag to build mpv with pulseaudio support

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -32,6 +32,7 @@ class Mpv < Formula
   depends_on "libdvdnav" => :optional
   depends_on "libbluray" => :optional
   depends_on "libaacs" => :optional
+  depends_on "pulseaudio" => :optional
   depends_on "vapoursynth" => :optional
   depends_on "uchardet" => :optional
   depends_on :x11 => :optional
@@ -55,6 +56,7 @@ class Mpv < Formula
       --zshdir=#{zsh_completion}
     ]
     args << "--enable-libarchive" if build.with? "libarchive"
+    args << "--enable-pulse" if build.with? "pulseaudio"
 
     system "./bootstrap.py"
     system "python3", "waf", "configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

It's dope to be able to forward sound to a Pulseaudio server.

Thank you
