### PR TITLE
bitlbee: look for plugins in HOMEBREW_PREFIX/lib/bitlbee

### DIFF
--- a/Formula/bitlbee.rb
+++ b/Formula/bitlbee.rb
@@ -31,6 +31,7 @@ class Bitlbee < Formula
   def install
     args = %W[
       --prefix=#{prefix}
+      --plugindir=#{HOMEBREW_PREFIX}/lib/bitlbee/
       --debug=0
       --ssl=gnutls
       --pidfile=#{var}/bitlbee/run/bitlbee.pid


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

current behavior is to look in `#{prefix}/lib/bitlbee`, which of course is erased every time bitlbee is updated. setting plugin path to `#{HOMEBREW_PREFIX}/lib/bitlbee` is in line with behavior of other formulas like python.