### PR TITLE
excel-compare 0.6.0 (new formula)

### DIFF
--- a/Formula/excel-compare.rb
+++ b/Formula/excel-compare.rb
@@ -5,7 +5,7 @@ class ExcelCompare < Formula
   sha256 "63bda982644ec8633b60eed5bc199892c428b54addb2eb63dda0b894d98a56c4"
 
   resource "sample_workbook" do
-    url "https://github.com/na-ka-na/ExcelCompare/raw/0.6.0/test/resources/ss1.xlsx"
+    url "https://github.com/na-ka-na/ExcelCompare/raw/0.6.0/test/resources/ss1.xlsx", :using => :nounzip
     sha256 "f362153aea24092e45a3d306a16a49e4faa19939f83cdcb703a215fe48cc196a"
   end
 
@@ -19,14 +19,8 @@ class ExcelCompare < Formula
   end
 
   test do
-    ss1path = testpath/"ss1"
-    resource("sample_workbook").stage ss1path
-    ss1path.cd do
-      # xlsx files are just zip archives, so Homebrew unpacks them automatically.
-      # We need to reconstruct the xlsx file before running excel_cmp
-      system "/usr/bin/zip", "-r", "ss1.xlsx", "."
-      assert_match /Excel files ss1.xlsx and ss1.xlsx match/,
-        shell_output("#{bin}/excel_cmp ss1.xlsx ss1.xlsx")
-    end
+    resource("sample_workbook").stage testpath
+    assert_match %r{Excel files #{testpath}/ss1.xlsx and #{testpath}/ss1.xlsx match},
+      shell_output("#{bin}/excel_cmp #{testpath}/ss1.xlsx #{testpath}/ss1.xlsx")
   end
 end

--- a/Formula/excel-compare.rb
+++ b/Formula/excel-compare.rb
@@ -13,7 +13,20 @@ class ExcelCompare < Formula
     EOS
   end
 
+  resource "sample_workbook" do
+    url "https://github.com/na-ka-na/ExcelCompare/raw/0.6.0/test/resources/ss1.xlsx"
+    sha256 "f362153aea24092e45a3d306a16a49e4faa19939f83cdcb703a215fe48cc196a"
+  end
+
   test do
-    assert_match /Usage> excel_cmp/, shell_output("#{bin}/excel_cmp --help", 255)
+    ss1path = testpath/"ss1"
+    resource("sample_workbook").stage ss1path
+    ss1path.cd do
+      # xlsx files are just zip archives, so Homebrew unpacks them automatically.
+      # We need to reconstruct the xlsx file before running excel_cmp
+      system "/usr/bin/zip", "-r", "ss1.xlsx", "."
+      assert_match /Excel files ss1.xlsx and ss1.xlsx match/,
+        shell_output("#{bin}/excel_cmp ss1.xlsx ss1.xlsx")
+    end
   end
 end

--- a/Formula/excel-compare.rb
+++ b/Formula/excel-compare.rb
@@ -4,6 +4,11 @@ class ExcelCompare < Formula
   url "https://github.com/na-ka-na/ExcelCompare/releases/download/0.6.0/ExcelCompare-0.6.0.zip"
   sha256 "63bda982644ec8633b60eed5bc199892c428b54addb2eb63dda0b894d98a56c4"
 
+  resource "sample_workbook" do
+    url "https://github.com/na-ka-na/ExcelCompare/raw/0.6.0/test/resources/ss1.xlsx"
+    sha256 "f362153aea24092e45a3d306a16a49e4faa19939f83cdcb703a215fe48cc196a"
+  end
+
   def install
     libexec.install Dir["bin/dist/*"]
 
@@ -11,11 +16,6 @@ class ExcelCompare < Formula
       #!/bin/sh
       java -ea -Xmx512m -cp "#{libexec}/*" com.ka.spreadsheet.diff.SpreadSheetDiffer "$@"
     EOS
-  end
-
-  resource "sample_workbook" do
-    url "https://github.com/na-ka-na/ExcelCompare/raw/0.6.0/test/resources/ss1.xlsx"
-    sha256 "f362153aea24092e45a3d306a16a49e4faa19939f83cdcb703a215fe48cc196a"
   end
 
   test do

--- a/Formula/excel-compare.rb
+++ b/Formula/excel-compare.rb
@@ -1,0 +1,19 @@
+class ExcelCompare < Formula
+  desc "Command-line tool (and API) for diffing Excel Workbooks"
+  homepage "https://github.com/na-ka-na/ExcelCompare"
+  url "https://github.com/na-ka-na/ExcelCompare/releases/download/0.6.0/ExcelCompare-0.6.0.zip"
+  sha256 "63bda982644ec8633b60eed5bc199892c428b54addb2eb63dda0b894d98a56c4"
+
+  def install
+    libexec.install Dir["bin/dist/*"]
+
+    (bin/"excel_cmp").write <<-EOS.undent
+      #!/bin/sh
+      java -ea -Xmx512m -cp "#{libexec}/*" com.ka.spreadsheet.diff.SpreadSheetDiffer "$@"
+    EOS
+  end
+
+  test do
+    assert_match /Usage> excel_cmp/, shell_output("#{bin}/excel_cmp --help", 255)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[ExcelCompare](https://github.com/na-ka-na/ExcelCompare) is a nifty little tool to diff Excel, OpenOffice, and LibreOffice workbooks from the command-line.

Unfortunately there wasn't much I could do in the `test do` block, as the tool only works with workbooks, which are binary files that I don't know how to create without using the respective applications.