### PR TITLE
Install Heroku CLI over HTTPS

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -1,7 +1,7 @@
 class Heroku < Formula
   desc "Everything you need to get started with Heroku"
   homepage "https://cli.heroku.com"
-  url "http://cli-assets.heroku.com/branches/stable/5.6.1-0976cf3/heroku-v5.6.1-0976cf3-darwin-amd64.tar.xz"
+  url "https://cli-assets.heroku.com/branches/stable/5.6.1-0976cf3/heroku-v5.6.1-0976cf3-darwin-amd64.tar.xz"
   version "5.6.1-0976cf3"
   sha256 "27994f23258ef21c0e40b9fa21fc24b5fcabc44c697c07bf2883fb9b6fc65869"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

cli-assets.heroku.com is listening on port 443 and presents a valid
certificate. We should use HTTPS for downloads to prevent man in the middle
attacks.