### PR TITLE
*env: remove non-Homebrew-specific caveats.

### DIFF
--- a/Formula/exenv.rb
+++ b/Formula/exenv.rb
@@ -12,15 +12,6 @@ class Exenv < Formula
     prefix.install Dir["*"]
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.exenv add to your profile:
-      export "EXENV_ROOT=#{var}/exenv"
-
-    To enable shims and autocompletion add to your profile:
-      if which exenv > /dev/null; then eval "$(exenv init -)"; fi
-    EOS
-  end
-
   test do
     system "#{bin}/exenv", "init", "-"
   end

--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -15,15 +15,6 @@ class Goenv < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.goenv add to your profile:
-      export GOENV_ROOT=#{var}/goenv
-
-    To enable shims and autocompletion add to your profile:
-      if which goenv > /dev/null; then eval "$(goenv init -)"; fi
-    EOS
-  end
-
   test do
     assert_match "Usage: goenv <command> [<args>]", shell_output("#{bin}/goenv help")
   end

--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -12,15 +12,6 @@ class Jenv < Formula
     bin.write_exec_script libexec/"bin/jenv"
   end
 
-  def caveats; <<-EOS.undent
-     To use Homebrew's directories rather than ~/.jenv add to your profile:
-       export JENV_ROOT=#{var}/jenv
-
-     To enable shims and autocompletion add to your profile:
-       if which jenv > /dev/null; then eval "$(jenv init -)"; fi
-     EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/jenv init -)\" && jenv versions")
   end

--- a/Formula/nodenv.rb
+++ b/Formula/nodenv.rb
@@ -14,15 +14,6 @@ class Nodenv < Formula
     prefix.install "bin", "libexec", "completions"
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.nodenv add to your profile:
-      export NODENV_ROOT=#{var}/nodenv
-
-    To enable shims and autocompletion add to your profile:
-      if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
-    EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/nodenv init -)\" && nodenv --version")
   end

--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -21,15 +21,6 @@ class Pyenv < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.pyenv add to your profile:
-      export PYENV_ROOT=#{var}/pyenv
-
-    To enable shims and autocompletion add to your profile:
-      if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi
-    EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/pyenv init -)\" && pyenv versions")
   end

--- a/Formula/rbenv.rb
+++ b/Formula/rbenv.rb
@@ -36,16 +36,6 @@ class Rbenv < Formula
     prefix.install ["bin", "completions", "libexec", "rbenv.d"]
   end
 
-  def caveats; <<-EOS.undent
-    Rbenv stores data under ~/.rbenv by default. If you absolutely need to
-    store everything under Homebrew's prefix, include this in your profile:
-      export RBENV_ROOT=#{var}/rbenv
-
-    To enable shims and autocompletion, run this and follow the instructions:
-      rbenv init
-    EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/rbenv init -)\" && rbenv versions")
   end

--- a/Formula/sbtenv.rb
+++ b/Formula/sbtenv.rb
@@ -28,15 +28,6 @@ class Sbtenv < Formula
     (var_lib/"plugins").install_symlink "#{prefix}/default-plugins/sbt-install"
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.sbtenv add to your profile:
-      export SBTENV_ROOT=#{var}/sbtenv
-
-    To enable shims and autocompletion add to your profile:
-      eval "$(sbtenv init -)"
-    EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/sbtenv init -)\" && sbtenv versions")
   end

--- a/Formula/scalaenv.rb
+++ b/Formula/scalaenv.rb
@@ -28,15 +28,6 @@ class Scalaenv < Formula
     (var_lib/"plugins").install_symlink "#{prefix}/default-plugins/scala-install"
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.scalaenv add to your profile:
-      export SCALAENV_ROOT=#{var}/scalaenv
-
-    To enable shims and autocompletion add to your profile:
-      eval "$(scalaenv init -)"
-    EOS
-  end
-
   test do
     shell_output("eval \"$(#{bin}/scalaenv init -)\" && scalaenv versions")
   end


### PR DESCRIPTION
These aren't causing too much harm but are proliferating endlessly as there's more and more *env formulae and none of these are Homebrew-specific caveats.