### PR TITLE
terraform: fix 0.8.5 build error from fmtcheck

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -77,7 +77,7 @@ class Terraform < Formula
       arch = MacOS.prefer_64_bit? ? "amd64" : "386"
       ENV["XC_OS"] = "darwin"
       ENV["XC_ARCH"] = arch
-      system "make", "bin"
+      ENV.deparallelize { system "make", "fmt", "bin" }
 
       # Install release binary
       bin.install "pkg/darwin_#{arch}/terraform"


### PR DESCRIPTION
Terraform 0.8.5 fails to build with the following error:

```
==> Upgrading 1 outdated package, with result:
terraform 0.8.5
==> Upgrading terraform
...
==> go build
==> go build
==> go build
==> make test vet
==> make bin
Last 15 lines from /Users/<USERNAME>/Library/Logs/Homebrew/terraform/05.make:
2017-01-31 15:35:44 -0500

make
bin

go generate $(go list ./... | grep -v /terraform/vendor/)
==> Checking that code complies with gofmt requirements...
2017/01/31 15:35:47 Generated command/internal_plugin_list.go
gofmt needs running on the following files:
./command/internal_plugin_list.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1

READ THIS: http://docs.brew.sh/Troubleshooting.html
```

This fix runs `make fmt` immediately before building the binary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
