### PR TITLE
vultr: update url and checksum

### DIFF
--- a/Formula/vultr.rb
+++ b/Formula/vultr.rb
@@ -3,8 +3,9 @@ require "language/go"
 class Vultr < Formula
   desc "Command-line tool for Vultr"
   homepage "https://jamesclonk.github.io/vultr"
-  url "https://github.com/JamesClonk/vultr/archive/v1.11.tar.gz"
-  sha256 "a717c3fc07e652822e2c567dd7b715553b754885948b40c430b640a1e5ef65ea"
+  url "https://github.com/JamesClonk/vultr/archive/1.11.0.tar.gz"
+  sha256 "a6af3e4e88cf45f2a6ccfac5530bfebbd1c347c18568932c51c0c28c82e953e8"
+  revision 1
   head "https://github.com/JamesClonk/vultr.git"
 
   bottle do
@@ -20,7 +21,7 @@ class Vultr < Formula
 
   go_resource "github.com/jawher/mow.cli" do
     url "https://github.com/jawher/mow.cli.git",
-        :revision => "660b9261e2c80bb92e5a0eaa581596084656140e"
+        :revision => "0de3d3b4ed00f261460d12ecde4efa90fbfcd8ed"
   end
 
   go_resource "github.com/juju/ratelimit" do


### PR DESCRIPTION
Upstream published a new tarball with the version updated from 1.11 to
1.11.0, which brew's version parsing treats as equivalent, so bump the
revision. Also, one of the resources has been updated.