### PR TITLE
folly 2016.12.19.00

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -3,6 +3,7 @@ class Folly < Formula
   homepage "https://github.com/facebook/folly"
   url "https://github.com/facebook/folly/archive/v2016.12.19.00.tar.gz"
   sha256 "471050ccd2a32f551eb11f43170d3f9cdd39d363ec026ca922b872d1c03831c1"
+  revision 1
   head "https://github.com/facebook/folly.git"
 
   bottle do
@@ -23,7 +24,6 @@ class Folly < Formula
   depends_on "xz"
   depends_on "snappy"
   depends_on "lz4"
-  depends_on "jemalloc"
   depends_on "openssl"
 
   # https://github.com/facebook/folly/issues/451
@@ -61,8 +61,7 @@ class Folly < Formula
 
       system "autoreconf", "-fvi"
       system "./configure", "--prefix=#{prefix}", "--disable-silent-rules",
-                            "--disable-dependency-tracking",
-                            "--with-jemalloc"
+                            "--disable-dependency-tracking"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
How mercurial of us, this disables jemalloc for folly because it doesn't
play nicely with the wangle and fbthrift builds that I'm going to submit in follow-up PRs after this is accepted.

Also bump to the most recent folly tag from this week; this same tag will be used for wangle and fbthrift.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
