### PR TITLE
elm-format: import from Homebrew/devel-only.

### DIFF
--- a/Formula/elm-format.rb
+++ b/Formula/elm-format.rb
@@ -1,0 +1,34 @@
+require "language/haskell"
+
+class ElmFormat < Formula
+  include Language::Haskell::Cabal
+  desc "Elm source code formatter, inspired by gofmt."
+  homepage "https://github.com/avh4/elm-format"
+  url "https://github.com/avh4/elm-format/archive/0.5.2-alpha.tar.gz"
+  version "0.5.2-alpha"
+  sha256 "3bf9d54298333139609a991364a3d8549766cf4462cb25021c65b7f5c5bc0bf3"
+  head "https://github.com/avh4/elm-format.git"
+
+  depends_on "ghc" => :build
+  depends_on "cabal-install" => :build
+
+  def install
+    (buildpath/"elm-format").install Dir["*"]
+
+    cabal_sandbox do
+      cabal_sandbox_add_source "elm-format"
+      cabal_install "--only-dependencies", "elm-format"
+      cabal_install "--prefix=#{prefix}", "elm-format"
+    end
+  end
+
+  test do
+    src_path = testpath/"Hello.elm"
+    src_path.write <<-EOS.undent
+      import Html exposing (text)
+      main = text "Hello, world!"
+    EOS
+
+    system bin/"elm-format-0.17", testpath/"Hello.elm", "--yes"
+  end
+end


### PR DESCRIPTION
This is a technically non-stable version but we have a few others in Homebrew/homebrew-core in a similar situation and analytics shows it is actually used so may as well migrate it so we can kill the Homebrew/devel-only tap (this is the last formula).