### PR TITLE
python3: fix caveats when python3 not installed

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -314,7 +314,11 @@ class Python3 < Formula
   end
 
   def caveats
-    xy = (prefix/"Frameworks/Python.framework/Versions").children.first.basename.to_s
+    if prefix.exist?
+      xy = (prefix/"Frameworks/Python.framework/Versions").children.first.basename.to_s
+    else
+      xy = version.to_s.slice(/(3\.\d)/) || "3.6"
+    end
     text = <<-EOS.undent
       Pip, setuptools, and wheel have been installed. To update them
         pip3 install --upgrade pip setuptools wheel


### PR DESCRIPTION
eec96a68d82 updated the caveats to look at the actual contents of the
prefix, but this doesn't work if either

a) python3 is not installed, or
b) an outdated version is installed

The result was that some users were getting exceptions raised on any
operations that evaluated `#caveats`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
