### PR TITLE
qt5: fix pkg-config

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -91,6 +91,7 @@ class Qt5 < Formula
 
   depends_on "dbus" => :optional
   depends_on :mysql => :optional
+  depends_on "pkg-config" => :build
   depends_on :postgresql => :optional
   depends_on :xcode => :build
 
@@ -128,6 +129,7 @@ class Qt5 < Formula
       -qt-pcre
       -nomake tests
       -no-rpath
+      -pkg-config
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Commit 77fd56f4a96b5deb8fc0139da6519e207ec43fee ("qt5: remove spurious
pkg-config dependency") dropped the pkg-config build dependency because the
missing ./configure --pkg-config option caused Qt to be built without
pkg-config support.

pkg-config makes it easy to link Qt applications against external
libraries.  Many libraries available in Homebrew ship with pkg-config .pc
files so it makes sense to enable this feature.

This patch re-enables pkg-config so qmake CONFIG += link_pkgconfig works as
originally intended in commit b4df7fce96791c72e8fb4c84a89258eea990117a ("qt5:
add pkg-config build dependency").

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>