### PR TITLE
Add dynamic option for vault

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -18,6 +18,8 @@ class Vault < Formula
     sha256 "2dc0195cf0aaae3a9508fa2e8312ad9211a2f7b0880ed939b81473714dba1757" => :yosemite
   end
 
+  option "with-dynamic", "Build dynamic binary with CGO_ENABLED=1"
+
   depends_on "go" => :build
 
   go_resource "github.com/mitchellh/iochan" do
@@ -45,7 +47,8 @@ class Vault < Formula
     end
 
     cd "src/github.com/hashicorp/vault" do
-      system "make", "dev"
+      target = build.with?("dynamic") ? "dev-dynamic" : "dev"
+      system "make", target
       bin.install "bin/vault"
       prefix.install_metafiles
     end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Add option “with-dynamic” to vault, in order to optionally build with CGO_ENABLED
- This is a common use case for VPN users on Mac OS X
- See:
https://github.com/hashicorp/vault/issues/1159

https://github.com/hashicorp/vault/issues/712