### PR TITLE
pdksh: update urls

### DIFF
--- a/Formula/pdksh.rb
+++ b/Formula/pdksh.rb
@@ -1,7 +1,9 @@
 class Pdksh < Formula
   desc "Public domain version of the Korn shell"
-  homepage "https://www.cs.mun.ca/~michael/pdksh/"
+  homepage "https://web.archive.org/web/20160719151612/http://www.cs.mun.ca/~michael/pdksh/"
   url "https://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14.tar.gz"
+  mirror "http://gd.tuwien.ac.at/utils/shells/pdksh/pdksh-5.2.14.tar.gz"
+  mirror "ftp://ftp.lip6.fr/pub/unix/shells/pdksh/pdksh-5.2.14.tar.gz"
   sha256 "ab15bcdd50f291edc632bca351b2edce5405d4f2ce3854d3d548d721ab9bbfa6"
 
   bottle do
@@ -13,17 +15,23 @@ class Pdksh < Formula
     sha256 "29bcb04237c4a30870c028220d6284303d85e55eaab91fd5a5b3ea47915e9785" => :mountain_lion
   end
 
-  patch :p2 do # Upstream patches
-    url "https://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.1"
+  # Upstream patch
+  # Used to be https://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.1
+  patch :p2 do
+    url "https://raw.githubusercontent.com/homebrew/patches/fa25f8f/pdksh/pdksh-5.2.14-patches.1"
     sha256 "b4adfc47e4d78eb8718ee10f7ffafc218b0e9d453413456fab263985ae02d356"
   end
 
+  # Upstream patch
+  # Used to be https://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.2
   patch :p0 do
-    url "https://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14-patches.2"
+    url "https://raw.githubusercontent.com/homebrew/patches/fa25f8f/pdksh/pdksh-5.2.14-patches.2"
     sha256 "82041113e0b3aeca57bb9b161257b43d9f8eba95fd450d2287666e77e6209afd"
   end
 
-  patch :p0 do # Use `sort -k 3n -k 1` instead of `sort +2n +0n`, via MacPorts.
+  # Use `sort -k 3n -k 1` instead of `sort +2n +0n`, via MacPorts
+  # https://github.com/macports/macports-ports/blob/a3395cb/shells/pdksh/files/patch-siglist.sh.diff
+  patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/af7a9de9/pdksh/patch-siglist.sh"
     sha256 "23a3b4cbf67886c358a26818a95f9b39304d0aab82dead78d5438b633a0917bc"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://www.cs.mun.ca/~michael/pdksh/ and ftp://ftp.cs.mun.ca/pub/pdksh/ have disappeared from the Internet, presumably because maintainer Michael Rendell left his institution. A new home cannot be located.

For the time being, use an archived homepage from the WayBack Machine, add mirrors (as listed on the homepage) that are still functioning for the tarball, and vendor the official patches.

Please merge https://github.com/Homebrew/formula-patches/pull/93 which vendors the patches.

P.S. I caught this when I was validating the checksums of all patches in core. I tried to locate contact info, but the only email address listed was pdksh AT cs.mun.ca, and assuming the maintainer left the institution, the email address would be useless, too.