### PR TITLE
Update openconnect to depend on gnutls with p11-kit support.

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -5,6 +5,7 @@ class Gnutls < Formula
   mirror "https://gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.17.tar.xz"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.4/gnutls-3.4.17.tar.xz"
   sha256 "9b50e8a670d5e950425d96935c7ddd415eb6f8079615a36df425f09a3143172e"
+  revision 1
 
   bottle do
     sha256 "613d98861f14e5a880d8a9567b42d680a118f5ee38946a0cf70c6952293a9dd2" => :sierra
@@ -16,6 +17,7 @@ class Gnutls < Formula
   depends_on "libtasn1"
   depends_on "gmp"
   depends_on "nettle"
+  depends_on "p11-kit" => :recommended
   depends_on "guile" => :optional
   depends_on "unbound" => :optional
 
@@ -34,8 +36,13 @@ class Gnutls < Formula
       --sysconfdir=#{etc}
       --with-default-trust-store-file=#{etc}/openssl/cert.pem
       --disable-heartbeat-support
-      --without-p11-kit
     ]
+
+    if build.with? "p11-kit"
+      args << "--with-p11-kit"
+    else
+      args << "--without-p11-kit"
+    end
 
     if build.with? "guile"
       args << "--enable-guile" << "--with-guile-site-dir"

--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -3,6 +3,7 @@ class Openconnect < Formula
   homepage "http://www.infradead.org/openconnect.html"
   url "ftp://ftp.infradead.org/pub/openconnect/openconnect-7.08.tar.gz"
   sha256 "1c44ec1f37a6a025d1ca726b9555649417f1d31a46f747922b84099ace628a03"
+  revision 1
 
   bottle do
     sha256 "6ca71944ac9c1f0f8324cf3eb3b494dc3838036265b786f479003e41dd053e32" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Once PR #5427 is merged in and p11-kit support is added to gnutls, we should make that dependency happen (since openconnect can leverage the p11 support in gnutls).

If we decide to make p11-kit support `:recommended` in gnutls (rather than `:optional`), then this PR not be necessary.