### PR TITLE
Remove 32 bit option

### DIFF
--- a/Formula/gmp@4.rb
+++ b/Formula/gmp@4.rb
@@ -30,7 +30,7 @@ class GmpAT4 < Formula
     args = ["--prefix=#{prefix}", "--enable-cxx"]
 
     # Build 32-bit where appropriate, and help configure find 64-bit CPUs
-    if MacOS.prefer_64_bit? && !build.build_32_bit?
+    if MacOS.prefer_64_bit?
       ENV.m64
       args << "--build=x86_64-apple-darwin"
     else

--- a/Formula/mpfr@2.rb
+++ b/Formula/mpfr@2.rb
@@ -34,7 +34,7 @@ class MpfrAT2 < Formula
 
     # Build 32-bit where appropriate, and help configure find 64-bit CPUs
     # Note: This logic should match what the GMP formula does.
-    if MacOS.prefer_64_bit? && !build.build_32_bit?
+    if MacOS.prefer_64_bit?
       ENV.m64
       args << "--build=x86_64-apple-darwin"
     else


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

No supported versions of macOS default to 32-bit and these can cause massive issues with dependencies.