### PR TITLE
source-to-image 1.1.4 (new formula)

### DIFF
--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -1,0 +1,14 @@
+class SourceToImage < Formula
+  desc "Tool for building source and injecting into docker images"
+  homepage "https://github.com/openshift/source-to-image"
+  url "https://github.com/openshift/source-to-image/releases/download/v1.1.3/source-to-image-v1.1.3-ddb10f1-darwin-amd64.tar.gz"
+  sha256 "b5d179e1da3e5e3d4b206a767c69bc6d5860d82227a475ecc17c4279bfb0f862"
+
+  def install
+    bin.install "s2i"
+  end
+
+  test do
+    system "#{bin}/s2i", "-h"
+  end
+end

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -9,6 +9,7 @@ class SourceToImage < Formula
   end
 
   test do
-    system "#{bin}/s2i", "-h"
+    system "#{bin}/s2i", "create", "testimage", testpath
+    assert_match(/Dockerfile/, shell_output("ls").chomp)
   end
 end

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -2,8 +2,8 @@ class SourceToImage < Formula
   desc "Tool for building source and injecting into docker images"
   homepage "https://github.com/openshift/source-to-image"
   url "https://github.com/openshift/source-to-image.git",
-    :tag => "v1.1.3",
-    :revision => "ddb10f16412977688136b77c76c30c0632e510d6"
+    :tag => "v1.1.4",
+    :revision => "870b2730357b2664598b47672a4840e3ebd31338"
   head "https://github.com/openshift/source-to-image.git"
 
   depends_on "go" => :build

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -15,6 +15,6 @@ class SourceToImage < Formula
 
   test do
     system "#{bin}/s2i", "create", "testimage", testpath
-    assert (testpath/"Dockerfile").exist?
+    assert (testpath/"Dockerfile").exist?, "s2i did not create the files."
   end
 end

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -1,11 +1,16 @@
 class SourceToImage < Formula
   desc "Tool for building source and injecting into docker images"
   homepage "https://github.com/openshift/source-to-image"
-  url "https://github.com/openshift/source-to-image/releases/download/v1.1.3/source-to-image-v1.1.3-ddb10f1-darwin-amd64.tar.gz"
-  sha256 "b5d179e1da3e5e3d4b206a767c69bc6d5860d82227a475ecc17c4279bfb0f862"
+  url "https://github.com/openshift/source-to-image.git",
+    :tag => "v1.1.3",
+    :revision => "ddb10f16412977688136b77c76c30c0632e510d6"
+  head "https://github.com/openshift/source-to-image.git"
+
+  depends_on "go" => :build
 
   def install
-    bin.install "s2i"
+    system "hack/build-go.sh"
+    bin.install "_output/local/bin/darwin/amd64/s2i"
   end
 
   test do

--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -10,6 +10,6 @@ class SourceToImage < Formula
 
   test do
     system "#{bin}/s2i", "create", "testimage", testpath
-    assert_match(/Dockerfile/, shell_output("ls").chomp)
+    assert (testpath/"Dockerfile").exist?
   end
 end


### PR DESCRIPTION
This adds the formula for Openshift's source-to-image tool.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
