### PR TITLE
elasticsearch 2.4.4

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -1,8 +1,8 @@
 class ElasticsearchAT24 < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.3/elasticsearch-2.4.3.tar.gz"
-  sha256 "01eb684943be01d4af3131c6795073187b1a5868b6525d9686cc0d7a315db12e"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.4/elasticsearch-2.4.4.tar.gz"
+  sha256 "981092e6ca65ba5560b8b97a74e5ed0eb2236e9128efdb85bb652cec340158e2"
 
   bottle :unneeded
   depends_on :java => "1.7+"


### PR DESCRIPTION
This pull request bumps the version on the Elasticsearch@2.4 formula from
version 2.4.3 to version 2.4.4.