### PR TITLE
chromaprint: remove examples.

### DIFF
--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -3,7 +3,7 @@ class Chromaprint < Formula
   homepage "https://acoustid.org/chromaprint"
   url "https://bitbucket.org/acoustid/chromaprint/downloads/chromaprint-1.3.tar.gz"
   sha256 "3dc3ff97abdce63abc1f52d5f5f8e72c22f9a690dd6625271aa96d3a585b695a"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -13,19 +13,10 @@ class Chromaprint < Formula
     sha256 "611f98dcc4855ad23b30ae5db399e5c6c6b659dc31fb09d5c7e573002e335448" => :mavericks
   end
 
-  option "without-examples", "Don't build examples (including fpcalc)"
-
   depends_on "cmake" => :build
-  depends_on "ffmpeg" if build.with? "examples"
 
   def install
-    args = std_cmake_args
-    args << "-DBUILD_EXAMPLES=ON" if build.with? "examples"
-    system "cmake", ".", *args
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
-  end
-
-  test do
-    system "#{bin}/fpcalc", test_fixtures("test.mp3") if build.with? "examples"
   end
 end


### PR DESCRIPTION
Remove examples because they introduce a recursive (optional) dependency from ffmpeg to chromaprint.