### PR TITLE
libmongoc 1.5.0

### DIFF
--- a/Formula/libmongoc.rb
+++ b/Formula/libmongoc.rb
@@ -1,8 +1,8 @@
 class Libmongoc < Formula
   desc "Cross Platform MongoDB Client Library for C"
   homepage "http://mongoc.org/"
-  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.4.2/mongo-c-driver-1.4.2.tar.gz"
-  sha256 "9154d8f6b3261f785a19d1f81506fb911c985f26dfdc9b19082e1bc7af479afb"
+  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.5.0/mongo-c-driver-1.5.0.tar.gz"
+  sha256 "b9b7514052fe7ec40786d8fc22247890c97d2b322aa38c851bba986654164bd6"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libmongoc 1.5.0.

This gets libmongoc in sync with libbson, in preparation for possible rearrangement of deps as discussed in #7303.
