### PR TITLE
pdftoipe: migrate from homebrew/homebrew-head-only

### DIFF
--- a/Formula/pdftoipe.rb
+++ b/Formula/pdftoipe.rb
@@ -1,0 +1,23 @@
+class Pdftoipe < Formula
+  desc "Reads arbitrary PDF files and generates an XML file readable by Ipe"
+  homepage "https://github.com/otfried/ipe-tools"
+  url "https://github.com/otfried/ipe-tools/archive/v7.2.7.tar.gz"
+  sha256 "889cb31bd8769ba111f541ba795cf53fad474aeeafbc87b7cd37c8a24b2dc6f6"
+
+  depends_on "pkg-config" => :build
+  depends_on "poppler"
+
+  def install
+    cd "pdftoipe" do
+      system "make"
+      bin.install "pdftoipe"
+      man1.install "pdftoipe.1"
+    end
+  end
+
+  test do
+    cp test_fixtures("test.pdf"), testpath
+    system bin/"pdftoipe", "test.pdf"
+    assert_match "Homebrew test.</text>", File.read("test.ipe")
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -227,7 +227,6 @@
   "pdf-tools": "homebrew/emacs",
   "pdf2image": "homebrew/x11",
   "pdfjam": "homebrew/tex",
-  "pdftoipe": "homebrew/head-only",
   "pdksh": "homebrew/boneyard",
   "pebble-sdk": "pebble/pebble-sdk",
   "peervpn": "homebrew/boneyard",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

See discussion at the bottom of https://github.com/Homebrew/homebrew-head-only/issues/186.

`brew audit --strict pdftoipe` reported:
```
homebrew/head-only/pdftoipe:
  * Formula name conflicts with existing core formula.
  * A `test do` test block should be added
Error: 2 problems in 1 formula
```

I did not run `brew install --build-from-source pdftoipe` as I did not want it to mess with my current installation of `pdftoipe` from HEAD, as I use it a lot.

Ping @ilovezfs for review.