### PR TITLE
blueutil: Drop dependency on Xcode, use makefile

### DIFF
--- a/Formula/blueutil.rb
+++ b/Formula/blueutil.rb
@@ -13,12 +13,9 @@ class Blueutil < Formula
     sha256 "ad5d8d0d865f9d369090698432c822c7842a4b59d8c5bc1627cd54959cb3329c" => :yosemite
   end
 
-  depends_on :xcode => :build
-
   def install
-    # Set to build with SDK=macosx10.6, but it doesn't actually need 10.6
-    xcodebuild "SDKROOT=", "SYMROOT=build"
-    bin.install "build/Release/blueutil"
+    system "make"
+    bin.install "blueutil"
   end
 
   test do

--- a/Formula/blueutil.rb
+++ b/Formula/blueutil.rb
@@ -14,8 +14,11 @@ class Blueutil < Formula
   end
 
   def install
-    system "make"
-    bin.install "blueutil"
+    bin.mkpath
+    inreplace "Makefile",
+      "@echo $(INSTALL_PROGRAM) blueutil $(DESTDIR)$(bindir)/blueutil",
+             "$(INSTALL_PROGRAM) blueutil #{bin}/blueutil"
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Version 1.1.0 introduced, and 1.1.2 repaired, a makefile that allows the user to avoid Xcode altogether.    Use it and drop the ":build" dep on Xcode.