### PR TITLE
gperftools: add patch to fix initialization on Sierra

### DIFF
--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -1,9 +1,19 @@
 class Gperftools < Formula
   desc "Multi-threaded malloc() and performance analysis tools"
   homepage "https://github.com/gperftools/gperftools"
-  url "https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz"
-  sha256 "6fa2748f1acdf44d750253e160cf6e2e72571329b42e563b455bde09e9e85173"
+  revision 1
   head "https://github.com/gperftools/gperftools.git"
+
+  stable do
+    url "https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz"
+    sha256 "6fa2748f1acdf44d750253e160cf6e2e72571329b42e563b455bde09e9e85173"
+
+    # Fix finding default zone on macOS Sierra (https://github.com/gperftools/gperftools/issues/827)
+    patch do
+      url "https://github.com/gperftools/gperftools/commit/acac6af26b0ef052b39f61a59507b23e9703bdfa.patch"
+      sha256 "36289228d240cb8714f7543772544dc1541e8fec37ab6cc7915296d7bcec3dcf"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

gperftool tcmalloc won't correctly initialize on Sierra and heap profiling/checking yields empty results. This change adds upstream patch that resolves the problem. 