### PR TITLE
spdylay: use https://nghttp2.org in the test

### DIFF
--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -35,6 +35,6 @@ class Spdylay < Formula
   end
 
   test do
-    system "#{bin}/spdycat", "-ns", "https://www.google.com"
+    system "#{bin}/spdycat", "-ns", "https://nghttp2.org"
   end
 end


### PR DESCRIPTION
https://google.com has dropped SPDY support