### PR TITLE
dmd use upstream VERSION file

### DIFF
--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -47,11 +47,6 @@ class Dmd < Formula
   def install
     make_args = ["INSTALL_DIR=#{prefix}", "MODEL=#{Hardware::CPU.bits}", "-f", "posix.mak"]
 
-    # VERSION file is wrong upstream, has happened before, so we just overwrite it here.
-    version_file = (buildpath/"VERSION")
-    rm version_file
-    version_file.write version
-
     system "make", "SYSCONFDIR=#{etc}", "TARGET_CPU=X86", "AUTO_BOOTSTRAP=1", "RELEASE=1", *make_args
 
     bin.install "src/dmd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It was a bad idea to do this as it messes up HEAD and devel builds (version formatting for homebrew isn't necessarily the same as for dmd). Better to use a patch if a mistake is made upstream again.

