### PR TITLE
watchman: launchctl unload post-install

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -42,6 +42,17 @@ class Watchman < Formula
   def post_install
     (var/"run/watchman").mkpath
     chmod 042777, var/"run/watchman"
+    # Older versions would use socket activation in the launchd.plist, and since
+    # the homebrew paths are versioned, this meant that launchd would continue
+    # to reference the old version of the binary after upgrading.
+    # https://github.com/facebook/watchman/issues/358
+    # To help swing folks from an older version to newer versions, force unloading
+    # the plist here.  This is needed even if someone wanted to add brew services
+    # support; while there are still folks with watchman <4.8 this is still an
+    # upgrade concern.
+    home = ENV["HOME"]
+    system "launchctl", "unload",
+           "-F", "#{home}/Library/LaunchAgents/com.github.facebook.watchman.plist"
   end
 
   test do


### PR DESCRIPTION
This is taking a run at: https://github.com/facebook/watchman/issues/358

Watchman installs and updates its own launchd.plist file on behalf of the user; it is not integrated with `brew services`.
In the linked issue, watchman would stop working for some homebrew users.  The problem was that the launchd.plist used socket activation to set up the service, and because launchd is maintaining the socket, and the socket connection attempt just hangs, watchman never had a chance to fix up the plist and things stayed broken.

To help solve this, we're forcing an unload in the post-install portion of the recipe.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
