### PR TITLE
fix docker-machine-driver-xhyve test command

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -68,6 +68,6 @@ class DockerMachineDriverXhyve < Formula
 
   test do
     assert_match "xhyve-memory-size",
-    shell_output("#{Formula["docker-machine"].bin}/docker-machine create --driver xhyve -h")
+    shell_output("#{Formula["docker-machine"].bin}/docker-machine create --driver xhyve --help")
   end
 end


### PR DESCRIPTION
-h doesn't get the help text, but --help does.