### PR TITLE
zsh-autosuggestions: install zsh-autosuggestions with zsh_function

### DIFF
--- a/Formula/zsh-autosuggestions.rb
+++ b/Formula/zsh-autosuggestions.rb
@@ -7,14 +7,14 @@ class ZshAutosuggestions < Formula
   bottle :unneeded
 
   def install
-    pkgshare.install "zsh-autosuggestions.zsh"
+    zsh_function.install "zsh-autosuggestions.zsh" => "zsh-autosuggestions"
   end
 
   def caveats
     <<-EOS.undent
     To activate the autosuggestions, add the following at the end of your .zshrc:
 
-      source #{HOMEBREW_PREFIX}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+      autoload -Uz zsh-autosuggestions && zsh-autosuggestions
 
     You will also need to force reload of your .zshrc:
 
@@ -24,6 +24,6 @@ class ZshAutosuggestions < Formula
 
   test do
     assert_match "default",
-      shell_output("zsh -c '. #{pkgshare}/zsh-autosuggestions.zsh && echo $ZSH_AUTOSUGGEST_STRATEGY'")
+      shell_output("zsh -c 'autoload -Uz zsh-autosuggestions && zsh-autosuggestions && echo $ZSH_AUTOSUGGEST_STRATEGY'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Instead of installing the zsh-autosuggestions zsh script to `prefix` and asking the user to
source that file in their zshrc, install the function using zsh_function which installs
the script to zsh's function directory, where it will be automatically loaded when
the user uses zsh's `autoload`.