### PR TITLE
folly 2016.12.12.00

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -1,8 +1,8 @@
 class Folly < Formula
   desc "Collection of reusable C++ library artifacts developed at Facebook"
   homepage "https://github.com/facebook/folly"
-  url "https://github.com/facebook/folly/archive/v2016.11.28.00.tar.gz"
-  sha256 "5a50f75dcf421bf723fbe8d69dc9e3d1bb9935d3b4d5982fc52f29c029ed8c04"
+  url "https://github.com/facebook/folly/archive/v2016.12.12.00.tar.gz"
+  sha256 "ea96682d14423506136edb51a0a761573f50814c1634eb06f1b5d1ea6038cb44"
   head "https://github.com/facebook/folly.git"
 
   bottle do
@@ -62,7 +62,8 @@ class Folly < Formula
 
       system "autoreconf", "-fvi"
       system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
-                            "--disable-dependency-tracking"
+                            "--disable-dependency-tracking",
+                            "--with-jemalloc"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update folly to a more recent tag.

The principal change that impacts homebrew is that we fixed
a problem with jemalloc linkage that affected wangle when
linking against the brew built folly.  We now make the jemalloc
linkage explicit by adding a configure argument.