### PR TITLE
tarsnapper 0.3.0 (new formula)

### DIFF
--- a/Formula/tarsnapper.rb
+++ b/Formula/tarsnapper.rb
@@ -43,24 +43,10 @@ class Tarsnapper < Formula
   end
 
   test do
-    (testpath/"tarsnapper.conf").write <<-EOF.undent
-      deltas: 1d 7d 30d
-      target: /localmachine/$name-$date
-
-      jobs:
-        tarsnapper-homebrew:
-          source: #{testpath}
-    EOF
-
-    # Using "--dry-run" ensures that tarsnap doesn't create an actual backup.
-    #
-    # WARNING:
-    # The user running the tests needs to have a valid ~/.tarsnaprc setup as
-    # tarsnapper invokes tarsnap directly.
-    #
-    # Although tarsnap supports to dry-run backups without a valid tarsnap key
-    # and config (via the "--no-default-config" option), tarsnapper doesn't
-    # provide support for this.
-    system bin/"tarsnapper", "--config", testpath/"tarsnapper.conf", "make", "--dry-run"
+    # A better test would be to run "tarsnapper make --dry-run". This would
+    # force the tester and CI system to have a tarsnap.com account. Calling
+    # "--help" to verify that the python dependencies are setup correctly is
+    # the next best option: https://github.com/Homebrew/homebrew-core/pull/6956
+    system bin/"tarsnapper", "--help"
   end
 end

--- a/Formula/tarsnapper.rb
+++ b/Formula/tarsnapper.rb
@@ -43,10 +43,6 @@ class Tarsnapper < Formula
   end
 
   test do
-    # A better test would be to run "tarsnapper make --dry-run". This would
-    # force the tester and CI system to have a tarsnap.com account. Calling
-    # "--help" to verify that the python dependencies are setup correctly is
-    # the next best option: https://github.com/Homebrew/homebrew-core/pull/6956
-    system bin/"tarsnapper", "--help"
+    assert_match /usage: tarsnapper/, shell_output("#{bin}/tarsnapper --help")
   end
 end

--- a/Formula/tarsnapper.rb
+++ b/Formula/tarsnapper.rb
@@ -1,0 +1,66 @@
+class Tarsnapper < Formula
+  include Language::Python::Virtualenv
+
+  desc "tarsnap wrapper which expires backups using a gfs-scheme."
+  homepage "https://github.com/miracle2k/tarsnapper"
+  url "https://github.com/miracle2k/tarsnapper/archive/0.3.0.tar.gz"
+  sha256 "519d95a91c436e8bd8379d74d9747cafffab8ee35d26d754bfe84cbbb074aa54"
+
+  depends_on "tarsnap"
+
+  resource "argparse" do
+    url "https://pypi.python.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz"
+    sha256 "62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4"
+  end
+
+  resource "pexpect" do
+    url "https://pypi.python.org/packages/e8/13/d0b0599099d6cd23663043a2a0bb7c61e58c6ba359b2656e6fb000ef5b98/pexpect-4.2.1.tar.gz"
+    sha256 "3d132465a75b57aa818341c6521392a06cc660feb3988d7f1074f39bd23c9a92"
+  end
+
+  resource "PyYAML" do
+    url "https://pypi.python.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"
+    sha256 "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab"
+  end
+
+  resource "python-dateutil" do
+    url "https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
+    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+  end
+
+  resource "ptyprocess" do
+    url "https://pypi.python.org/packages/db/d7/b465161910f3d1cef593c5e002bff67e0384898f597f1a7fdc8db4c02bf6/ptyprocess-0.5.1.tar.gz"
+    sha256 "0530ce63a9295bfae7bd06edc02b6aa935619f486f0f1dc0972f516265ee81a6"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"tarsnapper.conf").write <<-EOF.undent
+      deltas: 1d 7d 30d
+      target: /localmachine/$name-$date
+
+      jobs:
+        tarsnapper-homebrew:
+          source: #{testpath}
+    EOF
+
+    # Using "--dry-run" ensures that tarsnap doesn't create an actual backup.
+    #
+    # WARNING:
+    # The user running the tests needs to have a valid ~/.tarsnaprc setup as
+    # tarsnapper invokes tarsnap directly.
+    #
+    # Although tarsnap supports to dry-run backups without a valid tarsnap key
+    # and config (via the "--no-default-config" option), tarsnapper doesn't
+    # provide support for this.
+    system bin/"tarsnapper", "--config", testpath/"tarsnapper.conf", "make", "--dry-run"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[tarsnapper](https://github.com/miracle2k/tarsnapper/) is a wrapper for [tarsnap](https://www.tarsnap.com).

This is my first contribution. I'm not sure if I took the right decision to have a "real" test instead of just running the program to see if it can output the "--help" output. As you can read in my comments, running the test currently requires a setup ".tarsnaprc" which in turns requires to have an account at   [tarsnap](https://www.tarsnap.com).