### PR TITLE
Revert "yarn 0.20.0"

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Yarn < Formula
   desc "Javascript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://yarnpkg.com/downloads/0.20.0/yarn-v0.20.0.tar.gz"
-  sha256 "4622f3c7a2fdf0dac3ef38b49eb636b813734e06a5a688fb2545df857792ebe3"
+  url "https://yarnpkg.com/downloads/0.19.1/yarn-v0.19.1.tar.gz"
+  sha256 "751e1c0becbb2c3275f61d79ad8c4fc336e7c44c72d5296b5342a6f468526d7d"
   head "https://github.com/yarnpkg/yarn.git"
 
   bottle do


### PR DESCRIPTION
This reverts commit dcb7a486702a649c87a346671c59078e28057536.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
