### PR TITLE
pigz: fix the build on 10.11 with Xcode 8

### DIFF
--- a/Formula/pigz.rb
+++ b/Formula/pigz.rb
@@ -3,6 +3,7 @@ class Pigz < Formula
   homepage "http://www.zlib.net/pigz/"
   url "http://www.zlib.net/pigz/pigz-2.3.4.tar.gz"
   sha256 "6f031fa40bc15b1d80d502ff91f83ba14f4b079e886bfb83221374f7bf5c8f9a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,6 +13,12 @@ class Pigz < Formula
   end
 
   def install
+    # Fix dyld: lazy symbol binding failed: Symbol not found: _deflatePending
+    # Reported 8 Dec 2016 to madler at alumni.caltech.edu
+    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      inreplace "pigz.c", "ZLIB_VERNUM >= 0x1260", "ZLIB_VERNUM >= 0x9999"
+    end
+
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
     bin.install "pigz", "unpigz"
     man1.install "pigz.1"
@@ -25,5 +32,7 @@ class Pigz < Formula
     assert (testpath/"example.gz").file?
     system bin/"unpigz", testpath/"example.gz"
     assert_equal test_data, (testpath/"example").read
+    system "/bin/dd", "if=/dev/random", "of=foo.bin", "bs=1m", "count=10"
+    system bin/"pigz", "foo.bin"
   end
 end


### PR DESCRIPTION
Fix dyld: lazy symbol binding failed: Symbol not found: _deflatePending

Fixes #7637.
Fixes https://github.com/Homebrew/brew/issues/1596.