### PR TITLE
weechat: require ruby >= 2.1 and remove broken guile option

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -45,11 +45,10 @@ class Weechat < Formula
   depends_on "gnutls"
   depends_on "libgcrypt"
   depends_on "gettext"
-  depends_on "guile" => :optional
   depends_on "aspell" => :optional
   depends_on "lua" => :optional
   depends_on :python => :optional
-  depends_on :ruby => ["1.8", :optional]
+  depends_on :ruby => ["2.1", :optional]
   depends_on :perl => ["5.3", :optional]
   depends_on "curl" => :optional
 


### PR DESCRIPTION
Fixes #8452.