### PR TITLE
clipper: fix service not allowing to configure address and port from a config file

### DIFF
--- a/Formula/clipper.rb
+++ b/Formula/clipper.rb
@@ -38,10 +38,6 @@ class Clipper < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/clipper</string>
-        <string>--address</string>
-        <string>127.0.0.1</string>
-        <string>--port</string>
-        <string>8377</string>
       </array>
       <key>EnvironmentVariables</key>
       <dict>


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- Yes, but it lacks any test as mentioned in https://github.com/Homebrew/homebrew-core/pull/3832#issuecomment-239514897
-----
Clipper allows configuring the address and port for the service in a ~/.clipper.json file, but the parameters passed from the command line (from the .plist) take precedence. As the used values are the default ones in Clipper if not specified, this change should not cause any issue for people without a config file.