### PR TITLE
monitoring-plugins 2.2 (new formula)

### DIFF
--- a/Formula/monitoring-plugins.rb
+++ b/Formula/monitoring-plugins.rb
@@ -1,0 +1,39 @@
+class MonitoringPlugins < Formula
+  desc "Plugins for nagios compatible monitoring systems"
+  homepage "https://www.monitoring-plugins.org"
+  url "https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz"
+  sha256 "296a538f00a9cbef7f528ff2d43af357a44b384dc98a32389a675b62a6dd3665"
+
+  depends_on "openssl"
+  depends_on "postgresql" => :optional
+  depends_on :mysql => :optional
+
+  conflicts_with "nagios-plugins", :because => "nagios-plugins ships their plugins to the same folder."
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{libexec}
+      --libexecdir=#{libexec}/sbin
+      --with-openssl=#{Formula["openssl"].opt_prefix}
+    ]
+
+    args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"
+
+    system "./configure", *args
+    system "make", "install"
+    sbin.write_exec_script Dir["#{libexec}/sbin/*"]
+  end
+
+  def caveats
+    <<-EOS.undent
+    All plugins have been installed in:
+      #{HOMEBREW_PREFIX}/sbin
+    EOS
+  end
+
+  test do
+    output = shell_output("#{sbin}/check_dns -H 8.8.8.8 -t 3")
+    assert_match "google-public-dns", output
+  end
+end

--- a/Formula/nagios-plugins.rb
+++ b/Formula/nagios-plugins.rb
@@ -14,6 +14,8 @@ class NagiosPlugins < Formula
   depends_on "postgresql" => :optional
   depends_on :mysql => :optional
 
+  conflicts_with "monitoring-plugins", :because => "monitoring-plugins ships their plugins to the same folder."
+
   def install
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
adds a new formula for the monitoring plugins which are a collection of
plugins for nagios compatible systems like nagios, icinga, naemon or shinken.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
