### PR TITLE
curl: always be explicit with both ca-bundle and ca-path

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -69,12 +69,16 @@ class Curl < Formula
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["libressl"].opt_lib}/pkgconfig"
       args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
       args << "--with-ca-bundle=#{etc}/libressl/cert.pem"
+      args << "--with-ca-path=#{etc}/libressl/certs"
     elsif MacOS.version < :mountain_lion || build.with?("openssl") || build.with?("nghttp2")
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl"].opt_lib}/pkgconfig"
       args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
       args << "--with-ca-bundle=#{etc}/openssl/cert.pem"
+      args << "--with-ca-path=#{etc}/openssl/certs"
     else
       args << "--with-darwinssl"
+      args << "--without-ca-bundle"
+      args << "--without-ca-path"
     end
 
     args << (build.with?("libssh2") ? "--with-libssh2" : "--without-libssh2")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Otherwise, automatic detection of ca-bundle and/or ca-path may become problematic.

For example, `/etc/ssl` does not exist prior to macOS Sierra 10.12.2.  Starting with macOS Sierra 10.12.2 (16C32f), `/etc/ssl/cert.pem` has been shipped together with LibreSSL (see `/usr/lib/libssl.35.dylib` & `/usr/lib/libcrypto.35.dylib`), cURL will pick up `/etc/ssl/cert.pem` as the default ca bundle via automatic detection.  When building cURL with Secure Transport, the default ca bundle will provide anchor certificates exclusively, this will cause all user trust settings become ineffective.