### PR TITLE
httest 2.4.12 (new formula)

### DIFF
--- a/Formula/httest.rb
+++ b/Formula/httest.rb
@@ -1,0 +1,34 @@
+class Httest < Formula
+  desc "Provides a large variety of HTTP-related test functionality."
+  homepage "http://htt.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/htt/htt2.4/httest-2.4.12/httest-2.4.12.tar.gz"
+  sha256 "fd18cdc996c199d56d77e9355c07e1e1701d5550c03fbecb06a255ce72d79bd1"
+
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "openssl"
+  depends_on "pcre"
+  depends_on "lua"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-apr=#{Formula["apr"].opt_prefix/"bin"}",
+                          "--with-lua=#{Formula["lua"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.htt").write <<-EOS.undent
+      CLIENT 5
+        _TIME time
+      END
+    EOS
+    system bin/"httest", "--debug", testpath/"test.htt"
+  end
+end


### PR DESCRIPTION
A script based toolset for implementing a large variety of HTTP-related tests. See http://htt.sourceforge.net/cgi-bin/cwiki/bin/public

#### Provides the following binaries

* httest - main programm
* htproxy - generate httest scripts
* htntlm - enable ntlm in your httest scripts
* hturlext - extracts url from html (GNU General Public License 2.0)
* htremote - enable interactive scripts in your httest scripts

#### Tasks

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
