### PR TITLE
plplot: depend on cairo

### DIFF
--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -14,6 +14,7 @@ class Plplot < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "cairo"
   depends_on "pango"
   depends_on "freetype"
   depends_on "libtool" => :run


### PR DESCRIPTION
pango already depends on cairo, and it's required for the extcairo
support that the test assumes is present