### PR TITLE
closure-stylesheets 1.4.0 (new formula)

### DIFF
--- a/Formula/closure-stylesheets.rb
+++ b/Formula/closure-stylesheets.rb
@@ -1,0 +1,28 @@
+class ClosureStylesheets < Formula
+  desc "Extended CSS preprocessor, linter, and internationalizer"
+  homepage "https://github.com/google/closure-stylesheets"
+  url "https://github.com/google/closure-stylesheets/releases/download/v1.4.0/closure-stylesheets.jar"
+  version "1.4.0"
+  sha256 "08c7f4c9694f9cf07e2d401af831f9208fac937e906ac65288d308fc09d2a8e3"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    libexec.install "closure-stylesheets.jar"
+    bin.write_jar_script libexec/"closure-stylesheets.jar", "closure-stylesheets"
+  end
+
+  test do
+    (testpath/"test.gss").write <<-EOS.undent
+      @def A 5px;
+      @def B 10px;
+      .test {
+        width: add(A, B);
+      }
+    EOS
+    system bin/"closure-stylesheets", testpath/"test.gss", "-o", testpath/"out.css"
+    assert_equal (testpath/"out.css").read.chomp, ".test{width:15px}"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closure Stylesheets are Google's extensions to CSS, plus i18n and optimization.