### PR TITLE
libbtbb: fix build

### DIFF
--- a/Formula/libbtbb.rb
+++ b/Formula/libbtbb.rb
@@ -4,6 +4,7 @@ class Libbtbb < Formula
   url "https://github.com/greatscottgadgets/libbtbb/archive/2015-10-R1.tar.gz"
   version "2015-10-R1"
   sha256 "95f493d379a53ec1134cfb36349cc9aac95d77260db4fdb557313b0dbb5c1d5a"
+  revision 1
 
   head "https://github.com/greatscottgadgets/libbtbb.git"
 
@@ -39,6 +40,7 @@ class Libbtbb < Formula
     end
 
     ENV.prepend_path "PATH", libexec/"vendor/bin"
+    ENV.append_to_cflags "-I#{libexec}/vendor/include"
     mkdir "build" do
       system "cmake", "..", *args
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Need to insert the vendored include path into CFLAGS, or the compiler won't be able to find those headers.
#6408.

P.S. Without this patch:

```
In file included from /tmp/libbtbb-20161029-51164-1pawwbs/libbtbb-2015-10-R1/lib/src/pcap.c:25:
/tmp/libbtbb-20161029-51164-1pawwbs/libbtbb-2015-10-R1/lib/src/pcap-common.h:28:10: fatal error: 'pcap/bluetooth.h' file not found
#include <pcap/bluetooth.h>
         ^
[ 87%] Built target pcapdump
In file included from /tmp/libbtbb-20161029-51164-1pawwbs/libbtbb-2015-10-R1/lib/src/pcapng-bt.c:26:
In file included from /tmp/libbtbb-20161029-51164-1pawwbs/libbtbb-2015-10-R1/lib/src/pcapng-bt.h:25:
/tmp/libbtbb-20161029-51164-1pawwbs/libbtbb-2015-10-R1/lib/src/pcap-common.h:28:10: fatal error: 'pcap/bluetooth.h' file not found
#include <pcap/bluetooth.h>
         ^
1 error generated.
1 error generated.
```
