### PR TITLE
nuget: use correct case for NuGet.exe filename

### DIFF
--- a/Formula/nuget.rb
+++ b/Formula/nuget.rb
@@ -10,7 +10,7 @@ class Nuget < Formula
   depends_on "mono"
 
   def install
-    libexec.install "nuget.exe"
+    libexec.install "NuGet.exe" => "nuget.exe"
     (bin/"nuget").write <<-EOS.undent
       #!/bin/bash
       mono #{libexec}/nuget.exe "$@"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this fix `brew install nuget` fails on a case-sensitive filesystem with the error 

> Error: No such file or directory - nuget.exe

