### PR TITLE
caveats: eliminate `brew --prefix` calls in shell rcs

### DIFF
--- a/Formula/antigen.rb
+++ b/Formula/antigen.rb
@@ -13,14 +13,12 @@ class Antigen < Formula
 
   def caveats; <<-EOS.undent
     To activate antigen, add the following to your ~/.zshrc:
-
-      source $(brew --prefix)/share/antigen/antigen.zsh
-
+      source #{HOMEBREW_PREFIX}/share/antigen/antigen.zsh
     EOS
   end
 
   test do
-    (testpath/".zshrc").write "source `brew --prefix`/share/antigen/antigen.zsh\n"
+    (testpath/".zshrc").write "source #{HOMEBREW_PREFIX}/share/antigen/antigen.zsh\n"
     system "zsh", "--login", "-i", "-c", "antigen help"
   end
 end

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -26,7 +26,7 @@ class Autojump < Formula
   def caveats; <<-EOS.undent
     Add the following line to your ~/.bash_profile or ~/.zshrc file (and remember
     to source the file to update your current session):
-      [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh
+      [ -f #{etc}/profile.d/autojump.sh ] && . #{etc}/profile.d/autojump.sh
 
     If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
       [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ]; and source #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
@@ -37,7 +37,7 @@ class Autojump < Formula
     path = testpath/"foo/bar"
     path.mkpath
     output = %x(
-      source #{HOMEBREW_PREFIX}/etc/profile.d/autojump.sh
+      source #{etc}/profile.d/autojump.sh
       j -a "#{path.relative_path_from(testpath)}"
       j foo >/dev/null
       pwd

--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -37,9 +37,7 @@ class BashCompletion < Formula
 
   def caveats; <<-EOS.undent
     Add the following lines to your ~/.bash_profile:
-      if [ -f $(brew --prefix)/etc/bash_completion ]; then
-        . $(brew --prefix)/etc/bash_completion
-      fi
+      [ -f #{etc}/bash_completion ] && . #{etc}/bash_completion
     EOS
   end
 

--- a/Formula/bash-git-prompt.rb
+++ b/Formula/bash-git-prompt.rb
@@ -18,9 +18,9 @@ class BashGitPrompt < Formula
 
   def caveats; <<-EOS.undent
     You should add the following to your .bashrc (or equivalent):
-      if [ -f "$(brew --prefix bash-git-prompt)/share/gitprompt.sh" ]; then
+      if [ -f #{HOMEBREW_PREFIX}/share/gitprompt.sh ]; then
         GIT_PROMPT_THEME=Default
-        source "$(brew --prefix bash-git-prompt)/share/gitprompt.sh"
+        . #{HOMEBREW_PREFIX}/share/gitprompt.sh
       fi
     EOS
   end

--- a/Formula/bash-preexec.rb
+++ b/Formula/bash-preexec.rb
@@ -14,9 +14,7 @@ class BashPreexec < Formula
 
   def caveats; <<-EOS.undent
     Add the following line to your bash profile (e.g. ~/.bashrc, ~/.profile, or ~/.bash_profile)
-
-      [[ -f $(brew --prefix)/etc/profile.d/bash-preexec.sh ]] && . $(brew --prefix)/etc/profile.d/bash-preexec.sh
-
+      [ -f #{etc}/profile.d/bash-preexec.sh ] && . #{etc}/profile.d/bash-preexec.sh
     EOS
   end
 

--- a/Formula/byobu.rb
+++ b/Formula/byobu.rb
@@ -38,7 +38,7 @@ class Byobu < Formula
 
   def caveats; <<-EOS.undent
     Add the following to your shell configuration file:
-      export BYOBU_PREFIX=$(brew --prefix)
+      export BYOBU_PREFIX=#{HOMEBREW_PREFIX}
     EOS
   end
 

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -60,8 +60,8 @@ class DockerMachineDriverXhyve < Formula
   def caveats; <<-EOS.undent
     This driver requires superuser privileges to access the hypervisor. To
     enable, execute
-        sudo chown root:wheel $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-        sudo chmod u+s $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
+        sudo chown root:wheel #{opt_prefix}/bin/docker-machine-driver-xhyve
+        sudo chmod u+s #{opt_prefix}/bin/docker-machine-driver-xhyve
     EOS
   end
 

--- a/Formula/dvm.rb
+++ b/Formula/dvm.rb
@@ -28,7 +28,7 @@ class Dvm < Formula
 
       system "make", "VERSION=#{version}", "UPGRADE_DISABLED=true"
       prefix.install "dvm.sh"
-      prefix.install "bash_completion"
+      bash_completion.install "bash_completion" => "dvm"
       (prefix/"dvm-helper").install "dvm-helper/dvm-helper"
       prefix.install_metafiles
     end
@@ -37,12 +37,7 @@ class Dvm < Formula
   def caveats; <<-EOS.undent
     dvm is a shell function, and must be sourced before it can be used.
     Add the following command to your bash profile:
-
-        [[ -s "$(brew --prefix dvm)/dvm.sh" ]] && source "$(brew --prefix dvm)/dvm.sh"
-
-    To enable tab completion of commands, add the following command to your bash profile:
-        [[ -s "$(brew --prefix dvm)/bash_completion" ]] && source "$(brew --prefix dvm)/bash_completion"
-
+        [ -f #{opt_prefix}/dvm.sh ] && . #{opt_prefix}/dvm.sh
     EOS
   end
 

--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -25,7 +25,7 @@ class Grc < Formula
 
   def caveats; <<-EOS.undent
     New shell sessions will start using GRC after you add this to your profile:
-      source "`brew --prefix`/etc/grc.bashrc"
+      . #{etc}/grc.bashrc
     EOS
   end
 

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -30,7 +30,7 @@ class Piknik < Formula
 
   def caveats; <<-EOS.undent
     In order to get convenient shell aliases, put something like this in #{shell_profile}:
-      source "$(brew --prefix)/etc/profile.d/piknik.sh"
+      . #{etc}/profile.d/piknik.sh
     EOS
   end
 

--- a/Formula/z.rb
+++ b/Formula/z.rb
@@ -15,7 +15,7 @@ class Z < Formula
 
   def caveats; <<-EOS.undent
     For Bash or Zsh, put something like this in your $HOME/.bashrc or $HOME/.zshrc:
-      . `brew --prefix`/etc/profile.d/z.sh
+      . #{etc}/profile.d/z.sh
     EOS
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew --prefix` is slow, while shell rcs have to be fast. On my mid-2015 15'' rMBP with 2.5 GHz i7 and 512 GB SSD, `brew --prefix` takes 40–50 ms:

```zsh
$ time (repeat 1000 brew --prefix >/dev/null)
( repeat 1000; do; brew --prefix > /dev/null; done; )  23.20s user 18.35s system 82% cpu 50.538 total
```

It should be slower on HDD and worse still on NFS and likes. Moreover, `brew --prefix` is often called in a construct like

```sh
[ -f "$(brew --prefix)/path/to/script" ] && . "$(brew --prefix)/path/to/script"
```

i.e., it is called twice, consuming ~100 ms. As someone who has been obsessed with the art of Zsh customizations for years, I can confidently say that a 100 ms delay during shell init is in the noticeable range. We don't want to inflate shell init time of unsuspecting users; meanwhile, those advanced users who want to have a set of shell rcs that work accross multiple hosts with brew installed at different locations, or those who have multiple brew installations on a single host that are dynamically switched should know how to use `brew --prefix` (or better, use different hardcoded values for different values for different hosts) without us telling them.

This PR replaces all `$(brew --prefix)/...` in caveats with `#{HOMEBREW_PREFIX}/...` or `#{etc}/...`.

Note that `dvm` is also revisioned to use standard `bash_completion.install`, so if merged bottle needs to be pulled for `dvm`.