### PR TITLE
libmongoc: use brewed libbson

### DIFF
--- a/Formula/libbson.rb
+++ b/Formula/libbson.rb
@@ -1,6 +1,7 @@
 class Libbson < Formula
   desc "BSON utility library"
   homepage "https://github.com/mongodb/libbson"
+  # Note: libbson and libmongoc must be kept in sync. Do not update one without updating the other.
   url "https://github.com/mongodb/libbson/releases/download/1.5.0/libbson-1.5.0.tar.gz"
   sha256 "ba49eeebedfc1e403d20abb080f3a67201b799a05f4a012eee94139ad54a6e6f"
 

--- a/Formula/libmongoc.rb
+++ b/Formula/libmongoc.rb
@@ -1,8 +1,10 @@
 class Libmongoc < Formula
   desc "Cross Platform MongoDB Client Library for C"
   homepage "http://mongoc.org/"
+  # Note: libbson and libmongoc must be kept in sync. Do not update one without updating the other.
   url "https://github.com/mongodb/mongo-c-driver/releases/download/1.5.0/mongo-c-driver-1.5.0.tar.gz"
   sha256 "b9b7514052fe7ec40786d8fc22247890c97d2b322aa38c851bba986654164bd6"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,13 +13,17 @@ class Libmongoc < Formula
     sha256 "720675b55e6d98db395337582757fae96ebaa0c5e317c4f58cfc93ee8c3a4410" => :yosemite
   end
 
+  depends_on "libbson"
+  depends_on "pkg-config" => :build
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--enable-man-pages",
-                          "--enable-ssl=darwin"
+                          "--enable-ssl=darwin",
+                          "--with-libbson=system"
     system "make", "install"
   end
 
@@ -32,7 +38,7 @@ class Libmongoc < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-lbson-1.0", "-I#{include}/libbson-1.0", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lbson-1.0", "-I#{Formula["libbson"].opt_include}/libbson-1.0", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Modifies libmongoc to use the Homebrew-provided `libbson` instead of its own bundled `libbson`. This prevents `libmongoc` from installing the libbson libs and headers, avoiding a conflict with `libbson`, and allowing us to manage them as separate packages. See discussion in #7303.

Closes #7303.
Fixes #7291.
