### PR TITLE
kubernetes-helm: revision for non-cgo root cert discovery fix

### DIFF
--- a/Formula/kubernetes-helm.rb
+++ b/Formula/kubernetes-helm.rb
@@ -4,6 +4,7 @@ class KubernetesHelm < Formula
   url "https://github.com/kubernetes/helm.git",
       :tag => "v2.1.3",
       :revision => "5cbc48fb305ca4bf68c26eb8d2a7eb363227e973"
+  revision 1
   head "https://github.com/kubernetes/helm.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related to #8576 and https://github.com/kubernetes/helm/issues/1749.