### PR TITLE
mu: fix HEAD build failure due to miss a dependency

### DIFF
--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -15,6 +15,7 @@ class Mu < Formula
   end
 
   depends_on "autoconf" => :build
+  depends_on "autoconf-archive" => :build if build.head?
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -6,7 +6,6 @@ class Mu < Formula
   homepage "https://www.djcbsoftware.nl/code/mu/"
   url "https://github.com/djcb/mu/releases/download/0.9.18/mu-0.9.18.tar.gz"
   sha256 "6559ec888d53f8e03b87b67148a73f52fe086477cb10e43f3fc13ed7f717e809"
-  head "https://github.com/djcb/mu.git"
 
   bottle do
     sha256 "7a22948357dea29fea7aad7fb40a1d40c91587a9ae6d5584fdc926c051558394" => :sierra
@@ -14,8 +13,13 @@ class Mu < Formula
     sha256 "5021092fa9584e6ed4755a61d675dbd89108706de2b4f4e35fe0597a5a79fcb1" => :yosemite
   end
 
+  head do
+    url "https://github.com/djcb/mu.git"
+
+    depends_on "autoconf-archive" => :build
+  end
+
   depends_on "autoconf" => :build
-  depends_on "autoconf-archive" => :build if build.head?
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`mu` at HEAD depends on `autoconf-archive`, so I added it as a build dependency.

See https://github.com/djcb/mu/issues/975