### PR TITLE
mpv: build HTML man page

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -52,6 +52,7 @@ class Mpv < Formula
       --prefix=#{prefix}
       --enable-zsh-comp
       --enable-libmpv-shared
+      --enable-html-build
       --confdir=#{etc}/mpv
       --datadir=#{pkgshare}
       --mandir=#{man}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

mpv's man page is gigantic (479K), and at this length an HTML version is more user friendly (IMHO). The `--enable-html-build` configure option adds only one file, `share/doc/mpv/mpv.html` (716K). There's no extra dep, since we're already depending on `docutils` to build `mpv.1`.

This is probably not worth a revision; a bottle rebuild is enough.