### PR TITLE
Remove some non-Homebrew-specific caveats

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -33,14 +33,6 @@ class Awscli < Formula
   def caveats; <<-EOS.undent
     The "examples" directory has been installed to:
       #{HOMEBREW_PREFIX}/share/awscli/examples
-
-    Before using aws-cli, you need to tell it about your AWS credentials.
-    The quickest way to do this is to run:
-      aws configure
-
-    More information:
-      https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
-      https://pypi.python.org/pypi/awscli#getting-started
     EOS
   end
 

--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -20,28 +20,7 @@ class Chruby < Formula
 
   def caveats; <<-EOS.undent
     Add the following to the ~/.bashrc or ~/.zshrc file:
-
       source #{opt_share}/chruby/chruby.sh
-
-    By default chruby will search for Rubies installed into /opt/rubies/ or
-    ~/.rubies/. For non-standard installation locations, simply set the RUBIES
-    variable after loading chruby.sh:
-
-      RUBIES+=(
-        /opt/jruby-1.7.0
-        $HOME/src/rubinius
-      )
-
-    If you are migrating from another Ruby manager, set `RUBIES` accordingly:
-
-      RVM:   RUBIES+=(~/.rvm/rubies/*)
-      rbenv: RUBIES+=(~/.rbenv/versions/*)
-      rbfu:  RUBIES+=(~/.rbfu/rubies/*)
-
-    To enable auto-switching of Rubies specified by .ruby-version files,
-    add the following to ~/.bashrc or ~/.zshrc:
-
-      source #{opt_share}/chruby/auto.sh
     EOS
   end
 end

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -79,16 +79,6 @@ class Go < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
-    As of go 1.2, a valid GOPATH is required to use the `go get` command.
-    If $GOPATH is not specified, $HOME/go will be used by default:
-      https://golang.org/doc/code.html#GOPATH
-
-    You may wish to add the GOROOT-based install location to your PATH:
-      export PATH=$PATH:#{opt_libexec}/bin
-    EOS
-  end
-
   test do
     (testpath/"hello.go").write <<-EOS.undent
     package main

--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -17,13 +17,6 @@ class Liquidprompt < Formula
       if [ -f #{HOMEBREW_PREFIX}/share/liquidprompt ]; then
         . #{HOMEBREW_PREFIX}/share/liquidprompt
       fi
-
-    If you'd like to reconfigure options, you may do so in ~/.liquidpromptrc.
-    A sample file you may copy and modify has been installed to
-      #{HOMEBREW_PREFIX}/share/liquidpromptrc-dist
-
-    Don't modify the PROMPT_COMMAND variable elsewhere in your shell config;
-    that will break things.
     EOS
   end
 

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -39,15 +39,6 @@ class Tor < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
-    You will find a sample `torrc` file in #{etc}/tor.
-    It is advisable to edit the sample `torrc` to suit
-    your own security needs:
-      https://www.torproject.org/docs/faq#torrc
-    After editing the `torrc` you need to restart tor.
-    EOS
-  end
-
   plist_options :manual => "tor"
 
   def plist; <<-EOS.undent

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -11,11 +11,8 @@ class ZshGitPrompt < Formula
   end
 
   def caveats; <<-EOS.undent
-    First, make sure zsh-git-prompt is loaded from your .zshrc:
+    Make sure zsh-git-prompt is loaded from your .zshrc:
       source "#{opt_prefix}/zshrc.sh"
-
-    Then include $(git_super_status) in your PROMPT or RPROMPT, e.g.:
-      PROMPT='%B%m%~%b$(git_super_status) %# '
     EOS
   end
 

--- a/Formula/zsh-history-substring-search.rb
+++ b/Formula/zsh-history-substring-search.rb
@@ -10,10 +10,4 @@ class ZshHistorySubstringSearch < Formula
     inreplace "README.md", "source zsh-history", "source #{opt_prefix}/zsh-history"
     prefix.install Dir["*.zsh"]
   end
-
-  def caveats; <<-EOS.undent
-    For setup instructions:
-      more "#{opt_prefix}/README.md"
-    EOS
-  end
 end

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -20,17 +20,7 @@ class ZshSyntaxHighlighting < Formula
   def caveats
     <<-EOS.undent
     To activate the syntax highlighting, add the following at the end of your .zshrc:
-
       source #{HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-
-    You will also need to force reload of your .zshrc:
-
-      source ~/.zshrc
-
-    Additionally, if you receive "highlighters directory not found" error message,
-    you may need to add the following to your .zshenv:
-
-      export ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR=#{HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/highlighters
     EOS
   end
 

--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -77,12 +77,6 @@ class Zsh < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
-    In order to use this build of zsh as your login shell,
-    it must be added to /etc/shells.
-    EOS
-  end
-
   test do
     assert_equal "homebrew\n",
       shell_output("#{bin}/zsh -c 'echo homebrew'")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Following [this discussion](https://github.com/Homebrew/homebrew-core/commit/b30889b47eca461706ca57b6908f221129b7ffa4#commitcomment-20939142) with @MikeMcQuaid, I went through the caveats of all the formulae I had installed and removed any non-Homebrew-specific caveats.

There were some I wasn't sure of, so I didn't include them in this PR:

- gpg-agent
- python
- python3