### PR TITLE
openshift-cli: fix socat dependency not global

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -7,6 +7,8 @@ class OpenshiftCli < Formula
 
   head "https://github.com/openshift/origin.git"
 
+  depends_on "socat"
+
   bottle do
     cellar :any_skip_relocation
     sha256 "aa16bc29805dd80a448cc6af5c9cc9b140bdd37c945dd8efab0e0170c4a17975" => :sierra
@@ -19,8 +21,6 @@ class OpenshiftCli < Formula
       :tag => "v1.4.0-rc1",
       :revision => "b4e0954faa4a0d11d9c1a536b76ad4a8c0206b7c"
     version "1.4.0-rc1"
-
-    depends_on "socat"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The dependency on socat was added to the devel block in #4105 when the prerelease version was an alpha for 1.3.0. This has since been released, so socat is needed as a regular dependency.