### PR TITLE
emacs: depend on texinfo for newer makeinfo when building from head

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -22,6 +22,7 @@ class Emacs < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
+    depends_on "texinfo" => :build
   end
 
   option "with-cocoa", "Build a Cocoa version of emacs"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #8430 