### PR TITLE
libming 0.4.7

### DIFF
--- a/Formula/libming.rb
+++ b/Formula/libming.rb
@@ -1,9 +1,8 @@
 class Libming < Formula
   desc "C library for generating Macromedia Flash files"
   homepage "http://www.libming.org"
-  url "https://downloads.sourceforge.net/project/ming/Releases/ming-0.4.4.tar.bz2"
-  sha256 "40e09d781741ac961338ed8dec7ba2ed06217de9da44dd67af6b881b95d2af7e"
-  revision 1
+  url "https://github.com/libming/libming/archive/ming-0_4_7.tar.gz"
+  sha256 "118aa1338dd74b34dd2cd22bce286ca0571e8b9aa433999646d1c0157ea9a7dc"
 
   bottle do
     cellar :any
@@ -15,52 +14,33 @@ class Libming < Formula
     sha256 "fe516b67284f8de7a34ed1ac3dc68ee46d0bdb3593db16ba5f62b9e228336144" => :mountain_lion
   end
 
-  option "perl", "Build the perl extension"
-  option "php", "Build the php extension"
-
-  depends_on "libpng"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "freetype"
-  depends_on :python => :optional
-  depends_on "giflib" => :optional
-
-  # Helps us find libgif.dylib, not libungif.dylib which is retired.
-  patch :DATA
+  depends_on "giflib"
+  depends_on "libpng"
 
   def install
-    # TODO: Libming also includes scripting front-ends for Perl, Python, TCL
-    # and PHP. These are disabled by default. Figure out what it would take to
-    # enable them.
-    # - python works if we tell it to use our giflib not ungif.
-    # - perl works without any change
-    # - php builds, but tries to install to /usr/lib/php/extensions
-    # - tcl does not work, might need an older tcl, missing symbols.
-    args = %W[
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --prefix=#{prefix}
-    ]
-    args << "--enable-python" if build.with? "python"
-    args << "--enable-perl" if build.with? "perl"
-    args << "--enable-php" if build.with? "php"
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--enable-perl",
+                          "--enable-python"
+    system "make", "DEBUG=", "install"
+  end
 
-    system "./configure", *args
-    system "make"
-
-    # Won't install in parallel for some reason.
-    ENV.deparallelize
-    system "make", "install"
+  test do
+    (testpath/"test.c").write <<-'EOS'.undent
+      #include <ming.h>
+      int main() {
+        Ming_setScale(40.0);
+        printf("scale %f\n", Ming_getScale());
+        return Ming_init() != 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lming", "-I#{include}"
+    assert_match "scale 40.0", shell_output("./test")
   end
 end
-
-__END__
---- a/py_ext/setup.py.in	2011-10-25 23:33:18.000000000 -0700
-+++ b/py_ext/setup.py.in	2012-09-04 13:39:52.000000000 -0700
-@@ -19,7 +19,7 @@
- 	mylibs.append('png')
- 
- if "@GIFLIB@":
--	mylibs.append("ungif")
-+	mylibs.append("gif")
- 
- 
- setup(name = "mingc", version = "@MING_VERSION@",


### PR DESCRIPTION
add a test
always depend on giflib
always build the python and perl extensions
remove the php option since it violates the sandbox