### PR TITLE
libxml2: fix #9661 - update Debian patch link to new version

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -18,13 +18,8 @@ class Libxml2 < Formula
             "patches/0004-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch",
             "patches/0005-Fix-XPointer-paths-beginning-with-range-to.patch",
             "patches/0006-Disallow-namespace-nodes-in-XPointer-ranges.patch",
-            "patches/0007-Fix-more-NULL-pointer-derefs-in-xpointer.c.patch"
-    end
-
-    # https://bugzilla.gnome.org/show_bug.cgi?id=766834
-    patch do
-      url "https://git.gnome.org/browse/libxml2/patch/?id=3169602058bd2d04913909e869c61d1540bc7fb4"
-      sha256 "42082b0e7fa80eac68abeace98ea5a03e8cd44cd781c13966eb0758b9a1749b3"
+            "patches/0007-Fix-more-NULL-pointer-derefs-in-xpointer.c.patch",
+            "patches/0008-Fix-attribute-decoding-during-XML-schema-validation.patch"
     end
   end
 

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -11,9 +11,9 @@ class Libxml2 < Formula
     # All patches upstream already. Remove whenever 2.9.5 is released.
     # Fixes CVE-2016-4658, CVE-2016-5131.
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.1.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.1.debian.tar.xz"
-      sha256 "e71790a415e5d6b4a6490040d946d584fa79465571da3b186cc67b8f064cd104"
+      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.2.debian.tar.xz"
+      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.2.debian.tar.xz"
+      sha256 "c038bba02a56164cef7728509ba3c8f1856018573769ee9ffcc48c565e90bdc9"
       apply "patches/0003-Fix-NULL-pointer-deref-in-XPointer-range-to.patch",
             "patches/0004-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch",
             "patches/0005-Fix-XPointer-paths-beginning-with-range-to.patch",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`brew audit --strict libxml2` does not pass due to code that is not by me - it says:

```
libxml2:
  * macOS has been 64-bit only since 10.6 so universal options are deprecated.
```

I did not update anything related to whether the formula is available on 32-bit or 64-bit platform, that code has been there already before this PR.