### PR TITLE
qwt and qwtpolar: depend on qt5 instead of qt@5.7

### DIFF
--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -3,7 +3,7 @@ class Qwt < Formula
   homepage "http://qwt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2"
   sha256 "f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "e760d252093b926ecabe83dbe830f59dbcba2e69d746a3d616de46f1f51dd2f8" => :sierra
@@ -14,7 +14,7 @@ class Qwt < Formula
   option "with-qwtmathml", "Build the qwtmathml library"
   option "without-plugin", "Skip building the Qt Designer plugin"
 
-  depends_on "qt@5.7"
+  depends_on "qt5"
 
   # Update designer plugin linking back to qwt framework/lib after install
   # See: https://sourceforge.net/p/qwt/patches/45/
@@ -73,10 +73,10 @@ class Qwt < Formula
     system ENV.cxx, "test.cpp", "-o", "out",
       "-std=c++11",
       "-framework", "qwt", "-framework", "QtCore",
-      "-F#{lib}", "-F#{Formula["qt@5.7"].opt_lib}",
+      "-F#{lib}", "-F#{Formula["qt5"].opt_lib}",
       "-I#{lib}/qwt.framework/Headers",
-      "-I#{Formula["qt@5.7"].opt_lib}/QtCore.framework/Versions/5/Headers",
-      "-I#{Formula["qt@5.7"].opt_lib}/QtGui.framework/Versions/5/Headers"
+      "-I#{Formula["qt5"].opt_lib}/QtCore.framework/Versions/5/Headers",
+      "-I#{Formula["qt5"].opt_lib}/QtGui.framework/Versions/5/Headers"
     system "./out"
   end
 end

--- a/Formula/qwtpolar.rb
+++ b/Formula/qwtpolar.rb
@@ -3,7 +3,7 @@ class Qwtpolar < Formula
   homepage "http://qwtpolar.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/qwtpolar/qwtpolar/1.1.1/qwtpolar-1.1.1.tar.bz2"
   sha256 "6168baa9dbc8d527ae1ebf2631313291a1d545da268a05f4caa52ceadbe8b295"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "e734751a7cf473eadbb85ae4ccc80c219f96e7db7b2fc1e7bf2b57b782927d4f" => :sierra
@@ -13,7 +13,7 @@ class Qwtpolar < Formula
 
   option "without-plugin", "Skip building the Qt Designer plugin"
 
-  depends_on "qt@5.7"
+  depends_on "qt5"
   depends_on "qwt"
 
   # Update designer plugin linking back to qwtpolar framework/lib after install
@@ -61,7 +61,7 @@ class Qwtpolar < Formula
       s.gsub! "qwtPolarAddLibrary(qwtpolar)", "qwtPolarAddLibrary(qwtpolar)\nqwtPolarAddLibrary(qwt)"
     end
     cd "examples" do
-      system Formula["qt@5.7"].opt_bin/"qmake"
+      system Formula["qt5"].opt_bin/"qmake"
       rm_rf "bin" # just in case
       system "make"
       assert File.exist?("bin/polardemo.app/Contents/MacOS/polardemo"), "Failed to build polardemo"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now possible to use 5.8.0 since QTBUG-57656 was patched in #9541.