### PR TITLE
ldc v1.1.0-beta5 (devel)

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -22,9 +22,14 @@ class Ldc < Formula
   end
 
   devel do
-    url "https://github.com/ldc-developers/ldc/releases/download/v1.1.0-beta3/ldc-1.1.0-beta3-src.tar.gz"
-    sha256 "cf4aeb393eada610aa3bad18c3ae6a5de94250eaa968fe2d1b0a6afdf8ea54f6"
-    version "1.1.0-beta3"
+    url "https://github.com/ldc-developers/ldc/releases/download/v1.1.0-beta5/ldc-1.1.0-beta5-src.tar.gz"
+    sha256 "46c494ca1c29f2cd1e5d2e2d29681ceeb71fad72f34cc8d2308856c22b27a41b"
+    version "1.1.0-beta5"
+
+    patch do
+      url "https://github.com/ldc-developers/ldc/pull/1902.patch"
+      sha256 "dcb61bb49a56537f77d9153b687a591a48129bb1cb5ac30d7df78cd251431e6d"
+    end
 
     resource "ldc-lts" do
       url "https://github.com/ldc-developers/ldc/releases/download/v0.17.2/ldc-0.17.2-src.tar.gz"
@@ -68,6 +73,9 @@ class Ldc < Formula
       system "cmake", "..", *args
       system "make"
       system "make", "install"
+      unless build.stable?
+        lib.install bin/"libLTO-ldc.dylib"
+      end
     end
   end
 
@@ -79,7 +87,11 @@ class Ldc < Formula
       }
     EOS
 
-    system bin/"ldc2", "test.d"
+    if build.stable?
+      system bin/"ldc2", "test.d"
+    else
+      system bin/"ldc2", "-flto=full", "test.d"
+    end
     assert_match "Hello, world!", shell_output("./test")
     system bin/"ldmd2", "test.d"
     assert_match "Hello, world!", shell_output("./test")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### The following problem is now resolved with a patch taken from the relevant upstream pull request:

Doesn't pass audit because it installs `libLTO-ldc.dylib` in `bin`, which is currently where ldc looks for it.

2 parts to the problem: 1) where to put it and 2) how to get ldc to find it.

Things that can be done for 1):
* Allow it to install a non-executable in `bin` or
* Use a patch to modify `CmakeLists.txt` to make it install in another directory or
* Move it after `make install`

There is also the question of where it should go. `libexec` is a bit tempting, but `lib` makes sense as well.

and for 2)
* patch some code in `driver/linker.cpp` so ldc looks in a different place by default or
* patch `ldc_install.conf.in` to add `-flto-binary=#{lib}/libTLO-ldc.dylib`

Final option: wait for upstream to sort it out somehow.