### PR TITLE
lua: don't let makefile override CC=cc

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -32,6 +32,7 @@ class Lua < Formula
 
   # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
   # See: https://github.com/Homebrew/homebrew/pull/5043
+  # Also don't let the makefile override our CC
   patch :DATA
 
   # completion provided by advanced readline power patch
@@ -216,7 +217,7 @@ index 8c9ee67..7f92407 100644
 
  macosx:
 -	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline" CC=cc
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -fno-common" SYSLIBS="-lreadline" CC=cc
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -fno-common" SYSLIBS="-lreadline"
 
  mingw:
 	$(MAKE) "LUA_A=lua52.dll" "LUA_T=lua.exe" \


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The makefile specifies `CC=cc` in a recursive Make invocation for macOS for some reason. I think this does not affect superenv, but for the sake of stdenv, remove this.