### PR TITLE
Fix SVN repository URL for nmap HEAD

### DIFF
--- a/Formula/nmap.rb
+++ b/Formula/nmap.rb
@@ -3,7 +3,7 @@ class Nmap < Formula
   homepage "https://nmap.org/"
   url "https://nmap.org/dist/nmap-7.40.tar.bz2"
   sha256 "9e14665fffd054554d129d62c13ad95a7b5c7a046daa2290501909e65f4d3188"
-  head "https://guest:@svn.nmap.org/nmap/", :using => :svn
+  head "https://svn.nmap.org/nmap/"
 
   bottle do
     sha256 "a8a43b57a4ed84ba718e7ab64015d118d8a9f4b99309ab114edcb8587c2f1693" => :sierra


### PR DESCRIPTION
* The SVN URL incorrectly specified credentials which did not work.
* The SVN URL now matches the URL specified on the nmap documentation
page: https://nmap.org/book/install.html#inst-svn
* Remove redundant `, :using => :svn` per brew audit suggestion.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

> $ brew uninstall --force nmap; brew install --build-from-source --HEAD nmap; brew test nmap; brew audit --strict nmap
> Uninstalling nmap... (764 files, 24.4M)
> ==> Using the sandbox
> ==> Cloning https://svn.nmap.org/nmap/
> Updating /Users/user/Library/Caches/Homebrew/nmap--svn-HEAD
> ==> ./configure --prefix=/usr/local/Cellar/nmap/HEAD-36578 --with-libpcre=included --with-liblua=included --with-openssl=/usr/local/opt/openssl --without-nmap-update --disable-universal --without-zenmap
> ==> make
> ==> make install
> 🍺  /usr/local/Cellar/nmap/HEAD-36578: 764 files, 24.4M, built in 3 minutes 31 seconds
> Testing nmap
> ==> Using the sandbox
> ==> /usr/local/Cellar/nmap/HEAD-36578/bin/nmap -p80,443 google.com

-----
