### PR TITLE
swiftlint: separate Xcode requirement into runtime and build time

### DIFF
--- a/Formula/swiftlint.rb
+++ b/Formula/swiftlint.rb
@@ -12,7 +12,8 @@ class Swiftlint < Formula
     sha256 "ff0453102251cd2b3e5d8c7d1cc951818ee4e4a2e6f0e9b635892dc1c32fdb41" => :el_capitan
   end
 
-  depends_on :xcode => "8.0"
+  depends_on :xcode => ["7.0", :run]
+  depends_on :xcode => ["8.0", :build]
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SwiftLint.dst"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source swiftlint`, where `swiftlint` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict swiftlint` (after doing `brew install swiftlint`)?

-----

This changes requirement of swiftlint.
`swiftlint` depends on runtime Xcode 7.0 and later.
`swiftlint` depends on build time Xcode 8.0 and later.

I confirmed that following formula:
```ruby
depends_on :xcode => ["7.0", :run]
depends_on :xcode => ["8.0", :build]
```
works as I expected: https://gist.github.com/norio-nomura/85b96a77ba206f61e039ff17f362de04

See also: #9988