### PR TITLE
objconv 2.24 (new formula)

### DIFF
--- a/Formula/objconv.rb
+++ b/Formula/objconv.rb
@@ -1,0 +1,23 @@
+class Objconv < Formula
+  desc "Object file converter and disassembler"
+  homepage "http://www.agner.org/optimize/#objconv"
+  url "http://www.agner.org/optimize/objconv.zip"
+  version "2.42"
+  sha256 "01bc452c334e3105a516ffcab854b9af2b71c9505fd05681848b051ebf8337f4"
+  def install
+    system "unzip", "source.zip",
+                    "-dsrc"
+    # objconv doesn't have a Makefile, so we have to call
+    # the C++ compiler ourselves
+    system ENV.cxx, "-o", "objconv",
+                    "-O2",
+                    *Dir["src/*.cpp"],
+                    "--prefix=#{prefix}"
+    bin.install "objconv"
+  end
+
+  test do
+    system "#{bin}/objconv", "-h"
+    # TODO: write better tests
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`objconv` is a GPL program by Agner Fog. It is a utility for converting object files between the COFF/PE, OMF, ELF and Mach-O formats. See http://www.agner.org/optimize/#objconv for more information.

Note that the test currently included for this formula is just `objconv -h`. I'd like to improve the tests eventually.