### PR TITLE
gst-rtsp-server 1.10.2 (new formula)

### DIFF
--- a/Formula/gst-rtsp-server.rb
+++ b/Formula/gst-rtsp-server.rb
@@ -1,0 +1,31 @@
+class GstRtspServer < Formula
+  desc "RTSP server library based on GStreamer"
+  homepage "https://gstreamer.freedesktop.org/modules/gst-rtsp-server.html"
+  url "https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-1.10.2.tar.xz"
+  sha256 "822dd6f754fea2bbf3369a7c388372f49b74668fb57943c1888675e544b07235"
+
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "gstreamer"
+  depends_on "gst-plugins-base"
+  depends_on "gobject-introspection"
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-examples",
+                          "--disable-tests",
+                          "--enable-introspection=yes"
+
+    system "make", "install"
+  end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --gst-plugin-path #{lib} --plugin rtspclientsink")
+    assert_match /\s#{version.to_s}\s/, output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This provides two things: the "rtspclientsink" gstreamer element (odd but true), and the "libgstrtspserver" library for linking to (mostly custom/niche) applications. (I use it with a customized version of one the examples included in the tarball, which I use as a test/debug rtsp server for another client...)