### PR TITLE
grumpy --HEAD (new formula)

### DIFF
--- a/Formula/grumpy.rb
+++ b/Formula/grumpy.rb
@@ -1,0 +1,25 @@
+class Grumpy < Formula
+  desc "Python to Go source code transcompiler and runtime"
+  homepage "https://github.com/google/grumpy"
+  head "https://github.com/google/grumpy.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "make"
+    system "make", "DESTDIR=#{prefix}", "install"
+    system "mkdir", "-p", "#{bin}"
+    system "cp", "#{prefix}/usr/bin/grumpc", "#{bin}"
+    system "cp", "#{prefix}/usr/bin/grumprun", "#{bin}"
+    system "echo", "Do 'brew test grumpy' to see sample usage"
+    system "echo", "NOTE:  Before using grumpc and/or grumprun, you MUST:"
+    system "echo", "export GOPATH=#{prefix}/usr/lib/go"
+    system "echo", "export PYTHONPATH=#{prefix}/Library/Python/2.7/site-packages"
+  end
+
+  test do
+    system "GOPATH=#{prefix}/usr/lib/go"
+    system "PYTHONPATH=#{prefix}/Library/Python/2.7/site-packages"
+    system "echo", "\"print 'hello, grumpy world'\"", "\|", "grumprun"
+  end
+end

--- a/Formula/grumpy.rb
+++ b/Formula/grumpy.rb
@@ -15,8 +15,8 @@ class Grumpy < Formula
   def caveats
     <<-EOS.undent
       NOTE:  Before using grumpc and/or grumprun, you MUST:
-      export GOPATH="#{prefix}/usr/lib/go"
-      export PYTHONPATH="#{prefix}/Library/Python/2.7/site-packages"
+      export GOPATH="$(brew --prefix grumpy)/usr/lib/go"
+      export PYTHONPATH="$(brew --prefix grumpy)/Library/Python/2.7/site-packages"
 
       Then you can test out grumpy with:
       echo "print 'hello, grumpy world'" | grumprun
@@ -24,8 +24,8 @@ class Grumpy < Formula
   end
 
   test do
-    ENV["GOPATH"] = #{prefix}/usr/lib/go
-    ENV["PYTHONPATH"] = #{prefix}/Library/Python/2.7/site-packages
+    ENV["GOPATH"] = "#{prefix}/usr/lib/go"
+    ENV["PYTHONPATH"] = "#{prefix}/Library/Python/2.7/site-packages"
     system "echo", "\"print 'hello, grumpy world'\"", "\|", "grumprun"
   end
 end

--- a/Formula/grumpy.rb
+++ b/Formula/grumpy.rb
@@ -3,23 +3,29 @@ class Grumpy < Formula
   homepage "https://github.com/google/grumpy"
   head "https://github.com/google/grumpy.git"
 
-  depends_on "go" => :build
+  depends_on "go"
 
   def install
     system "make"
     system "make", "DESTDIR=#{prefix}", "install"
-    system "mkdir", "-p", "#{bin}"
-    system "cp", "#{prefix}/usr/bin/grumpc", "#{bin}"
-    system "cp", "#{prefix}/usr/bin/grumprun", "#{bin}"
-    system "echo", "Do 'brew test grumpy' to see sample usage"
-    system "echo", "NOTE:  Before using grumpc and/or grumprun, you MUST:"
-    system "echo", "export GOPATH=#{prefix}/usr/lib/go"
-    system "echo", "export PYTHONPATH=#{prefix}/Library/Python/2.7/site-packages"
+    bin.install "#{prefix}/usr/bin/grumpc"
+    bin.install "#{prefix}/usr/bin/grumprun"
+  end
+
+  def caveats
+    <<-EOS.undent
+      NOTE:  Before using grumpc and/or grumprun, you MUST:
+      export GOPATH="#{prefix}/usr/lib/go"
+      export PYTHONPATH="#{prefix}/Library/Python/2.7/site-packages"
+
+      Then you can test out grumpy with:
+      echo "print 'hello, grumpy world'" | grumprun
+    EOS
   end
 
   test do
-    system "GOPATH=#{prefix}/usr/lib/go"
-    system "PYTHONPATH=#{prefix}/Library/Python/2.7/site-packages"
+    ENV["GOPATH"] = #{prefix}/usr/lib/go
+    ENV["PYTHONPATH"] = #{prefix}/Library/Python/2.7/site-packages
     system "echo", "\"print 'hello, grumpy world'\"", "\|", "grumprun"
   end
 end


### PR DESCRIPTION
Google Grumpy is a Python to Go source code transcompiler and runtime.

This should fix https://github.com/Homebrew/homebrew-core/issues/9213

The export of the correct GOPATH and PYTHONPATH are essential to the proper function of these tools.

`Audit --strict` seems to want me to learn the Ruby programming language in order to work with Go and Python.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
