### PR TITLE
portmidi, add universal build option

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -14,6 +14,7 @@ class Portmidi < Formula
   end
 
   option "with-java", "Build Java-based app and bindings."
+  option :universal
 
   depends_on "cmake" => :build
   depends_on :python => :optional
@@ -29,6 +30,8 @@ class Portmidi < Formula
   end
 
   def install
+    ENV.universal_binary if build.universal?
+
     inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
 
     # need to create include/lib directories since make won't create them itself


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? 
-> No as there are no tests.

-----

This PR adds an `:universal` build option.

Short validation:
```
$ brew install portmidi --universal
Updating Homebrew...
==> Using the sandbox
==> Downloading https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip
Already downloaded: /Users/tommy/Library/Caches/Homebrew/portmidi-217.zip
==> Patching
patching file pm_common/CMakeLists.txt
==> make -f pm_mac/Makefile.osx
==> make -f pm_mac/Makefile.osx install
🍺  /usr/local/Cellar/portmidi/217: 8 files, 149.6K, built in 11 seconds
```

```
$ file /usr/local/Cellar/portmidi/217/lib/libportmidi.dylib 
/usr/local/Cellar/portmidi/217/lib/libportmidi.dylib: Mach-O universal binary with 2 architectures: [x86_64: Mach-O 64-bit dynamically linked shared library x86_64] [i386: Mach-O dynamically linked shared library i386]
/usr/local/Cellar/portmidi/217/lib/libportmidi.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
/usr/local/Cellar/portmidi/217/lib/libportmidi.dylib (for architecture i386):	Mach-O dynamically linked shared library i386
```