### PR TITLE
fix build error of minimal-racket

### DIFF
--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -24,6 +24,8 @@ class MinimalRacket < Formula
         --prefix=#{prefix}
         --man=#{man}
         --sysconfdir=#{etc}
+        CFLAGS=-D__CUDACC__
+        CPPFLAGS=-D__CUDACC__
       ]
 
       args << "--disable-mac64" unless MacOS.prefer_64_bit?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The error happened with Xcode 8.1 / MacOSX10.12.sdk.

My error message was like:

```
Xcode.app/.../Developer/SDKs/MacOSX10.12.sdk/usr/include/string.h:172:56:
error: expected ')'
__attribute__ ((availability (tvos , introduced = 10.0 .1 ) ) )
                                                       ^
```

which can be prevented with `__CUDACC__`:
(Definitily not the intention of this macro though)

```
 /* in string.h */
 #ifndef __CUDACC__
 __TVOS_AVAILABLE(10.0.1)
```