### PR TITLE
gradle: Add option to install gradle-all

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -1,8 +1,10 @@
 class Gradle < Formula
   desc "Build system based on the Groovy language"
   homepage "https://www.gradle.org/"
-  url "https://downloads.gradle.org/distributions/gradle-3.2.1-bin.zip"
-  sha256 "9843a3654d3e57dce54db06d05f18b664b95c22bf90c6becccb61fc63ce60689"
+  url "https://downloads.gradle.org/distributions/gradle-3.2.1-all.zip"
+  sha256 "0209696f1723f607c475109cf3ed8b51c8a91bb0cda05af0d4bd980bdefe75cd"
+
+  option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
 
   bottle :unneeded
 
@@ -10,6 +12,9 @@ class Gradle < Formula
 
   def install
     libexec.install %w[bin lib]
+    if build.with? "all"
+      libexec.install %w[docs media samples src]
+    end
     bin.install_symlink libexec/"bin/gradle"
   end
 

--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -12,9 +12,7 @@ class Gradle < Formula
 
   def install
     libexec.install %w[bin lib]
-    if build.with? "all"
-      libexec.install %w[docs media samples src]
-    end
+    libexec.install %w[docs media samples src] if build.with? "all"
     bin.install_symlink libexec/"bin/gradle"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? ❌ **I cannot run `RuboCop` as it currently segfaults on my system.**

-----

When writing Gradle plugins it's nice to have the source on hand. This PR adds the ability to install the `-all` distribution of Gradle, which, while larger, contains docs, source, and other useful files for a developer. I'm not sure if there is a recommended way to do such a thing, so I patched something together from what I could find on the documentation. If there's a better way, just tell me and I'd be glad to do it.
