### PR TITLE
macvim, libvpx: Remove otool usage.

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -44,6 +44,6 @@ class Libvpx < Formula
   end
 
   test do
-    system "otool", "-a", lib/"libvpx.a"
+    system "ar", "-x", "#{lib}/libvpx.a"
   end
 end

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -113,16 +113,8 @@ class Macvim < Formula
   test do
     # Simple test to check if MacVim was linked to Python version in $PATH
     if build.with? "python"
-      vim_path = prefix/"MacVim.app/Contents/MacOS/Vim"
-
-      # Get linked framework using otool
-      otool_output = `otool -L #{vim_path} | grep -m 1 Python`.gsub(/\(.*\)/, "").strip.chomp
-
-      # Expand the link and get the python exec path
-      vim_framework_path = Pathname.new(otool_output).realpath.dirname.to_s.chomp
       system_framework_path = `python-config --exec-prefix`.chomp
-
-      assert_equal system_framework_path, vim_framework_path
+      assert_match system_framework_path, `mvim --version`
     end
   end
 end


### PR DESCRIPTION
macvim puts its build flags in its version output, so we can
test against that instead of calling `otool`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
