### PR TITLE
yelp-tools 3.20.1

### DIFF
--- a/Formula/yelp-tools.rb
+++ b/Formula/yelp-tools.rb
@@ -20,11 +20,9 @@ class YelpTools < Formula
   depends_on "libxslt" => :build
   depends_on "pkg-config" => :build
 
-  yelp_tools_version = version
-
   resource "yelp-xsl" do
-    url "https://download.gnome.org/sources/yelp-xsl/3.18/yelp-xsl-#{yelp_tools_version}.tar.xz"
-    sha256 "893620857b72b3b43ee3b462281240b7ca4d80292f469552827f0597bf60d2b2"
+    url "https://download.gnome.org/sources/yelp-xsl/3.20/yelp-xsl-3.20.1.tar.xz"
+    sha256 "dc61849e5dca473573d32e28c6c4e3cf9c1b6afe241f8c26e29539c415f97ba0"
   end
 
   def install


### PR DESCRIPTION
This is a work in progress. I've added two dependencies that appear to be required now, but linking fails with "ld: unknown option: --no-as-needed".

```
==> ./configure --prefix=/usr/local/Cellar/yelp-tools/3.20.1
... snip ...
==> make install
... snip ...
  CCLD     libyelp/libyelp.la
  CCLD     libyelp/web-extension/libyelpwebextension.la
  CCLD     yelp
ld: unknown option: --no-as-needed
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [yelp] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install] Error 2
```

Perhaps we should disable some of the new yelp features in 3.20 by passing some disable options to configure? I'm taking a break from this for now.