### PR TITLE
ipmitool: add std=gnu99 to CFLAGS

### DIFF
--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -4,6 +4,7 @@ class Ipmitool < Formula
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -23,6 +23,7 @@ class Ipmitool < Formula
     # Upstream issue from 8 Nov 2016 https://sourceforge.net/p/ipmitool/bugs/474/
     inreplace "lib/ipmi_cfgp.c", "#include <malloc.h>", ""
 
+    ENV.append "CFLAGS", "--std=gnu99"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -21,11 +21,15 @@ class Ipmitool < Formula
 
     # https://sourceforge.net/p/ipmitool/bugs/436/
     ENV.append "CFLAGS", "--std=gnu99"
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--disable-intf-usb"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --disable-intf-usb
+    ]
+    system "./configure", *args
+    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -23,6 +23,7 @@ class Ipmitool < Formula
     # Upstream issue from 8 Nov 2016 https://sourceforge.net/p/ipmitool/bugs/474/
     inreplace "lib/ipmi_cfgp.c", "#include <malloc.h>", ""
 
+    # https://sourceforge.net/p/ipmitool/bugs/436/
     ENV.append "CFLAGS", "--std=gnu99"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -15,10 +15,6 @@ class Ipmitool < Formula
   depends_on "openssl"
 
   def install
-    # Required to get NI_MAXHOST and NI_MAXSERV defined in /usr/include/netdb.h, see
-    # https://sourceforge.net/p/ipmitool/bugs/418
-    inreplace "src/plugins/ipmi_intf.c", "#define _GNU_SOURCE 1", "#define _GNU_SOURCE 1\n#define _DARWIN_C_SOURCE 1"
-
     # Fix ipmi_cfgp.c:33:10: fatal error: 'malloc.h' file not found
     # Upstream issue from 8 Nov 2016 https://sourceforge.net/p/ipmitool/bugs/474/
     inreplace "lib/ipmi_cfgp.c", "#include <malloc.h>", ""


### PR DESCRIPTION
closes #9423

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
