### PR TITLE
Metricbeat 5.0.1

### DIFF
--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -1,8 +1,8 @@
 class Metricbeat < Formula
   desc "Collect metrics from your systems and services."
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://github.com/elastic/beats/archive/v5.0.0.tar.gz"
-  sha256 "3e6b7cf2ee5f52e78ae87ef04ab9dd49977c89f86a09416586896aeaea844e34"
+  url "https://github.com/elastic/beats/archive/v5.0.1.tar.gz"
+  sha256 "707bea8d8eb8cc358bddfcaffa5e90da2a09fab00f2fc53608cc013c79743117"
 
   head "https://github.com/elastic/beats.git"
 


### PR DESCRIPTION
This commit bumps the version for the Metricbeat formula from version
5.0.0. to version 5.0.1.