### PR TITLE
Scala 2.10 and 2.11 (new formulas)

### DIFF
--- a/Formula/scala@2.10.rb
+++ b/Formula/scala@2.10.rb
@@ -1,0 +1,65 @@
+class ScalaAT210 < Formula
+  desc "JVM-based programming language"
+  homepage "https://www.scala-lang.org/"
+  url "http://downloads.lightbend.com/scala/2.10.6/scala-2.10.6.tgz"
+  mirror "https://downloads.typesafe.com/scala/2.10.6/scala-2.10.6.tgz"
+  mirror "http://www.scala-lang.org/files/archive/scala-2.10.6.tgz"
+  sha256 "54adf583dae6734d66328cafa26d9fa03b8c4cf607e27b9f3915f96e9bcd2d67"
+
+  option "with-docs", "Also install library documentation"
+  option "with-src", "Also install sources for IDE support"
+
+  depends_on :java => "1.6+"
+
+  conflicts_with "scala", :because => "Differing version of same formula"
+  conflicts_with "scala@2.11", :because => "Differing version of same formula"
+
+  resource "docs" do
+    url "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.txz"
+    mirror "http://www.scala-lang.org/files/archive/scala-docs-2.10.6.txz"
+    sha256 "e9b5694255607ba069dcc0faa3ab1490164115ae000129c03100b196fce2025a"
+  end
+
+  resource "src" do
+    url "https://github.com/scala/scala/archive/v2.10.6.tar.gz"
+    sha256 "06d7467ff628ebac615c5e60af155e0b4cbbf4c31d10c03a45e9615d5b1e0420"
+  end
+
+  resource "completion" do
+    url "https://raw.githubusercontent.com/scala/scala-tool-support/0a217bc/bash-completion/src/main/resources/completion.d/2.9.1/scala"
+    sha256 "95aeba51165ce2c0e36e9bf006f2904a90031470ab8d10b456e7611413d7d3fd"
+  end
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    doc.install Dir["doc/*"]
+    share.install "man"
+    libexec.install "bin", "lib"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bash_completion.install resource("completion")
+    doc.install resource("docs") if build.with? "docs"
+    libexec.install resource("src").files("src") if build.with? "src"
+
+    # Set up an IntelliJ compatible symlink farm in 'idea'
+    idea = prefix/"idea"
+    idea.install_symlink libexec/"src", libexec/"lib"
+    idea.install_symlink doc => "doc"
+  end
+
+  test do
+    file = testpath/"Test.scala"
+    file.write <<-EOS.undent
+      object Test {
+        def main(args: Array[String]) {
+          println(s"${2 + 2}")
+        }
+      }
+    EOS
+
+    out = shell_output("#{bin}/scala #{file}").strip
+    # Shut down the compile server so as not to break Travis
+    system bin/"fsc", "-shutdown"
+
+    assert_equal "4", out
+  end
+end

--- a/Formula/scala@2.11.rb
+++ b/Formula/scala@2.11.rb
@@ -1,0 +1,65 @@
+class ScalaAT211 < Formula
+  desc "JVM-based programming language"
+  homepage "https://www.scala-lang.org/"
+  url "http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.tgz"
+  mirror "https://downloads.typesafe.com/scala/2.10.6/scala-2.11.8.tgz"
+  mirror "http://www.scala-lang.org/files/archive/scala-2.11.8.tgz"
+  sha256 "87fc86a19d9725edb5fd9866c5ee9424cdb2cd86b767f1bb7d47313e8e391ace"
+
+  option "with-docs", "Also install library documentation"
+  option "with-src", "Also install sources for IDE support"
+
+  depends_on :java => "1.6+"
+
+  conflicts_with "scala", :because => "Differing version of same formula"
+  conflicts_with "scala@2.10", :because => "Differing version of same formula"
+
+  resource "docs" do
+    url "https://downloads.lightbend.com/scala/2.11.8/scala-docs-2.11.8.txz"
+    mirror "http://www.scala-lang.org/files/archive/scala-docs-2.11.8.txz"
+    sha256 "f79180418c9a4827306c2e30d8de451d29daf72ec441e023ae73d25b39b3c0db"
+  end
+
+  resource "src" do
+    url "https://github.com/scala/scala/archive/v2.11.8.tar.gz"
+    sha256 "4f11273b4b3c771019253b2c09102245d063a7abeb65c7b1c4519bd57605edcf"
+  end
+
+  resource "completion" do
+    url "https://raw.githubusercontent.com/scala/scala-tool-support/0a217bc/bash-completion/src/main/resources/completion.d/2.9.1/scala"
+    sha256 "95aeba51165ce2c0e36e9bf006f2904a90031470ab8d10b456e7611413d7d3fd"
+  end
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    doc.install Dir["doc/*"]
+    share.install "man"
+    libexec.install "bin", "lib"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bash_completion.install resource("completion")
+    doc.install resource("docs") if build.with? "docs"
+    libexec.install resource("src").files("src") if build.with? "src"
+
+    # Set up an IntelliJ compatible symlink farm in 'idea'
+    idea = prefix/"idea"
+    idea.install_symlink libexec/"src", libexec/"lib"
+    idea.install_symlink doc => "doc"
+  end
+
+  test do
+    file = testpath/"Test.scala"
+    file.write <<-EOS.undent
+      object Test {
+        def main(args: Array[String]) {
+          println(s"${2 + 2}")
+        }
+      }
+    EOS
+
+    out = shell_output("#{bin}/scala #{file}").strip
+    # Shut down the compile server so as not to break Travis
+    system bin/"fsc", "-shutdown"
+
+    assert_equal "4", out
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -66,6 +66,8 @@
   "polarssl": "mbedtls",
   "qt55": "qt@5.5",
   "racket": "minimal-racket",
+  "scala210": "scala@2.10",
+  "scala211": "scala@2.11",
   "screenbrightness": "brightness",
   "sonar": "sonarqube",
   "stash-cli": "atlassian-cli",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


My organization (and likely at least a few others) are still using `Scala 2.11` for legacy projects, and noticed when it was removed in [homebrew-versions bb202ed](https://github.com/Homebrew/homebrew-versions/commit/bb202eda53e7a9174caee91ad6c5c7b2d01b61e9). Somewhat surprizingly to me, `scala210` is still in `homebrew-versions`. We have set up our own tap for now, as suggested by @MikeMcQuaid in [this comment](https://github.com/Homebrew/homebrew-versions/commit/ba8b293656ef8fb51eca2d3be022e69ad20277f4#commitcomment-20383905). I'm not sure what analytics are used to determine that a formula is "used by a very small number of people", and if you don't think keeping these formula around is worth it, I would completely understand.

With that said:

This PR adds `Scala 2.11` almost exactly as it was from [`homebrew-versions` `scala211.rb`](https://github.com/Homebrew/homebrew-versions/blob/2bbcc3f2009e55230d41d9c07dd538163350d8fb/scala211.rb).

This PR also updates the `Scala 2.10` formula from [`homebrew-versions` `scala210.rb`](https://github.com/Homebrew/homebrew-versions/blob/838311f4f825af653315c3f8511bbbad1bf6e5c2/scala210.rb) from homebrew-versions from `2.10.5` to `2.10.6` since `2.10` is still in homebrew-versions, and homebrew-versions is now deprecated. This would allow the `scala210` formula to be removed from there.

Both `2.10` and `2.11` formulas are added in this one PR because otherwise `brew audit --strict <formula>` will fail as a result of the `conflicts_with` in each formula pointing at a formula that wouldn't yet exist.