### PR TITLE
Move kubernetes-cli to tag/revision

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -1,8 +1,10 @@
 class KubernetesCli < Formula
   desc "Kubernetes command-line interface"
   homepage "http://kubernetes.io/"
-  url "https://github.com/kubernetes/kubernetes/archive/v1.5.1.tar.gz"
-  sha256 "629f73b8519157e863df9cf2e724c188ceff842aeafa9953727460707f615d85"
+  url "https://github.com/kubernetes/kubernetes.git",
+      :tag => "v1.5.1",
+      :revision => "82450d03cb057bab0950214ef122b67c83fb11df"
+  revision 1
   head "https://github.com/kubernetes/kubernetes.git"
 
   bottle do
@@ -34,7 +36,10 @@ class KubernetesCli < Formula
   end
 
   test do
-    output = shell_output("#{bin}/kubectl 2>&1")
-    assert_match "kubectl controls the Kubernetes cluster manager.", output
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current `kubectl version --client` outputs the following, as it's not compiled from the git source
```console
Client Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.1+82450d0", GitCommit:"82450d03cb057bab0950214ef122b67c83fb11df", GitTreeState:"not a git tree", BuildDate:"2016-12-14T04:09:31Z", GoVersion:"go1.7.4", Compiler:"gc", Platform:"darwin/amd64"}
```

Compiling it from the git source allows the build process to verify that the tree is clean.