### PR TITLE
mobile-shell: remove in-formula clock_gettime workaround

### DIFF
--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -28,12 +28,6 @@ class MobileShell < Formula
   depends_on "tmux" => :build if build.with?("test") || build.bottle?
 
   def install
-    # Fix for 'dyld: lazy symbol binding failed: Symbol not found: _clock_gettime' issue
-    # Reported 26 Sep 2016 https://github.com/mobile-shell/mosh/issues/807
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
-      ENV["ac_cv_search_clock_gettime"] = "no"
-    end
-
     # teach mosh to locate mosh-client without referring
     # PATH to support launching outside shell e.g. via launcher
     inreplace "scripts/mosh.pl", "'mosh-client", "\'#{bin}/mosh-client"


### PR DESCRIPTION
ac_cv_search_clock_gettime=no is now set by superenv for 10.11

Note that upstream is still working on a proper fix. See
https://github.com/mobile-shell/mosh/pull/838 and
https://github.com/mobile-shell/mosh/issues/807