### PR TITLE
skinny 2.3.4

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.3/skinny-2.3.3.tar.gz"
-  sha256 "e743d3ddcd4c6c6fe762dfe56eb1e1d06ad3739d10b072c0847982ec5832efe5"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.4/skinny-2.3.4.tar.gz"
+  sha256 "5dfe30d5d85b214e4acab08f162334b227d2188cc574e3dcf35df7c97e960f95"
 
   bottle :unneeded
 


### PR DESCRIPTION
skinny 2.3.3 is out. Thank you as always 🙇

https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.4

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.4/skinny-2.3.4.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/88898d40-e8e0-11e6-84a1-438d39d2f559.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20170201%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-D
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.4: 907 files, 96.7M, built in 34 seconds

$ brew audit --strict skinny
==> Installing or updating 'rubocop' gem
Fetching: parser-2.3.3.1.gem (100%)
Successfully installed parser-2.3.3.1
Fetching: rubocop-0.47.1.gem (100%)
Successfully installed rubocop-0.47.1
2 gems installed
$
```