### PR TITLE
qwt-qt4 6.1.3 (new formula)

### DIFF
--- a/Formula/qwt-qt4.rb
+++ b/Formula/qwt-qt4.rb
@@ -1,0 +1,112 @@
+class QwtQt4 < Formula
+  desc "Qt Widgets for Technical Applications"
+  homepage "http://qwt.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2"
+  sha256 "f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733"
+
+  keg_only "Newer Qt5-only version in homebrew-core"
+
+  option "with-qwtmathml", "Build the qwtmathml library"
+  option "without-plugin", "Skip building the Qt Designer plugin"
+
+  depends_on "qt"
+
+  # Update designer plugin linking back to qwt framework/lib after install
+  # See: https://sourceforge.net/p/qwt/patches/45/
+  patch :DATA
+
+  def install
+    inreplace "qwtconfig.pri" do |s|
+      s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
+      s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
+
+      # Install Qt plugin in `lib/qt-4/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt-4/\\2"
+    end
+
+    args = ["-config", "release", "-spec"]
+    # On Mavericks we want to target libc++, this requires a unsupported/macx-clang-libc++ flag
+    if ENV.compiler == :clang && MacOS.version >= :mavericks
+      args << "unsupported/macx-clang-libc++"
+    else
+      args << "macx-g++"
+    end
+
+    if build.with? "qwtmathml"
+      args << "QWT_CONFIG+=QwtMathML"
+      prefix.install "textengines/mathml/qtmmlwidget-license"
+    end
+
+    system "qmake", *args
+    system "make"
+    system "make", "install"
+
+    post_install
+  end
+
+  def post_install
+    # do symlinking of keg-only here, since `brew doctor` complains about it
+    # and user may need to re-link again after following suggestion to unlink
+    if build.with? "plugin"
+      dsubpth = "qt-4/plugins/designer"
+      dhppth = HOMEBREW_PREFIX/"lib/#{dsubpth}"
+      dhppth.mkpath
+      ln_sf "#{opt_lib.relative_path_from(dhppth)}/#{dsubpth}/libqwt_designer_plugin.dylib", "#{dhppth}/"
+    end
+  end
+
+  def caveats
+    s = ""
+
+    if build.with? "qwtmathml"
+      s += <<-EOS.undent
+        The qwtmathml library contains code of the MML Widget from the Qt solutions package.
+        Beside the Qwt license you also have to take care of its license:
+        #{opt_prefix}/qtmmlwidget-license
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <qwt_plot_curve.h>
+      int main() {
+        QwtPlotCurve *curve1 = new QwtPlotCurve("Curve 1");
+        return (curve1 == NULL);
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "out",
+      "-framework", "qwt", "-framework", "QtCore",
+      "-F#{Formula["qt-4"].opt_lib}", "-F#{lib}",
+      "-I#{lib}/qwt.framework/Headers",
+      "-I#{Formula["qt-4"].opt_lib}/QtCore.framework/Headers",
+      "-I#{Formula["qt-4"].opt_lib}/QtGui.framework/Headers"
+    system "./out"
+  end
+end
+
+__END__
+diff --git a/designer/designer.pro b/designer/designer.pro
+index c269e9d..c2e07ae 100644
+--- a/designer/designer.pro
++++ b/designer/designer.pro
+@@ -126,6 +126,16 @@ contains(QWT_CONFIG, QwtDesigner) {
+
+     target.path = $${QWT_INSTALL_PLUGINS}
+     INSTALLS += target
++
++    macx {
++        contains(QWT_CONFIG, QwtFramework) {
++            QWT_LIB = qwt.framework/Versions/$${QWT_VER_MAJ}/qwt
++        }
++        else {
++            QWT_LIB = libqwt.$${QWT_VER_MAJ}.dylib
++        }
++        QMAKE_POST_LINK = install_name_tool -change $${QWT_LIB} $${QWT_INSTALL_LIBS}/$${QWT_LIB} $(DESTDIR)$(TARGET)
++    }
+ }
+ else {
+     TEMPLATE        = subdirs # do nothing


### PR DESCRIPTION
PR to upstream QWT for QT4. The default qwt.rb builds against qt5. Ok, I admit I googled, found a qwt-qt4.rb, and just did minor cleanup. Since it's useful to me for a follow up pull request, I'd like to start with this PR upstreaming qwt-qt4.rb. I plan to coordinate with github.com/OSGeo/homebrew-osgeo4mac to remove it there once it is available in homebrew-core.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  I see PR676 and PR1735 which mention that github.com/OSGeo/homebrew-osgeo4mac will move someday to the geospatial tap.
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream qwt-qt4 from github.com/OSGeo/homebrew-osgeo4mac. I edited out the comment where it appears some work had begun to bottle the formula, but was incomplete.