### PR TITLE
Replace deprecated Utils::JSON in favor of corelib JSON

### DIFF
--- a/Formula/apache-zeppelin.rb
+++ b/Formula/apache-zeppelin.rb
@@ -30,7 +30,7 @@ class ApacheZeppelin < Formula
       begin
         sleep 10
         json_text = shell_output("curl -s http://localhost:9999/api/notebook/")
-        assert_operator Utils::JSON.load(json_text)["body"].length, :>=, 1
+        assert_operator JSON.parse(json_text)["body"].length, :>=, 1
       ensure
         system "#{bin}/zeppelin-daemon.sh", "stop"
       end

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -28,7 +28,7 @@ class AzureCli < Formula
   test do
     shell_output("#{bin}/azure telemetry --disable")
     json_text = shell_output("#{bin}/azure account env show AzureCloud --json")
-    azure_cloud = Utils::JSON.load(json_text)
+    azure_cloud = JSON.parse(json_text)
     assert_equal azure_cloud["name"], "AzureCloud"
     assert_equal azure_cloud["managementEndpointUrl"], "https://management.core.windows.net"
     assert_equal azure_cloud["resourceManagerEndpointUrl"], "https://management.azure.com/"

--- a/Formula/cfssl.rb
+++ b/Formula/cfssl.rb
@@ -35,7 +35,6 @@ class Cfssl < Formula
   end
 
   test do
-    require "utils/json"
     (testpath/"request.json").write <<-EOS.undent
     {
       "CN" : "Your Certificate Authority",
@@ -56,7 +55,7 @@ class Cfssl < Formula
     }
     EOS
     shell_output("#{bin}/cfssl genkey -initca request.json > response.json")
-    response = Utils::JSON.load(File.read(testpath/"response.json"))
+    response = JSON.parse(File.read(testpath/"response.json"))
     assert_match(/^-----BEGIN CERTIFICATE-----.*/, response["cert"])
     assert_match(/.*-----END CERTIFICATE-----$/, response["cert"])
     assert_match(/^-----BEGIN RSA PRIVATE KEY-----.*/, response["key"])

--- a/Formula/emp.rb
+++ b/Formula/emp.rb
@@ -25,7 +25,6 @@ class Emp < Formula
 
   test do
     require "webrick"
-    require "utils/json"
 
     server = WEBrick::HTTPServer.new :Port => 8035
     server.mount_proc "/apps/foo/releases" do |_req, res|
@@ -39,14 +38,14 @@ class Emp < Formula
         },
         "version" => 1,
       }
-      res.body = Utils::JSON.dump([resp])
+      res.body = JSON.generate([resp])
     end
 
     Thread.new { server.start }
 
     begin
       ENV["EMPIRE_API_URL"] = "http://127.0.0.1:8035"
-      assert_match /v1  zab  Oct 1(1|2|3) \d\d:00  my awesome release/,
+      assert_match /v1  zab  Oct 1(1|2|3)  2015  my awesome release/,
         shell_output("#{bin}/emp releases -a foo").strip
     ensure
       server.shutdown

--- a/Formula/etcd.rb
+++ b/Formula/etcd.rb
@@ -53,7 +53,6 @@ class Etcd < Formula
 
   test do
     begin
-      require "utils/json"
       test_string = "Hello from brew test!"
       etcd_pid = fork do
         exec bin/"etcd", "--force-new-cluster", "--data-dir=#{testpath}"
@@ -63,7 +62,7 @@ class Etcd < Formula
       etcd_uri = "http://127.0.0.1:2379/v2/keys/brew_test"
       system "curl", "--silent", "-L", etcd_uri, "-XPUT", "-d", "value=#{test_string}"
       curl_output = shell_output("curl --silent -L #{etcd_uri}")
-      response_hash = Utils::JSON.load(curl_output)
+      response_hash = JSON.parse(curl_output)
       assert_match(test_string, response_hash.fetch("node").fetch("value"))
     ensure
       # clean up the etcd process before we leave

--- a/Formula/goaccess.rb
+++ b/Formula/goaccess.rb
@@ -36,14 +36,12 @@ class Goaccess < Formula
   end
 
   test do
-    require "utils/json"
-
     (testpath/"access.log").write <<-EOS.undent
       127.0.0.1 - - [04/May/2015:15:48:17 +0200] "GET / HTTP/1.1" 200 612 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36"
     EOS
 
     output = shell_output("#{bin}/goaccess --time-format=%T --date-format=%d/%b/%Y --log-format='%h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"' -f access.log -o json 2>/dev/null")
 
-    assert_equal "Chrome", Utils::JSON.load(output)["browsers"]["data"][0]["data"]
+    assert_equal "Chrome", JSON.parse(output)["browsers"]["data"][0]["data"]
   end
 end

--- a/Formula/internetarchive.rb
+++ b/Formula/internetarchive.rb
@@ -1,5 +1,3 @@
-require "utils/json"
-
 class Internetarchive < Formula
   include Language::Python::Virtualenv
 
@@ -68,7 +66,7 @@ class Internetarchive < Formula
   end
 
   test do
-    metadata = Utils::JSON.load shell_output("#{bin}/ia metadata tigerbrew")
+    metadata = JSON.parse shell_output("#{bin}/ia metadata tigerbrew")
     assert_equal metadata["metadata"]["uploader"], "mistydemeo@gmail.com"
   end
 end

--- a/Formula/jsonnet.rb
+++ b/Formula/jsonnet.rb
@@ -22,8 +22,6 @@ class Jsonnet < Formula
   end
 
   test do
-    require "utils/json"
-
     (testpath/"example.jsonnet").write <<-EOS
       {
         person1: {
@@ -46,6 +44,6 @@ class Jsonnet < Formula
     }
 
     output = shell_output("#{bin}/jsonnet #{testpath}/example.jsonnet")
-    assert_equal expected_output, Utils::JSON.load(output)
+    assert_equal expected_output, JSON.parse(output)
   end
 end

--- a/Formula/libgraphqlparser.rb
+++ b/Formula/libgraphqlparser.rb
@@ -22,8 +22,6 @@ class Libgraphqlparser < Formula
   end
 
   test do
-    require "utils/json"
-
     sample_query = <<-EOS.undent
       { user }
     EOS
@@ -50,7 +48,7 @@ class Libgraphqlparser < Formula
                 "directives"=>nil,
                 "selectionSet"=>nil }] } }] }
 
-    test_ast = Utils::JSON.load pipe_output("#{libexec}/dump_json_ast", sample_query)
+    test_ast = JSON.parse pipe_output("#{libexec}/dump_json_ast", sample_query)
     assert_equal sample_ast, test_ast
   end
 end

--- a/Formula/libvbucket.rb
+++ b/Formula/libvbucket.rb
@@ -23,8 +23,7 @@ class Libvbucket < Formula
   end
 
   test do
-    require "utils/json"
-    json = Utils::JSON.dump(
+    json = JSON.generate(
       "hashAlgorithm" => "CRC",
       "numReplicas" => 2,
       "serverList" => ["server1:11211", "server2:11210", "server3:11211"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since `Utils::JSON` is still available via `compat`, the only changes that are strictly necessary in this PR are the removals of `require "utils/json"`. However, since we're getting rid of `Utils::JSON` eventually, I went ahead and updated all the calls to `JSON` anyways.