### PR TITLE
ammonite-repl requires Java 8

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -6,7 +6,7 @@ class AmmoniteRepl < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   def install
     bin.install Dir["*"].shift => "amm"


### PR DESCRIPTION
In 0.8.1, ammonite-repl upgraded to Scala 2.12, which requires Java 8.