### PR TITLE
WIP: zsh-git-prompt: install zsh-git-prompt with zsh_function

### DIFF
--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -7,12 +7,14 @@ class ZshGitPrompt < Formula
   bottle :unneeded
 
   def install
-    prefix.install Dir["*.{sh,py}"]
+    inreplace "zshrc.sh", "export __GIT_PROMPT_DIR=${0:A:h}", "export __GIT_PROMPT_DIR=#{opt_prefix}"
+    prefix.install Dir["*.py"]
+    zsh_function.install "zshrc.sh" => "zsh-git-prompt"
   end
 
   def caveats; <<-EOS.undent
     First, make sure zsh-git-prompt is loaded from your .zshrc:
-      source "#{opt_prefix}/zshrc.sh"
+      autoload -Uz zsh-git-prompt && zsh-git-prompt
 
     Then include $(git_super_status) in your PROMPT or RPROMPT, e.g.:
       PROMPT='%B%m%~%b$(git_super_status) %# '
@@ -21,7 +23,7 @@ class ZshGitPrompt < Formula
 
   test do
     system "git", "init"
-    zsh_command = ". #{opt_prefix}/zshrc.sh && git_super_status"
+    zsh_command = "autoload -Uz zsh-git-prompt && zsh-git-prompt && git_super_status"
     assert_match "master", shell_output("zsh -c '#{zsh_command}'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Instead of installing the zsh-git-prompt zsh script to `prefix` and asking the user to
source that file in their zshrc, install the function using zsh_function which installs
the script to zsh's function directory, where it will be automatically loaded when
the user uses zsh's `autoload`.