### PR TITLE
lnav: use GitHub for homepage

### DIFF
--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -1,6 +1,7 @@
 class Lnav < Formula
   desc "Curses-based tool for viewing and analyzing log files"
-  homepage "http://lnav.org"
+  # lnav.org has an SSL issue: https://github.com/tstack/lnav/issues/401
+  homepage "https://github.com/tstack/lnav"
   url "https://github.com/tstack/lnav/releases/download/v0.8.1/lnav-0.8.1.tar.gz"
   sha256 "db942abccdb5327d7594ca9e32e0b44802790fad8577bdbed44f81220fd62153"
   revision 1


### PR DESCRIPTION
lnav.org has an SSL problem currently, causing brew audit failure