### PR TITLE
go: Fix cross-compilation.

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -63,7 +63,9 @@ class Go < Formula
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
       ENV["GOOS"]         = "darwin"
-      ENV["CGO_ENABLED"]  = build.with?("cgo") ? "1" : "0"
+      if build.without? "cgo"
+        ENV["CGO_ENABLED"] = "0"
+      end
       system "./make.bash", "--no-clean"
     end
 


### PR DESCRIPTION
The build was forcing CGO_ENABLED=1, which is not necessary.  But as of
Go 1.8, not only it's not necessary, it's also harmful, as the value of
CGO_ENABLED used during Go's build gets recorded and used by default [1]
when building any Go code, which prevents the compiler from disabling cgo
automatically when cross-compiling. [2]

[1] See golang/go#12808
[2] See golang/go#18360

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
