### PR TITLE
Node@*: import from homebrew/versions.

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -1,5 +1,5 @@
 class Node < Formula
-  desc "Platform built on the V8 JavaScript runtime to build network applications"
+  desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
   url "https://nodejs.org/dist/v7.2.0/node-v7.2.0.tar.xz"
   sha256 "486d4db7ef659521ad2fafefca877638da07bef61e2aee090207ff52149294fb"
@@ -24,9 +24,14 @@ class Node < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl" => :optional
 
+  conflicts_with "node@0.10", :because => "Differing versions of the same formulae."
+  conflicts_with "node@0.12", :because => "Differing versions of the same formulae."
+  conflicts_with "node@4", :because => "Differing versions of the same formulae."
+  conflicts_with "node@5", :because => "Differing versions of the same formulae."
+  conflicts_with "node@6", :because => "Differing versions of the same formulae."
+
   # Per upstream - "Need g++ 4.8 or clang++ 3.4".
   fails_with :clang if MacOS.version <= :snow_leopard
-  fails_with :llvm
   fails_with :gcc_4_0
   fails_with :gcc
   ("4.3".."4.7").each do |n|

--- a/Formula/node@0.10.rb
+++ b/Formula/node@0.10.rb
@@ -1,0 +1,132 @@
+class NodeAT010 < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v0.10.48/node-v0.10.48.tar.xz"
+  sha256 "365a93d9acc076a0d93f087d269f376abeebccad599a9dab72f2f6ed96c8ae6e"
+  head "https://github.com/nodejs/node.git", :branch => "v0.10-staging"
+
+  deprecated_option "enable-debug" => "with-debug"
+
+  option "with-debug", "Build with debugger hooks"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+
+  depends_on :python => :build
+  depends_on "openssl" => :optional
+
+  conflicts_with "node", :because => "Differing versions of the same formula"
+  conflicts_with "node@0.12", :because => "Differing versions of the same formulae."
+  conflicts_with "node@4", :because => "Differing versions of the same formulae."
+  conflicts_with "node@5", :because => "Differing versions of the same formulae."
+  conflicts_with "node@6", :because => "Differing versions of the same formulae."
+
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-2.15.1.tgz"
+    sha256 "e3435100b37379354b899a31d073ef81b8aa7365c52eb138847ecfbf9f01ea93"
+  end
+
+  def install
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+
+    if build.with? "openssl"
+      args << "--shared-openssl"
+    else
+      args << "--without-ssl3"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
+        # Remove manpage symlinks from the buildpath, they are breaking bottle
+        # creation. The real manpages are living in libexec/npm/lib/node_modules/npm/man/
+        # https://github.com/Homebrew/homebrew/pull/47081#issuecomment-165280470
+        rm_rf libexec/"npm/share/"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/{npm,package.json}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+    end
+  end
+end

