### PR TITLE
thrift: specify location of openssl

### DIFF
--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -71,6 +71,7 @@ class Thrift < Formula
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
                           "--libdir=#{lib}",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}",
                           *exclusions
     ENV.deparallelize
     system "make"


### PR DESCRIPTION
Yosemite is picking up the 10.10 SDK's openssl headers not Homebrew's