### PR TITLE
swiftgen: fix Xcode dependency

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -11,7 +11,7 @@ class Swiftgen < Formula
     sha256 "90c013628201d4a6a3bd9bbd139012978b4e4520b5d11b84aedde10d3395223f" => :el_capitan
   end
 
-  depends_on :xcode => "8.0"
+  depends_on :xcode => ["8.0", :build]
 
   def install
     rake "install[#{bin},#{lib},#{pkgshare}/templates]"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Xcode 8 dependency was always only needed for building SwiftGen from source, not for running it.
See #7763

---

_Note: I've wondered about adding `revision 1`, but since this change doesn't require SwiftGen's bottles to be rebuilt and the generated and installed version would be exactly the same, so this formula doesn't change anything for people who already installed SwiftGen 4.0.1 I think that doesn't really require to generate a `4.0.1_1` version that would be the exact same as 4.0.1 binary-wise (and lib-dependency-wise), as all it does is loosen the requirements._