### PR TITLE
boost: enable context and coroutine on all archs

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -52,15 +52,6 @@ class Boost < Formula
     # Handle libraries that will not be built.
     without_libraries = ["python"]
 
-    # The context library is implemented as x86_64 ASM, so it
-    # won't build on PPC or 32-bit builds
-    # see https://github.com/Homebrew/homebrew/issues/17646
-    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit?
-      without_libraries << "context"
-      # The coroutine library depends on the context library.
-      without_libraries << "coroutine"
-    end
-
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
     without_libraries << "log" if ENV.compiler == :gcc
@@ -111,14 +102,6 @@ class Boost < Formula
       s += <<-EOS.undent
 
       Building of Boost.Log is disabled because it requires newer GCC or Clang.
-      EOS
-    end
-
-    if Hardware::CPU.ppc? || Hardware::CPU.is_32_bit?
-      s += <<-EOS.undent
-
-      Building of Boost.Context and Boost.Coroutine is disabled as they are
-      only supported on x86_64.
       EOS
     end
 


### PR DESCRIPTION
- `context` and `coroutine` were disabled for powerpc and i386 builds a long time ago, for boost 1.53 where they were not supported (https://github.com/Homebrew/homebrew-core/commit/53e164b1792ba5e75c5d491bd576c39011ffed52)
- There have been supported in Boost on those archs since version 1.56 (http://www.boost.org/doc/libs/1_56_0/libs/context/doc/html/context/architectures.html)

----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

The audit complains about `env :userpaths`, but it is a preexisting issue.