### PR TITLE
knot-resolver 1.2.1 (new formula)

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -1,0 +1,99 @@
+class KnotResolver < Formula
+  desc "Minimalistic, caching, DNSSEC-validating DNS resolver"
+  homepage "https://www.knot-resolver.cz"
+  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-1.2.1.tar.xz"
+  sha256 "1b6f55ea1dfec90f45c437f23e1ab440e478570498161d0f8a8f94a439305f8c"
+
+  head do
+    url "https://gitlab.labs.nic.cz/knot/resolver.git"
+  end
+
+  depends_on "knot"
+  depends_on "luajit"
+  depends_on "libuv"
+  depends_on "gnutls"
+  depends_on "lmdb"
+
+  depends_on "cmocka" => :build
+  depends_on "pkg-config" => :run
+
+  option "without-nettle", "Compile without DNS cookies support"
+  option "with-hiredis", "Compile with Redis cache storage support"
+  option "with-libmemcached", "Compile with memcached cache storage support"
+  depends_on "nettle" => :recommended
+  depends_on "hiredis" => :optional
+  depends_on "libmemcached" => :optional
+
+  def install
+    %w[all check lib-install daemon-install modules-install].each do |target|
+      system "make", target, "PREFIX=#{prefix}"
+    end
+
+    (buildpath/"config").write(config)
+    (etc/"kresd").install "config"
+
+    (buildpath/"root.keys").write(root_keys)
+    (var/"kresd").install "root.keys"
+  end
+
+  def config; <<-EOS.undent
+    -- vim:syntax=lua:
+    -- Refer to manual: http://knot-resolver.readthedocs.org/en/latest/daemon.html#configuration
+
+    net.listen(net.lo0)
+
+    -- Unmanaged DNSSEC root TA
+    trust_anchors.file = 'root.keys'
+
+    -- Load useful modules
+    modules = {
+        'stats',    -- Track internal statistics
+        'policy',   -- Block queries to local zones/bad sites
+        'predict',  -- Prefetch expiring/frequent records
+    }
+
+    -- Cache size
+    cache.size = 100 * MB
+    EOS
+  end
+
+  # DNSSEC root anchor published by IANA
+  def root_keys; <<-EOS.undent
+    . 172800 IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
+    EOS
+  end
+
+  plist_options :startup => true
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>WorkingDirectory</key>
+      <string>#{var}/kresd</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{sbin}/kresd</string>
+        <string>-c</string>
+        <string>#{etc}/kresd/config</string>
+      </array>
+      <key>StandardInPath</key>
+      <string>/dev/null</string>
+      <key>StandardOutPath</key>
+      <string>/dev/null</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/kresd.log</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system sbin/"kresd", "--version"
+  end
+end

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -26,32 +26,12 @@ class KnotResolver < Formula
       system "make", target, "PREFIX=#{prefix}"
     end
 
-    (buildpath/"config").write(config)
+    cp "etc/config.personal", "config"
+    inreplace "config", /^\s*user\(/, "-- user("
     (etc/"kresd").install "config"
 
     (buildpath/"root.keys").write(root_keys)
     (var/"kresd").install "root.keys"
-  end
-
-  def config; <<-EOS.undent
-    -- vim:syntax=lua:
-    -- Refer to manual: http://knot-resolver.readthedocs.org/en/latest/daemon.html#configuration
-
-    net.listen(net.lo0)
-
-    -- Unmanaged DNSSEC root TA
-    trust_anchors.file = 'root.keys'
-
-    -- Load useful modules
-    modules = {
-        'stats',    -- Track internal statistics
-        'policy',   -- Block queries to local zones/bad sites
-        'predict',  -- Prefetch expiring/frequent records
-    }
-
-    -- Cache size
-    cache.size = 100 * MB
-    EOS
   end
 
   # DNSSEC root anchor published by IANA

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -3,11 +3,7 @@ class KnotResolver < Formula
   homepage "https://www.knot-resolver.cz"
   url "https://secure.nic.cz/files/knot-resolver/knot-resolver-1.2.1.tar.xz"
   sha256 "1b6f55ea1dfec90f45c437f23e1ab440e478570498161d0f8a8f94a439305f8c"
-  revision 1
-
-  head do
-    url "https://gitlab.labs.nic.cz/knot/resolver.git"
-  end
+  head "https://gitlab.labs.nic.cz/knot/resolver.git"
 
   depends_on "knot"
   depends_on "luajit"

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -12,7 +12,7 @@ class KnotResolver < Formula
   depends_on "lmdb"
 
   depends_on "cmocka" => :build
-  depends_on "pkg-config" => :run
+  depends_on "pkg-config" => :build
 
   option "without-nettle", "Compile without DNS cookies support"
   option "with-hiredis", "Compile with Redis cache storage support"

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -3,6 +3,7 @@ class KnotResolver < Formula
   homepage "https://www.knot-resolver.cz"
   url "https://secure.nic.cz/files/knot-resolver/knot-resolver-1.2.1.tar.xz"
   sha256 "1b6f55ea1dfec90f45c437f23e1ab440e478570498161d0f8a8f94a439305f8c"
+  revision 1
 
   head do
     url "https://gitlab.labs.nic.cz/knot/resolver.git"
@@ -59,7 +60,8 @@ class KnotResolver < Formula
 
   # DNSSEC root anchor published by IANA
   def root_keys; <<-EOS.undent
-    . 172800 IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
+    . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
+    . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d
     EOS
   end
 

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -34,7 +34,7 @@ class KnotResolver < Formula
     (var/"kresd").install "root.keys"
   end
 
-  # DNSSEC root anchor published by IANA
+  # DNSSEC root anchor published by IANA (https://www.iana.org/dnssec/files)
   def root_keys; <<-EOS.undent
     . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
     . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -1,8 +1,8 @@
 class KnotResolver < Formula
   desc "Minimalistic, caching, DNSSEC-validating DNS resolver"
   homepage "https://www.knot-resolver.cz"
-  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-1.2.1.tar.xz"
-  sha256 "1b6f55ea1dfec90f45c437f23e1ab440e478570498161d0f8a8f94a439305f8c"
+  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-1.2.2.tar.xz"
+  sha256 "89ab2ac8058b297c1f73f1c12e0f16d6e160aa86363e99ffa590bee7fe307931"
   head "https://gitlab.labs.nic.cz/knot/resolver.git"
 
   depends_on "knot"


### PR DESCRIPTION
New formula for [Knot Resolver](https://www.knot-resolver.cz/) — Minimalistic, caching, DNSSEC-validating DNS resolver.

- The daemon and library are installed and fully working.
- DNSSEC trust anchor is intentionally provided in the formula. No bootstrapping is performed by default.
- Advanced cache backends (Redis and memcached) are optional.
- Documentation is not installed due to some missing Python dependencies (I might fix that in the future).
- Some advanced modules require various Lua modules which are not included yet (I might fix in the future).
- Go bindings are disabled as there are basically no existing modules yet.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?