### PR TITLE
[WIP] v8@5.8 5.8.60 (new formula)

### DIFF
--- a/Formula/v8@5.8.rb
+++ b/Formula/v8@5.8.rb
@@ -1,0 +1,118 @@
+# Track Chrome stable.
+# https://omahaproxy.appspot.com/
+class V8AT58 < Formula
+  desc "Google's JavaScript engine"
+  homepage "https://github.com/v8/v8/wiki"
+  url "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+  version "5.8.60"
+
+  keg_only "Provided V8 formula is co-installable and it is not installed in the library path."
+
+  # not building on Yosemite
+  # https://bugs.chromium.org/p/chromium/issues/detail?id=620127
+  depends_on :macos => :el_capitan
+
+  # depot_tools/GN require Python 2.7+
+  depends_on :python => :build
+
+  needs :cxx11
+
+
+  def install
+    (buildpath/"depot_tools").install buildpath.children - [buildpath/".brew_home"]
+    # This env variable used by gclient to prevent depot_tools to update depot_tools on every call
+    # see https://www.chromium.org/developers/how-tos/depottools#TOC-Disabling-auto-update
+    ENV["DEPOT_TOOLS_UPDATE"] = "0"
+    ENV.prepend_path "PATH", buildpath/"depot_tools"
+
+    system "gclient", "root"
+    system "gclient", "config", "--spec", <<-EOS.undent
+      solutions = [
+        {
+          "url": "https://chromium.googlesource.com/v8/v8.git",
+          "managed": False,
+          "name": "v8",
+          "deps_file": "DEPS",
+          "custom_deps": {},
+        },
+      ]
+      target_os = [ "mac" ]
+      target_os_only = True
+    EOS
+
+    # For formula development purposes we may want to avoid fetching v8 on every call as it is time-consuming,
+    # so we backup/restore fetched v8 sources to directory specified in DEV_CACHE_DEPS env variable (if any).
+    # To refresh cache you have to delete cached v8 folder (the one you pass as DEV_CACHE_DEPS), and it will be
+    # refreshed on a next run
+    cache_location = ENV["DEV_CACHE_DEPS"]
+    # For formula development purposes we may want to avoid syncing v8 sources and deps (to avoid full rebuild)
+    # so when DEV_NO_SYNC env variable passed alongside DEV_CACHE_DEPS, no v8 sync will be done.
+    no_sync = ENV["DEV_NO_SYNC"]
+
+    # Note: at this time we don't run tests
+    # For formula development purposes we may want to avoid running full v8 test suite as it's time consuming.
+    # run_tests = ENV["DEV_RUN_TESTS"]
+    # Always run tests when formula is being built as a bottle (uncomment below to make that happened)
+    # run_tests = build.bottle? || ENV["DEV_RUN_TESTS"]
+
+    # We consider x.y-lkgr as our version branch HEAD because v8 doesn't have version major.minor branches and
+    # real HEAD on v8 will point to master, so lkgr is the best simple ans reliable way to get latest version.
+    # Normally, it is just a few releases behind real latest version and as v8 releases quite often, it's ok.
+    v8_version = build.head? ? "5.8-lgkr" : version
+
+    if cache_location and File.directory?(cache_location)
+      cp_r(cache_location, "v8")
+    else
+      system "gclient", "sync", "-vvv", "-j #{Hardware::CPU.cores}", "-r", v8_version unless no_sync
+
+      if cache_location and !File.exist?(cache_location)
+        cp_r("v8", cache_location)
+      end
+    end
+
+    cd "v8" do
+      arch = MacOS.prefer_64_bit? ? "x64" : "x86"
+      output_name = "#{arch}.release"
+      output_path = "out.gn/#{output_name}"
+
+      # Configure build
+      gn_args = {
+        is_debug: false,
+        is_component_build: true,
+        v8_use_external_startup_data: false,
+      }
+
+      # Patch d8 (1/2) to make it relocatable: allows icudtl.dat being loaded from keg shared directory
+      inreplace "src/d8.cc",
+                "v8::V8::InitializeICUDefaultLocation(argv[0],",
+                "v8::V8::InitializeICUDefaultLocation(\"#{share}/\","
+
+      gn_command = "gn gen #{output_path} --args=\"#{gn_args.map { |k, v| "#{k}=#{v}" }.join(' ')}\""
+      system gn_command
+
+      system "ninja", "-j #{Hardware::CPU.cores}", "-v", "-C", output_path
+
+      # As we patched d8, we now need to have that new ICU data location to be created before we run tests,
+      # at this time we just ignore running tests rather then playing with running that tests
+      #system "tools/run-tests.py", "--outdir", output_path if run_tests
+
+      # Patch d8 (2/2) to make it relocatable: specify valid @rpath
+      File.chmod(0777, "#{output_path}/d8")
+      system "install_name_tool", "-add_rpath", lib, "#{output_path}/d8"
+      File.chmod(0555, "#{output_path}/d8")
+
+      include.install Dir["include/*"]
+
+      cd output_path do
+        lib.install Dir["lib*.dylib"]
+        share.install "icudtl.dat"
+        bin.install "d8" => "v8"
+      end
+    end
+  end
+
+  test do
+    assert_equal "Hello World!", pipe_output("#{bin}/v8 -e 'print(\"Hello World!\")'").chomp
+    assert_equal "12/20/2012", pipe_output("#{bin}/v8 -e 'var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0)); print(new Intl.DateTimeFormat(\"en-US\").format(date));'").chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

