### PR TITLE
yarn: fix missing caveat about setting PATH

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -21,6 +21,16 @@ class Yarn < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
+  def caveats; <<-EOS.undent
+    You will need to set up the PATH environment variable in your
+    terminal to have access to Yarn’s binaries globally. Add
+
+      export PATH="$PATH:`yarn global bin`"
+
+    to your profile (this may be in your .profile, .bashrc, .zshrc, etc.)
+    EOS
+  end
+
   test do
     (testpath/"package.json").write('{"name": "test"}')
     system bin/"yarn", "add", "jquery"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Yarn website specifies a how to configure PATH after installing via brew but this caveat was missing from the brew formula.

![screen shot 2016-11-21 at 9 56 08 pm](https://cloud.githubusercontent.com/assets/3443017/20502370/a80a6290-b035-11e6-8afe-b4111a349e27.png)

related:
https://github.com/yarnpkg/website/pull/274
https://github.com/yarnpkg/yarn/issues/1321


