### PR TITLE
ansible: added kerberos support

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -555,6 +555,16 @@ class Ansible < Formula
     sha256 "31fab8ca9b12aa5e6fe79b4463cfe62f33ded770ddc933a8d99c4debe934a0de"
   end
 
+  resource "pykerberos" do
+    url "https://files.pythonhosted.org/packages/bf/64/dd86215662d7df0f4f35632849e3576646fe29416deb7766ee00e09bdad3/pykerberos-1.1.14.tar.gz"
+    sha256 "60f84e1b606d58cc457b186914c195072ebebf5d5a05e75c0136541808e06523"
+  end
+
+  resource "requests-kerberos" do
+    url "https://files.pythonhosted.org/packages/f4/ad/f102020a3cbe7e229cf2f8dd298f378fe1180c3539d8872c00b13d5a7f7a/requests-kerberos-0.11.0.tar.gz"
+    sha256 "ae734f71f46a7b205a74fb90e160c7ba4cc4e0dff2d4f3129cf74806b51b94ba"
+  end
+
   def install
     # https://github.com/Homebrew/homebrew-core/issues/7197
     ENV.prepend "CPPFLAGS", "-I#{MacOS.sdk_path}/usr/include/ffi"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm facing issues with testing this locally even with not-modified version:

```
$ brew reinstall --build-from-source ansible.rb 
==> Reinstalling ansible 
==> Downloading https://releases.ansible.com/ansible/ansible-2.2.1.0.tar.gz
Already downloaded: /Users/user/Library/Caches/Homebrew/ansible-2.2.1.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz
Already downloaded: /Users/user/Library/Caches/Homebrew/ansible--homebrew-virtualenv-15.0.2.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/tmp/ansible--homebrew-virtualenv-20170222-62647-apex0m/target --single-version-externally-managed --record=installed.txt
==> python -s /tmp/ansible--homebrew-virtualenv-20170222-62647-apex0m/target/bin/virtualenv -p python /usr/local/Cellar/ansible/2.2.1.0_1/libexec
==> Downloading https://files.pythonhosted.org/packages/82/f7/d6dfd7595910a20a563a83a762bf79a253c4df71759c3b228accb3d7e5e4/cryptography-1.7.1.tar.gz
Already downloaded: /Users/user/Library/Caches/Homebrew/ansible--cryptography-1.7.1.tar.gz
==> /usr/local/Cellar/ansible/2.2.1.0_1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/ansible--cryptography-20170222-62647-inan6s/cryptography-1.7.1
==> Downloading https://files.pythonhosted.org/packages/c3/2c/63275fab26a0fd8cadafca71a3623e4d0f0ee8ed7124a5bb128853d178a7/pbr-1.10.0.tar.gz
Already downloaded: /Users/user/Library/Caches/Homebrew/ansible--pbr-1.10.0.tar.gz
==> /usr/local/Cellar/ansible/2.2.1.0_1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/ansible--pbr-20170222-62647-721p9k/pbr-1.10.0
Last 15 lines from /Users/user/Library/Logs/Homebrew/ansible/04.pip:
  File "/usr/local/lib/python2.7/site-packages/pip/commands/install.py", line 335, in run
    wb.build(autobuilding=True)
  File "/usr/local/lib/python2.7/site-packages/pip/wheel.py", line 749, in build
    self.requirement_set.prepare_files(self.finder)
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_set.py", line 380, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_set.py", line 634, in _prepare_file
    abstract_dist.prep_for_dist()
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_set.py", line 129, in prep_for_dist
    self.req_to_install.run_egg_info()
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_install.py", line 439, in run_egg_info
    command_desc='python setup.py egg_info')
  File "/usr/local/lib/python2.7/site-packages/pip/utils/__init__.py", line 707, in call_subprocess
    % (command_desc, proc.returncode, cwd))
InstallationError: Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-pxb5VV-build/

Do not report this issue to Homebrew/brew or Homebrew/core!

These open issues may also help:
ansible relocatable bottle https://github.com/Homebrew/homebrew-core/issues/9424
[ansible] New python dependency needs --with-custom-python option like vim https://github.com/Homebrew/homebrew-core/issues/6728
```

Is there anything I can do about it?