### PR TITLE
kubernetes-helm 2.2.0

### DIFF
--- a/Formula/kubernetes-helm.rb
+++ b/Formula/kubernetes-helm.rb
@@ -2,9 +2,8 @@ class KubernetesHelm < Formula
   desc "The Kubernetes package manager"
   homepage "https://helm.sh/"
   url "https://github.com/kubernetes/helm.git",
-      :tag => "v2.1.3",
-      :revision => "5cbc48fb305ca4bf68c26eb8d2a7eb363227e973"
-  revision 1
+      :tag => "v2.2.0",
+      :revision => "fc315ab59850ddd1b9b4959c89ef008fef5cdf89"
   head "https://github.com/kubernetes/helm.git"
 
   bottle do
@@ -27,6 +26,11 @@ class KubernetesHelm < Formula
     dir.install buildpath.children - [buildpath/".brew_home"]
 
     cd dir do
+      # Set git config to follow redirects
+      # Change in behavior in git: https://github.com/git/git/commit/50d3413740d1da599cdc0106e6e916741394cc98
+      # Upstream issue: https://github.com/niemeyer/gopkg/issues/50
+      system "git", "config", "--global", "http.https://gopkg.in.followRedirects", "true"
+
       # Bootstap build
       system "make", "bootstrap"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In addition to version bump, needed to add command to set git flag to permit redirects for gopkg.in. I've noted the upstream change in git functionality, as well as the upstream issue for tracking.