### PR TITLE
Lua: attempt to remove patching.

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -3,7 +3,7 @@ class Lua < Formula
   homepage "https://www.lua.org/"
   url "https://www.lua.org/ftp/lua-5.2.4.tar.gz"
   sha256 "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any
@@ -23,10 +23,6 @@ class Lua < Formula
   option "with-completion", "Enables advanced readline support"
   option "without-sigaction", "Revert to ANSI signal instead of improved POSIX sigaction"
   option "without-luarocks", "Don't build with Luarocks support embedded"
-
-  # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
-  # See: https://github.com/Homebrew/homebrew/pull/5043
-  patch :DATA
 
   # completion provided by advanced readline power patch
   # See http://lua-users.org/wiki/LuaPowerPatches
@@ -55,7 +51,6 @@ class Lua < Formula
     # Subtitute formula prefix in `src/Makefile` for install name (dylib ID).
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
-      s.gsub! "@LUA_PREFIX@", prefix
       s.remove_make_var! "CC"
       s.change_make_var! "CFLAGS", "#{ENV.cflags} -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
@@ -68,15 +63,6 @@ class Lua < Formula
     system "make", "macosx", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
     system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
     (lib/"pkgconfig/lua.pc").write pc_file
-
-    # Fix some software potentially hunting for different pc names.
-    bin.install_symlink "lua" => "lua5.2"
-    bin.install_symlink "lua" => "lua-5.2"
-    bin.install_symlink "luac" => "luac5.2"
-    bin.install_symlink "luac" => "luac-5.2"
-    (include/"lua5.2").install_symlink include.children
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua5.2.pc"
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-5.2.pc"
 
     # This resource must be handled after the main install, since there's a lua dep.
     # Keeping it in install rather than postinstall means we can bottle.
