### PR TITLE
unbound: fix build when using --with-python

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -36,6 +36,7 @@ class Unbound < Formula
     system "./configure", *args
 
     inreplace "doc/example.conf", 'username: "unbound"', 'username: "@@HOMEBREW-UNBOUND-USER@@"'
+    system "make"
     system "make", "test"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In the Makefile, neither the "test" nor "install" targets depend on the
"all" target so run just "make" first.

CC @RandomDSdevel

Fixes https://github.com/Homebrew/homebrew-core/issues/9493.