### PR TITLE
Properly setting a fake CPUID for GMP

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -18,7 +18,7 @@ class Gmp < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    args = ["--prefix=#{prefix}", "--enable-cxx"]
+    args = ["--prefix=#{prefix}", "--enable-cxx", "--enable-fake-cpuid", "--enable-fat", "GMP_CPU_TYPE=core2"]
 
     if build.build_32_bit?
       ENV.m32

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -18,15 +18,14 @@ class Gmp < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    args = ["--prefix=#{prefix}", "--enable-cxx", "--enable-fake-cpuid", "--enable-fat", "GMP_CPU_TYPE=core2"]
+    args = ["--prefix=#{prefix}", "--enable-cxx"]
 
     if build.build_32_bit?
       ENV.m32
       args << "ABI=32"
     end
 
-    # https://github.com/Homebrew/homebrew/issues/20693
-    args << "--disable-assembly" if build.build_32_bit? || build.bottle?
+    args << "--enable-fake-cpuid" << "GMP_CPU_TYPE=#{Hardware.oldest_cpu}" << "--enable-fat" if build.build_32_bit? || build.bottle?
 
     system "./configure", *args
     system "make"

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -19,17 +19,18 @@ class Gmp < Formula
   def install
     ENV.cxx11 if build.cxx11?
     args = ["--prefix=#{prefix}", "--enable-cxx"]
+    ENV["GMP_CPU_TYPE"] = Hardware.oldest_cpu
 
     if build.build_32_bit?
       ENV.m32
       args << "ABI=32"
     end
 
-    args << "--enable-fake-cpuid" << "GMP_CPU_TYPE=#{Hardware.oldest_cpu}" << "--enable-fat" if build.build_32_bit? || build.bottle?
+    args << "--enable-fake-cpuid" << "--enable-fat" if build.build_32_bit? || build.bottle?
 
     system "./configure", *args
     system "make"
-    system "make", "check", "GMP_CPU_TYPE=#{Hardware.oldest_cpu}"
+    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -29,7 +29,7 @@ class Gmp < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "check"
+    system "make", "check", "GMP_CPU_TYPE=#{Hardware.oldest_cpu}"
     system "make", "install"
   end
 


### PR DESCRIPTION
GMP exports its compilation options in its header file which may contain incorrect architecture optimizations.
This patch ensures that GMP builds with -mcore2 and also exports this.

See #7054 