### PR TITLE
yarn: bring back 0.17.10 as stable and move 0.18.0 to devel as this i…

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,9 +3,14 @@ require "language/node"
 class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://yarnpkg.com/downloads/0.18.0/yarn-v0.18.0.tar.gz"
-  sha256 "8fb1843d2a1283972ff5fead9d6c9f9002de793ecec6dfec7abec908403ecd19"
+  url "https://yarnpkg.com/downloads/0.17.10/yarn-v0.17.10.tar.gz"
+  sha256 "592140a9d387a892935ca49ee93a8207b95073e2b732693987420dd1a7606672"
   head "https://github.com/yarnpkg/yarn.git"
+
+  devel do
+    url "https://yarnpkg.com/downloads/0.18.0/yarn-v0.18.0.tar.gz"
+    sha256 "8fb1843d2a1283972ff5fead9d6c9f9002de793ecec6dfec7abec908403ecd19"
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

…s a pre-release