### PR TITLE
git: install netrc credential helper

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -105,6 +105,12 @@ class Git < Formula
       system "make", "clean"
     end
 
+    # Install the netrc credential helper
+    cd "contrib/credential/netrc" do
+      system "make", "test"
+      bin.install "git-credential-netrc"
+    end
+
     # Install git-subtree
     cd "contrib/subtree" do
       system "make", "CC=#{ENV.cc}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This might be a bit niche, but it supports gpg-encrypted `.netrc` files so it's a nice cross-platform helper (and one that doesn't add additional dependencies, like the libsecret one).