### PR TITLE
srclib 0.2.5

### DIFF
--- a/Formula/srclib.rb
+++ b/Formula/srclib.rb
@@ -3,9 +3,8 @@ require "language/go"
 class Srclib < Formula
   desc "Polyglot code analysis library, built for hackability"
   homepage "https://srclib.org"
-  url "https://github.com/sourcegraph/srclib/archive/v0.0.42.tar.gz"
-  sha256 "de9af74ec0805b0ef4f1c7ddf26c5aef43f84668b12c001f2f413ff20a19ebee"
-  revision 1
+  url "https://github.com/sourcegraph/srclib/archive/v0.2.5.tar.gz"
+  sha256 "f410dc87edb44bf10ce8ebd22d0b3c20b9a48fd3186ae38227380be04580574a"
   head "https://github.com/sourcegraph/srclib.git"
 
   bottle do
@@ -15,164 +14,121 @@ class Srclib < Formula
     sha256 "2e8c68f8948ae220448400680108083931ca78273fd1f320b084879d14a567bb" => :mavericks
   end
 
-  conflicts_with "src", :because => "both install a 'src' binary"
-
-  depends_on :hg => :build
   depends_on "go" => :build
 
-  go_resource "code.google.com/p/rog-go" do
-    url "https://code.google.com/p/rog-go",
-        :revision => "7088342b70fc1995ada4986ef2d093f340439c78", :using => :hg
-  end
-
-  go_resource "github.com/Sirupsen/logrus" do
-    url "https://github.com/Sirupsen/logrus",
-        :revision => "cdd90c38c6e3718c731b555b9c3ed1becebec3ba", :using => :git
-  end
-
   go_resource "github.com/alecthomas/binary" do
-    url "https://github.com/alecthomas/binary",
-        :revision => "21c37b530bec7c512af0208bfb15f34400301682", :using => :git
+    url "https://github.com/alecthomas/binary.git",
+        :revision => "8b2a3aa0ba1c1e495274f8e63f57dc7f76107753"
   end
 
   go_resource "github.com/alecthomas/unsafeslice" do
-    url "https://github.com/alecthomas/unsafeslice",
-        :revision => "a2ace32dbd4787714f87adb14a8aa369142efac5", :using => :git
+    url "https://github.com/alecthomas/unsafeslice.git",
+        :revision => "763102eafe597ba6cc5c6e847006e3e9851c2786"
   end
 
-  go_resource "github.com/aybabtme/color" do
-    url "https://github.com/aybabtme/color",
-        :revision => "28ad4cc941d69a60df8d0af1233fd5a2793c2801", :using => :git
-  end
-
-  go_resource "github.com/docker/docker" do
-    url "https://github.com/docker/docker",
-        :revision => "9c505c906d318df7b5e8652c37e4df06b4f30d56", :using => :git
-  end
-
-  go_resource "github.com/fsouza/go-dockerclient" do
-    url "https://github.com/fsouza/go-dockerclient",
-        :revision => "ddb122d10f547ee6cfc4ea7debff407d80abdabc", :using => :git
+  go_resource "github.com/alexsaveliev/go-colorable-wrapper" do
+    url "https://github.com/alexsaveliev/go-colorable-wrapper.git",
+        :revision => "99a0af7e4f8cb31ba0cbecd070648a1f3f7c4c33"
   end
 
   go_resource "github.com/gogo/protobuf" do
-    url "https://github.com/gogo/protobuf",
-        :revision => "bc946d07d1016848dfd2507f90f0859c9471681e", :using => :git
+    url "https://github.com/gogo/protobuf.git",
+        :revision => "8d70fb3182befc465c4a1eac8ad4d38ff49778e2"
   end
 
-  go_resource "github.com/google/go-querystring" do
-    url "https://github.com/google/go-querystring",
-        :revision => "d8840cbb2baa915f4836edda4750050a2c0b7aea", :using => :git
-  end
-
-  go_resource "github.com/gorilla/context" do
-    url "https://github.com/gorilla/context",
-        :revision => "215affda49addc4c8ef7e2534915df2c8c35c6cd", :using => :git
-  end
-
-  go_resource "github.com/inconshreveable/go-update" do
-    url "https://github.com/inconshreveable/go-update",
-        :revision => "68f5725818189545231c1fd8694793d45f2fc529", :using => :git
+  go_resource "github.com/golang/protobuf" do
+    url "https://github.com/golang/protobuf.git",
+        :revision => "8ee79997227bf9b34611aee7946ae64735e6fd93"
   end
 
   go_resource "github.com/kardianos/osext" do
