### PR TITLE
Force using building GTK from source

### DIFF
--- a/Formula/eiffelstudio.rb
+++ b/Formula/eiffelstudio.rb
@@ -12,7 +12,7 @@ class Eiffelstudio < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gtk+"
+  depends_on "gtk+" => "build-from-source"
 
   def ise_platform
     if Hardware::CPU.ppc?


### PR DESCRIPTION
This allows to use the patched version of GTK that allows EiffelStudio to run.