### PR TITLE
GCC*: import from homebrew/versions

### DIFF
--- a/Formula/cloog@0.15.rb
+++ b/Formula/cloog@0.15.rb
@@ -1,0 +1,28 @@
+class CloogAT015 < Formula
+  desc "Generate code for scanning Z-polyhedra"
+  homepage "http://repo.or.cz/w/cloog-ppl.git"
+  url "ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-ppl-0.15.11.tar.gz"
+  mirror "http://gcc.cybermirror.org/infrastructure/cloog-ppl-0.15.11.tar.gz"
+  sha256 "7cd634d0b2b401b04096b545915ac67f883556e9a524e8e803a6bf6217a84d5f"
+
+  keg_only "Older version of cloog"
+
+  depends_on "gmp@4"
+  depends_on "ppl@0.11"
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --with-gmp=#{Formula["gmp@4"].opt_prefix}"
+      --with-ppl=#{Formula["ppl@0.11"].opt_prefix}"
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    assert_match "CLooG", shell_output("#{bin}/cloog --help", 1)
+  end
+end

--- a/Formula/cloog@0.18.rb
+++ b/Formula/cloog@0.18.rb
@@ -1,0 +1,44 @@
+class CloogAT018 < Formula
+  desc "Generate code for scanning Z-polyhedra"
+  homepage "http://www.cloog.org/"
+  # Track gcc infrastructure releases.
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.0.tar.gz"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
+  sha256 "1c4aa8dde7886be9cbe0f9069c334843b21028f61d344a2d685f88cb1dcf2228"
+
+  keg_only "Older version of cloog"
+
+  depends_on "pkg-config" => :build
+  depends_on "gmp@4"
+  depends_on "isl@0.11"
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--with-gmp-prefix=#{Formula["gmp@4"].opt_prefix}",
+                          "--with-isl-prefix=#{Formula["isl@0.11"].opt_prefix}"
+    system "make", "install"
+  end
+
+  test do
+    cloog_source = <<-EOS.undent
+      c
+
+      0 2
+      0
+
+      1
+
+      1
+      0 2
+      0 0 0
+      0
+
+      0
+    EOS
+
+    assert_match "Generated from /dev/stdin by CLooG",
+      pipe_output("#{bin}/cloog /dev/stdin", cloog_source)
+  end
+end

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -60,7 +60,6 @@ class Gcc < Formula
   end
 
   fails_with :gcc_4_0
-  fails_with :llvm
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
@@ -131,8 +130,11 @@ class Gcc < Formula
       # files prior to comparison during bootstrap (broken by Xcode 6.3).
       "--with-build-config=bootstrap-debug",
       "--disable-werror",
-      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
-      "--with-bugurl=https://github.com/Homebrew/homebrew/issues",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      # Even when suffixes are appended, the info pages conflict when
+      # install-info is run.
+      "MAKEINFO=missing",
     ]
 
     # "Building GCC with plugin support requires a host that supports
@@ -181,13 +183,8 @@ class Gcc < Formula
 
     # Handle conflicts between GCC formulae and avoid interfering
     # with system compilers.
-    # Since GCC 4.8 libffi stuff are no longer shipped.
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
-    # Even when suffixes are appended, the info pages conflict when
-    # install-info is run. TODO fix this.
-    info.rmtree
-    # Since GCC 4.9 java properties are properly sandboxed.
   end
 
   def add_suffix(file, suffix)

