### PR TITLE
grpc 1.0.1 (new formula)

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -1,0 +1,44 @@
+class Grpc < Formula
+  desc "Google's open-source RPC framework, based on protocol buffers."
+  homepage "http://www.grpc.io/"
+  head "https://github.com/grpc/grpc.git"
+
+  stable do
+    # The script run below, which is no longer needed in versions newer than
+    # 1.0.1, requires fun sed things, which don't seem to work with mac's sed.
+    url "https://github.com/grpc/grpc/archive/v1.0.1.tar.gz"
+    sha256 "efad782944da13d362aab9b81f001b7b8b1458794751de818e9848c47acd4b32"
+    depends_on "gnu-sed" => :build
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "protobuf"
+  depends_on "openssl"
+
+  def install
+    ENV["prefix"] = prefix
+    ENV["HAS_SYSTEM_PROTOBUF"] = "true"
+    ENV["HAS_PKG_CONFIG"] = "true"
+    ENV["HAS_EMBEDDED_PROTOBUF"] = "0"
+
+    if build.stable?
+      # This isn't an issue after version 1.0.1. In version 1.0.1, some
+      # compiled protobufs are checked in. Those protobufs are compiled with
+      # an older version of protoc than the one in homebrew. Moreover, the
+      # script to build these files is broken, which this inreplace fixes.
+      inreplace "tools/codegen/extensions/gen_reflection_proto.sh" do |s|
+        s.gsub! "bins/opt/protobuf/protoc", "protoc"
+        s.gsub! "sed", "gsed"
+        s.gsub! /\{INCLUDE_DIR.+?\}/, "{INCLUDE_DIR}"
+        s.gsub! 'INCLUDE_DIR="grpc++/ext"', 'INCLUDE_DIR="grpc++\\/ext"'
+      end
+      system "make", "grpc_cpp_plugin"
+      system "tools/codegen/extensions/gen_reflection_proto.sh"
+    end
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/grpc_cpp_plugin < /dev/null"
+  end
+end


### PR DESCRIPTION
This commit adds grpc (Google's RPC framework) as a formula. The formula
for HEAD is straightforward. For grpc 1.0.1, some extra steps are
required to regenerate source files that have been checked into the grpc
tree. As of grpc 1.0.1, these source files are generated with protoc 3,
while Homebrew ships protoc 3.1. To rectify this, a few files are
in-replaced, and a separate build script is run. As the comments in the
formula indicate, these hacks should be able to be removed with the next
release of grpc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
