### PR TITLE
Fix audit --strict warning about sourceforge link

### DIFF
--- a/Formula/ant-contrib.rb
+++ b/Formula/ant-contrib.rb
@@ -1,6 +1,6 @@
 class AntContrib < Formula
   desc "Collection of tasks for Apache Ant"
-  homepage "http://ant-contrib.sourceforge.net/"
+  homepage "https://ant-contrib.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
   version "1.0b3"
   sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"

--- a/Formula/archivemail.rb
+++ b/Formula/archivemail.rb
@@ -1,6 +1,6 @@
 class Archivemail < Formula
   desc "Tool for archiving and compressing old email in mailboxes"
-  homepage "http://archivemail.sourceforge.net/"
+  homepage "https://archivemail.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/archivemail/archivemail-0.9.0.tar.gz"
   sha256 "4b430e2fba6f24970a67bd61eef39d7eae8209c7bef001196b997be1916fc663"
 

--- a/Formula/arss.rb
+++ b/Formula/arss.rb
@@ -1,6 +1,6 @@
 class Arss < Formula
   desc "Analyze a sound file into a spectrogram"
-  homepage "http://arss.sourceforge.net/"
+  homepage "https://arss.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/arss/arss/0.2.3/arss-0.2.3-src.tar.gz"
   sha256 "e2faca8b8a3902226353c4053cd9ab71595eec6ead657b5b44c14b4bef52b2b2"
 

--- a/Formula/aspcud.rb
+++ b/Formula/aspcud.rb
@@ -1,6 +1,6 @@
 class Aspcud < Formula
   desc "Package dependency solver"
-  homepage "http://potassco.sourceforge.net/"
+  homepage "https://potassco.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/potassco/aspcud/1.9.1/aspcud-1.9.1-source.tar.gz"
   sha256 "e0e917a9a6c5ff080a411ff25d1174e0d4118bb6759c3fe976e2e3cca15e5827"
 

--- a/Formula/astyle.rb
+++ b/Formula/astyle.rb
@@ -1,6 +1,6 @@
 class Astyle < Formula
   desc "Source code beautifier for C, C++, C#, and Java"
-  homepage "http://astyle.sourceforge.net/"
+  homepage "https://astyle.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.06/astyle_2.06_macos.tar.gz"
   sha256 "ad26b437365add1ec718b0f5f7c03ef0297616528619c2d1de19e940cd18d88a"
   head "svn://svn.code.sf.net/p/astyle/code/trunk/AStyle"

--- a/Formula/atari800.rb
+++ b/Formula/atari800.rb
@@ -1,6 +1,6 @@
 class Atari800 < Formula
   desc "Atari 8-bit machine emulator"
-  homepage "http://atari800.sourceforge.net/"
+  homepage "https://atari800.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/atari800/atari800/3.1.0/atari800-3.1.0.tar.gz"
   sha256 "901b02cce92ddb0b614f8034e6211f24cbfc2f8fb1c6581ba0097b1e68f91e0c"
 

--- a/Formula/avanor.rb
+++ b/Formula/avanor.rb
@@ -1,6 +1,6 @@
 class Avanor < Formula
   desc "Quick-growing roguelike game with easy ADOM-like UI"
-  homepage "http://avanor.sourceforge.net/"
+  homepage "https://avanor.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avanor/avanor/0.5.8/avanor-0.5.8-src.tar.bz2"
   sha256 "8f55be83d985470b9a5220263fc87d0a0a6e2b60dbbc977c1c49347321379ef3"
 

--- a/Formula/avra.rb
+++ b/Formula/avra.rb
@@ -1,6 +1,6 @@
 class Avra < Formula
   desc "Assember for the Atmel AVR microcontroller family"
-  homepage "http://avra.sourceforge.net/"
+  homepage "https://avra.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avra/1.3.0/avra-1.3.0.tar.bz2"
   sha256 "a62cbf8662caf9cc4e75da6c634efce402778639202a65eb2d149002c1049712"
 

--- a/Formula/bashish.rb
+++ b/Formula/bashish.rb
@@ -1,6 +1,6 @@
 class Bashish < Formula
   desc "Theme environment for text terminals"
-  homepage "http://bashish.sourceforge.net/"
+  homepage "https://bashish.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bashish/bashish/2.2.4/bashish-2.2.4.tar.gz"
   sha256 "3de48bc1aa69ec73dafc7436070e688015d794f22f6e74d5c78a0b09c938204b"
 

--- a/Formula/bitchx.rb
+++ b/Formula/bitchx.rb
@@ -1,6 +1,6 @@
 class Bitchx < Formula
   desc "Text-based, scriptable IRC client"
-  homepage "http://bitchx.sourceforge.net/"
+  homepage "https://bitchx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bitchx/ircii-pana/bitchx-1.2.1/bitchx-1.2.1.tar.gz"
   sha256 "2d270500dd42b5e2b191980d584f6587ca8a0dbda26b35ce7fadb519f53c83e2"
 

--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -1,6 +1,6 @@
 class Bochs < Formula
   desc "Open source IA-32 (x86) PC emulator written in C++"
-  homepage "http://bochs.sourceforge.net/"
+  homepage "https://bochs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bochs/bochs/2.6.8/bochs-2.6.8.tar.gz"
   sha256 "79700ef0914a0973f62d9908ff700ef7def62d4a28ed5de418ef61f3576585ce"
 

--- a/Formula/brag.rb
+++ b/Formula/brag.rb
@@ -1,6 +1,6 @@
 class Brag < Formula
   desc "Download and assemble multipart binaries from newsgroups"
-  homepage "http://brag.sourceforge.net/"
+  homepage "https://brag.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/brag/brag/1.4.3/brag-1.4.3.tar.gz"
   sha256 "f2c8110c38805c31ad181f4737c26e766dc8ecfa2bce158197b985be892cece6"
 

--- a/Formula/briss.rb
+++ b/Formula/briss.rb
@@ -1,6 +1,6 @@
 class Briss < Formula
   desc "Crop PDF files"
-  homepage "http://briss.sourceforge.net/"
+  homepage "https://briss.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/briss/release%200.9/briss-0.9.tar.gz"
   sha256 "45dd668a9ceb9cd59529a9fefe422a002ee1554a61be07e6fc8b3baf33d733d9"
 

--- a/Formula/bsdsfv.rb
+++ b/Formula/bsdsfv.rb
@@ -1,6 +1,6 @@
 class Bsdsfv < Formula
   desc "SFV utility tools"
-  homepage "http://bsdsfv.sourceforge.net/"
+  homepage "https://bsdsfv.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bsdsfv/bsdsfv/1.18/bsdsfv-1.18.tar.gz"
   sha256 "577245da123d1ea95266c1628e66a6cf87b8046e1a902ddd408671baecf88495"
 

--- a/Formula/camellia.rb
+++ b/Formula/camellia.rb
@@ -1,6 +1,6 @@
 class Camellia < Formula
   desc "Image Processing & Computer Vision library written in C"
-  homepage "http://camellia.sourceforge.net/"
+  homepage "https://camellia.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/camellia/Unix_Linux%20Distribution/v2.7.0/CamelliaLib-2.7.0.tar.gz"
   sha256 "a3192c350f7124d25f31c43aa17e23d9fa6c886f80459cba15b6257646b2f3d2"
 

--- a/Formula/ccd2iso.rb
+++ b/Formula/ccd2iso.rb
@@ -1,6 +1,6 @@
 class Ccd2iso < Formula
   desc "Convert CloneCD images to ISO images"
-  homepage "http://ccd2iso.sourceforge.net/"
+  homepage "https://ccd2iso.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ccd2iso/ccd2iso/ccd2iso-0.3/ccd2iso-0.3.tar.gz"
   sha256 "f874b8fe26112db2cdb016d54a9f69cf286387fbd0c8a55882225f78e20700fc"
 

--- a/Formula/cclive.rb
+++ b/Formula/cclive.rb
@@ -1,6 +1,6 @@
 class Cclive < Formula
   desc "Command-line video extraction utility"
-  homepage "http://cclive.sourceforge.net/"
+  homepage "https://cclive.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cclive/0.7/cclive-0.7.16.tar.xz"
   sha256 "586a120faddcfa16f5bb058b5c901f1659336c6fc85a0d3f1538882a44ee10e1"
 

--- a/Formula/ccrypt.rb
+++ b/Formula/ccrypt.rb
@@ -1,6 +1,6 @@
 class Ccrypt < Formula
   desc "Encrypt and decrypt files and streams"
-  homepage "http://ccrypt.sourceforge.net/"
+  homepage "https://ccrypt.sourceforge.io/"
   url "http://ccrypt.sourceforge.net/download/ccrypt-1.10.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/c/ccrypt/ccrypt_1.10.orig.tar.gz"
   sha256 "87d66da2170facabf6f2fc073586ae2c7320d4689980cfca415c74688e499ba0"

--- a/Formula/cdrdao.rb
+++ b/Formula/cdrdao.rb
@@ -1,6 +1,6 @@
 class Cdrdao < Formula
   desc "Record CDs in Disk-At-Once mode"
-  homepage "http://cdrdao.sourceforge.net/"
+  homepage "https://cdrdao.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cdrdao/cdrdao/1.2.3/cdrdao-1.2.3.tar.bz2"
   sha256 "8193cb8fa6998ac362c55807e89ad0b3c63edc6b01afaeb3d5042519527fb75e"
 

--- a/Formula/cfv.rb
+++ b/Formula/cfv.rb
@@ -1,6 +1,6 @@
 class Cfv < Formula
   desc "Test and create various files (e.g., .sfv, .csv, .crc., .torrent)"
-  homepage "http://cfv.sourceforge.net/"
+  homepage "https://cfv.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cfv/cfv/1.18.3/cfv-1.18.3.tar.gz"
   sha256 "ff28a8aa679932b83eb3b248ed2557c6da5860d5f8456ffe24686253a354cff6"
 

--- a/Formula/checkstyle.rb
+++ b/Formula/checkstyle.rb
@@ -1,6 +1,6 @@
 class Checkstyle < Formula
   desc "Check Java source against a coding standard"
-  homepage "http://checkstyle.sourceforge.net/"
+  homepage "https://checkstyle.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/checkstyle/checkstyle/7.5.1/checkstyle-7.5.1-all.jar"
   sha256 "fa26832b41ecab91dd570dff6aee96b79458a16a90258b61a09bf4ebf48a0a06"
 

--- a/Formula/clasp.rb
+++ b/Formula/clasp.rb
@@ -1,6 +1,6 @@
 class Clasp < Formula
   desc "Answer set solver for (extended) normal logic programs"
-  homepage "http://potassco.sourceforge.net/"
+  homepage "https://potassco.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/potassco/clasp/3.2.0/clasp-3.2.0-source.tar.gz"
   sha256 "eafb050408b586d561cd828aec331b4d3b92ea7a26d249a02c4f39b1675f4e68"
 

--- a/Formula/clean.rb
+++ b/Formula/clean.rb
@@ -1,6 +1,6 @@
 class Clean < Formula
   desc "Search for files matching a regex and delete them"
-  homepage "http://clean.sourceforge.net/"
+  homepage "https://clean.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/clean/clean/3.4/clean-3.4.tar.bz2"
   sha256 "761f3a9e1ed50747b6a62a8113fa362a7cc74d359ac6e8e30ba6b30d59115320"
 

--- a/Formula/clpbar.rb
+++ b/Formula/clpbar.rb
@@ -1,6 +1,6 @@
 class Clpbar < Formula
   desc "Command-line progress bar"
-  homepage "http://clpbar.sourceforge.net/"
+  homepage "https://clpbar.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/clpbar/clpbar/bar-1.11.1/bar_1.11.1.tar.gz"
   sha256 "fa0f5ec5c8400316c2f4debdc6cdcb80e186e668c2e4471df4fec7bfcd626503"
 

--- a/Formula/cmu-pocketsphinx.rb
+++ b/Formula/cmu-pocketsphinx.rb
@@ -1,6 +1,6 @@
 class CmuPocketsphinx < Formula
   desc "Lightweight speech recognition engine for mobile devices"
-  homepage "http://cmusphinx.sourceforge.net/"
+  homepage "https://cmusphinx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cmusphinx/pocketsphinx/0.8/pocketsphinx-0.8.tar.gz"
   sha256 "874c4c083d91c8ff26a2aec250b689e537912ff728923c141c4dac48662cce7a"
 

--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -1,6 +1,6 @@
 class CmuSphinxbase < Formula
   desc "Lightweight speech recognition engine for mobile devices"
-  homepage "http://cmusphinx.sourceforge.net/"
+  homepage "https://cmusphinx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cmusphinx/sphinxbase/0.8/sphinxbase-0.8.tar.gz"
   sha256 "55708944872bab1015b8ae07b379bf463764f469163a8fd114cbb16c5e486ca8"
 

--- a/Formula/cmuclmtk.rb
+++ b/Formula/cmuclmtk.rb
@@ -1,6 +1,6 @@
 class Cmuclmtk < Formula
   desc "Language model tools (from CMU Sphinx)"
-  homepage "http://cmusphinx.sourceforge.net/"
+  homepage "https://cmusphinx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cmusphinx/cmuclmtk/0.7/cmuclmtk-0.7.tar.gz"
   sha256 "d23e47f00224667c059d69ac942f15dc3d4c3dd40e827318a6213699b7fa2915"
 

--- a/Formula/cntlm.rb
+++ b/Formula/cntlm.rb
@@ -1,6 +1,6 @@
 class Cntlm < Formula
   desc "NTLM authentication proxy with tunneling"
-  homepage "http://cntlm.sourceforge.net/"
+  homepage "https://cntlm.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cntlm/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.bz2"
   sha256 "7b603d6200ab0b26034e9e200fab949cc0a8e5fdd4df2c80b8fc5b1c37e7b930"
 

--- a/Formula/cpptest.rb
+++ b/Formula/cpptest.rb
@@ -1,6 +1,6 @@
 class Cpptest < Formula
   desc "Unit testing framework handling automated tests in C++"
-  homepage "http://cpptest.sourceforge.net/"
+  homepage "https://cpptest.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cpptest/cpptest/cpptest-1.1.2/cpptest-1.1.2.tar.gz"
   sha256 "9e4fdf156b709397308536eb6b921e3aea1f463c6613f9a0c1dfec9614386027"
 

--- a/Formula/cracklib.rb
+++ b/Formula/cracklib.rb
@@ -1,6 +1,6 @@
 class Cracklib < Formula
   desc "LibCrack password checking library"
-  homepage "http://cracklib.sourceforge.net/"
+  homepage "https://cracklib.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cracklib/cracklib/2.9.5/cracklib-2.9.5.tar.gz"
   sha256 "59ab0138bc8cf90cccb8509b6969a024d5e58d2d02bcbdccbb9ba9b88be3fa33"
 

--- a/Formula/crm114.rb
+++ b/Formula/crm114.rb
@@ -1,6 +1,6 @@
 class Crm114 < Formula
   desc "Examine, sort, filter or alter logs or data streams"
