### PR TITLE
kubernetes-helm 2.1.2 (new formula)

### DIFF
--- a/Formula/kubernetes-helm.rb
+++ b/Formula/kubernetes-helm.rb
@@ -1,0 +1,48 @@
+class KubernetesHelm < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/kubernetes/helm.git",
+      :tag => "v2.1.2",
+      :revision => "58e545f47002e36ca71ac5d1f7a987b56e1937b3"
+  head "https://github.com/kubernetes/helm.git"
+
+  depends_on :hg => :build
+  depends_on "go" => :build
+  depends_on "glide" => :build
+
+  def install
+    contents = Dir["{*,.git,.gitignore}"]
+    gopath = buildpath/"gopath"
+    (gopath/"src/k8s.io/helm").install contents
+
+    ENV["GOPATH"] = gopath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", gopath/"bin"
+
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+
+    cd gopath/"src/k8s.io/helm" do
+      # Ensure a clean git tree for version output
+      system "git", "reset", "--hard"
+      system "git", "clean", "-xfd"
+
+      # Bootstap build
+      system "make", "bootstrap"
+
+      # Build/install binary
+      system "make", "build"
+      bin.install "bin/helm"
+
+      bash_completion.install "scripts/completions.bash" => "helm"
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -164,7 +164,6 @@
   "kismet": "homebrew/boneyard",
   "kjell": "homebrew/boneyard",
   "klavaro": "homebrew/gui",
-  "kubernetes-helm": "homebrew/boneyard",
   "kumofs": "homebrew/boneyard",
   "lastfmlib": "homebrew/boneyard",
   "latex-mk": "homebrew/tex",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New formula. This would migrate the CLI tool `helm` from [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask/blob/master/Casks/helm.rb) to homebrew-core.