### PR TITLE
fio: apply upstream fix for clock_gettime issue

### DIFF
--- a/Formula/fio.rb
+++ b/Formula/fio.rb
@@ -3,7 +3,6 @@ class Fio < Formula
   homepage "http://freecode.com/projects/fio"
   url "https://github.com/axboe/fio/archive/fio-2.17.tar.gz"
   sha256 "4d31ce145cc2d21e91aaf08bb4d14cca942ad6572131cba687906983478ce6e5"
-  head "git://git.kernel.dk/fio.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,13 +11,14 @@ class Fio < Formula
     sha256 "fcf155cd769b1328c40423c7081d34b37d585bc918d0d8590500c25aebf0b59c" => :yosemite
   end
 
-  def install
-    # Fixes "dyld: lazy symbol binding failed: Symbol not found: _clock_gettime"
-    # Reported 4 February 2017 https://github.com/axboe/fio/issues/305
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
-      inreplace "configure", "return clock_gettime(0, NULL);", "return foo();"
-    end
+  # Upstream fix for "dyld: lazy symbol binding failed: Symbol not found: _clock_gettime"
+  # https://github.com/axboe/fio/pull/309
+  patch do
+    url "https://github.com/axboe/fio/commit/ccf2d89d39.diff"
+    sha256 "6a714e9e40a8973549977bc3ae3b7d8fa7a6a25dd8c9d385fe8e0e58006339fe"
+  end
 
+  def install
     system "./configure"
     # fio's CFLAGS passes vital stuff around, and crushing it will break the build
     system "make", "prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
