### PR TITLE
Elasticsearch 5.1.1

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.2.tar.gz"
-  sha256 "bbe761788570d344801cb91a8ba700465deb10601751007da791743e9308cb83"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.1.tar.gz"
+  sha256 "cd45bafb1f74a7df9bad12c77b7bf3080069266bcbe0b256b0959ef2536e31e8"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"


### PR DESCRIPTION
This commit updates the Elasticsearch formula from version 5.0.2 to
version 5.1.1.
