### PR TITLE
h2o 2.1.0-beta4 (devel) & fixes.

### DIFF
--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -16,9 +16,9 @@ class H2o < Formula
   end
 
   devel do
-    url "https://github.com/h2o/h2o/archive/v2.1.0-beta3.tar.gz"
-    version "2.1.0-beta3"
-    sha256 "e85aa794b1d1dd074f44e1a2df6afee61175b443f8fa6413a47033c179485d2a"
+    url "https://github.com/h2o/h2o/archive/v2.1.0-beta4.tar.gz"
+    version "2.1.0-beta4"
+    sha256 "780d4b210f1a9b76a1a29cad794305631afb739c79b3835902b13aaf01507e60"
 
     depends_on "openssl@1.1"
   end

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -6,7 +6,7 @@ class H2o < Formula
     url "https://github.com/h2o/h2o/archive/v2.0.5.tar.gz"
     sha256 "0ce4f16184813d7c8045f41e293457a3526b7d8b18a89105cdfd16330005926b"
 
-    depends_on "openssl" => :recommended
+    depends_on "openssl"
   end
 
   bottle do
@@ -20,7 +20,7 @@ class H2o < Formula
     version "2.1.0-beta3"
     sha256 "e85aa794b1d1dd074f44e1a2df6afee61175b443f8fa6413a47033c179485d2a"
 
-    depends_on "openssl@1.1" => :recommended
+    depends_on "openssl@1.1"
   end
 
   option "with-libuv", "Build the H2O library in addition to the executable"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
git checkout 18f910fce82b563b35dde6f76afdb3c5832e93ad
brew install h2o --with-libressl --without-openssl
git checkout master
brew upgrade
```

```
-- Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing:  OPENSSL_INCLUDE_DIR)
-- Found ZLIB: /usr/lib/libz.dylib (found version "1.2.8")
CMake Error at CMakeLists.txt:86 (MESSAGE):
  OpenSSL not found (nor H2O was configured to used the bundled libressl)


-- Configuring incomplete, errors occurred!
See also "/tmp/h2o-20161221-13176-1hqdmvg/h2o-2.0.5/CMakeFiles/CMakeOutput.log".
```

If only there was some way this could have been caught, some kind of system where the person responsible for the change tested the potential issue before implementing it, but hey, I know nothing.