### PR TITLE
flow: remove --old-output-format from test

### DIFF
--- a/Formula/flow.rb
+++ b/Formula/flow.rb
@@ -29,7 +29,7 @@ class Flow < Formula
       /* @flow */
       var x: string = 123;
     EOS
-    expected = /number\nThis type is incompatible with\n.*string\n\nFound 1 error/
-    assert_match expected, shell_output("#{bin}/flow check --old-output-format #{testpath}", 2)
+    expected = /Found 1 error/
+    assert_match expected, shell_output("#{bin}/flow check #{testpath}", 2)
   end
 end


### PR DESCRIPTION
Flow is removing the `--old-output-format` flag in the next release (https://github.com/facebook/flow/issues/2844).

We're also planning on changing the error messages further in the future. Simplifying this test should make it future-proof, while still being pretty confident that flow is working.