### PR TITLE
sourcekitten: separate Xcode requirement into runtime and build time

### DIFF
--- a/Formula/sourcekitten.rb
+++ b/Formula/sourcekitten.rb
@@ -12,7 +12,8 @@ class Sourcekitten < Formula
     sha256 "af5fb3e859eefa13abde502f0ed311e66c5ae92238e31c19fe591b19f8bd3ff2" => :el_capitan
   end
 
-  depends_on :xcode => "8.0"
+  depends_on :xcode => ["6.0", :run]
+  depends_on :xcode => ["8.0", :build]
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SourceKitten.dst"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source sourcekitten`, where `sourcekitten` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict sourcekitten` (after doing `brew install sourcekitten`)?

-----

This changes requirement of sourcekitten.
`sourcekitten` depends on runtime Xcode 6.0 and later.
`sourcekitten` depends on build time Xcode 8.0 and later.

I confirmed that following formula:
```ruby
depends_on :xcode => ["6.0", :run]
depends_on :xcode => ["8.0", :build]
```
works as I expected.
Example of same method with SwiftLint: https://gist.github.com/norio-nomura/85b96a77ba206f61e039ff17f362de04