### PR TITLE
trace2html: fix project location/url

### DIFF
--- a/Formula/trace2html.rb
+++ b/Formula/trace2html.rb
@@ -1,8 +1,8 @@
 class Trace2html < Formula
   desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
-  homepage "https://github.com/google/trace-viewer"
-  url "https://github.com/google/trace-viewer/archive/2015-06-23.tar.gz"
-  sha256 "97ad0ca9c07a50c53a3d881b69b6b6f7424d6b0f4d9e9fb531c2d9273e413f19"
+  homepage "https://github.com/catapult-project/catapult/tree/master/tracing"
+  url "https://github.com/catapult-project/catapult/archive/9dae3963cdd72211f17a2c976dd077d1125cdde7.zip"
+  sha256 "82c7495ad6c3951fbf808f902936f354cf847dcce22e5ca6ae529a5014909dca"
 
   bottle :unneeded
 
@@ -10,7 +10,7 @@ class Trace2html < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"trace2html"
+    bin.install_symlink libexec/"tracing/bin/trace2html"
   end
 
   test do

--- a/Formula/trace2html.rb
+++ b/Formula/trace2html.rb
@@ -1,8 +1,8 @@
 class Trace2html < Formula
-  desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
+  desc "Trace2Html"
   homepage "https://github.com/catapult-project/catapult/tree/master/tracing"
-  url "https://github.com/catapult-project/catapult/archive/9dae3963cdd72211f17a2c976dd077d1125cdde7.zip"
-  sha256 "82c7495ad6c3951fbf808f902936f354cf847dcce22e5ca6ae529a5014909dca"
+  url "https://github.com/catapult-project/catapult/archive/9dae3963cdd72211f17a2c976dd077d1125cdde7.tar.gz"
+  sha256 "b0c0ecc94d63395c69393f79d5b5dd25b3871cf3849b1e7566a57fb7c571cb74"
 
   bottle :unneeded
 


### PR DESCRIPTION
Trace2html is no longer it's own project, and is now part of the "catapult-project": https://github.com/catapult-project/catapult