### PR TITLE
Fixed apache-geode forumla to not use Java 1.9

### DIFF
--- a/Formula/apache-geode.rb
+++ b/Formula/apache-geode.rb
@@ -7,6 +7,7 @@ class ApacheGeode < Formula
 
   bottle :unneeded
 
+  # Geode does not work with Java 1.9 (see https://issues.apache.org/jira/browse/GEODE-3)
   depends_on :java => "1.8"
 
   def install

--- a/Formula/apache-geode.rb
+++ b/Formula/apache-geode.rb
@@ -7,13 +7,13 @@ class ApacheGeode < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def install
     rm_f "bin/gfsh.bat"
     bash_completion.install "bin/gfsh-completion.bash" => "gfsh"
     libexec.install Dir["*"]
-    (bin/"gfsh").write_env_script libexec/"bin/gfsh", Language::Java.java_home_env("1.8+")
+    (bin/"gfsh").write_env_script libexec/"bin/gfsh", Language::Java.java_home_env("1.8")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

 I encountered an error when running `brew audit --strict foo`:

```
apache-geode:
  * version should not decrease
Error: 1 problem in 1 formula
```
-----

