### PR TITLE
remove mirror as the file is no longer present

### DIFF
--- a/Formula/oath-toolkit.rb
+++ b/Formula/oath-toolkit.rb
@@ -2,7 +2,6 @@ class OathToolkit < Formula
   desc "Tools for one-time password authentication systems"
   homepage "http://www.nongnu.org/oath-toolkit/"
   url "https://download.savannah.gnu.org/releases/oath-toolkit/oath-toolkit-2.6.1.tar.gz"
-  mirror "https://fossies.org/linux/privat/oath-toolkit-2.6.1.tar.gz"
   sha256 "9c57831907bc26eadcdf90ba1827d0bd962dd1f737362e817a1dd6d6ec036f79"
 
   bottle do


### PR DESCRIPTION
```
==> Installing openconnect dependency: oath-toolkit
==> Downloading https://download.savannah.gnu.org/releases/oath-toolkit/oath-toolkit-2.6.1.tar.gz
==> Downloading from http://mirrors.cicku.me/savannah//oath-toolkit/oath-toolkit-2.6.1.tar.gz
HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set.
Trying a mirror...
==> Downloading https://fossies.org/linux/privat/oath-toolkit-2.6.1.tar.gz

curl: (22) The requested URL returned error: 410 Gone
Error: Failed to download resource "oath-toolkit"
Download failed: https://fossies.org/linux/privat/oath-toolkit-2.6.1.tar.gz
```