### PR TITLE
makepkg: fix build

### DIFF
--- a/Formula/makepkg.rb
+++ b/Formula/makepkg.rb
@@ -4,6 +4,8 @@ class Makepkg < Formula
   url "https://projects.archlinux.org/git/pacman.git",
       :tag => "v5.0.1",
       :revision => "f38de43eb68f1d9c577b4378310640c1eaa93338"
+  revision 1
+
   head "https://projects.archlinux.org/git/pacman.git"
 
   bottle do
@@ -18,7 +20,7 @@ class Makepkg < Formula
 
   depends_on "automake" => :build
   depends_on "autoconf" => :build
-  depends_on "asciidoc" => :build
+  depends_on "asciidoc" => ["with-docbook-xsl", :build]
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libarchive"
@@ -29,6 +31,8 @@ class Makepkg < Formula
   depends_on "gpgme" => :optional
 
   def install
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Without docbook-xsl and the corresponding `XML_CATALOG_FILES` in the environment, `xsltproc(1)` attempts to load .xsl files — e.g., http://docbook.sourceforge.net/release/xsl/current/html/lists.xsl — from the Internet, and when the build is parallelized, that is, multiple `xsltproc` processes attempt to fetch the same .xsl file at the same time and presumably write to the same location, a race condition is triggered and all processes exit with status 5.

An alternative fix is `ENV.deparallelize` (at least during `make docs`), but having to fetch .xsl files on the go and thus preventing offline builds is probably something to be frowned upon.
#6408.
