### PR TITLE
homeshick: install fish function script with fish_function

### DIFF
--- a/Formula/homeshick.rb
+++ b/Formula/homeshick.rb
@@ -14,7 +14,7 @@ class Homeshick < Formula
     inreplace "bin/homeshick", /^homeshick=.*/, "homeshick=#{opt_prefix}"
 
     prefix.install "lib", "homeshick.sh"
-    prefix.install "homeshick.fish" if build.with? "fish"
+    fish_function.install "homeshick.fish" if build.with? "fish"
     bin.install "bin/homeshick"
     bin.install "bin/homeshick.csh" if build.with? "csh"
     zsh_completion.install "completions/_homeshick"
@@ -32,13 +32,6 @@ class Homeshick < Formula
       `source "#{opt_prefix}/homeshick.sh"`
       in your $HOME/.bashrc
     EOS
-    if build.with? "fish"
-      s += <<-EOS.undent
-        and
-        `#{opt_prefix}.fish`
-        in your $HOME/.config/fish/config.fish
-      EOS
-    end
     if build.with? "csh"
       s += <<-EOS.undent
         and


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Instead of installing the homeshick fish function script to `prefix` and asking the user to
source that file in their config, install the function using `fish_function` which installs
the script to the fish shell's function directory, where it will be automatically loaded when
the user runs the script's function.
No additional sourcing required :)