As discussed and proposed in #9343 and https://github.com/Homebrew/brew/issues/620#issuecomment-275857021

Rationale: I actively use latest v8 in [php-v8](https://github.com/pinepain/php-v8) PHP extension and I plan to make it available on homebrew (within `homebrew/php` tap). I already have formulae in [pinepain/devtools](https://github.com/pinepain/homebrew-devtools) tap, but want to make it available to larger audience. As building v8 is time-consuming, it would be nice to have it built once and hosted for all of us. Also, other formulae may utilize this version and thus move to versioned approach to reduce PITA level with preserving BC.

I would take about this formulae and will update it as mentioned in https://github.com/Homebrew/brew/issues/620#issuecomment-275857021, on monthly basis (or weekly, but it may abuse build system as building v8 is very time and resource consuming) to any v8  5.8.x changes. After v8 5.8 become stable, I will update it only if BC-compatible changes appears in public interface (`v8.h` only at this time as other things are highly volatile at this time).

FTR, I already package v8 for Ubuntu for more then a year, (see libv8-* PPAs at https://launchpad.net/~pinepain, packaging scripts are under https://github.com/pinepain/ppa-packaging), so I more or less into it and have some perspective of how much fun is to build v8. 

There are some PRs about updating v8 version at this time:
 - #9343 - which focuses only on having d8 and based on my formula which also includes d8, but as that PR targets updating `v8` version from 5.1 to 5.8 it will break all dependent formulae, v8 doesn't follow semver at all and can introduce BC-incompatible changes in patch versions.
- #7168 - which did an awesome work to adapt formula to new v8 build approach (they changed it somewhere at 5.4 or 5.5). This PR targets to update v8 from 5.1 to 5.4 which doesn't make much practical sense as it will also break BC and 5.4 is a bit outdated nowadays (5.6 is stable one). Also, this PR is not finished for some reasons, though, I highly appreciate it author, @Alhadis efforts. I used this PR as a reference to update own v8 version under [pinepain/devtools](https://github.com/pinepain/homebrew-devtools) tap.

Credits:
 - all `v8` formula contributors and maintainer;
 - @Alhadis for his efforts to deal with v8 build system changes in #7168;
 - @oaleynik for bringing up the question to update v8 in #9343 and all;
 - @ilovezfs, @mathiasbynens with commenters and reviewers on that PRs and formulae.

