### PR TITLE
plantuml: fix doxygen is searching for plantuml.jar

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -9,12 +9,14 @@ class Plantuml < Formula
   depends_on "graphviz"
 
   def install
-    jar = "plantuml.#{version}.jar"
-    prefix.install jar
+    jar = "plantuml.jar"
+    mv buildpath+"plantuml.#{version}.jar", jar
+    share.install jar
     (bin/"plantuml").write <<-EOS.undent
       #!/bin/bash
-      GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{prefix}/#{jar} "$@"
+      GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{share}/#{jar} "$@"
     EOS
+    chmod 0555, bin/"plantuml"
   end
 
   test do

--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -10,11 +10,10 @@ class Plantuml < Formula
 
   def install
     jar = "plantuml.jar"
-    mv buildpath+"plantuml.#{version}.jar", jar
-    share.install jar
+    libexec.install "plantuml.#{version}.jar" => jar
     (bin/"plantuml").write <<-EOS.undent
       #!/bin/bash
-      GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{share}/#{jar} "$@"
+      GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{libexec}/#{jar} "$@"
     EOS
     chmod 0555, bin/"plantuml"
   end


### PR DESCRIPTION
I found that doxygen is not able to use plantuml.8048.jar and it's using always plantuml.jar. Which is not available in this formula. I renamed the jar and move it to share/ where is placed in other systems.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

