### PR TITLE
stathat 0.2.0 (new formula)

### DIFF
--- a/Formula/stathat.rb
+++ b/Formula/stathat.rb
@@ -1,0 +1,21 @@
+class Stathat < Formula
+  desc "Command-line interface to stathat.com"
+  homepage "https://stathat.com"
+  url "https://github.com/stathat/cmd/archive/v0.2.0.tar.gz"
+  sha256 "f3771dac0394d15f670ab3073e09d1596b0d490cba99946e8631a3917144834a"
+
+  head "https://github.com/stathat/cmd.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/stathat/cmd/").install "stathat"
+
+    system "go", "build", "-o" bin/"stathat", "-a", "github.com/stathat/cmd/stathat"
+  end
+
+  test do
+    system "#{bin}/stathat", "version"
+  end
+end


### PR DESCRIPTION
Installs stathat command, a command-line interface to
the stathat.com service.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