-  homepage "http://crm114.sourceforge.net/"
+  homepage "https://crm114.sourceforge.io/"
   url "http://crm114.sourceforge.net/tarballs/crm114-20100106-BlameMichelson.src.tar.gz"
   sha256 "fb626472eca43ac2bc03526d49151c5f76b46b92327ab9ee9c9455210b938c2b"
 

--- a/Formula/cscope.rb
+++ b/Formula/cscope.rb
@@ -1,6 +1,6 @@
 class Cscope < Formula
   desc "Tool for browsing source code"
-  homepage "http://cscope.sourceforge.net/"
+  homepage "https://cscope.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cscope/cscope/15.8b/cscope-15.8b.tar.gz"
   sha256 "4889d091f05aa0845384b1e4965aa31d2b20911fb2c001b2cdcffbcb7212d3af"
 

--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -1,6 +1,6 @@
 class Ctags < Formula
   desc "Reimplementation of ctags(1)"
-  homepage "http://ctags.sourceforge.net/"
+  homepage "https://ctags.sourceforge.io/"
   revision 1
 
   stable do

--- a/Formula/cunit.rb
+++ b/Formula/cunit.rb
@@ -1,6 +1,6 @@
 class Cunit < Formula
   desc "Lightweight unit testing framework for C"
-  homepage "http://cunit.sourceforge.net/"
+  homepage "https://cunit.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cunit/CUnit/2.1-3/CUnit-2.1-3.tar.bz2"
   sha256 "f5b29137f845bb08b77ec60584fdb728b4e58f1023e6f249a464efa49a40f214"
 

--- a/Formula/cutter.rb
+++ b/Formula/cutter.rb
@@ -1,6 +1,6 @@
 class Cutter < Formula
   desc "Unit Testing Framework for C and C++"
-  homepage "http://cutter.sourceforge.net/"
+  homepage "https://cutter.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cutter/cutter/1.2.5/cutter-1.2.5.tar.gz"
   sha256 "e53613445e8fe20173a656db5a70a7eb0c4586be1d9f33dc93e2eddd2f646b20"
   head "https://github.com/clear-code/cutter.git"

--- a/Formula/davmail.rb
+++ b/Formula/davmail.rb
@@ -1,6 +1,6 @@
 class Davmail < Formula
   desc "POP/IMAP/SMTP/Caldav/Carddav/LDAP exchange gateway"
-  homepage "http://davmail.sourceforge.net/"
+  homepage "https://davmail.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/davmail/davmail/4.7.3/davmail-4.7.3-2438.zip"
   sha256 "d72056d820b4bcabee70f47aed7266596c8e9571e80511ba79ad900aa0464220"
 

--- a/Formula/dbacl.rb
+++ b/Formula/dbacl.rb
@@ -1,6 +1,6 @@
 class Dbacl < Formula
   desc "Digramic Bayesian classifier"
-  homepage "http://dbacl.sourceforge.net/"
+  homepage "https://dbacl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dbacl/dbacl/1.14.1/dbacl-1.14.1.tar.gz"
   sha256 "ff0dfb67682e863b1c3250acc441ce77c033b9b21d8e8793e55b622e42005abd"
 

--- a/Formula/dcfldd.rb
+++ b/Formula/dcfldd.rb
@@ -1,6 +1,6 @@
 class Dcfldd < Formula
   desc "Enhanced version of dd for forensics and security"
-  homepage "http://dcfldd.sourceforge.net/"
+  homepage "https://dcfldd.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dcfldd/dcfldd/1.3.4-1/dcfldd-1.3.4-1.tar.gz"
   sha256 "f5143a184da56fd5ac729d6d8cbcf9f5da8e1cf4604aa9fb97c59553b7e6d5f8"
 

--- a/Formula/detox.rb
+++ b/Formula/detox.rb
@@ -1,6 +1,6 @@
 class Detox < Formula
   desc "Utility to replace problematic characters in filenames"
-  homepage "http://detox.sourceforge.net/"
+  homepage "https://detox.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/detox/detox/1.2.0/detox-1.2.0.tar.bz2"
   sha256 "abfad90ee7d3e0fc53ce3b9da3253f9a800cdd92e3f8cc12a19394a7b1dcdbf8"
 

--- a/Formula/dfu-programmer.rb
+++ b/Formula/dfu-programmer.rb
@@ -1,6 +1,6 @@
 class DfuProgrammer < Formula
   desc "Device firmware update based USB programmer for Atmel chips"
-  homepage "http://dfu-programmer.sourceforge.net/"
+  homepage "https://dfu-programmer.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-0.7.2.tar.gz"
   sha256 "1db4d36b1aedab2adc976e8faa5495df3cf82dc4bf883633dc6ba71f7c4af995"
 

--- a/Formula/dfu-util.rb
+++ b/Formula/dfu-util.rb
@@ -1,6 +1,6 @@
 class DfuUtil < Formula
   desc "USB programmer"
-  homepage "http://dfu-util.sourceforge.net/"
+  homepage "https://dfu-util.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dfu-util/dfu-util-0.9.tar.gz"
   sha256 "36428c6a6cb3088cad5a3592933385253da5f29f2effa61518ee5991ea38f833"
 

--- a/Formula/dgen.rb
+++ b/Formula/dgen.rb
@@ -1,6 +1,6 @@
 class Dgen < Formula
   desc "Sega Genesis / Mega Drive emulator"
-  homepage "http://dgen.sourceforge.net/"
+  homepage "https://dgen.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dgen/dgen/1.33/dgen-sdl-1.33.tar.gz"
   sha256 "99e2c06017c22873c77f88186ebcc09867244eb6e042c763bb094b02b8def61e"
   bottle do

--- a/Formula/diffuse.rb
+++ b/Formula/diffuse.rb
@@ -1,6 +1,6 @@
 class Diffuse < Formula
   desc "Graphical tool for merging and comparing text files"
-  homepage "http://diffuse.sourceforge.net/"
+  homepage "https://diffuse.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/diffuse/diffuse/0.4.8/diffuse-0.4.8.tar.bz2"
   sha256 "c1d3b79bba9352fcb9aa4003537d3fece248fb824781c5e21f3fcccafd42df2b"
 

--- a/Formula/disktype.rb
+++ b/Formula/disktype.rb
@@ -1,6 +1,6 @@
 class Disktype < Formula
   desc "Detect content format of a disk or disk image"
-  homepage "http://disktype.sourceforge.net/"
+  homepage "https://disktype.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/disktype/disktype/9/disktype-9.tar.gz"
   sha256 "b6701254d88412bc5d2db869037745f65f94b900b59184157d072f35832c1111"
   head ":pserver:anonymous:@disktype.cvs.sourceforge.net:/cvsroot/disktype", :using => :cvs

--- a/Formula/ditaa.rb
+++ b/Formula/ditaa.rb
@@ -1,6 +1,6 @@
 class Ditaa < Formula
   desc "Convert ASCII diagrams into proper bitmap graphics"
-  homepage "http://ditaa.sourceforge.net/"
+  homepage "https://ditaa.sourceforge.io/"
   url "https://github.com/stathissideris/ditaa/archive/v0.10.tar.gz"
   sha256 "82e49065d408cba8b323eea0b7f49899578336d566096c6eb6e2d0a28745d63b"
 

--- a/Formula/djvulibre.rb
+++ b/Formula/djvulibre.rb
@@ -1,6 +1,6 @@
 class Djvulibre < Formula
   desc "DjVu viewer"
-  homepage "http://djvu.sourceforge.net/"
+  homepage "https://djvu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/djvu/DjVuLibre/3.5.27/djvulibre-3.5.27.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/d/djvulibre/djvulibre_3.5.27.orig.tar.gz"
   sha256 "e69668252565603875fb88500cde02bf93d12d48a3884e472696c896e81f505f"

--- a/Formula/docbook-xsl.rb
+++ b/Formula/docbook-xsl.rb
@@ -1,6 +1,6 @@
 class DocbookXsl < Formula
   desc "XML vocabulary to create presentation-neutral documents"
-  homepage "http://docbook.sourceforge.net/"
+  homepage "https://docbook.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/docbook/docbook-xsl/1.79.1/docbook-xsl-1.79.1.tar.bz2"
   sha256 "725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968"
 

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -1,6 +1,6 @@
 class Docbook < Formula
   desc "Standard SGML representation system for technical documents"
-  homepage "http://docbook.sourceforge.net/"
+  homepage "https://docbook.sourceforge.io/"
   url "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
   sha256 "3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e"
 

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -1,6 +1,6 @@
 class Docbook2x < Formula
   desc "Convert DocBook to UNIX manpages and GNU TeXinfo"
-  homepage "http://docbook2x.sourceforge.net/"
+  homepage "https://docbook2x.sourceforge.io/"
   url "https://downloads.sourceforge.net/docbook2x/docbook2X-0.8.8.tar.gz"
   sha256 "4077757d367a9d1b1427e8d5dfc3c49d993e90deabc6df23d05cfe9cd2fcdc45"
 

--- a/Formula/docx2txt.rb
+++ b/Formula/docx2txt.rb
@@ -1,6 +1,6 @@
 class Docx2txt < Formula
   desc "Converts Microsoft Office docx documents to equivalent text documents"
-  homepage "http://docx2txt.sourceforge.net/"
+  homepage "https://docx2txt.sourceforge.io/"
   url "https://downloads.sourceforge.net/docx2txt/docx2txt-1.4.tgz"
   sha256 "b297752910a404c1435e703d5aedb4571222bd759fa316c86ad8c8bbe58c6d1b"
 

--- a/Formula/doublecpp.rb
+++ b/Formula/doublecpp.rb
@@ -1,6 +1,6 @@
 class Doublecpp < Formula
   desc "Double dispatch in C++"
-  homepage "http://doublecpp.sourceforge.net/"
+  homepage "https://doublecpp.sourceforge.io/"
   url "https://downloads.sourceforge.net/doublecpp/doublecpp-0.6.3.tar.gz"
   sha256 "232f8bf0d73795558f746c2e77f6d7cb54e1066cbc3ea7698c4fba80983423af"
 

--- a/Formula/doxymacs.rb
+++ b/Formula/doxymacs.rb
@@ -1,6 +1,6 @@
 class Doxymacs < Formula
   desc "Elisp package for using doxygen under Emacs"
-  homepage "http://doxymacs.sourceforge.net/"
+  homepage "https://doxymacs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/doxymacs/doxymacs/1.8.0/doxymacs-1.8.0.tar.gz"
   sha256 "a23fd833bc3c21ee5387c62597610941e987f9d4372916f996bf6249cc495afa"
 

--- a/Formula/dtach.rb
+++ b/Formula/dtach.rb
@@ -1,6 +1,6 @@
 class Dtach < Formula
   desc "Emulates the detach feature of screen"
-  homepage "http://dtach.sourceforge.net/"
+  homepage "https://dtach.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dtach/dtach/0.9/dtach-0.9.tar.gz"
   sha256 "32e9fd6923c553c443fab4ec9c1f95d83fa47b771e6e1dafb018c567291492f3"
 

--- a/Formula/duff.rb
+++ b/Formula/duff.rb
@@ -1,6 +1,6 @@
 class Duff < Formula
   desc "Quickly find duplicates in a set of files from the command-line"
-  homepage "http://duff.sourceforge.net/"
+  homepage "https://duff.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/duff/duff/0.5.2/duff-0.5.2.tar.gz"
   sha256 "15b721f7e0ea43eba3fd6afb41dbd1be63c678952bf3d80350130a0e710c542e"
 

--- a/Formula/dvdauthor.rb
+++ b/Formula/dvdauthor.rb
@@ -1,6 +1,6 @@
 class Dvdauthor < Formula
   desc "DVD-authoring toolset"
-  homepage "http://dvdauthor.sourceforge.net/"
+  homepage "https://dvdauthor.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dvdauthor/dvdauthor/0.7.1/dvdauthor-0.7.1.tar.gz"
   sha256 "501fb11b09c6eb9c5a229dcb400bd81e408cc78d34eab6749970685023c51fe9"
   revision 1

--- a/Formula/e2fsprogs.rb
+++ b/Formula/e2fsprogs.rb
@@ -1,6 +1,6 @@
 class E2fsprogs < Formula
   desc "Utilities for the ext2, ext3, and ext4 file systems"
-  homepage "http://e2fsprogs.sourceforge.net/"
+  homepage "https://e2fsprogs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.42.13/e2fsprogs-1.42.13.tar.gz"
   mirror "https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.42.13/e2fsprogs-1.42.13.tar.gz"
   sha256 "59993ff3a44f82e504561e0ebf95e8c8fa9f9f5746eb6a7182239605d2a4e2d4"

--- a/Formula/ekhtml.rb
+++ b/Formula/ekhtml.rb
@@ -1,6 +1,6 @@
 class Ekhtml < Formula
   desc "Forgiving SAX-style HTML parser"
-  homepage "http://ekhtml.sourceforge.net/"
+  homepage "https://ekhtml.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ekhtml/ekhtml/0.3.2/ekhtml-0.3.2.tar.gz"
   sha256 "1ed1f0166cd56552253cd67abcfa51728ff6b88f39bab742dbf894b2974dc8d6"
 

--- a/Formula/espeak.rb
+++ b/Formula/espeak.rb
@@ -1,6 +1,6 @@
 class Espeak < Formula
   desc "Text to speech, software speech synthesizer"
-  homepage "http://espeak.sourceforge.net/"
+  homepage "https://espeak.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/espeak/espeak/espeak-1.48/espeak-1.48.04-source.zip"
   sha256 "bf9a17673adffcc28ff7ea18764f06136547e97bbd9edf2ec612f09b207f0659"
   revision 1

--- a/Formula/ex-vi.rb
+++ b/Formula/ex-vi.rb
@@ -1,6 +1,6 @@
 class ExVi < Formula
   desc "UTF8-friendly version of tradition vi"
-  homepage "http://ex-vi.sourceforge.net/"
+  homepage "https://ex-vi.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ex-vi/ex-vi/050325/ex-050325.tar.bz2"
   sha256 "da4be7cf67e94572463b19e56850aa36dc4e39eb0d933d3688fe8574bb632409"
 

--- a/Formula/exif.rb
+++ b/Formula/exif.rb
@@ -1,6 +1,6 @@
 class Exif < Formula
   desc "Read, write, modify, and display EXIF data on the command-line"
-  homepage "http://libexif.sourceforge.net/"
+  homepage "https://libexif.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libexif/exif/0.6.21/exif-0.6.21.tar.gz"
   sha256 "1e2e40e5d919edfb23717308eb5aeb5a11337741e6455c049852128a42288e6d"
 

--- a/Formula/exult.rb
+++ b/Formula/exult.rb
@@ -1,6 +1,6 @@
 class Exult < Formula
   desc "Recreation of Ultima 7"
-  homepage "http://exult.sourceforge.net/"
+  homepage "https://exult.sourceforge.io/"
   url "svn://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
   version "1.4.9rc1+r7520"
   head "svn://svn.code.sf.net/p/exult/code/exult/trunk"

--- a/Formula/fatsort.rb
+++ b/Formula/fatsort.rb
@@ -1,6 +1,6 @@
 class Fatsort < Formula
   desc "Sorts FAT16 and FAT32 partitions"
