### PR TITLE
dbt 0.5.4 (new formula)

### DIFF
--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -4,7 +4,6 @@ class Dbt < Formula
   desc "Data build tool"
   homepage "https://github.com/analyst-collective/dbt"
   url "https://github.com/analyst-collective/dbt/archive/v0.5.4.tar.gz"
-  version "0.5.4"
   sha256 "df830bb0355e46608727fc6c59fa4aadd2514aec227e55765fe56abcfc72918c"
 
   depends_on :python3
@@ -157,6 +156,6 @@ class Dbt < Formula
   end
 
   test do
-    system "#{bin}/dbt", "help"
+    system "#{bin}/dbt", "-h"
   end
 end

--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -1,0 +1,162 @@
+class Dbt < Formula
+  include Language::Python::Virtualenv
+
+  desc "Data build tool"
+  homepage "https://github.com/analyst-collective/dbt"
+  url "https://github.com/analyst-collective/dbt/archive/v0.5.4.tar.gz"
+  version "0.5.4"
+  sha256 "df830bb0355e46608727fc6c59fa4aadd2514aec227e55765fe56abcfc72918c"
+
+  depends_on :python3
+  depends_on "openssl"
+  depends_on :postgresql
+
+  resource "amqp" do
+    url "https://files.pythonhosted.org/packages/cc/a4/f265c6f9a7eb1dd45d36d9ab775520e07ff575b11ad21156f9866da047b2/amqp-1.4.9.tar.gz"
+    sha256 "2dea4d16d073c902c3b89d9b96620fb6729ac0f7a923bbc777cb4ad827c0c61a"
+  end
+
+  resource "anyjson" do
+    url "https://files.pythonhosted.org/packages/c3/4d/d4089e1a3dd25b46bebdb55a992b0797cff657b4477bc32ce28038fdecbc/anyjson-0.3.3.tar.gz"
+    sha256 "37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba"
+  end
+
+  resource "billiard" do
+    url "https://files.pythonhosted.org/packages/64/a6/d7b6fb7bd0a4680a41f1d4b27061c7b768c673070ba8ac116f865de4e7ca/billiard-3.3.0.23.tar.gz"
+    sha256 "692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b"
+  end
+
+  resource "celery" do
+    url "https://files.pythonhosted.org/packages/ea/a6/6da0bac3ea8abbc2763fd2664af2955702f97f140f2d7277069445532b7c/celery-3.1.23.tar.gz"
+    sha256 "1a359c815837f9dbf193a7dbc6addafa34612c077ff70c66e3b16e14eebd2418"
+  end
+
+  resource "csvkit" do
+    url "https://files.pythonhosted.org/packages/f6/5a/4843db5d3ea69c4984fbfd64859e5ae32847e9384ccc82849c27fd33720b/csvkit-0.9.1.tar.gz"
+    sha256 "92f8b8647becb5cb1dccb3af92a13a4e85702d42ba465ce8447881fb38c9f93a"
+  end
+
+  resource "dbt" do
+    url "https://files.pythonhosted.org/packages/7f/c5/7b2a8cb268af08e9cc469931e3011f38d461513063cf25310e65a51b96d5/dbt-0.5.4.tar.gz"
+    sha256 "298b48ba058652df13bb155170b225c4667470fb41ae43c8af5f10968dd1dfa2"
+  end
+
+  resource "decorator" do
+    url "https://files.pythonhosted.org/packages/13/8a/4eed41e338e8dcc13ca41c94b142d4d20c0de684ee5065523fee406ce76f/decorator-4.0.10.tar.gz"
+    sha256 "9c6e98edcb33499881b86ede07d9968c81ab7c769e28e9af24075f0a5379f070"
+  end
+
+  resource "gevent" do
+    url "https://files.pythonhosted.org/packages/43/8f/cb3224a0e6ab663547f45c10d0651cfd52633fde4283bf68d627084df8cc/gevent-1.1.2.tar.gz"
+    sha256 "cb15cf73d69a2eeefed330858f09634e2c50bf46da9f9e7635730fcfb872c02c"
+  end
+
+  resource "greenlet" do
+    url "https://files.pythonhosted.org/packages/03/a6/8842d7215e1c54537eb5d0b8fd3e8562cc869b6d193317b11027ff7d8009/greenlet-0.4.11.tar.gz"
+    sha256 "3095bda0db92736c3197912c9f7f8065e5630a03b2f6c431617338228d9811f6"
+  end
+
+  resource "jdcal" do
+    url "https://files.pythonhosted.org/packages/9b/fa/40beb2aa43a13f740dd5be367a10a03270043787833409c61b79e69f1dfd/jdcal-1.3.tar.gz"
+    sha256 "b760160f8dc8cc51d17875c6b663fafe64be699e10ce34b6a95184b5aa0fdc9e"
+  end
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/f2/2f/0b98b06a345a761bec91a079ccae392d282690c2d8272e708f4d10829e22/Jinja2-2.8.tar.gz"
+    sha256 "bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4"
+  end
+
+  resource "kombu" do
+    url "https://files.pythonhosted.org/packages/38/69/8d603be2df979f1b9ffefae1e51cde664c52a258aff6e8c3253032c8f2c8/kombu-3.0.37.tar.gz"
+    sha256 "e064a00c66b4d1058cd2b0523fb8d98c82c18450244177b6c0f7913016642650"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/c0/41/bae1254e0396c0cc8cf1751cb7d9afc90a602353695af5952530482c963f/MarkupSafe-0.23.tar.gz"
+    sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
+  end
+
+  resource "networkx" do
+    url "https://files.pythonhosted.org/packages/c2/93/dbb41b03cf7c878a7409c8e92226531f840a423c9309ea534873a83c9192/networkx-1.11.tar.gz"
+    sha256 "0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8"
+  end
+
+  resource "openpyxl" do
+    url "https://files.pythonhosted.org/packages/c8/bf/628855545eb7782be701ec1c51b2e84e0cf9325e36daa09fddab7894954f/openpyxl-2.2.0-b1.tar.gz"
+    sha256 "3394d92810796164ae1b12bb58c91b332174769ed0df5b7396a81471b9ba2058"
+  end
+
+  resource "psycopg2" do
+    url "https://files.pythonhosted.org/packages/86/fd/cc8315be63a41fe000cce20482a917e874cdc1151e62cb0141f5e55f711e/psycopg2-2.6.1.tar.gz"
+    sha256 "6acf9abbbe757ef75dc2ecd9d91ba749547941abaffbe69ff2086a9e37d4904c"
+  end
+
+  resource "PyContracts" do
+    url "https://files.pythonhosted.org/packages/05/cf/93c6bba08bf268063c13cd9ad7656c9ab12d15cd7d88a9abe38e7eb0c74e/PyContracts-1.7.15.tar.gz"
+    sha256 "24bf3ab5cfd61d0e296af82fb8b73ba875ea09733a8ca562f53016cf980dc469"
+  end
+
+  resource "pyparsing" do
+    url "https://files.pythonhosted.org/packages/38/bb/bf325351dd8ab6eb3c3b7c07c3978f38b2103e2ab48d59726916907cd6fb/pyparsing-2.1.10.tar.gz"
+    sha256 "811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/75/c5/85d027471fa665f8c8b8eb0b925f9d84b4eee745a257b16de4957de99e81/python-dateutil-2.2.tar.gz"
+    sha256 "eec865307ebe7f329a6a9945c15453265a449cdaaf3710340828a1934d53e468"
+  end
+
+  resource "pytz" do
+    url "https://files.pythonhosted.org/packages/d0/e1/aca6ef73a7bd322a7fc73fd99631ee3454d4fc67dc2bee463e2adf6bb3d3/pytz-2016.10.tar.bz2"
+    sha256 "7016b2c4fa075c564b81c37a252a5fccf60d8964aa31b7f5eae59aeb594ae02b"
+  end
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"
+    sha256 "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab"
+  end
+
+  resource "redis" do
+    url "https://files.pythonhosted.org/packages/68/44/5efe9e98ad83ef5b742ce62a15bea609ed5a0d1caf35b79257ddb324031a/redis-2.10.5.tar.gz"
+    sha256 "5dfbae6acfc54edf0a7a415b99e0b21c0a3c27a7f787b292eea727b1facc5533"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/5b/0b/34be574b1ec997247796e5d516f3a6b6509c4e064f2885a96ed885ce7579/requests-2.12.4.tar.gz"
+    sha256 "ed98431a0631e309bb4b63c81d561c1654822cb103de1ac7b47e45c26be7ae34"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  resource "snowplow-tracker" do
+    url "https://files.pythonhosted.org/packages/6d/af/7fea9ae4876a830d70dd17a24e647dd472b3b9f1d1f1dae75a2d44042505/snowplow-tracker-0.7.2.tar.gz"
+    sha256 "4eac1d5fe1e6d7d7d62fe4a780d9b5795c587ac1bf0430b1225bc744ab638268"
+  end
+
+  resource "SQLAlchemy" do
+    url "https://files.pythonhosted.org/packages/ca/ca/c2436fdb7bb75d772d9fa17ba60c4cfded6284eed053a7274b2beb96596a/SQLAlchemy-1.1.4.tar.gz"
+    sha256 "701b57d628b9fa1cfb82f10665e7214d5d2db23251ca6f23b91c5f56fcdbdeb5"
+  end
+
+  resource "sqlparse" do
+    url "https://files.pythonhosted.org/packages/9c/cc/3d8d34cfd0507dd3c278575e42baff2316a92513de0a87ac0ec9f32806c9/sqlparse-0.1.19.tar.gz"
+    sha256 "d896be1a1c7f24bffe08d7a64e6f0176b260e281c5f3685afe7826f8bada4ee8"
+  end
+
+  resource "xlrd" do
+    url "https://files.pythonhosted.org/packages/42/85/25caf967c2d496067489e0bb32df069a8361e1fd96a7e9f35408e56b3aab/xlrd-1.0.0.tar.gz"
+    sha256 "0ff87dd5d50425084f7219cb6f86bb3eb5aa29063f53d50bf270ed007e941069"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    bin.install_symlink "#{libexec}/bin/dbt" => "dbt"
+  end
+
+  test do
+    system "#{bin}/dbt", "help"
+  end
+end

