### PR TITLE
Rollback apt-dater to v0.9.0

### DIFF
--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -1,8 +1,8 @@
 class AptDater < Formula
   desc "Manage package updates on remote hosts using SSH"
   homepage "https://github.com/DE-IBH/apt-dater"
-  url "https://github.com/DE-IBH/apt-dater/archive/v1.0.3.tar.gz"
-  sha256 "891b15e4dd37c7b35540811bbe444e5f2a8d79b1c04644730b99069eabf1e10f"
+  url "https://github.com/DE-IBH/apt-dater/archive/v0.9.0.tar.gz"
+  sha256 "1c361dd686d66473b27db4af8d241d520535c5d5a33f42a35943bf4e16c13f47"
 
   bottle do
     sha256 "e4062b5a3202e29cd57cf95328348c20022857ec4486056dcc8bf9c10da5e97a" => :sierra

--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -3,6 +3,7 @@ class AptDater < Formula
   homepage "https://github.com/DE-IBH/apt-dater"
   url "https://github.com/DE-IBH/apt-dater/archive/v0.9.0.tar.gz"
   sha256 "1c361dd686d66473b27db4af8d241d520535c5d5a33f42a35943bf4e16c13f47"
+  version_scheme 1
 
   bottle do
     sha256 "e4062b5a3202e29cd57cf95328348c20022857ec4486056dcc8bf9c10da5e97a" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Does not pass audit only because of "stable version should not decrease (from 1.0.3 to 0.9.0)".

Please see https://github.com/Homebrew/homebrew-core/pull/8924#issuecomment-273152828 for reason to rollback. Thanks.