### PR TITLE
gnome-autoar 0.1.1 (new formula)

### DIFF
--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -1,5 +1,5 @@
 class GnomeAutoar < Formula
-  desc "A convenient library for archive handling"
+  desc "GNOME library for archive handling"
   homepage "https://github.com/GNOME/gnome-autoar"
   url "https://download.gnome.org/sources/gnome-autoar/0.1/gnome-autoar-0.1.1.tar.xz"
   sha256 "f65cb810b562dc038ced739fbf59739fd5df1a8e848636e21f363ded9f349ac9"
@@ -13,7 +13,7 @@ class GnomeAutoar < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-			  "--disable-glibtest",
+	                        "--disable-glibtest",
                           "--disable-schemas-compile"
     system "make", "install"
   end
@@ -23,39 +23,39 @@ class GnomeAutoar < Formula
   end
 
   test do
-    (testpath/"test.c").write <<-EOS.undent                                                           
-      #include <gnome-autoar/gnome-autoar.h>                                                          
+    (testpath/"test.c").write <<-EOS.undent
+      #include <gnome-autoar/gnome-autoar.h>
 
-      int main(int argc, char *argv[]) {                                                              
-        GType type = autoar_extractor_get_type();                                                     
+      int main(int argc, char *argv[]) {
+        GType type = autoar_extractor_get_type();
         return 0;
       }
     EOS
-    gettext = Formula["gettext"]                                                                      
+    gettext = Formula["gettext"]
     glib = Formula["glib"]
-    libarchive = Formula["libarchive"]                                                                
+    libarchive = Formula["libarchive"]
     pcre = Formula["pcre"]
-    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split         
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split
     flags += %W[
       -I#{gettext.opt_include}
-      -I#{glib.opt_include}/glib-2.0                                                                  
-      -I#{glib.opt_lib}/glib-2.0/include                                                              
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
       -I#{include}/gnome-autoar-0
-      -I#{libarchive.opt_include}                                                                     
-      -I#{pcre.opt_include}                                                                           
+      -I#{libarchive.opt_include}
+      -I#{pcre.opt_include}
       -D_REENTRANT
-      -L#{gettext.opt_lib}                                                                            
-      -L#{glib.opt_lib}                                                                               
-      -L#{libarchive.opt_lib}                                                                         
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{libarchive.opt_lib}
       -L#{lib}
       -larchive
-      -lgio-2.0                                                                                       
+      -lgio-2.0
       -lglib-2.0
-      -lgnome-autoar-0                                                                                
-      -lgobject-2.0                                                                                   
+      -lgnome-autoar-0
+      -lgobject-2.0
       -lintl
     ]
-    system ENV.cc, "test.c", "-o", "test", *flags                                                     
+    system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -4,9 +4,8 @@ class GnomeAutoar < Formula
   url "https://download.gnome.org/sources/gnome-autoar/0.1/gnome-autoar-0.1.1.tar.xz"
   sha256 "f65cb810b562dc038ced739fbf59739fd5df1a8e848636e21f363ded9f349ac9"
 
-  depends_on "pkg-config"
+  depends_on "pkg-config" => :build
   depends_on "libarchive"
-  depends_on "glib"
   depends_on "gtk+3"
 
   def install
@@ -24,6 +23,39 @@ class GnomeAutoar < Formula
   end
 
   test do
-    system "false"
+    (testpath/"test.c").write <<-EOS.undent                                                           
+      #include <gnome-autoar/gnome-autoar.h>                                                          
+
+      int main(int argc, char *argv[]) {                                                              
+        GType type = autoar_extractor_get_type();                                                     
+        return 0;
+      }
+    EOS
+    gettext = Formula["gettext"]                                                                      
+    glib = Formula["glib"]
+    libarchive = Formula["libarchive"]                                                                
+    pcre = Formula["pcre"]
+    flags = (ENV.cflags || "").split + (ENV.cppflags || "").split + (ENV.ldflags || "").split         
+    flags += %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0                                                                  
+      -I#{glib.opt_lib}/glib-2.0/include                                                              
+      -I#{include}/gnome-autoar-0
+      -I#{libarchive.opt_include}                                                                     
+      -I#{pcre.opt_include}                                                                           
+      -D_REENTRANT
+      -L#{gettext.opt_lib}                                                                            
+      -L#{glib.opt_lib}                                                                               
+      -L#{libarchive.opt_lib}                                                                         
+      -L#{lib}
+      -larchive
+      -lgio-2.0                                                                                       
+      -lglib-2.0
+      -lgnome-autoar-0                                                                                
+      -lgobject-2.0                                                                                   
+      -lintl
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags                                                     
+    system "./test"
   end
 end

--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -1,0 +1,29 @@
+class GnomeAutoar < Formula
+  desc "A convenient library for archive handling"
+  homepage "https://github.com/GNOME/gnome-autoar"
+  url "https://download.gnome.org/sources/gnome-autoar/0.1/gnome-autoar-0.1.1.tar.xz"
+  sha256 "f65cb810b562dc038ced739fbf59739fd5df1a8e848636e21f363ded9f349ac9"
+
+  depends_on "pkg-config"
+  depends_on "libarchive"
+  depends_on "glib"
+  depends_on "gtk+3"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+			  "--disable-glibtest",
+                          "--disable-schemas-compile"
+    system "make", "install"
+  end
+
+  def post_install
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -13,7 +13,7 @@ class GnomeAutoar < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-	                        "--disable-glibtest",
+	                  "--disable-glibtest",
                           "--disable-schemas-compile"
     system "make", "install"
   end

--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -13,7 +13,7 @@ class GnomeAutoar < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-	                  "--disable-glibtest",
+                          "--disable-glibtest",
                           "--disable-schemas-compile"
     system "make", "install"
   end


### PR DESCRIPTION
This commit adds a formula for GNOME autoar, which is
a convenience library providing GIO-style async wrappers
around libarchive.