### PR TITLE
qt5: Add patch to address macdeployqt issue

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -109,6 +109,13 @@ class Qt5 < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
 
+  # Fix macdeployqt
+  # Original patch from https://bugreports.qt.io/browse/QTBUG-56814
+  patch do
+    url "https://gist.githubusercontent.com/cawka/3025baecf3b05e14311b82210a15320f/raw/7ac6a2696f19630df5d02ccc0e48aec733da1364/qt5-patch"
+    sha256 "b18e4715fcef2992f051790d3784a54900508c93350c25b0f2228cb058567142"
+  end
+
   def install
     args = %W[
       -verbose


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