-  homepage "http://fatsort.sourceforge.net/"
+  homepage "https://fatsort.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/fatsort/fatsort-1.3.365.tar.gz"
   sha256 "77acc374b189e80e3d75d3508f3c0ca559f8030f1c220f7cfde719a4adb03f3d"
 

--- a/Formula/ffe.rb
+++ b/Formula/ffe.rb
@@ -1,6 +1,6 @@
 class Ffe < Formula
   desc "Parse flat file structures and print them in different formats"
-  homepage "http://ff-extractor.sourceforge.net/"
+  homepage "https://ff-extractor.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ff-extractor/ff-extractor/0.3.7/ffe-0.3.7.tar.gz"
   sha256 "20ef5fda32e6576e7c81a7a30f2929e99eb84ddeb0f2fa7fa8337e8c6c740141"
 

--- a/Formula/flac123.rb
+++ b/Formula/flac123.rb
@@ -1,6 +1,6 @@
 class Flac123 < Formula
   desc "Command-line program for playing FLAC audio files"
-  homepage "http://flac-tools.sourceforge.net/"
+  homepage "https://flac-tools.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/flac-tools/flac123/flac123-0.0.12-release.tar.gz"
   sha256 "1976efd54a918eadd3cb10b34c77cee009e21ae56274148afa01edf32654e47d"
 

--- a/Formula/flactag.rb
+++ b/Formula/flactag.rb
@@ -1,6 +1,6 @@
 class Flactag < Formula
   desc "Tag single album FLAC files with MusicBrainz CUE sheets"
-  homepage "http://flactag.sourceforge.net/"
+  homepage "https://flactag.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/flactag/v2.0.4/flactag-2.0.4.tar.gz"
   sha256 "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2"
 

--- a/Formula/fmpp.rb
+++ b/Formula/fmpp.rb
@@ -1,6 +1,6 @@
 class Fmpp < Formula
   desc "Text file preprocessing tool using FreeMarker templates."
-  homepage "http://fmpp.sourceforge.net/"
+  homepage "https://fmpp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/fmpp/fmpp/0.9.15/fmpp_0.9.15.tar.gz"
   sha256 "b893451b5450a7f35fe680e934f6903ec8143d88959dcfca5d17467fbe4142f9"
   head "https://github.com/freemarker/fmpp.git"

--- a/Formula/fondu.rb
+++ b/Formula/fondu.rb
@@ -1,6 +1,6 @@
 class Fondu < Formula
   desc "Tools to convert between different font formats"
-  homepage "http://fondu.sourceforge.net/"
+  homepage "https://fondu.sourceforge.io/"
   url "http://fondu.sourceforge.net/fondu_src-060102.tgz"
   sha256 "22bb535d670ebc1766b602d804bebe7e84f907c219734e6a955fcbd414ce5794"
 

--- a/Formula/foremost.rb
+++ b/Formula/foremost.rb
@@ -1,6 +1,6 @@
 class Foremost < Formula
   desc "Console program to recover files based on their headers and footers"
-  homepage "http://foremost.sourceforge.net/"
+  homepage "https://foremost.sourceforge.io/"
   url "http://foremost.sourceforge.net/pkg/foremost-1.5.7.tar.gz"
   sha256 "502054ef212e3d90b292e99c7f7ac91f89f024720cd5a7e7680c3d1901ef5f34"
 

--- a/Formula/freeglut.rb
+++ b/Formula/freeglut.rb
@@ -1,6 +1,6 @@
 class Freeglut < Formula
   desc "Open-source alternative to the OpenGL Utility Toolkit (GLUT) library"
-  homepage "http://freeglut.sourceforge.net/"
+  homepage "https://freeglut.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/freeglut/freeglut/3.0.0/freeglut-3.0.0.tar.gz"
   sha256 "2a43be8515b01ea82bcfa17d29ae0d40bd128342f0930cd1f375f1ff999f76a2"
 

--- a/Formula/fuego.rb
+++ b/Formula/fuego.rb
@@ -1,6 +1,6 @@
 class Fuego < Formula
   desc "Collection of C++ libraries for the game of Go"
-  homepage "http://fuego.sourceforge.net/"
+  homepage "https://fuego.sourceforge.io/"
   url "http://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
   version "1.1.SVN"
 

--- a/Formula/fuse-emulator.rb
+++ b/Formula/fuse-emulator.rb
@@ -1,6 +1,6 @@
 class FuseEmulator < Formula
   desc "Free Unix Spectrum Emulator"
-  homepage "http://fuse-emulator.sourceforge.net/"
+  homepage "https://fuse-emulator.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/fuse-emulator/fuse/1.3.2/fuse-1.3.2.tar.gz"
   sha256 "576bf916b499a4d5932acc34d315e2acd36636d1d5a3911c839589487a6b68e6"
 

--- a/Formula/gabedit.rb
+++ b/Formula/gabedit.rb
@@ -1,6 +1,6 @@
 class Gabedit < Formula
   desc "GUI to computational chemistry packages like Gamess-US, Gaussian, etc."
-  homepage "http://gabedit.sourceforge.net/"
+  homepage "https://gabedit.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gabedit/gabedit/Gabedit248/GabeditSrc248.tar.gz"
   version "2.4.8"
   sha256 "38d6437a18280387b46fd136f2201a73b33e45abde13fa802c64806b6b64e4d3"

--- a/Formula/gaffitter.rb
+++ b/Formula/gaffitter.rb
@@ -1,6 +1,6 @@
 class Gaffitter < Formula
   desc "Efficiently fit files/folders to fixed size volumes (like DVDs)"
-  homepage "http://gaffitter.sourceforge.net/"
+  homepage "https://gaffitter.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gaffitter/gaffitter/1.0.0/gaffitter-1.0.0.tar.gz"
   sha256 "c85d33bdc6c0875a7144b540a7cce3e78e7c23d2ead0489327625549c3ab23ee"
 

--- a/Formula/ganglia.rb
+++ b/Formula/ganglia.rb
@@ -1,6 +1,6 @@
 class Ganglia < Formula
   desc "Scalable distributed monitoring system"
-  homepage "http://ganglia.sourceforge.net/"
+  homepage "https://ganglia.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ganglia/ganglia%20monitoring%20core/3.7.2/ganglia-3.7.2.tar.gz"
   sha256 "042dbcaf580a661b55ae4d9f9b3566230b2232169a0898e91a797a4c61888409"
 

--- a/Formula/gaul.rb
+++ b/Formula/gaul.rb
@@ -1,6 +1,6 @@
 class Gaul < Formula
   desc "Genetic Algorithm Utility Library"
-  homepage "http://gaul.sourceforge.net/"
+  homepage "https://gaul.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gaul/gaul-devel/0.1850-0/gaul-devel-0.1850-0.tar.gz"
   sha256 "7aabb5c1c218911054164c3fca4f5c5f0b9c8d9bab8b2273f48a3ff573da6570"
 

--- a/Formula/genext2fs.rb
+++ b/Formula/genext2fs.rb
@@ -1,6 +1,6 @@
 class Genext2fs < Formula
   desc "Generates an ext2 filesystem as a normal (non-root) user"
-  homepage "http://genext2fs.sourceforge.net/"
+  homepage "https://genext2fs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/genext2fs/genext2fs/1.4.1/genext2fs-1.4.1.tar.gz"
   sha256 "404dbbfa7a86a6c3de8225c8da254d026b17fd288e05cec4df2cc7e1f4feecfc"
 

--- a/Formula/geographiclib.rb
+++ b/Formula/geographiclib.rb
@@ -1,6 +1,6 @@
 class Geographiclib < Formula
   desc "C++ geography library"
-  homepage "http://geographiclib.sourceforge.net/"
+  homepage "https://geographiclib.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/geographiclib/distrib/GeographicLib-1.46.tar.gz"
   sha256 "3a0606fd99fb099572ba1923f556b05b545965359edb92930a658fc99172d962"
 

--- a/Formula/gibbslda.rb
+++ b/Formula/gibbslda.rb
@@ -1,6 +1,6 @@
 class Gibbslda < Formula
   desc "Library wrapping imlib2's context API"
-  homepage "http://gibbslda.sourceforge.net/"
+  homepage "https://gibbslda.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gibbslda/GibbsLDA%2B%2B/0.2/GibbsLDA%2B%2B-0.2.tar.gz"
   sha256 "4ca7b51bd2f098534f2fdf82c3f861f5d8bf92e29a6b7fbdc50c3c2baeb070ae"
 

--- a/Formula/giflib.rb
+++ b/Formula/giflib.rb
@@ -4,7 +4,7 @@
 # Can `brew install homebrew/versions/giflib5` for now.
 class Giflib < Formula
   desc "GIF library using patented LZW algorithm"
-  homepage "http://giflib.sourceforge.net/"
+  homepage "https://giflib.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2"
   sha256 "0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766"
 

--- a/Formula/glew.rb
+++ b/Formula/glew.rb
@@ -1,6 +1,6 @@
 class Glew < Formula
   desc "OpenGL Extension Wrangler Library"
-  homepage "http://glew.sourceforge.net/"
+  homepage "https://glew.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/glew/glew/2.0.0/glew-2.0.0.tgz"
   sha256 "c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764"
   head "https://github.com/nigels-com/glew.git"

--- a/Formula/glui.rb
+++ b/Formula/glui.rb
@@ -1,6 +1,6 @@
 class Glui < Formula
   desc "C++ user interface library"
-  homepage "http://glui.sourceforge.net/"
+  homepage "https://glui.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/glui/Source/2.36/glui-2.36.tgz"
   sha256 "c1ef5e83cf338e225ce849f948170cd681c99661a5c2158b4074515926702787"
 

--- a/Formula/gmtl.rb
+++ b/Formula/gmtl.rb
@@ -1,6 +1,6 @@
 class Gmtl < Formula
   desc "Lightweight math library"
-  homepage "http://ggt.sourceforge.net/"
+  homepage "https://ggt.sourceforge.io/"
   head "https://ggt.svn.sourceforge.net/svnroot/ggt/trunk/"
 
   stable do

--- a/Formula/gnuski.rb
+++ b/Formula/gnuski.rb
@@ -1,6 +1,6 @@
 class Gnuski < Formula
   desc "Open source clone of Skifree"
-  homepage "http://gnuski.sourceforge.net/"
+  homepage "https://gnuski.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gnuski/gnuski/gnuski-0.3/gnuski-0.3.tar.gz"
   sha256 "1b629bd29dd6ad362b56055ccdb4c7ad462ff39d7a0deb915753c2096f5f959d"
 

--- a/Formula/gocr.rb
+++ b/Formula/gocr.rb
@@ -1,6 +1,6 @@
 class Gocr < Formula
   desc "Optical Character Recognition (OCR), converts images back to text"
-  homepage "http://jocr.sourceforge.net/"
+  homepage "https://jocr.sourceforge.io/"
   url "https://www-e.uni-magdeburg.de/jschulen/ocr/gocr-0.50.tar.gz"
   sha256 "bc261244f887419cba6d962ec1ad58eefd77176885093c4a43061e7fd565f5b5"
 

--- a/Formula/gplcver.rb
+++ b/Formula/gplcver.rb
@@ -1,6 +1,6 @@
 class Gplcver < Formula
   desc "Pragmatic C Software GPL Cver 2001"
-  homepage "http://gplcver.sourceforge.net/"
+  homepage "https://gplcver.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gplcver/gplcver/2.12a/gplcver-2.12a.src.tar.bz2"
   sha256 "f7d94677677f10c2d1e366eda2d01a652ef5f30d167660905c100f52f1a46e75"
 

--- a/Formula/gpsim.rb
+++ b/Formula/gpsim.rb
@@ -1,6 +1,6 @@
 class Gpsim < Formula
   desc "Simulator for Microchip's PIC microcontrollers"
-  homepage "http://gpsim.sourceforge.net/"
+  homepage "https://gpsim.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gpsim/gpsim/0.28.0/gpsim-0.28.1.tar.gz"
   sha256 "d8d41fb530630e6df31db89a0ca630038395aed4d07c48859655468ed25658ed"
 

--- a/Formula/gptsync.rb
+++ b/Formula/gptsync.rb
@@ -1,6 +1,6 @@
 class Gptsync < Formula
   desc "GPT and MBR partition tables synchronization tool"
-  homepage "http://refit.sourceforge.net/"
+  homepage "https://refit.sourceforge.io/"
   url "https://downloads.sourceforge.net/refit/refit-src-0.14.tar.gz"
   sha256 "c4b0803683c9f8a1de0b9f65d2b5a25a69100dcc608d58dca1611a8134cde081"
 

--- a/Formula/gputils.rb
+++ b/Formula/gputils.rb
@@ -1,6 +1,6 @@
 class Gputils < Formula
   desc "GNU PIC Utilities"
-  homepage "http://gputils.sourceforge.net/"
+  homepage "https://gputils.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gputils/gputils/1.5.0/gputils-1.5.0.tar.gz"
   sha256 "f6a517c186b991f504be5e4585316871d5950568257885d37487bb368dc76227"
 

--- a/Formula/gqlplus.rb
+++ b/Formula/gqlplus.rb
@@ -1,6 +1,6 @@
 class Gqlplus < Formula
   desc "Drop-in replacement for sqlplus, an Oracle SQL client"
-  homepage "http://gqlplus.sourceforge.net/"
+  homepage "https://gqlplus.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gqlplus/gqlplus/1.16/gqlplus-1.16.tar.gz"
   sha256 "9e0071d6f8bc24b0b3623c69d9205f7d3a19c2cb32b5ac9cff133dc75814acdd"
   revision 1

--- a/Formula/gringo.rb
+++ b/Formula/gringo.rb
@@ -1,6 +1,6 @@
 class Gringo < Formula
   desc "Grounder to translate user-provided logic programs"
-  homepage "http://potassco.sourceforge.net/"
+  homepage "https://potassco.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/potassco/gringo/4.5.4/gringo-4.5.4-source.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/g/gringo/gringo_4.5.4.orig.tar.gz"
   sha256 "81f8bbbb1b06236778028e5f1b8627ee38a712ec708724112fb08aecf9bc649a"

--- a/Formula/gtkextra.rb
+++ b/Formula/gtkextra.rb
@@ -1,6 +1,6 @@
 class Gtkextra < Formula
   desc "Widgets for creating GUIs for GTK+"
-  homepage "http://gtkextra.sourceforge.net/"
+  homepage "https://gtkextra.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gtkextra/3.3/gtkextra-3.3.3.tar.gz"
   sha256 "7889f958ee9fb6bd564aa941891909c3af7a03b92e232c5a90bab0289407d884"
 

--- a/Formula/gtkspell3.rb
+++ b/Formula/gtkspell3.rb
@@ -1,6 +1,6 @@
 class Gtkspell3 < Formula
   desc "Gtk widget for highlighting and replacing misspelled words"
-  homepage "http://gtkspell.sourceforge.net/"
+  homepage "https://gtkspell.sourceforge.io/"
   url "http://gtkspell.sourceforge.net/download/gtkspell3-3.0.7.tar.gz"
   sha256 "13f2e6d3e2554cc24253ef592074b28c117db33b7a4465c98c69a3e0a4fa3cc2"
 

