### PR TITLE
llvm@3.6: import from homebrew/versions.

### DIFF
--- a/Formula/llvm@3.6.rb
+++ b/Formula/llvm@3.6.rb
@@ -1,0 +1,209 @@
+class LlvmAT36 < Formula
+  desc "Next-gen compiler infrastructure"
+  homepage "http://llvm.org/"
+
+  stable do
+    url "http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz"
+    sha256 "f60dc158bfda6822de167e87275848969f0558b3134892ff54fced87e4667b94"
+
+    resource "clang" do
+      url "http://llvm.org/releases/3.6.2/cfe-3.6.2.src.tar.xz"
+      sha256 "ae9180466a23acb426d12444d866b266ff2289b266064d362462e44f8d4699f3"
+    end
+
+    resource "clang-tools-extra" do
+      url "http://llvm.org/releases/3.6.2/clang-tools-extra-3.6.2.src.tar.xz"
+      sha256 "6a0ec627d398f501ddf347060f7a2ccea4802b2494f1d4fd7bda3e0442d04feb"
+    end
+
+    resource "polly" do
+      url "http://llvm.org/releases/3.6.2/polly-3.6.2.src.tar.xz"
+      sha256 "f2a956730b76212f22a1c10f35f195795e4d027ad28c226f97ddb8c0fd16bcbc"
+    end
+
+    resource "libcxx" do
+      url "http://llvm.org/releases/3.6.2/libcxx-3.6.2.src.tar.xz"
+      sha256 "52f3d452f48209c9df1792158fdbd7f3e98ed9bca8ebb51fcd524f67437c8b81"
+    end
+
+    if MacOS.version <= :snow_leopard
+      resource "libcxxabi" do
+        url "http://llvm.org/releases/3.6.2/libcxxabi-3.6.2.src.tar.xz"
+        sha256 "6fb48ce5a514686b9b75e73e59869f782ed374a86d71be8423372e4b3329b09b"
+      end
+    end
+  end
+
+  head do
+    url "http://llvm.org/git/llvm.git", :branch => "release_36"
+
+    resource "clang" do
+      url "http://llvm.org/git/clang.git", :branch => "release_36"
+    end
+
+    resource "clang-tools-extra" do
+      url "http://llvm.org/git/clang-tools-extra.git", :branch => "release_36"
+    end
+
+    resource "polly" do
+      url "http://llvm.org/git/polly.git", :branch => "release_36"
+    end
+
+    resource "libcxx" do
+      url "http://llvm.org/git/libcxx.git", :branch => "release_36"
+    end
+
+    if MacOS.version <= :snow_leopard
+      resource "libcxxabi" do
+        url "http://llvm.org/git/libcxxabi.git", :branch => "release_36"
+      end
+    end
+  end
+
+  depends_on "gmp"
+  depends_on "isl@0.14"
+  depends_on "libffi"
+
+  patch :DATA
+
+  # version suffix
+  def ver
+    "3.6"
+  end
+
+  # LLVM installs its own standard library which confuses stdlib checking.
+  cxxstdlib_check :skip
+
+  # Apple's libstdc++ is too old to build LLVM
+  fails_with :gcc
+
+  def install
+    # Apple's libstdc++ is too old to build LLVM
+    ENV.libcxx if ENV.compiler == :clang
+
+    clang_buildpath = buildpath/"tools/clang"
+    libcxx_buildpath = buildpath/"projects/libcxx"
+    libcxxabi_buildpath = buildpath/"libcxxabi" # build failure if put in projects due to no Makefile
+
+    clang_buildpath.install resource("clang")
+    libcxx_buildpath.install resource("libcxx")
+    (buildpath/"tools/polly").install resource("polly")
+    (buildpath/"tools/clang/tools/extra").install resource("clang-tools-extra")
+
+    ENV["REQUIRES_RTTI"] = "1"
+    ENV.append "LDFLAGS", "-headerpad_max_install_names"
+
+    install_prefix = lib/"llvm-#{ver}"
+
+    args = [
+      "--prefix=#{install_prefix}",
+      "--enable-optimized",
+      "--disable-bindings",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.14"].opt_prefix}",
+      "--enable-targets=host",
+      "--enable-libffi",
+    ]
+
+    system "./configure", *args
+    system "make", "VERBOSE=1"
+    system "make", "VERBOSE=1", "install"
+
+    if MacOS.version <= :snow_leopard
+      libcxxabi_buildpath.install resource("libcxxabi")
+
+      cd libcxxabi_buildpath/"lib" do
+        # Set rpath to save user from setting DYLD_LIBRARY_PATH
+        inreplace "buildit", "-install_name /usr/lib/libc++abi.dylib", "-install_name #{install_prefix}/usr/lib/libc++abi.dylib"
+
+        ENV["CC"] = "#{install_prefix}/bin/clang"
+        ENV["CXX"] = "#{install_prefix}/bin/clang++"
+        ENV["TRIPLE"] = "*-apple-*"
+        system "./buildit"
+        (install_prefix/"usr/lib").install "libc++abi.dylib"
+        cp libcxxabi_buildpath/"include/cxxabi.h", install_prefix/"lib/c++/v1"
+      end
+
+      # Snow Leopard make rules hardcode libc++ and libc++abi path.
+      # Change to Cellar path here.
+      inreplace "#{libcxx_buildpath}/lib/buildit" do |s|
+        s.gsub! "-install_name /usr/lib/libc++.1.dylib", "-install_name #{install_prefix}/usr/lib/libc++.1.dylib"
+        s.gsub! "-Wl,-reexport_library,/usr/lib/libc++abi.dylib", "-Wl,-reexport_library,#{install_prefix}/usr/lib/libc++abi.dylib"
+      end
+
+      # On Snow Leopard and older system libc++abi is not shipped but
+      # needed here. It is hard to tweak environment settings to change
+      # include path as libc++ uses a custom build script, so just
+      # symlink the needed header here.
+      ln_s libcxxabi_buildpath/"include/cxxabi.h", libcxx_buildpath/"include"
+    end
+
+    # Putting libcxx in projects only ensures that headers are installed.
+    # Manually "make install" to actually install the shared libs.
+    libcxx_make_args = [
+      # Use the built clang for building
+      "CC=#{install_prefix}/bin/clang",
+      "CXX=#{install_prefix}/bin/clang++",
+      # Properly set deployment target, which is needed for Snow Leopard
+      "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
+      # The following flags are needed so it can be installed correctly.
+      "DSTROOT=#{install_prefix}",
+      "SYMROOT=#{libcxx_buildpath}",
+    ]
+
+    system "make", "-C", libcxx_buildpath, "install", *libcxx_make_args
+
+    (share/"clang-#{ver}/tools").install Dir["tools/clang/tools/scan-{build,view}"]
+    inreplace share/"clang-#{ver}/tools/scan-build/scan-build", "$RealBin/bin/clang", install_prefix/"bin/clang"
+    ln_s share/"clang-#{ver}/tools/scan-build/scan-build", install_prefix/"bin"
+    ln_s share/"clang-#{ver}/tools/scan-view/scan-view", install_prefix/"bin"
+    (install_prefix/"share/man/man1").install share/"clang-#{ver}/tools/scan-build/scan-build.1"
+
+    (lib/"python2.7/site-packages").install "bindings/python/llvm" => "llvm-#{ver}",
+                                            clang_buildpath/"bindings/python/clang" => "clang-#{ver}"
+
+    Dir.glob(install_prefix/"bin/*") do |exec_path|
+      basename = File.basename(exec_path)
+      bin.install_symlink exec_path => "#{basename}-#{ver}"
+    end
+
+    Dir.glob(install_prefix/"share/man/man1/*") do |manpage|
+      basename = File.basename(manpage, ".1")
+      man1.install_symlink manpage => "#{basename}-#{ver}.1"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    Extra tools are installed in #{opt_share}/clang-#{ver}
+
+    To link to libc++, something like the following is required:
+      CXX="clang++-#{ver} -stdlib=libc++"
+      CXXFLAGS="$CXXFLAGS -nostdinc++ -I#{opt_lib}/llvm-#{ver}/include/c++/v1"
+      LDFLAGS="$LDFLAGS -L#{opt_lib}/llvm-#{ver}/lib"
+    EOS
+  end
+
+  test do
+    system "#{bin}/llvm-config-#{ver}", "--version"
+  end
+end
+
+__END__
+diff --git a/Makefile.rules b/Makefile.rules
+index ebebc0a..b0bb378 100644
+--- a/Makefile.rules
++++ b/Makefile.rules
+@@ -599,7 +599,12 @@ ifneq ($(HOST_OS), $(filter $(HOST_OS), Cygwin MingW))
+ ifneq ($(HOST_OS),Darwin)
+   LD.Flags += $(RPATH) -Wl,'$$ORIGIN'
+ else
+-  LD.Flags += -Wl,-install_name  -Wl,"@rpath/lib$(LIBRARYNAME)$(SHLIBEXT)"
++  LD.Flags += -Wl,-install_name
++  ifdef LOADABLE_MODULE
++    LD.Flags += -Wl,"$(PROJ_libdir)/$(LIBRARYNAME)$(SHLIBEXT)"
++  else
++    LD.Flags += -Wl,"$(PROJ_libdir)/$(SharedPrefix)$(LIBRARYNAME)$(SHLIBEXT)"
++  endif
+ endif
+ endif
+ endif

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -36,6 +36,7 @@
   "libcppa": "caf",
   "libmongoclient": "mongo-cxx-driver",
   "libmpc08": "libmpc@0.8",
+  "llvm36": "llvm@3.6",
   "llvm37": "llvm@3.7",
   "llvm38": "llvm@3.8",
   "mongo-c": "mongo-c-driver",


### PR DESCRIPTION
This is the last LLVM version we'll try to import. There's an attempted fix for the Yosemite bottling error which, if it fails, will just cause me to abandon this PR.