### PR TITLE
Adding biscuit v0.1.3

### DIFF
--- a/Formula/biscuit.rb
+++ b/Formula/biscuit.rb
@@ -1,0 +1,29 @@
+require "language/go"
+
+class Biscuit < Formula
+  desc     "Biscuit is a multi-region HA key-value store for your AWS infrastructure secrets"
+  homepage "https://github.com/dcoker/biscuit"
+  url      "https://github.com/dcoker/biscuit.git", :tag => "v0.1.3"
+  version  "0.1.3"
+  sha256   "0461ddb50f74b46d125939b2216be1bb283188f7c5393b940204de89f72f3e2f"
+
+  head "https://github.com/dcoker/biscuit.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    contents = buildpath.children - [buildpath/".brew_home"]
+    (buildpath/"src/github.com/dcoker/biscuit").install contents
+
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    cd "src/github.com/dcoker/biscuit" do
+      system "go", "get", "-v", "./..."
+      system "go", "build", "-v"
+      bin.install "biscuit"
+      prefix.install_metafiles
+    end
+  end
+end


### PR DESCRIPTION
[biscuit](https://github.com/dcoker/biscuit) is a multi-region HA key-value store for your AWS infrastructure secrets.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?