### PR TITLE
open-mesh: Fix missing smoother files

### DIFF
--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -15,6 +15,11 @@ class OpenMesh < Formula
 
   depends_on "cmake" => :build
 
+  patch do
+    url "https://graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh/commit/c5cfef87427a793268f9e012856872bbed958d92.diff"
+    sha256 "5180b3ea8e92b88e9212a4fcfc214666d3b2ca2133a95c2f6b0a44855a298c79"
+  end
+
   def install
     mkdir "build" do
       system "cmake", "..", "-DBUILD_APPS=OFF", *std_cmake_args

--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -16,6 +16,7 @@ class OpenMesh < Formula
   depends_on "cmake" => :build
 
   patch do
+    # Fixes missing include files in OpenMesh/Tools/Smoother during install
     url "https://graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh/commit/c5cfef87427a793268f9e012856872bbed958d92.diff"
     sha256 "5180b3ea8e92b88e9212a4fcfc214666d3b2ca2133a95c2f6b0a44855a298c79"
   end

--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -3,7 +3,7 @@ class OpenMesh < Formula
   homepage "https://openmesh.org/"
   url "https://www.openmesh.org/media/Releases/5.1/OpenMesh-5.1.tar.gz"
   sha256 "643262dec62d1c2527950286739613a5b8d450943c601ecc42a817738556e6f7"
-  head "http://openmesh.org/svnrepo/OpenMesh/trunk/", :using => :svn
+  head "https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git"
 
   bottle do
     cellar :any
@@ -15,10 +15,12 @@ class OpenMesh < Formula
 
   depends_on "cmake" => :build
 
-  patch do
-    # Fixes missing include files in OpenMesh/Tools/Smoother during install
-    url "https://graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh/commit/c5cfef87427a793268f9e012856872bbed958d92.diff"
-    sha256 "5180b3ea8e92b88e9212a4fcfc214666d3b2ca2133a95c2f6b0a44855a298c79"
+  stable do
+    patch do
+      # Fixes missing include files in OpenMesh/Tools/Smoother during install
+      url "https://graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh/commit/c5cfef87427a793268f9e012856872bbed958d92.diff"
+      sha256 "5180b3ea8e92b88e9212a4fcfc214666d3b2ca2133a95c2f6b0a44855a298c79"
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Because of a typo in the cmake files, some files required for the Smoother were not installed, e.g. `#include <OpenMesh/Tools/Smoother/SmootherT.hh>` did not compile.