### PR TITLE
sdl_image: Disable ImageIO

### DIFF
--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -3,7 +3,7 @@ class SdlImage < Formula
   homepage "https://www.libsdl.org/projects/SDL_image"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -36,6 +36,7 @@ class SdlImage < Formula
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
+                          "--disable-imageio",
                           "--disable-sdltest"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? 
-> No as there are no tests.

-----

This disables the usage of the macOS ImageIO framework to load image files instead libpng, jpeg, libtiff are used.
This fixes issues when loading for example 1-bit png files (they are  loaded as RGB instead of color indexed as they are using `libpng`) as well as other issues where pixel colors are not exactly loaded.

Currently there are no available fixes/patches for theses issues (neither for SDL2 or SDL1).

This is also needed to pass some more [pygame tests](https://bitbucket.org/pygame/pygame/src/aa82244e06e5916f77cc585c6d421354b171d6e0/.travis_osx_before_install.sh?at=default&fileviewer=file-view-default#.travis_osx_before_install.sh-47) (It also requires a `sdl_image` version with ImageIO disabled).
See also https://github.com/Homebrew/homebrew-core/pull/739.

As ImageIO is also disabled in [`sdl2_image`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/sdl2_image.rb#L31) im suggesting to always use this configuration option instead of adding another build `option`.

The [patch](https://github.com/homebrew/homebrew-core/blob/master/Formula/sdl_image.rb#L25) from https://github.com/Homebrew/homebrew-core/pull/1864 could also be removed, as it is only needed when building with ImageIO enabled.

CC @illume