### PR TITLE
rdate: use server with RFC 868 support in the test

### DIFF
--- a/Formula/rdate.rb
+++ b/Formula/rdate.rb
@@ -21,6 +21,7 @@ class Rdate < Formula
   end
 
   test do
-    system "#{bin}/rdate", "-p", "-t", "2", "0.pool.ntp.org"
+    # note that the server must support RFC 868
+    system "#{bin}/rdate", "-p", "-t", "10", "ptbtime1.ptb.de"
   end
 end


### PR DESCRIPTION
Switch from 0.pool.ntp.org to a server known to have RFC 868 support.
(Some of the time.nist.gov servers also work.)