### PR TITLE
ansible: fix install

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -546,7 +546,7 @@ class Ansible < Formula
 
   def install
     # https://github.com/Homebrew/homebrew-core/issues/7197
-    ENV.prepend "CPPFLAGS", "-I#{MacOS.sdk.path}/usr/include/ffi"
+    ENV.prepend "CPPFLAGS", "-I#{MacOS.sdk_path}/usr/include/ffi"
 
     inreplace "lib/ansible/constants.py" do |s|
       s.gsub! "/usr/share/ansible", pkgshare


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  - I built formula using `brew install <formula>` and I eye-balled installation from source (I have non-standard prefix).
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Error was:
```
==> Downloading https://releases.ansible.com/ansible/ansible-2.2.1.0.tar.gz
Already downloaded: .../Homebrew/ansible-2.2.1.0.tar.gz
Error: undefined method `path' for nil:NilClass
Please report this bug:
  http://docs.brew.sh/Troubleshooting.html
.../homebrew/Library/Taps/homebrew/homebrew-core/Formula/ansible.rb:549:in `install'
```