### PR TITLE
zsh 5.2-test-1 (devel)

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -27,9 +27,21 @@ class Zsh < Formula
     sha256 "d140366f62354011a7de99949e847ae44d6aa70f2b51e1722028844e4fa0b252" => :yosemite
   end
 
+  devel do
+    url "http://www.zsh.org/pub/development/zsh-5.2-test-1.tar.gz"
+    version "5.2-test-1"
+    sha256 "50b18b837562e748ca2bc3054f167b71df4482d2da8263ef502acb5d21f23259"
+
+    option "with-texi2html", "Build HTML documentation"
+    option "with-unicode9", "Build with Unicode 9 character width support"
+    depends_on "texi2html" => [:build, :optional]
+  end
+
   head do
     url "git://git.code.sf.net/p/zsh/code"
     depends_on "autoconf" => :build
+
+    option "with-unicode9", "Build with Unicode 9 character width support"
   end
 
   option "without-etcdir", "Disable the reading of Zsh rc files in /etc"
@@ -56,6 +68,8 @@ class Zsh < Formula
       --enable-zsh-secure-free
       --with-tcsetpgrp
     ]
+
+    args << "--enable-unicode9" if build.with? "unicode9"
 
     if build.without? "etcdir"
       args << "--disable-etcdir"

--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -97,10 +97,6 @@ class Zsh < Formula
   def caveats; <<-EOS.undent
     In order to use this build of zsh as your login shell,
     it must be added to /etc/shells.
-    Add the following to your zshrc to access the online help:
-      unalias run-help
-      autoload run-help
-      HELPDIR=#{HOMEBREW_PREFIX}/share/zsh/help
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add option --with-unicode9 on devel and head for Unicode 9 character
width support. The option is not enabled by default because support is
required from both the shell and the terminal emulator; disparity could
cause garbled output. A simple test case is "echo 👍1👍2👍3" at the
prompt:

- If neither zsh nor the terminal emulator has Unicode 9 width tables,
  each digit will overlap with its previous emoji, but editing will still be
  very much possible;

- If zsh has Unicode 9 width tables but the terminal emulator doesn't,
  the string will be garbled and editing will be very difficult;

- If both zsh and the terminal emulator have Unicode 9 width tables,
  output will be correct and editing won't be hindered.

Terminal.app currently doesn't support Unicode 9, making the option a
tough sell as default. For the record, iTerm2 nightlies since 08/08/2016
have opt-in Unicode 9 width support and version switching. See
https://gitlab.com/gnachman/iterm2/wikis/unicodeversionswitching.

---

What's new:

> Changes from 5.2 to 5.3
>
> It is possible to enable character width support for Unicode 9 by
> configuring with `--enable-unicode9'; this compiles in some additional
> tables.  At some point this support may move into a module, in which
> case the configure option will be changed to cause the module to be
> permanently loaded.  This option is not useful unless your terminal also
> supports Unicode 9.
>
> The new word modifier ':P' computes the physical path of the argument.
> It is different from the existing ':a' modifier which always resolves
> '/before/here/../after' to '/before/after', and differs from the
> existing ':A' modifier which resolves symlinks only after 'here/..' is
> removed, even when /before/here is itself a symbolic link.  It is
> recommended to review uses of ':A' and, if appropriate, convert them
> to ':P' as soon as compatibility with 5.2 is no longer a requirement.
>
> The output of "typeset -p" uses "export" commands or the "-g" option
> for parameters that are not local to the current scope.  Previously,
> all output was in the form of "typeset" commands, never using "-g".