### PR TITLE
kops: 1.4.1 (fix) 

### DIFF
--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -16,6 +16,7 @@ class Kops < Formula
   depends_on "kubernetes-cli"
 
   def install
+    ENV["VERSION"] = version unless build.head?
     ENV["GOPATH"] = buildpath
     kopspath = buildpath/"src/k8s.io/kops"
     kopspath.install Dir["*"]

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -4,6 +4,7 @@ class Kops < Formula
   url "https://github.com/kubernetes/kops/archive/v1.4.1.tar.gz"
   sha256 "69b3c9d7e214109cfd197031091ed23963383c894e92804306629f6a32ab324b"
   head "https://github.com/kubernetes/kops.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
```kops version``` uses an ENV variable that needs to be present at build to denote the version. Without this, people don't know the version they are on.