### PR TITLE
libgit2-glib: vendor libgit2 0.24.x

### DIFF
--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -3,6 +3,7 @@ class Gitg < Formula
   homepage "https://wiki.gnome.org/Apps/Gitg"
   url "https://download.gnome.org/sources/gitg/3.22/gitg-3.22.0.tar.xz"
   sha256 "ba6895f85c18748294075980a5e03e0936ad4e84534dbb0d8f9e29aa874ddeaf"
+  revision 1
 
   bottle do
     rebuild 1
@@ -30,6 +31,8 @@ class Gitg < Formula
   depends_on "pygobject3" => "with-python3" if build.with?("python3")
 
   def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libgit2-glib"].opt_libexec/"libgit2/lib/pkgconfig"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -68,7 +71,7 @@ class Gitg < Formula
     libepoxy = Formula["libepoxy"]
     libffi = Formula["libffi"]
     libgee = Formula["libgee"]
-    libgit2 = Formula["libgit2"]
+    libgit2 = Formula["libgit2-glib"].opt_libexec/"libgit2"
     libgit2_glib = Formula["libgit2-glib"]
     libpng = Formula["libpng"]
     libsoup = Formula["libsoup"]
@@ -92,7 +95,7 @@ class Gitg < Formula
       -I#{libepoxy.opt_include}
       -I#{libgee.opt_include}/gee-0.8
       -I#{libffi.opt_lib}/libffi-3.0.13/include
-      -I#{libgit2.opt_include}
+      -I#{libgit2}/include
       -I#{libgit2_glib.opt_include}/libgit2-glib-1.0
       -I#{libpng.opt_include}/libpng16
       -I#{libsoup.opt_include}/libsoup-2.4
@@ -109,7 +112,7 @@ class Gitg < Formula
       -L#{gobject_introspection.opt_lib}
       -L#{gtkx3.opt_lib}
       -L#{libgee.opt_lib}
-      -L#{libgit2.opt_lib}
+      -L#{libgit2}/lib
       -L#{libgit2_glib.opt_lib}
       -L#{libsoup.opt_lib}
       -L#{lib}

--- a/Formula/gnome-builder.rb
+++ b/Formula/gnome-builder.rb
@@ -3,6 +3,7 @@ class GnomeBuilder < Formula
   homepage "https://wiki.gnome.org/Apps/Builder"
   url "https://download.gnome.org/sources/gnome-builder/3.22/gnome-builder-3.22.4.tar.xz"
   sha256 "d569446a83ab88872c265f238f8f42b5928a6b3eebb22fd1db3dbc0dd9128795"
+  revision 1
 
   bottle do
     sha256 "32b73e0764bc01b84d90c30a2cb374024940699617f90345c74efd1225aa0c43" => :sierra
@@ -34,6 +35,8 @@ class GnomeBuilder < Formula
   needs :cxx11
 
   def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libgit2-glib"].opt_libexec/"libgit2/lib/pkgconfig"
+
     ENV.cxx11
 
     system "./configure", "--disable-debug",


### PR DESCRIPTION
Re-evaluate whether to continue vendoring libgit2 when libgit2-glib gets
libgit2 0.25.x compatibility.

See https://github.com/Homebrew/homebrew-core/pull/8221#issuecomment-269237260.

CC @JCount @tschoonj