### PR TITLE
Juju 2.1-rc1

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -11,6 +11,11 @@ class Juju < Formula
     sha256 "9beb96271da0a17929a7af8dba29af789c31ab022aae07eb6444192c4255b6df" => :yosemite
   end
 
+  devel do
+    url "https://launchpad.net/juju/2.1/2.1-rc1/+download/juju-core_2.1-rc1.tar.gz"
+    sha256 "dde7058b904d167c671e68a6915f6448bdcb04f2102923e136e28dac15c2e229"
+  end
+
   depends_on "go" => :build
 
   def install
@@ -18,7 +23,11 @@ class Juju < Formula
     system "go", "build", "github.com/juju/juju/cmd/juju"
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
     bin.install "juju", "juju-metadata"
-    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
+    if build.stable?
+      bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
+    else
+      bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju"
+    end
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Juju 2.1 renamed the back completion file (It is the same file as in 2.0). Install now checks build.stable to install the bash completion file.