### PR TITLE
Apache Ant 1.9 (new formula)

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -17,8 +17,6 @@ class Ant < Formula
   option "with-ivy", "Install ivy dependency manager"
   option "with-bcel", "Install Byte Code Engineering Library"
 
-  conflicts_with "ant@1.9", :because => "Different versions of same formula"
-
   resource "ivy" do
     url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
     sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -5,12 +5,10 @@ class AntAT19 < Formula
   version "1.9"
   sha256 "6edeaab09fc0bb1eeeb6b6be9c0e463813b073c40189f760e70c85fa288d5125"
 
-  keg_only :provided_by_osx if MacOS.version < :mavericks
+  keg_only "Older version of formula"
 
   option "with-ivy", "Install ivy dependency manager"
   option "with-bcel", "Install Byte Code Engineering Library"
-
-  conflicts_with "ant", :because => "Different versions of same formula"
 
   resource "ivy" do
     url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -5,7 +5,7 @@ class AntAT19 < Formula
   version "1.9"
   sha256 "6edeaab09fc0bb1eeeb6b6be9c0e463813b073c40189f760e70c85fa288d5125"
 
-  keg_only "Older version of formula"
+  keg_only :versioned_formula
 
   option "with-ivy", "Install ivy dependency manager"
   option "with-bcel", "Install Byte Code Engineering Library"

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -7,19 +7,6 @@ class AntAT19 < Formula
 
   keg_only :versioned_formula
 
-  option "with-ivy", "Install ivy dependency manager"
-  option "with-bcel", "Install Byte Code Engineering Library"
-
-  resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-    sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
-  end
-
-  resource "bcel" do
-    url "https://search.maven.org/remotecontent?filepath=org/apache/bcel/bcel/6.0/bcel-6.0.jar"
-    sha256 "7eb80fdb30034dda26ba109a1b76af8dae0782c8cd27db32f1775086482d5bd0"
-  end
-
   def install
     rm Dir["bin/*.{bat,cmd,dll,exe}"]
     libexec.install Dir["*"]
@@ -29,16 +16,6 @@ class AntAT19 < Formula
       #!/bin/sh
       #{libexec}/bin/ant -lib #{HOMEBREW_PREFIX}/share/ant "$@"
     EOS
-    if build.with? "ivy"
-      resource("ivy").stage do
-        (libexec/"lib").install Dir["ivy-*.jar"]
-      end
-    end
-    if build.with? "bcel"
-      resource("bcel").stage do
-        (libexec/"lib").install Dir["bcel-*.jar"]
-      end
-    end
   end
 
   test do

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -2,7 +2,6 @@ class AntAT19 < Formula
   desc "Java build tool"
   homepage "https://ant.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.9.8-bin.tar.bz2"
-  version "1.9"
   sha256 "6edeaab09fc0bb1eeeb6b6be9c0e463813b073c40189f760e70c85fa288d5125"
 
   keg_only :versioned_formula

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -1,23 +1,16 @@
-class Ant < Formula
+class AntAT19 < Formula
   desc "Java build tool"
   homepage "https://ant.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.10.0-bin.tar.bz2"
-  sha256 "1c34158fb1e3b56c843afae3ef91a60e779f91f63e69d69150698c049d2893c5"
-  head "https://git-wip-us.apache.org/repos/asf/ant.git"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "014a680a8ddd0f46cda9a2fe1810f98b4f6be3b09203be032d58210dd51dd952" => :sierra
-    sha256 "7daabc4c4836853d92657ce7de727691ca8271455f1e2084b1f50766381232d9" => :el_capitan
-    sha256 "7daabc4c4836853d92657ce7de727691ca8271455f1e2084b1f50766381232d9" => :yosemite
-  end
+  url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.9.8-bin.tar.bz2"
+  version "1.9"
+  sha256 "6edeaab09fc0bb1eeeb6b6be9c0e463813b073c40189f760e70c85fa288d5125"
 
   keg_only :provided_by_osx if MacOS.version < :mavericks
 
   option "with-ivy", "Install ivy dependency manager"
   option "with-bcel", "Install Byte Code Engineering Library"
 
-  conflicts_with "ant@1.9", :because => "Different versions of same formula"
+  conflicts_with "ant", :because => "Different versions of same formula"
 
   resource "ivy" do
     url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"


### PR DESCRIPTION
Version of ant formula for Apache Ant 1.9.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Apache Ant 1.10.0 (provided by the `ant` formula) is the first version which requires Java 8. This adds a 1.9 version formula for developers that still need Java 7 (or below) support. The Ant team are still maintaining the 1.9.x branch and 1.9.8 was released at the same time as 1.10.0.