### PR TITLE
libvpx: remove hard-coded 10.6 32-bit target, add basic test

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -21,6 +21,10 @@ class Libvpx < Formula
 
   depends_on "yasm" => :build
 
+  # configure misdetects 32-bit 10.6
+  # https://code.google.com/p/webm/issues/detail?id=401
+  depends_on :macos => :lion
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -33,15 +37,13 @@ class Libvpx < Formula
     args << "--enable-gcov" if !ENV.compiler == :clang && build.with?("gcov")
     args << "--enable-postproc" << "--enable-postproc-visualizer" if build.with? "visualizer"
 
-    # configure misdetects 32-bit 10.6
-    # https://code.google.com/p/webm/issues/detail?id=401
-    if MacOS.version == "10.6" && Hardware::CPU.is_32_bit?
-      args << "--target=x86-darwin10-gcc"
-    end
-
     mkdir "macbuild" do
       system "../configure", *args
       system "make", "install"
     end
+  end
+
+  test do
+    system "otool", "-a", lib/"libvpx.a"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

solve potential build issues by setting macOS >= 10.7 as a requirement