### PR TITLE
fluid-synth: add universal build option

### DIFF
--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -14,6 +14,8 @@ class FluidSynth < Formula
     sha256 "83b972cf7aec57e78dc1c1a6b3e286d8b9bf2a2622e174bca42efa8576e36e5f" => :mountain_lion
   end
 
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "glib"
@@ -21,6 +23,8 @@ class FluidSynth < Formula
   depends_on "portaudio" => :optional
 
   def install
+    ENV.universal_binary if build.universal?
+
     args = std_cmake_args
     args << "-Denable-framework=OFF" << "-DLIB_SUFFIX="
     args << "-Denable-portaudio=ON" if build.with? "portaudio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add a `:universal` build option to `fluid-synth`.

Short validation:
```
$ file /usr/local/Cellar/fluid-synth/1.1.6/bin/fluidsynth
/usr/local/Cellar/fluid-synth/1.1.6/bin/fluidsynth: Mach-O universal binary with 2 architectures: [x86_64: Mach-O 64-bit executable x86_64] [i386: Mach-O executable i386]
/usr/local/Cellar/fluid-synth/1.1.6/bin/fluidsynth (for architecture x86_64):	Mach-O 64-bit executable x86_64
/usr/local/Cellar/fluid-synth/1.1.6/bin/fluidsynth (for architecture i386):	Mach-O executable i386
```

```
$ file /usr/local/Cellar/fluid-synth/1.1.6/lib/libfluidsynth.dylib 
/usr/local/Cellar/fluid-synth/1.1.6/lib/libfluidsynth.dylib: Mach-O universal binary with 2 architectures: [x86_64: Mach-O 64-bit dynamically linked shared library x86_64] [i386: Mach-O dynamically linked shared library i386]
/usr/local/Cellar/fluid-synth/1.1.6/lib/libfluidsynth.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
/usr/local/Cellar/fluid-synth/1.1.6/lib/libfluidsynth.dylib (for architecture i386):	Mach-O dynamically linked shared library i386
```