### PR TITLE
Fix caveats for emscripten

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -89,7 +89,7 @@ class Emscripten < Formula
   def caveats; <<-EOS.undent
     Manually set LLVM_ROOT to
       #{opt_libexec}/llvm/bin
-    and uncomment BINARYEN_ROOT
+    and comment out BINARYEN_ROOT
     in ~/.emscripten after running `emcc` for the first time.
     EOS
   end


### PR DESCRIPTION
This appears to be a typo - BINARYEN_ROOT is uncommented by default, and commenting the line out fixes the build.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

cc @bodokaiser @MikeMcQuaid 