### PR TITLE
aws-apigateway-importer: patch for compat issue

### DIFF
--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -3,6 +3,13 @@ class AwsApigatewayImporter < Formula
   homepage "https://github.com/awslabs/aws-apigateway-importer"
   url "https://github.com/awslabs/aws-apigateway-importer/archive/aws-apigateway-importer-1.0.1.tar.gz"
   sha256 "1aecfd348135c2e364ce5e105d91d5750472ac4cb8848679d774a2ac00024d26"
+  revision 1
+
+  # Pin aws-sdk-java-core for JSONObject compatibility
+  patch do
+    url "https://github.com/awslabs/aws-apigateway-importer/commit/660e3ce.diff"
+    sha256 "0dcfd1e03d653708726672dc6e6bf6f4b3e5d0184a75f224bf64f9bc7974b931"
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

See https://github.com/awslabs/aws-apigateway-importer/pull/193.
#6408.
