### PR TITLE
osm2pgrouting 2.2.0

### DIFF
--- a/Formula/osm2pgrouting.rb
+++ b/Formula/osm2pgrouting.rb
@@ -1,8 +1,8 @@
 class Osm2pgrouting < Formula
   desc "Import OSM data into pgRouting database"
   homepage "http://pgrouting.org/docs/tools/osm2pgrouting.html"
-  url "https://github.com/pgRouting/osm2pgrouting/archive/osm2pgrouting-2.0.0.tar.gz"
-  sha256 "607e67b85664a40a495bfa37fdc236b617c3c6b41c3aa4fd68f780ba6a629469"
+  url "https://github.com/pgRouting/osm2pgrouting/archive/v2.2.0.tar.gz"
+  sha256 "bdd3095123cf21ee2f56e5cf04b2ea7b781dea629bff909fa45ebc5dbe50f8a6"
   head "https://github.com/pgRouting/osm2pgrouting.git"
 
   bottle do
@@ -15,23 +15,24 @@ class Osm2pgrouting < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
+  depends_on "expat"
+  depends_on "pgrouting"
+  depends_on "postgis"
   depends_on :postgresql
 
   def install
-    # Fixes the default hard-coded /usr/share which the program would be installed in.
-    # Instead we supply relative paths, and run cmake with flag -DCMAKE_INSTALL_PREFIX=#{prefix} so that
-    # we get a proper path inside prefix.
     inreplace "CMakeLists.txt" do |s|
-      s.gsub! "/usr/share/osm2pgrouting", "."
-      s.gsub! "/usr/share/bin", "bin"
+      s.gsub! "RUNTIME DESTINATION \"/usr/bin\"",
+              "RUNTIME DESTINATION \"#{bin}\""
+      s.gsub! "set (SHARE_DIR \"/usr/share/osm2pgrouting\")",
+              "set (SHARE_DIR \"#{pkgshare}\")"
     end
 
     system "cmake", ".", *std_cmake_args
-    system "make"
     system "make", "install"
   end
 
   test do
-    shell_output("#{bin}/osm2pgrouting", 1)
+    system bin/"osm2pgrouting", "--help"
   end
 end


### PR DESCRIPTION
add dependencies listed by upstream
update string replacements
use `system` in the test since the exit code is now zero

Supersedes #6042.