### PR TITLE
ucspi-tcp: vendor IPv6 patch

### DIFF
--- a/Formula/ucspi-tcp.rb
+++ b/Formula/ucspi-tcp.rb
@@ -3,6 +3,7 @@ class UcspiTcp < Formula
   homepage "https://cr.yp.to/ucspi-tcp.html"
   url "https://cr.yp.to/ucspi-tcp/ucspi-tcp-0.88.tar.gz"
   sha256 "4a0615cab74886f5b4f7e8fd32933a07b955536a3476d74ea087a3ea66a23e9c"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/ucspi-tcp.rb
+++ b/Formula/ucspi-tcp.rb
@@ -12,9 +12,11 @@ class UcspiTcp < Formula
     sha256 "67eb31db588a2299c5e69a4a60f3c56d07624a58e52e77cff2e58be554085d9f" => :mavericks
   end
 
+  # IPv6 patch
+  # Used to be https://www.fefe.de/ucspi/ucspi-tcp-0.88-ipv6.diff19.bz2
   patch do
-    url "https://www.fefe.de/ucspi/ucspi-tcp-0.88-ipv6.diff19.bz2"
-    sha256 "35952cd290d714452c840580126004cbae8db65b1632df67ac9c8fad7d1f9ace"
+    url "https://raw.githubusercontent.com/homebrew/patches/2b3e4da/ucspi-tcp/patch-0.88-ipv6.diff"
+    sha256 "c2d6ce17c87397253f298cc28499da873efe23afe97e855bdcf34ae66374036a"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

fefe.de disappeared from the Internet. The current patch was downloaded from the Wayback Machine [1], then unzipped.

Please merge https://github.com/Homebrew/formula-patches/pull/94.

P.S. I caught this when I was validating the checksums of all patches in core.

[1] https://web.archive.org/web/20160403064123/http://www.fefe.de/ucspi/ucspi-tcp-0.88-ipv6.diff19.bz2