### PR TITLE
emscripten head: fix build

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -70,7 +70,7 @@ class Emscripten < Formula
       "--disable-bindings",
     ]
 
-    cmake_args = std_cmake_args.reject{|s| s["CMAKE_INSTALL_PREFIX"] }
+    cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] }
     cmake_args += [
       "-DCMAKE_INSTALL_PREFIX=#{libexec}/llvm",
       "-DLLVM_TARGETS_TO_BUILD=X86;JSBackend",

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -70,9 +70,9 @@ class Emscripten < Formula
       "--disable-bindings",
     ]
 
-    cmake_args = [
+    cmake_args = std_cmake_args.reject{|s| s["CMAKE_INSTALL_PREFIX"] }
+    cmake_args += [
       "-DCMAKE_INSTALL_PREFIX=#{libexec}/llvm",
-      "-DCMAKE_BUILD_TYPE=Release",
       "-DLLVM_TARGETS_TO_BUILD=X86;JSBackend",
       "-DLLVM_INCLUDE_EXAMPLES=OFF",
       "-DLLVM_INCLUDE_TESTS=OFF",

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -34,6 +34,8 @@ class Emscripten < Formula
     resource "fastcomp-clang" do
       url "https://github.com/kripken/emscripten-fastcomp-clang.git", :branch => "incoming"
     end
+
+    depends_on "cmake" => :build
   end
 
   needs :cxx11
@@ -60,7 +62,7 @@ class Emscripten < Formula
     (buildpath/"fastcomp").install resource("fastcomp")
     (buildpath/"fastcomp/tools/clang").install resource("fastcomp-clang")
 
-    args = [
+    configure_args = [
       "--prefix=#{libexec}/llvm",
       "--enable-optimized",
       "--enable-targets=host,js",
@@ -68,8 +70,24 @@ class Emscripten < Formula
       "--disable-bindings",
     ]
 
+    cmake_args = [
+      "-DCMAKE_INSTALL_PREFIX=#{libexec}/llvm",
+      "-DCMAKE_BUILD_TYPE=Release",
+      "-DLLVM_TARGETS_TO_BUILD=X86;JSBackend",
+      "-DLLVM_INCLUDE_EXAMPLES=OFF",
+      "-DLLVM_INCLUDE_TESTS=OFF",
+      "-DCLANG_INCLUDE_EXAMPLES=OFF",
+      "-DCLANG_INCLUDE_TESTS=OFF",
+      "-DOCAMLFIND=/usr/bin/false",
+      "-DGO_EXECUTABLE=/usr/bin/false",
+    ]
+
     mkdir "fastcomp/build" do
-      system "../configure", *args
+      if build.head?
+        system "cmake", "..", *cmake_args
+      else
+        system "../configure", *configure_args
+      end
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The HEAD build of emscripten was broken because the fastcomp installation of the formula depended on the configure script disabled now by the upstream (LLVM).

The configure script suggests the recommended way to build is using CMake.
(https://github.com/llvm-mirror/llvm/blob/master/configure)

Thus, the build process of fastcomp when installing the HEAD version is changed to use CMake instead of the disabled configure script.

Note that the part for the stable version is kept unchanged, since the current stable version of fastcomp can still be built with the configure script.