### PR TITLE
qxmpp: use Qt5.

### DIFF
--- a/Formula/qxmpp.rb
+++ b/Formula/qxmpp.rb
@@ -3,6 +3,7 @@ class Qxmpp < Formula
   homepage "https://github.com/qxmpp-project/qxmpp/"
   url "https://github.com/qxmpp-project/qxmpp/archive/v0.9.3.tar.gz"
   sha256 "13f5162a1df720702c6ae15a476a4cb8ea3e57d861a992c4de9147909765e6de"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Qxmpp < Formula
     sha256 "1ed8aeb55b725d9ea9f78be16a58d72ceb1b08c81c3ccc16f00634e552bc5514" => :mavericks
   end
 
-  depends_on "qt"
+  depends_on "qt5"
 
   def install
     system "qmake", "-config", "release", "PREFIX=#{prefix}"

--- a/Formula/qxmpp.rb
+++ b/Formula/qxmpp.rb
@@ -19,4 +19,31 @@ class Qxmpp < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    (testpath/"test.pro").write <<-EOS.undent
+      TEMPLATE     = app
+      CONFIG      += console
+      CONFIG      -= app_bundle
+      TARGET       = test
+      QT          += network
+      SOURCES     += test.cpp
+      INCLUDEPATH += #{include}
+      LIBPATH     += #{lib}
+      LIBS        += -lqxmpp
+    EOS
+
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <qxmpp/QXmppClient.h>
+      int main() {
+        QXmppClient client;
+        return 0;
+      }
+    EOS
+
+    system "#{Formula["qt5"].bin}/qmake", "test.pro"
+    system "make"
+    assert File.exist?("test"), "test output file does not exist!"
+    system "./test"
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Qt4 is EOL.