### PR TITLE
dnscrypt-proxy: remove minisign option on 10.10

### DIFF
--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -20,7 +20,7 @@ class DnscryptProxy < Formula
   depends_on "pkg-config" => :build
   depends_on "libtool" => :run
   depends_on "libsodium"
-  depends_on "minisign" => :recommended
+  depends_on "minisign" => :recommended if MacOS.version >= :el_capitan
   depends_on "ldns" => :recommended
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When running `dnscrypt-update-resolvers`, Yosemite's curl gets the error
"SSL peer handshake failed, the server most likely requires a client
certificate to connect."