### PR TITLE
mps-youtube: fix (Add youtube_dl as resource)

### DIFF
--- a/Formula/mps-youtube.rb
+++ b/Formula/mps-youtube.rb
@@ -14,7 +14,6 @@ class MpsYoutube < Formula
 
   depends_on "python3"
   depends_on "mpv" => :recommended
-  depends_on "youtube-dl" => :recommended
   depends_on "mplayer" => :optional
 
   resource "pafy" do
@@ -22,11 +21,18 @@ class MpsYoutube < Formula
     sha256 "11e0cb83bd9e636bc4d0d6f7d7ce964f4975c6f0e037fe285ef2acedafcf7bb2"
   end
 
+  resource "youtube_dl" do
+    url "https://pypi.python.org/packages/33/53/be5fd3d2e8b4af17cce81cdece45426856868692e2b7821a957108ff302e/youtube_dl-2016.12.31.tar.gz"
+    sha256 "cdba662fc6ff00b9b972da3bf4ac76d3db95841767871155a9518bfc6afb9a82"
+  end
+
   def install
     virtualenv_install_with_resources
   end
 
   test do
-    system "#{bin}/mpsyt", "/september,", "da 1,", "q"
+    Open3.popen3("#{bin}/mpsyt", "/september,", "da 1,", "q") do |_, _, stderr|
+      assert_empty stderr.read, "Some warnings were raised"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes following warning on `mpsyt` launch:

  > WARNING:root:pafy: youtube-dl not found; falling back to internal backend.
  > This is not as well maintained as the youtube-dl backend
  > To hide this message, set the environmental variable PAFY_BACKEND to"internal".

From what I've inferred, having `youtube-dl` formula installed doesn't
satisfy `youtube_dl` python library dependency and placing it as package
is necessary for pafy's [`import`](https://github.com/mps-youtube/pafy/blob/66d0f262dd230a947015b3f1fa114551d3bc2bc1/pafy/pafy.py#L48) to find.

---

/cc @tonynater 
Follows: #8310