### PR TITLE
i2p 0.9.27

### DIFF
--- a/Formula/i2p.rb
+++ b/Formula/i2p.rb
@@ -1,8 +1,8 @@
 class I2p < Formula
   desc "Anonymous overlay network - a network within a network"
   homepage "https://geti2p.net"
-  url "https://download.i2p2.de/releases/0.9.26/i2pinstall_0.9.26.jar"
-  sha256 "563eb6f2cb9220c380190e90290cd154da3f30b4fa96a212a80e4bbc7a8fd44f"
+  url "https://download.i2p2.de/releases/0.9.27/i2pinstall_0.9.27.jar"
+  sha256 "5e9ae0b1e8fb5707ae6903e09aa1110b6d98742b5c2952f24667133e563843f0"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source i2p`
- [ ] Does your build pass `brew audit --strict i2p` (after doing `brew install i2p`)?

-----

Updated i2p from 0.9.26 to 0.9.27

### Assistance needed
Was unable to do an audit with `brew audit --strict i2p`. It gave me the following error:
```
i2p:
  * The installation was broken.
    Broken dylib links found:
      /usr/lib/libgcc_s_ppc64.1.dylib
```
