### PR TITLE
gcc@4.*, cloog@0.18: use isl@0.12.

### DIFF
--- a/Formula/cloog@0.18.rb
+++ b/Formula/cloog@0.18.rb
@@ -17,14 +17,14 @@ class CloogAT018 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gmp@4"
-  depends_on "isl@0.11"
+  depends_on "isl@0.12"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--with-gmp-prefix=#{Formula["gmp@4"].opt_prefix}",
-                          "--with-isl-prefix=#{Formula["isl@0.11"].opt_prefix}"
+                          "--with-isl-prefix=#{Formula["isl@0.12"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/gcc@4.8.rb
+++ b/Formula/gcc@4.8.rb
@@ -67,7 +67,7 @@ class GccAT48 < Formula
   depends_on "libmpc@0.8"
   depends_on "mpfr@2"
   depends_on "cloog@0.18"
-  depends_on "isl@0.11"
+  depends_on "isl@0.12"
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   # The as that comes with Tiger isn't capable of dealing with the
@@ -119,7 +119,7 @@ class GccAT48 < Formula
       "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
       "--with-cloog=#{Formula["cloog@0.18"].opt_prefix}",
-      "--with-isl=#{Formula["isl@0.11"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.12"].opt_prefix}",
       "--with-system-zlib",
       "--enable-libstdcxx-time=yes",
       "--enable-stage1-checking",

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -66,7 +66,7 @@ class GccAT49 < Formula
   depends_on "libmpc@0.8"
   depends_on "mpfr@2"
   depends_on "cloog@0.18"
-  depends_on "isl@0.11"
+  depends_on "isl@0.12"
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   # The bottles are built on systems with the CLT installed, and do not work
@@ -108,7 +108,7 @@ class GccAT49 < Formula
       "--with-mpfr=#{Formula["mpfr@2"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc@0.8"].opt_prefix}",
       "--with-cloog=#{Formula["cloog@0.18"].opt_prefix}",
-      "--with-isl=#{Formula["isl@0.11"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.12"].opt_prefix}",
       "--with-system-zlib",
       "--enable-libstdcxx-time=yes",
       "--enable-stage1-checking",

--- a/Formula/isl@0.12.rb
+++ b/Formula/isl@0.12.rb
@@ -1,0 +1,39 @@
+class IslAT012 < Formula
+  desc "Integer Set Library for the polyhedral model"
+  homepage "http://isl.gforge.inria.fr/"
+  # Track gcc infrastructure releases.
+  url "http://isl.gforge.inria.fr/isl-0.12.2.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.12.2.tar.bz2"
+  sha256 "f4b3dbee9712850006e44f0db2103441ab3d13b406f77996d1df19ee89d11fb4"
+
+  keg_only "Older version of isl"
+
+  depends_on "gmp@4"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp@4"].opt_prefix}"
+    system "make"
+    system "make", "install"
+    (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["gmp@4"].opt_include}", "-L#{lib}", "-lisl", "-o", "test"
+    system "./test"
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -24,6 +24,7 @@
   "hamsterdb": "upscaledb",
   "heroku-toolbelt": "heroku",
   "isl011": "isl@0.11",
+  "isl012": "isl@0.12",
   "isl014": "isl@0.14",
   "kotlin-compiler": "kotlin",
   "juju": "juju@1.25",


### PR DESCRIPTION
Suggested by @equal-l2 in #7557.