### PR TITLE
libgit2 0.25.0

### DIFF
--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -5,6 +5,7 @@ class Gitless < Formula
   homepage "http://gitless.com/"
   url "https://github.com/sdg-mit/gitless/archive/v0.8.5.tar.gz"
   sha256 "c93f8f558d05f41777ae36fab7434cfcdb13035ae2220893d5ee222ced1e7b9f"
+  revision 1
 
   bottle do
     cellar :any
@@ -37,8 +38,8 @@ class Gitless < Formula
   end
 
   resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/29/fb/fd98403ed4ec5554ed4f6de3719d2c672ca2518598061ff7231301ff864b/pygit2-0.24.2.tar.gz"
-    sha256 "2aae85836c3a8da686220db7db05f91f8797e37edf91cc2a1f88b09fb653166a"
+    url "https://files.pythonhosted.org/packages/08/d5/6cc33ce2990b8502d9796902f686e622f647f3f59d5b7123e4d17ad34769/pygit2-0.25.0.tar.gz"
+    sha256 "de0ed85fd840dfeb32bcaa94c643307551dc0d967c3714e49087e7edc0cdc571"
   end
 
   resource "sh" do

--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -1,20 +1,14 @@
 class Libgit2 < Formula
   desc "C library of Git core methods that is re-entrant and linkable"
   homepage "https://libgit2.github.com/"
-  url "https://github.com/libgit2/libgit2/archive/v0.24.5.tar.gz"
-  sha256 "f6135ee64b174f449c8857272352c11ca182af05a340237834cedcc9eb390cba"
+  url "https://github.com/libgit2/libgit2/archive/v0.25.0.tar.gz"
+  sha256 "10c66211a3346644e55af9651d5f89966f9c4fa2f92972fca4e8560d0d3c837a"
   head "https://github.com/libgit2/libgit2.git"
 
   bottle do
     sha256 "810f5055462205c867b65d6d2bb830f94ccdb001172245e9ced873c8febf53c7" => :sierra
     sha256 "4f05d9aa455d1b6f6e8608d48acc7522804fd514bbfcb7e259a651e05b96e44f" => :el_capitan
     sha256 "e837edf7cee23fa3ff9b04583dee57bba2496bcd062f8e48704767abae242255" => :yosemite
-  end
-
-  devel do
-    url "https://github.com/libgit2/libgit2/archive/v0.25.0-rc2.tar.gz"
-    version "0.25.0-rc2"
-    sha256 "4bb27401ec30349690a7e2c937d497c7d32b2fc3ba75a4e8f71b38a6d2e15eb9"
   end
 
   option :universal


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
**libgit 0.25.0**

-----

- **gitless 0.8.5** is a new version and should probably be put in a separate PR before this is merged

- **libgit2-glib** currently only has support through the libgit2-0.24.x version series

- **gnome-builder** and **gitg** depend on **libgit2-glib** so they are held up at least until libgit2-glib gets support for libgit2 0.25.0

-----
cc @ilovezfs since this originated from his #8184