### PR TITLE
sdl_image: Add option to statically link libraries

### DIFF
--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -3,7 +3,7 @@ class SdlImage < Formula
   homepage "https://www.libsdl.org/projects/SDL_image"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any
@@ -33,10 +33,19 @@ class SdlImage < Formula
     ENV.universal_binary if build.universal?
     inreplace "SDL_image.pc.in", "@prefix@", HOMEBREW_PREFIX
 
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
-                          "--disable-imageio",
-                          "--disable-sdltest"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-imageio
+      --disable-sdltest
+    ]
+
+    args << "--disable-png-shared" if build.with? "libpng"
+    args << "--disable-jpg-shared" if build.with? "jpeg"
+    args << "--disable-tif-shared" if build.with? "libtiff"
+    args << "--disable-webp-shared" if build.with? "webp"
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  No, as the tests are missing.
-----

This PR adds a new option to `sdl_image` to build without dynamically loading dylibs (using `dlopen`) for png, jpg, tiff and webp files.
This is very useful when packaging `sdl_image` for example in [`pygame`](https://bitbucket.org/pygame/pygame/issues/300/os-x-wheels-dmg-and-zip-builds-with-travis#comment-32409453) using `delocate`. As this makes all required libraries visible using `otool -L` and prevents `sdl` from searching for these libraries at runtime.

Example output after building with `--without-shared`:
```
$ otool -L /usr/local/Cellar/sdl_image/1.2.12_4/lib/libSDL_image.dylib
/usr/local/Cellar/sdl_image/1.2.12_4/lib/libSDL_image.dylib:
	/usr/local/opt/sdl_image/lib/libSDL_image-1.2.0.dylib (compatibility version 9.0.0, current version 9.4.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 43.0.0, current version 43.0.0)
	/usr/local/opt/jpeg/lib/libjpeg.8.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/local/opt/libtiff/lib/libtiff.5.dylib (compatibility version 8.0.0, current version 8.5.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/usr/local/opt/webp/lib/libwebp.6.dylib (compatibility version 7.0.0, current version 7.1.0)
	/usr/local/opt/sdl/lib/libSDL-1.2.0.dylib (compatibility version 12.0.0, current version 12.4.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 22.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```

