### PR TITLE
gig 0.0.3 (new formula)

### DIFF
--- a/Formula/gig.rb
+++ b/Formula/gig.rb
@@ -1,0 +1,40 @@
+class Gig < Formula
+  desc "Draw sample from the Generalized Inverse Gaussian distribution."
+  homepage "https://github.com/Horta/gig"
+  url "https://github.com/Horta/gig/archive/v0.0.3.tar.gz"
+  sha256 "0289839b01536bdaeba8cef5cd61a5ff07ffd7b0776dccd60d9a4c5395fc2387"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"gig_test.cpp").write <<-EOS
+    #include "gig/gig.h"
+
+    #include <cassert>
+    #include <cmath>
+    #include <random>
+
+    using std::abs;
+
+    int main()
+    {
+      Random random(0);
+
+      double lambda = 2.1;
+      double chi = 0.1;
+      double psi = 1.0;
+
+      assert(abs(random.gig(lambda, chi, psi) - 1.30869321355819901) < 1e-7);
+
+      return 0;
+    }
+    EOS
+    system ENV.cxx, "-I#{include}", "-L#{lib}", "-lgig", "-o", "gig_test", "gig_test.cpp"
+    system "./gig_test"
+  end
+end


### PR DESCRIPTION
This commit adds gig (https://github.com/Horta/gig) as a new formula for
Homebrew. Gig is a C++ library for sampling from the Generalized Inverse
Gaussian distribution.

- [x] Have you followed the guidelines for contributing?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with brew install --build-from-source <formula>, where <formula> is the name of the formula you're submitting?
- [x] Does your build pass brew audit --strict <formula> (after doing brew install <formula>)?