### PR TITLE
Add dynamic option for nomad

### DIFF
--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -20,7 +20,7 @@ class Nomad < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/hashicorp/nomad").install buildpath.children
     cd "src/github.com/hashicorp/nomad" do
-      if build.with? "dynamic" then ENV["CGO_ENABLED"] = "1" end
+      ENV["CGO_ENABLED"] = "1" if build.with? "dynamic"
       system "go", "build", "-o", bin/"nomad"
       prefix.install_metafiles
     end

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -12,12 +12,15 @@ class Nomad < Formula
     sha256 "f292943027d1ee394312ec6286ef3ef944a6cdcac882b6086801d12eda7864ba" => :yosemite
   end
 
+  option "with-dynamic", "Build dynamic binary with CGO_ENABLED=1"
+
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/hashicorp/nomad").install buildpath.children
     cd "src/github.com/hashicorp/nomad" do
+      if build.with? "dynamic" then ENV["CGO_ENABLED"] = "1" end
       system "go", "build", "-o", bin/"nomad"
       prefix.install_metafiles
     end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Add option “with-dynamic” to nomad, in order to optionally build with CGO_ENABLED
- This is a common use case for some VPN users on Mac OS X
- See:   https://github.com/Homebrew/homebrew-core/pull/7238