### PR TITLE
neo4j: add plist to enable usage with brew services

### DIFF
--- a/Formula/neo4j.rb
+++ b/Formula/neo4j.rb
@@ -29,6 +29,35 @@ class Neo4j < Formula
     EOS
   end
 
+  plist_options :manual => "neo4j start"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <false/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/neo4j</string>
+          <string>console</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/neo4j.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/neo4j.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
   test do
     ENV["NEO4J_HOME"] = libexec
     ENV.java_cache

--- a/Formula/neo4j.rb
+++ b/Formula/neo4j.rb
@@ -29,6 +29,10 @@ class Neo4j < Formula
     EOS
   end
 
+  def post_install
+    (var/"log").mkpath
+  end
+
   plist_options :manual => "neo4j start"
 
   def plist; <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Implements `#plist` for `neo4j` formula which enables usage with `brew services`.

I used the `elasticsearch`, `redis` and `postgres` formulas as inspiration and have tested this is worked as expected after following the steps in `CONTRIBUTING.md` to build from source.