### PR TITLE
Percona + Symbol not found: _clock_gettime

### DIFF
--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -79,6 +79,10 @@ class PerconaServer < Formula
       -DCMAKE_BUILD_TYPE=RelWithDebInfo
     ]
 
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0"
+    end
+
     # PAM plugin is Linux-only at the moment
     args.concat %w[
       -DWITHOUT_AUTH_PAM=1


### PR DESCRIPTION
If Homebrew was updated on Aug 10-11th 2016 and `brew update` always says `Already up-to-date.` you need to run: `cd "$(brew --repo)" && git fetch && git reset --hard origin/master && brew update`.

# Please follow the general troubleshooting steps first:

- [x] Ran `brew update` and retried your prior step?
- [x] Ran `brew doctor`, fixed as many issues as possible and retried your prior step?
- [x] Confirmed this is problem with specific formulae and not Homebrew/brew? If it's a general Homebrew/brew problem please file this issue at https://github.com/Homebrew/brew/issues/new

_You can erase any parts of this template not applicable to your Issue._

### Bug reports:

Getting the seemingly very common `Symbol not found: _clock_gettime` error. 

```
$ brew config
HOMEBREW_VERSION: 1.1.5-20-g0027ded5a
ORIGIN: https://github.com/Homebrew/brew.git
HEAD: 0027ded5aa6195dcc153ecf0d3d3b05e99f339af
Last commit: 13 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 7a7a1fe7ff55e3ef5d67c7ffbbc04d034bb35cc0
Core tap last commit: 3 hours ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_REPOSITORY: /usr/local/Homebrew
HOMEBREW_CELLAR: /usr/local/Cellar
HOMEBREW_BOTTLE_DOMAIN: https://homebrew.bintray.com
CPU: octa-core 64-bit haswell
Homebrew Ruby: 2.0.0-p648
Clang: 8.0 build 800
Git: 2.11.0 => /usr/local/bin/git
Perl: /usr/bin/perl
Python: /usr/local/bin/python => /usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/bin/python2.7
Ruby: /Users/nthompson/.rbenv/shims/ruby => /usr/local/Cellar/ruby/2.3.3/bin/ruby
Java: 1.8.0_66
macOS: 10.11.6-x86_64
Xcode: 8.2
CLT: 8.2.0.0.1.1480973914
X11: 2.7.11 => /opt/X11
```

```
$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry and just ignore them. Thanks!

Warning: You have unlinked kegs in your Cellar
Leaving kegs unlinked can lead to build-trouble and cause brews that depend on
those kegs to fail to run properly once built. Run `brew link` on these:
  php54
  php56
  redis24
```

Gist Log: https://gist.github.com/njt1982/2141193c4cebb909a70707aa5799fd26

I suspect this is because I left my laptop running software updates on Friday night...

```
$ xcode-select --install
xcode-select: error: command line tools are already installed, use "Software Update" to install updates
```

I have tried reinstalling from source (well, uninstalling and installing from source). I got no errors during install, I just get an error when I try to run MySQL server.

```
$ tail Nicholass-MacBook-Pro.local.err
2016-12-19T13:27:16.6NZ mysqld_safe Starting mysqld daemon with databases from /usr/local/var/mysql
dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
  Referenced from: /usr/local/Cellar/percona-server/5.7.16-10/bin/mysqld
  Expected in: /usr/lib/libSystem.B.dylib

dyld: Symbol not found: _clock_gettime
  Referenced from: /usr/local/Cellar/percona-server/5.7.16-10/bin/mysqld
  Expected in: /usr/lib/libSystem.B.dylib

2016-12-19T13:27:16.6NZ mysqld_safe mysqld from pid file /usr/local/var/mysql/Nicholass-MacBook-Pro.local.pid ended
```

I've seen several other posts about this, but no clear direction for fix... The closest is [a post by](https://github.com/Homebrew/homebrew-core/issues/2674#issuecomment-250896730) @ilovezfs...

Suggesting what looks like a patch to percona 56 using `-DHAVE_CLOCK_GETTIME:INTERNAL=0` - does this simply need applying to the 57 release too?
