### PR TITLE
qt5: add general plugin search path to Designer.app

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -199,6 +199,13 @@ class Qt5 < Formula
               /\n# pkgconfig\n(PKG_CONFIG_(SYSROOT_DIR|LIBDIR) = .*\n){2}\n/,
               "\n"
 
+    # Make `HOMEBREW_PREFIX/lib/qt5/plugins` an additional plug-in search path
+    # for Qt Designer to support formulae that provide Qt Designer plug-ins.
+    system "/usr/libexec/PlistBuddy",
+           "-c", "Add :LSEnvironment:QT_PLUGIN_PATH string \"#{HOMEBREW_PREFIX}/lib/qt5/plugins\"",
+           "#{bin}/Designer.app/Contents/Info.plist"
+    touch "#{bin}/Designer.app" # re-register edited bundle with Launch Services
+
     # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and
     # because we don't like having them in `bin`. Also add a `-qt5` suffix to
     # avoid conflict with the `*.app` bundles provided by the `qt` formula.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Same as was previously done for Qt4, but with additional re-registration
of edited bundle to ensure change is noticed upon reinstalls.