### PR TITLE
mercurial: --with-custom-python can be a no-op

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -14,11 +14,7 @@ class Mercurial < Formula
   end
 
   option "with-custom-python", "Install against the python in PATH instead of Homebrew's python"
-  if build.with? "custom-python"
-    depends_on :python
-  else
-    depends_on "python"
-  end
+  depends_on :python
 
   def install
     ENV.minimal_optimization if MacOS.version <= :snow_leopard


### PR DESCRIPTION
... without changing its behavior.