### PR TITLE
cabal-install: improve Sierra compatibility

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -1,9 +1,26 @@
 class CabalInstall < Formula
   desc "Command-line interface for Cabal and Hackage"
   homepage "https://www.haskell.org/cabal/"
-  url "https://hackage.haskell.org/package/cabal-install-1.24.0.0/cabal-install-1.24.0.0.tar.gz"
-  sha256 "d840ecfd0a95a96e956b57fb2f3e9c81d9fc160e1fd0ea350b0d37d169d9e87e"
-  revision 1
+  revision 2
+  head "https://github.com/haskell/cabal.git", :branch => "1.24"
+
+  stable do
+    if MacOS.version >= :sierra
+      url "https://github.com/haskell/cabal.git",
+          :branch => "1.24",
+          :revision => "51ff8b66468977dcccb81d19ac2d42ee27c9ccd1"
+      version "1.24.0.0"
+    else
+      url "https://hackage.haskell.org/package/cabal-install-1.24.0.0/cabal-install-1.24.0.0.tar.gz"
+      sha256 "d840ecfd0a95a96e956b57fb2f3e9c81d9fc160e1fd0ea350b0d37d169d9e87e"
+
+      # disables haddock for hackage-security
+      patch :p2 do
+        url "https://github.com/haskell/cabal/commit/9441fe.patch"
+        sha256 "5506d46507f38c72270efc4bb301a85799a7710804e033eaef7434668a012c5e"
+      end
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -17,13 +34,8 @@ class CabalInstall < Formula
 
   fails_with :clang if MacOS.version <= :lion # Same as ghc.rb
 
-  # disables haddock for hackage-security
-  patch :p2 do
-    url "https://github.com/haskell/cabal/commit/9441fe.patch"
-    sha256 "5506d46507f38c72270efc4bb301a85799a7710804e033eaef7434668a012c5e"
-  end
-
   def install
+    cd "cabal-install" if MacOS.version >= :sierra || build.head?
     system "sh", "bootstrap.sh", "--sandbox"
     bin.install ".cabal-sandbox/bin/cabal"
     bash_completion.install "bash-completion/cabal"


### PR DESCRIPTION
On Sierra, uses the new --dynlibdir, which upstream backported to the
1.24 release branch. The setting defaults to $libdir/$abi and avoids

  ghc: panic! (the 'impossible' happened)
  malformed mach-o: load commands size (x) > 32768

See
haskell/cabal#3979 (haskell/cabal@d2da655)
haskell/cabal#4011 (haskell/cabal@5c901a6)
https://ghc.haskell.org/trac/ghc/ticket/12479
https://phabricator.haskell.org/D2611
