### PR TITLE
qt@5.5: fixes Error building capybara-webkit against qt55 on MacOS Si…

### DIFF
--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -116,8 +116,18 @@ class QtAT55 < Formula
     inreplace prefix/"mkspecs/qconfig.pri", /\n\n# pkgconfig/, ""
     inreplace prefix/"mkspecs/qconfig.pri", /\nPKG_CONFIG_.*=.*$/, ""
 
+    # In Xcode 8 on Sierra, when Qt tries to find xcrun but should be looking
+    # for xcodebuild. The error is "Project ERROR: Xcode not set up properly.
+    # You may need to confirm the license agreement by running
+    # /usr/bin/xcodebuild."
     # see: https://github.com/Homebrew/homebrew-core/issues/8777
-    inreplace prefix/"mkspecs/features/mac/default_pre.prf", Regexp.escape('isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null")))'), 'isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null")))'
+    unless MacOS.version < :sierra
+      inreplace(
+        prefix/"mkspecs/features/mac/default_pre.prf",
+        /xcrun -find xcrun/,
+        "xcrun -find xcodebuild"
+      )
+    end
 
     # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and
     # because we don't like having them in `bin`. Also add a `-qt5` suffix to

--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -115,6 +115,9 @@ class QtAT55 < Formula
     inreplace prefix/"mkspecs/qconfig.pri", /\n\n# pkgconfig/, ""
     inreplace prefix/"mkspecs/qconfig.pri", /\nPKG_CONFIG_.*=.*$/, ""
 
+    # see: https://github.com/Homebrew/homebrew-core/issues/8777
+    inreplace prefix/"mkspecs/features/mac/default_pre.prf", Regexp.escape('isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null")))'), 'isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null")))'
+
     # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and
     # because we don't like having them in `bin`. Also add a `-qt5` suffix to
     # avoid conflict with the `*.app` bundles provided by the `qt` formula.

--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -6,6 +6,7 @@ class QtAT55 < Formula
   url "https://download.qt.io/archive/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
   mirror "https://www.mirrorservice.org/sites/download.qt-project.org/archive/qt/5.5/5.5.1/single/qt-everywhere-opensource-src-5.5.1.tar.xz"
   sha256 "6f028e63d4992be2b4a5526f2ef3bfa2fe28c5c757554b11d9e8d86189652518"
+  revision 1
 
   # Build error: Fix library detection for QtWebEngine with Xcode 7.
   # https://codereview.qt-project.org/#/c/1w27759/

--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -116,17 +116,14 @@ class QtAT55 < Formula
     inreplace prefix/"mkspecs/qconfig.pri", /\n\n# pkgconfig/, ""
     inreplace prefix/"mkspecs/qconfig.pri", /\nPKG_CONFIG_.*=.*$/, ""
 
-    # In Xcode 8 on Sierra, when Qt tries to find xcrun but should be looking
-    # for xcodebuild. The error is "Project ERROR: Xcode not set up properly.
-    # You may need to confirm the license agreement by running
+    # In Xcode 8 (especially on Sierra), Qt tries to find xcrun but should be
+    # looking for xcodebuild. The error is "Project ERROR: Xcode not set up
+    # properly. You may need to confirm the license agreement by running
     # /usr/bin/xcodebuild."
     # see: https://github.com/Homebrew/homebrew-core/issues/8777
-    unless MacOS.version < :sierra
-      inreplace(
-        prefix/"mkspecs/features/mac/default_pre.prf",
-        /xcrun -find xcrun/,
-        "xcrun -find xcodebuild"
-      )
+    if MacOS::Xcode.version >= "8.0"
+      inreplace prefix/"mkspecs/features/mac/default_pre.prf",
+                /xcrun -find xcrun/, "xcrun -find xcodebuild"
     end
 
     # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR is regarding issue https://github.com/Homebrew/homebrew-core/issues/8777
I work with @lukaso who raised the issue and have worked with him on the PR.

I've not been able to get the  `brew install --build-from-source` to work as the build time is 10 hours + as the compiling of QT takes a very long time.