### PR TITLE
vim: fix building with Lua, add --enable-luainterp

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -84,6 +84,10 @@ class Vim < Formula
       opts << "--without-x"
     end
 
+    if build.with? "lua"
+      opts << "--enable-luainterp"
+    end
+
     if build.with? "luajit"
       opts << "--with-luajit"
       opts << "--enable-luainterp"


### PR DESCRIPTION
- [+] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [+] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [+] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [+] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When building --with-lua, the vim binary doesn't link against the Lua library unless configure is ran with --enable-luainterp.