### PR TITLE
apk-patch-size-estimator 0.2 (new formula)

### DIFF
--- a/Formula/apk-patch-size-estimator.rb
+++ b/Formula/apk-patch-size-estimator.rb
@@ -1,0 +1,19 @@
+class ApkPatchSizeEstimator < Formula
+  desc "Estimates the size of Play patches / gzipped APKs."
+  homepage "https://github.com/googlesamples/apk-patch-size-estimator"
+  url "https://github.com/googlesamples/apk-patch-size-estimator/archive/0.2.tar.gz"
+  sha256 "cbab54effbbbb2abf3ddb58cf004e8ee0e38b520fbc5266f08a5fd6a8cf9c9ff"
+  depends_on "bsdiff"
+
+  def install
+    libexec.install Dir["*"]
+
+    Dir.glob("#{libexec}/*.py") do |script|
+      bin.install_symlink script => File.basename(script, ".py").tr("_", "-")
+    end
+  end
+
+  test do
+    assert_match /^usage: apk-patch-size-estimator/, shell_output("#{bin}/apk-patch-size-estimator --help").strip
+  end
+end


### PR DESCRIPTION
This adds apk-patch-size-estimator to Homebrew. This tool Estimates the size of Google Play patches and the new gzipped APK.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
