### PR TITLE
Fix audit errors related to :apr usage

### DIFF
--- a/Formula/apib.rb
+++ b/Formula/apib.rb
@@ -16,7 +16,7 @@ class Apib < Formula
     sha256 "c538b9389b1849704720383f03fb2fe4eaf145ecd01d7dca5fd08d95e0e961ba" => :mountain_lion
   end
 
-  depends_on :apr => :build
+  depends_on "apr"
   depends_on "openssl"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes `:apr is deprecated. Usage should be "apr-util"` audit error.