### PR TITLE
tundra (new formula)

### DIFF
--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -8,10 +8,9 @@ class Tundra < Formula
   def install
     system "make"
     system "make", "install", "PREFIX=#{prefix}"
-#    bin.install "tundra2"
   end
 
   test do
-    system "#{bin}/tundra -h"
+    system "#{bin}/tundra2 -h"
   end
 end

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -1,5 +1,5 @@
 class Tundra < Formula
-  desc "Code build system that tries to be accurate and fast for incremental builds"
+  desc "Code build system that tries to be fast for incremental builds"
   homepage "https://github.com/deplinenoise/tundra"
   url "https://github.com/deplinenoise/tundra/archive/v2.0.tar.gz"
   sha256 "0d9f2b756959db76619aab563b412fa9e8a8bbf6fe0fc44836a725febb2c7662"

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -1,5 +1,5 @@
 class Tundra < Formula
-  desc "Tundra is a code build system that tries to be accurate and fast for incremental builds"
+  desc "Code build system that tries to be accurate and fast for incremental builds"
   homepage "https://github.com/deplinenoise/tundra"
   url "https://github.com/deplinenoise/tundra/archive/469c9bfc3f1ff4b855f172cd874d0740734f292a.tar.gz"
   version "0.20161210"
@@ -11,6 +11,6 @@ class Tundra < Formula
   end
 
   test do
-    system "#{bin}/tundra2 -h"
+    system "#{bin}/tundra2",  "-h"
   end
 end

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -1,0 +1,17 @@
+class Tundra < Formula
+  desc "Tundra is a code build system that tries to be accurate and fast for incremental builds"
+  homepage "https://github.com/deplinenoise/tundra"
+  url "https://github.com/deplinenoise/tundra/archive/469c9bfc3f1ff4b855f172cd874d0740734f292a.tar.gz"
+  version "0.20161210"
+  sha256 "bee27c6df2b2960c2075e911fe04daa444b0185083a0c8615ee12434e7e23ed6"
+
+  def install
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+#    bin.install "tundra2"
+  end
+
+  test do
+    system "#{bin}/tundra -h"
+  end
+end

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -1,8 +1,8 @@
 class Tundra < Formula
   desc "Code build system that tries to be accurate and fast for incremental builds"
   homepage "https://github.com/deplinenoise/tundra"
-  url "https://github.com/deplinenoise/tundra/archive/469c9bfc3f1ff4b855f172cd874d0740734f292a.tar.gz"
-  version "0.20161210"
+  url "https://github.com/deplinenoise/tundra/archive/v2.0.tar.gz"
+  version "2.0"
   sha256 "bee27c6df2b2960c2075e911fe04daa444b0185083a0c8615ee12434e7e23ed6"
 
   def install

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -2,8 +2,7 @@ class Tundra < Formula
   desc "Code build system that tries to be accurate and fast for incremental builds"
   homepage "https://github.com/deplinenoise/tundra"
   url "https://github.com/deplinenoise/tundra/archive/v2.0.tar.gz"
-  version "2.0"
-  sha256 "bee27c6df2b2960c2075e911fe04daa444b0185083a0c8615ee12434e7e23ed6"
+  sha256 "0d9f2b756959db76619aab563b412fa9e8a8bbf6fe0fc44836a725febb2c7662"
 
   def install
     system "make"
@@ -11,6 +10,32 @@ class Tundra < Formula
   end
 
   test do
-    system "#{bin}/tundra2", "-h"
+    (testpath/"test.c").write <<-'EOS_SRC'.undent
+      #include <stdio.h>
+      int main() {
+        printf("Hello World\n");
+        return 0;
+      }
+    EOS_SRC
+    (testpath/"tundra.lua").write <<-'EOS_CONFIG'.undent
+      Build {
+        Units = function()
+          local test = Program {
+            Name = "test",
+            Sources = { "test.c" },
+          }
+          Default(test)
+        end,
+        Configs = {
+          {
+            Name = "macosx-clang",
+            DefaultOnHost = "macosx",
+            Tools = { "clang-osx" },
+          },
+        },
+      }
+    EOS_CONFIG
+    system bin/"tundra2"
+    system "./t2-output/macosx-clang-debug-default/test"
   end
 end

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -11,6 +11,6 @@ class Tundra < Formula
   end
 
   test do
-    system "#{bin}/tundra2",  "-h"
+    system "#{bin}/tundra2", "-h"
   end
 end


### PR DESCRIPTION
Version number hasn't changed in years, even though there are active commits, so using the last commit's date for the version number.