@@ -91,8 +77,6 @@ class Lua < Formula
         system "make", "install"
 
         (pkgshare/"5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
-        bin.install_symlink libexec/"bin/luarocks-5.2"
-        bin.install_symlink libexec/"bin/luarocks-admin-5.2"
         bin.install_symlink libexec/"bin/luarocks"
         bin.install_symlink libexec/"bin/luarocks-admin"
 
@@ -143,72 +127,10 @@ class Lua < Formula
   test do
     system "#{bin}/lua", "-e", "print ('Ducks are cool')"
 
-    if File.exist?(bin/"luarocks-5.2")
+    if File.exist?(bin/"luarocks")
       mkdir testpath/"luarocks"
-      system bin/"luarocks-5.2", "install", "moonscript", "--tree=#{testpath}/luarocks"
+      system bin/"luarocks", "install", "moonscript", "--tree=#{testpath}/luarocks"
       assert File.exist? testpath/"luarocks/bin/moon"
     end
   end
 end
-
-__END__
-diff --git a/Makefile b/Makefile
-index bd9515f..5940ba9 100644
---- a/Makefile
-+++ b/Makefile
-@@ -41,7 +41,7 @@ PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
- # What to install.
- TO_BIN= lua luac
- TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
--TO_LIB= liblua.a
-+TO_LIB= liblua.5.2.4.dylib
- TO_MAN= lua.1 luac.1
-
- # Lua version and release.
-@@ -63,6 +63,8 @@ install: dummy
-	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
-	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
-	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
-+	ln -s -f liblua.5.2.4.dylib $(INSTALL_LIB)/liblua.5.2.dylib
-+	ln -s -f liblua.5.2.dylib $(INSTALL_LIB)/liblua.dylib
-
- uninstall:
-	cd src && cd $(INSTALL_BIN) && $(RM) $(TO_BIN)
-diff --git a/src/Makefile b/src/Makefile
-index 8c9ee67..7f92407 100644
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -28,7 +28,7 @@ MYOBJS=
-
- PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
-
--LUA_A=	liblua.a
-+LUA_A=	liblua.5.2.4.dylib
- CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
-	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
-	ltm.o lundump.o lvm.o lzio.o
-@@ -56,11 +56,12 @@ o:	$(ALL_O)
- a:	$(ALL_A)
-
- $(LUA_A): $(BASE_O)
--	$(AR) $@ $(BASE_O)
--	$(RANLIB) $@
-+	$(CC) -dynamiclib -install_name @LUA_PREFIX@/lib/liblua.5.2.dylib \
-+		-compatibility_version 5.2 -current_version 5.2.4 \
-+		-o liblua.5.2.4.dylib $^
-
- $(LUA_T): $(LUA_O) $(LUA_A)
--	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
-+	$(CC) -fno-common $(MYLDFLAGS) -o $@ $(LUA_O) $(LUA_A) -L. -llua.5.2.4 $(LIBS)
-
- $(LUAC_T): $(LUAC_O) $(LUA_A)
-	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
-@@ -106,7 +107,7 @@ linux:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
-
- macosx:
--	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline" CC=cc
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -fno-common" SYSLIBS="-lreadline" CC=cc
-
- mingw:
-	$(MAKE) "LUA_A=lua52.dll" "LUA_T=lua.exe" \

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -6,7 +6,7 @@ class LuaAT51 < Formula
   url "https://www.lua.org/ftp/lua-5.1.5.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
   sha256 "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any
@@ -15,13 +15,11 @@ class LuaAT51 < Formula
     sha256 "1bc63e65986763d0501b26de2d712b055ae7d2e036b9257d48cb59fd6cb6e3c4" => :yosemite
   end
 
+  keg_only :versioned_formula
+
   option "with-completion", "Enables advanced readline support"
   option "without-sigaction", "Revert to ANSI signal instead of improved POSIX sigaction"
   option "without-luarocks", "Don't build with Luarocks support embedded"
-
-  # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
-  # See: https://github.com/Homebrew/homebrew/pull/5043
-  patch :DATA
 
   # sigaction provided by posix signalling power patch from
   # http://lua-users.org/wiki/LuaPowerPatches
@@ -52,7 +50,7 @@ class LuaAT51 < Formula
       s.remove_make_var! "CC"
       s.change_make_var! "CFLAGS", "#{ENV.cflags} $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags
-      s.sub! "MYCFLAGS_VAL", "-fno-common -DLUA_USE_LINUX"
+      s.sub! "MYCFLAGS=-DLUA_USE_LINUX", "MYCFLAGS=-DLUA_USE_LINUX -fno-common"
     end
 
     # Fix path in the config header
@@ -62,28 +60,12 @@ class LuaAT51 < Formula
     inreplace "etc/lua.pc" do |s|
       s.gsub! "prefix= /usr/local", "prefix=#{HOMEBREW_PREFIX}"
       s.gsub! "INSTALL_MAN= ${prefix}/man/man1", "INSTALL_MAN= ${prefix}/share/man/man1"
-      s.gsub! "INSTALL_INC= ${prefix}/include", "INSTALL_INC= ${prefix}/include/lua-5.1"
-      s.gsub! "includedir=${prefix}/include", "includedir=${prefix}/include/lua-5.1"
-      s.gsub! "Libs: -L${libdir} -llua -lm", "Libs: -L${libdir} -llua.5.1 -lm"
     end
 
-    system "make", "macosx", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}", "INSTALL_INC=#{include}/lua-5.1"
-    system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}", "INSTALL_INC=#{include}/lua-5.1"
+    system "make", "macosx", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
+    system "make", "install", "INSTALL_TOP=#{prefix}", "INSTALL_MAN=#{man1}"
 
     (lib/"pkgconfig").install "etc/lua.pc"
-
-    # Renaming from Lua to Lua51.
-    # Note that the naming must be both lua-version & lua.version.
-    # Software can't find the libraries without supporting both the hyphen or full stop.
-    mv "#{bin}/lua", "#{bin}/lua-5.1"
-    mv "#{bin}/luac", "#{bin}/luac-5.1"
-    mv "#{man1}/lua.1", "#{man1}/lua-5.1.1"
-    mv "#{man1}/luac.1", "#{man1}/luac-5.1.1"
-    mv "#{lib}/pkgconfig/lua.pc", "#{lib}/pkgconfig/lua-5.1.pc"
-    bin.install_symlink "lua-5.1" => "lua5.1"
-    bin.install_symlink "luac-5.1" => "luac5.1"
-    include.install_symlink "lua-5.1" => "lua5.1"
-    (lib/"pkgconfig").install_symlink "lua-5.1.pc" => "lua5.1.pc"
 
     # This resource must be handled after the main install, since there's a lua dep.
     # Keeping it in install rather than postinstall means we can bottle.
@@ -98,8 +80,8 @@ class LuaAT51 < Formula
         system "make", "install"
 
         (share/"lua/5.1/luarocks").install_symlink Dir["#{libexec}/share/lua/5.1/luarocks/*"]
