### PR TITLE
tty-clock: audit fix

### DIFF
--- a/Formula/tty-clock.rb
+++ b/Formula/tty-clock.rb
@@ -20,6 +20,6 @@ class TtyClock < Formula
   end
 
   test do
-    system "#{bin}/tty-clock -i"
+    system "#{bin}/tty-clock", "-i"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
tty-clock:
  * Use `system "#{bin}/tty-clock", "-i"` instead of `system "#{bin}/tty-clock -i"`
```