### PR TITLE
mercurial 4.1

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -3,8 +3,8 @@
 class Mercurial < Formula
   desc "Scalable distributed version control system"
   homepage "https://mercurial-scm.org/"
-  url "https://mercurial-scm.org/release/mercurial-4.0.2.tar.gz"
-  sha256 "ae6659dba27508a9a6417d535a89e282d5c8a5ea77b6e00af102822145b06d02"
+  url "https://mercurial-scm.org/release/mercurial-4.1.tar.gz"
+  sha256 "7b33c32cdd1d518bc2e2ae223e6ef63c486cf52e9d01a45b99cf8eab7bea5274"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1_.282017-2-1.29

One possible issue that whoever merges this might want to consider is that this version of mercurial bundles zstd for improved compression performance. Since it's using private APIs to do this it does not make sense to use a version of zstd provided by homebrew. For more details about this, see https://www.mercurial-scm.org/pipermail/mercurial-packaging/2016-November/000178.html as well as replies to that thread.