### PR TITLE
netpbm 10.73.07

### DIFF
--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -2,10 +2,11 @@ class Netpbm < Formula
   desc "Image manipulation"
   homepage "http://netpbm.sourceforge.net"
   # Maintainers: Look at https://sourceforge.net/p/netpbm/code/HEAD/tree/
-  # for stable versions and matching revisions
-  url "http://svn.code.sf.net/p/netpbm/code/advanced", :revision => 2825
-  version "10.76"
-  revision 2
+  # for stable versions and matching revisions.
+  url "http://svn.code.sf.net/p/netpbm/code/stable", :revision => 2885
+  version "10.73.07"
+  version_scheme 1
+
   head "http://svn.code.sf.net/p/netpbm/code/trunk"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@ilovezfs This was bumped accidentally(?) from stable to advanced in the past, but there are some issues with both current stable/advanced that would encourage a bump to the latest release on either branch. Are you happy staying on `advanced` or do you want a `version_scheme` bump here and a drop back down to stable?