### PR TITLE
portaudio 19.6.0

### DIFF
--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -4,6 +4,7 @@ class Portaudio < Formula
   url "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz"
   version "19.6.0"
   sha256 "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
+  version_scheme 1
   head "https://git.assembla.com/portaudio.git"
 
   bottle do

--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -1,9 +1,10 @@
 class Portaudio < Formula
   desc "Cross-platform library for audio I/O"
   homepage "http://www.portaudio.com"
-  url "http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz"
-  sha256 "8fe024a5f0681e112c6979808f684c3516061cc51d3acc0b726af98fc96c8d57"
-  head "https://subversion.assembla.com/svn/portaudio/portaudio/trunk/", :using => :svn
+  url "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz"
+  version "19.6.0"
+  sha256 "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
+  head "https://git.assembla.com/portaudio.git"
 
   bottle do
     cellar :any
@@ -15,16 +16,13 @@ class Portaudio < Formula
     sha256 "1386972e0632b4ebe2b2770f1ade4c5921c7726fb7fa70f764f5fe09df085c5e" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}",
                           "--disable-debug",
                           "--disable-dependency-tracking",
-                          "--enable-mac-universal=#{build.universal? ? "yes" : "no"}",
+                          "--enable-mac-universal=no",
                           "--enable-cxx"
     system "make", "install"
 

--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -30,4 +30,29 @@ class Portaudio < Formula
     # Need 'pa_mac_core.h' to compile PyAudio
     include.install "include/pa_mac_core.h"
   end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+      #include "portaudio.h"
+
+      int main(){
+        printf("%s",Pa_GetVersionInfo()->versionText);
+      }
+    EOS
+
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <iostream>
+      #include "portaudiocpp/System.hxx"
+
+      int main(){
+        std::cout << portaudio::System::versionText();
+      }
+    EOS
+
+    system ENV.cc, testpath/"test.c", "-lportaudio", "-o", "test"
+    system ENV.cxx, testpath/"test.cpp", "-lportaudiocpp", "-o", "test_cpp"
+    assert_match version.to_s, shell_output(testpath/"test")
+    assert_match version.to_s, shell_output(testpath/"test_cpp")
+  end
 end

--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -50,9 +50,9 @@ class Portaudio < Formula
       }
     EOS
 
-    system ENV.cc, testpath/"test.c", "-lportaudio", "-o", "test"
-    system ENV.cxx, testpath/"test.cpp", "-lportaudiocpp", "-o", "test_cpp"
-    assert_match version.to_s, shell_output(testpath/"test")
-    assert_match version.to_s, shell_output(testpath/"test_cpp")
+    system ENV.cc, testpath/"test.c", "-I#{include}", "-L#{lib}", "-lportaudio", "-o", "test"
+    system ENV.cxx, testpath/"test.cpp", "-I#{include}", "-L#{lib}", "-lportaudiocpp", "-o", "test_cpp"
+    assert_match stable.version.to_s, shell_output(testpath/"test")
+    assert_match stable.version.to_s, shell_output(testpath/"test_cpp")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Also remove universal binary support since audit says it's deprecated.