### PR TITLE
wine: fix version mismatch in devel mirror

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -28,7 +28,7 @@ class Wine < Formula
 
   devel do
     url "https://dl.winehq.org/wine/source/1.9/wine-1.9.22.tar.bz2"
-    mirror "https://downloads.sourceforge.net/project/wine/Source/wine-1.9.21.tar.bz2"
+    mirror "https://downloads.sourceforge.net/project/wine/Source/wine-1.9.22.tar.bz2"
     sha256 "a3bf8e1ac7c7a742601e4215687c8374dda4050ea64c0fc90fb196645a41ec41"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello,

the commit fixes version mismatch in devel mirror.

Thanks!