### PR TITLE
complx 4.15.0 (new formula)

### DIFF
--- a/Formula/complx.rb
+++ b/Formula/complx.rb
@@ -1,0 +1,25 @@
+class Complx < Formula
+  desc "The LC-3 Simulator used in Georgia Tech CS2110."
+  homepage "https://github.com/TricksterGuy/complx"
+  url "https://github.com/TricksterGuy/complx.git", :using => :git, :revision => "dc81110be4d2338f17ec276f2a80fc5aad765b78", :tag => "4.15.0"
+
+  # This pulls from the master branch instead of the specified version tag
+  head do
+    url "https://github.com/TricksterGuy/complx.git", :using => :git, :branch => "master"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "wxmac" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/complx", "--help"
+  end
+end


### PR DESCRIPTION
complx is a simulator, assembler and tester package for the computer architecture LC-3 that is used in Computer Organization courses in many universities around the world. This particular simulator was developed for use at the Georgia Institute of Technology by former TA Brandon Whitehead. It is provided online on GitHub for students to install from source, but because most are unfamiliar with this procedure, the class instead provides an apt-get package, and requires students to install Linux VMs to run the suite, when Mac-user students (most of the class) could easily run on their Mac without this VM, unnecessarily complicating things. This brew formula intends to simplify the installation process for students in order to make it feasible for everyone to run the application directly on their Mac.

- [+] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [+] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [+] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [+] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
