### PR TITLE
Migrate MySQL and Elasticsearch formulae from homebrew/versions

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -13,6 +13,9 @@ class Elasticsearch < Formula
 
   depends_on :java => "1.8+"
 
+  conflicts_with "elasticsearch@1.7", :because => "Different versions of same formula"
+  conflicts_with "elasticsearch@2.4", :because => "Different versions of same formula"
+
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end

--- a/Formula/elasticsearch@1.7.rb
+++ b/Formula/elasticsearch@1.7.rb
@@ -8,6 +8,9 @@ class ElasticsearchAT17 < Formula
 
   depends_on :java => "1.7+"
 
+  conflicts_with "elasticsearch", :because => "Different versions of same formula"
+  conflicts_with "elasticsearch@2.4", :because => "Different versions of same formula"
+
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end
@@ -98,9 +101,9 @@ class ElasticsearchAT17 < Formula
           <key>WorkingDirectory</key>
           <string>#{var}</string>
           <key>StandardErrorPath</key>
-          <string>#{var}/log/elasticsearch@1.7.log</string>
+          <string>#{var}/log/#{name}.log</string>
           <key>StandardOutPath</key>
-          <string>#{var}/log/elasticsearch@1.7.log</string>
+          <string>#{var}/log/#{name}.log</string>
         </dict>
       </plist>
     EOS

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -1,0 +1,115 @@
+class ElasticsearchAT24 < Formula
+  desc "Distributed search & analytics engine"
+  homepage "https://www.elastic.co/products/elasticsearch"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.2/elasticsearch-2.4.2.tar.gz"
+  sha256 "7741a2e78f5f155c5005ba891f9b6e57a4e45178cb540beed101d30517cbe22f"
+
+  bottle :unneeded
+  depends_on :java => "1.7+"
+
+  conflicts_with "elasticsearch", :because => "Different versions of same formula"
+  conflicts_with "elasticsearch@1.7", :because => "Different versions of same formula"
+
+  def cluster_name
+    "elasticsearch_#{ENV["USER"]}"
+  end
+
+  def install
+    # Remove Windows files
+    rm_f Dir["bin/*.bat"]
+    rm_f Dir["bin/*.exe"]
+
+    # Install everything else into package directory
+    libexec.install "bin", "config", "lib", "modules"
+
+    # Set up Elasticsearch for local development:
+    inreplace "#{libexec}/config/elasticsearch.yml" do |s|
+      # 1. Give the cluster a unique name
+      s.gsub!(/#\s*cluster\.name\: .*/, "cluster.name: #{cluster_name}")
+
+      # 2. Configure paths
+      s.sub!(%r{#\s*path\.data: /path/to.+$}, "path.data: #{var}/elasticsearch/")
+      s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/elasticsearch/")
+    end
+
+    inreplace "#{libexec}/bin/elasticsearch.in.sh" do |s|
+      # Configure ES_HOME
+      s.sub!(%r{#\!/bin/sh\n}, "#!/bin/sh\n\nES_HOME=#{libexec}")
+    end
+
+    inreplace "#{libexec}/bin/plugin" do |s|
+      # Add the proper ES_CLASSPATH configuration
+      s.sub!(/SCRIPT="\$0"/, %Q(SCRIPT="$0"\nES_CLASSPATH=#{libexec}/lib))
+      # Replace paths to use libexec instead of lib
+      s.gsub!(%r{\$ES_HOME/lib/}, "$ES_CLASSPATH/")
+    end
+
+    # Move config files into etc
+    (etc/"elasticsearch").install Dir[libexec/"config/*"]
+    (etc/"elasticsearch/scripts").mkpath
+    (libexec/"config").rmtree
+
+    bin.write_exec_script Dir[libexec/"bin/elasticsearch"]
+  end
+
+  def post_install
+    # Make sure runtime directories exist
+    (var/"elasticsearch/#{cluster_name}").mkpath
+    (var/"log/elasticsearch").mkpath
+    ln_s etc/"elasticsearch", libexec/"config"
+    (libexec/"plugins").mkdir
+  end
+
+  def caveats; <<-EOS.undent
+    Data:    #{var}/elasticsearch/#{cluster_name}/
+    Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
+    Plugins: #{libexec}/plugins/
+    Config:  #{etc}/elasticsearch/
+    plugin script: #{libexec}/bin/plugin
+    EOS
+  end
+
+  plist_options :manual => "elasticsearch"
+
+  def plist; <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <false/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{HOMEBREW_PREFIX}/bin/elasticsearch</string>
+          </array>
+          <key>EnvironmentVariables</key>
+          <dict>
+          </dict>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/#{name}.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/#{name}.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    system "#{libexec}/bin/plugin", "list"
+    pid = "#{testpath}/pid"
+    begin
+      mkdir testpath/"config"
+      system "#{bin}/elasticsearch", "-d", "-p", pid, "--path.home", testpath
+      sleep 10
+      system "curl", "-XGET", "localhost:9200/"
+    ensure
+      Process.kill(9, File.read(pid).to_i)
+    end
+  end
+end

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -37,11 +37,6 @@ class Mysql < Formula
   conflicts_with "mariadb-connector-c",
     :because => "both install plugins"
 
-  fails_with :llvm do
-    build 2326
-    cause "https://github.com/Homebrew/homebrew/issues/issue/144"
-  end
-
   def datadir
     var/"mysql"
   end

--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -1,0 +1,172 @@
+class MysqlAT55 < Formula
+  desc "Open source relational database management system"
+  homepage "http://dev.mysql.com/doc/refman/5.5/en/"
+  url "https://dev.mysql.com/get/Downloads/MySQL-5.5/mysql-5.5.49.tar.gz"
+  sha256 "cd9ca49b01a76bca635f2888b9d4d30fa6583dd198994d407cdd0dd7170e9e1f"
+
+  option :universal
+  option "with-test", "Build with unit tests"
+  option "with-embedded", "Build the embedded server"
+  option "with-archive-storage-engine", "Compile with the ARCHIVE storage engine enabled"
+  option "with-blackhole-storage-engine", "Compile with the BLACKHOLE storage engine enabled"
+  option "with-local-infile", "Build with local infile loading support"
+  option "with-memcached", "Enable innodb-memcached support"
+  option "with-debug", "Build with debug support"
+
+  deprecated_option "enable-local-infile" => "with-local-infile"
+  deprecated_option "enable-memcached" => "with-memcached"
+  deprecated_option "enable-debug" => "with-debug"
+  deprecated_option "with-tests" => "with-test"
+
+  depends_on "cmake" => :build
+  depends_on "pidof" unless MacOS.version >= :mountain_lion
+  depends_on "openssl"
+
+  conflicts_with "mysql", :because => "Different versions of same formula"
+  conflicts_with "mysql@5.6", :because => "Different versions of same formula"
+
+  conflicts_with "mysql-cluster", "mariadb", "percona-server",
+    :because => "mysql, mariadb, and percona install the same binaries."
+  conflicts_with "mysql-connector-c",
+    :because => "both install MySQL client libraries"
+  conflicts_with "mariadb-connector-c",
+    :because => "both install plugins"
+
+  def datadir
+    var/"mysql"
+  end
+
+  def install
+    # Don't hard-code the libtool path. See:
+    # https://github.com/Homebrew/homebrew/issues/20185
+    inreplace "cmake/libutils.cmake",
+      "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
+      "COMMAND libtool -static -o ${TARGET_LOCATION}"
+
+    # Build without compiler or CPU specific optimization flags to facilitate
+    # compilation of gems and other software that queries `mysql-config`.
+    ENV.minimal_optimization
+
+    # -DINSTALL_* are relative to prefix
+    args = %W[
+      -DMYSQL_DATADIR=#{datadir}
+      -DINSTALL_INCLUDEDIR=include/mysql
+      -DINSTALL_MANDIR=share/man
+      -DINSTALL_DOCDIR=share/doc/#{name}
+      -DINSTALL_INFODIR=share/info
+      -DINSTALL_MYSQLSHAREDIR=share/mysql
+      -DWITH_SSL=yes
+      -DWITH_SSL=system
+      -DDEFAULT_CHARSET=utf8
+      -DDEFAULT_COLLATION=utf8_general_ci
+      -DSYSCONFDIR=#{etc}
+      -DCOMPILATION_COMMENT=Homebrew
+      -DWITH_EDITLINE=system
+    ]
+
+    # To enable unit testing at build, we need to download the unit testing suite
+    if build.with? "tests"
+      args << "-DENABLE_DOWNLOADS=ON"
+    else
+      args << "-DWITH_UNIT_TESTS=OFF"
+    end
+
+    # Build the embedded server
+    args << "-DWITH_EMBEDDED_SERVER=ON" if build.with? "embedded"
+
+    # Compile with ARCHIVE engine enabled if chosen
+    args << "-DWITH_ARCHIVE_STORAGE_ENGINE=1" if build.with? "archive-storage-engine"
+
+    # Compile with BLACKHOLE engine enabled if chosen
+    args << "-DWITH_BLACKHOLE_STORAGE_ENGINE=1" if build.with? "blackhole-storage-engine"
+
+    # Make universal for binding to universal applications
+    if build.universal?
+      ENV.universal_binary
+      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
+    end
+
+    # Build with local infile loading support
+    args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"
+
+    # Build with memcached support
+    args << "-DWITH_INNODB_MEMCACHED=1" if build.with? "memcached"
+
+    # Build with debug support
+    args << "-DWITH_DEBUG=1" if build.with? "debug"
+
+    system "cmake", ".", *std_cmake_args, *args
+    system "make"
+    system "make", "install"
+
+    # Don't create databases inside of the prefix!
+    # See: https://github.com/Homebrew/homebrew/issues/4975
+    rm_rf prefix/"data"
+
+    # Link the setup script into bin
+    bin.install_symlink prefix/"scripts/mysql_install_db"
+
+    # Fix up the control script and link into bin
+    inreplace "#{prefix}/support-files/mysql.server" do |s|
+      s.gsub!(/^(PATH=".*)(")/, "\\1:#{HOMEBREW_PREFIX}/bin\\2")
+      # pidof can be replaced with pgrep from proctools on Mountain Lion
+      s.gsub!(/pidof/, "pgrep") if MacOS.version >= :mountain_lion
+    end
+
+    bin.install_symlink prefix/"support-files/mysql.server"
+
+    libexec.install bin/"mysqlaccess"
+    libexec.install bin/"mysqlaccess.conf"
+  end
+
+  def post_install
+    # Make sure the datadir exists
+    datadir.mkpath
+    unless (datadir/"mysql/user.frm").exist?
+      ENV["TMPDIR"] = nil
+      system bin/"mysql_install_db", "--verbose", "--user=#{ENV["USER"]}",
+        "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    A "/etc/my.cnf" from another install may interfere with a Homebrew-built
+    server starting up correctly.
+
+    To connect:
+        #{opt_bin}/mysql -uroot
+    EOS
+  end
+
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mysql55/bin/mysql.server start"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/mysqld_safe</string>
+        <string>--bind-address=127.0.0.1</string>
+        <string>--datadir=#{datadir}</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{datadir}</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    (prefix/"mysql-test").cd do
+      system "./mysql-test-run.pl", "status", "--vardir=#{testpath}"
+    end
+  end
+end

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -1,0 +1,173 @@
+class MysqlAT56 < Formula
+  desc "Open source relational database management system"
+  homepage "https://dev.mysql.com/doc/refman/5.6/en/"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.34.tar.gz"
+  sha256 "ee90bafec6af3abe2715ccb0b3cc9345ed8d1cce025d41e6ec2b2b7a7d820823"
+
+  option :universal
+  option "with-test", "Build with unit tests"
+  option "with-embedded", "Build the embedded server"
+  option "with-archive-storage-engine", "Compile with the ARCHIVE storage engine enabled"
+  option "with-blackhole-storage-engine", "Compile with the BLACKHOLE storage engine enabled"
+  option "with-local-infile", "Build with local infile loading support"
+  option "with-memcached", "Enable innodb-memcached support"
+  option "with-debug", "Build with debug support"
+
+  deprecated_option "enable-local-infile" => "with-local-infile"
+  deprecated_option "enable-memcached" => "with-memcached"
+  deprecated_option "enable-debug" => "with-debug"
+  deprecated_option "with-tests" => "with-test"
+
+  depends_on "cmake" => :build
+  depends_on "pidof" unless MacOS.version >= :mountain_lion
+  depends_on "openssl"
+
+  conflicts_with "mysql", :because => "Different versions of same formula"
+  conflicts_with "mysql@5.5", :because => "Different versions of same formula"
+
+  conflicts_with "mysql-cluster", "mariadb", "percona-server",
+    :because => "mysql, mariadb, and percona install the same binaries."
+  conflicts_with "mysql-connector-c",
+    :because => "both install MySQL client libraries"
+  conflicts_with "mariadb-connector-c",
+    :because => "both install plugins"
+
+  def datadir
+    var/"mysql"
+  end
+
+  def install
+    # Don't hard-code the libtool path. See:
+    # https://github.com/Homebrew/homebrew/issues/20185
+    inreplace "cmake/libutils.cmake",
+      "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
+      "COMMAND libtool -static -o ${TARGET_LOCATION}"
+
+    # Build without compiler or CPU specific optimization flags to facilitate
+    # compilation of gems and other software that queries `mysql-config`.
+    ENV.minimal_optimization
+
+    # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
+    args = %W[
+      -DMYSQL_DATADIR=#{datadir}
+      -DINSTALL_INCLUDEDIR=include/mysql
+      -DINSTALL_MANDIR=share/man
+      -DINSTALL_DOCDIR=share/doc/#{name}
+      -DINSTALL_INFODIR=share/info
+      -DINSTALL_MYSQLSHAREDIR=share/mysql
+      -DWITH_SSL=yes
+      -DWITH_SSL=system
+      -DDEFAULT_CHARSET=utf8
+      -DDEFAULT_COLLATION=utf8_general_ci
+      -DSYSCONFDIR=#{etc}
+      -DCOMPILATION_COMMENT=Homebrew
+      -DWITH_EDITLINE=system
+    ]
+
+    # To enable unit testing at build, we need to download the unit testing suite
+    if build.with? "tests"
+      args << "-DENABLE_DOWNLOADS=ON"
+    else
+      args << "-DWITH_UNIT_TESTS=OFF"
+    end
+
+    # Build the embedded server
+    args << "-DWITH_EMBEDDED_SERVER=ON" if build.with? "embedded"
+
+    # Compile with ARCHIVE engine enabled if chosen
+    args << "-DWITH_ARCHIVE_STORAGE_ENGINE=1" if build.with? "archive-storage-engine"
+
+    # Compile with BLACKHOLE engine enabled if chosen
+    args << "-DWITH_BLACKHOLE_STORAGE_ENGINE=1" if build.with? "blackhole-storage-engine"
+
+    # Make universal for binding to universal applications
+    if build.universal?
+      ENV.universal_binary
+      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
+    end
+
+    # Build with local infile loading support
+    args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"
+
+    # Build with memcached support
+    args << "-DWITH_INNODB_MEMCACHED=1" if build.with? "memcached"
+
+    # Build with debug support
+    args << "-DWITH_DEBUG=1" if build.with? "debug"
+
+    system "cmake", ".", *std_cmake_args, *args
+    system "make"
+    system "make", "install"
+
+    # Don't create databases inside of the prefix!
+    # See: https://github.com/Homebrew/homebrew/issues/4975
+    rm_rf prefix/"data"
+
+    # Link the setup script into bin
+    bin.install_symlink prefix/"scripts/mysql_install_db"
+
+    # Fix up the control script and link into bin
+    inreplace "#{prefix}/support-files/mysql.server" do |s|
+      s.gsub!(/^(PATH=".*)(")/, "\\1:#{HOMEBREW_PREFIX}/bin\\2")
+      # pidof can be replaced with pgrep from proctools on Mountain Lion
+      s.gsub!(/pidof/, "pgrep") if MacOS.version >= :mountain_lion
+    end
+
+    bin.install_symlink prefix/"support-files/mysql.server"
+
+    libexec.install bin/"mysqlaccess"
+    libexec.install bin/"mysqlaccess.conf"
+  end
+
+  def post_install
+    # Make sure the datadir exists
+    datadir.mkpath
+    unless (datadir/"mysql/user.frm").exist?
+      ENV["TMPDIR"] = nil
+      system bin/"mysql_install_db", "--verbose", "--user=#{ENV["USER"]}",
+        "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    A "/etc/my.cnf" from another install may interfere with a Homebrew-built
+    server starting up correctly.
+
+    To connect:
+        mysql -uroot
+    EOS
+  end
+
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mysql56/bin/mysql.server start"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/mysqld_safe</string>
+        <string>--bind-address=127.0.0.1</string>
+        <string>--datadir=#{datadir}</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{datadir}</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "/bin/sh", "-n", "#{bin}/mysqld_safe"
+    (prefix/"mysql-test").cd do
+      system "./mysql-test-run.pl", "status", "--vardir=#{testpath}"
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Second test after https://github.com/Homebrew/brew/pull/1371 and https://github.com/Homebrew/homebrew-core/pull/6533 were merged of importing formulae from homebrew/versions to the new version scheme.

Will hold off merging for a few days to spot any issues with https://github.com/Homebrew/homebrew-core/pull/6533.