### PR TITLE
rust: fix issue #8656; allow CARGO_PATH

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -39,6 +39,7 @@ class Rust < Formula
 
   option "with-llvm", "Build with brewed LLVM. By default, Rust's LLVM will be used."
   option "with-racer", "Build Racer code completion tool, and retain Rust sources."
+  option "with-cargo", "Build with 'cargo' binary in CARGO_PATH."
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :run
@@ -71,6 +72,7 @@ class Rust < Formula
 
     resource("cargo").stage do
       cargo_stage_path = pwd
+      cargo_path = ENV["CARGO_PATH"]
 
       if build.stable?
         resource("cargo-nightly-2015-09-17").stage do
@@ -78,6 +80,16 @@ class Rust < Formula
           # satisfy make target to skip download
           touch "#{cargo_stage_path}/target/snapshot/cargo/bin/cargo"
         end
+      end
+
+      if build.with? "cargo"
+        ohai "Building with 'cargo' binary from #{cargo_path.inspect}"
+
+        unless which("cargo", cargo_path)
+          odie "Couldn't find cargo binary in #{cargo_path.inspect}"
+        end
+
+        ENV.prepend_path "PATH", cargo_path
       end
 
       system "./configure", "--prefix=#{prefix}", "--local-rust-root=#{prefix}", "--enable-optimize"


### PR DESCRIPTION
Fixes #8656

This patch allows to specify `CARGO_PATH` with previous **cargo** version to be added to `PATH` on build.

Without this fix I couldn't brew *HEAD* version of  **rust** package.
Now I use following command to brew with previous **cargo**:

~~~sh
CARGO_PATH="/usr/local/Cellar/rust/1.13.0/bin" brew install --HEAD --with-cargo rust
~~~

- [x] Guidelines?
- [x] Open pull requests?
- [x] Local build with `brew install --build-from-source rust`?
- [ ] Pass `brew audit --strict rust` (after doing `brew install rust`)?

Brew audit doesn't pass with following error:

~~~
rust:
  * The installation was broken.
    Broken dylib links found:
      /usr/local/Cellar/rust/HEAD-78c892d/lib//private/tmp/rust-20170110-47474-1gbw9ld/build/x86_64-apple-darwin/stage1-rustc/x86_64-apple-darwin/release/deps/librustc_driver-3b169b4b1f044fbc.dylib
     ...
~~~

Any suggestions on this error?