### PR TITLE
Freeimage: Linuxbrew download strategy fix

### DIFF
--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -1,7 +1,7 @@
 class FreeimageHttpDownloadStrategy < CurlDownloadStrategy
   def stage
     # need to convert newlines or patch chokes
-    quiet_safe_system "/usr/bin/unzip", { :quiet_flag => "-qq" }, "-aa", cached_location
+    quiet_safe_system "#{Formula["unzip"].bin}/unzip", { :quiet_flag => "-qq" }, "-aa", cached_location
     chdir
   end
 end
@@ -13,6 +13,7 @@ class Freeimage < Formula
     :using => FreeimageHttpDownloadStrategy
   version "3.17.0"
   sha256 "fbfc65e39b3d4e2cb108c4ffa8c41fd02c07d4d436c594fff8dab1a6d5297f89"
+  revision 1
 
   bottle do
     cellar :any
@@ -23,7 +24,7 @@ class Freeimage < Formula
     sha256 "9d1e914ae20deb7066caf5f1cf52c3d48c0c04ccd36b791170c7e1fcb3528a36" => :mountain_lion
   end
 
-  option :universal
+  depends_on "homebrew/dupes/unzip" => :build
 
   patch :DATA
 
@@ -39,6 +40,19 @@ class Freeimage < Formula
     system "make", "-f", "Makefile.gnu", "install", "PREFIX=#{prefix}"
     system "make", "-f", "Makefile.fip"
     system "make", "-f", "Makefile.fip", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <FreeImage.h>
+      int main() {
+         FreeImage_Initialise(0);
+         FreeImage_DeInitialise();
+         exit(0);
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lfreeimage", "-o", "test"
+    system "./test"
   end
 end
 


### PR DESCRIPTION
  * Formula assumed unzip 6.0 exists in /usr/bin.  Added unzip
    as a build dependency and modified download strategy to use
    brewed unzip for safety/integrity
  * Back-ported Linuxbrew formula os-specific patching
  * Fixed all brew audit issues, including adding a test block

Refs Homebrew/homebrew-science#5098

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
