### PR TITLE
Fix test call scopes

### DIFF
--- a/Formula/admesh.rb
+++ b/Formula/admesh.rb
@@ -33,6 +33,6 @@ class Admesh < Formula
       ENDFACET
       ENDSOLID Untitled1
     EOS
-    system "admesh", "test.stl"
+    system "#{bin}/admesh", "test.stl"
   end
 end

--- a/Formula/dirmngr.rb
+++ b/Formula/dirmngr.rb
@@ -36,7 +36,7 @@ class Dirmngr < Formula
   end
 
   test do
-    system "dirmngr-client", "--help"
-    system "dirmngr", "--help"
+    system "#{bin}/dirmngr-client", "--help"
+    system "#{bin}/dirmngr", "--help"
   end
 end

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -46,6 +46,6 @@ class Elinks < Formula
       <ol><li>one</li><li>two</li></ol>
     EOS
     assert_match /^\s*Hello world!\n+ *1. one\n *2. two\s*$/,
-                 shell_output("elinks test.html")
+                 shell_output("#{bin}/elinks test.html")
   end
 end

--- a/Formula/epeg.rb
+++ b/Formula/epeg.rb
@@ -28,7 +28,7 @@ class Epeg < Formula
   end
 
   test do
-    system "epeg", "--width=1",
+    system "#{bin}/epeg", "--width=1",
                    "--height=1",
                    test_fixtures("test.jpg")
     "out.jpg"

--- a/Formula/fsevent_watch.rb
+++ b/Formula/fsevent_watch.rb
@@ -21,6 +21,6 @@ class FseventWatch < Formula
   end
 
   test do
-    system "fsevent_watch", "--version"
+    system "#{bin}/fsevent_watch", "--version"
   end
 end

--- a/Formula/fsh.rb
+++ b/Formula/fsh.rb
@@ -25,6 +25,6 @@ class Fsh < Formula
   end
 
   test do
-    system "fsh", "-V"
+    system "#{bin}/fsh", "-V"
   end
 end

--- a/Formula/idnits.rb
+++ b/Formula/idnits.rb
@@ -20,7 +20,7 @@ class Idnits < Formula
 
   test do
     resource("test").stage do
-      system "idnits", "draft-ietf-tcpm-undeployed-03.txt"
+      system "#{bin}/idnits", "draft-ietf-tcpm-undeployed-03.txt"
     end
   end
 end

--- a/Formula/kakasi.rb
+++ b/Formula/kakasi.rb
@@ -21,7 +21,7 @@ class Kakasi < Formula
 
   test do
     hiragana = "\xa4\xa2 \xa4\xab \xa4\xb5"
-    romanji = pipe_output("kakasi -rh -ieuc -Ha", hiragana).chomp
+    romanji = pipe_output("#{bin}/kakasi -rh -ieuc -Ha", hiragana).chomp
     assert_equal "a ka sa", romanji
   end
 end

--- a/Formula/makeself.rb
+++ b/Formula/makeself.rb
@@ -18,6 +18,6 @@ class Makeself < Formula
   test do
     touch "testfile"
     system "tar", "cvzf", "testfile.tar.gz", "testfile"
-    system "makeself", ".", "testfile.run", '"A test file"', "echo"
+    system "#{bin}/makeself", ".", "testfile.run", '"A test file"', "echo"
   end
 end

--- a/Formula/mlogger.rb
+++ b/Formula/mlogger.rb
@@ -17,6 +17,6 @@ class Mlogger < Formula
   end
 
   test do
-    system "mlogger", "-i", "-d", "test"
+    system "#{bin}/mlogger", "-i", "-d", "test"
   end
 end

--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -36,6 +36,6 @@ class Mpw < Formula
 
   test do
     assert_equal "RoliQeka7/Deqi",
-      shell_output("mpw -u user -P password test.com 2>/dev/null").strip
+      shell_output("#{bin}/mpw -u user -P password test.com 2>/dev/null").strip
   end
 end

--- a/Formula/pinfo.rb
+++ b/Formula/pinfo.rb
@@ -28,6 +28,6 @@ class Pinfo < Formula
   end
 
   test do
-    system "pinfo", "-h"
+    system "#{bin}/pinfo", "-h"
   end
 end

--- a/Formula/pipemeter.rb
+++ b/Formula/pipemeter.rb
@@ -27,6 +27,6 @@ class Pipemeter < Formula
   end
 
   test do
