### PR TITLE
ffmpeg: fix fatal patch error when building head

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -1,18 +1,21 @@
 class Ffmpeg < Formula
   desc "Play, record, convert, and stream audio and video"
   homepage "https://ffmpeg.org/"
-  url "https://ffmpeg.org/releases/ffmpeg-3.2.tar.bz2"
-  sha256 "76d6cd9f5e64463a5b9940736da8a515c990bcbbe506a722e2040916cb366d74"
   revision 1
 
   head "https://github.com/FFmpeg/FFmpeg.git"
 
-  patch do
+  stable do
+    url "https://ffmpeg.org/releases/ffmpeg-3.2.tar.bz2"
+    sha256 "76d6cd9f5e64463a5b9940736da8a515c990bcbbe506a722e2040916cb366d74"
+
     # Fix aac_adtstoasc_bsf regression.
     # https://trac.ffmpeg.org/ticket/5973
     # Remove when 3.2.1 is released.
-    url "https://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=6e1902b"
-    sha256 "668d0291ca70f32e8f1a9b9554bd73664adce4345e0d746db47099df349f7e15"
+    patch do
+      url "https://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=6e1902b"
+      sha256 "668d0291ca70f32e8f1a9b9554bd73664adce4345e0d746db47099df349f7e15"
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

the aac_adtstoasc_bsf regression patch was backported to 3.2 from
master, therefore do not try and apply it during head builds

_NOTE:_ This currently breaks the `HEAD` build, since brew aborts after two fatal:
```
Error: Failure while executing: /usr/bin/patch -g 0 -f -p1 -i /private/tmp/ffmpeg--patch-*
```