--- a/Formula/gtmess.rb
+++ b/Formula/gtmess.rb
@@ -1,6 +1,6 @@
 class Gtmess < Formula
   desc "Console MSN messenger client"
-  homepage "http://gtmess.sourceforge.net/"
+  homepage "https://gtmess.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gtmess/gtmess/0.97/gtmess-0.97.tar.gz"
   sha256 "606379bb06fa70196e5336cbd421a69d7ebb4b27f93aa1dfd23a6420b3c6f5c6"
   revision 1

--- a/Formula/gts.rb
+++ b/Formula/gts.rb
@@ -1,6 +1,6 @@
 class Gts < Formula
   desc "GNU triangulated surface library"
-  homepage "http://gts.sourceforge.net/"
+  homepage "https://gts.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gts/gts/0.7.6/gts-0.7.6.tar.gz"
   sha256 "059c3e13e3e3b796d775ec9f96abdce8f2b3b5144df8514eda0cc12e13e8b81e"
 

--- a/Formula/h264bitstream.rb
+++ b/Formula/h264bitstream.rb
@@ -1,6 +1,6 @@
 class H264bitstream < Formula
   desc "Library for reading and writing H264 video streams"
-  homepage "http://h264bitstream.sourceforge.net/"
+  homepage "https://h264bitstream.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/h264bitstream/h264bitstream/0.1.9/h264bitstream-0.1.9.tar.gz"
   sha256 "a18dee311adf6533931f702853b39058b1b7d0e484d91b33c6ba6442567d4764"
 

--- a/Formula/htmlcxx.rb
+++ b/Formula/htmlcxx.rb
@@ -1,6 +1,6 @@
 class Htmlcxx < Formula
   desc "Non-validating CSS1 and HTML parser for C++"
-  homepage "http://htmlcxx.sourceforge.net/"
+  homepage "https://htmlcxx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/htmlcxx/htmlcxx/0.86/htmlcxx-0.86.tar.gz"
   sha256 "07542b5ea2442143b125ba213b6823ff4a23fff352ecdd84bbebe1d154f4f5c1"
 

--- a/Formula/httest.rb
+++ b/Formula/httest.rb
@@ -1,6 +1,6 @@
 class Httest < Formula
   desc "Provides a large variety of HTTP-related test functionality."
-  homepage "http://htt.sourceforge.net/"
+  homepage "https://htt.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/htt/htt2.4/httest-2.4.12/httest-2.4.12.tar.gz"
   sha256 "fd18cdc996c199d56d77e9355c07e1e1701d5550c03fbecb06a255ce72d79bd1"
 

--- a/Formula/id3lib.rb
+++ b/Formula/id3lib.rb
@@ -1,6 +1,6 @@
 class Id3lib < Formula
   desc "ID3 tag manipulation"
-  homepage "http://id3lib.sourceforge.net/"
+  homepage "https://id3lib.sourceforge.io/"
   revision 1
 
   stable do

--- a/Formula/id3v2.rb
+++ b/Formula/id3v2.rb
@@ -1,6 +1,6 @@
 class Id3v2 < Formula
   desc "Command-line editor"
-  homepage "http://id3v2.sourceforge.net/"
+  homepage "https://id3v2.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/id3v2/id3v2/0.1.12/id3v2-0.1.12.tar.gz"
   sha256 "8105fad3189dbb0e4cb381862b4fa18744233c3bbe6def6f81ff64f5101722bf"
 

--- a/Formula/iperf.rb
+++ b/Formula/iperf.rb
@@ -1,6 +1,6 @@
 class Iperf < Formula
   desc "Tool to measure maximum TCP and UDP bandwidth"
-  homepage "http://iperf.sourceforge.net/"
+  homepage "https://iperf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/iperf/iperf-2.0.5.tar.gz"
   sha256 "636b4eff0431cea80667ea85a67ce4c68698760a9837e1e9d13096d20362265b"
 

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -1,6 +1,6 @@
 class Ipmitool < Formula
   desc "Utility for IPMI control with kernel driver or LAN interface"
-  homepage "http://ipmitool.sourceforge.net/"
+  homepage "https://ipmitool.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"

--- a/Formula/ipmiutil.rb
+++ b/Formula/ipmiutil.rb
@@ -1,6 +1,6 @@
 class Ipmiutil < Formula
   desc "IPMI server management utility"
-  homepage "http://ipmiutil.sourceforge.net/"
+  homepage "https://ipmiutil.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz"
   sha256 "eb00f0582ee75e1f8d371e398d546ddd7639595b9a0a1f27a84cc6ecb038dbe6"
 

--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -1,6 +1,6 @@
 class Irrlicht < Formula
   desc "Realtime 3D engine"
-  homepage "http://irrlicht.sourceforge.net/"
+  homepage "https://irrlicht.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/irrlicht/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip"
   sha256 "f42b280bc608e545b820206fe2a999c55f290de5c7509a02bdbeeccc1bf9e433"
   head "https://irrlicht.svn.sourceforge.net/svnroot/irrlicht/trunk"

--- a/Formula/isync.rb
+++ b/Formula/isync.rb
@@ -1,6 +1,6 @@
 class Isync < Formula
   desc "Synchronize a maildir with an IMAP server"
-  homepage "http://isync.sourceforge.net/"
+  homepage "https://isync.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/isync/isync/1.2.1/isync-1.2.1.tar.gz"
   sha256 "e716de28c9a08e624a035caae3902fcf3b511553be5d61517a133e03aa3532ae"
 

--- a/Formula/jasmin.rb
+++ b/Formula/jasmin.rb
@@ -1,6 +1,6 @@
 class Jasmin < Formula
   desc "Assembler for the Java Virtual Machine"
-  homepage "http://jasmin.sourceforge.net/"
+  homepage "https://jasmin.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/jasmin/jasmin/jasmin-2.4/jasmin-2.4.zip"
   sha256 "eaa10c68cec68206fd102e9ec7113739eccd790108a1b95a6e8c3e93f20e449d"
 

--- a/Formula/klavaro.rb
+++ b/Formula/klavaro.rb
@@ -1,6 +1,6 @@
 class Klavaro < Formula
   desc "Free touch typing tutor program"
-  homepage "http://klavaro.sourceforge.net/"
+  homepage "https://klavaro.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/klavaro/klavaro-3.02.tar.bz2"
   sha256 "5f77730a8c1c8dfd4443ec8390c7226e3f82537df0882cd1222b140f0d0fcd6c"
 

--- a/Formula/kpcli.rb
+++ b/Formula/kpcli.rb
@@ -1,6 +1,6 @@
 class Kpcli < Formula
   desc "command-line interface to KeePass database files"
-  homepage "http://kpcli.sourceforge.net/"
+  homepage "https://kpcli.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/kpcli/kpcli-3.1.pl"
   sha256 "f1f07704a30d0eae126717d5dae0d24ccced43c316454e4a7b868fe0a239a21a"
   revision 1

--- a/Formula/ktoblzcheck.rb
+++ b/Formula/ktoblzcheck.rb
@@ -1,6 +1,6 @@
 class Ktoblzcheck < Formula
   desc "Library for German banks"
-  homepage "http://ktoblzcheck.sourceforge.net/"
+  homepage "https://ktoblzcheck.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.48.tar.gz"
   sha256 "0f4e66d3a880355b1afc88870d224755e078dfaf192242d9c6acb8853f5bcf58"
 

--- a/Formula/lame.rb
+++ b/Formula/lame.rb
@@ -1,6 +1,6 @@
 class Lame < Formula
   desc "High quality MPEG Audio Layer III (MP3) encoder"
-  homepage "http://lame.sourceforge.net/"
+  homepage "https://lame.sourceforge.io/"
   url "https://downloads.sourceforge.net/sourceforge/lame/lame-3.99.5.tar.gz"
   sha256 "24346b4158e4af3bd9f2e194bb23eb473c75fb7377011523353196b19b9a23ff"
 

--- a/Formula/latex2rtf.rb
+++ b/Formula/latex2rtf.rb
@@ -1,6 +1,6 @@
 class Latex2rtf < Formula
   desc "Translate LaTeX to RTF"
-  homepage "http://latex2rtf.sourceforge.net/"
+  homepage "https://latex2rtf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/latex2rtf/latex2rtf-unix/2.3.8/latex2rtf-2.3.8.tar.gz"
   sha256 "5484530de16e96ce76aedf969c464656a5f8834e748849d9009049e26f8c4143"
 

--- a/Formula/launch4j.rb
+++ b/Formula/launch4j.rb
@@ -1,6 +1,6 @@
 class Launch4j < Formula
   desc "Cross-platform Java executable wrapper"
-  homepage "http://launch4j.sourceforge.net/"
+  homepage "https://launch4j.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.9/launch4j-3.9-macosx-x86.tgz"
   version "3.9"
   sha256 "5de7594b877827be169d88111f6d184db334871c88c2314cd70cc33c3c7344e1"

--- a/Formula/lci.rb
+++ b/Formula/lci.rb
@@ -1,6 +1,6 @@
 class Lci < Formula
   desc "Interpreter for the lambda calculus"
-  homepage "http://lci.sourceforge.net/"
+  homepage "https://lci.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/lci/lci/0.6/lci-0.6.tar.gz"
   sha256 "204f1ca5e2f56247d71ab320246811c220ed511bf08c9cb7f305cf180a93948e"
 

--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -1,6 +1,6 @@
 class Lensfun < Formula
   desc "Remove defects from digital images"
-  homepage "http://lensfun.sourceforge.net/"
+  homepage "https://lensfun.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/lensfun/0.3.2/lensfun-0.3.2.tar.gz"
   sha256 "ae8bcad46614ca47f5bda65b00af4a257a9564a61725df9c74cb260da544d331"
   revision 1

--- a/Formula/libbs2b.rb
+++ b/Formula/libbs2b.rb
@@ -1,6 +1,6 @@
 class Libbs2b < Formula
   desc "Bauer stereophonic-to-binaural DSP"
-  homepage "http://bs2b.sourceforge.net/"
+  homepage "https://bs2b.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bs2b/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz"
   sha256 "6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528"
 

--- a/Formula/libcddb.rb
+++ b/Formula/libcddb.rb
@@ -1,6 +1,6 @@
 class Libcddb < Formula
   desc "CDDB server access library"
-  homepage "http://libcddb.sourceforge.net/"
+  homepage "https://libcddb.sourceforge.io/"
   url "https://downloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2"
   sha256 "35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b"
   revision 1

--- a/Formula/libexif.rb
+++ b/Formula/libexif.rb
@@ -1,6 +1,6 @@
 class Libexif < Formula
   desc "EXIF parsing library"
-  homepage "http://libexif.sourceforge.net/"
+  homepage "https://libexif.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libexif/libexif/0.6.21/libexif-0.6.21.tar.gz"
   sha256 "edb7eb13664cf950a6edd132b75e99afe61c5effe2f16494e6d27bc404b287bf"
 

--- a/Formula/libgetdata.rb
+++ b/Formula/libgetdata.rb
@@ -1,6 +1,6 @@
 class Libgetdata < Formula
   desc "Reference implementation of the Dirfile Standards"
-  homepage "http://getdata.sourceforge.net/"
+  homepage "https://getdata.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/getdata/getdata/0.10.0/getdata-0.10.0.tar.xz"
   sha256 "d547a022f435b9262dcf06dc37ebd41232e2229ded81ef4d4f5b3dbfc558aba3"
 

--- a/Formula/libicns.rb
+++ b/Formula/libicns.rb
@@ -1,6 +1,6 @@
 class Libicns < Formula
   desc "Library for manipulation of the macOS .icns resource format"
-  homepage "http://icns.sourceforge.net/"
+  homepage "https://icns.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
   sha256 "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"

--- a/Formula/libiptcdata.rb
+++ b/Formula/libiptcdata.rb
@@ -1,6 +1,6 @@
 class Libiptcdata < Formula
   desc "Virtual package provided by libiptcdata0"
-  homepage "http://libiptcdata.sourceforge.net/"
+  homepage "https://libiptcdata.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz"
   sha256 "79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e"
 

--- a/Formula/liblo.rb
+++ b/Formula/liblo.rb
@@ -1,6 +1,6 @@
 class Liblo < Formula
   desc "Lightweight Open Sound Control implementation"
-  homepage "http://liblo.sourceforge.net/"
+  homepage "https://liblo.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/liblo/liblo/0.28/liblo-0.28.tar.gz"
   sha256 "da94a9b67b93625354dd89ff7fe31e5297fc9400b6eaf7378c82ee1caf7db909"
 

--- a/Formula/libmodplug.rb
+++ b/Formula/libmodplug.rb
@@ -1,6 +1,6 @@
 class Libmodplug < Formula
   desc "Library from the Modplug-XMMS project"
-  homepage "http://modplug-xmms.sourceforge.net/"
+  homepage "https://modplug-xmms.sourceforge.io/"
   url "https://downloads.sourceforge.net/modplug-xmms/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz"
   sha256 "77462d12ee99476c8645cb5511363e3906b88b33a6b54362b4dbc0f39aa2daad"
 

--- a/Formula/libmpeg2.rb
+++ b/Formula/libmpeg2.rb
@@ -1,6 +1,6 @@
 class Libmpeg2 < Formula
   desc "Library to decode mpeg-2 and mpeg-1 video streams"
-  homepage "http://libmpeg2.sourceforge.net/"
+  homepage "https://libmpeg2.sourceforge.io/"
   url "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
   sha256 "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
 

--- a/Formula/libmtp.rb
+++ b/Formula/libmtp.rb
@@ -1,6 +1,6 @@
 class Libmtp < Formula
   desc "Implementation of Microsoft's Media Transfer Protocol (MTP)"
-  homepage "http://libmtp.sourceforge.net/"
+  homepage "https://libmtp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libmtp/libmtp/1.1.12/libmtp-1.1.12.tar.gz"
   sha256 "cdf59e816c6cda3e908a876c7fb42943f40b85669aea0029a1ca431c89afa1a0"
 

--- a/Formula/libnids.rb
+++ b/Formula/libnids.rb
@@ -1,6 +1,6 @@
 class Libnids < Formula
   desc "Implements E-component of network intrusion detection system"
-  homepage "http://libnids.sourceforge.net/"
+  homepage "https://libnids.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libnids/libnids/1.24/libnids-1.24.tar.gz"
   sha256 "314b4793e0902fbf1fdb7fb659af37a3c1306ed1aad5d1c84de6c931b351d359"
 

--- a/Formula/libpano.rb
+++ b/Formula/libpano.rb
@@ -1,6 +1,6 @@
 class Libpano < Formula
   desc "Build panoramic images from a set of overlapping images"
-  homepage "http://panotools.sourceforge.net/"
+  homepage "https://panotools.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz"
   version "13-2.9.19"
   sha256 "037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8"

--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -1,6 +1,6 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
-  homepage "http://qalculate.sourceforge.net/"
+  homepage "https://qalculate.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qalculate/libqalculate/libqalculate-0.9.7/libqalculate-0.9.7.tar.gz"
   sha256 "9a6d97ce3339d104358294242c3ecd5e312446721e93499ff70acc1604607955"
   revision 1

