### PR TITLE
stk-4.5.0 enable C++11

### DIFF
--- a/Formula/stk.rb
+++ b/Formula/stk.rb
@@ -23,6 +23,8 @@ class Stk < Formula
   end
 
   def install
+    # Allow pre-10.9 clangs to build in C++11 mode
+    ENV.libcxx
     args = %W[--prefix=#{prefix}]
 
     if build.with? "debug"


### PR DESCRIPTION
 Allows pre-10.9 clangs to build stk in C++11 mode

To use before merged (as long as this PR is still open):

```bash
brew reinstall https://raw.githubusercontent.com/tresf/homebrew-core/patch-2/Formula/stk.rb
```

If this PR is merged, you should update your homebrew.

Fixes `CXX` compile error:

```bash
Linking CXX shared module
Undefined symbols for architecture x86_64:
```