-    assert_match "3.00B", pipe_output("pipemeter -r 2>&1 >/dev/null", "foo", 0)
+    assert_match "3.00B", pipe_output("#{bin}/pipemeter -r 2>&1 >/dev/null", "foo", 0)
   end
 end

--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -40,6 +40,6 @@ class Profanity < Formula
   end
 
   test do
-    system "profanity", "-v"
+    system "#{bin}/profanity", "-v"
   end
 end

--- a/Formula/redis-leveldb.rb
+++ b/Formula/redis-leveldb.rb
@@ -26,6 +26,6 @@ class RedisLeveldb < Formula
   end
 
   test do
-    system "redis-leveldb", "-h"
+    system "#{bin}/redis-leveldb", "-h"
   end
 end

--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -33,6 +33,6 @@ class Shellcheck < Formula
         echo "$f"
       done
     EOS
-    assert_match "[SC2045]", shell_output("shellcheck -f gcc #{sh}", 1)
+    assert_match "[SC2045]", shell_output("#{bin}/shellcheck -f gcc #{sh}", 1)
   end
 end

--- a/Formula/shyaml.rb
+++ b/Formula/shyaml.rb
@@ -35,8 +35,8 @@ class Shyaml < Formula
         - 1st
         - 2nd
     EOS
-    assert_equal "val", pipe_output("shyaml get-value key", yaml, 0)
-    assert_equal "1st", pipe_output("shyaml get-value arr.0", yaml, 0)
-    assert_equal "2nd", pipe_output("shyaml get-value arr.-1", yaml, 0)
+    assert_equal "val", pipe_output("#{bin}/shyaml get-value key", yaml, 0)
+    assert_equal "1st", pipe_output("#{bin}/shyaml get-value arr.0", yaml, 0)
+    assert_equal "2nd", pipe_output("#{bin}/shyaml get-value arr.-1", yaml, 0)
   end
 end

--- a/Formula/spawn-fcgi.rb
+++ b/Formula/spawn-fcgi.rb
@@ -24,6 +24,6 @@ class SpawnFcgi < Formula
   end
 
   test do
-    system "spawn-fcgi", "--version"
+    system "#{bin}/spawn-fcgi", "--version"
   end
 end

--- a/Formula/sshrc.rb
+++ b/Formula/sshrc.rb
@@ -20,6 +20,6 @@ class Sshrc < Formula
     EOS
     chmod 0755, testpath/"ssh"
     ENV.prepend_path "PATH", testpath
-    system "sshrc"
+    system "#{bin}/sshrc"
   end
 end

--- a/Formula/stklos.rb
+++ b/Formula/stklos.rb
@@ -23,6 +23,6 @@ class Stklos < Formula
   end
 
   test do
-    assert_equal "42", shell_output("stklos -e '(print (+ 41 1))'").chomp
+    assert_equal "42", shell_output("#{bin}/stklos -e '(print (+ 41 1))'").chomp
   end
 end

--- a/Formula/unarj.rb
+++ b/Formula/unarj.rb
@@ -27,7 +27,7 @@ class Unarj < Formula
   test do
     # Ensure that you can extract ARJ.EXE from a sample self-extracting file
     resource("testfile").stage do
-      system "unarj", "e", "ARJ286.EXE"
+      system "#{bin}/unarj", "e", "ARJ286.EXE"
       assert File.exist? "ARJ.EXE"
     end
   end

--- a/Formula/vpcs.rb
+++ b/Formula/vpcs.rb
@@ -21,6 +21,6 @@ class Vpcs < Formula
   end
 
   test do
-    system "vpcs", "--version"
+    system "#{bin}/vpcs", "--version"
   end
 end

--- a/Formula/webarchiver.rb
+++ b/Formula/webarchiver.rb
@@ -22,7 +22,7 @@ class Webarchiver < Formula
   end
 
   test do
-    system "webarchiver", "-url", "https://www.google.com", "-output", "foo.webarchive"
+    system "#{bin}/webarchiver", "-url", "https://www.google.com", "-output", "foo.webarchive"
     assert_match /Apple binary property list/, shell_output("file foo.webarchive", 0)
   end
 end

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -59,6 +59,6 @@ class Weechat < Formula
   end
 
   test do
-    system "weechat", "-r", "/quit"
+    system "#{bin}/weechat", "-r", "/quit"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit` gave a warning `fully scope test <method> calls` for a variety of methods called from the test blocks of various formulae. This branch fixes the majority of those relatively scoped method calls.