--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -6,9 +6,9 @@ class Dbt < Formula
   url "https://github.com/analyst-collective/dbt/archive/v0.5.4.tar.gz"
   sha256 "df830bb0355e46608727fc6c59fa4aadd2514aec227e55765fe56abcfc72918c"
 
-  depends_on :python3
+  depends_on "python3"
   depends_on "openssl"
-  depends_on :postgresql
+  depends_on "postgresql"
 
   resource "amqp" do
     url "https://files.pythonhosted.org/packages/cc/a4/f265c6f9a7eb1dd45d36d9ab775520e07ff575b11ad21156f9866da047b2/amqp-1.4.9.tar.gz"
@@ -156,6 +156,8 @@ class Dbt < Formula
   end
 
   test do
-    system "#{bin}/dbt", "-h"
+    (testpath/"dbt_project.yml").write("name: 'test'")
+    (testpath/"models/test.sql").write("select * from test")
+    system "#{bin}/dbt", "compile"
   end
 end


### PR DESCRIPTION
Adds a new formula for dbt (data build tool).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit --new-formula dbt` returns two problems:

```
dbt:
  * Stable: version 0.5.4 is redundant with version scanned from URL
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
Error: 2 problems in 1 formula
```

The version is taken straight from a tag on Github. To me, that seems like the ideal URL / version combo, let me know if / how you'd like me to resolve that.

On the second issue, this is mostly used by semi-technical users so Github forks / stars are not their go-to engagement mechanism :) Please let me know if that's a dealbreaker.