### PR TITLE
ohcount 3.0.0-g331

### DIFF
--- a/Formula/ohcount.rb
+++ b/Formula/ohcount.rb
@@ -1,8 +1,10 @@
 class Ohcount < Formula
   desc "Source code line counter"
   homepage "https://github.com/blackducksw/ohcount"
-  url "https://github.com/blackducksw/ohcount/archive/3.0.0.tar.gz"
-  sha256 "46ef92e1bbf9313de507a03decaf8279173584555fb580bb3d46d42c65aa4a6d"
+  url "https://github.com/blackducksw/ohcount.git",
+      :revision => "d54514399013f2f9566baf40edd0e801b27fe17b"
+  version "3.0.0-g331"
+  head "https://github.com/blackducksw/ohcount.git"
 
   bottle do
     cellar :any
@@ -12,11 +14,7 @@ class Ohcount < Formula
     sha256 "055b2eb9460b1723bcb8a0f215ddda35750ce6d9b9c3cd0bce75d4e9584f0b62" => :mavericks
   end
 
-  head do
-    url "https://github.com/blackducksw/ohcount.git"
-    depends_on "libmagic"
-  end
-
+  depends_on "libmagic"
   depends_on "ragel"
   depends_on "pcre"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an attempt to make ohcount more useful in the modern world.

The 3.0.0 release is just too old (from 2009) and doesn't recognize CoffeeScript, Go and Rust, among other languages. See https://github.com/blackducksoftware/ohcount/issues/45 (where I ask for a release) for details. I realized this after failing to count a project in Go a week ago, and have been using HEAD since then, but having to install HEAD to meet a basic expectation (being able to count Go) of a modern programmer is really bad user experience.

Judging from the fact that the last commit was made in 2014, and most PRs are left to rot without a reply, I don't expect any meaningful official response on blackducksoftware/ohcount#45, which has been sitting there for a week too. I'm taking the matter into my own hands here, but I'm not the first — openSUSE has been packaging `master~6` (see their [`ohcount-3.0.0.g312` package](https://build.opensuse.org/package/show/openSUSE:13.1/ohcount)) since 13.1 released in 2013, and slightly earlier revisions in earlier releases.