### PR TITLE
criterion 2.3.0-1 (new formula)

### DIFF
--- a/Formula/criterion.rb
+++ b/Formula/criterion.rb
@@ -1,0 +1,29 @@
+class Criterion < Formula
+  desc "Dead-simple, non-intrusive unit testing framework for C and C++"
+  homepage "http://criterion.readthedocs.io"
+  url "https://github.com/Snaipe/Criterion/releases/download/v2.3.0-1/criterion-v2.3.0-1.tar.bz2"
+  version "2.3.0-1"
+  sha256 "46a9473b7b35c5ffbb55927f1d9ad0d204dda3a6f0b8fea4003e2490e55619d5"
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                      "-DCMAKE_INSTALL_PREFIX=#{prefix}", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test_criterion.c").write <<-EOS.undent
+      #include <criterion/criterion.h>
+
+      Test(sample, test) {
+        cr_assert(1);
+      }
+    EOS
+    system ENV.cc, "test_criterion.c", "-lcriterion", "-o", "test_criterion"
+    system "./test_criterion"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Criterion is a dead-simple, non-intrusive unit testing framework for C and C++.

Most test frameworks for C require a lot of boilerplate code to set up tests and test suites – you need to create a main, then register new test suites, then register the tests within these suits, and finally call the right functions.

This gives the user great control, at the unfortunate cost of simplicity.

Criterion follows the KISS principle, while keeping the control the user would have with other frameworks.

- C99 and C++11 compatible.
- Tests are automatically registered when declared.
- Implements a xUnit framework structure.
- A default entry point is provided, no need to declare a main unless you want to do special handling.
- Test are isolated in their own process, crashes and signals can be reported and tested.
- Unified interface between C and C++: include the criterion header and it just works.
- Supports parameterized tests and theories.
- Progress and statistics can be followed in real time with report hooks.
- TAP output format can be enabled with an option.
- Runs on Linux, FreeBSD, Mac OS X, and Windows (Compiling with MinGW GCC and Visual Studio 2015+).