--- a/Formula/libquicktime.rb
+++ b/Formula/libquicktime.rb
@@ -1,6 +1,6 @@
 class Libquicktime < Formula
   desc "Library for reading and writing quicktime files"
-  homepage "http://libquicktime.sourceforge.net/"
+  homepage "https://libquicktime.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz"
   sha256 "1c53359c33b31347b4d7b00d3611463fe5e942cae3ec0fefe0d2fd413fd47368"
   revision 2

--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -1,6 +1,6 @@
 class Libquvi < Formula
   desc "C library to parse flash media stream properties"
-  homepage "http://quvi.sourceforge.net/"
+  homepage "https://quvi.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2"
   sha256 "f5a2fb0571634483e8a957910f44e739f5a72eb9a1900bd10b453c49b8d5f49d"
   revision 1

--- a/Formula/libreadline-java.rb
+++ b/Formula/libreadline-java.rb
@@ -1,6 +1,6 @@
 class LibreadlineJava < Formula
   desc "Port of GNU readline for Java"
-  homepage "http://java-readline.sourceforge.net/"
+  homepage "https://java-readline.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/java-readline/java-readline/0.8.0/libreadline-java-0.8.0-src.tar.gz"
   sha256 "cdcfd9910bfe2dca4cd08b2462ec05efee7395e9b9c3efcb51e85fa70548c890"
   revision 1

--- a/Formula/libstxxl.rb
+++ b/Formula/libstxxl.rb
@@ -1,6 +1,6 @@
 class Libstxxl < Formula
   desc "C++ implementation of STL for extra large data sets"
-  homepage "http://stxxl.sourceforge.net/"
+  homepage "https://stxxl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/stxxl/stxxl/1.4.1/stxxl-1.4.1.tar.gz"
   sha256 "92789d60cd6eca5c37536235eefae06ad3714781ab5e7eec7794b1c10ace67ac"
 

--- a/Formula/libupnp.rb
+++ b/Formula/libupnp.rb
@@ -1,6 +1,6 @@
 class Libupnp < Formula
   desc "Portable UPnP development kit"
-  homepage "http://pupnp.sourceforge.net/"
+  homepage "https://pupnp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pupnp/pupnp/libUPnP%201.6.21/libupnp-1.6.21.tar.bz2"
   sha256 "af3f3c0846a1d75baeadae4aa5a2bda427567e2a1fb4559bf73ccff0a4f9a39b"
 

--- a/Formula/libvo-aacenc.rb
+++ b/Formula/libvo-aacenc.rb
@@ -1,6 +1,6 @@
 class LibvoAacenc < Formula
   desc "VisualOn AAC encoder library"
-  homepage "http://opencore-amr.sourceforge.net/"
+  homepage "https://opencore-amr.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/opencore-amr/vo-aacenc/vo-aacenc-0.1.3.tar.gz"
   sha256 "e51a7477a359f18df7c4f82d195dab4e14e7414cbd48cf79cc195fc446850f36"
 

--- a/Formula/libwpd.rb
+++ b/Formula/libwpd.rb
@@ -1,6 +1,6 @@
 class Libwpd < Formula
   desc "General purpose library for reading WordPerfect files"
-  homepage "http://libwpd.sourceforge.net/"
+  homepage "https://libwpd.sourceforge.io/"
   url "http://dev-www.libreoffice.org/src/libwpd-0.10.1.tar.bz2"
   sha256 "efc20361d6e43f9ff74de5f4d86c2ce9c677693f5da08b0a88d603b7475a508d"
 

--- a/Formula/libwpg.rb
+++ b/Formula/libwpg.rb
@@ -1,6 +1,6 @@
 class Libwpg < Formula
   desc "Library for reading and parsing Word Perfect Graphics format"
-  homepage "http://libwpg.sourceforge.net/"
+  homepage "https://libwpg.sourceforge.io/"
   url "http://dev-www.libreoffice.org/src/libwpg-0.3.1.tar.bz2"
   sha256 "29049b95895914e680390717a243b291448e76e0f82fb4d2479adee5330fbb59"
 

--- a/Formula/libxspf.rb
+++ b/Formula/libxspf.rb
@@ -1,6 +1,6 @@
 class Libxspf < Formula
   desc "C++ library for XSPF playlist reading and writing"
-  homepage "http://libspiff.sourceforge.net/"
+  homepage "https://libspiff.sourceforge.io/"
   url "http://downloads.xiph.org/releases/xspf/libxspf-1.2.0.tar.bz2"
   sha256 "ba9e93a0066469b074b4022b480004651ad3aa5b4313187fd407d833f79b43a5"
 

--- a/Formula/lifelines.rb
+++ b/Formula/lifelines.rb
@@ -1,6 +1,6 @@
 class Lifelines < Formula
   desc "Text-based genealogy software"
-  homepage "http://lifelines.sourceforge.net/"
+  homepage "https://lifelines.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/lifelines/lifelines/3.0.62/lifelines-3.0.62.tar.gz"
   sha256 "2f00441ac0ed64aab8f76834c055e2b95600ed4c6f5845b9f6e5284ac58a9a52"
 

--- a/Formula/log4c.rb
+++ b/Formula/log4c.rb
@@ -1,6 +1,6 @@
 class Log4c < Formula
   desc "Logging Framework for C"
-  homepage "http://log4c.sourceforge.net/"
+  homepage "https://log4c.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/log4c/log4c/1.2.4/log4c-1.2.4.tar.gz"
   sha256 "5991020192f52cc40fa852fbf6bbf5bd5db5d5d00aa9905c67f6f0eadeed48ea"
 

--- a/Formula/log4cpp.rb
+++ b/Formula/log4cpp.rb
@@ -1,6 +1,6 @@
 class Log4cpp < Formula
   desc "Configurable logging for C++"
-  homepage "http://log4cpp.sourceforge.net/"
+  homepage "https://log4cpp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.1.tar.gz"
   sha256 "35abf332630a6809c969276b1d60b90c81a95daf24c86cfd7866ffef72f9bed0"
 

--- a/Formula/lpc21isp.rb
+++ b/Formula/lpc21isp.rb
@@ -1,6 +1,6 @@
 class Lpc21isp < Formula
   desc "In-circuit programming (ISP) tool for several NXP microcontrollers"
-  homepage "http://lpc21isp.sourceforge.net/"
+  homepage "https://lpc21isp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/lpc21isp/lpc21isp/1.97/lpc21isp_197.tar.gz"
   version "1.97"
   sha256 "9f7d80382e4b70bfa4200233466f29f73a36fea7dc604e32f05b9aa69ef591dc"

--- a/Formula/lxsplit.rb
+++ b/Formula/lxsplit.rb
@@ -1,6 +1,6 @@
 class Lxsplit < Formula
   desc "Tool for splitting or joining files"
-  homepage "http://lxsplit.sourceforge.net/"
+  homepage "https://lxsplit.sourceforge.io/"
   url "https://downloads.sourceforge.net/lxsplit/lxsplit-0.2.4.tar.gz"
   sha256 "858fa939803b2eba97ccc5ec57011c4f4b613ff299abbdc51e2f921016845056"
 

--- a/Formula/mailcheck.rb
+++ b/Formula/mailcheck.rb
@@ -1,6 +1,6 @@
 class Mailcheck < Formula
   desc "Check multiple mailboxes/maildirs for mail"
-  homepage "http://mailcheck.sourceforge.net/"
+  homepage "https://mailcheck.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mailcheck/mailcheck/1.91.2/mailcheck_1.91.2.tar.gz"
   sha256 "6ca6da5c9f8cc2361d4b64226c7d9486ff0962602c321fc85b724babbbfa0a5c"
 

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -1,6 +1,6 @@
 class Makensis < Formula
   desc "System to create Windows installers"
-  homepage "http://nsis.sourceforge.net/"
+  homepage "https://nsis.sourceforge.io/"
 
   stable do
     url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-src.tar.bz2"

--- a/Formula/makepp.rb
+++ b/Formula/makepp.rb
@@ -1,6 +1,6 @@
 class Makepp < Formula
   desc "Drop-in replacement for GNU make"
-  homepage "http://makepp.sourceforge.net/"
+  homepage "https://makepp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/makepp/2.0/makepp-2.0.tgz"
   sha256 "d1b64c6f259ed50dfe0c66abedeb059e5043fc02ca500b2702863d96cdc15a19"
 

--- a/Formula/mcpp.rb
+++ b/Formula/mcpp.rb
@@ -1,6 +1,6 @@
 class Mcpp < Formula
   desc "Alternative C/C++ preprocessor"
-  homepage "http://mcpp.sourceforge.net/"
+  homepage "https://mcpp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mcpp/mcpp/V.2.7.2/mcpp-2.7.2.tar.gz"
   sha256 "3b9b4421888519876c4fc68ade324a3bbd81ceeb7092ecdbbc2055099fcb8864"
 

--- a/Formula/mergelog.rb
+++ b/Formula/mergelog.rb
@@ -1,6 +1,6 @@
 class Mergelog < Formula
   desc "Merges httpd logs from web servers behind round-robin DNS"
-  homepage "http://mergelog.sourceforge.net/"
+  homepage "https://mergelog.sourceforge.io/"
   url "https://downloads.sourceforge.net/mergelog/mergelog-4.5.tar.gz"
   sha256 "fd97c5b9ae88fbbf57d3be8d81c479e0df081ed9c4a0ada48b1ab8248a82676d"
 

--- a/Formula/mhash.rb
+++ b/Formula/mhash.rb
@@ -1,6 +1,6 @@
 class Mhash < Formula
   desc "Uniform interface to a large number of hash algorithms"
-  homepage "http://mhash.sourceforge.net/"
+  homepage "https://mhash.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mhash/mhash/0.9.9.9/mhash-0.9.9.9.tar.gz"
   sha256 "3dcad09a63b6f1f634e64168dd398e9feb9925560f9b671ce52283a79604d13e"
 

--- a/Formula/minidjvu.rb
+++ b/Formula/minidjvu.rb
@@ -1,6 +1,6 @@
 class Minidjvu < Formula
   desc "DjVu multipage encoder, single page encoder/decoder"
-  homepage "http://minidjvu.sourceforge.net/"
+  homepage "https://minidjvu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/minidjvu/minidjvu/0.8/minidjvu-0.8.tar.gz"
   sha256 "e9c892e0272ee4e560eaa2dbd16b40719b9797a1fa2749efeb6622f388dfb74a"
 

--- a/Formula/mjpegtools.rb
+++ b/Formula/mjpegtools.rb
@@ -1,6 +1,6 @@
 class Mjpegtools < Formula
   desc "Record and playback videos and perform simple edits"
-  homepage "http://mjpeg.sourceforge.net/"
+  homepage "https://mjpeg.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mjpeg/mjpegtools/2.1.0/mjpegtools-2.1.0.tar.gz"
   sha256 "864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
   revision 1

--- a/Formula/mktorrent.rb
+++ b/Formula/mktorrent.rb
@@ -1,6 +1,6 @@
 class Mktorrent < Formula
   desc "Create BitTorrent metainfo files"
-  homepage "http://mktorrent.sourceforge.net/"
+  homepage "https://mktorrent.sourceforge.io/"
   url "https://github.com/Rudde/mktorrent/archive/v1.1.tar.gz"
   sha256 "d0f47500192605d01b5a2569c605e51ed319f557d24cfcbcb23a26d51d6138c9"
 

--- a/Formula/modules.rb
+++ b/Formula/modules.rb
@@ -1,6 +1,6 @@
 class Modules < Formula
   desc "Dynamic modification of a user's environment via modulefiles"
-  homepage "http://modules.sourceforge.net/"
+  homepage "https://modules.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/modules/Modules/modules-3.2.10/modules-3.2.10.tar.bz2"
   sha256 "e8403492a8d57ace6485813ad6cdaafe0a735b7d93b9435553a8d11d3fdd29a2"
 

--- a/Formula/mp3unicode.rb
+++ b/Formula/mp3unicode.rb
@@ -1,6 +1,6 @@
 class Mp3unicode < Formula
   desc "Command-line utility to convert mp3 tags between different encodings"
-  homepage "http://mp3unicode.sourceforge.net/"
+  homepage "https://mp3unicode.sourceforge.io/"
   url "https://github.com/downloads/alonbl/mp3unicode/mp3unicode-1.2.1.tar.bz2"
   sha256 "375b432ce784407e74fceb055d115bf83b1bd04a83b95256171e1a36e00cfe07"
 

--- a/Formula/mp3val.rb
+++ b/Formula/mp3val.rb
@@ -1,6 +1,6 @@
 class Mp3val < Formula
   desc "Program for MPEG audio stream validation"
-  homepage "http://mp3val.sourceforge.net/"
+  homepage "https://mp3val.sourceforge.io/"
   url "https://downloads.sourceforge.net/mp3val/mp3val-0.1.8-src.tar.gz"
   sha256 "95a16efe3c352bb31d23d68ee5cb8bb8ebd9868d3dcf0d84c96864f80c31c39f"
 

--- a/Formula/mp3wrap.rb
+++ b/Formula/mp3wrap.rb
@@ -1,6 +1,6 @@
 class Mp3wrap < Formula
   desc "Wrap two or more mp3 files in a single large file"
-  homepage "http://mp3wrap.sourceforge.net/"
+  homepage "https://mp3wrap.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mp3wrap/mp3wrap/mp3wrap%200.5/mp3wrap-0.5-src.tar.gz"
   sha256 "1b4644f6b7099dcab88b08521d59d6f730fa211b5faf1f88bd03bf61fedc04e7"
 

--- a/Formula/mpg321.rb
+++ b/Formula/mpg321.rb
@@ -1,6 +1,6 @@
 class Mpg321 < Formula
   desc "Command-line MP3 player"
-  homepage "http://mpg321.sourceforge.net/"
+  homepage "https://mpg321.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mpg321/mpg321/0.3.2/mpg321_0.3.2.orig.tar.gz"
   sha256 "056fcc03e3f5c5021ec74bb5053d32c4a3b89b4086478dcf81adae650eac284e"
 

--- a/Formula/mpop.rb
+++ b/Formula/mpop.rb
@@ -1,6 +1,6 @@
 class Mpop < Formula
   desc "POP3 client"
-  homepage "http://mpop.sourceforge.net/"
+  homepage "https://mpop.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mpop/mpop/1.2.6/mpop-1.2.6.tar.xz"
   sha256 "9fec7a9dd08fc0f04bf6178bc651b036d1fe0e46903146f38a8d182887e9315c"
 

--- a/Formula/mussh.rb
+++ b/Formula/mussh.rb
@@ -1,6 +1,6 @@
 class Mussh < Formula
   desc "Multi-host SSH wrapper"
-  homepage "http://mussh.sourceforge.net/"
+  homepage "https://mussh.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/mussh/mussh/1.0/mussh-1.0.tgz"
   sha256 "6ba883cfaacc3f54c2643e8790556ff7b17da73c9e0d4e18346a51791fedd267"
 

--- a/Formula/myman.rb
+++ b/Formula/myman.rb
@@ -1,6 +1,6 @@
 class Myman < Formula
   desc "Text-mode videogame inspired by Namco's Pac-Man"
