### PR TITLE
unfs3: fix removal to boneyard

### DIFF
--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -1,0 +1,30 @@
+class Unfs3 < Formula
+  desc "User-space NFSv3 server"
+  homepage "http://unfs3.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
+  sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "39efb568edcd8eb1898deb664c1f016baed60b60cb9d6031743da32b6f615cd3" => :sierra
+    sha256 "b1387de21ce9672d5caea47ff223fdbca37e0ed08137a252ae14c7c80dea36e1" => :el_capitan
+    sha256 "8daaa9ce7c48d3a0efbf72dac2e7cdb429aa7aa8475b64837eaa4f5159b2a4d8" => :yosemite
+    sha256 "43e89011e0472b5a7aea6583f930d05d18a449474617f5d11b10b10b52badc66" => :mavericks
+  end
+
+  head do
+    url "http://svn.code.sf.net/p/unfs3/code/trunk/"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
+  def install
+    ENV.j1 # Build is not parallel-safe
+    system "./bootstrap" if build.head?
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+end

--- a/Formula/unfs3.rb
+++ b/Formula/unfs3.rb
@@ -27,4 +27,11 @@ class Unfs3 < Formula
     system "make"
     system "make", "install"
   end
+
+  test do
+    (testpath/"exports").write <<-EOS.undent
+    "#{Dir.pwd}" 192.168.0.1(ro)
+    EOS
+    system("#{sbin}/unfsd", "-T", "-e", (testpath/"exports").to_s)
+  end
 end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -331,7 +331,6 @@
   "ucspi-tools": "homebrew/boneyard",
   "uim": "homebrew/x11",
   "ume": "homebrew/games",
-  "unfs3": "homebrew/boneyard",
   "upnp-router-control": "homebrew/gui",
   "ushare": "homebrew/boneyard",
   "validns": "homebrew/boneyard",


### PR DESCRIPTION
This formula was migrated to boneyard because of a report of it not working at all
on OS X, but it does work. See the discussion in
https://github.com/Homebrew/homebrew-core/pull/7667

This reverts commit 0b48a2e0efa738545e2cf278da6ea7e6d4b718de.