### PR TITLE
ice: add python support

### DIFF
--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -18,12 +18,14 @@ class Ice < Formula
 
   option "with-additional-compilers", "Build additional Slice compilers (slice2py, slice2js, slice2rb)"
   option "with-java", "Build Ice for Java and the IceGrid GUI app"
+  option "without-python", "Build without Ice for Python"
   option "without-xcode-sdk", "Build without the Xcode SDK for iOS development (includes static libs)"
 
   depends_on "mcpp"
   depends_on "lmdb"
   depends_on :java => ["1.8+", :optional]
   depends_on :macos => :mavericks
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
 
   def install
     # Ensure Gradle uses a writable directory even in sandbox mode
@@ -37,8 +39,17 @@ class Ice < Formula
       "CONFIGS=shared cpp11-shared #{build.with?("xcode-sdk") ? "xcodesdk cpp11-xcodesdk" : ""}",
       "PLATFORMS=all",
       "SKIP=slice2confluence #{build.without?("additional-compilers") ? "slice2py slice2rb slice2js" : ""}",
-      "LANGUAGES=cpp objective-c #{build.with?("java") ? "java java-compat" : ""}",
+      "LANGUAGES=cpp objective-c #{build.with?("java") ? "java java-compat" : ""} #{build.with?("python") ? "python" : ""}",
     ]
+
+    if build.with? "python"
+      args << "PYTHON_LIB_NAME=-Wl,-undefined,dynamic_lookup"
+      cd "python" do
+        inreplace "config/install_dir", "print(e.install_dir)", "print('#{lib}/python2.7/site-packages')"
+        inreplace "config/Make.rules", /^python_ldflags\s*:=\s*-L\$\(PYTHON_LIB_DIR\) -l\$\(PYTHON_LIB_NAME\)$/, "python_ldflags := -Wl,-undefined,dynamic_lookup"
+      end
+    end
+
     system "make", "install", *args
   end
 
@@ -76,5 +87,8 @@ class Ice < Formula
     system ENV.cxx, "-DICE_CPP11_MAPPING", "-std=c++11", "-c", "-I#{include}", "-I.", "Test.cpp"
     system ENV.cxx, "-L#{lib}", "-o", "test", "Test.o", "Hello.o", "-lIce++11"
     system "./test"
+    if build.with? "python"
+      system "python", "-c", "import Ice; Ice.initialize().destroy()"
+    end
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This makes PHP support optional and adds Python support. Please check if I'm doing the Python executable/library/site-packages selection right - I basically followed `audit` output instead of hardcoded linkage against a certain libpython.

@externl FYI ;)