### PR TITLE
gcc: add gcc@6 alias.

### DIFF
--- a/Aliases/gcc@6
+++ b/Aliases/gcc@6
@@ -1,0 +1,1 @@
+../Formula/gcc.rb

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -27,6 +27,7 @@
   "gcc49": "gcc@4.9",
   "gcc5": "gcc@5",
   "gcc6": "gcc",
+  "gcc@6": "gcc",
   "geode": "apache-geode",
   "glfw3": "glfw",
   "gmp4": "gmp@4",


### PR DESCRIPTION
This is useful now https://github.com/Homebrew/brew/pull/1847 is merged in order to allow people to not upgrade to gcc 7 when it comes along if they `brew install gcc@6`.

CC @shanematley and @ilovezfs as we talked about this.