### PR TITLE
sdl_mixer: Add option to disable shared libraries

### DIFF
--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -3,6 +3,7 @@ class SdlMixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
+  revision 1
 
   bottle do
     cellar :any
@@ -29,8 +30,18 @@ class SdlMixer < Formula
 
     ENV.universal_binary if build.universal?
 
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+    ]
+
+    args << "--disable-music-mod-shared" if build.with? "libmikmod"
+    args << "--disable-music-fluidsynth-shared" if build.with? "fluid-synth"
+    args << "--disable-music-ogg-shared" if build.with? "libvorbis"
+    args << "--disable-music-flac-shared" if build.with? "flac"
+    args << "--disable-music-mp3-shared" if build.with? "smpeg"
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No tests available.
-----
Same reasoning as for https://github.com/Homebrew/homebrew-core/pull/7285.

Example output:
```
$ otool -L /usr/local/Cellar/sdl_mixer/1.2.12/lib/libSDL_mixer.dylib 
/usr/local/Cellar/sdl_mixer/1.2.12/lib/libSDL_mixer.dylib:
	/usr/local/opt/sdl_mixer/lib/libSDL_mixer-1.2.0.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/local/opt/libmikmod/lib/libmikmod.3.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/fluid-synth/lib/libfluidsynth.1.dylib (compatibility version 1.0.0, current version 1.5.2)
	/usr/local/opt/libvorbis/lib/libvorbisfile.3.dylib (compatibility version 7.0.0, current version 7.7.0)
	/usr/local/opt/libvorbis/lib/libvorbis.0.dylib (compatibility version 5.0.0, current version 5.8.0)
	/usr/local/opt/libogg/lib/libogg.0.dylib (compatibility version 9.0.0, current version 9.2.0)
	/usr/local/opt/flac/lib/libFLAC.8.dylib (compatibility version 12.0.0, current version 12.0.0)
	/usr/local/opt/smpeg/lib/libsmpeg-0.4.0.dylib (compatibility version 2.0.0, current version 2.4.0)
	/usr/local/opt/sdl/lib/libSDL-1.2.0.dylib (compatibility version 12.0.0, current version 12.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 22.0.0)
	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 492.0.0)
	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 775.8.2)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1348.15.0)
```