### PR TITLE
afflib: fix 3.7.10 to build with osxfuse

### DIFF
--- a/Formula/afflib.rb
+++ b/Formula/afflib.rb
@@ -29,7 +29,7 @@ class Afflib < Formula
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
 
     if build.with? "osxfuse"
-      ENV["CPPFLAGS"] = "-I#{Formula["osxfuse"].include}/osxfuse"
+      ENV["CPPFLAGS"] = "-I/usr/local/include/osxfuse"
       args << "--enable-fuse"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is because `osxfuse` is moved to Casks.