--- a/Formula/node@0.12.rb
+++ b/Formula/node@0.12.rb
@@ -1,0 +1,148 @@
+class NodeAT012 < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v0.12.17/node-v0.12.17.tar.xz"
+  sha256 "e2e82229200ef973e033d6dae910d789ab440e913f8c4c6225bf5e6e4a446420"
+  head "https://github.com/nodejs/node.git", :branch => "v0.12-staging"
+
+  option "with-debug", "Build with debugger hooks"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+
+  depends_on :python => :build if MacOS.version <= :snow_leopard
+  depends_on "pkg-config" => :build
+  depends_on "openssl" => :optional
+
+  # https://github.com/nodejs/node-v0.x-archive/issues/7919
+  # https://github.com/Homebrew/homebrew/issues/36681
+  depends_on "icu4c" => :optional
+
+  conflicts_with "node", :because => "Differing versions of the same formula"
+  conflicts_with "node@0.10", :because => "Differing versions of the same formulae."
+  conflicts_with "node@4", :because => "Differing versions of the same formulae."
+  conflicts_with "node@5", :because => "Differing versions of the same formulae."
+  conflicts_with "node@6", :because => "Differing versions of the same formulae."
+
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-2.15.1.tgz"
+    sha256 "e3435100b37379354b899a31d073ef81b8aa7365c52eb138847ecfbf9f01ea93"
+  end
+
+  def install
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+    args << "--with-intl=system-icu" if build.with? "icu4c"
+
+    if build.with? "openssl"
+      args << "--shared-openssl"
+    else
+      args << "--without-ssl3"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
+        # Remove manpage symlinks from the buildpath, they are breaking bottle
+        # creation. The real manpages are living in libexec/npm/lib/node_modules/npm/man/
+        # https://github.com/Homebrew/homebrew/pull/47081#issuecomment-165280470
+        rm_rf libexec/"npm/share/"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/{npm,package.json}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    if build.with? "icu4c"
+      s += <<-EOS.undent
+
+        Please note `icu4c` is built with a newer deployment target than Node and
+        this may cause issues in certain usage. Node itself is built against the
+        outdated `libstdc++` target, which is the root cause. For more information see:
+          https://github.com/nodejs/node-v0.x-archive/issues/7919
+
+        If this is an issue for you, do `brew install node --without-icu4c`.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+    end
+  end
+end

--- a/Formula/node@4.rb
+++ b/Formula/node@4.rb
@@ -1,0 +1,146 @@
+class NodeAT4 < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v4.6.2/node-v4.6.2.tar.xz"
+  sha256 "859458b337686556c1f9e195062abc6c394210c2280ee47ed1ddc725b2982c9e"
+  head "https://github.com/nodejs/node.git", :branch => "v4.x-staging"
+
+  option "with-debug", "Build with debugger hooks"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+  option "with-full-icu", "Build with full-icu (all locales) instead of small-icu (English only)"
+
+  depends_on :python => :build if MacOS.version <= :snow_leopard
+  depends_on "pkg-config" => :build
+  depends_on "openssl" => :optional
+
+  conflicts_with "node", :because => "Differing versions of the same formula"
+  conflicts_with "node@0.10", :because => "Differing versions of the same formulae."
+  conflicts_with "node@0.12", :because => "Differing versions of the same formulae."
+  conflicts_with "node@5", :because => "Differing versions of the same formulae."
+  conflicts_with "node@6", :because => "Differing versions of the same formulae."
+
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-2.15.9.tgz"
+    sha256 "111243bdcf37c3cc8d16e2e7dc15f5ed422c20a9a7201a1620b3136d1e858081"
+  end
+
+  resource "icu4c" do
+    url "https://ssl.icu-project.org/files/icu4c/56.1/icu4c-56_1-src.tgz"
+    version "56.1"
+    sha256 "3a64e9105c734dcf631c0b3ed60404531bce6c0f5a64bfe1a6402a4cc2314816"
+  end
+
+  def install
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+    args << "--shared-openssl" if build.with? "openssl"
+
+    if build.with? "full-icu"
+      args << "--with-intl=full-icu"
+    else
+      args << "--with-intl=small-icu"
+    end
+    args << "--tag=head" if build.head?
+
+    resource("icu4c").stage buildpath/"deps/icu"
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
+        # Remove manpage symlinks from the buildpath, they are breaking bottle
+        # creation. The real manpages are living in libexec/npm/lib/node_modules/npm/man/
+        # https://github.com/Homebrew/homebrew/pull/47081#issuecomment-165280470
+        rm_rf libexec/"npm/share/"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/{npm,package.json}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+    output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"en-EN\").format(1234.56))'").strip
+    assert_equal "1,234.56", output
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      ENV.delete "NVM_NODEJS_ORG_MIRROR"
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "bignum" unless head?
+    end
+  end
+end

