### PR TITLE
Fix --libdir in lbdb formula

### DIFF
--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -15,7 +15,7 @@ class Lbdb < Formula
   depends_on "abook" => :recommended
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--libdir=#{libexec}"
+    system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -15,7 +15,7 @@ class Lbdb < Formula
   depends_on "abook" => :recommended
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--libdir=#{prefix}/lib/lbdb"
+    system "./configure", "--prefix=#{prefix}", "--libdir=#{lib}/lbdb"
     system "make", "install"
   end
 

--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -15,7 +15,7 @@ class Lbdb < Formula
   depends_on "abook" => :recommended
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--libdir=#{prefix}/lib/lbdb"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This `--libdir` argument produces a broken product.

Specifically, in the upstream source tree, we have the source file `lbdb-munge.sh.in` which contains:

```
prefix=@prefix@
exec_prefix=@exec_prefix@
dotlock=@DOTLOCK@
fetchaddr=@libdir@/fetchaddr
db=$HOME/.lbdb/m_inmail.utf-8
munge="${prefix}/lib/lbdb/munge"
```

Passing in `--libdir=#{libexec}` in the formula causes the `munge` file to be installed into `/usr/local/Cellar/lbdb/0.42/libexec/munge`, but the built `lbdb-munge` file will look for it in the hardcoded `${prefix}/lib/lbdb/munge` location, where it does not exist.

This breakage manifests as an error like:

```
/usr/local/Cellar/lbdb/0.42/libexec/lbdb-munge: line 64: /usr/local/Cellar/lbdb/0.42/lib/lbdb/munge: No such file or directory
```

when you try to use `lbdbq` (which invokes `lbdb-munge`).

Dropping the `--libdir` configure option causes everything to work just fine.

Tested by:

1. `brew uninstall lbdb` (removes broken install).
2. Download [source](https://www.spinnaker.de/debian/lbdb_0.42.tar.xz) and unpack.
3. Run: `./configure --prefix=/usr/local/Cellar/lbdb/0.42`
4. Build and install: `make install`
5. Link: `brew link lbdb`
6. Run: `lbdbq greg` (matching one of the addresses in my lbdb database) and see it work.

Note that this doesn't pass `brew audit --strict ` because:

```
  * Non-libraries were installed to "/usr/local/Cellar/lbdb/0.42/lib"
    Installing non-libraries to "lib" is discouraged.
 ```

But due to the hard-coded path segment in the upstream source, we don't have a lot of choice (short of patching upstream).