### PR TITLE
ktmpl 0.5.0 (new formula)

### DIFF
--- a/Formula/ktmpl.rb
+++ b/Formula/ktmpl.rb
@@ -1,0 +1,42 @@
+class Ktmpl < Formula
+  desc "Parameterized templates for Kubernetes manifests."
+  homepage "https://github.com/InQuicker/ktmpl"
+  url "https://github.com/InQuicker/ktmpl/archive/0.5.0.tar.gz"
+  sha256 "36924798cb88ddc98f43fea33aff894297cf4068a00157e08bf53373a79bb12c"
+  head "https://github.com/InQuicker/ktmpl.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--release"
+    bin.install "target/release/ktmpl"
+  end
+
+  test do
+    (testpath/"test.yml").write <<-EOS.undent
+      ---
+      kind: "Template"
+      apiVersion: "v1"
+      metadata:
+        name: "test"
+      objects:
+        - kind: "Service"
+          apiVersion: "v1"
+          metdata:
+            name: "test"
+          spec:
+            ports:
+              - name: "test"
+                protocol: "TCP"
+                targetPort: "$((PORT))"
+            selector:
+              app: "test"
+      parameters:
+        - name: "PORT"
+          description: "The port the service should run on"
+          required: true
+          parameterType: "int"
+    EOS
+    system bin/"ktmpl", "test.yml", "-p", "PORT", "8080"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[ktmpl](https://github.com/InQuicker/ktmpl) is a tool for processing [Kubernetes](http://kubernetes.io/) manifest templates. It is a very simple client-side implementation of the [Templates + Parameterization proposal](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/templates.md).