-  homepage "http://myman.sourceforge.net/"
+  homepage "https://myman.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/myman/myman-cvs/myman-cvs-2009-10-30/myman-wip-2009-10-30.tar.gz"
   sha256 "bf69607eabe4c373862c81bf56756f2a96eecb8eaa8c911bb2abda78b40c6d73"
   head ":pserver:anonymous:@myman.cvs.sourceforge.net:/cvsroot/myman", :using => :cvs

--- a/Formula/netcat.rb
+++ b/Formula/netcat.rb
@@ -1,6 +1,6 @@
 class Netcat < Formula
   desc "Utility for managing network connections"
-  homepage "http://netcat.sourceforge.net/"
+  homepage "https://netcat.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2"
   sha256 "b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb"
 

--- a/Formula/nettoe.rb
+++ b/Formula/nettoe.rb
@@ -1,6 +1,6 @@
 class Nettoe < Formula
   desc "Tic Tac Toe-like game for the console"
-  homepage "http://nettoe.sourceforge.net/"
+  homepage "https://nettoe.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nettoe/nettoe/1.5.1/nettoe-1.5.1.tar.gz"
   sha256 "dbc2c08e7e0f7e60236954ee19a165a350ab3e0bcbbe085ecd687f39253881cb"
 

--- a/Formula/ngrep.rb
+++ b/Formula/ngrep.rb
@@ -1,6 +1,6 @@
 class Ngrep < Formula
   desc "Network grep"
-  homepage "http://ngrep.sourceforge.net/"
+  homepage "https://ngrep.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ngrep/ngrep/1.45/ngrep-1.45.tar.bz2"
   sha256 "aea6dd337da8781847c75b3b5b876e4de9c58520e0d77310679a979fc6402fa7"
   revision 1

--- a/Formula/ninvaders.rb
+++ b/Formula/ninvaders.rb
@@ -1,6 +1,6 @@
 class Ninvaders < Formula
   desc "Space Invaders in the terminal"
-  homepage "http://ninvaders.sourceforge.net/"
+  homepage "https://ninvaders.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ninvaders/ninvaders/0.1.1/ninvaders-0.1.1.tar.gz"
   sha256 "bfbc5c378704d9cf5e7fed288dac88859149bee5ed0850175759d310b61fd30b"
 

--- a/Formula/npush.rb
+++ b/Formula/npush.rb
@@ -1,6 +1,6 @@
 class Npush < Formula
   desc "Logic game simliar to Sokoban and Boulder Dash"
-  homepage "http://npush.sourceforge.net/"
+  homepage "https://npush.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/npush/npush/0.7/npush-0.7.tgz"
   sha256 "f216d2b3279e8737784f77d4843c9e6f223fa131ce1ebddaf00ad802aba2bcd9"
   head "svn://svn.code.sf.net/p/npush/code/"

--- a/Formula/nsuds.rb
+++ b/Formula/nsuds.rb
@@ -1,6 +1,6 @@
 class Nsuds < Formula
   desc "Ncurses Sudoku system"
-  homepage "http://nsuds.sourceforge.net/"
+  homepage "https://nsuds.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nsuds/nsuds/nsuds-0.7B/nsuds-0.7B.tar.gz"
   sha256 "6d9b3e53f3cf45e9aa29f742f6a3f7bc83a1290099a62d9b8ba421879076926e"
 

--- a/Formula/nuvie.rb
+++ b/Formula/nuvie.rb
@@ -1,6 +1,6 @@
 class Nuvie < Formula
   desc "The Ultima 6 engine"
-  homepage "http://nuvie.sourceforge.net/"
+  homepage "https://nuvie.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nuvie/Nuvie/0.5/nuvie-0.5.tgz"
   sha256 "ff026f6d569d006d9fe954f44fdf0c2276dbf129b0fc5c0d4ef8dce01f0fc257"
 

--- a/Formula/nxengine.rb
+++ b/Formula/nxengine.rb
@@ -1,6 +1,6 @@
 class Nxengine < Formula
   desc "Rewrite of Cave Story (Doukutsu Monogatari)"
-  homepage "http://nxengine.sourceforge.net/"
+  homepage "https://nxengine.sourceforge.io/"
   url "http://nxengine.sourceforge.net/dl/nx-src-1006.tar.bz2"
   version "1.0.0.6"
   sha256 "cf9cbf15dfdfdc9936720a714876bb1524afbd2931e3eaa4c89984a40b21ad68"

--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -1,6 +1,6 @@
 class Ocamlsdl < Formula
   desc "OCaml interface with the SDL C library"
-  homepage "http://ocamlsdl.sourceforge.net/"
+  homepage "https://ocamlsdl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha256 "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f"
   revision 4

--- a/Formula/omniorb.rb
+++ b/Formula/omniorb.rb
@@ -1,6 +1,6 @@
 class Omniorb < Formula
   desc "IOR and naming service utilities for omniORB"
-  homepage "http://omniorb.sourceforge.net/"
+  homepage "https://omniorb.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/omniorb/omniORB/omniORB-4.2.1/omniORB-4.2.1-2.tar.bz2"
   sha256 "9b638c7047a05551c42fe13901194e63b58750d4124654bfa26203d09cb5072d"
 

--- a/Formula/open-jtalk.rb
+++ b/Formula/open-jtalk.rb
@@ -1,6 +1,6 @@
 class OpenJtalk < Formula
   desc "Japanese text-to-speech system"
-  homepage "http://open-jtalk.sourceforge.net/"
+  homepage "https://open-jtalk.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-1.10/open_jtalk-1.10.tar.gz"
   sha256 "5b77ee729e546ca6a22d0b08cda0923fb4225fa782b26c2511b66cc644c14b7d"
   revision 1

--- a/Formula/opencore-amr.rb
+++ b/Formula/opencore-amr.rb
@@ -1,6 +1,6 @@
 class OpencoreAmr < Formula
   desc "Audio codecs extracted from Android open source project"
-  homepage "http://opencore-amr.sourceforge.net/"
+  homepage "https://opencore-amr.sourceforge.io/"
   url "https://downloads.sourceforge.net/opencore-amr/opencore-amr-0.1.4.tar.gz"
   sha256 "029918505e6a357b2b09432c7892a192d740d8b82f8a44c2e0805ba45643a95b"
 

--- a/Formula/opensyobon.rb
+++ b/Formula/opensyobon.rb
@@ -1,6 +1,6 @@
 class Opensyobon < Formula
   desc "Parody of Super Mario Bros"
-  homepage "http://opensyobon.sourceforge.net/"
+  homepage "https://opensyobon.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/opensyobon/src/SyobonAction_rc2_src.tar.gz"
   version "1.0rc2"
   sha256 "a61a621de7e4603be047e8666c0376892200f2876c244fb2adc9e4afebc79728"

--- a/Formula/ophcrack.rb
+++ b/Formula/ophcrack.rb
@@ -1,6 +1,6 @@
 class Ophcrack < Formula
   desc "Microsoft Windows password cracker using rainbow tables"
-  homepage "http://ophcrack.sourceforge.net/"
+  homepage "https://ophcrack.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ophcrack/ophcrack/3.6.1/ophcrack-3.6.1.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/o/ophcrack/ophcrack_3.6.1.orig.tar.bz2"
   sha256 "82dd1699eb7340ce8c7913758db2ab434659f8ad0a27abb186467627a0b8b798"

--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -1,6 +1,6 @@
 class Optipng < Formula
   desc "PNG file optimizer"
-  homepage "http://optipng.sourceforge.net/"
+  homepage "https://optipng.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.6/optipng-0.7.6.tar.gz"
   sha256 "4870631fcbd3825605f00a168b8debf44ea1cda8ef98a73e5411eee97199be80"
   head "http://hg.code.sf.net/p/optipng/mercurial", :using => :hg

--- a/Formula/p7zip.rb
+++ b/Formula/p7zip.rb
@@ -1,6 +1,6 @@
 class P7zip < Formula
   desc "7-Zip (high compression file archiver) implementation"
-  homepage "http://p7zip.sourceforge.net/"
+  homepage "https://p7zip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/p7zip/p7zip/16.02/p7zip_16.02_src_all.tar.bz2"
   sha256 "5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f"
 

--- a/Formula/paps.rb
+++ b/Formula/paps.rb
@@ -1,6 +1,6 @@
 class Paps < Formula
   desc "Pango to PostScript converter"
-  homepage "http://paps.sourceforge.net/"
+  homepage "https://paps.sourceforge.io/"
   url "https://downloads.sourceforge.net/paps/paps-0.6.8.tar.gz"
   sha256 "db214c4ea7ecde2f7986b869f6249864d3ff364e6f210c15aa2824bcbd850a20"
 

--- a/Formula/par2.rb
+++ b/Formula/par2.rb
@@ -1,6 +1,6 @@
 class Par2 < Formula
   desc "Parchive: Parity Archive Volume Set for data recovery"
-  homepage "http://parchive.sourceforge.net/"
+  homepage "https://parchive.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/parchive/par2cmdline/0.4/par2cmdline-0.4.tar.gz"
   sha256 "9e32b7dbcf7bca8249f98824757d4868714156fe2276516504cd26f736e9f677"
 

--- a/Formula/pcal.rb
+++ b/Formula/pcal.rb
@@ -1,6 +1,6 @@
 class Pcal < Formula
   desc "Generate Postscript calendars without X"
-  homepage "http://pcal.sourceforge.net/"
+  homepage "https://pcal.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pcal/pcal/pcal-4.11.0/pcal-4.11.0.tgz"
   sha256 "8406190e7912082719262b71b63ee31a98face49aa52297db96cc0c970f8d207"
 

--- a/Formula/pdfcrack.rb
+++ b/Formula/pdfcrack.rb
@@ -1,6 +1,6 @@
 class Pdfcrack < Formula
   desc "PDF files password cracker"
-  homepage "http://pdfcrack.sourceforge.net/"
+  homepage "https://pdfcrack.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pdfcrack/pdfcrack/pdfcrack-0.15/pdfcrack-0.15.tar.gz"
   sha256 "791043693f9fc261fa326dbcb5e4de3801d6ae552dbea39293f9b2674c250d3e"
 

--- a/Formula/pdftohtml.rb
+++ b/Formula/pdftohtml.rb
@@ -1,6 +1,6 @@
 class Pdftohtml < Formula
   desc "PDF to HTML converter (based on xpdf)"
-  homepage "http://pdftohtml.sourceforge.net/"
+  homepage "https://pdftohtml.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pdftohtml/Experimental%20Versions/pdftohtml%200.40/pdftohtml-0.40a.tar.gz"
   sha256 "277ec1c75231b0073a458b1bfa2f98b7a115f5565e53494822ec7f0bcd8d4655"
 

--- a/Formula/perceptualdiff.rb
+++ b/Formula/perceptualdiff.rb
@@ -1,6 +1,6 @@
 class Perceptualdiff < Formula
   desc "Perceptual image comparison tool"
-  homepage "http://pdiff.sourceforge.net/"
+  homepage "https://pdiff.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pdiff/pdiff/perceptualdiff-1.1.1/perceptualdiff-1.1.1-src.tar.gz"
   sha256 "ab349279a63018663930133b04852bde2f6a373cc175184b615944a10c1c7c6a"
 

--- a/Formula/pioneers.rb
+++ b/Formula/pioneers.rb
@@ -1,6 +1,6 @@
 class Pioneers < Formula
   desc "Settlers of Catan clone"
-  homepage "http://pio.sourceforge.net/"
+  homepage "https://pio.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pio/Source/pioneers-15.3.tar.gz"
   sha256 "69afa51b71646565536b571b0f89786d3a7616965265f196fd51656b51381a89"
 

--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -1,6 +1,6 @@
 class Plantuml < Formula
   desc "Draw UML diagrams"
-  homepage "http://plantuml.sourceforge.net/"
+  homepage "https://plantuml.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/plantuml/plantuml.8053.jar"
   sha256 "9551a8d4a7cce5c7a2fb1124910ff7347aee9a3a90ff2e451d6629fe82f7a380"
 

--- a/Formula/ploticus.rb
+++ b/Formula/ploticus.rb
@@ -1,6 +1,6 @@
 class Ploticus < Formula
   desc "Scriptable plotting and graphing utility"
-  homepage "http://ploticus.sourceforge.net/"
+  homepage "https://ploticus.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ploticus/ploticus/2.42/ploticus242_src.tar.gz"
   version "2.42"
   sha256 "3f29e4b9f405203a93efec900e5816d9e1b4381821881e241c08cab7dd66e0b0"

--- a/Formula/pngnq.rb
+++ b/Formula/pngnq.rb
@@ -1,6 +1,6 @@
 class Pngnq < Formula
   desc "Tool for optimizing PNG images"
-  homepage "http://pngnq.sourceforge.net/"
+  homepage "https://pngnq.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pngnq/pngnq/1.1/pngnq-1.1.tar.gz"
   sha256 "c147fe0a94b32d323ef60be9fdcc9b683d1a82cd7513786229ef294310b5b6e2"
   revision 1

--- a/Formula/postgres-xc.rb
+++ b/Formula/postgres-xc.rb
@@ -1,6 +1,6 @@
 class PostgresXc < Formula
   desc "PostgreSQL cluster based on shared-nothing architecture"
-  homepage "http://postgres-xc.sourceforge.net/"
+  homepage "https://postgres-xc.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/postgres-xc/Version_1.0/pgxc-v1.0.4.tar.gz"
   sha256 "b467cbb7d562a8545645182958efd1608799ed4e04a9c3906211878d477b29c1"
   revision 1

--- a/Formula/proctools.rb
+++ b/Formula/proctools.rb
@@ -1,6 +1,6 @@
 class Proctools < Formula
   desc "pgrep, pkill, and pfind for OpenBSD and Darwin (macOS)"
-  homepage "http://proctools.sourceforge.net/"
+  homepage "https://proctools.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/proctools/proctools/0.4pre1/proctools-0.4pre1.tar.gz"
   version "0.4pre1"
   sha256 "4553b9c6eda959b12913bc39b6e048a8a66dad18f888f983697fece155ec5538"

--- a/Formula/proguard.rb
+++ b/Formula/proguard.rb
@@ -1,6 +1,6 @@
 class Proguard < Formula
   desc "Java class file shrinker, optimizer, and obfuscator"
-  homepage "http://proguard.sourceforge.net/"
+  homepage "https://proguard.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/proguard/proguard/5.3/proguard5.3.tar.gz"
   sha256 "8f185c343dcc4504b3c496bdbf870feba3523abe7cec060b44bbacd1fc2da955"
 

--- a/Formula/proxytunnel.rb
+++ b/Formula/proxytunnel.rb
@@ -1,6 +1,6 @@
 class Proxytunnel < Formula
   desc "Create TCP tunnels through HTTPS proxies"
-  homepage "http://proxytunnel.sourceforge.net/"
+  homepage "https://proxytunnel.sourceforge.io/"
   url "https://downloads.sourceforge.net/proxytunnel/proxytunnel-1.9.0.tgz"
   sha256 "2ef5bbf8d81ddf291d71f865c5dab89affcc07c4cb4b3c3f23e1e9462721a6b9"
   revision 1

