### PR TITLE
app-engine-java: fix missing libexec path for bin/scripts(eg. appcfg.sh)

### DIFF
--- a/Formula/app-engine-java.rb
+++ b/Formula/app-engine-java.rb
@@ -3,6 +3,7 @@ class AppEngineJava < Formula
   homepage "https://cloud.google.com/appengine/docs/java/"
   url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.42.zip"
   sha256 "3003892e89fb32a51dc3e2d91658fc7ba8b31f8b0b3fc22ccbd856ed94a03424"
+  revision 1
 
   bottle :unneeded
 
@@ -11,7 +12,7 @@ class AppEngineJava < Formula
   def install
     rm Dir["bin/*.cmd"]
     libexec.install Dir["*"]
-    bin.write_exec_script %w[appcfg.sh dev_appserver.sh endpoints.sh google_sql.sh].each { |fn| libexec/"bin/#{fn}" }
+    bin.write_exec_script %w[appcfg.sh dev_appserver.sh endpoints.sh google_sql.sh].map { |fn| libexec/"bin/#{fn}" }
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
app-engine-java scripts like appcfg.sh(eg. bin/appcfg.sh) doesn't work because absolute path for scripts is missing.
libexec path should be used for bin/scripts(eg. bin/appcfg..)
