### PR TITLE
fossil: fix 1.35 with osxfuse to use the correct include path

### DIFF
--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -35,7 +35,7 @@ class Fossil < Formula
     end
 
     if build.with? "osxfuse"
-      ENV.prepend "CFLAGS", "-I#{HOMEBREW_PREFIX}/include/osxfuse"
+      ENV.prepend "CFLAGS", "-I/usr/local/include/osxfuse"
     else
       args << "--disable-fusefs"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
With cask, osxfuse will always installed in `/usr/local`.
