### PR TITLE
poppler: add missing conflicts

### DIFF
--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -31,7 +31,8 @@ class Poppler < Formula
   depends_on "qt5" => :optional
   depends_on "little-cms2" => :optional
 
-  conflicts_with "pdftohtml", :because => "both install `pdftohtml` binaries"
+  conflicts_with "pdftohtml", "pdf2image", "xpdf",
+    :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"
 
   resource "font-data" do
     url "https://poppler.freedesktop.org/poppler-data-0.4.7.tar.gz"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`poppler` is not marked as conflicting with `pdf2image` and `xpdf`, although it does (and those formulas are correctly marked as conflicting with `poppler`). Hence, currently an install of `xpdf` or `pdf2image` followed by an install of `poppler` fails to link, instead of showing the nice conflict error message.