-        bin.install_symlink libexec/"bin/luarocks-5.1"
-        bin.install_symlink libexec/"bin/luarocks-admin-5.1"
+        bin.install_symlink libexec/"bin/luarocks"
+        bin.install_symlink libexec/"bin/luarocks-admin"
 
         # This block ensures luarock exec scripts don't break across updates.
         inreplace libexec/"share/lua/5.1/luarocks/site_config.lua" do |s|
@@ -123,74 +105,12 @@ class LuaAT51 < Formula
   end
 
   test do
-    system "#{bin}/lua5.1", "-e", "print ('Ducks are cool')"
+    system "#{bin}/lua", "-e", "print ('Ducks are cool')"
 
-    if File.exist?(bin/"luarocks-5.1")
+    if File.exist?(bin/"luarocks")
       mkdir testpath/"luarocks"
-      system bin/"luarocks-5.1", "install", "moonscript", "--tree=#{testpath}/luarocks"
+      system bin/"luarocks", "install", "moonscript", "--tree=#{testpath}/luarocks"
       assert File.exist? testpath/"luarocks/bin/moon"
     end
   end
 end
-
-__END__
-diff --git a/Makefile b/Makefile
-index 209a132..9387b09 100644
---- a/Makefile
-+++ b/Makefile
-@@ -43,7 +43,7 @@ PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
- # What to install.
- TO_BIN= lua luac
- TO_INC= lua.h luaconf.h lualib.h lauxlib.h ../etc/lua.hpp
--TO_LIB= liblua.a
-+TO_LIB= liblua.5.1.5.dylib
- TO_MAN= lua.1 luac.1
-
- # Lua version and release.
-@@ -64,6 +64,8 @@ install: dummy
-	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
-	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
-	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
-+	ln -s -f liblua.5.1.5.dylib $(INSTALL_LIB)/liblua.5.1.dylib
-+	ln -s -f liblua.5.1.dylib $(INSTALL_LIB)/liblua5.1.dylib
-
- ranlib:
-	cd src && cd $(INSTALL_LIB) && $(RANLIB) $(TO_LIB)
-diff --git a/src/Makefile b/src/Makefile
-index e0d4c9f..4477d7b 100644
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -22,7 +22,7 @@ MYLIBS=
-
- PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
-
--LUA_A=	liblua.a
-+LUA_A=	liblua.5.1.5.dylib
- CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
-	lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o  \
-	lundump.o lvm.o lzio.o
-@@ -48,11 +48,13 @@ o:	$(ALL_O)
- a:	$(ALL_A)
-
- $(LUA_A): $(CORE_O) $(LIB_O)
--	$(AR) $@ $(CORE_O) $(LIB_O)	# DLL needs all object files
--	$(RANLIB) $@
-+	$(CC) -dynamiclib -install_name HOMEBREW_PREFIX/lib/liblua.5.1.dylib \
-+		-compatibility_version 5.1 -current_version 5.1.5 \
-+		-o liblua.5.1.5.dylib $^
-
- $(LUA_T): $(LUA_O) $(LUA_A)
--	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
-+	$(CC) -fno-common $(MYLDFLAGS) \
-+		-o $@ $(LUA_O) $(LUA_A) -L. -llua.5.1.5 $(LIBS)
-
- $(LUAC_T): $(LUAC_O) $(LUA_A)
-	$(CC) -o $@ $(MYLDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
-@@ -99,7 +101,7 @@ linux:
-	$(MAKE) all MYCFLAGS=-DLUA_USE_LINUX MYLIBS="-Wl,-E -ldl -lreadline -lhistory -lncurses"
-
- macosx:
--	$(MAKE) all MYCFLAGS=-DLUA_USE_LINUX MYLIBS="-lreadline"
-+	$(MAKE) all MYCFLAGS="MYCFLAGS_VAL" MYLIBS="-lreadline"
- # use this on Mac OS X 10.3-
- #	$(MAKE) all MYCFLAGS=-DLUA_USE_MACOSX


### PR DESCRIPTION
Let's see how badly this explodes and try to remove the patches that relate to different versions of Lua. As-is Lua is in [violation of our docs here](https://github.com/Homebrew/brew/blob/master/docs/Versions.md) because it requires buildsystem patching to maintain side-by-side versions.