### PR TITLE
Build mariadb with C++11 by default

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -60,6 +60,7 @@ class Mariadb < Formula
 
     # -DINSTALL_* are relative to prefix
     args = %W[
+      -DCMAKE_CXX_STANDARD=11
       -DMYSQL_DATADIR=#{var}/mysql
       -DINSTALL_INCLUDEDIR=include/mysql
       -DINSTALL_MANDIR=share/man


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Parts of MariaDB require std::bind, which is only available in C++11 and
above.