--- a/Formula/puf.rb
+++ b/Formula/puf.rb
@@ -1,6 +1,6 @@
 class Puf < Formula
   desc "Parallel URL fetcher"
-  homepage "http://puf.sourceforge.net/"
+  homepage "https://puf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/puf/puf/1.0.0/puf-1.0.0.tar.gz"
   sha256 "3f1602057dc47debeb54effc2db9eadcffae266834389bdbf5ab14fc611eeaf0"
 

--- a/Formula/pwgen.rb
+++ b/Formula/pwgen.rb
@@ -1,6 +1,6 @@
 class Pwgen < Formula
   desc "Password generator"
-  homepage "http://pwgen.sourceforge.net/"
+  homepage "https://pwgen.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pwgen/pwgen/2.07/pwgen-2.07.tar.gz"
   sha256 "eb74593f58296c21c71cd07933e070492e9222b79cedf81d1a02ce09c0e11556"
 

--- a/Formula/qpdf.rb
+++ b/Formula/qpdf.rb
@@ -1,6 +1,6 @@
 class Qpdf < Formula
   desc "Tools for and transforming and inspecting PDF files"
-  homepage "http://qpdf.sourceforge.net/"
+  homepage "https://qpdf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qpdf/qpdf/6.0.0/qpdf-6.0.0.tar.gz"
   sha256 "a9fdc7e94d38fcd3831f37b6e0fe36492bf79aa6d54f8f66062cf7f9c4155233"
 

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -1,6 +1,6 @@
 class Qtads < Formula
   desc "TADS multimedia interpreter"
-  homepage "http://qtads.sourceforge.net/"
+  homepage "https://qtads.sourceforge.io/"
   head "https://github.com/realnc/qtads.git"
 
   stable do

--- a/Formula/quazip.rb
+++ b/Formula/quazip.rb
@@ -1,6 +1,6 @@
 class Quazip < Formula
   desc "C++ wrapper over Gilles Vollant's ZIP/UNZIP package"
-  homepage "http://quazip.sourceforge.net/"
+  homepage "https://quazip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/quazip/quazip/0.7.3/quazip-0.7.3.tar.gz"
   sha256 "2ad4f354746e8260d46036cde1496c223ec79765041ea28eb920ced015e269b5"
 

--- a/Formula/queequeg.rb
+++ b/Formula/queequeg.rb
@@ -1,6 +1,6 @@
 class Queequeg < Formula
   desc "English grammar checker for non-native speakers"
-  homepage "http://queequeg.sourceforge.net/"
+  homepage "https://queequeg.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/queequeg/queequeg/queequeg-0.91/queequeg-0.91.tar.gz"
   sha256 "44e2f2bb8b68d08b7ee95ece24cefeeea8ec6ff9150851922015b73fc8908136"
 

--- a/Formula/quvi.rb
+++ b/Formula/quvi.rb
@@ -1,6 +1,6 @@
 class Quvi < Formula
   desc "Parse video download URLs"
-  homepage "http://quvi.sourceforge.net/"
+  homepage "https://quvi.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/quvi/0.4/quvi/quvi-0.4.2.tar.bz2"
   sha256 "1f4e40c14373cb3d358ae1b14a427625774fd09a366b6da0c97d94cb1ff733c3"
 

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -1,6 +1,6 @@
 class Qwt < Formula
   desc "Qt Widgets for Technical Applications"
-  homepage "http://qwt.sourceforge.net/"
+  homepage "https://qwt.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2"
   sha256 "f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733"
   revision 3

--- a/Formula/qwtpolar.rb
+++ b/Formula/qwtpolar.rb
@@ -1,6 +1,6 @@
 class Qwtpolar < Formula
   desc "Library for displaying values on a polar coordinate system"
-  homepage "http://qwtpolar.sourceforge.net/"
+  homepage "https://qwtpolar.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qwtpolar/qwtpolar/1.1.1/qwtpolar-1.1.1.tar.bz2"
   sha256 "6168baa9dbc8d527ae1ebf2631313291a1d545da268a05f4caa52ceadbe8b295"
   revision 2

--- a/Formula/regina-rexx.rb
+++ b/Formula/regina-rexx.rb
@@ -1,6 +1,6 @@
 class ReginaRexx < Formula
   desc "Regina REXX interpreter"
-  homepage "http://regina-rexx.sourceforge.net/"
+  homepage "https://regina-rexx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/regina-rexx/regina-rexx/3.9.1/Regina-REXX-3.9.1.tar.gz"
   sha256 "5d13df26987e27f25e7779a2efa87a5775213beeda449a9efac59b57a5d5f3ee"
 

--- a/Formula/rig.rb
+++ b/Formula/rig.rb
@@ -1,6 +1,6 @@
 class Rig < Formula
   desc "Provides fake name and address data"
-  homepage "http://rig.sourceforge.net/"
+  homepage "https://rig.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/rig/rig/1.11/rig-1.11.tar.gz"
   sha256 "00bfc970d5c038c1e68bc356c6aa6f9a12995914b7d4fda69897622cb5b77ab8"
 

--- a/Formula/rkhunter.rb
+++ b/Formula/rkhunter.rb
@@ -1,6 +1,6 @@
 class Rkhunter < Formula
   desc "Rootkit hunter"
-  homepage "http://rkhunter.sourceforge.net/"
+  homepage "https://rkhunter.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/rkhunter/rkhunter/1.4.2/rkhunter-1.4.2.tar.gz"
   sha256 "789cc84a21faf669da81e648eead2e62654cfbe0b2d927119d8b1e55b22b65c3"
 

--- a/Formula/rtf2latex2e.rb
+++ b/Formula/rtf2latex2e.rb
@@ -1,6 +1,6 @@
 class Rtf2latex2e < Formula
   desc "RTF-to-LaTeX translation"
-  homepage "http://rtf2latex2e.sourceforge.net/"
+  homepage "https://rtf2latex2e.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/rtf2latex2e/rtf2latex2e-unix/2-2/rtf2latex2e-2-2-2.tar.gz"
   version "2.2.2"
   sha256 "eb742af22f2ae43c40ea1abc5f50215e04779e51dc9d91cac9276b98f91bb1af"

--- a/Formula/sary.rb
+++ b/Formula/sary.rb
@@ -1,6 +1,6 @@
 class Sary < Formula
   desc "Suffix array library"
-  homepage "http://sary.sourceforge.net/"
+  homepage "https://sary.sourceforge.io/"
   url "http://sary.sourceforge.net/sary-1.2.0.tar.gz"
   sha256 "d4b16e32c97a253b546922d2926c8600383352f0af0d95e2938b6d846dfc6a11"
 

--- a/Formula/saxon-b.rb
+++ b/Formula/saxon-b.rb
@@ -1,6 +1,6 @@
 class SaxonB < Formula
   desc "XSLT and XQuery processor"
-  homepage "http://saxon.sourceforge.net/"
+  homepage "https://saxon.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip"
   version "9.1.0.8"
   sha256 "92bcdc4a0680c7866fe5828adb92c714cfe88dcf3fa0caf5bf638fcc6d9369b4"

--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -1,6 +1,6 @@
 class Scrollkeeper < Formula
   desc "Transitional package for scrollkeeper"
-  homepage "http://scrollkeeper.sourceforge.net/"
+  homepage "https://scrollkeeper.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/scrollkeeper/scrollkeeper/0.3.14/scrollkeeper-0.3.14.tar.gz"
   sha256 "4a0bd3c3a2c5eca6caf2133a504036665485d3d729a16fc60e013e1b58e7ddad"
   revision 1

--- a/Formula/sdcc.rb
+++ b/Formula/sdcc.rb
@@ -1,6 +1,6 @@
 class Sdcc < Formula
   desc "ANSI C compiler for Intel 8051, Maxim 80DS390, and Zilog Z80"
-  homepage "http://sdcc.sourceforge.net/"
+  homepage "https://sdcc.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sdcc/sdcc/3.6.0/sdcc-src-3.6.0.tar.bz2"
   sha256 "e85dceb11e01ffefb545ec389da91265130c91953589392dddd2e5ec0b7ca374"
 

--- a/Formula/sec.rb
+++ b/Formula/sec.rb
@@ -1,6 +1,6 @@
 class Sec < Formula
   desc "Event correlation tool for event processing of various kinds"
-  homepage "http://simple-evcorr.sourceforge.net/"
+  homepage "https://simple-evcorr.sourceforge.io/"
   url "https://github.com/simple-evcorr/sec/releases/download/2.7.11/sec-2.7.11.tar.gz"
   sha256 "59cd744c36be43c0cb69f1570d2aa6911ebb3492ff01fc292347ec8876dfe991"
 

--- a/Formula/shakespeare.rb
+++ b/Formula/shakespeare.rb
@@ -1,6 +1,6 @@
 class Shakespeare < Formula
   desc "Write programs in Shakespearean English"
-  homepage "http://shakespearelang.sourceforge.net/"
+  homepage "https://shakespearelang.sourceforge.io/"
   url "http://shakespearelang.sf.net/download/spl-1.2.1.tar.gz"
   sha256 "1206ef0a2c853b8b40ca0c682bc9d9e0a157cc91a7bf4e28f19ccd003674b7d3"
 

--- a/Formula/shmcat.rb
+++ b/Formula/shmcat.rb
@@ -1,6 +1,6 @@
 class Shmcat < Formula
   desc "Tool that dumps shared memory segments (System V and POSIX)"
-  homepage "http://shmcat.sourceforge.net/"
+  homepage "https://shmcat.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/shmcat/shmcat-1.8.tar.bz2"
   sha256 "43fbf1b62f22f7cfcfd21228225151441450441d47ca73c9c2951c9af5549dde"
 

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -1,6 +1,6 @@
 class Sipp < Formula
   desc "Traffic generator for the SIP protocol"
-  homepage "http://sipp.sourceforge.net/"
+  homepage "https://sipp.sourceforge.io/"
   url "https://github.com/SIPp/sipp/releases/download/v3.5.1/sipp-3.5.1.tar.gz"
   sha256 "56421ba7b43b67e9b04e21894b726502a82a6149fc86ba06df33dfc7252a1891"
 

--- a/Formula/sispmctl.rb
+++ b/Formula/sispmctl.rb
@@ -1,6 +1,6 @@
 class Sispmctl < Formula
   desc "Control Gembird SIS-PM programmable power outlet strips"
-  homepage "http://sispmctl.sourceforge.net/"
+  homepage "https://sispmctl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sispmctl/sispmctl/sispmctl-3.1/sispmctl-3.1.tar.gz"
   sha256 "e9a99cc81ef0a93f3484e5093efd14d93cc967221fcd22c151f0bea32eb91da7"
 

--- a/Formula/slrn.rb
+++ b/Formula/slrn.rb
@@ -1,6 +1,6 @@
 class Slrn < Formula
   desc "Powerful console-based newsreader"
-  homepage "http://slrn.sourceforge.net/"
+  homepage "https://slrn.sourceforge.io/"
   url "http://jedsoft.org/releases/slrn/slrn-1.0.2.tar.bz2"
   sha256 "99acbc51e7212ccc5c39556fa8ec6ada772f0bb5cc45a3bb90dadb8fe764fb59"
 

--- a/Formula/snap7.rb
+++ b/Formula/snap7.rb
@@ -1,6 +1,6 @@
 class Snap7 < Formula
   desc "Ethernet communication suite that works natively with Siemens S7 PLCs"
-  homepage "http://snap7.sourceforge.net/"
+  homepage "https://snap7.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/snap7/1.4.2/snap7-full-1.4.2.7z"
   sha256 "65af129e11de4b0d942751bcd9c563f7012cae174931860c03dbb2cdf2e80ae7"
 

--- a/Formula/snapraid.rb
+++ b/Formula/snapraid.rb
@@ -1,6 +1,6 @@
 class Snapraid < Formula
   desc "Backup program for disk arrays"
-  homepage "http://snapraid.sourceforge.net/"
+  homepage "https://snapraid.sourceforge.io/"
   url "https://github.com/amadvance/snapraid/releases/download/v11.0/snapraid-11.0.tar.gz"
   sha256 "30a72b8853ea750128c96784b73bb55f7faa4b16367b2e03f40c1f78515c5771"
 

--- a/Formula/sntop.rb
+++ b/Formula/sntop.rb
@@ -1,6 +1,6 @@
 class Sntop < Formula
   desc "Curses-based utility that polls hosts to determine connectivity"
-  homepage "http://sntop.sourceforge.net/"
+  homepage "https://sntop.sourceforge.io/"
   url "http://distcache.freebsd.org/ports-distfiles/sntop-1.4.3.tar.gz"
   sha256 "943a5af1905c3ae7ead064e531cde6e9b3dc82598bbda26ed4a43788d81d6d89"
 

--- a/Formula/sofia-sip.rb
+++ b/Formula/sofia-sip.rb
@@ -1,6 +1,6 @@
 class SofiaSip < Formula
   desc "SIP User-Agent library"
-  homepage "http://sofia-sip.sourceforge.net/"
+  homepage "https://sofia-sip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
   sha256 "2b01bc2e1826e00d1f7f57d29a2854b15fd5fe24695e47a14a735d195dd37c81"
   revision 1

--- a/Formula/sox.rb
+++ b/Formula/sox.rb
@@ -1,6 +1,6 @@
 class Sox < Formula
   desc "SOund eXchange: universal sound sample translator"
-  homepage "http://sox.sourceforge.net/"
+  homepage "https://sox.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz"
   sha256 "b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c"
 

--- a/Formula/spim.rb
+++ b/Formula/spim.rb
@@ -1,6 +1,6 @@
 class Spim < Formula
   desc "MIPS32 simulator"
-  homepage "http://spimsimulator.sourceforge.net/"
+  homepage "https://spimsimulator.sourceforge.io/"
   # No source code tarball exists
   url "http://svn.code.sf.net/p/spimsimulator/code", :revision => 681
   version "9.1.17"

--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -1,6 +1,6 @@
 class Squashfs < Formula
   desc "Compressed read-only file system for Linux"
-  homepage "http://squashfs.sourceforge.net/"
+  homepage "https://squashfs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
   sha256 "0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6"
 

--- a/Formula/srecord.rb
+++ b/Formula/srecord.rb
@@ -1,6 +1,6 @@
 class Srecord < Formula
   desc "Tools for manipulating EPROM load files"
-  homepage "http://srecord.sourceforge.net/"
+  homepage "https://srecord.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/srecord/srecord/1.64/srecord-1.64.tar.gz"
   sha256 "49a4418733c508c03ad79a29e95acec9a2fbc4c7306131d2a8f5ef32012e67e2"
 

--- a/Formula/ssdeep.rb
+++ b/Formula/ssdeep.rb
@@ -1,6 +1,6 @@
 class Ssdeep < Formula
   desc "Recursive piecewise hashing tool"
-  homepage "http://ssdeep.sourceforge.net/"
+  homepage "https://ssdeep.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz"
   sha256 "6e4ca94457cb50ff3343d4dd585473817a461a55a666da1c5a74667924f0f8c5"
 

