### PR TITLE
aactivator 1.0.0 (new formula)

### DIFF
--- a/Formula/aactivator.rb
+++ b/Formula/aactivator.rb
@@ -1,0 +1,27 @@
+class Aactivator < Formula
+  include Language::Python::Virtualenv
+
+  desc "Automatically source and unsource a project's environment"
+  homepage "https://github.com/Yelp/aactivator"
+  url "https://github.com/Yelp/aactivator/archive/v1.0.0.tar.gz"
+  sha256 "395430f9dbabd2644a030d534761899165e2d5c8cb5aa71bf620808543cdfb02"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  def caveats; <<-EOS.undent
+    To add aactivator to your shell, add the following line to your .bashrc or .zshrc:
+
+       eval "$(aactivator init)"
+
+    More information: https://github.com/Yelp/aactivator
+    EOS
+  end
+
+  test do
+    assert_match "aactivator", shell_output("#{bin}/aactivator -h")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Yelp/aactivator/issues/16

This adds [aactivator](https://github.com/Yelp/aactivator) to homebrew. aactivator will automatically source and unsource a project's python virtual environment.