### PR TITLE
yaz: add universal build option

### DIFF
--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -18,10 +18,16 @@ class Yaz < Formula
     depends_on "libtool" => :build
   end
 
+  # to support an app called MarcEdit that uses yaz for Z39.50 client
+  # functionality and expects it to be installed with  --universal and
+  # --without-icu4c
+  option :universal
+
   depends_on "pkg-config" => :build
   depends_on "icu4c" => :recommended
 
   def install
+    ENV.universal_binary if build.universal?
     system "./buildconf.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No; patch intentionally (re)adds the deprecated universal build option for the sake of a Mono app called MarcEdit, which [expects](http://marcedit.reeset.net/marcedit-mac-installation-instructions) yaz to be built with `--universal` and `--without-icu4c`
-----
