### PR TITLE
wireguard-tools 0.0.20170115

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -3,8 +3,8 @@ class WireguardTools < Formula
   homepage "https://www.wireguard.io/"
   # Please only update version when the tools have been modified/updated,
   # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20170105.tar.xz"
-  sha256 "1bd990eeae6fbf599ccddde81caa92770f58623ad9705f875bcfab8254583896"
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20170115.tar.xz"
+  sha256 "7e5f9f4699a2d4ace90d0df5d81bf0f67205ee08c45b95e0acc379bedef5ffe8"
   head "https://git.zx2c4.com/WireGuard", :using => :git
 
   bottle do


### PR DESCRIPTION
Just a version bump, but there are some important tool changes here to assist authors writing WireGuard clients for Mac, so it's important this gets merged.