### PR TITLE
berkeley-db: up formula version to 6.2.23, enable dbm, depend on java

### DIFF
--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -1,8 +1,8 @@
 class BerkeleyDb < Formula
   desc "High performance key/value database"
   homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
-  url "http://download.oracle.com/berkeley-db/db-6.1.26.tar.gz"
-  sha256 "dd1417af5443f326ee3998e40986c3c60e2a7cfb5bfa25177ef7cadb2afb13a6"
+  url "http://download.oracle.com/berkeley-db/db-6.2.23.tar.gz"
+  sha256 "47612c8991aa9ac2f6be721267c8d3cdccf5ac83105df8e50809daea24e95dc7"
 
   bottle do
     cellar :any
@@ -13,10 +13,10 @@ class BerkeleyDb < Formula
     sha256 "8f5a87bc3336e01f8528ae8aaae24c83e8fa10e8f01ee65e8cac4af7d0786bf1" => :mountain_lion
   end
 
-  option "with-java", "Compile with Java support."
-  option "with-sql", "Compile with SQL support."
+  option "without-sql", "Build without SQL support."
+  option "without-dbm", "Build without dbm interface."
 
-  deprecated_option "enable-sql" => "with-sql"
+  depends_on :java => [:recommended, :build]
 
   def install
     # BerkeleyDB dislikes parallel builds
@@ -32,6 +32,7 @@ class BerkeleyDb < Formula
     ]
     args << "--enable-java" if build.with? "java"
     args << "--enable-sql" if build.with? "sql"
+    args << "--enable-dbm" if build.with? "dbm"
 
     # BerkeleyDB requires you to build everything from the build_unix subdirectory
     cd "build_unix" do

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -13,9 +13,6 @@ class BerkeleyDb < Formula
     sha256 "8f5a87bc3336e01f8528ae8aaae24c83e8fa10e8f01ee65e8cac4af7d0786bf1" => :mountain_lion
   end
 
-  option "without-sql", "Build without SQL support."
-  option "without-dbm", "Build without dbm interface."
-
   depends_on :java => [:optional, :build]
 
   def install
@@ -29,10 +26,11 @@ class BerkeleyDb < Formula
       --mandir=#{man}
       --enable-cxx
       --enable-compat185
+      --enable-sql
+      --enable-sql_codegen
+      --enable-dbm
     ]
     args << "--enable-java" if build.with? "java"
-    args << "--enable-sql" if build.with? "sql"
-    args << "--enable-dbm" if build.with? "dbm"
 
     # BerkeleyDB requires you to build everything from the build_unix subdirectory
     cd "build_unix" do

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -16,7 +16,7 @@ class BerkeleyDb < Formula
   option "without-sql", "Build without SQL support."
   option "without-dbm", "Build without dbm interface."
 
-  depends_on :java => [:recommended, :build]
+  depends_on :java => [:optional, :build]
 
   def install
     # BerkeleyDB dislikes parallel builds

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -29,6 +29,7 @@ class BerkeleyDb < Formula
       --enable-sql
       --enable-sql_codegen
       --enable-dbm
+      --enable-stl
     ]
     args << "--enable-java" if build.with? "java"
 

--- a/Formula/bogofilter.rb
+++ b/Formula/bogofilter.rb
@@ -3,6 +3,7 @@ class Bogofilter < Formula
   homepage "http://bogofilter.sourceforge.net"
   url "https://downloads.sourceforge.net/project/bogofilter/bogofilter-1.2.4/bogofilter-1.2.4.tar.bz2"
   sha256 "e10287a58d135feaea26880ce7d4b9fa2841fb114a2154bf7da8da98aab0a6b4"
+  revision 1
 
   bottle do
     sha256 "92301b235bfd5088a5b20fa263de2c012f31f90860f3b1b1fd93a918d93fff7c" => :sierra

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -22,6 +22,9 @@ class Darkice < Formula
   depends_on "jack"
 
   def install
