### PR TITLE
skinny 2.3.3

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.2/skinny-2.3.2.tar.gz"
-  sha256 "8898d62996b7406a5b23276a3c942d5b2ce5b77a9e7b26de5725cbd896bf7017"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.3/skinny-2.3.3.tar.gz"
+  sha256 "e743d3ddcd4c6c6fe762dfe56eb1e1d06ad3739d10b072c0847982ec5832efe5"
 
   bottle :unneeded
 


### PR DESCRIPTION
skinny 2.3.3 is out. Thank you as always 🙇

https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.3

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.3/skinny-2.3.3.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/8978d7e6-cafa-11e6-87d7-2be38f1b126a.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20161225%2Fus-east-1%2Fs3%2Faws
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.3: 915 files, 98.9M, built in 1 minute 36 seconds

$ brew audit --strict skinny
```