### PR TITLE
python3: CPython has migrated to GitHub

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -3,7 +3,7 @@ class Python3 < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz"
   sha256 "b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622"
-  head "https://hg.python.org/cpython", :using => :hg
+  head "https://github.com/python/cpython", :using => :git
 
   bottle do
     sha256 "b9b1de457689c84376fb8c35c67b0de4745ccb573ddc5f8ce0257b3b73358917" => :sierra


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

CPython has migrated to GitHub. [1][2] The old mercurial repository [3] is no longer updated.

Since Homebrew/brew#1844, ```brew audit --strict``` returns an error:
```
$ brew audit --strict python3
==> Installing or updating 'rubocop' gem
Fetching: rubocop-0.47.1.gem (100%)
Successfully installed rubocop-0.47.1
1 gem installed
python3:
  * macOS has been 64-bit only since 10.6 so universal options are deprecated.
Error: 1 problem in 1 formula
```
Should I handle it in this PR, too?

[1] https://github.com/python/cpython/
[2] https://mail.python.org/pipermail/python-dev/2017-February/147381.html
[3] https://hg.python.org/cpython/