### PR TITLE
xstow: allow to build with clang compiler

### DIFF
--- a/Formula/xstow.rb
+++ b/Formula/xstow.rb
@@ -11,12 +11,10 @@ class Xstow < Formula
     sha256 "f8b4bd43dce5410280683721e4bbff8419a671f6764215d20bc4d17eddc00863" => :mavericks
   end
 
-  fails_with :clang do
-    cause <<-EOS.undent
-      clang does not support unqualified lookups in c++ templates, see:
-      http://clang.llvm.org/compatibility.html#dep_lookup
-      EOS
-  end
+  # Patches to allow clang to compile
+  # Patches from: https://svnweb.freebsd.org/ports?view=revision&revision=319588
+  # Upstream bug report: https://sourceforge.net/p/xstow/bugs/7/
+  patch :p0, :DATA
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
@@ -28,3 +26,35 @@ class Xstow < Formula
     system "#{bin}/xstow", "-Version"
   end
 end
+
+__END__
+diff -u src/string_utils.h~ src/string_utils.h
+--- src/string_utils.h~	2013-06-01 23:10:50.000000000 +0300
++++ src/string_utils.h	2013-06-01 22:56:43.000000000 +0300
+@@ -28,6 +28,9 @@
+ #  define STRSTREAM
+ #endif  
+ 
++typedef std::vector<std::string> vec_string;
++std::ostream& operator<<( std::ostream& out, const vec_string &v );
++
+ std::string toupper( std::string s );
+ std::string strip( const std::string& str, const std::string& what = " \t\n\0" );
+ bool is_int( const std::string &s );
+diff -u src/leoini.h~ src/leoini.h
+--- src/leoini.h~	2013-06-01 22:28:45.000000000 +0300
++++ src/leoini.h	2013-06-01 22:32:05.000000000 +0300
+@@ -260,11 +260,9 @@
+ 
+     if( start == std::string::npos ||
+ 	end == std::string::npos )
+-      s = "";
+-    else
+-      s = s.substr( start+1, start-end -1 );
++      return s2x<A>("");
+ 
+-    return s2x<A>(s);
++    return s2x<A>(s.substr( start+1, start-end -1 ));
+   }
+ } // namespace Leo
+ 


### PR DESCRIPTION
- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Patch to allow building with clang compiler.
Patch source: https://svnweb.freebsd.org/ports?view=revision&revision=319588
Upstream bug report: https://sourceforge.net/p/xstow/bugs/7/