### PR TITLE
fabric: fix vendored lib "cryptography" linking to getentropy()

### DIFF
--- a/Formula/fabric.rb
+++ b/Formula/fabric.rb
@@ -3,6 +3,8 @@ class Fabric < Formula
   homepage "http://www.fabfile.org"
   url "https://github.com/fabric/fabric/archive/1.13.1.tar.gz"
   sha256 "59ee3b780e0cd3b8c5db7333d2006a5f932e8e79e2f334aec76c6f97b298bac6"
+  revision 1
+
   head "https://github.com/fabric/fabric.git"
 
   bottle do
@@ -69,6 +71,13 @@ class Fabric < Formula
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
     resources.each do |r|
       r.stage do
+        if r.name == "cryptography" && MacOS.version < :sierra
+          # Fixes .../cryptography/hazmat/bindings/_openssl.so: Symbol not found: _getentropy
+          # Reported Dec 20 2016: https://github.com/pyca/cryptography/issues/3332
+          inreplace "src/_cffi_src/openssl/src/osrandom_engine.h",
+            "#elif defined(BSD) && defined(SYS_getentropy)",
+            "#elif defined(BSD) && defined(SYS_getentropy) && 0"
+        end
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end


### PR DESCRIPTION
paramiko 2.x uses the "cryptography" module, which can have issues linking to _getentropy from libSystem.B.dylib on OS X 10.11

fix for #8044

-----

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----