### PR TITLE
llvm@3.8: Fix installation of .inc files

### DIFF
--- a/Formula/llvm@3.8.rb
+++ b/Formula/llvm@3.8.rb
@@ -134,6 +134,9 @@ class LlvmAT38 < Formula
     mktemp do
       system buildpath/"configure", *args
       system "make", "VERBOSE=1", "install"
+      cd "tools/clang" do
+        system "make", "install"
+      end
     end
 
     if MacOS.version <= :snow_leopard


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a fix for #8626.

Currently the `llvm@3.8` formula does not properly install `.inc` files to the `include` directory for Clang. As a result, it is not possible to build software against the Clang installed by this formula (although Clang itself works properly). This change adds a `make install` command to the formula to make sure that Clang's `.inc` files are properly installed.

This was previously discussed (and a fix applied) for LLVM 3.1 here, but for some reason that fix never made it into this version of the formula: https://github.com/Homebrew/legacy-homebrew/issues/14924