### PR TITLE
tmux: enhance Formula to make utf8proc support optional

### DIFF
--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -3,7 +3,7 @@ class Tmux < Formula
   homepage "https://tmux.github.io/"
   url "https://github.com/tmux/tmux/releases/download/2.3/tmux-2.3.tar.gz"
   sha256 "55313e132f0f42de7e020bf6323a1939ee02ab79c48634aa07475db41573852b"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -22,7 +22,7 @@ class Tmux < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libevent"
-  depends_on "utf8proc"
+  depends_on "utf8proc" => :optional
 
   resource "completion" do
     url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/homebrew_1.0.0/completions/tmux"
@@ -32,11 +32,16 @@ class Tmux < Formula
   def install
     system "sh", "autogen.sh" if build.head?
 
+    args = %W[
+      --disable-Dependency-tracking
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+    ]
+
+    args << "--enable-utf8proc" if build.with?("utf8proc")
+
     ENV.append "LDFLAGS", "-lresolv"
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
-                          "--enable-utf8proc"
+    system "./configure", *args
 
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change enhances the `tmux` Formula so that `utf8proc` support is an
opt-in change when building `tmux`.

There have been reports of rendering issues in versions of `tmux` when
`utf8proc` support is enabled. Specifically these issues appear to
happen when special symbols are printed, such as those commonly used in
the powerline-themed status lines and shell prompts.

The change to include `utf8proc` in `tmux` was in Homebrew PR #5665. In
that some PR some `tmux` users have reported issues with text being
rendered in builds of `tmux`. There are also some other issues on the
`tmux` tracker around similar rendering problems:

* https://github.com/tmux/tmux/issues/631
* https://github.com/tmux/tmux/issues/632
* https://github.com/tmux/tmux/issues/637
* https://github.com/tmux/tmux/issues/639