### PR TITLE
mingw-w64-binutils 2.27 (new formula)

### DIFF
--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -32,7 +32,7 @@ class MingwW64Binutils < Formula
     system "#{bin}/x86_64-w64-mingw32-as", "-o", "test.o", "test.s"
     assert_match "file format pe-x86-64", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test.o")
     system "#{bin}/x86_64-w64-mingw32-ld", "-o", "test.exe", "test.o"
-    assert_match "PE32+ executable (console) x86-64", shell_output("file test.exe")
+    assert_match /PE32\+ executable .* x86-64/, shell_output("file test.exe")
 
     # Assemble a simple 32-bit routine
     (testpath/"test32.s").write <<-EOS.undent
@@ -46,6 +46,6 @@ class MingwW64Binutils < Formula
     system "#{bin}/x86_64-w64-mingw32-as", "--32", "-o", "test32.o", "test32.s"
     assert_match "file format pe-i386", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test32.o")
     system "#{bin}/x86_64-w64-mingw32-ld", "-m", "i386pe", "-o", "test32.exe", "test32.o"
-    assert_match "PE32 executable (console) Intel 80386", shell_output("file test32.exe")
+    assert_match /PE32 executable .* Intel 80386/, shell_output("file test32.exe")
   end
 end

--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -20,10 +20,6 @@ class MingwW64Binutils < Formula
   end
 
   test do
-    # Check target and version number
-    assert_match "x86_64-w64-mingw32", shell_output("#{bin}/x86_64-w64-mingw32-as --version")
-    assert_match version.to_s, shell_output("#{bin}/x86_64-w64-mingw32-ld --version")
-
     # Assemble a simple 64-bit routine
     (testpath/"test.s").write <<-EOS.undent
       foo:
@@ -35,6 +31,8 @@ class MingwW64Binutils < Formula
     EOS
     system "#{bin}/x86_64-w64-mingw32-as", "-o", "test.o", "test.s"
     assert_match "file format pe-x86-64", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test.o")
+    system "#{bin}/x86_64-w64-mingw32-ld", "-o", "test.exe", "test.o"
+    assert_match "PE32+ executable (console) x86-64", shell_output("file test.exe")
 
     # Assemble a simple 32-bit routine
     (testpath/"test32.s").write <<-EOS.undent
@@ -47,5 +45,7 @@ class MingwW64Binutils < Formula
     EOS
     system "#{bin}/x86_64-w64-mingw32-as", "--32", "-o", "test32.o", "test32.s"
     assert_match "file format pe-i386", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test32.o")
+    system "#{bin}/x86_64-w64-mingw32-ld", "-m", "i386pe", "-o", "test32.exe", "test32.o"
+    assert_match "PE32 executable (console) Intel 80386", shell_output("file test32.exe")
   end
 end

--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -26,24 +26,24 @@ class MingwW64Binutils < Formula
 
     # Assemble a simple 64-bit routine
     (testpath/"test.s").write <<-EOS.undent
-foo:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	movl	$42, %eax
-	popq	%rbp
-	ret
+      foo:
+        pushq  %rbp
+        movq   %rsp, %rbp
+        movl   $42, %eax
+        popq   %rbp
+        ret
     EOS
     system "#{bin}/x86_64-w64-mingw32-as", "-o", "test.o", "test.s"
     assert_match "file format pe-x86-64", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test.o")
 
     # Assemble a simple 32-bit routine
     (testpath/"test32.s").write <<-EOS.undent
-_foo:
-	pushl	%ebp
-	movl	%esp, %ebp
-	movl	$42, %eax
-	popl	%ebp
-	ret
+      _foo:
+        pushl  %ebp
+        movl   %esp, %ebp
+        movl   $42, %eax
+        popl   %ebp
+        ret
     EOS
     system "#{bin}/x86_64-w64-mingw32-as", "--32", "-o", "test32.o", "test32.s"
     assert_match "file format pe-i386", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test32.o")

--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -20,7 +20,32 @@ class MingwW64Binutils < Formula
   end
 
   test do
+    # Check target and version number
     assert_match "x86_64-w64-mingw32", shell_output("#{bin}/x86_64-w64-mingw32-as --version")
     assert_match version.to_s, shell_output("#{bin}/x86_64-w64-mingw32-ld --version")
+
+    # Assemble a simple 64-bit routine
+    (testpath/"test.s").write <<-EOS.undent
+foo:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movl	$42, %eax
+	popq	%rbp
+	ret
+    EOS
+    system "#{bin}/x86_64-w64-mingw32-as", "-o", "test.o", "test.s"
+    assert_match "file format pe-x86-64", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test.o")
+
+    # Assemble a simple 32-bit routine
+    (testpath/"test32.s").write <<-EOS.undent
+_foo:
+	pushl	%ebp
+	movl	%esp, %ebp
+	movl	$42, %eax
+	popl	%ebp
+	ret
+    EOS
+    system "#{bin}/x86_64-w64-mingw32-as", "--32", "-o", "test32.o", "test32.s"
+    assert_match "file format pe-i386", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test32.o")
   end
 end

--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -32,7 +32,7 @@ class MingwW64Binutils < Formula
     system "#{bin}/x86_64-w64-mingw32-as", "-o", "test.o", "test.s"
     assert_match "file format pe-x86-64", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test.o")
     system "#{bin}/x86_64-w64-mingw32-ld", "-o", "test.exe", "test.o"
-    assert_match /PE32\+ executable .* x86-64/, shell_output("file test.exe")
+    assert_match "PE32+ executable", shell_output("file test.exe")
 
     # Assemble a simple 32-bit routine
     (testpath/"test32.s").write <<-EOS.undent
@@ -46,6 +46,6 @@ class MingwW64Binutils < Formula
     system "#{bin}/x86_64-w64-mingw32-as", "--32", "-o", "test32.o", "test32.s"
     assert_match "file format pe-i386", shell_output("#{bin}/x86_64-w64-mingw32-objdump -a test32.o")
     system "#{bin}/x86_64-w64-mingw32-ld", "-m", "i386pe", "-o", "test32.exe", "test32.o"
-    assert_match /PE32 executable .* Intel 80386/, shell_output("file test32.exe")
+    assert_match "PE32 executable", shell_output("file test32.exe")
   end
 end

--- a/Formula/mingw-w64-binutils.rb
+++ b/Formula/mingw-w64-binutils.rb
@@ -1,0 +1,26 @@
+class MingwW64Binutils < Formula
+  desc "Binutils for Windows mingw-w64 (32 and 64 bits)"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftpmirror.gnu.org/binutils/binutils-2.27.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz"
+  sha256 "26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f"
+
+  def install
+    system "./configure", "--disable-werror",
+                          "--target=x86_64-w64-mingw32",
+                          "--enable-targets=x86_64-w64-mingw32,i686-w64-mingw32",
+                          "--prefix=#{prefix}",
+                          "--with-sysroot=#{prefix}"
+    system "make"
+    system "make", "install"
+
+    # Info pages and localization files conflict with native tools
+    info.rmtree
+    (share/"locale").rmtree
+  end
+
+  test do
+    assert_match "x86_64-w64-mingw32", shell_output("#{bin}/x86_64-w64-mingw32-as --version")
+    assert_match version.to_s, shell_output("#{bin}/x86_64-w64-mingw32-ld --version")
+  end
+end


### PR DESCRIPTION
Cross-compiling binutils for mingw-w64 (Windows) target, 32 and 64-bit

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----