### PR TITLE
Remove PowerPC support from GCC formula

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -1,17 +1,9 @@
 class Gcc < Formula
   def arch
-    if Hardware::CPU.type == :intel
-      if MacOS.prefer_64_bit?
-        "x86_64"
-      else
-        "i686"
-      end
-    elsif Hardware::CPU.type == :ppc
-      if MacOS.prefer_64_bit?
-        "powerpc64"
-      else
-        "powerpc"
-      end
+    if MacOS.prefer_64_bit?
+      "x86_64"
+    else
+      "i686"
     end
   end
 
@@ -53,12 +45,6 @@ class Gcc < Formula
   depends_on "isl"
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
-  if MacOS.version < :leopard
-    # The as that comes with Tiger isn't capable of dealing with the
-    # PPC asm that comes in libitm
-    depends_on "cctools" => :build
-  end
-
   fails_with :gcc_4_0
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
@@ -91,10 +77,6 @@ class Gcc < Formula
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
-
-    if MacOS.version < :leopard
-      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
-    end
 
     if build.with? "all-languages"
       # Everything but Ada, which requires a pre-existing GCC Ada compiler
@@ -129,7 +111,6 @@ class Gcc < Formula
       "--with-mpc=#{Formula["libmpc"].opt_prefix}",
       "--with-isl=#{Formula["isl"].opt_prefix}",
       "--with-system-zlib",
-      "--enable-libstdcxx-time=yes",
       "--enable-stage1-checking",
       "--enable-checking=release",
       "--enable-lto",
@@ -140,10 +121,6 @@ class Gcc < Formula
       "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
       "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
     ]
-
-    # "Building GCC with plugin support requires a host that supports
-    # -fPIC, -shared, -ldl and -rdynamic."
-    args << "--enable-plugin" if MacOS.version > :tiger
 
     # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
     # format to avoid failure during the stage 3 comparison of object files.


### PR DESCRIPTION
GCC 6.3.0 and trunk do not actively support powerpc OS X targets. The latest successful build and test-results reported were in 2014 for darwin8 (https://gcc.gnu.org/ml/gcc-testresults/2014-07/msg02093.html). Making the GCC formula shorter and simpler will makes maintenance easier.

- Drop support for powerpc
- Drop dependency on cctools that was ppc-only
- Forcing `AS` and `AS_FOR_TARGET` was pre-Leopard only and not required anymore
- `--enable-plugin` is the default (see gcc's `config/gcc-plugin.m4`)
- `--enable-libstdcxx-time=yes` is not necessary anymore as configure checks now work for darwin (see `libstdc++-v3/acinclude.m4`)

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
