### PR TITLE
GCC*: import from homebrew/versions (take 2)

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -111,6 +111,11 @@ class Gcc < Formula
 
     languages -= ["java"] if build.head?
 
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run so pretend we have an outdated makeinfo
+    # to prevent their build.
+    ENV["gcc_cv_prog_makeinfo_modern"] = "no"
+
     args = [
       "--build=#{arch}-apple-darwin#{osmajor}",
       "--prefix=#{prefix}",
@@ -133,9 +138,6 @@ class Gcc < Formula
       "--disable-werror",
       "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
       "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
-      # Even when suffixes are appended, the info pages conflict when
-      # install-info is run.
-      "MAKEINFO=missing",
     ]
 
     # "Building GCC with plugin support requires a host that supports

--- a/Formula/gcc@4.6.rb
+++ b/Formula/gcc@4.6.rb
@@ -1,0 +1,205 @@
+class GccAT46 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.6.4/gcc-4.6.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.6.4/gcc-4.6.4.tar.bz2"
+  sha256 "35af16afa0b67af9b8eb15cafb76d2bc5f568540552522f5dc2c88dd45d977e8"
+
+  # Fixes build with Xcode 7.
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+  patch do
+    url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+    sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp@4"
+  depends_on "libmpc@0.8"
+  depends_on "mpfr@2"
+  depends_on "ppl@0.11"
+  depends_on "cloog@0.15"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://trac.macports.org/export/126996/trunk/dports/lang/gcc48/files/patch-10.10.diff"
+    sha256 "61e5d0f18db59220cbd99717e9b644c1d0f3502b09ada746b60850cacda07328"
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp@4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl@0.11"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog@0.15"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      # Even when suffixes are appended, the info pages conflict when
+      # install-info is run.
+      "MAKEINFO=missing",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.6", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Formula/gcc@4.7.rb
+++ b/Formula/gcc@4.7.rb
@@ -1,0 +1,203 @@
+class GccAT47 < Formula
+  desc "GNU compiler collection"
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2"
+  sha256 "92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_7-branch"
+
+  # Fixes build with Xcode 7.
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+  patch do
+    url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+    sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp@4"
+  depends_on "libmpc@0.8"
+  depends_on "mpfr@2"
+  depends_on "ppl@0.11"
+  depends_on "cloog@0.15"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/7293b7d3/gcc47/patch-10.10.diff"
+    sha256 "61e5d0f18db59220cbd99717e9b644c1d0f3502b09ada746b60850cacda07328"
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp@4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl@0.11"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog@0.15"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      # Even when suffixes are appended, the info pages conflict when
+      # install-info is run.
+      "MAKEINFO=missing",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.7", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -1,0 +1,203 @@
+class GccAT5 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+  sha256 "608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a"
+
+  # GCC's Go compiler is not currently supported on Mac OS X.
+  # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  option "with-jit", "Build the jit compiler"
+  option "without-fortran", "Build without the gfortran compiler"
+  # enabling multilib on a host that can"t run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl@0.14"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  if MacOS.version < :leopard
+    # The as that comes with Tiger isn't capable of dealing with the
+    # PPC asm that comes in libitm
+    depends_on "cctools" => :build
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix for libgccjit.so linkage on Darwin.
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++ jit]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+      languages << "jit" if build.with? "jit"
+    end
+
+    version_suffix = version.to_s.slice(/\d/)
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run so pretend we have an outdated makeinfo
+    # to prevent their build.
+    ENV["gcc_cv_prog_makeinfo_modern"] = "no"
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.14"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-5", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end
+
+__END__
+--- a/gcc/jit/Make-lang.in	2015-02-03 17:19:58.000000000 +0000
++++ b/gcc/jit/Make-lang.in	2015-04-08 22:08:24.000000000 +0100
+@@ -85,8 +85,7 @@
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -1,0 +1,207 @@
+class GccAT6 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+
+  # GCC's Go compiler is not currently supported on Mac OS X.
+  # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  option "with-jit", "Build the jit compiler"
+  option "without-fortran", "Build without the gfortran compiler"
+  # enabling multilib on a host that can"t run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl@0.14"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  if MacOS.version < :leopard
+    # The as that comes with Tiger isn't capable of dealing with the
+    # PPC asm that comes in libitm
+    depends_on "cctools" => :build
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix for libgccjit.so linkage on Darwin
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++ jit]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+      languages << "jit" if build.with? "jit"
+    end
+
+    version_suffix = version.to_s.slice(/\d/)
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run so pretend we have an outdated makeinfo
+    # to prevent their build.
+    ENV["gcc_cv_prog_makeinfo_modern"] = "no"
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.14"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
+    # format to avoid failure during the stage 3 comparison of object files.
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version <= :mountain_lion
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-6", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end
+
+__END__
+--- a/gcc/jit/Make-lang.in	2015-02-03 17:19:58.000000000 +0000
++++ b/gcc/jit/Make-lang.in	2015-04-08 22:08:24.000000000 +0100
+@@ -85,8 +85,7 @@
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -12,6 +12,7 @@
   "elasticsearch17": "elasticsearch@1.7",
   "elasticsearch24": "elasticsearch@2.4",
   "fig": "docker-compose",
+  "gcc46": "gcc@4.6",
   "gcc48": "gcc@4.8",
   "gcc49": "gcc@4.9",
   "geode": "apache-geode",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -13,6 +13,7 @@
   "elasticsearch24": "elasticsearch@2.4",
   "fig": "docker-compose",
   "gcc46": "gcc@4.6",
+  "gcc47": "gcc@4.7",
   "gcc48": "gcc@4.8",
   "gcc49": "gcc@4.9",
   "geode": "apache-geode",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -17,6 +17,7 @@
   "gcc48": "gcc@4.8",
   "gcc49": "gcc@4.9",
   "gcc5": "gcc@5",
+  "gcc6": "gcc@6",
   "geode": "apache-geode",
   "glfw3": "glfw",
   "gmp4": "gmp@4",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -16,6 +16,7 @@
   "gcc47": "gcc@4.7",
   "gcc48": "gcc@4.8",
   "gcc49": "gcc@4.9",
+  "gcc5": "gcc@5",
   "geode": "apache-geode",
   "glfw3": "glfw",
   "gmp4": "gmp@4",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew/versions PR: https://github.com/Homebrew/homebrew-versions/pull/1472

If any of these don't build they will likely be 💥. I've skipped the older GCC versions that are either unused or barely used from analytics.