### PR TITLE
Remove LibreSSL options where OpenSSL is already used.

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -20,8 +20,7 @@ class Curl < Formula
   option "with-c-ares", "Build with C-Ares async DNS support"
   option "with-gssapi", "Build with GSSAPI/Kerberos authentication support."
   option "with-libmetalink", "Build with libmetalink support."
-  option "with-libressl", "Build with LibreSSL instead of Secure Transport or OpenSSL"
-  option "with-nghttp2", "Build with HTTP/2 support (requires OpenSSL or LibreSSL)"
+  option "with-nghttp2", "Build with HTTP/2 support (requires OpenSSL)"
 
   deprecated_option "with-idn" => "with-libidn"
   deprecated_option "with-rtmp" => "with-rtmpdump"
@@ -30,7 +29,7 @@ class Curl < Formula
 
   # HTTP/2 support requires OpenSSL 1.0.2+ or LibreSSL 2.1.3+ for ALPN Support
   # which is currently not supported by Secure Transport (DarwinSSL).
-  if MacOS.version < :mountain_lion || (build.with?("nghttp2") && build.without?("libressl"))
+  if MacOS.version < :mountain_lion || build.with?("nghttp2")
     depends_on "openssl"
   else
     option "with-openssl", "Build with OpenSSL instead of Secure Transport"
@@ -43,19 +42,9 @@ class Curl < Formula
   depends_on "libssh2" => :optional
   depends_on "c-ares" => :optional
   depends_on "libmetalink" => :optional
-  depends_on "libressl" => :optional
   depends_on "nghttp2" => :optional
 
   def install
-    # Fail if someone tries to use both SSL choices.
-    # Long-term, handle conflicting options case in core code.
-    if build.with?("libressl") && build.with?("openssl")
-      odie <<-EOS.undent
-      --with-openssl and --with-libressl are both specified and
-      curl can only use one at a time.
-      EOS
-    end
-
     args = %W[
       --disable-debug
       --disable-dependency-tracking
@@ -66,12 +55,7 @@ class Curl < Formula
     # cURL has a new firm desire to find ssl with PKG_CONFIG_PATH instead of using
     # "--with-ssl" any more. "when possible, set the PKG_CONFIG_PATH environment
     # variable instead of using this option". Multi-SSL choice breaks w/o using it.
-    if build.with? "libressl"
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["libressl"].opt_lib}/pkgconfig"
-      args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
-      args << "--with-ca-bundle=#{etc}/libressl/cert.pem"
-      args << "--with-ca-path=#{etc}/libressl/certs"
-    elsif MacOS.version < :mountain_lion || build.with?("openssl") || build.with?("nghttp2")
+    if MacOS.version < :mountain_lion || build.with?("openssl") || build.with?("nghttp2")
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl"].opt_lib}/pkgconfig"
       args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
       args << "--with-ca-bundle=#{etc}/openssl/cert.pem"

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -29,7 +29,6 @@ class H2o < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "libressl" => :optional
   depends_on "libuv" => :optional
   depends_on "wslay" => :optional
 
@@ -39,9 +38,6 @@ class H2o < Formula
     ENV.delete("SDKROOT")
 
     openssl = build.stable? ? Formula["openssl"] : Formula["openssl@1.1"]
-    if build.with?("libressl") && build.with?(openssl)
-      odie "--without-#{openssl} must be passed when building --with-libressl"
-    end
 
     args = std_cmake_args
     args << "-DWITH_BUNDLED_SSL=OFF"

--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -20,10 +20,7 @@ class Libssh2 < Formula
     depends_on "libtool" => :build
   end
 
-  option "with-libressl", "build with LibreSSL instead of OpenSSL"
-
   depends_on "openssl" => :recommended
-  depends_on "libressl" => :optional
 
   def install
     args = %W[
@@ -34,13 +31,8 @@ class Libssh2 < Formula
       --disable-examples-build
       --with-openssl
       --with-libz
+      --with-libssl-prefix=#{Formula["openssl"].opt_prefix}
     ]
-
-    if build.with? "libressl"
-      args << "--with-libssl-prefix=#{Formula["libressl"].opt_prefix}"
-    else
-      args << "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}"
-    end
 
     system "./buildconf" if build.head?
     system "./configure", *args

--- a/Formula/links.rb
+++ b/Formula/links.rb
@@ -13,7 +13,6 @@ class Links < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl" => :recommended
-  depends_on "libressl" => :optional
   depends_on "libtiff" => :optional
   depends_on "jpeg" => :optional
   depends_on "librsvg" => :optional
@@ -25,13 +24,8 @@ class Links < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --mandir=#{man}
+      --with-ssl=#{Formula["openssl"].opt_prefix}
     ]
-
-    if build.with? "libressl"
-      args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
-    else
-      args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
-    end
 
     args << "--enable-graphics" if build.with? "x11"
     args << "--without-libtiff" if build.without? "libtiff"

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -32,7 +32,6 @@ class Wget < Formula
   depends_on "pkg-config" => :build
   depends_on "pod2man" => :build if MacOS.version <= :snow_leopard
   depends_on "openssl" => :recommended
-  depends_on "libressl" => :optional
   depends_on "libidn" if build.with? "iri"
   depends_on "pcre" => :optional
   depends_on "libmetalink" => :optional
@@ -47,13 +46,8 @@ class Wget < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-ssl=openssl
+      --with-libssl-prefix=#{Formula["openssl"].opt_prefix}
     ]
-
-    if build.with? "libressl"
-      args << "--with-libssl-prefix=#{Formula["libressl"].opt_prefix}"
-    else
-      args << "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}"
-    end
 
     args << "--disable-debug" if build.without? "debug"
     args << "--disable-iri" if build.without? "iri"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Formulae should not depend on both OpenSSL and LibreSSL (even
optionally). This is to avoid descending into madness where every
formulae that could use LibreSSL has to have option and switching logic.

Homebrew has standardised on OpenSSL and will do so everywhere that
LibreSSL is not a hard requirement.

CC @ilovezfs for thoughts.