### PR TITLE
natalie: fix build on Xcode 8.1 (Swift 3.0.1)

### DIFF
--- a/Formula/natalie.rb
+++ b/Formula/natalie.rb
@@ -14,6 +14,7 @@ class Natalie < Formula
   depends_on :xcode => ["8.0", :build]
 
   def install
+    ENV["CC"] = which(ENV.cc)
     system "swift", "build", "-c", "release", "-Xswiftc", "-static-stdlib"
     bin.install ".build/release/natalie"
     share.install "NatalieExample"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

In Swift 3.0.1 Swift Pacakge Manager now interprets `CC` as either an
absolute path or a path relative to pwd (see https://github.com/apple/swift-package-manager/commit/be54a9f line 47-50).

Our `CC` is usually just `clang`, which is interpreted as `buildpath/clang` and leads to an invalid toolchain error. Sample logs: https://gist.github.com/c8541f621bc2cc1028638391c7b50269.

Kind of funny that I discovered the bug while setting out to fix natalie on Sierra (for #5488), not knowing that it was already updated, just not ticked off.
