### PR TITLE
chrootkit 0.51

### DIFF
--- a/Formula/chkrootkit.rb
+++ b/Formula/chkrootkit.rb
@@ -1,9 +1,9 @@
 class Chkrootkit < Formula
   desc "Rootkit detector"
   homepage "http://www.chkrootkit.org/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/chkrootkit/chkrootkit_0.50.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/chkrootkit/chkrootkit_0.50.orig.tar.gz"
-  sha256 "9548fc922b0cb8ddf055faff4a4887f140a31c45f2f5e3aa64aad91ecfa56cc7"
+  url "ftp://ftp.pangeia.com.br/pub/seg/pac/chkrootkit-0.51.tar.gz"
+  mirror "https://fossies.org/linux/misc/chkrootkit-0.51.tar.gz"
+  sha256 "f66166f5cbff39d9079fc0cac303fdf9e6b4a65a987110e947de94803c5c1378"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https:///Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https:///Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is not on the Debian mirrors yet though it has been out for almost two months (Release Date: Sun Oct 30 2016)
---
first patch to -core; hoping a bot will bottle this, I couldn't find docs on how to trip this other than "leave as-is".
---
What's New
0.51 is now available! (Release Date: Sun Oct 30 2016) This version includes:
- chkrootkit Mumblehard backdoor/botnet detection
- Linux.Xor.DDoS Malware detection <
- Malicious TinyNDS detection
- Backdoors.Linux.Mokes.a detection
- minor (and no so minor) bug fixes