### PR TITLE
Update xhyve formula to include test resources, examples, and manpages

### DIFF
--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -19,11 +19,9 @@ class Xhyve < Formula
     args << "GIT_VERSION=#{version}" if build.stable?
     system "make", *args
     bin.install "build/xhyve"
-    prefix.install "test/"
-    prefix.install "xhyverun.sh"
-    if File.exist?("xhyve.1")
-      man1.install "xhyve.1"
-    end
+    pkgshare.install "test/"
+    pkgshare.install "xhyverun.sh"
+    man1.install "xhyve.1" if build.head?
   end
 
   test do

--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -19,6 +19,11 @@ class Xhyve < Formula
     args << "GIT_VERSION=#{version}" if build.stable?
     system "make", *args
     bin.install "build/xhyve"
+    prefix.install "test/"
+    prefix.install "xhyverun.sh"
+    if File.exist?("xhyve.1")
+      man1.install "xhyve.1"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These files are important resources referred to by many tutorials that use `xhyve`, but are not installed with it. This causes bad directions. For example, [this tutorial](https://gist.github.com/tanb/f8fefa22332edc7a641d), which has been forked/linked all over the place, refers to the Homebrew cache directory for those files. Not only has the cache directory moved in the past, but it also may not exist due to `brew cleanup`. As a result of those bad directions, there's confusion: for example, [this SO question](http://apple.stackexchange.com/questions/242305/install-freebsd-on-xhyve).

All of the added files are only installed when building from source. I've opened mist64/xhyve#120 to get these files added to future release tarballs.

The if/else conditional is because the manpage is only available at `HEAD` currently. It ought to be included in the next tagged release.
