### PR TITLE
Git: Don't require replacement of "lime" with "99ff00" in gitk

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -49,11 +49,6 @@ class Git < Formula
     ENV["PYTHON_PATH"] = which "python"
     ENV["PERL_PATH"] = which "perl"
 
-    # Support Tcl versions before "lime" color name was introduced
-    # https://github.com/Homebrew/homebrew-core/issues/115
-    # https://www.mail-archive.com/git%40vger.kernel.org/msg92017.html
-    inreplace "gitk-git/gitk", "lime", '"#99FF00"'
-
     perl_version = /\d\.\d+/.match(`perl --version`)
 
     if build.with? "brewed-svn"

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -55,7 +55,7 @@ class Git < Formula
     #
     # This has been resolved in Git (6e8fda5fd), which is currently present
     # in HEAD but not in the stable.  This should be removed later.
-    inreplace "gitk-git/gitk", "lime", '"#99FF00"' if build.head?
+    inreplace "gitk-git/gitk", "lime", '"#99FF00"' if build.stable?
 
     perl_version = /\d\.\d+/.match(`perl --version`)
 

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -49,6 +49,14 @@ class Git < Formula
     ENV["PYTHON_PATH"] = which "python"
     ENV["PERL_PATH"] = which "perl"
 
+    # Support Tcl versions before "lime" color name was introduced
+    # https://github.com/Homebrew/homebrew-core/issues/115
+    # https://www.mail-archive.com/git%40vger.kernel.org/msg92017.html
+    #
+    # This has been resolved in Git (6e8fda5fd), which is currently present
+    # in HEAD but not in the stable.  This should be removed later.
+    inreplace "gitk-git/gitk", "lime", '"#99FF00"' if build.head?
+
     perl_version = /\d\.\d+/.match(`perl --version`)
 
     if build.with? "brewed-svn"


### PR DESCRIPTION
It appears that the issue that the covered lines were introduced to solve, #115, was resolved upstream, and that we don't need to do this anymore.  As it stands, I get build errors when installing Git with the --HEAD flag, and this PR resolves them. (See #9202.)