### PR TITLE
git-series 0.8.11

### DIFF
--- a/Formula/git-series.rb
+++ b/Formula/git-series.rb
@@ -1,8 +1,8 @@
 class GitSeries < Formula
   desc "Track changes to a patch series over time"
   homepage "https://github.com/git-series/git-series"
-  url "https://github.com/git-series/git-series/archive/0.8.10.tar.gz"
-  sha256 "d70c9a2105c69fdd6059c04285ddb74b3b10852d9729dd8a14681b9bf36790be"
+  url "https://github.com/git-series/git-series/archive/0.8.11.tar.gz"
+  sha256 "d884e77c03304ba77cac3845b5e51a7856d517771db72c652f53b47cbaa13890"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

'brew audit --strict' fails for me at the moment with SSL related error (Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (https://rubygems.org/specs.4.8.gz)), so I haven't yet checked brew audit.

But given that this is only a version bump, I thought it might be Ok anyway.