### PR TITLE
doxygen: set CMAKE_OSX_DEPLOYMENT_TARGET

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -26,7 +26,7 @@ class Doxygen < Formula
   depends_on "llvm" => :optional
 
   def install
-    args = std_cmake_args
+    args = std_cmake_args << "-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=#{MacOS.version}"
     args << "-Dbuild_wizard=ON" if build.with? "qt5"
     args << "-Duse_libclang=ON -DLLVM_CONFIG=#{Formula["llvm"].opt_bin}/llvm-config" if build.with? "llvm"
 


### PR DESCRIPTION
otherwise when Xcode isn't installed, the deployment target ends up
getting set too low to use c++11 and --with-qt5 fails to build

Fixes #8446.