### PR TITLE
xcproj: fix HEAD branch name

### DIFF
--- a/Formula/xcproj.rb
+++ b/Formula/xcproj.rb
@@ -4,7 +4,7 @@ class Xcproj < Formula
   url "https://github.com/0xced/xcproj/archive/0.1.2.tar.gz"
   sha256 "5281fbe618eb406cc012f1fb2996662c2a7919400c1eb6fdd03f4e85f2da0bfb"
 
-  head "https://github.com/0xced/xcproj.git"
+  head "https://github.com/0xced/xcproj.git", :branch => "develop"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? - No, but if we can come up with a sensible test for this, I'd be happy to add it

-----

[xcproj](https://github.com/0xced/xcproj) doesn't have a master branch, it instead uses `develop` as it's "main branch"