### PR TITLE
imagesnap: use 10.11 bottle on 10.12.

### DIFF
--- a/Formula/imagesnap.rb
+++ b/Formula/imagesnap.rb
@@ -7,7 +7,7 @@ class Imagesnap < Formula
   bottle do
     cellar :any_skip_relocation
     revision 1
-    sha256 "79b7735956a130731615aacf83610110a8b01a9e63eccbb8888687e8dadb1133" => :el_capitan
+    sha256 "79b7735956a130731615aacf83610110a8b01a9e63eccbb8888687e8dadb1133" => :el_capitan_or_later
     sha256 "a8326b38e6f61d48ccd738482b353a714ededbe5dd16a2fb31aae0a575ebf2cc" => :yosemite
     sha256 "b2b1d9d52e2c5284ece4d846a4cff19d417132265f53dd5e1a0c02a964076f90" => :mavericks
     sha256 "31fb3b202848e852d647a11c50634971f4c33dd61c0222f787a81fd7546ab973" => :mountain_lion

--- a/Formula/imagesnap.rb
+++ b/Formula/imagesnap.rb
@@ -20,4 +20,8 @@ class Imagesnap < Formula
     xcodebuild "-project", "ImageSnap.xcodeproj", "SYMROOT=build", "-sdk", "macosx#{MacOS.version}"
     bin.install "build/Release/imagesnap"
   end
+
+  test do
+    assert_match "imagesnap", shell_output("#{bin}/imagesnap -h")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It's used so let's allow people to use the bottle on Sierra.