--- a/Formula/node@5.rb
+++ b/Formula/node@5.rb
@@ -1,0 +1,165 @@
+class NodeAT5 < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v5.12.0/node-v5.12.0.tar.xz"
+  sha256 "4f926373f11f2a25156eee1804ec012eb912c42e5d34fc2909889da22efdadfe"
+  head "https://github.com/nodejs/node.git", :branch => "v5.x-staging"
+
+  option "with-debug", "Build with debugger hooks"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+  option "with-full-icu", "Build with full-icu (all locales) instead of small-icu (English only)"
+
+  depends_on :python => :build if MacOS.version <= :snow_leopard
+  depends_on "pkg-config" => :build
+  depends_on "openssl" => :optional
+
+  conflicts_with "node", :because => "Differing versions of the same formula"
+  conflicts_with "node@0.10", :because => "Differing versions of the same formulae."
+  conflicts_with "node@0.12", :because => "Differing versions of the same formulae."
+  conflicts_with "node@4", :because => "Differing versions of the same formulae."
+  conflicts_with "node@6", :because => "Differing versions of the same formulae."
+
+  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
+  fails_with :clang if MacOS.version <= :snow_leopard
+  fails_with :gcc_4_0
+  fails_with :gcc
+  ("4.3".."4.7").each do |n|
+    fails_with :gcc => n
+  end
+
+  # We track major/minor from upstream Node releases.
+  # We will accept *important* npm patch releases when necessary.
+  # https://github.com/Homebrew/homebrew/pull/46098#issuecomment-157802319
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-3.8.6.tgz"
+    sha256 "29bc9d6f6123c9281914b298e863f683fd98ac2762632a55458308bb88b005e8"
+  end
+
+  resource "icu4c" do
+    url "https://ssl.icu-project.org/files/icu4c/56.1/icu4c-56_1-src.tgz"
+    mirror "https://ftp.mirrorservice.org/sites/download.qt-project.org/development_releases/prebuilt/icu/src/icu4c-56_1-src.tgz"
+    version "56.1"
+    sha256 "3a64e9105c734dcf631c0b3ed60404531bce6c0f5a64bfe1a6402a4cc2314816"
+  end
+
+  def install
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+    args << "--shared-openssl" if build.with? "openssl"
+    if build.with? "full-icu"
+      args << "--with-intl=full-icu"
+    else
+      args << "--with-intl=small-icu"
+    end
+    args << "--tag=head" if build.head?
+
+    resource("icu4c").stage buildpath/"deps/icu"
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
+        # Remove manpage symlinks from the buildpath, they are breaking bottle
+        # creation. The real manpages are living in libexec/npm/lib/node_modules/npm/man/
+        # https://github.com/Homebrew/homebrew/pull/47081#issuecomment-165280470
+        rm_rf libexec/"npm/share/"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/{npm,package.json}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    if build.without? "full-icu"
+      s += <<-EOS.undent
+        Please note by default only English locale support is provided. If you need
+        full locale support you should:
+          `brew reinstall node --with-full-icu`
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+    output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat().format(1234.56))'").strip
+    assert_equal "1,234.56", output
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      ENV.delete "NVM_NODEJS_ORG_MIRROR"
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "bignum" unless head?
+    end
+  end
+end

