### PR TITLE
spdlog 0.11.0 (new formula)

### DIFF
--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -11,7 +11,6 @@ class Spdlog < Formula
 
   def install
     ENV.cxx11
-    ENV.universal_binary if build.universal?
 
     mkdir "spdlog-build" do
       args = std_cmake_args

--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -1,0 +1,37 @@
+class Spdlog < Formula
+  desc "Super fast C++ logging library."
+  homepage "https://github.com/gabime/spdlog"
+  url "https://github.com/gabime/spdlog/archive/v0.11.0.tar.gz"
+  sha256 "8c0f1810fb6b7d23fef70c2ea8b6fa6768ac8d18d6e0de39be1f48865e22916e"
+  head "https://github.com/gabime/spdlog.git", :branch => "master"
+
+  depends_on "cmake" => :build
+
+  needs :cxx11
+
+  def install
+    ENV.cxx11
+    ENV.universal_binary if build.universal?
+
+    mkdir "spdlog-build" do
+      args = std_cmake_args
+      args << "-Dpkg_config_libdir=#{lib}" << ".."
+      system "cmake", *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include "spdlog/spdlog.h"
+      #include <iostream>
+      #include <memory>
+      int main()
+      {
+        auto console = spdlog::stdout_logger_mt("console");
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -3,7 +3,7 @@ class Spdlog < Formula
   homepage "https://github.com/gabime/spdlog"
   url "https://github.com/gabime/spdlog/archive/v0.11.0.tar.gz"
   sha256 "8c0f1810fb6b7d23fef70c2ea8b6fa6768ac8d18d6e0de39be1f48865e22916e"
-  head "https://github.com/gabime/spdlog.git", :branch => "master"
+  head "https://github.com/gabime/spdlog.git"
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Add spdlog 0.11.0 in spdlog.rb  which is "a super fast C++ logging library". Found at https://github.com/gabime/spdlog

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
