### PR TITLE
open-sp: Fix default catalog path

### DIFF
--- a/Formula/open-sp.rb
+++ b/Formula/open-sp.rb
@@ -18,7 +18,7 @@ class OpenSp < Formula
                           "--mandir=#{man}",
                           "--disable-doc-build",
                           "--enable-http",
-                          "--enable-default-catalog=#{HOMEBREW_PREFIX}/share/sgml/catalog",
+                          "--enable-default-catalog=#{etc}/sgml/catalog",
                           "--enable-default-search-path=#{HOMEBREW_PREFIX}/share/sgml"
     system "make", "pkgdatadir=#{share}/sgml/opensp", "install"
   end


### PR DESCRIPTION
The previous value `#{HOMEBREW_PREFIX}/share/sgml/catalog` didn't make much sense, since that is not a configuration file location.  Change it to `#{etc}/sgml/catalog`, which is similar to the default XML catalog path used by most formulae.

Previous change was Homebrew/legacy-homebrew#15955. The claims there about OpenJade are not correct AFAICT. I have an OpenJade package at https://github.com/petere/homebrew-sgml/blob/master/openjade.rb, which does the right thing (I think) about catalog installation and works with my change.
