### PR TITLE
tesseract: fix missing build dependency to autoconf-archive

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -16,6 +16,7 @@ class Tesseract < Formula
     url "https://github.com/tesseract-ocr/tesseract.git"
 
     depends_on "autoconf" => :build
+    depends_on "autoconf-archive" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
     depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds the `autoconf-archive` dependency which is required to build from `HEAD`.
See [this section](https://github.com/tesseract-ocr/tesseract/wiki/Compiling#install-dependencies) of the documentation and the issue https://github.com/tesseract-ocr/tesseract/issues/647.