### PR TITLE
goenv: move to correct directory.

### DIFF
--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -1,7 +1,7 @@
 class Goenv < Formula
   desc "Go version management"
   homepage "https://github.com/syndbg/goenv"
-  url "https://github.com/syndbg/goenv/archive/20161028.tar.gz"
+  url "https://github.com/syndbg/goenv/archive/v20161028.tar.gz"
   sha256 "3f283537c2b4f64a7549a009361ac4da6115be6b2c45462b008a58f8366a8804"
   head "https://github.com/syndbg/goenv.git"
 
@@ -25,6 +25,6 @@ class Goenv < Formula
   end
 
   test do
-    shell_output("eval \"$(#{bin}/goenv init -)\" && goenv versions")
+    assert_match "Usage: goenv <command> [<args>]", shell_output("#{bin}/goenv help")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#6832 seems to have dropped `goenv.rb` in the tap root, rather than in `Formula/`. This PR just moves it.

Edit: I also fixed the `url` and added `go` as a dep.