### PR TITLE
riak 2.2.0

### DIFF
--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -9,7 +9,6 @@ class Riak < Formula
 
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
-  depends_on "openssl"
 
   def install
     logdir = var + "log/riak"

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -9,6 +9,7 @@ class Riak < Formula
 
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
+  depends_on "openssl"
 
   def install
     logdir = var + "log/riak"

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -1,9 +1,9 @@
 class Riak < Formula
   desc "Distributed database"
   homepage "https://basho.com/products/#riak"
-  url "https://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.4/osx/10.8/riak-2.1.4-OSX-x86_64.tar.gz"
-  version "2.1.4"
-  sha256 "ece75fa1d1ac89525162537ac3cb258c37da5adf0f03b6a04cc49e9f29cbfb8a"
+  url "http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/osx/10.8/riak-2.2.0-OSX-x86_64.tar.gz"
+  version "2.2.0"
+  sha256 "51ea63d6efaa3bba4efb0ca13de81da2e2662b6691b4132cf552ca7635c8a857"
 
   bottle :unneeded
 

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -1,6 +1,6 @@
 class Riak < Formula
   desc "Distributed database"
-  homepage "https://basho.com/products/#riak"
+  homepage "http://basho.com/products/riak-kv/"
   url "http://s3.amazonaws.com/downloads.basho.com/riak/2.2/2.2.0/osx/10.8/riak-2.2.0-OSX-x86_64.tar.gz"
   version "2.2.0"
   sha256 "51ea63d6efaa3bba4efb0ca13de81da2e2662b6691b4132cf552ca7635c8a857"

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -9,11 +9,11 @@ class Riak < Formula
 
   # Broken dylib links (should be fixed in 2.2.1)
   # https://github.com/basho/eleveldb/issues/236
-  
+
   # Currently refuses to use non-system OpenSSL
   # https://github.com/basho/riak/issues/888
   # depends_on "openssl"
-  
+
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
 
@@ -39,6 +39,6 @@ class Riak < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/riak version")    
+    assert_match version.to_s, shell_output("#{bin}/riak version")
   end
 end

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -30,4 +30,8 @@ class Riak < Formula
     bin.write_exec_script libexec/"bin/riak-debug"
     bin.write_exec_script libexec/"bin/search-cmd"
   end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/riak version")    
+  end
 end

--- a/Formula/riak.rb
+++ b/Formula/riak.rb
@@ -7,6 +7,13 @@ class Riak < Formula
 
   bottle :unneeded
 
+  # Broken dylib links (should be fixed in 2.2.1)
+  # https://github.com/basho/eleveldb/issues/236
+  
+  # Currently refuses to use non-system OpenSSL
+  # https://github.com/basho/riak/issues/888
+  # depends_on "openssl"
+  
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
The build process audit did throw this warning but the riak binary does return a version correctly so I don't have enough info what's the best way to proceed.

```
==> Installing or updating 'rubocop' gem
Fetching: rubocop-0.45.0.gem (100%)
Successfully installed rubocop-0.45.0
1 gem installed
riak:
  * A `test do` test block should be added
  * object files were linked against system openssl
    These object files were linked against the deprecated system OpenSSL or
    the system's private LibreSSL.
    Adding `depends_on "openssl"` to the formula may help.
      /usr/local/Cellar/riak/2.2.0/libexec/lib/crypto-3.1/priv/lib/crypto.so
  * The installation was broken.
    Broken dylib links found:
      /Users/buildbot/masters/riak/riak-build-osx-108-64/build/distdir/riak-2.2.0/deps/eleveldb/c_src/system/lib/libsnappy.1.dylib
Error: 3 problems in 1 formula
```

-----
