### PR TITLE
neofetch: fix image display in iTerm2

### DIFF
--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -12,6 +12,13 @@ class Neofetch < Formula
     sha256 "eb1cbc74bba6487b48d9c7c6f9118bd49ce0572751f42461f52341d9b0b43f86" => :yosemite
   end
 
+  patch do
+    # Fixes image display in iTerm2
+    # Will be removed in the next released version
+    url "https://github.com/dylanaraps/neofetch/commit/926dea972b82d1b81e5501e63c8d4395ee274b84.patch"
+    sha256 "d0132c00c50111de60cc31b07c2dcf07aaba8ce378e1553e3322dce159198155"
+  end
+
   depends_on "screenresolution" => :recommended
   depends_on "imagemagick" => :recommended
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This will be removed in the next version (2.1 I believe) but as it was decided to not make a whole new release for this fix that is macOS specific, patching it here is the better option