### PR TITLE
global: --with-universal-ctags

### DIFF
--- a/Formula/global.rb
+++ b/Formula/global.rb
@@ -23,12 +23,14 @@ class Global < Formula
   end
 
   option "with-ctags", "Enable Exuberant Ctags as a plug-in parser"
+  option "with-universal-ctags", "Enable Universal Ctags as a plug-in parser"
   option "with-pygments", "Enable Pygments as a plug-in parser (should enable exuberent-ctags too)"
   option "with-sqlite3", "Use SQLite3 API instead of BSD/DB API for making tag files"
 
   deprecated_option "with-exuberant-ctags" => "with-ctags"
 
   depends_on "ctags" => :optional
+  depends_on "universal-ctags/universal-ctags/universal-ctags" => :optional
 
   skip_clean "lib/gtags"
 
@@ -50,6 +52,10 @@ class Global < Formula
 
     if build.with? "ctags"
       args << "--with-exuberant-ctags=#{Formula["ctags"].opt_bin}/ctags"
+    end
+
+    if build.with? "universal-ctags"
+      args << "--with-universal-ctags=#{Formula["universal-ctags"].opt_bin}/ctags"
     end
 
     if build.with? "pygments"
@@ -78,7 +84,7 @@ class Global < Formula
        int c2func (void) { return 0; }
        void cfunc (void) {int cvar = c2func(); }")
     EOS
-    if build.with?("pygments") || build.with?("ctags")
+    if build.with?("pygments") || build.with?("ctags") || build.with?("universal-ctags")
       (testpath/"test.py").write <<-EOS
         def py2func ():
              return 0
@@ -88,7 +94,7 @@ class Global < Formula
     end
     if build.with? "pygments"
       assert shell_output("#{bin}/gtags --gtagsconf=#{share}/gtags/gtags.conf --gtagslabel=pygments .")
-      if build.with? "ctags"
+      if build.with?("ctags") || build.with?("universal-ctags")
         assert_match "test.c", shell_output("#{bin}/global -d cfunc")
         assert_match "test.c", shell_output("#{bin}/global -d c2func")
         assert_match "test.c", shell_output("#{bin}/global -r c2func")


### PR DESCRIPTION
GNU Global supports using Universal Ctags and Exuberant Ctags as plug-in parsers, but the current formula only exposes the Exuberant Ctags option.

This is problematic, as Universal Ctags is the actively maintained/developed implementation. The Global documentation describes how to configure Universal Ctags and makes no mention of Exuberant Ctags.

Expose `--with-universal-ctags` option to remedy this.

To install:

    $ brew install global --with-universal-ctags

To use:

    $ export GTAGSCONF=/usr/local/share/gtags/gtags.conf
    $ export GTAGSLABEL=new-ctags
    $ gtags                         # gtags invokes Universal Ctags internally

References:
  https://www.gnu.org/software/global/manual/global.html#Plug_002din
  https://github.com/universal-ctags/homebrew-universal-ctags