### PR TITLE
cabal-install 1.24.0.2

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -1,8 +1,8 @@
 class CabalInstall < Formula
   desc "Command-line interface for Cabal and Hackage"
   homepage "https://www.haskell.org/cabal/"
-  url "https://hackage.haskell.org/package/cabal-install-1.24.0.1/cabal-install-1.24.0.1.tar.gz"
-  sha256 "09f5fd8a2aa7f9565800a711a133f8142d36d59b38f59da09c25045b83ee9ecc"
+  url "https://hackage.haskell.org/package/cabal-install-1.24.0.2/cabal-install-1.24.0.2.tar.gz"
+  sha256 "2ac8819238a0e57fff9c3c857e97b8705b1b5fef2e46cd2829e85d96e2a00fe0"
   head "https://github.com/haskell/cabal.git", :branch => "1.24"
 
   bottle do
@@ -19,10 +19,6 @@ class CabalInstall < Formula
   def install
     cd "cabal-install" if build.head?
 
-    # Fix "'Distribution.Simple.Configure' does not export 'computeEffectiveProfiling'"
-    # Equivalent to upstream PR from 16 Nov 2016 https://github.com/haskell/cabal/pull/4117
-    inreplace "bootstrap.sh", 'CABAL_VER_REGEXP="1\.24\.[0-9]"',
-                              'CABAL_VER_REGEXP="1\.24\.[1-9]"'
     system "sh", "bootstrap.sh", "--sandbox"
     bin.install ".cabal-sandbox/bin/cabal"
     bash_completion.install "bash-completion/cabal"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi,

I am coming from https://github.com/Linuxbrew/homebrew-core/pull/1366 and I have been advised to submit this PR because it should apply here. It simplifies the formula for MacOS and makes it work for Linuxbrew (it removes the workaround introduced in https://github.com/Homebrew/homebrew-core/commit/4fbc28e6929c1bc34dbabd3b5fb0c201a9df0684 because of haskell/cabal#4117).

I could not test it locally (I did test it with Linuxbrew), so I am going to rely on the CI system. 