### PR TITLE
crystal-lang: Install completion.zsh as _crystal

### DIFF
--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -102,7 +102,7 @@ class CrystalLang < Formula
     bin.install ".build/crystal"
     prefix.install "src"
     bash_completion.install "etc/completion.bash" => "crystal"
-    zsh_completion.install "etc/completion.zsh" => "crystal"
+    zsh_completion.install "etc/completion.zsh" => "_crystal"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Only completion files beginning with _ will be loaded by zsh automatically.
