### PR TITLE
cabal-install: remove directory 1.3 workaround

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -3,7 +3,7 @@ class CabalInstall < Formula
   homepage "https://www.haskell.org/cabal/"
   url "https://hackage.haskell.org/package/cabal-install-1.24.0.2/cabal-install-1.24.0.2.tar.gz"
   sha256 "2ac8819238a0e57fff9c3c857e97b8705b1b5fef2e46cd2829e85d96e2a00fe0"
-  revision 1
+  revision 2
   head "https://github.com/haskell/cabal.git", :branch => "1.24"
 
   bottle do
@@ -20,10 +20,7 @@ class CabalInstall < Formula
   def install
     cd "cabal-install" if build.head?
 
-    # Remove EXTRA_CONFIGURE_OPTS once hackage-security > 0.5.2.2 is released
-    # https://github.com/well-typed/hackage-security/pull/177
-    system "sh", "-c", "EXTRA_CONFIGURE_OPTS=--allow-newer=directory ./bootstrap.sh --sandbox"
-
+    system "sh", "bootstrap.sh", "--sandbox"
     bin.install ".cabal-sandbox/bin/cabal"
     bash_completion.install "bash-completion/cabal"
   end


### PR DESCRIPTION
hackage-security 0.5.2.2 revision 1 was released containing the fix.