### PR TITLE
luaver 1.0.0-p1

### DIFF
--- a/Formula/luaver.rb
+++ b/Formula/luaver.rb
@@ -1,42 +1,37 @@
 class Luaver < Formula
   desc "Manage and switch between versions of Lua, LuaJIT, and Luarocks"
   homepage "https://github.com/DhavalKapil/luaver"
+
+  url "https://github.com/DhavalKapil/luaver.git",
+      :revision => "61861f2a966645a663971cd4e26d2a6104d075f6"
+  version "1.0.0-p1"
   head "https://github.com/DhavalKapil/luaver.git"
 
-  stable do
-    url "https://github.com/DhavalKapil/luaver/archive/v1.0.0.tar.gz"
-    sha256 "5c7eb65ea9b3cb4f10987c1d564e6e86bd6ad4f9d829a799121c83f0d85bd390"
-
-    patch do
-      url "https://github.com/DhavalKapil/luaver/pull/9.patch"
-      sha256 "390929ef53b6e8e372451049eeffbfa51b9e31d7071e386478b871a835aba2db"
-    end
-  end
-
   bottle :unneeded
-
   depends_on "wget" => :run
 
   def install
-    bin.install "luaver"
+    share.install "luaver"
   end
 
   def caveats; <<-EOS.undent
-    Add the following at the end of the correct file yourself:
-      if which luaver > /dev/null; then . `which luaver`; fi
+    You should add the following to your .bashrc (or equivalent):
+      if [ -f #{HOMEBREW_PREFIX}/share/luaver ]; then
+        . #{HOMEBREW_PREFIX}/share/luaver
+      fi
     EOS
   end
 
   test do
     lua_versions = %w[5.3.3 5.2.4 5.1.5]
     lua_versions.each do |v|
-      ENV.deparallelize { system ". #{bin}/luaver && luaver install #{v} < /dev/null" }
-      system ". #{bin}/luaver && luaver use #{v} && lua -v"
+      ENV.deparallelize { system ". #{share}/luaver && luaver install #{v} < /dev/null" }
+      system ". #{share}/luaver && luaver use #{v} && lua -v"
     end
     luajit_versions = %w[2.0.4]
     luajit_versions.each do |v|
-      system ". #{bin}/luaver && luaver install-luajit #{v} < /dev/null"
-      system ". #{bin}/luaver && luaver use-luajit #{v} && luajit -v"
+      system ". #{share}/luaver && luaver install-luajit #{v} < /dev/null"
+      system ". #{share}/luaver && luaver use-luajit #{v} && luajit -v"
     end
   end
 end


### PR DESCRIPTION
This commit cleans up the luaver installation process.

luaver is not a proper executable, rather it is a set of shell functions
that are typically sourced from a ~/.bashrc

The first change is to not install the sourced file to /usr/local/bin,
but rather to /usr/local/share, and then provide instructions for
sourcing in the caveats.

The next change is to use a git-style installation, rather than a
release download.  This will make it easier to manage versions via tags,
and osx-specific patches via revisions.

I've bumped the version here with a patch (-p1), which will include the
latest osx-specific fix, which was added directly after the 1.0 version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