--- a/Formula/ssldump.rb
+++ b/Formula/ssldump.rb
@@ -1,6 +1,6 @@
 class Ssldump < Formula
   desc "SSLv3/TLS network protocol analyzer"
-  homepage "http://ssldump.sourceforge.net/"
+  homepage "https://ssldump.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
   sha256 "6422c16718d27c270bbcfcc1272c4f9bd3c0799c351f1d6dd54fdc162afdab1e"
 

--- a/Formula/stella.rb
+++ b/Formula/stella.rb
@@ -1,6 +1,6 @@
 class Stella < Formula
   desc "Atari 2600 VCS emulator"
-  homepage "http://stella.sourceforge.net/"
+  homepage "https://stella.sourceforge.io/"
   url "https://github.com/stella-emu/stella/releases/download/release-4.7.3/stella-4.7.3-src.tar.xz"
   sha256 "93a75d1b343b1e66b6dc526c0f9d8a0c3678d346033f7cdfe76dc93f14d956ad"
   head "http://svn.code.sf.net/p/stella/code/trunk"

--- a/Formula/stoken.rb
+++ b/Formula/stoken.rb
@@ -1,6 +1,6 @@
 class Stoken < Formula
   desc "Tokencode generator compatible with RSA SecurID 128-bit (AES)"
-  homepage "http://stoken.sourceforge.net/"
+  homepage "https://stoken.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/stoken/stoken-0.91.tar.gz"
   sha256 "419ed84000bc455ef77c78e3ebfd4c6fd2d932384563989f864becbafd51bcf4"
 

--- a/Formula/streamripper.rb
+++ b/Formula/streamripper.rb
@@ -1,6 +1,6 @@
 class Streamripper < Formula
   desc "Separate tracks via Shoutcasts title-streaming"
-  homepage "http://streamripper.sourceforge.net/"
+  homepage "https://streamripper.sourceforge.io/"
   url "https://downloads.sourceforge.net/sourceforge/streamripper/streamripper-1.64.6.tar.gz"
   sha256 "c1d75f2e9c7b38fd4695be66eff4533395248132f3cc61f375196403c4d8de42"
 

--- a/Formula/sz81.rb
+++ b/Formula/sz81.rb
@@ -1,6 +1,6 @@
 class Sz81 < Formula
   desc "ZX80/81 emulator"
-  homepage "http://sz81.sourceforge.net/"
+  homepage "https://sz81.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sz81/sz81/2.1.7/sz81-2.1.7-source.tar.gz"
   sha256 "4ad530435e37c2cf7261155ec43f1fc9922e00d481cc901b4273f970754144e1"
   head "svn://svn.code.sf.net/p/sz81/code/sz81"

--- a/Formula/tclap.rb
+++ b/Formula/tclap.rb
@@ -1,6 +1,6 @@
 class Tclap < Formula
   desc "Templatized C++ command-line parser library"
-  homepage "http://tclap.sourceforge.net/"
+  homepage "https://tclap.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz"
   sha256 "9f9f0fe3719e8a89d79b6ca30cf2d16620fba3db5b9610f9b51dd2cd033deebb"
 

--- a/Formula/teem.rb
+++ b/Formula/teem.rb
@@ -1,6 +1,6 @@
 class Teem < Formula
   desc "Libraries for scientific raster data"
-  homepage "http://teem.sourceforge.net/"
+  homepage "https://teem.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
   sha256 "a01386021dfa802b3e7b4defced2f3c8235860d500c1fa2f347483775d4c8def"
   head "https://teem.svn.sourceforge.net/svnroot/teem/teem/trunk"

--- a/Formula/timidity.rb
+++ b/Formula/timidity.rb
@@ -1,6 +1,6 @@
 class Timidity < Formula
   desc "Software synthesizer"
-  homepage "http://timidity.sourceforge.net/"
+  homepage "https://timidity.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/timidity/TiMidity++/TiMidity++-2.14.0/TiMidity++-2.14.0.tar.bz2"
   sha256 "f97fb643f049e9c2e5ef5b034ea9eeb582f0175dce37bc5df843cc85090f6476"
 

--- a/Formula/tkdiff.rb
+++ b/Formula/tkdiff.rb
@@ -1,6 +1,6 @@
 class Tkdiff < Formula
   desc "Graphical side by side diff utility"
-  homepage "http://tkdiff.sourceforge.net/"
+  homepage "https://tkdiff.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tkdiff/tkdiff/4.2/tkdiff-4.2.tar.gz"
   sha256 "734bb417184c10072eb64e8d274245338e41b7fdeff661b5ef30e89f3e3aa357"
 

--- a/Formula/tn5250.rb
+++ b/Formula/tn5250.rb
@@ -1,6 +1,6 @@
 class Tn5250 < Formula
   desc "5250 terminal and printer emulator"
-  homepage "http://tn5250.sourceforge.net/"
+  homepage "https://tn5250.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tn5250/tn5250/0.17.4/tn5250-0.17.4.tar.gz"
   sha256 "354237d400dc46af887cb3ffa4ed1f2c371f5b8bee8be046a683a4ac9db4f9c5"
   revision 1

--- a/Formula/tnote.rb
+++ b/Formula/tnote.rb
@@ -1,6 +1,6 @@
 class Tnote < Formula
   desc "Small note-taking program for the terminal"
-  homepage "http://tnote.sourceforge.net/"
+  homepage "https://tnote.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tnote/tnote/tnote-0.2.1/tnote-0.2.1.tar.gz"
   sha256 "451e0e352cb279725c5e12ad1c1377be63c7113f3fe568fb6213ede478ba6a87"
 

--- a/Formula/torrentcheck.rb
+++ b/Formula/torrentcheck.rb
@@ -1,6 +1,6 @@
 class Torrentcheck < Formula
   desc "Command-line torrent viewer and hash checker"
-  homepage "http://torrentcheck.sourceforge.net/"
+  homepage "https://torrentcheck.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/torrentcheck/torrentcheck-1.00.zip"
   sha256 "a839f9ac9669d942f83af33db96ce9902d84f85592c99b568ef0f5232ff318c5"
 

--- a/Formula/ttf2pt1.rb
+++ b/Formula/ttf2pt1.rb
@@ -1,6 +1,6 @@
 class Ttf2pt1 < Formula
   desc "True Type Font to Postscript Type 1 converter"
-  homepage "http://ttf2pt1.sourceforge.net/"
+  homepage "https://ttf2pt1.sourceforge.io/"
   url "https://downloads.sourceforge.net/ttf2pt1/ttf2pt1-3.4.4.tgz"
   sha256 "ae926288be910073883b5c8a3b8fc168fde52b91199fdf13e92d72328945e1d0"
 

--- a/Formula/ucon64.rb
+++ b/Formula/ucon64.rb
@@ -1,6 +1,6 @@
 class Ucon64 < Formula
   desc "ROM backup tool and emulator's Swiss Army knife program"
-  homepage "http://ucon64.sourceforge.net/"
+  homepage "https://ucon64.sourceforge.io/"
   url "https://downloads.sourceforge.net/ucon64/ucon64-2.0.2-src.tar.gz"
   sha256 "2df3972a68d1d7237dfedb99803048a370b466a015a5e4c1343f7e108601d4c9"
   head ":pserver:anonymous:@ucon64.cvs.sourceforge.net:/cvsroot/ucon64", :using => :cvs

--- a/Formula/uncrustify.rb
+++ b/Formula/uncrustify.rb
@@ -1,6 +1,6 @@
 class Uncrustify < Formula
   desc "Source code beautifier"
-  homepage "http://uncrustify.sourceforge.net/"
+  homepage "https://uncrustify.sourceforge.io/"
   url "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.64.tar.gz"
   sha256 "2a8cb3ab82ca53202d50fc2c2cec0edd11caa584def58d356c1c759b57db0b32"
   head "https://github.com/uncrustify/uncrustify.git"

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,6 +1,6 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
-  homepage "http://uriparser.sourceforge.net/"
+  homepage "https://uriparser.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/uriparser/Sources/0.8.4/uriparser-0.8.4.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/u/uriparser/uriparser_0.8.4.orig.tar.bz2"
   sha256 "ce7ccda4136974889231e8426a785e7578e66a6283009cfd13f1b24a5e657b23"

--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -1,6 +1,6 @@
 class Vde < Formula
   desc "Ethernet compliant virtual network"
-  homepage "http://vde.sourceforge.net/"
+  homepage "https://vde.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/vde/vde2/2.3.2/vde2-2.3.2.tar.gz"
   sha256 "22df546a63dac88320d35d61b7833bbbcbef13529ad009c7ce3c5cb32250af93"
 

--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -1,6 +1,6 @@
 class Vice < Formula
   desc "Versatile Commodore Emulator"
-  homepage "http://vice-emu.sourceforge.net/"
+  homepage "https://vice-emu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/vice-emu/releases/vice-3.0.tar.gz"
   sha256 "bc56811381920d43ab5f2f85a5e08f21ab5bdf6190dd5dfe9f500a745d14972b"
 

--- a/Formula/vpcs.rb
+++ b/Formula/vpcs.rb
@@ -1,6 +1,6 @@
 class Vpcs < Formula
   desc "Virtual PC simulator for testing IP routing"
-  homepage "http://vpcs.sourceforge.net/"
+  homepage "https://vpcs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/vpcs/0.6/vpcs-0.6-src.tbz"
   sha256 "cc311b0dea9ea02ef95f26704d73e34d293caa503600a0acca202d577afd3ceb"
 

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,6 +1,6 @@
 class W3m < Formula
   desc "Pager/text based browser"
-  homepage "http://w3m.sourceforge.net/"
+  homepage "https://w3m.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
   sha256 "e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3"
 

--- a/Formula/wput.rb
+++ b/Formula/wput.rb
@@ -1,6 +1,6 @@
 class Wput < Formula
   desc "Tiny, wget-like FTP client for uploading files"
-  homepage "http://wput.sourceforge.net/"
+  homepage "https://wput.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz"
   sha256 "229d8bb7d045ca1f54d68de23f1bc8016690dc0027a16586712594fbc7fad8c7"
 

--- a/Formula/wv.rb
+++ b/Formula/wv.rb
@@ -1,6 +1,6 @@
 class Wv < Formula
   desc "Programs for accessing Microsoft Word documents"
-  homepage "http://wvware.sourceforge.net/"
+  homepage "https://wvware.sourceforge.io/"
   url "http://abisource.com/downloads/wv/1.2.9/wv-1.2.9.tar.gz"
   sha256 "4c730d3b325c0785450dd3a043eeb53e1518598c4f41f155558385dd2635c19d"
 

--- a/Formula/wv2.rb
+++ b/Formula/wv2.rb
@@ -1,6 +1,6 @@
 class Wv2 < Formula
   desc "Programs for accessing Microsoft Word documents"
-  homepage "http://wvware.sourceforge.net/"
+  homepage "https://wvware.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/wvware/wv2-0.4.2.tar.bz2"
   sha256 "9f2b6d3910cb0e29c9ff432f935a594ceec0101bca46ba2fc251aff251ee38dc"
 

--- a/Formula/xmlrpc-c.rb
+++ b/Formula/xmlrpc-c.rb
@@ -1,6 +1,6 @@
 class XmlrpcC < Formula
   desc "Lightweight RPC library (based on XML and HTTP)"
-  homepage "http://xmlrpc-c.sourceforge.net/"
+  homepage "https://xmlrpc-c.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xmlrpc-c/Xmlrpc-c%20Super%20Stable/1.39.12/xmlrpc-c-1.39.12.tgz"
   sha256 "d830f3264a832dfe09f629cc64036acfd08121692526d0fabe090f7ff881ce08"
 

--- a/Formula/xmlstarlet.rb
+++ b/Formula/xmlstarlet.rb
@@ -1,6 +1,6 @@
 class Xmlstarlet < Formula
   desc "XML command-line utilities"
-  homepage "http://xmlstar.sourceforge.net/"
+  homepage "https://xmlstar.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz"
   sha256 "15d838c4f3375332fd95554619179b69e4ec91418a3a5296e7c631b7ed19e7ca"
 

--- a/Formula/xplanet.rb
+++ b/Formula/xplanet.rb
@@ -1,6 +1,6 @@
 class Xplanet < Formula
   desc "Create HQ wallpapers of planet Earth"
-  homepage "http://xplanet.sourceforge.net/"
+  homepage "https://xplanet.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xplanet/xplanet/1.3.1/xplanet-1.3.1.tar.gz"
   sha256 "4380d570a8bf27b81fb629c97a636c1673407f4ac4989ce931720078a90aece7"
 

--- a/Formula/xqilla.rb
+++ b/Formula/xqilla.rb
@@ -1,6 +1,6 @@
 class Xqilla < Formula
   desc "XQuery and XPath 2 command-line interpreter"
-  homepage "http://xqilla.sourceforge.net/"
+  homepage "https://xqilla.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xqilla/XQilla-2.3.3.tar.gz"
   sha256 "8f76b9b4f966f315acc2a8e104e426d8a76ba4ea3441b0ecfdd1e39195674fd6"
 

--- a/Formula/xstow.rb
+++ b/Formula/xstow.rb
@@ -1,6 +1,6 @@
 class Xstow < Formula
   desc "Extended replacement for GNU Stow"
-  homepage "http://xstow.sourceforge.net/"
+  homepage "https://xstow.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xstow/xstow-1.0.2.tar.bz2"
   sha256 "6f041f19a5d71667f6a9436d56f5a50646b6b8c055ef5ae0813dcecb35a3c6ef"
 

--- a/Formula/xu4.rb
+++ b/Formula/xu4.rb
@@ -1,6 +1,6 @@
 class Xu4 < Formula
   desc "Remake of Ultima IV"
-  homepage "http://xu4.sourceforge.net/"
+  homepage "https://xu4.sourceforge.io/"
   url "http://xu4.svn.sourceforge.net/svnroot/xu4/trunk/u4", :revision => "3088"
   version "1.0beta4+r3088"
   head "http://xu4.svn.sourceforge.net/svnroot/xu4/trunk/u4"

--- a/Formula/zboy.rb
+++ b/Formula/zboy.rb
@@ -1,6 +1,6 @@
 class Zboy < Formula
   desc "GameBoy emulator"
-  homepage "http://zboy.sourceforge.net/"
+  homepage "https://zboy.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/zboy/zBoy%20v0.60/zboy-0.60.tar.gz"
   sha256 "f81e61433a5b74c61ab84cac33da598deb03e49699f3d65dcb983151a6f1c749"
   head "http://svn.code.sf.net/p/zboy/code/trunk"

--- a/Formula/zssh.rb
+++ b/Formula/zssh.rb
@@ -1,6 +1,6 @@
 class Zssh < Formula
   desc "Interactive file transfers over SSH"
-  homepage "http://zssh.sourceforge.net/"
+  homepage "https://zssh.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/zssh/zssh/1.5/zssh-1.5c.tgz"
   sha256 "a2e840f82590690d27ea1ea1141af509ee34681fede897e58ae8d354701ce71b"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

``` shell
FORMULAE:
  * http://FORMULAE.sourceforge.net/ should be `https://FORMULAE.sourceforge.io/`
```