### PR TITLE
llnode fix lldb resource for Xcode < 8.0

### DIFF
--- a/Formula/llnode.rb
+++ b/Formula/llnode.rb
@@ -20,8 +20,17 @@ class Llnode < Formula
   end
 
   resource "lldb" do
-    url "https://github.com/llvm-mirror/lldb.git",
-        :revision => "839b868e2993dcffc7fea898a1167f1cec097a82"
+    if MacOS::Xcode.version >= "8.0"
+      # lldb 360.1
+      url "https://github.com/llvm-mirror/lldb.git",
+          :revision => "839b868e2993dcffc7fea898a1167f1cec097a82"
+    else
+      # It claims it to be lldb 350.0 for Xcode 7.3, but in fact it is based
+      # of 34.
+      # Xcode < 7.3 uses 340.4, so I assume we should be safe to go with this.
+      url "http://llvm.org/svn/llvm-project/lldb/tags/RELEASE_34/final/",
+          :using => :svn
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello!

I'm not quite sure if I should update it with next release or not, but decided to request the feedback anyway.

While investigating a bug report, I've discovered that Yosemite (actually Xcode on Yosemite) has much older lldb which made bottles for it unusable. Is it a right way to make resource dependent on OS X version?

I'd love to make it dependent on Xcode version, but the version correspondence of Xcode to lldb is unknown to me.

Thanks!