### PR TITLE
Fix bug #6889 mysql++ blocks mysql

### DIFF
--- a/Formula/mysql++.rb
+++ b/Formula/mysql++.rb
@@ -13,7 +13,7 @@ class Mysqlxx < Formula
     sha256 "154e219e9cac151437d47b281ca35aa35eaf3d510b04f5e9886a0257a983a760" => :mountain_lion
   end
 
-  depends_on "mysql-connector-c"
+  depends_on :mysql
 
   def install
     system "./configure", "--disable-debug",
@@ -23,5 +23,20 @@ class Mysqlxx < Formula
                           "--with-mysql-lib=#{HOMEBREW_PREFIX}/lib",
                           "--with-mysql-include=#{HOMEBREW_PREFIX}/include"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <mysql++/cmdline.h>
+      int main(int argc, char *argv[]) {
+        mysqlpp::examples::CommandLine cmdline(argc, argv);
+        if (!cmdline) {
+          return 1;
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lmysqlpp", "-o", "test"
+    system "./test", "-u", "foo", "-p", "bar"
   end
 end

--- a/Formula/mysql++.rb
+++ b/Formula/mysql++.rb
@@ -16,12 +16,13 @@ class Mysqlxx < Formula
   depends_on :mysql
 
   def install
+    mysql_include_dir = %x(mysql_config --variable=pkgincludedir)
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-field-limit=40",
                           "--with-mysql-lib=#{HOMEBREW_PREFIX}/lib",
-                          "--with-mysql-include=#{HOMEBREW_PREFIX}/include"
+                          "--with-mysql-include=#{mysql_include_dir}"
     system "make", "install"
   end
 

--- a/Formula/mysql++.rb
+++ b/Formula/mysql++.rb
@@ -16,7 +16,7 @@ class Mysqlxx < Formula
   depends_on :mysql
 
   def install
-    mysql_include_dir = %x(mysql_config --variable=pkgincludedir)
+    mysql_include_dir = `mysql_config --variable=pkgincludedir`
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -37,7 +37,7 @@ class Mysqlxx < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-L#{lib}", "-lmysqlpp", "-o", "test"
+    system ENV.cxx, "test.cpp", `mysql_config --include`.chomp, "-L#{lib}", "-lmysqlpp", "-o", "test"
     system "./test", "-u", "foo", "-p", "bar"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Also added a trivial test