### PR TITLE
pypy: use upstream patch for clock_gettime

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -6,6 +6,14 @@ class Pypy < Formula
   stable do
     url "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-src.tar.bz2"
     sha256 "7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0"
+
+    # Disable clock_gettime() use on Darwin; applied upstream.
+    # This fixes 10.11 when built using the Xcode 8 SDK.
+    # See: https://github.com/Homebrew/homebrew-core/issues/6949
+    patch do
+      url "https://bitbucket.org/pypy/pypy/commits/91e202bbd0b983c88fa9c33b9215b0f910d1f405/raw"
+      sha256 "7a5f5d1c3c0e7bd1652c4d17018d8c1328338b73858712c02c41ef563a04314c"
+    end
   end
 
   bottle do
@@ -160,6 +168,7 @@ class Pypy < Formula
 
   test do
     system bin/"pypy", "-c", "print('Hello, world!')"
+    system bin/"pypy", "-c", "import time; time.clock()"
     system scripts_folder/"pip", "list"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #6949.

cc @tdsmith, @MikeMcQuaid 