### PR TITLE
platformio 3.2.1

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/50/d1/2d686878f636a131318aeff67a73e3fd75c1c596a2471cd92bb2c7231da3/platformio-3.2.0.tar.gz"
-  sha256 "d2a571b79ae45b0ec457538b91d567d2781c777943e56b899f5ec93f06bc5b01"
+  url "https://pypi.python.org/packages/01/29/5720a510593527335710a6f0219d7e7cff177d799cfeb61a74e2a2e94f84/platformio-3.2.1.tar.gz"
+  sha256 "fad4b32bc68f44ac0df7582d2965be456012bd79bb6c220797155d220c503d17"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/b1/16/b74f0d085932905149118119aef58525bdb9b0f24e28bf25550b70581794/platformio-3.1.0.tar.gz"
-  sha256 "6fc9e4c9a7b8271156daa3095b1efaba7940547e663f16e68f55f77247211c09"
+  url "https://pypi.python.org/packages/50/d1/2d686878f636a131318aeff67a73e3fd75c1c596a2471cd92bb2c7231da3/platformio-3.2.0.tar.gz"
+  sha256 "d2a571b79ae45b0ec457538b91d567d2781c777943e56b899f5ec93f06bc5b01"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,8 +21,8 @@ class Platformio < Formula
   end
 
   resource "bottle" do
-    url "https://files.pythonhosted.org/packages/d2/59/e61e3dc47ed47d34f9813be6d65462acaaba9c6c50ec863db74101fa8757/bottle-0.12.9.tar.gz"
-    sha256 "fe0a24b59385596d02df7ae7845fe7d7135eea73799d03348aeb9f3771500051"
+    url "https://pypi.python.org/packages/7e/b5/a8404cf922bdedb63b41e9b6f3ae64c93f99cf1accdf0fc265ae75f063a2/bottle-0.12.10.tar.gz"
+    sha256 "1308133647adc2d266f0ba5fea6684ba955cbf5e8133590cf0314c8beb814ff4"
   end
 
   resource "click" do
@@ -41,8 +41,8 @@ class Platformio < Formula
   end
 
   resource "pyserial" do
-    url "https://files.pythonhosted.org/packages/3c/d8/a9fa247ca60b02b3bebbd61766b4f321393b57b13c53b18f6f62cf172c08/pyserial-3.1.1.tar.gz"
-    sha256 "d657051249ce3cbd0446bcfb2be07a435e1029da4d63f53ed9b4cdde7373364c"
+    url "https://pypi.python.org/packages/1f/3b/ee6f354bcb1e28a7cd735be98f39ecf80554948284b41e9f7965951befa6/pyserial-3.2.1.tar.gz"
+    sha256 "1eecfe4022240f2eab5af8d414f0504e072ee68377ba63d3b6fe6e66c26f66d1"
   end
 
   resource "requests" do
@@ -51,8 +51,8 @@ class Platformio < Formula
   end
 
   resource "semantic_version" do
-    url "https://files.pythonhosted.org/packages/8e/0e/33052dd97ab9d07dae8ddffcfb2740efe58c46d72efbc060cf6da250439f/semantic_version-2.5.0.tar.gz"
-    sha256 "3baad35dcb074a49419539cea6a33b484706b6c2dd03f05b67763eba4c1bb65c"
+    url "https://pypi.python.org/packages/72/83/f76958017f3094b072d8e3a72d25c3ed65f754cc607fdb6a7b33d84ab1d5/semantic_version-2.6.0.tar.gz"
+    sha256 "2a4328680073e9b243667b201119772aefc5fc63ae32398d6afafff07c4f54c0"
   end
 
   def install


### PR DESCRIPTION
# PlatformIO 3.2

* [PIO Remote™](http://docs.platformio.org/page/plus/pio-remote.html). **Your devices are always with you!**
    - Over-The-Air (OTA) Device Manager
    - OTA Serial Port Monitor
    - OTA Firmware Updates
    - Continuous Deployment
    - Continuous Delivery
* [PIO Account](http://docs.platformio.org/page/userguide/account/index.html)
* Integration with [Cloud IDEs](http://docs.platformio.org/en/latest/ide.html#cloud-ide)
  - Cloud9
  - Codeanywhere
  - Eclipse Che (Codenvy)
* Refactored [PlatformIO Documentation](http://docs.platformio.org/page/index.html)
* [Remote Unit Testing](http://docs.platformio.org/page/plus/unit-testing.html)
* Inject system environment variables to configuration settings in
  [Project Configuration File "platformio.ini"](http://docs.platformio.org/en/stable/projectconf.html) ([issue #792](https://github.com/platformio/platformio/issues/792))
* Custom boards per project with ``boards_dir`` option in [Project Configuration File "platformio.ini"](http://docs.platformio.org/en/stable/projectconf.html)
* Unix shell-style wildcards for [upload_port](http://docs.platformio.org/page/projectconf.html#upload-port)
* Refactored [Library Dependency Finder (LDF)](http://docs.platformio.org/en/stable/librarymanager/ldf.html) C/C++ Preprocessor for conditional syntax (``#ifdef``, ``#if``, ``#else``,  ``#elif``, ``#define``, etc.)
* Added new [LDF Modes](http://docs.platformio.org/page/librarymanager/ldf.html#ldf-mode)  ``chain+`` and ``deep+``, and set ``chain+`` as default
* Added global ``lib_extra_dirs`` option to ``[platformio]`` section for  [Project Configuration File "platformio.ini"](http://docs.platformio.org/en/stable/projectconf.html)
* New [espressif32](http://docs.platformio.org/en/stable/platforms/espressif32.html) development platform
* Other improvements and bug fixes.