### PR TITLE
temporal_tables 1.1.0 (new formula)

### DIFF
--- a/Formula/temporal_tables.rb
+++ b/Formula/temporal_tables.rb
@@ -1,0 +1,37 @@
+class TemporalTables < Formula
+  desc "Temporal Tables PostgreSQL Extension"
+  homepage "http://pgxn.org/dist/temporal_tables/"
+  url "https://github.com/arkhipov/temporal_tables/archive/v1.1.0.tar.gz"
+  sha256 "1fe210a349d1418d097f229c36f30a1daef1ff17cf0f027685171c52e366308a"
+
+  depends_on "postgresql"
+
+  def install
+    ENV["PG_CONFIG"] = Formula["postgresql"].opt_bin/"pg_config"
+
+    # Use stage directory to prevent installing to pg_config-defined dirs,
+    # which would not be within this package's Cellar.
+    mkdir "stage"
+    system "make", "install", "DESTDIR=#{buildpath}/stage"
+
+    lib.install Dir["stage/**/lib/*"]
+    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
+  end
+
+  test do
+    pg_bin = Formula["postgresql"].opt_bin
+    pg_port = "55562"
+    system "#{pg_bin}/initdb", testpath/"test"
+    pid = fork { exec "#{pg_bin}/postgres", "-D", testpath/"test", "-p", pg_port }
+
+    begin
+      sleep 2
+
+      system "#{pg_bin}/createdb", "-p", pg_port, "test"
+      system "#{pg_bin}/psql", "-p", pg_port, "-d", "test", "--command", "CREATE EXTENSION temporal_tables;"
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

temporal_tables is a PostgreSQL extension to add support for transaction time tables. Compatible with PostgreSQL 9.6.