### PR TITLE
fstar: unpin ocamlfind version to fix the build

### DIFF
--- a/Formula/fstar.rb
+++ b/Formula/fstar.rb
@@ -4,8 +4,7 @@ class Fstar < Formula
   url "https://github.com/FStarLang/FStar.git",
       :tag => "v0.9.2.0",
       :revision => "2a8ce0b3dfbfb9703079aace0d73f2479f0d0ce2"
-  revision 1
-
+  revision 2
   head "https://github.com/FStarLang/FStar.git"
 
   bottle do
@@ -20,45 +19,24 @@ class Fstar < Formula
   depends_on "ocaml" => :recommended
   depends_on "z3" => :recommended
 
-  resource "ocamlfind" do
-    url "http://download.camlcity.org/download/findlib-1.5.5.tar.gz"
-    sha256 "aafaba4f7453c38347ff5269c6fd4f4c243ae2bceeeb5e10b9dab89329905946"
-  end
-
-  resource "batteries" do
-    url "https://github.com/ocaml-batteries-team/batteries-included/archive/v2.5.2.tar.gz"
-    sha256 "649038b47cdc2b7d4d4331fdb54b1e726212ce904c3472687a86aaa8d6006451"
-  end
-
-  resource "zarith" do
-    url "https://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz"
-    sha256 "946687d6f032b96ab9db9661d876e39437bff783e0ad473ac463c06259b7a3d7"
-  end
-
-  resource "yojson" do
-    url "http://mjambon.com/releases/yojson/yojson-1.1.6.tar.gz"
-    sha256 "d97497f4d0694f515a9c12708eda2654dddb289b2ed567a377706e62e54c480d"
-  end
-
   def install
     ENV.deparallelize # Not related to F* : OCaml parallelization
-
-    opamroot = buildpath/"opamroot"
-    ENV["OPAMROOT"] = opamroot
+    ENV["OPAMROOT"] = buildpath/"opamroot"
     ENV["OPAMYES"] = "1"
+
+    # avoid having to depend on coreutils
+    inreplace "src/ocaml-output/Makefile", "$(DATE_EXEC) -Iseconds",
+                                           "$(DATE_EXEC) '+%Y-%m-%dT%H:%M:%S%z'"
+
     system "opam", "init", "--no-setup"
-    archives = opamroot/"repo/default/archives"
-    modules = []
-    resources.each do |r|
-      r.verify_download_integrity(r.fetch)
-      original_name = File.basename(r.url)
-      cp r.cached_download, archives/original_name
-      modules << "#{r.name}=#{r.version}"
+
+    if build.stable?
+      system "opam", "install", "batteries=2.5.2", "zarith=1.3", "yojson=1.1.6"
+    else
+      system "opam", "install", "batteries", "zarith", "yojson"
     end
 
-    system "opam", "install", *modules
-    system "opam", "config", "exec", "--",
-    "make", "-C", "src/ocaml-output/"
+    system "opam", "config", "exec", "--", "make", "-C", "src", "boot-ocaml"
 
     bin.install "src/ocaml-output/fstar.exe"
 


### PR DESCRIPTION
let opam choose the ocamlfind version to use (it picks 1.6.2 not 1.5.5)
use `opam install` to download the tarballs
unpin versions when building the head spec
replace the GNU-only `-Iseconds` with a BSD `date` compatible equivalent

Fixes #5123.

CC @vmrsss @dunn @josephlr