### PR TITLE
Add stable libevent@2.0 for dependencies that can't utilize 2.1+

### DIFF
--- a/Formula/libevent@2.0.rb
+++ b/Formula/libevent@2.0.rb
@@ -1,0 +1,53 @@
+class LibeventAT20 < Formula
+  desc "Asynchronous event library"
+  homepage "http://libevent.org"
+
+  stable do
+    url "https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz"
+    sha256 "71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3"
+
+    # https://github.com/Homebrew/homebrew-core/issues/2869
+    # https://github.com/libevent/libevent/issues/376
+    patch do
+      url "https://github.com/libevent/libevent/commit/df6f99e5b51a3.patch"
+      sha256 "26e831f7b000c7a0d79fed68ddc1d9bd1f1c3fab8a3c150fcec04a3e282b1acb"
+    end
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "doxygen" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "openssl"
+
+  def install
+    inreplace "Doxyfile", /GENERATE_MAN\s*=\s*NO/, "GENERATE_MAN = YES"
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-debug-mode",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+    system "make", "doxygen"
+    man3.install Dir["doxygen/man/man3/*.3"]
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <event2/event.h>
+
+      int main()
+      {
+        struct event_base *base;
+        base = event_base_new();
+        event_base_free(base);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-levent", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source libevent@2.0`, where `libevent@2.0` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict libevent@2.0` (after doing `brew install libevent@2.0`)?

-----
Please see [this diff](https://github.com/Homebrew/homebrew-core/commit/fa9c5e5815f5eacd39a6f96ddd442d9686b29461) from libevent before 2.1+ was merged this past week.