### PR TITLE
bazel: Remove support for building formula from HEAD

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -3,7 +3,6 @@ class Bazel < Formula
   homepage "https://bazel.build/"
   url "https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-dist.zip"
   sha256 "d52a21dda271ae645711ce99c70cf44c5d3a809138e656bbff00998827548ebb"
-  head "https://github.com/bazelbuild/bazel.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
It is no longer possible to build Bazel using "./compile.sh" from HEAD.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
