### PR TITLE
LDNS support for plugins

### DIFF
--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -25,6 +25,7 @@ class DnscryptProxy < Formula
 
   depends_on "libsodium"
   depends_on "minisign" => :recommended
+  depends_on "ldns" => :recommended
 
   def install
     system "autoreconf", "-if" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Included LDNS as a recommended dependency for dnscrypt-proxy formula in order to resolve missing example plugins (e.g. `libdcplugin_example_ldns_aaaa_blocking.so` and `libdcplugin_example_ldns_blocking.so`). Related to #6244.