### PR TITLE
Poppler 0.49.0

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha256 "cb90f2e0fd4bc3fe235111f982bc20455a1d6bc13f4219babcba6bd60c1fe466"
-  revision 14
+  revision 15
 
   bottle do
     cellar :any

--- a/Formula/pdf2htmlex.rb
+++ b/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.14.6.tar.gz"
   sha256 "320ac2e1c2ea4a2972970f52809d90073ee00a6c42ef6d9833fb48436222f0e5"
-  revision 7
+  revision 8
 
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -3,7 +3,7 @@ class Pdftoedn < Formula
   homepage "https://github.com/edporras/pdftoedn"
   url "https://github.com/edporras/pdftoedn/archive/v0.34.1.tar.gz"
   sha256 "d00ed04a4f58cc1163cc581cf738e53d872ea59f9e5f94fa9cc61ef59b8d9c13"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -1,8 +1,8 @@
 class Poppler < Formula
   desc "PDF rendering library (based on the xpdf-3.0 code base)"
   homepage "https://poppler.freedesktop.org/"
-  url "https://poppler.freedesktop.org/poppler-0.48.0.tar.xz"
-  sha256 "85a003968074c85d8e13bf320ec47cef647b496b56dcff4c790b34e5482fef93"
+  url "https://poppler.freedesktop.org/poppler-0.49.0.tar.xz"
+  sha256 "14485f0e1e43dcddf49cfc02c2ccb92910ba3e0e91e06f4bd2642ec00cb3a79f"
 
   bottle do
     sha256 "88dded32895ac3807b5e7496a60f63598c82fceba3b77577d405805b61440a52" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit` reports the following error:

```sh
admin@doppio $ brew audit --new-formula poppler.rb 
==> Installing or updating 'rubocop' gem
Fetching: rubocop-0.45.0.gem (100%)
Successfully installed rubocop-0.45.0
1 gem installed
poppler:
  * New formulae should not use `deprecated_option`.
Error: 1 problem in 1 formula
```

Should I really remove those options?