+    # Fixes  "invalid conversion from ‘const float*’ to ‘float*’ [-fpermissive]"
+    # Upstream issue Oct 25, 2016 https://github.com/rafael2k/darkice/issues/119
+    # Suggested fix  Oct 25, 2016 https://github.com/rafael2k/darkice/pull/120
     ["aacPlusEncoder.cpp", "FaacEncoder.cpp", "OpusLibEncoder.cpp", "VorbisLibEncoder.cpp"].each do |f|
       inreplace "src/#{f}", ", converterData.data_in", ", const_cast<float*>( converterData.data_in )"
     end

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -3,6 +3,7 @@ class Darkice < Formula
   homepage "http://www.darkice.org/"
   url "https://downloads.sourceforge.net/project/darkice/darkice/1.3/darkice-1.3.tar.gz"
   sha256 "2c0d0faaa627c0273b2ce8b38775a73ef97e34ef866862a398f660ad8f6e9de6"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -22,7 +22,7 @@ class Darkice < Formula
   depends_on "jack"
 
   def install
-    # Fixes  "invalid conversion from ‘const float*’ to ‘float*’ [-fpermissive]"
+    # Fixes  "invalid conversion from 'const float*' to 'float*' [-fpermissive]"
     # Upstream issue Oct 25, 2016 https://github.com/rafael2k/darkice/issues/119
     # Suggested fix  Oct 25, 2016 https://github.com/rafael2k/darkice/pull/120
     ["aacPlusEncoder.cpp", "FaacEncoder.cpp", "OpusLibEncoder.cpp", "VorbisLibEncoder.cpp"].each do |f|

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -22,6 +22,9 @@ class Darkice < Formula
   depends_on "jack"
 
   def install
+    ["aacPlusEncoder.cpp", "FaacEncoder.cpp", "OpusLibEncoder.cpp", "VorbisLibEncoder.cpp"].each do |f|
+      inreplace "src/#{f}", ", converterData.data_in", ", const_cast<float*>( converterData.data_in )"
+    end
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",

--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -3,6 +3,7 @@ class Dbxml < Formula
   homepage "https://www.oracle.com/us/products/database/berkeley-db/xml/overview/index.html"
   url "http://download.oracle.com/berkeley-db/dbxml-6.0.18.tar.gz"
   sha256 "5851f60a47920718b701752528a449f30b16ddbf5402a2a5e8cde8b4aecfabc8"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/dirt.rb
+++ b/Formula/dirt.rb
@@ -3,6 +3,7 @@ class Dirt < Formula
   homepage "https://github.com/tidalcycles/Dirt"
   url "https://github.com/tidalcycles/Dirt/archive/1.1.tar.gz"
   sha256 "bb1ae52311813d0ea3089bf3837592b885562518b4b44967ce88a24bc10802b6"
+  revision 1
   head "https://github.com/tidalcycles/Dirt.git"
 
   bottle do

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -1,7 +1,7 @@
 class GnuCobol < Formula
   desc "Implements much of the COBOL 85 and COBOL 2002 standards"
   homepage "http://www.opencobol.org/"
-  revision 3
+  revision 4
 
   stable do
     url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/1.1/gnu-cobol-1.1.tar.gz"

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -3,7 +3,7 @@ class Gnuradio < Formula
   homepage "https://gnuradio.squarespace.com/"
   url "https://gnuradio.org/releases/gnuradio/gnuradio-3.7.9.1.tar.gz"
   sha256 "9c06f0f1ec14113203e0486fd526dd46ecef216dfe42f12d78d9b781b1ef967e"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -10,6 +10,7 @@ class Jack < Formula
   homepage "http://jackaudio.org"
   url "http://jackaudio.org/downloads/jack-audio-connection-kit-0.125.0.tar.gz"
   sha256 "3517b5bff82139a76b2b66fe2fd9a3b34b6e594c184f95a988524c575b11d444"
+  revision 1
 
   bottle do
     sha256 "09037cc758f7fbb1906e9f57722143ac6fad688dafc8a3737b23ee6cf60f3277" => :sierra

--- a/Formula/jigdo.rb
+++ b/Formula/jigdo.rb
@@ -3,7 +3,7 @@ class Jigdo < Formula
   homepage "http://atterer.org/jigdo/"
   url "http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-0.7.3.tar.bz2"
   sha256 "875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
-  revision 2
+  revision 3
 
   bottle do
     rebuild 2

--- a/Formula/ltc-tools.rb
+++ b/Formula/ltc-tools.rb
@@ -4,6 +4,7 @@ class LtcTools < Formula
   url "https://github.com/x42/ltc-tools/archive/v0.6.4.tar.gz"
   sha256 "8fc9621df6f43ab24c65752a9fee67bee6625027c19c088e5498d2ea038a22ec"
   head "https://github.com/x42/ltc-tools.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/memcacheq.rb
