### PR TITLE
logstash: 5.2.1

### DIFF
--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -3,8 +3,8 @@ class Logstash < Formula
   homepage "https://www.elastic.co/products/logstash"
 
   stable do
-    url "https://artifacts.elastic.co/downloads/logstash/logstash-5.2.0.tar.gz"
-    sha256 "f371d20127fb9b34a6575ba0d69fa764df73718eda02adc177a85fd3117500f0"
+    url "https://artifacts.elastic.co/downloads/logstash/logstash-5.2.1.tar.gz"
+    sha256 "c02e87ab7d410b4d42928e247e6e0714a38c4990c2768cbddde6008ba61b4a2e"
   end
 
   head do


### PR DESCRIPTION
This commit bumps the Logstash formula from version 5.2.0 to version 5.2.1.