--- a/Formula/gcc@4.8.rb
+++ b/Formula/gcc@4.8.rb
@@ -1,0 +1,223 @@
+class GccAT48 < Formula
+  desc "GNU compiler collection"
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  sha256 "22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_8-branch"
+
+  if MacOS.version >= :yosemite
+    # Fixes build on El Capitan
+    # https://trac.macports.org/ticket/48471
+    patch :p0 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/dcfc5a2e6/gcc48/define_non_standard_clang_macros.patch"
+      sha256 "e727383c9186fdc36f804c69ad550f5cfd2b996e37083be94c0c9aa8fde226ee"
+    end
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
+  option "without-fortran", "Build without the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp@4"
+  depends_on "libmpc@0.8"
+  depends_on "mpfr@2"
+  depends_on "cloog@0.18"
+  depends_on "isl@0.11"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The as that comes with Tiger isn't capable of dealing with the
+  # PPC asm that comes in libitm
+  depends_on "cctools" => :build if MacOS.version < :leopard
+
+  fails_with :gcc_4_0
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp@4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog@0.18"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.11"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      # Even when suffixes are appended, the info pages conflict when
+      # install-info is run.
+      "MAKEINFO=missing",
+    ]
+
+    # Use 'bootstrap-debug' build configuration to force stripping of object
+    # files prior to comparison during bootstrap (broken by Xcode 6.3).
+    # This causes bottle errors for gcc48 on Mountain Lion, so scope it to 10.10.
+    args << "--with-build-config=bootstrap-debug" if MacOS.version >= :yosemite
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-header"s will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.8", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -1,0 +1,195 @@
+class GccAT49 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  sha256 "2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
+
+  if MacOS.version >= :yosemite
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+    # Fixes assembler generation with XCode 7
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509
+    patch do
+      url "https://gist.githubusercontent.com/tdsmith/d248e025029add31e7aa/raw/444e292786df41346a3a1cc6267bba587408a007/gcc.diff"
+      sha256 "636b65a160ccb7417cc4ffc263fc815382f8bb895e32262205cd10d65ea7804a"
+    end
+  end
+
+  option "without-fortran", "Build without the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp@4"
+  depends_on "libmpc@0.8"
+  depends_on "mpfr@2"
+  depends_on "cloog@0.18"
+  depends_on "isl@0.11"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp@4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog@0.18"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.11"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      # Even when suffixes are appended, the info pages conflict when
+      # install-info is run.
+      "MAKEINFO=missing",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.9", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Formula/gmp@4.rb
+++ b/Formula/gmp@4.rb
@@ -1,0 +1,79 @@
+class GmpAT4 < Formula
+  desc "GNU multiple precision arithmetic library"
+  homepage "http://gmplib.org/"
+  # Track gcc infrastructure releases.
+  url "https://ftpmirror.gnu.org/gmp/gmp-4.3.2.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gmp/gmp-4.3.2.tar.bz2"
+  mirror "ftp://ftp.gmplib.org/pub/gmp-4.3.2/gmp-4.3.2.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/gmp-4.3.2.tar.bz2"
+  sha256 "936162c0312886c21581002b79932829aa048cfaf9937c6265aeaa14f1cd1775"
+
+  keg_only "Older version of gmp"
+
+  fails_with :gcc_4_0 do
+    cause "Reports of problems using gcc 4.0 on Leopard: https://github.com/mxcl/homebrew/issues/issue/2302"
+  end
+
+  # Patches gmp.h to remove the __need_size_t define, which
+  # was preventing libc++ builds from getting the ptrdiff_t type
+  # Applied upstream in http://gmplib.org:8000/gmp/raw-rev/6cd3658f5621
+  patch :DATA
+
+  def install
+    args = ["--prefix=#{prefix}", "--enable-cxx"]
+
+    # Build 32-bit where appropriate, and help configure find 64-bit CPUs
+    if MacOS.prefer_64_bit? && !build.build_32_bit?
+      ENV.m64
+      args << "--build=x86_64-apple-darwin"
+    else
+      ENV.m32
+      args << "--host=none-apple-darwin"
+    end
+
+    system "./configure", *args
+    system "make"
+    ENV.j1 # Doesn't install in parallel on 8-core Mac Pro
+    system "make", "install"
+
+    # Different compilers and options can cause tests to fail even
+    # if everything compiles, so yes, we want to do this step.
+    system "make", "check"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gmp.h>
+
+      int main()
+      {
+        mpz_t integ;
+        mpz_init (integ);
+        mpz_clear (integ);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lgmp", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end
+
+__END__
+diff --git a/gmp-h.in b/gmp-h.in
+index d7fbc34..3c57c48 100644
+--- a/gmp-h.in
++++ b/gmp-h.in
+@@ -46,13 +46,11 @@ along with the GNU MP Library.  If not, see http://www.gnu.org/licenses/.  */
+ #ifndef __GNU_MP__
+ #define __GNU_MP__ 4
+
+-#define __need_size_t  /* tell gcc stddef.h we only want size_t */
+ #if defined (__cplusplus)
+ #include <cstddef>     /* for size_t */
+ #else
+ #include <stddef.h>    /* for size_t */
+ #endif
+-#undef __need_size_t
+
+ /* Instantiated by configure. */
+ #if ! defined (__GMP_WITHIN_CONFIGURE)

--- a/Formula/isl@0.11.rb
+++ b/Formula/isl@0.11.rb
@@ -1,0 +1,38 @@
+class IslAT011 < Formula
+  desc "Integer Set Library for the polyhedral model"
+  homepage "http://freecode.com/projects/isl"
+  # Track gcc infrastructure releases.
+  url "http://isl.gforge.inria.fr/isl-0.11.1.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.11.1.tar.bz2"
+  sha256 "095f4b54c88ca13a80d2b025d9c551f89ea7ba6f6201d701960bfe5c1466a98d"
+
+  keg_only "Older version of isl"
+
+  depends_on "gmp@4"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp@4"].opt_prefix}"
+    system "make", "install"
+    (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lisl",
+      "-I#{include}", "-I#{Formula["gmp@4"].include}", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/isl@0.14.rb
+++ b/Formula/isl@0.14.rb
@@ -1,0 +1,38 @@
+class IslAT014 < Formula
+  desc "Integer Set Library for the polyhedral model"
+  homepage "http://freecode.com/projects/isl"
+  # Track gcc infrastructure releases.
+  url "http://isl.gforge.inria.fr/isl-0.14.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.14.tar.bz2"
+  sha256 "7e3c02ff52f8540f6a85534f54158968417fd676001651c8289c705bd0228f36"
+
+  keg_only "Older version of isl"
+
+  depends_on "gmp"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}"
+    system "make"
+    system "make", "install"
+    (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lisl", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libmpc@0.8.rb
+++ b/Formula/libmpc@0.8.rb
@@ -1,0 +1,49 @@
+class LibmpcAT08 < Formula
+  desc "C library for high precision complex numbers"
+  homepage "http://multiprecision.org"
+  # Track gcc infrastructure releases.
+  url "http://multiprecision.org/mpc/download/mpc-0.8.1.tar.gz"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/mpc-0.8.1.tar.gz"
+  sha256 "e664603757251fd8a352848276497a4c79b7f8b21fd8aedd5cc0598a38fee3e4"
+
+  keg_only "Older version of libmpc"
+
+  depends_on "gmp@4"
+  depends_on "mpfr@2"
+
+  def install
+    args = [
+      "--prefix=#{prefix}",
+      "--disable-dependency-tracking",
+      "--with-gmp=#{Formula["gmp@4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
+    ]
+
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <mpc.h>
+
+      int main()
+      {
+        mpc_t x;
+        mpc_init2 (x, 256);
+        mpc_clear (x);
+        return 0;
+      }
+    EOS
+    gmp = Formula["gmp@4"]
+    mpfr = Formula["mpfr@2"]
+    system ENV.cc, "test.c",
+      "-I#{gmp.include}", "-L#{gmp.lib}", "-lgmp",
+      "-I#{mpfr.include}", "-L#{mpfr.lib}", "-lmpfr",
+      "-I#{include}", "-L#{lib}", "-lmpc",
+      "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/mpfr@2.rb
+++ b/Formula/mpfr@2.rb
@@ -1,0 +1,63 @@
+class MpfrAT2 < Formula
+  desc "Multiple-precision floating-point computations C lib"
+  homepage "http://www.mpfr.org/"
+  # Track gcc infrastructure releases.
+  url "http://www.mpfr.org/mpfr-2.4.2/mpfr-2.4.2.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/mpfr-2.4.2.tar.bz2"
+  sha256 "c7e75a08a8d49d2082e4caee1591a05d11b9d5627514e678f02d66a124bcf2ba"
+
+  keg_only "Older version of mpfr"
+
+  depends_on "gmp@4"
+
+  fails_with :clang do
+    build 421
+    cause <<-EOS.undent
+      clang build 421 segfaults while building in superenv;
+      see https://github.com/mxcl/homebrew/issues/15061
+      EOS
+  end
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --with-gmp=#{Formula["gmp@4"].opt_prefix}
+    ]
+
+    # Build 32-bit where appropriate, and help configure find 64-bit CPUs
+    # Note: This logic should match what the GMP formula does.
+    if MacOS.prefer_64_bit? && !build.build_32_bit?
+      ENV.m64
+      args << "--build=x86_64-apple-darwin"
+    else
+      ENV.m32
+      args << "--build=none-apple-darwin"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gmp.h>
+      #include <mpfr.h>
+
+      int main()
+      {
+        mpfr_t x;
+        mpfr_init(x);
+        mpfr_clear(x);
+        return 0;
+      }
+    EOS
+    gmp = Formula["gmp@4"]
+    system ENV.cc, "test.c", "-o", "test",
+                   "-lgmp", "-I#{gmp.include}", "-L#{gmp.lib}",
+                   "-lmpfr", "-I#{include}", "-L#{lib}"
+    system "./test"
+  end
+end

--- a/Formula/ppl@0.11.rb
+++ b/Formula/ppl@0.11.rb
@@ -1,0 +1,51 @@
+class PplAT011 < Formula
+  desc "Numerical abstractions for analysis, verification"
+  homepage "http://bugseng.com/products/ppl/"
+  # Track gcc infrastructure releases.
+  url "http://bugseng.com/products/ppl/download/ftp/releases/0.11/ppl-0.11.tar.gz"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/ppl-0.11.tar.gz"
+  sha256 "3453064ac192e095598576c5b59ecd81a26b268c597c53df05f18921a4f21c77"
+  revision 1
+
+  keg_only "Older version of ppl"
+
+  depends_on "homebrew/dupes/m4" => :build if MacOS.version < :leopard
+  depends_on "gmp@4"
+
+  # https://www.cs.unipr.it/mantis/view.php?id=596
+  # https://github.com/Homebrew/homebrew/issues/27431
+  # Using different patch from upstream bug report to avoid autoreconf.
+  patch do
+    url "https://gist.githubusercontent.com/manphiz/9507743/raw/45081e12c2f1faf81e8536f365af05173c6dab5c/patch-ppl-flexible-array-clang_v2.patch"
+    sha256 "db8ced5366ec4c3efb6fd20d3b4e440de3f8b9ec1d930a33b6a23d006dc25944"
+  end
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-ppl_lpsol",
+                          "--disable-ppl_lcdd",
+                          "--disable-ppl_pips",
+                          "--with-gmp-prefix=#{Formula["gmp@4"].opt_prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <ppl_c.h>
+      #ifndef PPL_VERSION_MAJOR
+      #error "No PPL header"
+      #endif
+      int main() {
+        ppl_initialize();
+        return ppl_finalize();
+      }
+    EOS
+    gmp = Formula["gmp@4"]
+    system ENV.cc, "test.c", "-o", "test",
+                   "-lgmp", "-I#{gmp.include}", "-L#{gmp.lib}",
+                   "-lppl_c", "-lppl", "-I#{include}", "-L#{lib}"
+    system "./test"
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -28,6 +28,7 @@
   "letsencrypt": "certbot",
   "libcppa": "caf",
   "libmongoclient": "mongo-cxx-driver",
+  "libmpc08": "libmpc@0.8",
   "mongo-c": "mongo-c-driver",
   "mpich2": "mpich",
   "mysql55": "mysql@5.5",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -21,6 +21,7 @@
   "google-perftools": "gperftools",
   "hamsterdb": "upscaledb",
   "heroku-toolbelt": "heroku",
+  "isl011": "isl@0.11",
   "kotlin-compiler": "kotlin",
   "juju": "juju@1.25",
   "letsencrypt": "certbot",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -12,6 +12,7 @@
   "elasticsearch17": "elasticsearch@1.7",
   "elasticsearch24": "elasticsearch@2.4",
   "fig": "docker-compose",
+  "gcc48": "gcc@4.8",
   "geode": "apache-geode",
   "glfw3": "glfw",
   "gmp4": "gmp@4",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,6 +1,7 @@
 {
   "app-engine-java-sdk": "app-engine-java",
   "beanstalk": "beanstalkd",
+  "cloog-ppl015": "cloog@0.15",
   "commonmark": "cmark",
   "cppformat": "fmt",
   "crystal": "autocode",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -13,6 +13,7 @@
   "elasticsearch24": "elasticsearch@2.4",
   "fig": "docker-compose",
   "gcc48": "gcc@4.8",
+  "gcc49": "gcc@4.9",
   "geode": "apache-geode",
   "glfw3": "glfw",
   "gmp4": "gmp@4",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -2,6 +2,7 @@
   "app-engine-java-sdk": "app-engine-java",
   "beanstalk": "beanstalkd",
   "cloog-ppl015": "cloog@0.15",
+  "cloog018": "cloog@0.18",
   "commonmark": "cmark",
   "cppformat": "fmt",
   "crystal": "autocode",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -14,6 +14,7 @@
   "fig": "docker-compose",
   "geode": "apache-geode",
   "glfw3": "glfw",
+  "gmp4": "gmp@4",
   "go-app-engine-32": "app-engine-go-32",
   "go-app-engine-64": "app-engine-go-64",
   "google-app-engine": "app-engine-python",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -30,6 +30,7 @@
   "libmongoclient": "mongo-cxx-driver",
   "libmpc08": "libmpc@0.8",
   "mongo-c": "mongo-c-driver",
+  "mpfr2": "mpfr@2",
   "mpich2": "mpich",
   "mysql55": "mysql@5.5",
   "mysql56": "mysql@5.6",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -22,6 +22,7 @@
   "hamsterdb": "upscaledb",
   "heroku-toolbelt": "heroku",
   "isl011": "isl@0.11",
+  "isl014": "isl@0.14",
   "kotlin-compiler": "kotlin",
   "juju": "juju@1.25",
   "letsencrypt": "certbot",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -43,6 +43,7 @@
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "plt-racket": "racket",
+  "ppl011": "ppl@0.11",
   "polarssl": "mbedtls",
   "qt55": "qt@5.5",
   "racket": "minimal-racket",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew/versions PR: https://github.com/Homebrew/homebrew-versions/pull/1472

If any of these don't build they will likely be 💥. I've skipped the older GCC versions that are either unused or barely used from analytics. I'm trying to depend on the latest versions of the various GCC libraries to see if we can avoid importing them but on the inevitable failures will pull in stuff like `gmp4` where needed.