### PR TITLE
xml2: use URLs from Wayback Machine

### DIFF
--- a/Formula/xml2.rb
+++ b/Formula/xml2.rb
@@ -19,6 +19,6 @@ class Xml2 < Formula
   end
 
   test do
-    system "echo '<test/>' | \"#{bin}/xml2\""
+    assert_equal "/test", pipe_output("#{bin}/xml2", "<test/>", 0).chomp
   end
 end

--- a/Formula/xml2.rb
+++ b/Formula/xml2.rb
@@ -1,7 +1,7 @@
 class Xml2 < Formula
   desc "Makes XML and HTML more amenable to classic UNIX text tools"
-  homepage "https://ofb.net/~egnor/xml2/"
-  url "http://download.ofb.net/gale/xml2-0.5.tar.gz"
+  homepage "https://web.archive.org/web/20160730094113/http://www.ofb.net/~egnor/xml2/"
+  url "https://web.archive.org/web/20160427221603/http://download.ofb.net/gale/xml2-0.5.tar.gz"
   sha256 "e3203a5d3e5d4c634374e229acdbbe03fea41e8ccdef6a594a3ea50a50d29705"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

According to http://ofb.net:

> 9/6/2016: OFB.net suffered a disk failure. We are in the process of restoring basic functionality.

Unfortunately I can't find this elsewhere on the Internet.
#6408.
