### PR TITLE
bochs 2.6.8 (new formula)

### DIFF
--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -1,0 +1,79 @@
+class Bochs < Formula
+  desc "Open source IA-32 (x86) PC emulator written in C++"
+  homepage "http://bochs.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/bochs/bochs/2.6.8/bochs-2.6.8.tar.gz"
+  sha256 "79700ef0914a0973f62d9908ff700ef7def62d4a28ed5de418ef61f3576585ce"
+
+  option "with-gdb-stub", "Enable GDB Stub"
+
+  depends_on "pkg-config" => :build
+  depends_on "sdl2"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --with-sdl2
+      --with-nogui
+      --enable-disasm
+      --disable-docbook
+      --enable-x86-64
+      --enable-pci
+      --enable-all-optimizations
+      --enable-plugins
+      --enable-cdrom
+      --enable-a20-pin
+      --enable-fpu
+      --enable-alignment-check
+      --enable-large-ramfile
+      --enable-debugger-gui
+      --enable-readline
+      --enable-iodebug
+      --enable-xpm
+      --enable-show-ips
+      --enable-logging
+      --enable-usb
+      --enable-ne2000
+      --enable-cpu-level=6
+      --enable-clgd54xx
+      --with-term
+    ]
+
+    if build.with? "gdb-stub"
+      args << "--enable-gdb-stub"
+    else
+      args << "--enable-debugger"
+    end
+
+    system "./configure", *args
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    require "open3"
+
+    (testpath/"bochsrc.txt").write <<-EOS.undent
+        panic: action=fatal
+        error: action=report
+        info: action=ignore
+        debug: action=ignore
+      EOS
+
+    expected = <<-ERR.undent
+        Bochs is exiting with the following message:
+        \[BIOS  \] No bootable device\.
+      ERR
+
+    command = "#{bin}/bochs -qf bochsrc.txt"
+    if build.without? "gdb-stub"
+      # When the debugger is enabled, bochs will stop on a breakpoint early
+      # during boot. We can pass in a command file to continue when it is hit.
+      (testpath/"debugger.txt").write("c\n")
+      command << " -rc debugger.txt"
+    end
+
+    _, stderr, = Open3.capture3(command)
+    assert_match(expected, stderr)
+  end
+end


### PR DESCRIPTION
The bochs formula was formerly part of homebrew-x11 but was not migrated since it failed to build on Sierra.

Old formula: https://github.com/Homebrew/homebrew-x11/blob/2ba3b8da7ed5dd7a8087465f580f6d032b6e5a2a/bochs.rb

GIthub issue: https://github.com/Homebrew/homebrew-x11/issues/263

This formula is based on that one with two changes:

1) Workaround to make it build
Removed the `--enable-sb16` configure argument since the the soundblaster module is responsible for the build failures on Sierra.

2) Switch from using x11 to sdl2. Dependencies have been adjusted accordingly.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----