-    url "https://github.com/kardianos/osext",
-        :revision => "efacde03154693404c65e7aa7d461ac9014acd0c", :using => :git
+    url "https://github.com/kardianos/osext.git",
+        :revision => "c2c54e542fb797ad986b31721e1baedf214ca413"
   end
 
   go_resource "github.com/kr/binarydist" do
-    url "https://github.com/kr/binarydist",
-        :revision => "9955b0ab8708602d411341e55fffd7e0700f86bd", :using => :git
+    url "https://github.com/kr/binarydist.git",
+        :revision => "3035450ff8b987ec4373f65c40767f096b35f2d2"
   end
 
   go_resource "github.com/kr/fs" do
-    url "https://github.com/kr/fs",
-        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b", :using => :git
+    url "https://github.com/kr/fs.git",
+        :revision => "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
   end
 
-  go_resource "github.com/petar/GoLLRB" do
-    url "https://github.com/petar/GoLLRB",
-        :revision => "53be0d36a84c2a886ca057d34b6aa4468df9ccb4", :using => :git
+  go_resource "github.com/mattn/go-colorable" do
+    url "https://github.com/mattn/go-colorable.git",
+        :revision => "d228849504861217f796da67fae4f6e347643f15"
   end
 
-  go_resource "github.com/peterbourgon/diskv" do
-    url "https://github.com/peterbourgon/diskv",
-        :revision => "72aa5da9f7d1125b480b83c6dc5ad09a1f04508c", :using => :git
+  go_resource "github.com/neelance/parallel" do
+    url "https://github.com/neelance/parallel.git",
+        :revision => "4de9ce63d14c18517a79efe69e10e99d32c850c3"
   end
 
-  go_resource "github.com/peterh/liner" do
-    url "https://github.com/peterh/liner",
-        :revision => "1bb0d1c1a25ed393d8feb09bab039b2b1b1fbced", :using => :git
+  go_resource "github.com/rogpeppe/rog-go" do
+    url "https://github.com/rogpeppe/rog-go.git",
+        :revision => "f57ad5e24ab7813942c045f86eda1066eb969e98"
   end
 
   go_resource "github.com/smartystreets/mafsa" do
-    url "https://github.com/smartystreets/mafsa",
-        :revision => "ab6b5abc58c9d82560b127e23bfd3e39a25e8f05", :using => :git
-  end
-
-  go_resource "github.com/sourcegraph/go-github" do
-    url "https://github.com/sourcegraph/go-github",
-        :revision => "c6edc3e74760ee3c825f46ad9d4eb3e40469cb92", :using => :git
-  end
-
-  go_resource "github.com/sourcegraph/httpcache" do
-    url "https://github.com/sourcegraph/httpcache",
-        :revision => "e2fdd7ddabf459df5cd87bd18a4616ae7084763e", :using => :git
-  end
-
-  go_resource "github.com/sourcegraph/mux" do
-    url "https://github.com/sourcegraph/mux",
-        :revision => "dd22f369d469f65c3946889f5d8a1fb3933192e9", :using => :git
+    url "https://github.com/smartystreets/mafsa.git",
+        :revision => "1575156d598714bb1c41713191eefb7f5ccf3e8b"
   end
 
   go_resource "github.com/sqs/fileset" do
-    url "https://github.com/sqs/fileset",
-        :revision => "4317e899aa9438ba7603a6e322389571cb3ffdff", :using => :git
+    url "https://github.com/sqs/fileset.git",
+        :revision => "012a6d31cbc4d10f3148918e0a37cd333db58a34"
+  end
+
+  go_resource "github.com/sqs/go-selfupdate" do
+    url "https://github.com/sqs/go-selfupdate.git",
+        :revision => "d36f0a97c909dccd193274709266ff9b68a003db"
+  end
+
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+        :revision => "4971afdc2f162e82d185353533d3cf16188a9f4e"
   end
 
   go_resource "golang.org/x/tools" do
-    url "https://go.googlesource.com/tools",
-        :revision => "a18bb1d557dac8d19062dd0240b44ab09cfa14fd", :using => :git
+    url "https://go.googlesource.com/tools.git",
+        :revision => "167995c67fa45f3a7fc8dab62bb872212e397c11"
   end
 
