### PR TITLE
mal4s: increase sleep in the test

### DIFF
--- a/Formula/mal4s.rb
+++ b/Formula/mal4s.rb
@@ -52,7 +52,7 @@ class Mal4s < Formula
       pid = fork do
         exec bin/"mal4s", "-t", "2", "-o", "out", pkgshare/"sample--newns.mal4s"
       end
-      sleep 2
+      sleep 5
       assert File.exist?("out"), "Failed to output PPM stream!"
     ensure
       Process.kill("TERM", pid)


### PR DESCRIPTION
two seconds isn't enough for the El Capitan VM