### PR TITLE
p11-kit 0.23.3

### DIFF
--- a/Formula/p11-kit.rb
+++ b/Formula/p11-kit.rb
@@ -1,9 +1,8 @@
 class P11Kit < Formula
   desc "Library to load and enumerate PKCS#11 modules"
   homepage "https://p11-glue.freedesktop.org"
-  url "https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz"
-  sha256 "ba726ea8303c97467a33fca50ee79b7b35212964be808ecf9b145e9042fdfaf0"
-  revision 1
+  url "https://github.com/p11-glue/p11-kit/releases/download/0.23.3/p11-kit-0.23.3.tar.gz"
+  sha256 "d487f04dba3f9e8256f53034c59c944ca45fd7b8434c095da6a74079644dcd82"
 
   bottle do
     sha256 "019c020bf72aee03d4ca861443045693ec97d189c08b3ae4f876f2491f1f9739" => :sierra
@@ -16,15 +15,6 @@ class P11Kit < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libffi"
-
-  # Remove for > 0.23.2
-  # Upstream commit from 3 Oct 2016 "Fix link of p11-kit-proxy.dylib on Mac OS X"
-  # https://bugs.freedesktop.org/show_bug.cgi?id=98022
-  # https://cgit.freedesktop.org/p11-glue/p11-kit/commit/?id=6923e8fb56692b20d24398d4746d2399490acdc1
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/5271336/p11-kit/p11-kit-proxy-so-link.patch"
-    sha256 "a05a10c22a3053c5370678997aed0c200b866f4aea8c69c82665fc47d61466f9"
-  end
 
   def install
     # https://bugs.freedesktop.org/show_bug.cgi?id=91602#c1


### PR DESCRIPTION
Update to a newer p11-kit version. The patch for p11-kit-proxy.dylib symlinking was merged upstream, so drop it from the formula.