### PR TITLE
WIP: antigen: install with zsh_function

### DIFF
--- a/Formula/antigen.rb
+++ b/Formula/antigen.rb
@@ -8,17 +8,17 @@ class Antigen < Formula
   bottle :unneeded
 
   def install
-    pkgshare.install "bin/antigen.zsh"
+    zsh_function.install "bin/antigen.zsh" => "antigen"
   end
 
   def caveats; <<-EOS.undent
     To activate antigen, add the following to your ~/.zshrc:
-      source #{HOMEBREW_PREFIX}/share/antigen/antigen.zsh
+      autoload -Uz antigen && antigen
     EOS
   end
 
   test do
-    (testpath/".zshrc").write "source #{HOMEBREW_PREFIX}/share/antigen/antigen.zsh\n"
+    (testpath/".zshrc").write "autoload -Uz antigen && antigen\n"
     system "zsh", "--login", "-i", "-c", "antigen help"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Instead of installing the antigen zsh script to `prefix` and asking the user to
source that file in their zshrc, install the function using zsh_function which installs
the script to zsh's function directory, where it will be automatically loaded when
the user uses zsh's `autoload`.