### PR TITLE
lftp 4.7.5 (new formula)

### DIFF
--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -1,0 +1,34 @@
+class Lftp < Formula
+  desc "Sophisticated file transfer program"
+  homepage "https://lftp.tech"
+  url "https://lftp.yar.ru/ftp/lftp-4.7.5.tar.bz2"
+  mirror "ftp://ftp.st.ryukoku.ac.jp/pub/network/ftp/lftp/lftp-4.7.5.tar.bz2"
+  sha256 "90f3cbc827534c3b3a391a2dd8b39cc981ac4991fa24b6f90e2008ccc0a5207d"
+
+  depends_on "readline"
+  depends_on "openssl"
+  depends_on "libidn"
+
+  # On Yosemite, the system's openssl gets chosen over ours, and it is too old
+  depends_on :macos => :el_capitan
+
+  # Fix a cast issue, patch was merged upstream: https://github.com/lavv17/lftp/pull/307
+  # Remove when lftp-4.7.6 is released
+  patch do
+    url "https://github.com/lavv17/lftp/commit/259d642e1fea2ddf38763d49e8e7701f0a947d4c.diff"
+    sha256 "729e9d8e2759e79d2f2a07564dc740dada37870cd8bd7065b322bf827138d2c5"
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--with-openssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-readline=#{Formula["readline"].opt_prefix}",
+                          "--with-libidn=#{Formula["libidn"].opt_prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/lftp", "-c", "open ftp://mirrors.kernel.org; ls"
+  end
+end

--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -10,6 +10,7 @@ class Lftp < Formula
   depends_on "libidn"
 
   # On Yosemite, the system's openssl gets chosen over ours, and it is too old
+  # https://github.com/lavv17/lftp/issues/317
   depends_on :macos => :el_capitan
 
   # Fix a cast issue, patch was merged upstream: https://github.com/lavv17/lftp/pull/307

--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -29,6 +29,6 @@ class Lftp < Formula
   end
 
   test do
-    system "#{bin}/lftp", "-c", "open ftp://mirrors.kernel.org; ls"
+    system "#{bin}/lftp", "-c", "open ftp://ftp.gnu.org/; ls"
   end
 end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -166,7 +166,6 @@
   "kumofs": "homebrew/boneyard",
   "lastfmlib": "homebrew/boneyard",
   "latex-mk": "homebrew/tex",
-  "lftp": "homebrew/boneyard",
   "libdbusmenu-qt": "homebrew/boneyard",
   "libdlna": "homebrew/boneyard",
   "libechonest": "homebrew/boneyard",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a pull request to revive lftp, now that it builds again on macOS (almost unpatched). There was a pull request already, but its author has stopped updating it in response to reviews (https://github.com/Homebrew/homebrew-core/pull/7371) so I am opening this one.