--- a/Formula/node@6.rb
+++ b/Formula/node@6.rb
@@ -1,0 +1,170 @@
+class NodeAT6 < Formula
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v6.9.1/node-v6.9.1.tar.xz"
+  sha256 "0bdd8d1305777cc8cd206129ea494d6c6ce56001868dd80147aff531d6df0729"
+  head "https://github.com/nodejs/node.git", :branch => "v6.x-staging"
+
+  option "with-debug", "Build with debugger hooks"
+  option "with-openssl", "Build against Homebrew's OpenSSL instead of the bundled OpenSSL"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+  option "with-full-icu", "Build with full-icu (all locales) instead of small-icu (English only)"
+
+  depends_on :python => :build if MacOS.version <= :snow_leopard
+  depends_on "pkg-config" => :build
+  depends_on "openssl" => :optional
+
+  conflicts_with "node", :because => "Differing versions of the same formula"
+  conflicts_with "node@0.10", :because => "Differing versions of the same formulae."
+  conflicts_with "node@0.12", :because => "Differing versions of the same formulae."
+  conflicts_with "node@4", :because => "Differing versions of the same formulae."
+  conflicts_with "node@5", :because => "Differing versions of the same formulae."
+
+  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
+  fails_with :clang if MacOS.version <= :snow_leopard
+  fails_with :gcc_4_0
+  fails_with :gcc
+  ("4.3".."4.7").each do |n|
+    fails_with :gcc => n
+  end
+
+  # We track major/minor from upstream Node releases.
+  # We will accept *important* npm patch releases when necessary.
+  # https://github.com/Homebrew/homebrew/pull/46098#issuecomment-157802319
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-3.10.8.tgz"
+    sha256 "1121a75a370fd0efb320fffb7c9e4a8bcb3840d1cf2fbd585c54837b7014dd76"
+  end
+
+  resource "icu4c" do
+    url "https://ssl.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz"
+    mirror "https://fossies.org/linux/misc/icu4c-57_1-src.tgz"
+    version "57.1"
+    sha256 "ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581"
+  end
+
+  def install
+    # Never install the bundled "npm", always prefer our
+    # installation from tarball for better packaging control.
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+    args << "--shared-openssl" if build.with? "openssl"
+
+    if build.with? "full-icu"
+      resource("icu4c").stage buildpath/"deps/icu"
+      args << "--with-intl=full-icu"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+      # unset prefix temporarily for npm's `make install`
+      ENV.delete "NPM_CONFIG_PREFIX"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+        # `package.json` has relative paths to the npm_install directory.
+        # This copies back over the vanilla `package.json` that is expected.
+        # https://github.com/Homebrew/homebrew/issues/46131#issuecomment-157845008
+        cp buildpath/"npm_install/package.json", libexec/"npm/lib/node_modules/npm"
+        # Remove manpage symlinks from the buildpath, they are breaking bottle
+        # creation. The real manpages are living in libexec/npm/lib/node_modules/npm/man/
+        # https://github.com/Homebrew/homebrew/pull/47081#issuecomment-165280470
+        rm_rf libexec/"npm/share/"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/{npm,package.json}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    if build.without? "full-icu"
+      s += <<-EOS.undent
+        Please note by default only English locale support is provided. If you need
+        full locale support you should either rebuild with full icu:
+          `brew reinstall node --with-full-icu`
+        or add full icu data at runtime following:
+          https://github.com/nodejs/node/wiki/Intl#using-and-customizing-the-small-icu-build
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = shell_output("#{bin}/node #{path}").strip
+    assert_equal "hello", output
+    output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"en-EN\").format(1234.56))'").strip
+    assert_equal "1,234.56", output
+    if build.with? "full-icu"
+      output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"de-DE\").format(1234.56))'").strip
+      assert_equal "1.234,56", output
+    end
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      ENV.delete "NVM_NODEJS_ORG_MIRROR"
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+    end
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -30,6 +30,7 @@
   "nimrod": "nim",
   "node010": "node@0.10",
   "node012": "node@0.12",
+  "node4-lts": "node@4",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -31,6 +31,7 @@
   "node010": "node@0.10",
   "node012": "node@0.12",
   "node4-lts": "node@4",
+  "node5": "node@5",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -29,6 +29,7 @@
   "mysql56": "mysql@5.6",
   "nimrod": "nim",
   "node010": "node@0.10",
+  "node012": "node@0.12",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -28,6 +28,7 @@
   "mysql55": "mysql@5.5",
   "mysql56": "mysql@5.6",
   "nimrod": "nim",
+  "node010": "node@0.10",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -32,6 +32,7 @@
   "node012": "node@0.12",
   "node4-lts": "node@4",
   "node5": "node@5",
+  "node6-lts": "node@6",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew/versions PR: https://github.com/Homebrew/homebrew-versions/pull/1471

If any of these don't build they will likely be 💥. If we are going to not import any then https://nodejs.org/en/download/releases/ would imply dropping `node@5` (but analytics show it's widely used).