### PR TITLE
docker-machine-driver-xhyve: fix #6678 for installs outside of default location

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -52,6 +52,7 @@ class DockerMachineDriverXhyve < Formula
       go_ldflags = "-w -s -X 'github.com/zchee/docker-machine-driver-xhyve/xhyve.GitCommit=Homebrew#{git_hash}'"
       ENV["GO_LDFLAGS"] = go_ldflags
       ENV["GO_BUILD_TAGS"] = build_tags
+      ENV["LIBEV_FILE"] = "#{Formula["libev"].lib}/libev.a"
       system "make", "lib9p"
       system "make", "build"
       bin.install "bin/docker-machine-driver-xhyve"

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -52,7 +52,7 @@ class DockerMachineDriverXhyve < Formula
       go_ldflags = "-w -s -X 'github.com/zchee/docker-machine-driver-xhyve/xhyve.GitCommit=Homebrew#{git_hash}'"
       ENV["GO_LDFLAGS"] = go_ldflags
       ENV["GO_BUILD_TAGS"] = build_tags
-      ENV["LIBEV_FILE"] = "#{Formula["libev"].lib}/libev.a"
+      ENV["LIBEV_FILE"] = "#{Formula["libev"].opt_lib}/libev.a"
       system "make", "lib9p"
       system "make", "build"
       bin.install "bin/docker-machine-driver-xhyve"


### PR DESCRIPTION
The project Makefile contains hardcoded
`LIBEV_FILE ?= /usr/local/lib/libev.a`
so it works only with the default install location

The patch sets the LIBEV_FILE value from the libev Formula hash