### PR TITLE
knot 2.4.0

### DIFF
--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -4,8 +4,13 @@ class Knot < Formula
   revision 1
 
   stable do
-    url "https://secure.nic.cz/files/knot-dns/knot-2.3.3.tar.xz"
-    sha256 "a929bce3b957a81776b1db7b43b0e4473339bf16be8dbba5abb4b0593bf43c94"
+    url "https://secure.nic.cz/files/knot-dns/knot-2.4.0.tar.xz"
+    sha256 "0ba4d3e6951fc4d5c0e3dc88a720462690dd1d25f4bc1e7c24bb5747d3853679"
+
+    patch do
+      url "https://gitlab.labs.nic.cz/labs/knot/commit/ed5d4421657d7250813a2aae789b75e8baf7468a.patch"
+      sha256 "39167126370786f844394c71ad044ccfd588394c0d2a30e6e57d56e00194d156"
+    end
 
     resource "fstrm" do
       url "https://github.com/farsightsec/fstrm/archive/v0.3.0.tar.gz"
@@ -87,12 +92,7 @@ class Knot < Formula
 
     log:
       - target: "stderr"
-        any: "error"
-
-      - target: "syslog"
-        server: "info"
-        zone: "warning"
-        any: "error"
+        any: "info"
 
     control:
       listen: "knot.sock"


### PR DESCRIPTION
This PR updates the knot formula to 2.4.0. There is an existing PR #9063 for Knot DNS, but it doesn't address following issues:

- The changes also include upstream patch to address compilation issues on macOS older than Sierra.
- The default configuration is tweaked to log onto stderr only. launchd will collect the logs so it's no reason to log with syslog as well.

(I'm Knot DNS developer.)