### PR TITLE
sdl2: fix tests' resource paths

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -57,6 +57,13 @@ class Sdl2 < Formula
       # We need the build to point at the newly-built (not yet linked) copy of SDL.
       inreplace bin/"sdl2-config", "prefix=#{HOMEBREW_PREFIX}", "prefix=#{prefix}"
       cd "test" do
+        # These test source files produce binaries which by default will reference
+        # some sample resources in the working directory.
+        # Let's point them to the test_extras directory we're about to set up instead!
+        inreplace %w[controllermap.c loopwave.c loopwavequeue.c testmultiaudio.c
+                     testoverlay2.c testsprite2.c],
+                  /"(\w+\.(?:bmp|dat|wav))"/,
+                  "\"#{share}/test_extras/\\1\""
         system "./configure", "--without-x"
         system "make"
         # Tests don't have a "make install" target


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

SDL2's test binaries reference sample resources, expecting them to be in the working directory. This patches them to instead seek them out in the share directory.