### PR TITLE
Convert formulae to prefer ruby-macho over cctools

### DIFF
--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -34,8 +34,8 @@ class Amap < Formula
   end
 
   test do
-    output = shell_output("otool -L #{bin}/amap")
-    assert_match Formula["openssl"].opt_lib.to_s, output
+    openssl_linked = MachO::Tools.dylibs("#{bin}/amap").any? { |d| d.include? Formula["openssl"].opt_lib.to_s }
+    assert openssl_linked
     # We can do more than this, but unsure how polite it is to port-scan
     # someone's domain every time this goes through CI.
     assert_match version.to_s, shell_output("#{bin}/amap", 255)

--- a/Formula/espeak.rb
+++ b/Formula/espeak.rb
@@ -32,7 +32,7 @@ class Espeak < Formula
       lib.install "libespeak.a"
       system "make", "libespeak.so", "DATADIR=#{share}/espeak-data", "PREFIX=#{prefix}"
       lib.install "libespeak.so.1.1.48" => "libespeak.dylib"
-      system "install_name_tool", "-id", "#{lib}/libespeak.dylib", "#{lib}/libespeak.dylib"
+      MachO::Tools.change_dylib_id("#{lib}/libespeak.dylib", "#{lib}/libespeak.dylib")
       # macOS does not use the convention libraryname.so.X.Y.Z. macOS uses the convention libraryname.X.dylib
       # See https://stackoverflow.com/questions/4580789/ld-unknown-option-soname-on-os-x/32280483#32280483
     end

--- a/Formula/g3log.rb
+++ b/Formula/g3log.rb
@@ -21,7 +21,7 @@ class G3log < Formula
     # No install target yet: https://github.com/KjellKod/g3log/issues/49
     include.install "src/g3log"
     lib.install "libg3logger.a", "libg3logger.dylib"
-    system "install_name_tool", "-id", "#{lib}/libg3logger.dylib", "#{lib}/libg3logger.dylib"
+    MachO::Tools.change_dylib_id("#{lib}/libg3logger.dylib", "#{lib}/libg3logger.dylib")
   end
 
   test do

--- a/Formula/leveldb.rb
+++ b/Formula/leveldb.rb
@@ -27,7 +27,7 @@ class Leveldb < Formula
     lib.install "out-shared/libleveldb.dylib.1.19" => "libleveldb.1.19.dylib"
     lib.install_symlink lib/"libleveldb.1.19.dylib" => "libleveldb.dylib"
     lib.install_symlink lib/"libleveldb.1.19.dylib" => "libleveldb.1.dylib"
-    system "install_name_tool", "-id", "#{lib}/libleveldb.1.dylib", "#{lib}/libleveldb.1.19.dylib"
+    MachO::Tools.change_dylib_id("#{lib}/libleveldb.1.dylib", "#{lib}/libleveldb.1.19.dylib")
   end
 
   test do

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -50,10 +50,10 @@ class Libgcrypt < Formula
     # normal place on >10.10 where SIP is enabled.
     # https://github.com/Homebrew/homebrew-core/pull/3004
     # https://bugs.gnupg.org/gnupg/issue2056
-    system "install_name_tool", "-change",
-                                lib/"libgcrypt.20.dylib",
-                                buildpath/"src/.libs/libgcrypt.20.dylib",
-                                buildpath/"tests/.libs/random"
+    MachO::Tools.change_install_name("#{buildpath}/tests/.libs/random",
+                                     "#{lib}/libgcrypt.20.dylib",
+                                     "#{buildpath}/src/.libs/libgcrypt.20.dylib")
+
     system "make", "check"
     system "make", "install"
 

--- a/Formula/libsvm.rb
+++ b/Formula/libsvm.rb
@@ -18,7 +18,7 @@ class Libsvm < Formula
     bin.install "svm-scale", "svm-train", "svm-predict"
     lib.install "libsvm.so.2" => "libsvm.2.dylib"
     lib.install_symlink "libsvm.2.dylib" => "libsvm.dylib"
-    system "install_name_tool", "-id", "#{lib}/libsvm.2.dylib", "#{lib}/libsvm.2.dylib"
+    MachO::Tools.change_dylib_id("#{lib}/libsvm.2.dylib", "#{lib}/libsvm.2.dylib")
     include.install "svm.h"
   end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -350,7 +350,7 @@ class Llvm < Formula
               "-I#{libclangclt}/include",
               "-I/usr/include", # need it because /Library/.../usr/include/c++/v1/iosfwd refers to <wchar.h>, which CLT installs to /usr/include
               "test.cpp", "-o", "testCLT++"
