### PR TITLE
Migrate simutrans from homebrew-games

### DIFF
--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -1,0 +1,47 @@
+class Simutrans < Formula
+  desc "Transport simulator"
+  homepage "http://www.simutrans.com/"
+  url "https://downloads.sourceforge.net/project/simutrans/simutrans/120-1-3/simutrans-src-120-1-3.zip"
+  version "120.1.3"
+  sha256 "2d29b849fc39d25a0580091e1377270bddb2cae36c0fc32bd7c2d0f1d7ccfb84"
+  head "https://github.com/aburch/simutrans.git"
+
+  option "with-makeobj", "Build makeobj tool"
+
+  depends_on "libpng" if build.with? "makeobj"
+  depends_on "sdl2"
+
+  resource "pak64" do
+    url "https://downloads.sourceforge.net/project/simutrans/pak64/120-1/simupak64-120-1-2.zip"
+    sha256 "125fa5c13a51bb0630ca651fddb8af06a823e8c4d4638bfa1bb2d89e92cc1d54"
+  end
+
+  resource "text" do
+    url "http://simutrans-germany.com/translator/data/tab/language_pack-Base+texts.zip"
+    sha256 "4c711c343db25e4055bf62b54c3bd8d96da5d43148db1c7767a72e586336790b"
+  end
+
+  def install
+    args = %w[
+      BACKEND=sdl2
+      COLOUR_DEPTH=16
+      OSTYPE=mac
+    ]
+    system "make", *args
+    libexec.install "build/default/sim" => "simutrans"
+    libexec.install Dir["simutrans/*"]
+    bin.write_exec_script libexec/"simutrans"
+
+    libexec.install resource("pak64")
+    (libexec/"text").install resource("text")
+
+    if build.with? "makeobj"
+      system "make", "makeobj", *args
+      bin.install "build/default/makeobj/makeobj"
+    end
+  end
+
+  test do
+    system "#{bin}/simutrans", "--help"
+  end
+end

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -1,10 +1,21 @@
 class Simutrans < Formula
   desc "Transport simulator"
   homepage "http://www.simutrans.com/"
-  url "https://downloads.sourceforge.net/project/simutrans/simutrans/120-1-3/simutrans-src-120-1-3.zip"
-  version "120.1.3"
-  sha256 "2d29b849fc39d25a0580091e1377270bddb2cae36c0fc32bd7c2d0f1d7ccfb84"
   head "https://github.com/aburch/simutrans.git"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/simutrans/simutrans/120-1-3/simutrans-src-120-1-3.zip"
+    version "120.1.3"
+    sha256 "2d29b849fc39d25a0580091e1377270bddb2cae36c0fc32bd7c2d0f1d7ccfb84"
+
+    # Port Mac audio code from QTKit to AVFoundation
+    # Required since 10.12 SDK no longer includes QTKit.
+    # Submitted upstream: http://forum.simutrans.com/index.php?topic=16675.0
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bea80842a6ccc5639341add0d8abbca2d49b04c2/simutrans/avfoundation.patch"
+      sha256 "9b9c9e6d89de49f152faaf584fcbbeec628bb07315b7c767e1f8b6791ad1e3ee"
+    end
+  end
 
   option "with-makeobj", "Build makeobj tool"
 

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -19,6 +19,7 @@ class Simutrans < Formula
 
   option "with-makeobj", "Build makeobj tool"
 
+  depends_on :macos => :lion
   depends_on "libpng" if build.with? "makeobj"
   depends_on "sdl2"
 

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -17,10 +17,8 @@ class Simutrans < Formula
     end
   end
 
-  option "with-makeobj", "Build makeobj tool"
-
   depends_on :macos => :lion
-  depends_on "libpng" if build.with? "makeobj"
+  depends_on "libpng"
   depends_on "sdl2"
 
   resource "pak64" do
@@ -47,10 +45,8 @@ class Simutrans < Formula
     libexec.install resource("pak64")
     (libexec/"text").install resource("text")
 
-    if build.with? "makeobj"
-      system "make", "makeobj", *args
-      bin.install "build/default/makeobj/makeobj"
-    end
+    system "make", "makeobj", *args
+    bin.install "build/default/makeobj/makeobj"
   end
 
   test do

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -18,7 +18,7 @@ class Simutrans < Formula
 
   resource "text" do
     url "http://simutrans-germany.com/translator/data/tab/language_pack-Base+texts.zip"
-    sha256 "4c711c343db25e4055bf62b54c3bd8d96da5d43148db1c7767a72e586336790b"
+    sha256 "202816f67750cfb9decdfca3bacfebbc5bfc3474c8703239418edc093ce3774d"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Extracted from #9753. This wasn't building because it used the long-deprecated QTKit framework; I've ported it to AVFoundation, and submitted the patch upstream.