### PR TITLE
qjson: move to using Qt5.

### DIFF
--- a/Formula/qjson.rb
+++ b/Formula/qjson.rb
@@ -1,9 +1,9 @@
 class Qjson < Formula
   desc "Map JSON to QVariant objects"
-  homepage "http://qjson.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/qjson/qjson/0.8.1/qjson-0.8.1.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/q/qjson/qjson_0.8.1.orig.tar.bz2"
-  sha256 "cd4db5b956247c4991a9c3e95512da257cd2a6bd011357e363d02300afc814d9"
+  homepage "https://github.com/flavio/qjson"
+  url "https://github.com/flavio/qjson/archive/0.8.1.tar.gz"
+  sha256 "920c94166cb91b1cf11c7d2745bdbcc8c0ea82411ca7b3732ce0b00ee2d56e98"
+  revision 1
   head "https://github.com/flavio/qjson.git"
 
   bottle do
@@ -15,7 +15,7 @@ class Qjson < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt5"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Qt4 is EOL. Also, use GitHub tarball.