### PR TITLE
polyml: add a with-x option

### DIFF
--- a/Formula/polyml.rb
+++ b/Formula/polyml.rb
@@ -12,9 +12,26 @@ class Polyml < Formula
     sha256 "1b6f485f1840b4f8d28978b82902a978030fde47f35fbc81cd6c83d61cf4d5ff" => :mavericks
   end
 
+  option "with-x", "With X11/Motif support"
+
+  if build.with? "x"
+    depends_on :x11
+    depends_on "openmotif"
+  end
+
   def install
-    system "./configure", "--disable-dependency-tracking", "--disable-debug",
-                          "--prefix=#{prefix}"
+    args = %W[
+      --disable-dependency-tracking
+      --disable-debug
+      --prefix=#{prefix}
+    ]
+    if build.with? "x"
+      args << "--with-x"
+    else
+      args << "--without-x"
+    end
+
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
To enable building the X11 and Motif bindings for Poly/ML

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - `brew audit` complains about the lack of a test, which is not a newly introduced issue

-----
