### PR TITLE
pygobject3: add python3 support

### DIFF
--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -13,6 +13,7 @@ class Pygobject3 < Formula
 
   option :universal
   option "without-python", "Build without python2 support"
+  option "without-python3", "Build without python3 support"
 
   depends_on "pkg-config" => :build
   depends_on "libffi" => :optional


### PR DESCRIPTION
without this option `Language::Python.each_python` will never return `python3` for this build

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
