### PR TITLE
quantlib 1.9: fix flag for intra-day times

### DIFF
--- a/Formula/quantlib.rb
+++ b/Formula/quantlib.rb
@@ -29,10 +29,9 @@ class Quantlib < Formula
   end
 
   def install
-   
     args = []
     if build.with? "intraday"
-        args << "--enable-intraday"
+      args << "--enable-intraday"
     end
 
     ENV.cxx11 if build.cxx11?

--- a/Formula/quantlib.rb
+++ b/Formula/quantlib.rb
@@ -29,15 +29,12 @@ class Quantlib < Formula
   end
 
   def install
-    args = []
-    if build.with? "intraday"
-      args << "--enable-intraday"
-    end
-
     ENV.cxx11 if build.cxx11?
     (buildpath/"QuantLib").install buildpath.children if build.stable?
     cd "QuantLib" do
       system "./autogen.sh" if build.head?
+      args = []
+      args << "--enable-intraday" if build.with? "intraday"
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{prefix}",
                             "--with-lispdir=#{elisp}",

--- a/Formula/quantlib.rb
+++ b/Formula/quantlib.rb
@@ -20,6 +20,7 @@ class Quantlib < Formula
   end
 
   option :cxx11
+  option "with-intraday", "Enable intraday components to dates"
 
   if build.cxx11?
     depends_on "boost" => "c++11"
@@ -28,13 +29,21 @@ class Quantlib < Formula
   end
 
   def install
+   
+    args = []
+    if build.with? "intraday"
+        args << "--enable-intraday"
+    end
+
     ENV.cxx11 if build.cxx11?
     (buildpath/"QuantLib").install buildpath.children if build.stable?
     cd "QuantLib" do
       system "./autogen.sh" if build.head?
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{prefix}",
-                            "--with-lispdir=#{elisp}"
+                            "--with-lispdir=#{elisp}",
+                            *args
+
       system "make", "install"
       prefix.install_metafiles
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a flag, `--enable-intraday`, to the formula that enables 
intra-day data type during the installation of quantlib. Specifically,
the date specifications gain hours, minutes, seconds, milliseconds,
and microseconds. Related to issue in eddelbuettel/rquantlib#80
that warns on lack of intraday support.