### PR TITLE
ghostscript: use secure homepage and head url

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -1,6 +1,6 @@
 class Ghostscript < Formula
   desc "Interpreter for PostScript and PDF"
-  homepage "http://www.ghostscript.com/"
+  homepage "https://www.ghostscript.com/"
 
   stable do
     url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs919/ghostscript-9.19.tar.gz"
@@ -23,7 +23,7 @@ class Ghostscript < Formula
 
   head do
     # Can't use shallow clone. Doing so = fatal errors.
-    url "git://git.ghostscript.com/ghostpdl.git", :shallow => false
+    url "https://git.ghostscript.com/ghostpdl.git", :shallow => false
 
     resource "djvu" do
       url "git://git.code.sf.net/p/djvu/gsdjvu-git"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Tested `head` `url` fine using this command:
`git clone https://git.ghostscript.com/ghostpdl.git`
