### PR TITLE
iwyu 0.7 (new formula)

### DIFF
--- a/Formula/iwyu.rb
+++ b/Formula/iwyu.rb
@@ -1,0 +1,59 @@
+require "English"
+
+class Iwyu < Formula
+  desc "analyze includes in C and C++ source files"
+  homepage "https://include-what-you-use.org"
+  url "https://include-what-you-use.org/downloads/include-what-you-use-0.7-x86_64-apple-darwin.tar.gz"
+  version "0.7"
+  sha256 "ba343d452b5d7b999c85387dff1750ca2d01af0c4e5a88a2144b395fa22d1575"
+
+  def install
+    # include-what-you-use looks for a lib directory one level up from its bin-
+    # dir, but putting it directly in prefix results in it getting linked in
+    # /usr/local/lib
+    #
+    # To solve this, we put iwyu in a custom dir and make bin links.
+    iwyu_subdir_path = (prefix / "iwyu")
+    iwyu_subdir_path.mkpath
+
+    # just copy everything from the tarball's lib directory
+    iwyu_subdir_path.install("lib")
+
+    # selectively include certain binaries; give them better names
+    iwyu_bindir = (iwyu_subdir_path / "bin")
+    iwyu_bindir.mkpath
+
+    iwyu_bindir.install("bin/fix_includes.py" => "fix_include")
+    iwyu_bindir.install("bin/include-what-you-use")
+    iwyu_bindir.install_symlink("include-what-you-use" => "iwyu")
+
+    bin.install_symlink Dir["#{iwyu_bindir}/*"]
+  end
+
+  test do
+    # write out a header and a C++ file relying on transitive dependencies
+    (testpath / "demo.hpp").write <<-EOS.undent
+    #include <stdio.h>
+    #include <stdarg.h>
+    #include <locale>
+    EOS
+
+    (testpath / "demo.cpp").write <<-EOS.undent
+    #include "demo.hpp"
+
+    int main(void)
+    { printf("hello world"); }
+    EOS
+
+    # iwyu exits with a code equal to the number of suggested edits + 2
+    fixes = shell_output "#{bin}/iwyu #{testpath}/demo.cpp 2>&1", 6
+    assert_not_match(/file not found/, fixes)
+
+    # pass the output to the fixer script and assert that it fixed two files
+    results = pipe_output "#{bin}/fix_include", fixes
+    assert_match(/IWYU edited 2 files/, results)
+
+    # sigh. they use the status code to signal how many files were edited
+    assert_equal 2, $CHILD_STATUS.exitstatus
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

So there's a bit of a history here. I initially opened Homebrew/legacy-homebrew#32610 over two years ago because I found IWYU fairly obnoxious to build and install correctly and wanted a simple Homebrew formula for coworkers, etc.

That request was closed for two primary reasons:

  * Building `include-what-you-use` requires LLVM development headers, not immediately available on OS X, creating a dependency on LLVM (making builds _very slow_)
  * Though `include-what-you-use` provides binaries which might sidestep the above issue, they need access to `clang`'s built-in headers and expect them at a particular relative path, so I had to write somewhat brittle code to ensure this structure. Upgrading Xcode would have broken my Formula

To get around the above, I created my [own tap](https://github.com/jasonmp85/homebrew-iwyu) and added a `caveat` for the Xcode upgrade case. In addition, I found that I [hadn't covered the C++ case very well](https://github.com/jasonmp85/homebrew-iwyu/pull/5), so I fixed that, too.

Eventually, upstream [did two things](https://github.com/include-what-you-use/include-what-you-use/issues/247):

  * They added code to auto-search Xcode's header paths, if available (fixing the C++ issue)
  * Binaries now come bundled with compiler built-in headers, which can be installed alongside the binary directly

I've tweaked my tap's formula to use these new developments, meaning I no longer need to symlink to version-specific Xcode directories (!). The C++ headers will be found automatically, and the built-ins are included with the tarball.

Unless I'm mistaken, I think that means this is eligible for inclusion in `homebrew-core`?