### PR TITLE
eris 0.12.0-rc3 (devel)

### DIFF
--- a/Formula/eris.rb
+++ b/Formula/eris.rb
@@ -3,6 +3,7 @@ class Eris < Formula
   homepage "https://erisindustries.com"
   url "https://github.com/eris-ltd/eris-cli/archive/v0.11.4.tar.gz"
   sha256 "e2eb02d01b76e8be9f28aac31b2e56ebadc4d0decb21fcfefb2f219cb03d1238"
+  version_scheme 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,8 +14,9 @@ class Eris < Formula
   end
 
   devel do
-    url "https://github.com/eris-ltd/eris-cli/archive/v0.12.0-rc1.tar.gz"
-    sha256 "1924f18a721c0533570191a857fad03e1c4a395b2d1a0f34826499ac41ccf144"
+    url "https://github.com/eris-ltd/eris-cli/archive/v0.12.0-rc3.tar.gz"
+    version "0.12.0-rc3"
+    sha256 "7b3455b3019cc3a440e54f16ef9cda4359bc09d54f178b56b23555f97c4c7868"
   end
 
   depends_on "go" => :build
@@ -31,6 +33,7 @@ class Eris < Formula
   end
 
   test do
-    system "#{bin}/eris", "--version"
+    cmd = build.devel? ? "version" : "--version"
+    system "#{bin}/eris", cmd
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --devel <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Bumping the version scheme because `v0.12.0-rc1` was incorrectly detected as version `1`.