### PR TITLE
Remove ENV.enable_warnings no-op.

### DIFF
--- a/Formula/neon.rb
+++ b/Formula/neon.rb
@@ -26,7 +26,6 @@ class Neon < Formula
 
   def install
     ENV.universal_binary if build.universal?
-    ENV.enable_warnings
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
                           "--enable-shared",
@@ -45,7 +44,7 @@ index d7702d2..5c3b5a3 100755
 +++ b/configure
 @@ -4224,7 +4224,6 @@ fi
  $as_echo "$ne_cv_os_uname" >&6; }
- 
+
  if test "$ne_cv_os_uname" = "Darwin"; then
 -  CPPFLAGS="$CPPFLAGS -no-cpp-precomp"
    LDFLAGS="$LDFLAGS -flat_namespace"

--- a/Formula/socat.rb
+++ b/Formula/socat.rb
@@ -22,7 +22,6 @@ class Socat < Formula
   depends_on "openssl"
 
   def install
-    ENV.enable_warnings # -w causes build to fail
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"
   end

--- a/Formula/tin.rb
+++ b/Formula/tin.rb
@@ -13,7 +13,6 @@ class Tin < Formula
   conflicts_with "mutt", :because => "both install mmdf.5 and mbox.5 man pages"
 
   def install
-    ENV.enable_warnings
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -29,9 +29,6 @@ class Trafficserver < Formula
   def install
     ENV.cxx11
 
-    # Needed for correct ./configure detections
-    ENV.enable_warnings
-
     # Needed for OpenSSL headers
     if MacOS.version <= :lion
       ENV.append_to_cflags "-Wno-deprecated-declarations"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With superenv (used on all these formulae) this now does nothing.