### PR TITLE
Remove 32-bit options

### DIFF
--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -17,8 +17,6 @@ class Ejabberd < Formula
     depends_on "autoconf" => :build
   end
 
-  option "32-bit"
-
   depends_on "openssl"
   depends_on "erlang"
   depends_on "libyaml"
@@ -29,10 +27,6 @@ class Ejabberd < Formula
     ENV["TARGET_DIR"] = ENV["DESTDIR"] = "#{lib}/ejabberd/erlang/lib/ejabberd-#{version}"
     ENV["MAN_DIR"] = man
     ENV["SBIN_DIR"] = sbin
-
-    if build.build_32_bit?
-      ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
-    end
 
     args = ["--prefix=#{prefix}",
             "--sysconfdir=#{etc}",

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -13,20 +13,14 @@ class Gmp < Formula
     sha256 "b604a20e2501a10773abc384d9750fa27112cf9ad9c532367ebd7caf241c8d4b" => :mavericks
   end
 
-  option "32-bit"
   option :cxx11
 
   def install
     ENV.cxx11 if build.cxx11?
     args = ["--prefix=#{prefix}", "--enable-cxx"]
 
-    if build.build_32_bit?
-      ENV.m32
-      args << "ABI=32"
-    end
-
     # https://github.com/Homebrew/homebrew/issues/20693
-    args << "--disable-assembly" if build.build_32_bit? || build.bottle?
+    args << "--disable-assembly" if build.bottle?
 
     system "./configure", *args
     system "make"

--- a/Formula/mpfi.rb
+++ b/Formula/mpfi.rb
@@ -15,10 +15,7 @@ class Mpfi < Formula
   depends_on "gmp"
   depends_on "mpfr"
 
-  option "32-bit"
-
   def install
-    ENV.m32 if build.build_32_bit?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"
     system "make", "check"

--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -13,8 +13,6 @@ class Mpfr < Formula
     sha256 "ca737c71556161c37563b78305aa93c6663cde07f06d94e4d7de091983327c48" => :yosemite
   end
 
-  option "32-bit"
-
   depends_on "gmp"
 
   fails_with :clang do
@@ -26,7 +24,6 @@ class Mpfr < Formula
   end
 
   def install
-    ENV.m32 if build.build_32_bit?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
                           "--disable-silent-rules"
     system "make"

--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -11,14 +11,11 @@ class Openrtsp < Formula
     sha256 "0288928ad21138b15680fb534f4c40f50254748c423f33e4000cf58946d2ede0" => :yosemite
   end
 
-  option "32-bit"
-
   def install
-    if build.build_32_bit? || !MacOS.prefer_64_bit?
-      ENV.m32
-      system "./genMakefiles", "macosx-32bit"
-    else
+    if MacOS.prefer_64_bit?
       system "./genMakefiles", "macosx"
+    else
+      system "./genMakefiles", "macosx-32bit"
     end
 
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -16,13 +16,10 @@ class OsspUuid < Formula
   end
 
   option :universal
-  option "32-bit"
 
   def install
     if build.universal?
       ENV.universal_binary
-    elsif build.build_32_bit?
-      ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
     end
 
     # upstream ticket: http://cvs.ossp.org/tktview?tn=200

--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -43,7 +43,7 @@ class Pike < Formula
   def install
     args = ["--prefix=#{prefix}", "--without-bundles"]
 
-    if MacOS.prefer_64_bit? && !build.build_32_bit?
+    if MacOS.prefer_64_bit?
       ENV.append "CFLAGS", "-m64"
       args << "--with-abi=64"
     else

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -12,7 +12,6 @@ class Postgresql < Formula
     sha256 "6f535922dca6457f0b16a5a22be5d35ec9138dc2334acc60a660dbb7594c1d41" => :yosemite
   end
 
-  option "32-bit"
   option "without-perl", "Build without Perl support"
   option "without-tcl", "Build without Tcl support"
   option "with-dtrace", "Build with DTrace support"
@@ -87,10 +86,6 @@ class Postgresql < Formula
 
     args << "--enable-dtrace" if build.with? "dtrace"
     args << "--with-uuid=e2fs"
-
-    if build.build_32_bit?
-      ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/sbcl.rb
+++ b/Formula/sbcl.rb
@@ -12,7 +12,6 @@ class Sbcl < Formula
     sha256 "94b9b75914e6b1b98f2adf21ea3bb409bf25922aa150026fa962ed3fbe7254b0" => :yosemite
   end
 
-  option "32-bit"
   option "with-internal-xref", "Include XREF information for SBCL internals (increases core size by 5-6MB)"
   option "with-ldb", "Include low-level debugger in the build"
   option "without-sources", "Don't install SBCL sources"
@@ -77,7 +76,7 @@ class Sbcl < Formula
       ascii_val =~ /[\x80-\xff]/n
     end
 
-    bootstrap = (build.build_32_bit? || !MacOS.prefer_64_bit?) ? "bootstrap32" : "bootstrap64"
+    bootstrap = MacOS.prefer_64_bit? ? "bootstrap64" : "bootstrap32"
     resource(bootstrap).stage do
       # We only need the binaries for bootstrapping, so don't install anything:
       command = "#{Dir.pwd}/src/runtime/sbcl"
@@ -85,7 +84,6 @@ class Sbcl < Formula
       xc_cmdline = "#{command} --core #{core} --disable-debugger --no-userinit --no-sysinit"
 
       cd buildpath do
-        ENV["SBCL_ARCH"] = "x86" if build.build_32_bit?
         Pathname.new("version.lisp-expr").write('"1.0.99.999"') if build.head?
         system "./make.sh", "--prefix=#{prefix}", "--xc-host=#{xc_cmdline}"
       end

--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -21,7 +21,6 @@ class Yaws < Formula
   end
 
   option "without-yapp", "Omit yaws applications"
-  option "32-bit"
 
   depends_on "erlang"
 
@@ -31,10 +30,6 @@ class Yaws < Formula
   skip_clean "lib/yaws/examples/include"
 
   def install
-    if build.build_32_bit?
-      ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
-    end
-
     system "autoreconf", "-fvi" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           # Ensure pam headers are found on Xcode-only installs


### PR DESCRIPTION
No supported versions of macOS default to 32-bit and these can cause massive issues with dependencies.