### PR TITLE
dbus: add manpages and missing build dependencies

### DIFF
--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -29,11 +29,6 @@ class Dbus < Formula
 
   depends_on "xmlto" => :build
 
-  # Docbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
-  # install() uses files created by docbook, so best to be explicit in case
-  # the install process for docbook ever stops creating those files.
-  depends_on "docbook" => :build
-
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
   patch do
@@ -45,8 +40,6 @@ class Dbus < Formula
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
 
-    # Manpages won't build without a current docbook catalog. This should exist
-    # if xmlto and docbook (build dependencies of this package) are installed.
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     system "./autogen.sh", "--no-configure" if build.head?

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -5,6 +5,7 @@ class Dbus < Formula
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.12.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.12.orig.tar.gz"
   sha256 "210a79430b276eafc6406c71705e9140d25b9956d18068df98a70156dc0e475d"
+  head "https://anongit.freedesktop.org/git/dbus/dbus.git"
 
   bottle do
     sha256 "8848b7e368750df3a9526f4c5d47a0649359e9e89cd9d94cb45e706402bdb66c" => :sierra
@@ -18,13 +19,16 @@ class Dbus < Formula
     sha256 "474de2afde8087adbd26b3fc5cbf6ec45559763c75b21981169a9a1fbac256c9"
   end
 
-  head do
-    url "https://anongit.freedesktop.org/git/dbus/dbus.git"
+  depends_on "autoconf" => :build
+  depends_on "autoconf-archive" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "xmlto" => :build
 
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  # Docbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
+  # install() uses files created by docbook, so best to be explicit in case
+  # the install process for docbook ever stops creating those files.
+  depends_on "docbook" => :build
 
   # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
   # Homebrew pr/issue: 50219
@@ -36,13 +40,15 @@ class Dbus < Formula
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
-
-    system "./autogen.sh", "--no-configure" if build.head?
+    # Manpages won't build without a current docbook catalog. This should exist
+    # if xmlto and docbook (build dependencies of this package) are installed.
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+    system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
                           "--sysconfdir=#{etc}",
-                          "--disable-xml-docs",
+                          "--enable-xml-docs",
                           "--disable-doxygen-docs",
                           "--enable-launchd",
                           "--with-launchd-agent-dir=#{prefix}",

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -29,7 +29,7 @@ class Dbus < Formula
 
   depends_on "xmlto" => :build
 
-  # doccbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
+  # Docbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
   # install() uses files created by docbook, so best to be explicit in case
   # the install process for docbook ever stops creating those files.
   depends_on "docbook" => :build

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -5,7 +5,6 @@ class Dbus < Formula
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.12.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.12.orig.tar.gz"
   sha256 "210a79430b276eafc6406c71705e9140d25b9956d18068df98a70156dc0e475d"
-  head "https://anongit.freedesktop.org/git/dbus/dbus.git"
 
   bottle do
     sha256 "8848b7e368750df3a9526f4c5d47a0649359e9e89cd9d94cb45e706402bdb66c" => :sierra
@@ -19,13 +18,18 @@ class Dbus < Formula
     sha256 "474de2afde8087adbd26b3fc5cbf6ec45559763c75b21981169a9a1fbac256c9"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "autoconf-archive" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
+  head do
+    url "https://anongit.freedesktop.org/git/dbus/dbus.git"
+
+    depends_on "autoconf" => :build
+    depends_on "autoconf-archive" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "xmlto" => :build
 
-  # Docbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
+  # doccbook is a dependency of xmlto, but the XML_CATALOG_FILES env-set in
   # install() uses files created by docbook, so best to be explicit in case
   # the install process for docbook ever stops creating those files.
   depends_on "docbook" => :build
@@ -40,10 +44,12 @@ class Dbus < Formula
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
+    
     # Manpages won't build without a current docbook catalog. This should exist
     # if xmlto and docbook (build dependencies of this package) are installed.
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-    system "./autogen.sh"
+
+    system "./autogen.sh", "--no-configure" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -44,7 +44,7 @@ class Dbus < Formula
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
-    
+
     # Manpages won't build without a current docbook catalog. This should exist
     # if xmlto and docbook (build dependencies of this package) are installed.
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There are a few problems with the `dbus` formula:
- This package has many scripts, all of which have manpages. However, those manpages aren't available in many standard (e.g. linux.die) websites, and are not compiled when this package is built. We should build the manpages. This requires some new build-time dependencies.
- Building at `HEAD` (and possibly elsewhere) requires `autoconf-archive`, which is not listed as a dependency, and the build fails as a result.
- `--build-from-source` is totally broken, since all of the build toolchain dependencies are inside a `head` block, preventing the toolchain from being available unless building at `HEAD`.
- [Re]configure bootstrapping is disabled unless building at `HEAD`. This prevents documentation from building, and, aside from another ~6sec of build time (which isn't bad, considering what DBus is), is a totally unnecessary behavior fork. However, if there's good reason to leave this override in place, I am happy to undo this change.

Ordinarily I'd fix some of those in separate PRs, but they all block my ability to add the manpages (the real goal), so I'll fix 'em all in this PR.