### PR TITLE
qt5: Add patch for QTBUG-57656

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -3,10 +3,23 @@
 class Qt5 < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  url "https://download.qt.io/official_releases/qt/5.8/5.8.0/single/qt-everywhere-opensource-src-5.8.0.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.8/5.8.0/single/qt-everywhere-opensource-src-5.8.0.tar.xz"
-  sha256 "0f4c54386d3dbac0606a936a7145cebb7b94b0ca2d29bc001ea49642984824b6"
+  revision 1
   head "https://code.qt.io/qt/qt5.git", :branch => "5.8", :shallow => false
+
+  stable do
+    url "https://download.qt.io/official_releases/qt/5.8/5.8.0/single/qt-everywhere-opensource-src-5.8.0.tar.xz"
+    mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.8/5.8.0/single/qt-everywhere-opensource-src-5.8.0.tar.xz"
+    sha256 "0f4c54386d3dbac0606a936a7145cebb7b94b0ca2d29bc001ea49642984824b6"
+
+    # Upstream issue "Qt5.8: macOS, designer examples fails to compile"
+    # Reported 15 Dec 2016 https://bugreports.qt.io/browse/QTBUG-57656
+    # Upstream PR from 31 Jan 2017 "fix installation of header-only frameworks"
+    # See https://codereview.qt-project.org/#/c/184053/1
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/634a19fb/qt5/QTBUG-57656.patch"
+      sha256 "a69fc727f4378dbe0cf05ecf6e633769fe7ee6ea52b1630135a05d5adfa23d87"
+    end
+  end
 
   bottle do
     sha256 "ecffbbbfc0d16771da5de32973d6db83b866463bd42e2a103e70add9f204721f" => :sierra


### PR DESCRIPTION
- [ X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this patch, none of the QtDesigner plugins will build.