### PR TITLE
moreutils: fix compatibility with task-spooler, pwntools, & parallel

### DIFF
--- a/Formula/moreutils.rb
+++ b/Formula/moreutils.rb
@@ -15,12 +15,14 @@ class Moreutils < Formula
   end
 
   option "without-parallel", "Build without the 'parallel' tool."
+  option "without-errno",    "Build without the 'errno' tool, for compatibility with 'pwntools'."
+  option "without-ts",       "Build without the 'ts' tool, for compatibility with 'task-spooler'."
 
   depends_on "docbook-xsl" => :build
 
-  conflicts_with "parallel", :because => "Both install a `parallel` executable."
-  conflicts_with "pwntools", :because => "Both install an `errno` executable."
-  conflicts_with "task-spooler", :because => "Both install a `ts` executable."
+  conflicts_with "parallel", :because => "Both install a `parallel` executable."  if build.with? "parallel"
+  conflicts_with "pwntools", :because => "Both install an `errno` executable."    if build.with? "errno"
+  conflicts_with "task-spooler", :because => "Both install a `ts` executable."    if build.with? "ts"
 
   resource "Time::Duration" do
     url "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Time-Duration-1.20.tar.gz"
@@ -53,6 +55,14 @@ class Moreutils < Formula
     if build.without? "parallel"
       inreplace "Makefile", /^BINS=.*\Kparallel/, ""
       inreplace "Makefile", /^MANS=.*\Kparallel\.1/, ""
+    end
+    if build.without? "errno"
+      inreplace "Makefile", /^BINS=.*\Kerrno/, ""
+      inreplace "Makefile", /^MANS=.*\Kerrno\.1/, ""
+    end
+    if build.without? "ts"
+      inreplace "Makefile", /^PERLSCRIPTS=.*\Kts/, ""
+      inreplace "Makefile", /^MANS=.*\Kts\.1/, ""
     end
     system "make", "all"
     system "make", "check"


### PR DESCRIPTION
The formula `moreutils` is a meta-package that provides a number of tools. Presently, it has listed conflicts with `task-spooler`, `pwntools`, and `parallel`. This PR adds installation options to obviate those conflicts by simply not installing the infringing binary. 

The formula previously has the option to install `without-parallel`, but this wasn't reflected in the `conflicts_with` section. This PR also fixes that.

----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?