### PR TITLE
watson: install shell completions

### DIFF
--- a/Formula/watson.rb
+++ b/Formula/watson.rb
@@ -13,6 +13,8 @@ class Watson < Formula
     sha256 "49a31680d09bafb7f4067f10da498ea542f90c3630bc65ab31552ec59dd02c72" => :yosemite
   end
 
+  option "with-completion", "Install Zsh & Bash completions"
+
   depends_on :python
 
   resource "arrow" do
@@ -42,6 +44,20 @@ class Watson < Formula
 
   def install
     virtualenv_install_with_resources
+
+    if build.with? "completion"
+      bash_completion.install "watson.completion" => "watson"
+      zsh_completion.install "watson.zsh-completion" => "_watson"
+    end
+  end
+
+  def caveats
+    <<-EOS.undent
+    To activate these completions, make sure that your .zshrc enables compinit:
+
+        autoload -Uz compinit && compinit
+
+    EOS
   end
 
   test do

--- a/Formula/watson.rb
+++ b/Formula/watson.rb
@@ -13,8 +13,6 @@ class Watson < Formula
     sha256 "49a31680d09bafb7f4067f10da498ea542f90c3630bc65ab31552ec59dd02c72" => :yosemite
   end
 
-  option "with-completion", "Install Zsh & Bash completions"
-
   depends_on :python
 
   resource "arrow" do
@@ -45,19 +43,9 @@ class Watson < Formula
   def install
     virtualenv_install_with_resources
 
-    if build.with? "completion"
-      bash_completion.install "watson.completion" => "watson"
-      zsh_completion.install "watson.zsh-completion" => "_watson"
+    bash_completion.install "watson.completion" => "watson"
+    zsh_completion.install "watson.zsh-completion" => "_watson"
     end
-  end
-
-  def caveats
-    <<-EOS.undent
-    To activate these completions, make sure that your .zshrc enables compinit:
-
-        autoload -Uz compinit && compinit
-
-    EOS
   end
 
   test do

--- a/Formula/watson.rb
+++ b/Formula/watson.rb
@@ -45,7 +45,6 @@ class Watson < Formula
 
     bash_completion.install "watson.completion" => "watson"
     zsh_completion.install "watson.zsh-completion" => "_watson"
-    end
   end
 
   test do


### PR DESCRIPTION
This PR adds the installation of the completions for Bash and Zsh to the formula. The `caveats` section parrots the install instructions from the [homepage](https://tailordev.github.io/Watson/#command-line-completion).

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?