### PR TITLE
gnutls: actually disable Guile when not requested

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -42,7 +42,12 @@ class Gnutls < Formula
       --disable-heartbeat-support
       --without-p11-kit
     ]
-    args << "--enable-guile" << "--with-guile-site-dir" if build.with? "guile"
+
+    if build.with? "guile"
+      args << "--enable-guile" << "--with-guile-site-dir"
+    else
+      args << "--disable-guile"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I think this does not affect superenv (?), but this can be useful if the user requests stdenv, where GnuTLS will automatically pick up Guile if it’s installed and linked.