### PR TITLE
mdk: force en_US.UTF-8 locale during tests to suppress the "german bug"

### DIFF
--- a/Formula/mdk.rb
+++ b/Formula/mdk.rb
@@ -30,6 +30,8 @@ class Mdk < Formula
   end
 
   test do
+    ENV["LANG"] = "en_US.UTF-8"
+
     (testpath/"hello.mixal").write <<-EOS.undent
       *                                                        (1)
       * hello.mixal: say "hello world" in MIXAL                (2)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This *should* fix the "german bug" appearing occasionally on the Sierra CI. 

Currently blocking #7492