### PR TITLE
Rename SpiderMonkey binary

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -1,10 +1,10 @@
 class Spidermonkey < Formula
-  desc "JavaScript-C Engine"
+  desc "Mozilla's JavaScript engine, as used in Firefox"
   homepage "https://developer.mozilla.org/en/SpiderMonkey"
   url "https://archive.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz"
   version "1.8.5"
   sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
-  revision 2
+  revision 3
 
   head "https://hg.mozilla.org/tracemonkey/archive/tip.tar.gz"
 
@@ -15,14 +15,12 @@ class Spidermonkey < Formula
     sha256 "38d1b7f54b5dbdd4a0e28e3a1077aed2ada42a9266cfaddeda6a08d761a2d8b2" => :yosemite
   end
 
-  conflicts_with "narwhal", :because => "both install a js binary"
-
   depends_on "readline"
   depends_on "nspr"
 
   def install
     cd "js/src" do
-      # Remove the broken *(for anyone but FF) install_name
+      # Remove the broken *(for anyone but Firefox) install_name
       inreplace "config/rules.mk",
         "-install_name @executable_path/$(SHARED_LIBRARY) ",
         "-install_name #{lib}/$(SHARED_LIBRARY) "
@@ -41,14 +39,16 @@ class Spidermonkey < Formula
       system "make"
       system "make", "install"
 
-      # Also install js REPL.
-      bin.install "shell/js"
+      # Install the REPL.
+      bin.install "shell/js" => "spidermonkey"
+      bin.install_symlink "spidermonkey" => "sm"
     end
   end
 
   test do
     path = testpath/"test.js"
     path.write "print('hello');"
-    assert_equal "hello", shell_output("#{bin}/js #{path}").strip
+    assert_equal "hello", shell_output("#{bin}/spidermonkey #{path}").strip
+    assert_equal "hello", shell_output("#{bin}/sm #{path}").strip
   end
 end


### PR DESCRIPTION
Use `spidermonkey` instead of `js` which is overly generic and conflicts with Narwhal.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
