### PR TITLE
Fix typos in minio.plist

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -61,14 +61,22 @@ class Minio < Formula
       <array>
         <string>#{opt_bin}/minio</string>
         <string>server</string>
-        <string>--config-dir=etc/minio</string>
+        <string>--config-dir=#{etc}/minio</string>
         <string>--address :9000</string>
-        <string>var/minio</string>
+        <string>#{var}/minio</string>
       </array>
       <key>RunAtLoad</key>
       <true/>
+      <key>KeepAlive</key>
+      <true/>
       <key>WorkingDirectory</key>
-      <string>var/minio</string>
+      <string>#{HOMEBREW_PREFIX}</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/minio/output.log</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/minio/output.log</string>
+      <key>RunAtLoad</key>
+      <true/>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
Fixes an issue with 

```
brew services start minio
Jan 11 15:04:41 My-MacBook-Pro com.apple.xpc.launchd[1] (homebrew.mxcl.minio[39214]): Service exited with abnormal code: 1
Jan 11 15:04:41 My-MacBook-Pro com.apple.xpc.launchd[1] (homebrew.mxcl.minio): Service only ran for 0 seconds. Pushing respawn out by 10 seconds.
```

From log
```
Unknown flags. ‘--config-dir=etc/minio, --address :9000, var/minio’
```

Reference https://github.com/minio/minio/issues/3564

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