+++ b/Formula/memcacheq.rb
@@ -3,6 +3,7 @@ class Memcacheq < Formula
   homepage "http://memcachedb.org/memcacheq"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/memcacheq/memcacheq-0.2.0.tar.gz"
   sha256 "b314c46e1fb80d33d185742afe3b9a4fadee5575155cb1a63292ac2f28393046"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -3,6 +3,7 @@ class Moc < Formula
   homepage "https://moc.daper.net"
   url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
   sha256 "f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08"
+  revision 1
 
   bottle do
     sha256 "c6441a6396a213644e39dae1bf920a7b773bb7c4730bfd1e751dd480d0bb80a0" => :sierra

--- a/Formula/nvi.rb
+++ b/Formula/nvi.rb
@@ -4,7 +4,7 @@ class Nvi < Formula
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   sha256 "8bc348889159a34cf268f80720b26f459dbd723b5616107d36739d007e4c978d"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/open-cobol.rb
+++ b/Formula/open-cobol.rb
@@ -3,6 +3,7 @@ class OpenCobol < Formula
   homepage "http://www.opencobol.org/"
   url "https://downloads.sourceforge.net/project/open-cobol/open-cobol/1.1/open-cobol-1.1.tar.gz"
   sha256 "6ae7c02eb8622c4ad55097990e9b1688a151254407943f246631d02655aec320"
+  revision 1
 
   bottle do
     sha256 "5803c69bb9b04d1fdebd4aa8a3e2b211a97ec3e8bc8e50f3918635d367d9d1bf" => :sierra

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -3,6 +3,7 @@ class Qjackctl < Formula
   homepage "http://qjackctl.sourceforge.net"
   url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.4.4.tar.gz"
   sha256 "531db2f7eca654fd8769a1281dccb54ebca57a0b2a575734d1bafc3896a46ba5"
+  revision 1
   head "http://git.code.sf.net/p/qjackctl/code.git"
 
   bottle do

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -18,6 +18,7 @@ class Rpm < Formula
       :using => RpmDownloadStrategy
   version "5.4.15"
   sha256 "d4ae5e9ed5df8ab9931b660f491418d20ab5c4d72eb17ed9055b80b71ef6c4ee"
+  revision 1
 
   bottle do
     sha256 "718f3e01ea9eac8516a4566403627da074b7cc2b20c40d7797828f5fe93bfae7" => :sierra

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -115,7 +115,8 @@ class Rpm < Formula
     EOS
 
     system "#{bin}/rpm", "-vv", "-qa", "--dbpath=#{testpath}/var/lib/rpm"
-    assert File.exist?(testpath/"var/lib/rpm/Packages")
+    assert File.exist?(testpath/"var/lib/rpm/sqldb"), "Failed to create 'sqldb' file!"
+    assert_match "Packages", shell_output("sqlite3 #{testpath}/var/lib/rpm/sqldb <<< .tables")
     rpmdir("%_builddir").mkpath
     specfile = rpmdir("%_specdir")+"test.spec"
     specfile.write(test_spec)

--- a/Formula/webalizer.rb
+++ b/Formula/webalizer.rb
@@ -4,6 +4,7 @@ class Webalizer < Formula
   url "ftp://ftp.mrunix.net/pub/webalizer/webalizer-2.23-08-src.tgz"
   mirror "https://mirrors.kernel.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
   sha256 "edaddb5aa41cc4a081a1500e3fa96615d4b41bc12086bcedf9938018ce79ed8d"
+  revision 1
 
   bottle do
     sha256 "dab2f6da9c48ff9b4841ed5e6585db534476a080f032782388cb0db2af471d3d" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR does several things:
1. updates `berkeley-db` to 6.2.23.
1. updates default options to build with java and sql support
1. adds `:java` dependency
1. adds `dbm` support (needed for some formulas)

Related (and closed) PRs: #2549 and #3263

```txt
$ brew audit --strict berkeley-db
berkeley-db:
  * JARs were installed to "/usr/local/Cellar/berkeley-db/6.2.23/lib"
    Installing JARs to "lib" can cause conflicts between packages.
    For Java software, it is typically better for the formula to
    install to "libexec" and then symlink or wrap binaries into "bin".
    See "activemq", "jruby", etc. for examples.
    The offending files are:
      /usr/local/Cellar/berkeley-db/6.2.23/lib/db.jar
Error: 1 problem in 1 formula
```