### PR TITLE
qpid-proton 0.17.0 (new formula)

### DIFF
--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -7,10 +7,11 @@ class QpidProton < Formula
   depends_on "cmake" => :build
   depends_on "libuv"
   depends_on "openssl"
+  depends_on "perl" if Formula["perl"].installed?
+  depends_on "python" if Formula["python"].installed?
 
   def install
     # Javascript bindings switched off - leads to build errors
-
     args = %w[
       -DBUILD_JAVASCRIPT=OFF
     ]
@@ -21,6 +22,10 @@ class QpidProton < Formula
         "CHECK_SYMBOL_EXISTS(undefined_gibberish \"time.h\" CLOCK_GETTIME_IN_LIBC)"
     end
 
+    inreplace "proton-c/bindings/perl/CMakeLists.txt",
+        "RENAME cproton_perl.so",
+        "RENAME cproton_perl.bundle"
+
     ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
 
     # Enforce installation into lib/ instead of lib64/
@@ -30,6 +35,12 @@ class QpidProton < Formula
       system "cmake", "..", *args, *std_cmake_args
       system "make", "install"
     end
+  end
+
+ def caveats; <<-EOS.undent
+      The modules for the perl and python bindings can be found in
+        #{Formula["qpid-proton"].opt_prefix}/lib/proton/bindings
+    EOS
   end
 
   test do

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -1,0 +1,49 @@
+class QpidProton < Formula
+  desc "is a high-performance, lightweight AMQP 1.0 messaging library."
+  homepage "https://qpid.apache.org/proton/"
+  url "https://www-eu.apache.org/dist/qpid/proton/0.17.0/qpid-proton-0.17.0.tar.gz"
+  sha256 "6ffd26d3d0e495bfdb5d9fefc5349954e6105ea18cc4bb191161d27742c5a01a"
+
+  depends_on "cmake" => :build
+  depends_on "libuv"
+  depends_on "openssl"
+
+  def install
+    # Javascript bindings switched off - leads to build errors
+    # Perl, Python, Ruby bindings switched off - leads to linking errors
+    cmake_args = %w[
+      -DBUILD_JAVASCRIPT=OFF
+      -DBUILD_PYTHON=OFF
+      -DBUILD_PERL=OFF
+      -DBUILD_RUBY=OFF
+    ]
+
+    # qpid-proton require build in a subdirectory
+    Dir.mkdir("build")
+    Dir.chdir("build")
+
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
+
+    system "cmake", "..", *cmake_args, *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+          #include "proton/message.h"
+          #include "proton/messenger.h"
+          int main()
+          {
+              pn_message_t * message;
+              pn_messenger_t * messenger;
+              pn_data_t * body;
+
+              message = pn_message();
+              messenger = pn_messenger(NULL);
+              return 0;
+          }
+        EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}64", "-lqpid-proton", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -37,7 +37,7 @@ class QpidProton < Formula
     end
   end
 
- def caveats; <<-EOS.undent
+  def caveats; <<-EOS.undent
       The modules for the perl and python bindings can be found in
         #{Formula["qpid-proton"].opt_prefix}/lib/proton/bindings
     EOS

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -15,8 +15,10 @@ class QpidProton < Formula
       -DBUILD_JAVASCRIPT=OFF
     ]
 
-    if MacOS.version == "10.12" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
-      args << "-DCLOCK_GETTIME_IN_LIBC:INTERNAL=0"
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      inreplace "proton-c/CMakeLists.txt",
+        "CHECK_SYMBOL_EXISTS(clock_gettime \"time.h\" CLOCK_GETTIME_IN_LIBC)",
+        "CHECK_SYMBOL_EXISTS(undefined_gibberish \"time.h\" CLOCK_GETTIME_IN_LIBC)"
     end
 
     ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix


### PR DESCRIPTION
New formula for Apache Qpid Proton AMQP library.
Provides C and Go language bindings.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
