### PR TITLE
Added caveats to support usage with zsh.

### DIFF
--- a/Formula/gnu-time.rb
+++ b/Formula/gnu-time.rb
@@ -35,6 +35,18 @@ class GnuTime < Formula
     system "make", "install"
   end
 
+  def caveats
+    <<-EOS.undent
+    If you compiled "with-default-names" and you use zsh, then
+    this command will be overshadowed by a built-in. To fix this,
+    add the following to your .zshrc:
+
+        ## Disable builtin `time` command so that gnu-time may be used instead
+        if ! [ -x "$(which time)" ] ;then disable -r time ; fi
+
+    EOS
+  end
+
   test do
     system bin/"gtime", "ruby", "--version"
   end


### PR DESCRIPTION
Zsh provides a similar utility with the builtin `times`, which aliased as the reserved word `time`. If `gnu-time` is compiled `--with-default-names`, then it will not be visible in PATH, because it will be overshadowed by Zsh's reserved word. This PR amends the formula with a `caveats` section to notify the user of this and recommends that they modify their `.zshc` with a (provided) command that will disable the reserved word. 


-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
