### PR TITLE
boost: Disable universal builds.

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -14,7 +14,6 @@ class Boost < Formula
 
   env :userpaths
 
-  option :universal
   option "with-icu4c", "Build regexp engine with icu support"
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"
@@ -34,8 +33,6 @@ class Boost < Formula
   needs :cxx11 if build.cxx11?
 
   def install
-    ENV.universal_binary if build.universal?
-
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
       file.write "using darwin : : #{ENV.cxx} ;\n"
@@ -58,7 +55,7 @@ class Boost < Formula
     # The context library is implemented as x86_64 ASM, so it
     # won't build on PPC or 32-bit builds
     # see https://github.com/Homebrew/homebrew/issues/17646
-    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit? || build.universal?
+    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit?
       without_libraries << "context"
       # The coroutine library depends on the context library.
       without_libraries << "coroutine"
@@ -92,8 +89,6 @@ class Boost < Formula
       args << "link=shared"
     end
 
-    args << "address-model=32_64" << "architecture=x86" << "pch=off" if build.universal?
-
     # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
     # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
     if build.cxx11?
@@ -119,7 +114,7 @@ class Boost < Formula
       EOS
     end
 
-    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit? || build.universal?
+    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit?
       s += <<-EOS.undent
 
       Building of Boost.Context and Boost.Coroutine is disabled as they are


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Previously, universal builds had removed several modules from i386/ppc
targets to get the build to succeed. This is becoming increasingly
unsustainable as i386 and PPC age and are no longer supported.

See #7852.