-      assert_match "/usr/lib/libc++.1.dylib", shell_output("otool -L ./testCLT++").chomp
+      assert_includes MachO::Tools.dylibs("testCLT++"), "/usr/lib/libc++.1.dylib"
       assert_equal "Hello World!", shell_output("./testCLT++").chomp
 
       system "#{bin}/clang", "-v", "-nostdinc",
@@ -368,7 +368,7 @@ class Llvm < Formula
               "-I#{libclangxc}/include",
               "-I#{MacOS.sdk_path}/usr/include",
               "test.cpp", "-o", "testXC++"
-      assert_match "/usr/lib/libc++.1.dylib", shell_output("otool -L ./testXC++").chomp
+      assert_includes MachO::Tools.dylibs("testXC++"), "/usr/lib/libc++.1.dylib"
       assert_equal "Hello World!", shell_output("./testXC++").chomp
 
       system "#{bin}/clang", "-v", "-nostdinc",
@@ -387,7 +387,7 @@ class Llvm < Formula
               "-I#{MacOS.sdk_path}/usr/include",
               "-L#{lib}",
               "-Wl,-rpath,#{lib}", "test.cpp", "-o", "test"
-      assert_match "#{opt_lib}/libc++.1.dylib", shell_output("otool -L ./test").chomp
+      assert_includes MachO::Tools.dylibs("test"), "#{opt_lib}/libc++.1.dylib"
       assert_equal "Hello World!", shell_output("./test").chomp
     end
   end

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -81,9 +81,9 @@ class Pypy < Formula
     end
 
     (libexec/"lib").install libexec/"bin/libpypy-c.dylib"
-    system "install_name_tool", "-change", "@rpath/libpypy-c.dylib",
-                                "#{libexec}/lib/libpypy-c.dylib",
-                                "#{libexec}/bin/pypy"
+    MachO::Tools.change_install_name("#{libexec}/bin/pypy",
+                                     "@rpath/libpypy-c.dylib",
+                                     "#{libexec}/lib/libpypy-c.dylib")
 
     # The PyPy binary install instructions suggest installing somewhere
     # (like /opt) and symlinking in binaries as needed. Specifically,

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -1,7 +1,7 @@
 class Pypy3 < Formula
   desc "Implementation of Python 3 in Python"
   homepage "http://pypy.org/"
-  url "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.5.0-alpha-src.tar.bz2"
+  url "https://dl.bintray.com/homebrew/mirror/pypy3-5.5.0.tar.bz2"
   sha256 "d5591c34d77253e9ed57d182b6f49585b95f7c09c3e121f0e8630e5a7e75ab5f"
 
   bottle do
@@ -79,8 +79,11 @@ class Pypy3 < Formula
 
     (libexec/"lib").install libexec/"bin/libpypy-c.dylib" => "libpypy3-c.dylib"
 
-    system "install_name_tool", "-change", "@rpath/libpypy-c.dylib", libexec/"lib/libpypy3-c.dylib", "#{libexec}/bin/pypy3.3"
-    system "install_name_tool", "-id", opt_libexec/"lib/libpypy3-c.dylib", libexec/"lib/libpypy3-c.dylib"
+    MachO::Tools.change_install_name("#{libexec}/bin/pypy3.3",
+                                     "@rpath/libpypy-c.dylib",
+                                     "#{libexec}/lib/libpypy3-c.dylib")
+    MachO::Tools.change_dylib_id("#{libexec}/lib/libpypy3-c.dylib",
+                                 "#{opt_libexec}/lib/libpypy3-c.dylib")
 
     (libexec/"lib-python").install "lib-python/3"
     libexec.install %w[include lib_pypy]

--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -19,7 +19,7 @@ class Re2 < Formula
     ENV.cxx11
 
     system "make", "install", "prefix=#{prefix}"
-    system "install_name_tool", "-id", "#{lib}/libre2.0.dylib", "#{lib}/libre2.0.0.0.dylib"
+    MachO::Tools.change_dylib_id("#{lib}/libre2.0.0.0.dylib", "#{lib}/libre2.0.dylib")
     lib.install_symlink "libre2.0.0.0.dylib" => "libre2.0.dylib"
     lib.install_symlink "libre2.0.0.0.dylib" => "libre2.dylib"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Just replacing usages of `install_name_tool` and `otool` with calls to `ruby-macho`, where possible.

There's still ~~quite~~ a few more formulae to convert, so this is WIP.

Remaining: 
- [ ] `macvim`

Not applicable:
- `cctools`
- `ucommon`
