### PR TITLE
gmic 1.7.9

### DIFF
--- a/Formula/gmic.rb
+++ b/Formula/gmic.rb
@@ -1,8 +1,8 @@
 class Gmic < Formula
   desc "Full-Featured Open-Source Framework for Image Processing"
   homepage "https://gmic.eu/"
-  url "https://gmic.eu/files/source/gmic_1.7.8.tar.gz"
-  sha256 "3a2f32d79714239cfa56ecb10799b7d73362b4e2a852444bc24866272cd041a4"
+  url "https://gmic.eu/files/source/gmic_1.7.9.tar.gz"
+  sha256 "93d8eb70780328fa207cef8555c77f7e9e5399ff7d204dfcab145809c51e34e4"
   head "https://github.com/dtschump/gmic.git"
 
   bottle do
@@ -33,9 +33,6 @@ class Gmic < Formula
     args << "-DENABLE_OPENEXR=OFF" if build.without? "openexr"
     system "cmake", *args
     system "make", "install"
-
-    # https://github.com/dtschump/gmic/issues/11
-    man1.install "man/gmic.1.gz"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi!

This PR upgrades gmic from version 1.7.8 to 1.7.9 and removes the manual installation of the manpage since this is now handled in the `make install` step.