### PR TITLE
gcc: Do not build gcj for HEAD builds

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -111,6 +111,8 @@ class Gcc < Formula
       languages << "jit" if build.with? "jit"
     end
 
+    languages -= ["java"] if build.head?
+
     args = [
       "--build=#{arch}-apple-darwin#{osmajor}",
       "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

gcj and other Java-related stuff was removed from the GCC codebase in
revision 240662.

    See https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=240662