### PR TITLE
[obsolete] ldc 1.1.0-beta6

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -5,8 +5,10 @@ class Ldc < Formula
   stable do
     # for the sake of LLVM 3.9 compatibility
     url "https://github.com/ldc-developers/ldc.git",
-        :branch => "release-1.1.0"
-    version "1.1.0"
+        :branch => "release-1.1.0",
+        :revision => "a86f87637d4880709ee0bde3ae741e6617b835b2"
+    # NOTE sure what suffix should be after 1.1.0
+    version "1.1.0-alpha1"
 
     resource "ldc-lts" do
       url "https://github.com/ldc-developers/ldc/releases/download/v0.17.2/ldc-0.17.2-src.tar.gz"

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -5,9 +5,8 @@ class Ldc < Formula
   stable do
     # for the sake of LLVM 3.9 compatibility
     url "https://github.com/ldc-developers/ldc.git",
-        :branch => "release-1.0.1",
-        :revision => "3461e00f3531f855f9fc6e92515d7affb8201827"
-    version "1.0.1-alpha1"
+        :branch => "release-1.1.0"
+    version "1.1.0"
 
     resource "ldc-lts" do
       url "https://github.com/ldc-developers/ldc/releases/download/v0.17.2/ldc-0.17.2-src.tar.gz"

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -5,10 +5,8 @@ class Ldc < Formula
   stable do
     # for the sake of LLVM 3.9 compatibility
     url "https://github.com/ldc-developers/ldc.git",
-        :branch => "release-1.1.0",
-        :revision => "a86f87637d4880709ee0bde3ae741e6617b835b2"
-    # NOTE sure what suffix should be after 1.1.0
-    version "1.1.0-alpha1"
+        :tag => "v1.1.0-beta6"
+    version "1.1.0-beta6"
 
     resource "ldc-lts" do
       url "https://github.com/ldc-developers/ldc/releases/download/v0.17.2/ldc-0.17.2-src.tar.gz"

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -22,17 +22,6 @@ class Ldc < Formula
     sha256 "8d827625dea278303befcbb997d3e1713b7d85e257705a30da72ce1519eab147" => :yosemite
   end
 
-  devel do
-    url "https://github.com/ldc-developers/ldc/releases/download/v1.1.0-beta3/ldc-1.1.0-beta3-src.tar.gz"
-    sha256 "cf4aeb393eada610aa3bad18c3ae6a5de94250eaa968fe2d1b0a6afdf8ea54f6"
-    version "1.1.0-beta3"
-
-    resource "ldc-lts" do
-      url "https://github.com/ldc-developers/ldc/releases/download/v0.17.2/ldc-0.17.2-src.tar.gz"
-      sha256 "8498f0de1376d7830f3cf96472b874609363a00d6098d588aac5f6eae6365758"
-    end
-  end
-
   head do
     url "https://github.com/ldc-developers/ldc.git", :shallow => false
 


### PR DESCRIPTION
- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Updates ldc to 1.1.0 branch, and also fixes https://github.com/Linuxbrew/homebrew-core/issues/852

```
brew audit --strict ldc
ldc:
  * devel version 1.1.0-beta3 is older than stable version 1.1.0
Error: 1 problem in 1 formula
```

But not sure what else to put here since latest tar.gz release in https://github.com/ldc-developers/ldc/releases/ would be still older than 1.1.0 branch name

NOTE: it supersedes https://github.com/Linuxbrew/homebrew-core/pull/1525 

