### PR TITLE
[xctool] Codesign all xctool libraries

### DIFF
--- a/Formula/xctool.rb
+++ b/Formula/xctool.rb
@@ -19,6 +19,14 @@ class Xctool < Formula
     bin.install_symlink "#{libexec}/bin/xctool"
   end
 
+  def post_install
+    # all libraries need to be signed to avoid codesign errors when
+    # injecting them into xcodebuild or Simulator.app.
+    Dir.glob("#{libexec}/lib/*.dylib") do |lib_file|
+      system "/usr/bin/codesign", "-f", "-s", "-", lib_file
+    end
+  end
+
   test do
     system "(#{bin}/xctool -help; true)"
   end


### PR DESCRIPTION
macOS and/or Xcode at some point started requiring to sign libraries that are injected into xcodebuild and Simulator.app processes. I think we were seeing numerous reports in the past (but really vary rare) when injecting the library was failing and as a result xctool failed as a whole. Since it is very difficult to debug we have never really fixed it.

Based on latest reports from xctool users (https://github.com/facebook/xctool/issues/721) and googling I have figured that we can just codesign all xctool libraries to fix mentioned issues after install is complete.

Epic fail but I hit the same issue with my homebrew installation of xctool (yes, I need to update formula test plan). But it made it much easier to debug and fix.

