### PR TITLE
boost: Split boost-mpi into separate formula

### DIFF
--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -1,0 +1,98 @@
+class BoostMpi < Formula
+  desc "C++ library for C++/MPI interoperability"
+  homepage "https://www.boost.org/"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
+  sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
+  head "https://github.com/boostorg/boost.git"
+
+  bottle do
+    cellar :any
+  end
+
+  option :cxx11
+
+  if build.cxx11?
+    depends_on "boost" => "c++11"
+    depends_on "open-mpi" => "c++11"
+  else
+    depends_on "boost"
+    depends_on :mpi => [:cc, :cxx]
+  end
+
+  def install
+    # "layout" should be synchronized with boost
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "--user-config=user-config.jam",
+            "threading=multi,single",
+            "link=shared,static"]
+
+    # Build in C++11 mode if boost was built in C++11 mode.
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
+    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
+    if build.cxx11?
+      args << "cxxflags=-std=c++11"
+      if ENV.compiler == :clang
+        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+      end
+    elsif Tab.for_name("boost").cxx11?
+      odie "boost was built in C++11 mode so boost-mpi must be built with --c++11."
+    end
+
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+      file.write "using mpi ;\n"
+    end
+
+    system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}", "--with-libraries=mpi"
+
+    system "./b2", *args
+
+    lib.install Dir["stage/lib/*mpi*"]
+
+    # libboost_mpi links to libboost_serialization, which comes from the main boost formula
+    boost = Formula["boost"]
+    MachO::Tools.change_install_name("#{lib}/libboost_mpi-mt.dylib",
+                                     "libboost_serialization-mt.dylib",
+                                     "#{boost.lib}/libboost_serialization-mt.dylib")
+    MachO::Tools.change_install_name("#{lib}/libboost_mpi.dylib",
+                                     "libboost_serialization.dylib",
+                                     "#{boost.lib}/libboost_serialization.dylib")
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <boost/mpi.hpp>
+      #include <iostream>
+      #include <boost/serialization/string.hpp>
+      namespace mpi = boost::mpi;
+
+      int main(int argc, char* argv[])
+      {
+        mpi::environment env(argc, argv);
+        mpi::communicator world;
+
+        if (world.rank() == 0) {
+          world.send(1, 0, std::string("Hello"));
+          std::string msg;
+          world.recv(1, 1, msg);
+          std::cout << msg << "!" << std::endl;
+        } else {
+          std::string msg;
+          world.recv(0, 0, msg);
+          std::cout << msg << ", ";
+          std::cout.flush();
+          world.send(0, 1, std::string("world"));
+        }
+
+        return 0;
+      }
+    EOS
+    boost = Formula["boost"]
+    system "mpic++", "test.cpp", "-L#{lib}", "-L#{boost.lib}", "-lboost_mpi", "-lboost_serialization", "-o", "test"
+    system "mpirun", "-np", "2", "./test"
+  end
+end

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -5,10 +5,6 @@ class BoostMpi < Formula
   sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   head "https://github.com/boostorg/boost.git"
 
-  bottle do
-    cellar :any
-  end
-
   option :cxx11
 
   if build.cxx11?

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -17,17 +17,14 @@ class Boost < Formula
   option "with-icu4c", "Build regexp engine with icu support"
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"
-  option "with-mpi", "Build with MPI support"
   option :cxx11
 
   deprecated_option "with-icu" => "with-icu4c"
 
   if build.cxx11?
     depends_on "icu4c" => [:optional, "c++11"]
-    depends_on "open-mpi" => "c++11" if build.with? "mpi"
   else
     depends_on "icu4c" => :optional
-    depends_on :mpi => [:cc, :cxx, :optional]
   end
 
   needs :cxx11 if build.cxx11?
@@ -36,7 +33,6 @@ class Boost < Formula
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
       file.write "using darwin : : #{ENV.cxx} ;\n"
-      file.write "using mpi ;\n" if build.with? "mpi"
     end
 
     # libdir should be set by --prefix but isn't
@@ -50,7 +46,7 @@ class Boost < Formula
     end
 
     # Handle libraries that will not be built.
-    without_libraries = ["python"]
+    without_libraries = ["python", "mpi"]
 
     # The context library is implemented as x86_64 ASM, so it
     # won't build on PPC or 32-bit builds
@@ -64,11 +60,10 @@ class Boost < Formula
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
     without_libraries << "log" if ENV.compiler == :gcc
-    without_libraries << "mpi" if build.without? "mpi"
 
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
 
-    # layout should be synchronized with boost-python
+    # layout should be synchronized with boost-python and boost-mpi
     args = ["--prefix=#{prefix}",
             "--libdir=#{lib}",
             "-d2",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request moves the building of Boost::MPI into a separate formula, _boost-mpi_. Previously, it was available as an option of the _boost_ formula, _boost --with-mpi_. Having it as a separate formula has two advantages: Boost will not need to be rebuilt in its entirety when Boost::MPI is installed, and Boost::MPI will be available as a bottle, thus speeding up installation. Furthermore, _boost-python_ has always been a separate formula.