### PR TITLE
xc-resave 0.0.1 (new formula)

### DIFF
--- a/Formula/xc-resave.rb
+++ b/Formula/xc-resave.rb
@@ -1,0 +1,13 @@
+
+class XcResave < Formula
+  desc "Force Xcode to re-save a project from command line"
+  homepage "https://github.com/cezheng/xc-resave"
+  url "https://github.com/alexgarbarev/xc-resave/archive/0.0.1.tar.gz"
+  sha256 "cc872a719c324ce4d4c05fc2c489dfdf18ced2a8f4ac07c9000eefc48224620b"
+
+  def install
+    system "make"
+    bin.install "xc-resave"
+  end
+
+end


### PR DESCRIPTION
- [v] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [v] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [v] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

No, `brew audit --strict` always crashes for me. It says 
"You may have encountered a bug in the Ruby interpreter or extension libraries."
```
~/.rvm/gems/ruby-2.2.1/gems/psych-2.2.1/lib/psych.bundle: [BUG] Segmentation fault
ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin16]
```
btw `brew audit` happy

-----

A minimum executable to make Xcode resave a xcodeproj.