### PR TITLE
hunspell: let hunspell depend on gettext all the time

### DIFF
--- a/Formula/hunspell.rb
+++ b/Formula/hunspell.rb
@@ -13,7 +13,7 @@ class Hunspell < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "gettext" => :build
+  depends_on "gettext"
   depends_on "libtool" => :build
   depends_on "readline"
 


### PR DESCRIPTION
Fixed #8807.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
