### PR TITLE
dropbox-uploader: Install dropShell.sh to $PATH

### DIFF
--- a/Formula/dropbox-uploader.rb
+++ b/Formula/dropbox-uploader.rb
@@ -7,7 +7,7 @@ class DropboxUploader < Formula
   bottle :unneeded
 
   def install
-    bin.install "dropbox_uploader.sh"
+    bin.install "dropbox_uploader.sh", "dropShell.sh"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[Dropbox-Uploader](https://github.com/andreafabrizi/Dropbox-Uploader) exposes two executables, `dropbox_uploader.sh` and `dropShell.sh`. Only the first was being installed. This PR installs the other.