### PR TITLE
unixodbc: enable static libraries

### DIFF
--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -14,15 +14,13 @@ class Unixodbc < Formula
 
   keg_only "Shadows system iODBC header files" if MacOS.version < :mavericks
 
-  option :universal
-
   conflicts_with "virtuoso", :because => "Both install `isql` binaries."
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--enable-static",
                           "--enable-gui=no"
     system "make", "install"
   end


### PR DESCRIPTION
Also remove the universal option, as it is now deprecated.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I verified that `--enable-static` still builds the dynamic libraries as well, so it should be safe to include globally.

If you would prefer the universal changes were in a separate PR / commit I can do that, the audit mentioned that they were now deprecated.