### PR TITLE
codequery: fix audit --strict

### DIFF
--- a/Formula/codequery.rb
+++ b/Formula/codequery.rb
@@ -1,5 +1,5 @@
 class Codequery < Formula
-  desc "Index, query, or search C, C++, Java, Python, Ruby, Go and Javascript code"
+  desc "Code-understanding, code-browsing or code-search tool."
   homepage "https://github.com/ruben2020/codequery"
   url "https://github.com/ruben2020/codequery/archive/v0.18.1.tar.gz"
   sha256 "482fa737691c260e16adcc32bc3fd43ba50a309495faec6b2f3098b517e6c0e9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
codequery:
  * Description is too long. "name: desc" should be less than 80 characters.
    Length is calculated as codequery + desc. (currently 85)
```