### PR TITLE
ripgrep: install bash and fish completions

### DIFF
--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -19,6 +19,12 @@ class Ripgrep < Formula
 
     bin.install "target/release/rg"
     man1.install "doc/rg.1"
+
+    # Completion scripts are generated in the crate's build directory, which
+    # includes a fingerprint hash. Try to locate it first
+    out_dir = Dir["target/release/build/ripgrep-*/out"].first
+    bash_completion.install "#{out_dir}/rg.bash-completion"
+    fish_completion.install "#{out_dir}/rg.fish"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sorry for not including this with the 0.3.1 patch! It didn't occur to me before.