### PR TITLE
gtkextra: use autoreconf to avoid flat_namespace

### DIFF
--- a/Formula/gtkextra.rb
+++ b/Formula/gtkextra.rb
@@ -3,6 +3,7 @@ class Gtkextra < Formula
   homepage "http://gtkextra.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/gtkextra/3.3/gtkextra-3.3.2.tar.gz"
   sha256 "3388692306b1afc79f17f5472a194c607fa67d5a38f1b4e79eda27a27f54f1a4"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,10 +12,14 @@ class Gtkextra < Formula
     sha256 "57d90385f07bfd83ee52f4570f2694aa7a5594df1829213f4bda1c7fce9af763" => :yosemite
   end
 
-  depends_on "gtk+"
   depends_on "pkg-config" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "gtk+"
 
   def install
+    system "autoreconf", "-i"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
The gtkextra tarball was generated with an old libtool, causing the flat_namespace to get passed to the linker...