### PR TITLE
pcap_dnsproxy: fix plist issues

### DIFF
--- a/Formula/pcap_dnsproxy.rb
+++ b/Formula/pcap_dnsproxy.rb
@@ -21,36 +21,10 @@ class PcapDnsproxy < Formula
     xcodebuild "-project", "./Source/Pcap_DNSProxy.xcodeproj", "-target", "Pcap_DNSProxy", "-configuration", "Release", "SYMROOT=build"
     bin.install "Source/build/Release/Pcap_DNSProxy"
     (etc/"pcap_DNSproxy").install Dir["Source/ExampleConfig/*.{ini,txt}"]
+    prefix.install "Source/ExampleConfig/pcap_dnsproxy.service.plist"
   end
 
-  plist_options :startup => true, :manual => "sudo #{HOMEBREW_PREFIX}/opt/pcap_dnsproxy/bin/Pcap_DNSProxy -c #{HOMEBREW_PREFIX}/etc/pcap_dnsproxy/"
-
-  def plist; <<-EOS.undent
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/Pcap_DNSProxy</string>
-          <string>-c</string>
-          <string>#{etc}/pcap_DNSproxy/</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-        <key>SoftResourceLimits</key>
-        <dict>
-          <key>NumberOfFiles</key>
-          <integer>10240</integer>
-        </dict>
-      </dict>
-    </plist>
-    EOS
-  end
+  plist_options :startup => true, :manual => "sudo #{HOMEBREW_PREFIX}/opt/pcap_dnsproxy/bin/Pcap_DNSProxy -c #{HOMEBREW_PREFIX}/etc/pcap_DNSproxy/"
 
   test do
     (testpath/"pcap_DNSproxy").mkpath

--- a/Formula/pcap_dnsproxy.rb
+++ b/Formula/pcap_dnsproxy.rb
@@ -36,12 +36,17 @@ class PcapDnsproxy < Formula
         <array>
           <string>#{opt_bin}/Pcap_DNSProxy</string>
           <string>-c</string>
-          <string>#{etc}/pcap_dnsproxy/</string>
+          <string>#{etc}/pcap_DNSproxy/</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>
         <true/>
+        <key>SoftResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>10240</integer>
+        </dict>
       </dict>
     </plist>
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

1. case sensitivity fixed in the plist, via this [issue](https://github.com/chengr28/Pcap_DNSProxy/issues/190).
2. network error 24 fixed by increasing max open files, via this [issue](https://github.com/chengr28/Pcap_DNSProxy/pull/185).
