### PR TITLE
OpenOCD 0.10.0 remove libftdi configure options

### DIFF
--- a/Formula/open-ocd.rb
+++ b/Formula/open-ocd.rb
@@ -42,13 +42,6 @@ class OpenOcd < Formula
       --enable-remote-bitbang
     ]
 
-    if build.with? "libftdi"
-      args << "--enable-usb_blaster_libftdi"
-      args << "--enable-presto_libftdi"
-      args << "--enable-openjtag_ftdi"
-      args << "--enable-legacy-ft2232_libftdi"
-    end
-
     ENV["CCACHE"] = "none"
 
     system "./bootstrap", "nosubmodule" if build.head?


### PR DESCRIPTION
Since 0.10.0 the drivers that depend on libftdi are enabled
automatically if libftdi is present, same as all the other USB
drivers, previous options are a no-op now.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>
