### PR TITLE
terraform 0.7.13 (retag, fix sha)

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -4,7 +4,7 @@ class Terraform < Formula
   desc "Tool to build, change, and version infrastructure"
   homepage "https://www.terraform.io/"
   url "https://github.com/hashicorp/terraform/archive/v0.7.13.tar.gz"
-  sha256 "86d19f7a927bbdca3fe320e5213e25a11a4ddffd0458d449b8b1c488f4fe7295"
+  sha256 "8b5a3b76a81aff962d51120d7c9fd4da03a8c57d6932053cb9887579ac23b959"
   head "https://github.com/hashicorp/terraform.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updating sha256, as the release was retagged to fix https://github.com/hashicorp/terraform/issues/10357
Note: Due to the tagging issue (wrong commit), bottles should be rebuilt for this version.