### PR TITLE
Add apr dependency

### DIFF
--- a/Formula/activemq-cpp.rb
+++ b/Formula/activemq-cpp.rb
@@ -13,6 +13,7 @@ class ActivemqCpp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
+  depends_on "apr"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The build failed on Sierra due to a missing dependency to `apr`. This should fix the sierra bottle issue #6408  for this formula. 
