### PR TITLE
cn 1.0.0 (new formula)

### DIFF
--- a/Formula/cn.rb
+++ b/Formula/cn.rb
@@ -1,0 +1,19 @@
+class Cn < Formula
+  desc "CLI for CommonNumerics routines (CRC-8/16/32/64, Base16/32/64)"
+  homepage "https://github.com/JayBrown/cn"
+  url "https://github.com/JayBrown/cn/archive/1.00.tar.gz"
+  version "1.0.0"
+  sha256 "4a11ccf8ba82f344f4d8faffc9a3cc28c5971d00f8e0f85d2682bb70e351e660"
+
+  def install
+    system "make prefix=#{prefix}"
+    system "make clean"
+    system "make cn"
+    bin.install "cn"
+    man1.install "cn.1"
+  end
+
+  test do
+    system "#{bin}/cn", "version"
+  end
+end


### PR DESCRIPTION
cn is short for "Common Numerics"
It is originally part of Apple's Open Source Project, taken from the CommonCrypto library, published open source under APSL v2.0.
However, it is not installed in macOS as a binary in /usr/bin.
It adds some important functionality to macOS:
not only Base16 and Base32 encoding/decoding plus additional options for Base64, but also many CRC hash functions, which can work alongside the native crc32 and cksum/sum commands:
several CRC-8 hashes
several CRC-16 hashes
several CRC-32 hashes, incl. CRC-32C (Castagnoli), which is used by Google Storage (compare the gsutil CLI)
plus one CRC-64 hash (ECMA 182)
Please note that auditing produced some errors regarding the system make commands; however, they've been entered like this by design, and installation worked fine.
cn will probably always remain at v1.0.0, because we should not expect an update from Apple

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
