### PR TITLE
git-recent 1.0.3 (new formula)

### DIFF
--- a/Formula/git-recent.rb
+++ b/Formula/git-recent.rb
@@ -1,0 +1,20 @@
+class GitRecent < Formula
+  desc "See your latest local git branches, formatted real fancy"
+  homepage "https://github.com/paulirish/git-recent"
+  url "https://github.com/paulirish/git-recent/archive/v1.0.3.tar.gz"
+  sha256 "2ea954f3c1cc3917ad1a0ff5cd361dff7c3f82410bd464a9f5decb0a539155ff"
+
+  def install
+    bin.install "git-recent"
+  end
+
+  test do
+    system "git", "init"
+    system "git", "recent"
+    # User will be 'BrewTestBot' on CI, needs to be set here to work locally
+    system "git", "config", "user.name", "BrewTestBot"
+    system "git", "config", "user.email", "brew@test.bot"
+    system "git", "commit", "--allow-empty", "-m", "test_commit"
+    assert_match(/.*master.*seconds? ago.*BrewTestBot.*\n.*test_commit/, shell_output("git recent"))
+  end
+end


### PR DESCRIPTION
Adds git-recent [0] - a git utility for listing the users' most recently active branches.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

[0] - https://github.com/paulirish/git-recent