-  go_resource "sourcegraph.com/sourcegraph/go-diff" do
-    url "https://github.com/sourcegraph/go-diff",
-        :revision => "07d9929e8741ec84aa708aba12a4b1efd3a7a0dd", :using => :git
+  go_resource "google.golang.org/grpc" do
+    url "https://github.com/grpc/grpc-go.git",
+        :revision => "eca2ad68af4d7bf894ada6bd263133f069a441d5"
+  end
+
+  go_resource "gopkg.in/inconshreveable/go-update.v0" do
+    url "https://gopkg.in/inconshreveable/go-update.v0.git",
+        :revision => "d8b0b1d421aa1cbf392c05869f8abbc669bb7066"
   end
 
   go_resource "sourcegraph.com/sourcegraph/go-flags" do
-    url "https://github.com/sourcegraph/go-flags",
-        :revision => "f59c328da6215a0b6acf0441ef19e361660ff405", :using => :git
-  end
-
-  go_resource "sourcegraph.com/sourcegraph/go-nnz" do
-    url "https://github.com/sourcegraph/go-nnz",
-        :revision => "62f271ba06026cf310d94721425eda2ec72f894c", :using => :git
-  end
-
-  go_resource "sourcegraph.com/sourcegraph/go-sourcegraph" do
-    url "https://github.com/sourcegraph/go-sourcegraph",
-        :revision => "6f1cd4d2b721cff7913ed2f04bcd820590ce3b94", :using => :git
-  end
-
-  go_resource "sourcegraph.com/sourcegraph/go-vcs" do
-    url "https://github.com/sourcegraph/go-vcs",
-        :revision => "1dcc4655df7318c3f105f9212900e1d0c68f7424", :using => :git
+    url "https://github.com/sourcegraph/go-flags.git",
+        :revision => "dace7e122742808bf6016bdc6510649d84f2a31e"
   end
 
   go_resource "sourcegraph.com/sourcegraph/makex" do
-    url "https://github.com/sourcegraph/makex",
-        :revision => "ba5e243479d710a5d378c97d007568a405d04492", :using => :git
+    url "https://github.com/sourcegraph/makex.git",
+        :revision => "3f62e8d29c0ff8c517a78ced8318b03110c3f532"
   end
 
   go_resource "sourcegraph.com/sourcegraph/rwvfs" do
-    url "https://github.com/sourcegraph/rwvfs",
-        :revision => "451122bc19b9f1cdfeb2f1fdccadbc33ef5aa9f7", :using => :git
+    url "https://github.com/sourcegraph/rwvfs.git",
+        :revision => "d433415e8d1212f40c9a508851f08ba91e5996da"
   end
 
-  go_resource "sourcegraph.com/sourcegraph/vcsstore" do
-    url "https://github.com/sourcegraph/vcsstore",
-        :revision => "53d0c58fd11f7dc451456eb983050c58cd005268", :using => :git
+  go_resource "sourcegraph.com/sourcegraph/srclib" do
+    url "https://github.com/sourcegraph/srclib.git",
+        :revision => "28ba5745ba2ee2cbe539a8d696cab64556db542f"
+  end
+
+  go_resource "sourcegraph.com/sqs/pbtypes" do
+    url "https://github.com/sqs/pbtypes.git",
+        :revision => "4d1b9dc7ffc3f7b555de9b02055fa616f0ebcd18"
   end
 
   def install
@@ -183,26 +139,13 @@ class Srclib < Formula
     ln_sf buildpath, buildpath/"src/sourcegraph.com/sourcegraph/srclib"
     Language::Go.stage_deps resources, buildpath/"src"
 
-    cd "cmd/src" do
-      system "go", "build", "-o", "src"
-      bin.install "src"
+    cd "cmd/srclib" do
+      system "go", "build", "-o", "srclib"
+      bin.install "srclib"
     end
-  end
-
-  # For test
-  resource "srclib-sample" do
-    url "https://github.com/sourcegraph/srclib-sample.git",
-        :revision => "e753b113784bf383f627394e86e4936629a3b588"
   end
 
   test do
-    resource("srclib-sample").stage do
-      # Avoid automatic writing to $HOME/.srclib
-      ENV["SRCLIBPATH"] = testpath
-      ENV.prepend_path "PATH", bin
-      system "#{bin}/src", "toolchain", "add", "--force", "sourcegraph.com/sourcegraph/srclib-sample"
-      result = pipe_output("#{bin}/src api units")
-      assert_match '"Type":"sample"', result
-    end
+    system "#{bin}/srclib", "info"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Bump srclib to version 0.2.5. I rebuilt the go resources with `gdm`. I scrapped the previous test since the repository it is based on is outdated and I couldn't find out how to upgrade the instructions. This should also fix the Sierra bottle issue #6408 for this formula.