### PR TITLE
terraform: revision for non-cgo root cert discovery fix

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -5,6 +5,7 @@ class Terraform < Formula
   homepage "https://www.terraform.io/"
   url "https://github.com/hashicorp/terraform/archive/v0.8.2.tar.gz"
   sha256 "bc38273dcaf50e240788f6174dff0ad3cb6b252da22617fae768164cf6065c3b"
+  revision 1
   head "https://github.com/hashicorp/terraform.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #8576.

CC @mwarkentin @mitchellh