### PR TITLE
ffmpeg: add more dependencies and fix libbluray dependency

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -111,6 +111,7 @@ class Ffmpeg < Formula
     args << "--enable-ffplay" if build.with? "sdl2"
     args << "--enable-frei0r" if build.with? "frei0r"
     args << "--enable-libass" if build.with? "libass"
+    args << "--enable-libbluray" if build.with? "libbluray"
     args << "--enable-libbs2b" if build.with? "libbs2b"
     args << "--enable-libcaca" if build.with? "libcaca"
     args << "--enable-libebur128" if build.with? "libebur128"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -53,11 +53,14 @@ class Ffmpeg < Formula
   depends_on "fontconfig" => :optional
   depends_on "freetype" => :optional
   depends_on "frei0r" => :optional
+  depends_on "game-music-emu" => :optional
   depends_on "libass" => :optional
   depends_on "libbluray" => :optional
   depends_on "libbs2b" => :optional
   depends_on "libcaca" => :optional
   depends_on "libebur128" => :optional
+  depends_on "libgsm" => :optional
+  depends_on "libmodplug" => :optional
   depends_on "libsoxr" => :optional
   depends_on "libssh" => :optional
   depends_on "libvidstab" => :optional
@@ -76,6 +79,8 @@ class Ffmpeg < Formula
   depends_on "speex" => :optional
   depends_on "tesseract" => :optional
   depends_on "theora" => :optional
+  depends_on "two-lame" => :optional
+  depends_on "wavpack" => :optional
   depends_on "webp" => :optional
   depends_on "x265" => :optional
   depends_on "xz" => :optional
@@ -112,6 +117,9 @@ class Ffmpeg < Formula
     args << "--enable-libfdk-aac" if build.with? "fdk-aac"
     args << "--enable-libfontconfig" if build.with? "fontconfig"
     args << "--enable-libfreetype" if build.with? "freetype"
+    args << "--enable-libgme" if build.with? "game-music-emu"
+    args << "--enable-libgsm" if build.with? "libgsm"
+    args << "--enable-libmodplug" if build.with? "libmodplug"
     args << "--enable-libmp3lame" if build.with? "lame"
     args << "--enable-libopencore-amrnb" << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
     args << "--enable-libopenh264" if build.with? "openh264"
@@ -125,9 +133,11 @@ class Ffmpeg < Formula
     args << "--enable-libssh" if build.with? "libssh"
     args << "--enable-libtesseract" if build.with? "tesseract"
     args << "--enable-libtheora" if build.with? "theora"
+    args << "--enable-libtwolame" if build.with? "two-lame"
     args << "--enable-libvidstab" if build.with? "libvidstab"
     args << "--enable-libvorbis" if build.with? "libvorbis"
     args << "--enable-libvpx" if build.with? "libvpx"
+    args << "--enable-libwavpack" if build.with? "wavpack"
     args << "--enable-libwebp" if build.with? "webp"
     args << "--enable-libx264" if build.with? "x264"
     args << "--enable-libx265" if build.with? "x265"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I wanted to also add a dependency on `celt` but discovered that it’s in the boneyard. I’m guessing we can’t have any dependencies on boneyard formulae in the core, is that right? It’s a bit unfortunate (e. g. in this case functionality is lost IIUC), but this probably isn’t the place to discuss that.