### PR TITLE
skinny 2.3.2

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.1/skinny-2.3.1.tar.gz"
-  sha256 "f09c564c150a286f51bfe08617887ff2092045106c9cd841d2c52a60749f95e5"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.2/skinny-2.3.2.tar.gz"
+  sha256 "8898d62996b7406a5b23276a3c942d5b2ce5b77a9e7b26de5725cbd896bf7017"
 
   bottle :unneeded
 


### PR DESCRIPTION
skinny 2.3.2 is out. Thank you as always 🙇

https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.2

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
$ brew install --build-from-source skinny.rb
Updating Homebrew...
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.2/skinny-2.3.2.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/a8cc452a-c4cd-11e6-9a77-4e7ea71be708.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20161217%2Fus-east-1%2Fs3%2Faws4_reques
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.2: 915 files, 98.9M, built in 52 seconds
$ brew audit --strict skinny
==> Installing or updating 'rubocop' gem
Fetching: rubocop-0.45.0.gem (100%)
Successfully installed rubocop-0.45.0
1 gem installed
$
```