### PR TITLE
webp: added HTTPS mirror

### DIFF
--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -3,6 +3,7 @@ class Webp < Formula
   homepage "https://developers.google.com/speed/webp/"
   url "http://downloads.webmproject.org/releases/webp/libwebp-0.5.2.tar.gz"
   # Because Google-hosted upstream URL gets firewalled in some countries.
+  mirror "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-0.5.2.tar.gz"
   sha256 "b75310c810b3eda222c77f6d6c26b061240e3d9060095de44b2c1bae291ecdef"
 
   bottle do


### PR DESCRIPTION
The URL is official, because https://developers.google.com/speed/webp/docs/compiling links there.
The linked file's SHA256 matches to the one already in the formula.
This mirror is useful for those users who block unencrypted connections by default.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
the only error reported by audit is
>   * macOS has been 64-bit only since 10.6 so universal options are deprecated.

this is unrelated to my change though.