### PR TITLE
inkscape: Import from homebrew-gui

### DIFF
--- a/Formula/inkscape.rb
+++ b/Formula/inkscape.rb
@@ -1,0 +1,73 @@
+class Inkscape < Formula
+  desc "Professional vector graphics editor"
+  homepage "https://inkscape.org/"
+  url "https://inkscape.org/gallery/item/10552/inkscape-0.92.0.tar.bz2"
+  mirror "https://mirrors.kernel.org/debian/pool/main/i/inkscape/inkscape_0.92.orig.tar.gz"
+  sha256 "b8b4c159a00448d465384533e5a70d3f33e5f9c6b74c76ea5d636ddd6dd7ba56"
+
+  bottle do
+    sha256 "16d7547e6b69e6c39aaba1dc35429a09f202c1c80aa6c8858e2db9d43279fc46" => :sierra
+    sha256 "7fbf9abafaf5aad37041122e0f0b8ca110df282cd3efffc3adea73c45eee4014" => :el_capitan
+    sha256 "b46487ca8fc59b9c8dd861a48d1619f7a26bba37277babd1ec3a05a69366278b" => :yosemite
+  end
+
+  head do
+    url "lp:inkscape", :using => :bzr
+  end
+
+  option "with-gtk3", "Build Inkscape with GTK+3 (Experimental)"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "boost-build" => :build
+  depends_on "intltool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "poppler" => :optional
+  depends_on "bdw-gc"
+  depends_on "boost"
+  depends_on "cairomm"
+  depends_on "gettext"
+  depends_on "glibmm"
+  depends_on "gsl"
+  depends_on "hicolor-icon-theme"
+  depends_on "little-cms"
+  depends_on "pango"
+  depends_on "popt"
+
+  depends_on "gtkmm3" if build.with? "gtk3"
+  depends_on "gdl" if build.with? "gtk3"
+  depends_on "gtkmm" if build.without? "gtk3"
+
+  needs :cxx11
+
+  if MacOS.version < :mavericks
+    fails_with :clang do
+      cause "inkscape's dependencies will be built with libstdc++ and fail to link."
+    end
+  end
+
+  def install
+    ENV.cxx11
+    ENV.append "LDFLAGS", "-liconv"
+
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --disable-strict-build
+      --enable-lcms
+      --without-gnome-vfs
+    ]
+    args << "--disable-poppler-cairo" if build.without? "poppler"
+    args << "--enable-gtk3-experimental" if build.with? "gtk3"
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/inkscape", "-x"
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -114,7 +114,6 @@
   "icmake": "homebrew/boneyard",
   "idcomments": "homebrew/boneyard",
   "ifuse": "homebrew/fuse",
-  "inkscape": "caskroom/cask",
   "iodine": "homebrew/boneyard",
   "ipe": "homebrew/boneyard",
   "ipopt": "homebrew/science",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Inkscape formula in homebrew-gui was deprecated in favour the Inkscape cask. However, the Inkscape project has decided to abandon producing official Mac releases (for the time being) as of release 0.92, leaving the cask stuck at 0.91.

Having followed the discussion about this on the inkscape-devel mailing list, users are being pointed towards using macports to get the 0.92 release. In light of this, I propose resurrecting the formula from homebrew-gui here in homebrew-core. At least until official releases are available again in the future to bring the cask up-to-date.

The version of the formula is the same as the last version from homebrew-gui, modified to meet the `brew audit --strict` requirements.