### PR TITLE
llvm@3.8: fix missing build targets

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -130,7 +130,6 @@ class Llvm < Formula
   option "with-python", "Build bindings against custom Python"
   option "with-shared-libs", "Build shared instead of static libraries"
   option "without-libffi", "Do not use libffi to call external functions"
-  option "with-all-targets", "Build all targets. Default targets: AMDGPU, ARM, NVPTX, and X86"
 
   depends_on "libffi" => :recommended # http://llvm.org/docs/GettingStarted.html#requirement
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
@@ -215,8 +214,8 @@ class Llvm < Formula
       -DLLVM_INSTALL_UTILS=ON
       -DWITH_POLLY=ON
       -DLINK_POLLY_INTO_TOOLS=ON
+      -DLLVM_TARGETS_TO_BUILD=all
     ]
-    args << "-DLLVM_TARGETS_TO_BUILD=#{build.with?("all-targets") ? "all" : "AMDGPU;ARM;NVPTX;X86"}"
     args << "-DLIBOMP_ARCH=x86_64"
     args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON" if build.with? "compiler-rt"
     args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=ON" if build.with? "toolchain"

--- a/Formula/llvm@3.7.rb
+++ b/Formula/llvm@3.7.rb
@@ -108,7 +108,7 @@ class LlvmAT37 < Formula
       --disable-bindings
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --enable-shared
-      --enable-targets=host
+      --enable-targets=all
       --enable-libffi
     ]
 

--- a/Formula/llvm@3.8.rb
+++ b/Formula/llvm@3.8.rb
@@ -86,6 +86,8 @@ class LlvmAT38 < Formula
 
   patch :DATA
 
+  option "with-all-targets", "Build all targets. Default: AMDGPU, ARM, NVPTX, and X86"
+
   depends_on "gnu-sed" => :build
   depends_on "gmp"
   depends_on "libffi"
@@ -127,9 +129,9 @@ class LlvmAT38 < Formula
       --disable-bindings
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --enable-shared
-      --enable-targets=host
       --enable-libffi
     ]
+    args << "--enable-targets=#{build.with?("all-targets") ? "all" : "amdgpu,arm,nvptx,x86"}"
 
     mktemp do
       system buildpath/"configure", *args

--- a/Formula/llvm@3.8.rb
+++ b/Formula/llvm@3.8.rb
@@ -86,8 +86,6 @@ class LlvmAT38 < Formula
 
   patch :DATA
 
-  option "with-all-targets", "Build all targets. Default: AMDGPU, ARM, NVPTX, and X86"
-
   depends_on "gnu-sed" => :build
   depends_on "gmp"
   depends_on "libffi"
@@ -129,9 +127,9 @@ class LlvmAT38 < Formula
       --disable-bindings
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --enable-shared
+      --enable-targets=all
       --enable-libffi
     ]
-    args << "--enable-targets=#{build.with?("all-targets") ? "all" : "amdgpu,arm,nvptx,x86"}"
 
     mktemp do
       system buildpath/"configure", *args


### PR DESCRIPTION
This seems to have been dropped in the transition to homebrew-core. Reverts to the old behaviour of building x86, ARM, NVPTX and AMDGPU targets by default, with this flag building all targets. This matches the behaviour of the llvm formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
