### PR TITLE
snappystream 0.2.5

### DIFF
--- a/Formula/snappystream.rb
+++ b/Formula/snappystream.rb
@@ -1,8 +1,8 @@
 class Snappystream < Formula
   desc "C++ snappy stream realization (compatible with snappy)"
   homepage "https://github.com/hoxnox/snappystream"
-  url "https://github.com/hoxnox/snappystream/archive/0.2.3.tar.gz"
-  sha256 "f7c0a5d7c0a1f03afeb980d87d374dc3d01019387a4494ece1dd127b69f4ed8b"
+  url "https://github.com/hoxnox/snappystream/archive/0.2.5.tar.gz"
+  sha256 "de2fdccd512ca7acf374323ab335227e2a79d9c4a63b9ec5627ba1d9b44c4c60"
 
   head "https://github.com/hoxnox/snappystream.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixed upstream and formula due to missing googlecode repositories.