### PR TITLE
ffmpeg: patch for aac_adtstoasc_bsf regression

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,7 +3,17 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-3.2.tar.bz2"
   sha256 "76d6cd9f5e64463a5b9940736da8a515c990bcbbe506a722e2040916cb366d74"
+  revision 1
+
   head "https://github.com/FFmpeg/FFmpeg.git"
+
+  patch do
+    # Fix aac_adtstoasc_bsf regression.
+    # https://trac.ffmpeg.org/ticket/5973
+    # Remove when 3.2.1 is released.
+    url "https://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=6e1902b"
+    sha256 "668d0291ca70f32e8f1a9b9554bd73664adce4345e0d746db47099df349f7e15"
+  end
 
   bottle do
     sha256 "84fba610ee0802576eef1a25020ff7dcd1d4f080c2a667444e47394a36980df7" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a regression in 3.2. Patch has been merged and backported to the 3.2 branch, scheduled to be part of 3.2.1.

This regression affects one of my personal workflows, so I have it patched locally and am offering the patch to everyone. Also, the regression has the potential to corrupt data, making the patch a bit more important than other minor fixes. However, it's probably a niche that won't affect 99% of users, so I'm not convinced that it's worth dropping a 3.2_1 on everyone. In short, I don't care if this PR is merged or not, just offering.