### PR TITLE
git-annex-map: use xdot instead of dot 

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -26,6 +26,7 @@ class GitAnnex < Formula
   depends_on "libmagic"
   depends_on "gnutls"
   depends_on "quvi"
+  depends_on "xdot" => :recommended
 
   resource "esqueleto-2.4.3" do
     url "https://mirrors.ocf.berkeley.edu/debian/pool/main/h/haskell-esqueleto/haskell-esqueleto_2.4.3.orig.tar.gz"
@@ -44,6 +45,15 @@ class GitAnnex < Formula
   end
 
   def install
+    # use `xdot` instead of `dot -Tx11` to display generated maps
+    inreplace "Command/Map.hs" do |s|
+      s.gsub! "dot", "xdot"
+      # eliminate extra parameter in actual invocation
+      s.gsub! "Param \"-Tx11\",", ""
+      # change status message
+      s.gsub! "-Tx11", ""
+    end
+
     cabal_sandbox do
       (buildpath/"esqueleto-2.4.3").install resource("esqueleto-2.4.3")
       resource("esqueleto-newer-persistent-patch").stage do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Using `xdot` instead of `dot -Tx11` gives the  correct display behavior on OS X. 

`xdot` is only marked as recommended because this is not essential behavior and you can manually generate desired output after running  `git annex map --fast` even without `xdot` if you have other software that understands the GraphViz format.

