### PR TITLE
lastpass-cli: add dependency on cmake

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -15,6 +15,8 @@ class LastpassCli < Formula
 
   option "with-doc", "Install man pages"
 
+  depends_on "cmake" => :build
+
   depends_on "asciidoc" => :build if build.with? "doc"
   depends_on "openssl"
   depends_on "pinentry" => :optional

--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -3,7 +3,6 @@ class LastpassCli < Formula
   homepage "https://github.com/lastpass/lastpass-cli"
   url "https://github.com/lastpass/lastpass-cli/archive/v1.0.0.tar.gz"
   sha256 "42096c0bd3972b0e9cc9cef32fbf141e47b04b9e2387fb3abe8b105e135fb41e"
-  head "https://github.com/lastpass/lastpass-cli.git"
 
   bottle do
     cellar :any
@@ -13,9 +12,13 @@ class LastpassCli < Formula
     sha256 "dc2eb72ebe79a0963dc9cae50ec6a38633740866b356e7521f37bf1c586a37f0" => :mavericks
   end
 
+  head do
+    url "https://github.com/lastpass/lastpass-cli.git"
+    
+    depends_on "cmake" => :build
+  end
+  
   option "with-doc", "Install man pages"
-
-  depends_on "cmake" => :build
 
   depends_on "asciidoc" => :build if build.with? "doc"
   depends_on "openssl"


### PR DESCRIPTION
lastpass-cli (HEAD) build now uses cmake.  There is a top-level
Makefile which emulates most of previous targets, so no other
changes are needed to the actual build steps.

Signed-off-by: Bob Copeland <copeland@lastpass.com>

- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
