### PR TITLE
emacs: make librsvg optional again

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -30,7 +30,7 @@ class Emacs < Formula
   depends_on "pkg-config" => :build
   depends_on "dbus" => :optional
   depends_on "gnutls" => :optional
-  depends_on "librsvg" => :recommended
+  depends_on "librsvg" => :optional
   depends_on "imagemagick" => :optional
   depends_on "mailutils" => :optional
 


### PR DESCRIPTION
librsvg drags in cairo, fontconfig, freetype, gdk-pixbuf, gettext, git,
glib gobject-introspection, harfbuzz, icu4c, intltool, jpeg, libcroco,
libffi, libpng, librsvg, libtiff, pango, pcre, pixman, and
shared-mime-info, and still manages not to be linked unless you build
with cocoa, which defaults to off.

Corrects a regression introduced by #3531 in 829f0d1f.
CC @mikemcquaid
