### PR TITLE
knot: update plist to log stderr

### DIFF
--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -1,6 +1,7 @@
 class Knot < Formula
   desc "High-performance authoritative-only DNS server"
   homepage "https://www.knot-dns.cz/"
+  revision 1
 
   stable do
     url "https://secure.nic.cz/files/knot-dns/knot-2.4.1.tar.xz"
@@ -116,8 +117,12 @@ class Knot < Formula
         <string>-c</string>
         <string>#{etc}/knot.conf</string>
       </array>
-      <key>ServiceIPC</key>
-      <false/>
+      <key>StandardInPath</key>
+      <string>/dev/null</string>
+      <key>StandardOutPath</key>
+      <string>/dev/null</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/knot.log</string>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The patch updates .plist for Knot DNS by removing obsolete ServiceIPC option and enabling logging of stderr. This also fixes my recent update to this formula which disabled logging to syslog so all logs were dropped.