### PR TITLE
gpsbabel: add -std=c++11 to compilation flags

### DIFF
--- a/Formula/gpsbabel.rb
+++ b/Formula/gpsbabel.rb
@@ -17,6 +17,7 @@ class Gpsbabel < Formula
   depends_on "qt5"
 
   def install
+    ENV.cxx11
     args = ["--disable-debug", "--disable-dependency-tracking",
             "--prefix=#{prefix}"]
     args << "--without-libusb" if build.without? "libusb"


### PR DESCRIPTION
This one should fix issue #7023 .  As this is my first attempt at contributing, and I'm not sure if this is the most appropriate way of fixing, please review carefully!

Fixes #7023