### PR TITLE
tor: add post_install step that creates /usr/local/var/lib/tor

### DIFF
--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -39,6 +39,10 @@ class Tor < Formula
     system "make", "install"
   end
 
+  def post_install
+    mkdir_p "#{HOMEBREW_PREFIX}/var/lib/tor"
+  end
+
   plist_options :manual => "tor"
 
   def plist; <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, the version of `tor` installed won't start because of a missing folder.  We should create it in the post-install step.