### PR TITLE
Remove LLVM compiler check no-op.

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -66,7 +66,7 @@ class Boost < Formula
 
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
-    without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
+    without_libraries << "log" if ENV.compiler == :gcc
     without_libraries << "mpi" if build.without? "mpi"
 
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -125,8 +125,6 @@ class Ghc < Formula
 
     if ENV.compiler == :clang
       args << "--with-clang=#{ENV.cc}"
-    elsif ENV.compiler == :llvm
-      args << "--with-gcc-4.2=#{ENV.cc}"
     end
 
     # As of Xcode 7.3 (and the corresponding CLT) `nm` is a symlink to `llvm-nm`

--- a/Formula/luabind.rb
+++ b/Formula/luabind.rb
@@ -53,8 +53,6 @@ class Luabind < Formula
     args = %w[release install]
     if ENV.compiler == :clang
       args << "--toolset=clang"
-    elsif ENV.compiler == :llvm
-      args << "--toolset=llvm"
     elsif ENV.compiler == :gcc
       args << "--toolset=darwin"
     end

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -31,9 +31,6 @@ class Mplayer < Formula
   end
 
   def install
-    # It turns out that ENV.O1 fixes link errors with llvm.
-    ENV.O1 if ENV.compiler == :llvm
-
     # we disable cdparanoia because homebrew's version is hacked to work on macOS
     # and mplayer doesn't expect the hacks we apply. So it chokes. Only relevant
     # if you have cdparanoia installed.
@@ -65,7 +62,7 @@ index addc461..3b871aa 100755
 +++ b/configure
 @@ -1517,8 +1517,6 @@ if test -e ffmpeg/mp_auto_pull ; then
  fi
- 
+
  if test "$ffmpeg_a" != "no" && ! test -e ffmpeg ; then
 -    echo "No FFmpeg checkout, press enter to download one with git or CTRL+C to abort"
 -    read tmp

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -69,7 +69,7 @@ class Sdl < Formula
     args = %W[--prefix=#{prefix}]
     args << "--disable-nasm" unless MacOS.version >= :mountain_lion # might work with earlier, might only work with new clang
     # LLVM-based compilers choke on the assembly code packaged with SDL.
-    if ENV.compiler == :llvm || (ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421)
+    if ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421
       args << "--disable-assembly"
     end
 

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -42,7 +42,7 @@ class Sdl2 < Formula
     args = %W[--prefix=#{prefix}]
 
     # LLVM-based compilers choke on the assembly code packaged with SDL.
-    if ENV.compiler == :llvm || (ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421)
+    if ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421
       args << "--disable-assembly"
     end
     args << "--without-x"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This compiler is never used so these checks will never pass.