### PR TITLE
qt@5.5 (fix mirrors)

### DIFF
--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -3,8 +3,8 @@
 class QtAT55 < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  url "https://download.qt.io/official_releases/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
+  url "https://download.qt.io/archive/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
+  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/archive/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
   sha256 "6f028e63d4992be2b4a5526f2ef3bfa2fe28c5c757554b11d9e8d86189652518"
 
   # Build error: Fix library detection for QtWebEngine with Xcode 7.


### PR DESCRIPTION
To use before merged (as long as this PR is still open):

```bash
brew install https://raw.githubusercontent.com/tresf/homebrew-core/patch-1/Formula/qt@5.5.rb
```

If this PR is merged, you should update your homebrew.

Fixes:

```bash
brew install qt@5.5
==> Downloading https://download.qt.io/official_releases/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz

curl: (22) The requested URL returned error: 404
Trying a mirror...
==> Downloading https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.5/5.5.1/single/qt-ev

curl: (22) The requested URL returned error: 404
Error: Failed to download resource "qt@5.5"
```