### PR TITLE
kawa 2.3

### DIFF
--- a/Formula/kawa.rb
+++ b/Formula/kawa.rb
@@ -1,32 +1,24 @@
 class Kawa < Formula
   desc "Programming language for Java (implementation of Scheme)"
   homepage "https://www.gnu.org/software/kawa/"
-  url "https://ftpmirror.gnu.org/kawa/kawa-2.2.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/kawa/kawa-2.2.tar.gz"
-  sha256 "c3e2cb5ae772e7441ac31484083bcee651de941bbfed5dbe4874964839b9ba32"
+  url "https://ftpmirror.gnu.org/kawa/kawa-2.3.zip"
+  mirror "https://ftp.gnu.org/gnu/kawa/kawa-2.3.zip"
+  sha256 "76431f9acd758df8c1a7c16d8a4fde91b625bb14c730e5ea6540bca6b724ef5a"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "6835c16df5b606317d824e24fa77a6ebbcba2d84bf65f3e4c7651e78d19b265d" => :sierra
-    sha256 "4597b613cb09de8c983842bb9a430165c3f573e1721759ee6522acd3b62fe957" => :el_capitan
-    sha256 "e90e2696e371914074e8a23bf787f5f490cbdce83ec87d8ca00034c9dd541386" => :yosemite
-  end
+  bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.7+"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
-    system "make"
-    system "make", "install"
-    inreplace bin/"kawa",
-      'while test -L "$thisfile"; do thisfile=$(readlink -f "$thisfile"); done',
-      "thisfile=#{pkgshare}/bin/kawa"
+    rm Dir["bin/*.bat"]
+    inreplace "bin/kawa", "thisfile=`type -p \$0`",
+                          "thisfile=#{libexec}/bin/kawa"
+    libexec.install "bin", "lib"
+    bin.install_symlink libexec/"bin/kawa"
+    doc.install Dir["doc/*"]
   end
 
   test do
-    system bin/"kawa", "--help"
+    system bin/"kawa", "-e", "(import (srfi 1))"
   end
 end


### PR DESCRIPTION
The existing formula builds kawa using incorrect configure flags. The
resulting jar file is missing functionality (can't import SRFI
libraries). The installation also doesn't include the new JARs that's
part of the distribution, and domterm.jar, jline.jar and servlet.jar,
which means the REPL is crippled without line editing functionality.

Fix the formula to use the official binary that's distributed by the
maintainer and add test for importing built-in libraries.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
