### PR TITLE
Remove universal support, except for wine dependencies

### DIFF
--- a/Formula/airspy.rb
+++ b/Formula/airspy.rb
@@ -11,8 +11,6 @@ class Airspy < Formula
     sha256 "1d6af7e52534bc50625eabcaa2b586e5824a3abbb4c3b42e032e5b4de41c6bfb" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "libusb"
@@ -23,11 +21,6 @@ class Airspy < Formula
     libusb = Formula["libusb"]
     args << "-DLIBUSB_INCLUDE_DIR=#{libusb.opt_include}/libusb-1.0"
     args << "-DLIBUSB_LIBRARIES=#{libusb.opt_lib}/libusb-1.0.dylib"
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -14,8 +14,6 @@ class AprUtil < Formula
 
   keg_only :provided_by_osx, "Apple's CLT package contains apr."
 
-  option :universal
-
   depends_on "apr"
   depends_on "openssl"
   depends_on "postgresql" => :optional
@@ -26,8 +24,6 @@ class AprUtil < Formula
   depends_on "homebrew/dupes/openldap" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     # Stick it in libexec otherwise it pollutes lib with a .exp file.
     args = %W[
       --prefix=#{libexec}

--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -15,10 +15,7 @@ class Apr < Formula
 
   keg_only :provided_by_osx, "Apple's CLT package contains apr."
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     ENV["SED"] = "sed" # prevent libtool from hardcoding sed path from superenv
 
     # https://bz.apache.org/bugzilla/show_bug.cgi?id=57359

--- a/Formula/atk.rb
+++ b/Formula/atk.rb
@@ -10,14 +10,11 @@ class Atk < Formula
     sha256 "5f9a612ac3616d720a14f148f19e0a4d3a2259d58fc18edc548443635bc28f48" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gobject-introspection"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-introspection=yes"

--- a/Formula/aubio.rb
+++ b/Formula/aubio.rb
@@ -13,8 +13,6 @@ class Aubio < Formula
     sha256 "c826af70ae0ac208299282b6935747736ef58d5505b9c7235c699590ac26020d" => :yosemite
   end
 
-  option :universal
-
   depends_on :macos => :lion
 
   depends_on :python => :optional
@@ -32,8 +30,6 @@ class Aubio < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     # Needed due to issue with recent cland (-fno-fused-madd))
     ENV.refurbish_args
 

--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -18,14 +18,10 @@ class BdwGc < Formula
     depends_on "libtool"  => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libatomic_ops" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -12,7 +12,6 @@ class BoostPython < Formula
     sha256 "14b55a75a1328adfe89f9234c72ed769d159f93fc0a7e140c956de2c3c5d54c9" => :yosemite
   end
 
-  option :universal
   option :cxx11
 
   option "without-python", "Build without python 2 support"
@@ -25,8 +24,6 @@ class BoostPython < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",
             "--libdir=#{lib}",
@@ -36,8 +33,6 @@ class BoostPython < Formula
             "--user-config=user-config.jam",
             "threading=multi,single",
             "link=shared,static"]
-
-    args << "address-model=32_64" << "architecture=x86" << "pch=off" if build.universal?
 
     # Build in C++11 mode if boost was built in C++11 mode.
     # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11

--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -25,8 +25,6 @@ class Cairo < Formula
 
   keg_only :provided_pre_mountain_lion
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on :x11 => :optional if MacOS.version > :leopard
   depends_on "freetype"
@@ -36,8 +34,6 @@ class Cairo < Formula
   depends_on "glib"
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}

--- a/Formula/check.rb
+++ b/Formula/check.rb
@@ -13,10 +13,7 @@ class Check < Formula
     sha256 "b223c76b5519c5aa3300488b230c5b5b2cbd32d896f2fab0f1a0700a24e1f975" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/cppunit.rb
+++ b/Formula/cppunit.rb
@@ -14,10 +14,7 @@ class Cppunit < Formula
     sha256 "0494ee4b157acec4c86c4d26a2c1155e71e11e5dc3a897ae1888a3da4edbb21f" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -19,7 +19,6 @@ class Czmq < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
   option "with-drafts", "Build and install draft classes and methods"
 
   depends_on "asciidoc" => :build
@@ -30,7 +29,6 @@ class Czmq < Formula
   conflicts_with "mono", :because => "both install `makecert` binaries"
 
   def install
-    ENV.universal_binary if build.universal?
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]

--- a/Formula/devil.rb
+++ b/Formula/devil.rb
@@ -12,8 +12,6 @@ class Devil < Formula
     sha256 "906a89e5b5b593260a6bbd4cbab351adee051bde3dcaec7e61db62eacbcd74bd" => :yosemite
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on "jasper"
   depends_on "jpeg"
@@ -22,7 +20,6 @@ class Devil < Formula
   depends_on "little-cms2"
 
   def install
-    ENV.universal_binary if build.universal?
     cd "DevIL" do
       system "cmake", ".", *std_cmake_args
       system "make", "install"

--- a/Formula/editorconfig.rb
+++ b/Formula/editorconfig.rb
@@ -13,14 +13,10 @@ class Editorconfig < Formula
     sha256 "34d07fd7086716d9b0e4b078b6f45c95aa7575a1bd56acf8730a6fb69d1750e9" => :mavericks
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on "pcre"
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "cmake", ".", "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}"
     system "make", "install"
   end

--- a/Formula/exiv2.rb
+++ b/Formula/exiv2.rb
@@ -20,10 +20,7 @@ class Exiv2 < Formula
     depends_on "libssh"
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     if build.head?
       args = std_cmake_args
       args += %W[

--- a/Formula/exodriver.rb
+++ b/Formula/exodriver.rb
@@ -14,13 +14,9 @@ class Exodriver < Formula
     sha256 "bcc5eea01c69b14b1a2f3256105523016294ae54f9e026f03fbd4f65f7ce5c66" => :mavericks
   end
 
-  option :universal
-
   depends_on "libusb"
 
   def install
-    ENV.universal_binary if build.universal?
-
     cd "liblabjackusb"
     system "make", "-f", "Makefile",
                    "DESTINATION=#{lib}",

--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -16,10 +16,7 @@ class Expat < Formula
 
   keg_only :provided_by_osx, "macOS includes Expat 1.5."
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}"
     system "make", "install"

--- a/Formula/fftw.rb
+++ b/Formula/fftw.rb
@@ -13,7 +13,6 @@ class Fftw < Formula
   end
 
   option "with-fortran", "Enable Fortran bindings"
-  option :universal
   option "with-mpi", "Enable MPI parallel transforms"
   option "with-openmp", "Enable OpenMP parallel transforms"
 
@@ -34,8 +33,6 @@ class Fftw < Formula
     args << "--disable-fortran" if build.without? "fortran"
     args << "--enable-mpi" if build.with? "mpi"
     args << "--enable-openmp" if build.with? "openmp"
-
-    ENV.universal_binary if build.universal?
 
     # single precision
     # enable-sse2, enable-avx and enable-avx2 work for both single and double precision

--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -20,8 +20,6 @@ class Flac < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libogg" => :optional
 
@@ -31,8 +29,6 @@ class Flac < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --disable-dependency-tracking
       --disable-debug
@@ -40,7 +36,7 @@ class Flac < Formula
       --enable-static
     ]
 
-    args << "--disable-asm-optimizations" if build.universal? || Hardware::CPU.is_32_bit?
+    args << "--disable-asm-optimizations" if Hardware::CPU.is_32_bit?
     args << "--without-ogg" if build.without? "libogg"
 
     system "./autogen.sh" if build.head?

--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -20,7 +20,6 @@ class Freetds < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
   option "with-msdblib", "Enable Microsoft behavior in the DB-Library API where it diverges from Sybase's"
   option "with-sybase-compat", "Enable close compatibility with Sybase's ABI, at the expense of other features"
   option "with-odbc-wide", "Enable odbc wide, prevent unicode - MemoryError's"
@@ -66,8 +65,6 @@ class Freetds < Formula
         args << "--enable-#{option}"
       end
     end
-
-    ENV.universal_binary if build.universal?
 
     if build.head?
       system "./autogen.sh", *args

--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -13,14 +13,11 @@ class Fribidi < Formula
     sha256 "70caed8cb2f44044c41e0b91c2645111b9f177d98b4d49cef01fb0d8558c0f98" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "pcre"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--with-glib", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/gcore.rb
+++ b/Formula/gcore.rb
@@ -14,7 +14,6 @@ class Gcore < Formula
   end
 
   def install
-    ENV.universal_binary
     system "make"
     bin.install "gcore"
   end

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -13,12 +13,9 @@ class Gdbm < Formula
     sha256 "87bfecf948e8b6182519f627f95c244531b2a48c1941352bee0980275b515f43" => :mavericks
   end
 
-  option :universal
   option "with-libgdbm-compat", "Build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -10,7 +10,6 @@ class GdkPixbuf < Formula
     sha256 "1aa5969773dbaff17cc38c6c21cf0e17e5bae650d88e9aa867ee06eb53984155" => :yosemite
   end
 
-  option :universal
   option "with-relocations", "Build with relocation support for bundles"
   option "without-modules", "Disable dynamic module loading"
   option "with-included-loaders=", "Build the specified loaders into gdk-pixbuf"
@@ -39,7 +38,6 @@ class GdkPixbuf < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.append_to_cflags "-DGDK_PIXBUF_LIBDIR=\\\"#{HOMEBREW_PREFIX}/lib\\\""
     args = %W[
       --disable-dependency-tracking

--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -20,8 +20,6 @@ class Gegl < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "babl"
@@ -37,23 +35,11 @@ class Gegl < Formula
   depends_on "sdl" => :optional
 
   def install
-    argv = %W[
-      --disable-debug
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --disable-docs
-    ]
-
-    if build.universal?
-      ENV.universal_binary
-      # ffmpeg's formula is currently not universal-enabled
-      argv << "--without-libavformat"
-
-      opoo "Compilation may fail at gegl-cpuaccel.c using gcc for a universal build" if ENV.compiler == :gcc
-    end
-
     system "./autogen.sh" if build.head?
-    system "./configure", *argv
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--disable-docs"
     system "make", "install"
   end
 

--- a/Formula/geoip.rb
+++ b/Formula/geoip.rb
@@ -14,13 +14,9 @@ class Geoip < Formula
     sha256 "5ee66187d1b4510fd463ebb8bf360c2d78a4252467a0e10e905a2a3502f9bcaa" => :mavericks
   end
 
-  option :universal
-
   depends_on "geoipupdate" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--datadir=#{var}",

--- a/Formula/geoipupdate.rb
+++ b/Formula/geoipupdate.rb
@@ -17,11 +17,7 @@ class Geoipupdate < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./bootstrap" if build.head?
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/geos.rb
+++ b/Formula/geos.rb
@@ -11,7 +11,6 @@ class Geos < Formula
     sha256 "5b20acb4dfa59515be97f9f731f497c59d11deee2547ca61191b0da4eb8cf735" => :yosemite
   end
 
-  option :universal
   option :cxx11
   option "with-php", "Build the PHP extension"
   option "without-python", "Do not build the Python extension"
@@ -20,7 +19,6 @@ class Geos < Formula
   depends_on "swig" => :build if build.with?("python") || build.with?("ruby")
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?
 
     # https://trac.osgeo.org/geos/ticket/771

--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -14,14 +14,10 @@ class Gettext < Formula
 
   keg_only :shadowed_by_osx, "macOS provides the BSD gettext library and some software gets confused if both are in the library path."
 
-  option :universal
-
   # https://savannah.gnu.org/bugs/index.php?46844
   depends_on "libxml2" if MacOS.version <= :mountain_lion
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--disable-debug",

--- a/Formula/giflib.rb
+++ b/Formula/giflib.rb
@@ -18,13 +18,9 @@ class Giflib < Formula
     sha256 "76953a4ac103ff0931f2e4f70dafe9283c9289de2dda7f800e8ca3b47b6830db" => :mountain_lion
   end
 
-  option :universal
-
   depends_on :x11 => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking

--- a/Formula/glew.rb
+++ b/Formula/glew.rb
@@ -13,16 +13,7 @@ class Glew < Formula
     sha256 "2b72bd7d59343ae64eaa87fd69f806759ac356a77300bb6b6a6ab40247384dc2" => :mavericks
   end
 
-  option :universal
-
   def install
-    if build.universal?
-      ENV.universal_binary
-
-      # Do not strip resulting binaries; https://sourceforge.net/p/glew/bugs/259/
-      ENV["STRIP"] = ""
-    end
-
     inreplace "glew.pc.in", "Requires: @requireslib@", ""
     system "make", "GLEW_PREFIX=#{prefix}", "GLEW_DEST=#{prefix}", "all"
     system "make", "GLEW_PREFIX=#{prefix}", "GLEW_DEST=#{prefix}", "install.all"

--- a/Formula/glfw.rb
+++ b/Formula/glfw.rb
@@ -13,7 +13,6 @@ class Glfw < Formula
     sha256 "ecfc037c61cedd936d230880dd052691e8c07c4f10c3c95ccde4d8bc4e3f5e35" => :yosemite
   end
 
-  option :universal
   option "without-shared-library", "Build static library only (defaults to building dylib only)"
   option "with-examples", "Build examples"
   option "with-test", "Build test programs"
@@ -26,13 +25,10 @@ class Glfw < Formula
   deprecated_option "with-tests" => "with-test"
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = std_cmake_args + %w[
       -DGLFW_USE_CHDIR=TRUE
       -DGLFW_USE_MENUBAR=TRUE
     ]
-    args << "-DGLFW_BUILD_UNIVERSAL=TRUE" if build.universal?
     args << "-DBUILD_SHARED_LIBS=TRUE" if build.with? "shared-library"
     args << "-DGLFW_BUILD_EXAMPLES=TRUE" if build.with? "examples"
     args << "-DGLFW_BUILD_TESTS=TRUE" if build.with? "test"

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -10,7 +10,6 @@ class Glib < Formula
     sha256 "cec760af010c6740593f8e8b888c3981b8d66225e4524737f79f7f75d985047d" => :yosemite
   end
 
-  option :universal
   option "with-test", "Build a debug build and run tests. NOTE: Not all tests succeed yet"
 
   deprecated_option "test" => "with-test"
@@ -42,13 +41,6 @@ class Glib < Formula
     sha256 "284cbf626f814c21f30167699e6e59dcc0d31000d71151f25862b997a8c8493d"
   end
 
-  if build.universal?
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/fe50d25d/glib/universal.diff"
-      sha256 "e21f902907cca543023c930101afe1d0c1a7ad351daa0678ba855341f3fd1b57"
-    end
-  end
-
   # Reverts GNotification support on macOS.
   # This only supports OS X 10.9, and the reverted commits removed the
   # ability to build glib on older versions of OS X.
@@ -64,8 +56,6 @@ class Glib < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     inreplace %w[gio/gdbusprivate.c gio/xdgmime/xdgmime.c glib/gutils.c],
       "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
 
@@ -87,11 +77,6 @@ class Glib < Formula
     ]
 
     system "./configure", *args
-
-    if build.universal?
-      buildpath.install resource("config.h.ed")
-      system "ed -s - config.h <config.h.ed"
-    end
 
     # disable creating directory for GIO_MOUDLE_DIR, we will do this manually in post_install
     inreplace "gio/Makefile", "$(mkinstalldirs) $(DESTDIR)$(GIO_MODULE_DIR)", ""

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -11,8 +11,6 @@ class Gnuradio < Formula
     sha256 "464555aaac52b55b9e09ec2b0b2e0e4cabc024b655a1bf815d7ddde59aec92fe" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
 
   depends_on :python if MacOS.version <= :snow_leopard
@@ -104,11 +102,6 @@ class Gnuradio < Formula
     resource("cppzmq").stage include.to_s
 
     args = std_cmake_args
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
 
     args << "-DENABLE_DEFAULT=OFF"
     enabled_components = %w[gr-analog gr-fft volk gr-filter gnuradio-runtime

--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -10,8 +10,6 @@ class GobjectIntrospection < Formula
     sha256 "cb851182a1a2c6bdd29ed88b8f186fc7f2453e0b3cbf2c36409e80c00c3a100c" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :run
   depends_on "glib"
   depends_on "cairo"
@@ -28,7 +26,6 @@ class GobjectIntrospection < Formula
 
   def install
     ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
-    ENV.universal_binary if build.universal?
     inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"
     inreplace "configure" do |s|
       s.change_make_var! "GOBJECT_INTROSPECTION_LIBDIR", "#{HOMEBREW_PREFIX}/lib"

--- a/Formula/graphite2.rb
+++ b/Formula/graphite2.rb
@@ -13,8 +13,6 @@ class Graphite2 < Formula
     sha256 "a483f552d39ed4d3dbfb3abb73301fe273b81fb4842c67b294f96dc25f353ac2" => :yosemite
   end
 
-  option :universal
-
   depends_on "cmake" => :build
 
   resource "testfont" do
@@ -23,8 +21,6 @@ class Graphite2 < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "cmake", *std_cmake_args
     system "make", "install"
   end

--- a/Formula/gsl.rb
+++ b/Formula/gsl.rb
@@ -12,11 +12,7 @@ class Gsl < Formula
     sha256 "27e916ed0e2bec74aeb88e694a22f0076e225c6a0b8c9b5450d5cbc0db842e3e" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make" # A GNU tool which doesn't support just make install! Shameful!
     system "make", "install"

--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -10,7 +10,6 @@ class Gtkx3 < Formula
     sha256 "d5686fe43e5f51a2cc42ee787abcc02b2e6e3087a0e564910cf677bb7721ad4e" => :yosemite
   end
 
-  option :universal
   option "with-quartz-relocation", "Build with quartz relocation support"
 
   depends_on "pkg-config" => :build
@@ -25,8 +24,6 @@ class Gtkx3 < Formula
   depends_on "jasper" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --enable-debug=minimal
       --disable-dependency-tracking

--- a/Formula/gts.rb
+++ b/Formula/gts.rb
@@ -12,8 +12,6 @@ class Gts < Formula
     sha256 "b6e2ce541c5b4b46076843076c6842723a896afa36619cfab8155194795c9817" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
@@ -24,7 +22,6 @@ class Gts < Formula
   patch :DATA
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
 

--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -17,11 +17,9 @@ class Icu4c < Formula
 
   keg_only :provided_by_osx, "macOS provides libicucore.dylib (but nothing else)."
 
-  option :universal
   option :cxx11
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?
 
     args = %W[--prefix=#{prefix} --disable-samples --disable-tests --enable-static]

--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -12,10 +12,7 @@ class Ilmbase < Formula
     sha256 "2bfd8bef08f89e6c84d6f9da5f5b3db38b787d33a3c6e6bb9751a9c43bbea2de" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/jansson.rb
+++ b/Formula/jansson.rb
@@ -11,10 +11,7 @@ class Jansson < Formula
     sha256 "03a6016b16023b314916147e7ece853c39450a249644fceb2dac3a0417b11fdc" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/jbigkit.rb
+++ b/Formula/jbigkit.rb
@@ -17,15 +17,11 @@ class Jbigkit < Formula
     sha256 "0afb6297101bc3269f0ebca1590cda66a62cbd90e3fdbec38dc011131711d32b" => :mountain_lion
   end
 
-  option :universal
   option "with-test", "Verify the library during install"
 
   deprecated_option "with-check" => "with-test"
 
   def install
-    # Set for a universal build and patch the Makefile.
-    # There's no configure. It creates a static lib.
-    ENV.universal_binary if build.universal?
     system "make", "CC=#{ENV.cc}", "CCFLAGS=#{ENV.cflags}"
 
     if build.with? "test"

--- a/Formula/json-c.rb
+++ b/Formula/json-c.rb
@@ -23,11 +23,7 @@ class JsonC < Formula
     depends_on "autoconf" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/jsoncpp.rb
+++ b/Formula/jsoncpp.rb
@@ -12,8 +12,6 @@ class Jsoncpp < Formula
     sha256 "9f33d38dc6d459622705c4982204e0eea49a5d9a14440a032695dd1b72214cad" => :yosemite
   end
 
-  option :universal
-
   needs :cxx11
 
   depends_on "cmake" => :build
@@ -21,18 +19,12 @@ class Jsoncpp < Formula
   def install
     ENV.cxx11
 
-    cmake_args = std_cmake_args + %w[
-      -DBUILD_STATIC_LIBS=ON
-      -DBUILD_SHARED_LIBS=ON
-      -DJSONCPP_WITH_CMAKE_PACKAGE=ON
-      -DJSONCPP_WITH_TESTS=OFF
-      -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF
-    ]
-    if build.universal?
-      ENV.universal_binary
-      cmake_args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-    system "cmake", ".", *cmake_args
+    system "cmake", ".", *cmake_args,
+                         "-DBUILD_STATIC_LIBS=ON",
+                         "-DBUILD_SHARED_LIBS=ON",
+                         "-DJSONCPP_WITH_CMAKE_PACKAGE=ON",
+                         "-DJSONCPP_WITH_TESTS=OFF",
+                         "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF"
     system "make", "install"
   end
 

--- a/Formula/lame.rb
+++ b/Formula/lame.rb
@@ -14,11 +14,7 @@ class Lame < Formula
     sha256 "db743baefa0ec1b0f8c00df4728536418916c4d42c71c548dc43d43a1b24b523" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-debug",
                           "--prefix=#{prefix}",

--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -11,22 +11,13 @@ class Libbladerf < Formula
     sha256 "0db3f3411af41d50509487ab199092d2264aca0ab6212616d0ff8ec008cdc612" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "libusb"
 
   def install
-    args = std_cmake_args
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     mkdir "host/build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/libbtbb.rb
+++ b/Formula/libbtbb.rb
@@ -15,8 +15,6 @@ class Libbtbb < Formula
     sha256 "0ccf46429a2bddd4a71aeaaf24df9dc85c34f1c64062059ed0e630b551fcddd2" => :yosemite
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on :python if MacOS.version <= :snow_leopard
 
@@ -27,13 +25,6 @@ class Libbtbb < Formula
   end
 
   def install
-    args = std_cmake_args
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     resource("libpcap").stage do
       system "./configure", "--prefix=#{libexec}/vendor", "--enable-ipv6"
       system "make", "install"
@@ -42,7 +33,7 @@ class Libbtbb < Formula
     ENV.prepend_path "PATH", libexec/"vendor/bin"
     ENV.append_to_cflags "-I#{libexec}/vendor/include"
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/libconfig.rb
+++ b/Formula/libconfig.rb
@@ -19,11 +19,7 @@ class Libconfig < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "autoreconf", "-i" if build.head?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
 

--- a/Formula/libdap.rb
+++ b/Formula/libdap.rb
@@ -28,11 +28,6 @@ class Libdap < Formula
   needs :cxx11 if MacOS.version < :mavericks
 
   def install
-    # NOTE:
-    # To future maintainers: if you ever want to build this library as a
-    # universal binary, see William Kyngesburye's notes:
-    #     http://www.kyngchaos.com/macosx/build/dap
-
     # Otherwise, "make check" fails
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/libdc1394.rb
+++ b/Formula/libdc1394.rb
@@ -14,8 +14,6 @@ class Libdc1394 < Formula
     sha256 "989b8f20b2ad01c6c3d607fe974c3cf5ad005b51afa8455ec712325c8d4d5b22" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "sdl"
 
   # fix issue due to bug in OSX Firewire stack
@@ -24,7 +22,6 @@ class Libdc1394 < Formula
   patch :DATA
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-examples",

--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -11,8 +11,6 @@ class Libepoxy < Formula
     sha256 "f95aff4f5d3aed6991335ea6f67e3377a8a99200a554ca2cb0026c5e20630523" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on :python => :build if MacOS.version <= :snow_leopard
 

--- a/Formula/libestr.rb
+++ b/Formula/libestr.rb
@@ -12,12 +12,9 @@ class Libestr < Formula
     sha256 "5215ffe64cf57a7c95561588e8e117983419fece70fbc3c61d26099a249cf098" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"
     system "make", "install"

--- a/Formula/libfreenect.rb
+++ b/Formula/libfreenect.rb
@@ -13,22 +13,13 @@ class Libfreenect < Formula
     sha256 "f714532e1b21365063746846544a340dac70cf0c5cc877a207dd17284ee100b7" => :mavericks
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on "libusb"
 
   def install
-    args = std_cmake_args
-    args << "-DBUILD_OPENNI2_DRIVER=ON"
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args,
+                      "-DBUILD_OPENNI2_DRIVER=ON"
       system "make", "install"
     end
   end

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -12,8 +12,6 @@ class Libgcrypt < Formula
     sha256 "461822c0429c16e33c2c5f8be173fedc3228cea786683e463ae628789ea6c1e1" => :yosemite
   end
 
-  option :universal
-
   depends_on "libgpg-error"
 
   resource "config.h.ed" do
@@ -30,19 +28,12 @@ class Libgcrypt < Formula
     # https://github.com/Homebrew/homebrew-core/issues/1957
     ENV.O1 if DevelopmentTools.clang_build_version >= 800
 
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--enable-static",
                           "--prefix=#{prefix}",
                           "--disable-asm",
                           "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}"
-
-    if build.universal?
-      buildpath.install resource("config.h.ed")
-      system "ed -s - config.h <config.h.ed"
-    end
 
     # Parallel builds work, but only when run as separate steps
     system "make"

--- a/Formula/libghthash.rb
+++ b/Formula/libghthash.rb
@@ -13,14 +13,11 @@ class Libghthash < Formula
     sha256 "67fa9f1cda39b827ecd318a9f08980e322be034f00f198c0b7c83c2cf9a3d6a8" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "libtool" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",
            "--prefix=#{prefix}"

--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -11,8 +11,6 @@ class Libgit2 < Formula
     sha256 "1c9a4e6b427e80df70d78c9dfdf857b269888a2c8091ddcdcc3ce96e6d0acd8d" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "libssh2" => :recommended
@@ -23,11 +21,6 @@ class Libgit2 < Formula
     args << "-DBUILD_EXAMPLES=YES"
     args << "-DBUILD_CLAR=NO" # Don't build tests.
     args << "-DUSE_SSH=NO" if build.without? "libssh2"
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/libgpg-error.rb
+++ b/Formula/libgpg-error.rb
@@ -11,11 +11,7 @@ class LibgpgError < Formula
     sha256 "c7ca03639e52db681ed04b799343e63c61996e5781286ef00c6cb5f6b7a18731" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",

--- a/Formula/libgsm.rb
+++ b/Formula/libgsm.rb
@@ -14,8 +14,6 @@ class Libgsm < Formula
     sha256 "8b9054832ecbd7a4e41b1b3e7f8ef7a4aa4e0006a5332a19d176119c6b4121f3" => :mountain_lion
   end
 
-  option :universal
-
   # Builds a dynamic library for gsm, this package is no longer developed
   # upstream. Patch taken from Debian and modified to build a dylib.
   patch do
@@ -24,7 +22,6 @@ class Libgsm < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.append_to_cflags "-c -O2 -DNeedFunctionPrototypes=1"
 
     # Only the targets for which a directory exists will be installed

--- a/Formula/libhttpserver.rb
+++ b/Formula/libhttpserver.rb
@@ -14,8 +14,6 @@ class Libhttpserver < Formula
     sha256 "aec3bba3f8db0cb1e9fd99d66aafb1f2ed399197f11af43654f911205b62d5ee" => :mavericks
   end
 
-  option :universal
-
   depends_on "libmicrohttpd"
 
   depends_on "pkg-config" => :build
@@ -24,8 +22,6 @@ class Libhttpserver < Formula
   depends_on "libtool" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = [
       "--disable-dependency-tracking",
       "--disable-silent-rules",

--- a/Formula/libical.rb
+++ b/Formula/libical.rb
@@ -10,8 +10,6 @@ class Libical < Formula
     sha256 "f4cbcfb04208a01f1589f119e785c656b74713d033949e8a6a367a759ea142eb" => :yosemite
   end
 
-  option :universal
-
   depends_on "cmake" => :build
 
   def install
@@ -19,14 +17,9 @@ class Libical < Formula
     # Upstream issue https://github.com/libical/libical/issues/225
     inreplace "src/libical/icallangbind.h", "*callangbind_quote_as_ical_r(",
                                             "*icallangbind_quote_as_ical_r("
-    args = std_cmake_args
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
 
     mkdir "build" do
-      system "cmake", "..", "-DSHARED_ONLY=true", *args
+      system "cmake", "..", "-DSHARED_ONLY=true", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/libidl.rb
+++ b/Formula/libidl.rb
@@ -14,14 +14,11 @@ class Libidl < Formula
     sha256 "7aee2ea7f3760687e9acd4a35c393e240f8f59e94a36c2a31812d15a41cfcac8" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/libidn.rb
+++ b/Formula/libidn.rb
@@ -13,12 +13,9 @@ class Libidn < Formula
     sha256 "07e19d25263d77030cccc3899967c4505dcf0c771da90a658b4f27de136a326b" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-csharp",

--- a/Formula/liblo.rb
+++ b/Formula/liblo.rb
@@ -21,14 +21,11 @@ class Liblo < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
   option "with-ipv6", "Compile with support for ipv6"
 
   deprecated_option "enable-ipv6" => "with-ipv6"
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --disable-debug
       --disable-dependency-tracking

--- a/Formula/libmagic.rb
+++ b/Formula/libmagic.rb
@@ -11,13 +11,9 @@ class Libmagic < Formula
     sha256 "2ca4f55351b129933f8625b19958ecc21ce9d301ef18f771572f0bcba484f1e5" => :yosemite
   end
 
-  option :universal
-
   depends_on :python => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",

--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -13,7 +13,6 @@ class Libmicrohttpd < Formula
   end
 
   option "with-ssl", "Enable SSL support"
-  option :universal
 
   if build.with? "ssl"
     depends_on "libgcrypt"
@@ -21,8 +20,6 @@ class Libmicrohttpd < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     # Remove for > 0.9.52
     # Equivalent to upstream commit from 11 Nov 2016 https://gnunet.org/git/libmicrohttpd.git/commit/?id=52e995c0a7741967ab68883a63a8c7e70a4589ee
     # "mhd_itc.c: fixed typo preventing build on Solaris and other systems"

--- a/Formula/libmikmod.rb
+++ b/Formula/libmikmod.rb
@@ -12,11 +12,9 @@ class Libmikmod < Formula
   end
 
   option "with-debug", "Enable debugging symbols"
-  option :universal
 
   def install
     ENV.O2 if build.with? "debug"
-    ENV.universal_binary if build.universal?
 
     # macOS has CoreAudio, but ALSA is not for this OS nor is SAM9407 nor ULTRA.
     args = %W[

--- a/Formula/libmpd.rb
+++ b/Formula/libmpd.rb
@@ -14,14 +14,11 @@ class Libmpd < Formula
     sha256 "85c97dbfb2a3a419495e702df451b00bf84e355d69c2e8512a54014ff702f45c" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/libmpdclient.rb
+++ b/Formula/libmpdclient.rb
@@ -21,15 +21,12 @@ class Libmpdclient < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "doxygen" => :build
 
   def install
     inreplace "autogen.sh", "libtoolize", "glibtoolize"
     system "./autogen.sh" if build.head?
 
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -22,11 +22,7 @@ class Libogg < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/libpgm.rb
+++ b/Formula/libpgm.rb
@@ -15,11 +15,8 @@ class Libpgm < Formula
     sha256 "682fb0731817ab2f01c9247b1579dcd4a5ff8e28a938ddcd7045ee30acc81499" => :mountain_lion
   end
 
-  option :universal
-
   def install
     cd "openpgm/pgm" do
-      ENV.universal_binary if build.universal?
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{prefix}"
       system "make", "install"

--- a/Formula/librsync.rb
+++ b/Formula/librsync.rb
@@ -12,14 +12,10 @@ class Librsync < Formula
     sha256 "bc7ada34fb6aae7fcb9a303a3daeda5861ab11e0a966425aaed2e549fd88e6b9" => :mavericks
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on "popt"
 
   def install
-    ENV.universal_binary if build.universal?
-
     # https://github.com/librsync/librsync/commit/1765ad0d416
     # https://github.com/librsync/librsync/issues/50
     # Safe to remove when the next stable release is cut.

--- a/Formula/librtlsdr.rb
+++ b/Formula/librtlsdr.rb
@@ -15,22 +15,13 @@ class Librtlsdr < Formula
     sha256 "1d6986e78140d3135492e087356435b19647f090d902b334b400315bc8baebd5" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "libusb"
 
   def install
-    args = std_cmake_args
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -11,8 +11,6 @@ class Libsndfile < Formula
     sha256 "4b6e891dc0dde551f1ee73ea508553ebb1c84c08fbdc5ae0e874e30ab0367ffb" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -22,8 +20,6 @@ class Libsndfile < Formula
   depends_on "libvorbis"
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "autoreconf", "-i"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/libsodium.rb
+++ b/Formula/libsodium.rb
@@ -20,11 +20,7 @@ class Libsodium < Formula
     depends_on "automake" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/libtermkey.rb
+++ b/Formula/libtermkey.rb
@@ -11,14 +11,10 @@ class Libtermkey < Formula
     sha256 "d8bbe8d3e78821cd3785c7582ed7355ea74e966a3572abd92499db014907fefa" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libtool" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "make", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -21,14 +21,10 @@ class Libvorbis < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libogg"
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -41,12 +41,9 @@ class Libxml2 < Formula
 
   keg_only :provided_by_osx
 
-  option :universal
-
   depends_on :python => :optional
 
   def install
-    ENV.universal_binary if build.universal?
     if build.head?
       inreplace "autogen.sh", "libtoolize", "glibtoolize"
       system "./autogen.sh"

--- a/Formula/libyaml.rb
+++ b/Formula/libyaml.rb
@@ -12,11 +12,7 @@ class Libyaml < Formula
     sha256 "3a7788655c3c8f3b7ad73521928277ca5433789e134f437534702145171b1104" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/libyubikey.rb
+++ b/Formula/libyubikey.rb
@@ -13,11 +13,7 @@ class Libyubikey < Formula
     sha256 "53122ea8a869ed5c811273df1c2767e46138797f1af122db93beda2b7254b407" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -12,10 +12,7 @@ class Libzip < Formula
     sha256 "e5c8a9203db8983a448ab144a7457b069f560354f2a0f6ee677e89dc4b07c21e" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "CXX=#{ENV.cxx}",

--- a/Formula/libzzip.rb
+++ b/Formula/libzzip.rb
@@ -14,7 +14,6 @@ class Libzzip < Formula
   end
 
   option "with-sdl", "Enable SDL usage and create SDL_rwops_zzip.pc"
-  option :universal
 
   deprecated_option "sdl" => "with-sdl"
 
@@ -22,12 +21,6 @@ class Libzzip < Formula
   depends_on "sdl" => :optional
 
   def install
-    if build.universal?
-      ENV.universal_binary
-      # See: https://sourceforge.net/p/zziplib/feature-requests/5/
-      ENV["ac_cv_sizeof_long"] = "(LONG_BIT/8)"
-    end
-
     args = %W[
       --without-debug
       --disable-dependency-tracking

--- a/Formula/little-cms.rb
+++ b/Formula/little-cms.rb
@@ -14,14 +14,11 @@ class LittleCms < Formula
     sha256 "0d2af3b585f79b60e617301d5251a19114e14f82b5b75f3feda5be11c09404da" => :mountain_lion
   end
 
-  option :universal
-
   depends_on :python => :optional
   depends_on "jpeg" => :recommended
   depends_on "libtiff" => :recommended
 
   def install
-    ENV.universal_binary if build.universal?
     args = %W[--disable-dependency-tracking --disable-debug --prefix=#{prefix}]
     args << "--without-tiff" if build.without? "libtiff"
     args << "--without-jpeg" if build.without? "jpeg"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -123,7 +123,6 @@ class Llvm < Formula
 
   keg_only :provided_by_osx
 
-  option :universal
   option "without-compiler-rt", "Do not build Clang runtime support libraries for code sanitizers, builtins, and profiling"
   option "without-libcxx", "Do not build libc++ standard library"
   option "with-toolchain", "Build with Toolchain to facilitate overriding system compiler"
@@ -240,11 +239,6 @@ class Llvm < Formula
       args << "-DLLVM_ENABLE_FFI=ON"
       args << "-DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_lib}/libffi-#{Formula["libffi"].version}/include"
       args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}"
-    end
-
-    if build.universal?
-      ENV.permit_arch_flags
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
     end
 
     mktemp do

--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -12,7 +12,6 @@ class Log4cxx < Formula
     sha256 "b96afe3f4e4b63017d2061028ed8792c4190996b1e008d8c87c3f52dba660ec5" => :yosemite
   end
 
-  option :universal
   option :cxx11
 
   depends_on "autoconf" => :build
@@ -42,7 +41,6 @@ class Log4cxx < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.O2 # Using -Os causes build failures on Snow Leopard.
     ENV.cxx11 if build.cxx11?
 

--- a/Formula/mcrypt.rb
+++ b/Formula/mcrypt.rb
@@ -13,8 +13,6 @@ class Mcrypt < Formula
     sha256 "b6dd5f1210d4b0fffa7b14e4fce445c11d6245840fd38f08255149b6e27832c2" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "mhash"
 
   resource "libmcrypt" do
@@ -27,8 +25,6 @@ class Mcrypt < Formula
   patch :DATA
 
   def install
-    ENV.universal_binary if build.universal?
-
     resource("libmcrypt").stage do
       system "./configure", "--prefix=#{prefix}",
                             "--mandir=#{man}"

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -11,14 +11,11 @@ class Minizip < Formula
     sha256 "60235f0fe3bd432857c27b5c5b912d538925a7a477ff3822ac2af95ea9b00c22" => :yosemite
   end
 
-  option :universal
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}"
     system "make"
 

--- a/Formula/muparser.rb
+++ b/Formula/muparser.rb
@@ -14,11 +14,7 @@ class Muparser < Formula
     sha256 "e6945023b6e8e758c0fd3ec69d66119a60b3179881b4dedd18bdfbddeb75eb53" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -83,12 +83,6 @@ class Mysql < Formula
     # Compile with BLACKHOLE engine enabled if chosen
     args << "-DWITH_BLACKHOLE_STORAGE_ENGINE=1" if build.with? "blackhole-storage-engine"
 
-    # Make universal for binding to universal applications
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     # Build with local infile loading support
     args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"
 

--- a/Formula/nasm.rb
+++ b/Formula/nasm.rb
@@ -19,10 +19,7 @@ class Nasm < Formula
     depends_on "xmlto" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "manpages" if build.head?

--- a/Formula/neon.rb
+++ b/Formula/neon.rb
@@ -13,8 +13,6 @@ class Neon < Formula
 
   keg_only :provided_pre_mountain_lion
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "openssl"
 
@@ -25,7 +23,6 @@ class Neon < Formula
   patch :DATA
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
                           "--enable-shared",

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -16,16 +16,12 @@ class Netpbm < Formula
     sha256 "fb5df9f31a1202bf9a25cabb48a3d67a35dabbaa645875e558c4a359da784fa9" => :yosemite
   end
 
-  option :universal
-
   depends_on "libtiff"
   depends_on "jasper"
   depends_on "jpeg"
   depends_on "libpng"
 
   def install
-    ENV.universal_binary if build.universal?
-
     cp "config.mk.in", "config.mk"
 
     inreplace "config.mk" do |s|

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -15,8 +15,6 @@ class OpenalSoft < Formula
 
   keg_only :provided_by_osx, "macOS provides OpenAL.framework."
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "portaudio" => :optional
@@ -27,8 +25,6 @@ class OpenalSoft < Formula
   fails_with(:clang) { build 425 }
 
   def install
-    ENV.universal_binary if build.universal?
-
     # Please don't reenable example building. See:
     # https://github.com/Homebrew/homebrew/issues/38274
     args = std_cmake_args

--- a/Formula/openexr.rb
+++ b/Formula/openexr.rb
@@ -13,8 +13,6 @@ class Openexr < Formula
     sha256 "9c21b70caff58d8d699a58a50249f220b03c23f450a219276782827e6c03ff33" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "ilmbase"
 
@@ -31,7 +29,6 @@ class Openexr < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -14,7 +14,6 @@ class OpensslAT11 < Formula
 
   keg_only :versioned_formula
 
-  option :universal
   option "without-test", "Skip build-time tests (not recommended)"
 
   # Only needs 5.10 to run, but needs >5.13.4 to run the testsuite.
@@ -24,13 +23,6 @@ class OpensslAT11 < Formula
     depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
   else
     depends_on :perl => "5.10"
-  end
-
-  def arch_args
-    {
-      :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
-      :i386 => %w[darwin-i386-cc],
-    }
   end
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
@@ -57,69 +49,17 @@ class OpensslAT11 < Formula
       ENV["PERL"] = Formula["perl"].opt_bin/"perl"
     end
 
-    if build.universal?
-      ENV.permit_arch_flags
-      archs = Hardware::CPU.universal_archs
-    elsif MacOS.prefer_64_bit?
-      archs = [Hardware::CPU.arch_64_bit]
+    if MacOS.prefer_64_bit?
+      arch_args = %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128]
     else
-      archs = [Hardware::CPU.arch_32_bit]
+      arch_args = %w[darwin-i386-cc]
     end
 
-    dirs = []
-
-    archs.each do |arch|
-      if build.universal?
-        dir = "build-#{arch}"
-        dirs << dir
-        mkdir dir
-        mkdir "#{dir}/engines"
-      end
-
-      ENV.deparallelize
-      system "perl", "./Configure", *(configure_args + arch_args[arch])
-      system "make", "clean" if build.universal?
-      system "make"
-      system "make", "test" if build.with?("test")
-
-      next unless build.universal?
-      cp "include/openssl/opensslconf.h", dir
-      cp Dir["*.?.?.dylib", "*.a", "apps/openssl"], dir
-      cp Dir["engines/**/*.dylib"], "#{dir}/engines"
-    end
-
+    ENV.deparallelize
+    system "perl", "./Configure", *(configure_args + arch_args)
+    system "make"
+    system "make", "test" if build.with?("test")
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
-
-    if build.universal?
-      %w[libcrypto libssl].each do |libname|
-        system "lipo", "-create", "#{dirs.first}/#{libname}.1.1.dylib",
-                                  "#{dirs.last}/#{libname}.1.1.dylib",
-                       "-output", "#{lib}/#{libname}.1.1.dylib"
-        system "lipo", "-create", "#{dirs.first}/#{libname}.a",
-                                  "#{dirs.last}/#{libname}.a",
-                       "-output", "#{lib}/#{libname}.a"
-      end
-
-      Dir.glob("#{dirs.first}/engines/*.dylib") do |engine|
-        libname = File.basename(engine)
-        system "lipo", "-create", "#{dirs.first}/engines/#{libname}",
-                                  "#{dirs.last}/engines/#{libname}",
-                       "-output", "#{lib}/engines-1.1/#{libname}"
-      end
-
-      system "lipo", "-create", "#{dirs.first}/openssl",
-                                "#{dirs.last}/openssl",
-                     "-output", "#{bin}/openssl"
-
-      confs = archs.map do |arch|
-        <<-EOS.undent
-          #ifdef __#{arch}__
-          #{(buildpath/"build-#{arch}/opensslconf.h").read}
-          #endif
-        EOS
-      end
-      (include/"openssl/opensslconf.h").atomic_write confs.join("\n")
-    end
   end
 
   def openssldir

--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -15,13 +15,7 @@ class OsspUuid < Formula
     sha256 "5253f4fab035aca3ca3b867ce0d081812eb17fe0dcaab6599087abaa385c478d" => :mavericks
   end
 
-  option :universal
-
   def install
-    if build.universal?
-      ENV.universal_binary
-    end
-
     # upstream ticket: http://cvs.ossp.org/tktview?tn=200
     # pkg-config --cflags uuid returns the wrong directory since we override the
     # default, but uuid.pc.in does not use it

--- a/Formula/pam_yubico.rb
+++ b/Formula/pam_yubico.rb
@@ -12,15 +12,12 @@ class PamYubico < Formula
     sha256 "8b68985a95c26661f9cad4467449a60e826cbbf95e67c20a2edbbcf474cf13f6" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libyubikey"
   depends_on "ykclient"
   depends_on "ykpers"
 
   def install
-    ENV.universal_binary if build.universal?
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -20,8 +20,6 @@ class Pango < Formula
     depends_on "gtk-doc" => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on :x11 => :optional
   depends_on "glib"
@@ -31,8 +29,6 @@ class Pango < Formula
   depends_on "gobject-introspection"
 
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules

--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -21,11 +21,7 @@ class Pcre < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -14,11 +14,7 @@ class Pcre2 < Formula
     sha256 "64f26a62c8d94ced2b82d41d1dae3485d95639daaf8806aea9fb5f063d27690c" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-pcre2-16",

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -10,7 +10,6 @@ class PerconaServer < Formula
     sha256 "0898a9e1fcd34e0f10451dbd25a6da6eed0b7d23f3a7fa1b78410b0673e5148e" => :yosemite
   end
 
-  option :universal
   option "with-test", "Build with unit tests"
   option "with-embedded", "Build the embedded server"
   option "with-local-infile", "Build with local infile loading support"
@@ -104,12 +103,6 @@ class PerconaServer < Formula
 
     # Build with InnoDB Memcached plugin
     args << "-DWITH_INNODB_MEMCACHED=ON" if build.with? "memcached"
-
-    # Make universal for binding to universal applications
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
 
     # Build with local infile loading support
     args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"

--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -14,12 +14,9 @@ class Physfs < Formula
     sha256 "c4d372b4db8a7b0ed8019562cebce7ac59b1778c8a88d27a0d6cd508607826b9" => :mavericks
   end
 
-  option :universal
-
   depends_on "cmake" => :build
 
   def install
-    ENV.universal_binary if build.universal?
     mkdir "macbuild" do
       args = std_cmake_args
       args << "-DPHYSFS_BUILD_TEST=TRUE"

--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -14,13 +14,9 @@ class Pixman < Formula
 
   keg_only :provided_pre_mountain_lion
 
-  option :universal
-
   depends_on "pkg-config" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-gtk",
                           "--disable-mmx", # MMX assembler fails with Xcode 7

--- a/Formula/popt.rb
+++ b/Formula/popt.rb
@@ -13,10 +13,7 @@ class Popt < Formula
     sha256 "6d95c3530a7bd4d7099d91f448669b53bb51a071c5e9a8b9915cdc750bd72aec" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -13,7 +13,6 @@ class Portmidi < Formula
   end
 
   option "with-java", "Build Java-based app and bindings."
-  option :universal
 
   depends_on "cmake" => :build
   depends_on :python => :optional
@@ -29,8 +28,6 @@ class Portmidi < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
     inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
 
     # need to create include/lib directories since make won't create them itself

--- a/Formula/proxychains-ng.rb
+++ b/Formula/proxychains-ng.rb
@@ -13,15 +13,8 @@ class ProxychainsNg < Formula
     sha256 "2298ad9f27411a1da59bd925bf9cf49ae5579d368acbaebf1c29103e84684a09" => :yosemite
   end
 
-  option :universal
-
   def install
-    args = ["--prefix=#{prefix}", "--sysconfdir=#{etc}"]
-    if build.universal?
-      ENV.universal_binary
-      args << "--fat-binary"
-    end
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
     system "make"
     system "make", "install"
     system "make", "install-config"

--- a/Formula/py2cairo.rb
+++ b/Formula/py2cairo.rb
@@ -15,8 +15,6 @@ class Py2cairo < Formula
     sha256 "784e49b2f15f30af7f4e255eb2263c6e99ae4e0d0ec961412ff033d0954fd298" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on :python if MacOS.version <= :snow_leopard
@@ -31,7 +29,7 @@ class Py2cairo < Formula
     ENV.append_to_cflags `python-config --includes`
 
     # Python extensions default to universal but cairo may not be universal
-    ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}" unless build.universal?
+    ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
 
     system "./waf", "configure", "--prefix=#{prefix}", "--nopyc", "--nopyo"
     system "./waf", "install"

--- a/Formula/pygobject.rb
+++ b/Formula/pygobject.rb
@@ -13,8 +13,6 @@ class Pygobject < Formula
     sha256 "7cc44858e152e843aa0709d5f6d60659f11ac7dbd505379a5f15056ba88d91ae" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on :python
@@ -26,7 +24,6 @@ class Pygobject < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-introspection"

--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -11,7 +11,6 @@ class Pygobject3 < Formula
     sha256 "dd5e3f9c4c01bd6633635d3189f6ca3af9af81c1c302de8df22414e067252ee0" => :yosemite
   end
 
-  option :universal
   option "without-python", "Build without python2 support"
 
   depends_on "pkg-config" => :build
@@ -23,8 +22,6 @@ class Pygobject3 < Formula
   depends_on "gobject-introspection"
 
   def install
-    ENV.universal_binary if build.universal?
-
     Language::Python.each_python(build) do |python, _version|
       system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}", "PYTHON=#{python}"
       system "make", "install"

--- a/Formula/pygtk.rb
+++ b/Formula/pygtk.rb
@@ -14,8 +14,6 @@ class Pygtk < Formula
     sha256 "603694d87d2c6193caa164029bc441d93d45cdcd75419c8f8ed11b0902577457" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gtk+"
@@ -26,7 +24,6 @@ class Pygtk < Formula
 
   def install
     ENV.append "CFLAGS", "-ObjC"
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -14,7 +14,6 @@ class Python < Formula
 
   # Please don't add a wide/ucs4 option as it won't be accepted.
   # More details in: https://github.com/Homebrew/homebrew/pull/32368
-  option :universal
   option "with-quicktest", "Run `make quicktest` after the build (for devs; may fail)"
   option "with-tcl-tk", "Use Homebrew's Tk instead of macOS Tk (has optional Cocoa and threads support)"
   option "with-poll", "Enable select.poll, which is not fully implemented on macOS (https://bugs.python.org/issue5154)"
@@ -138,11 +137,6 @@ class Python < Formula
               "do_readline = '#{Formula["readline"].opt_lib}/libhistory.dylib'"
       s.gsub! "/usr/local/ssl", Formula["openssl"].opt_prefix
       s.gsub! "/usr/include/db4", Formula["berkeley-db@4"].opt_include
-    end
-
-    if build.universal?
-      ENV.universal_binary
-      args << "--enable-universalsdk=/" << "--with-universal-archs=intel"
     end
 
     if build.with? "sqlite"

--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -11,7 +11,6 @@ class Python3 < Formula
     sha256 "6db855fa31e33ceed7703f249f6c0e098e74db05294d7191cf175f0a4bffb1e2" => :yosemite
   end
 
-  option :universal
   option "with-tcl-tk", "Use Homebrew's Tk instead of macOS Tk (has optional Cocoa and threads support)"
   option "with-quicktest", "Run `make quicktest` after the build"
   option "with-sphinx-doc", "Build HTML documentation"
@@ -115,11 +114,6 @@ class Python3 < Formula
       s.gsub! "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
               "do_readline = '#{Formula["readline"].opt_lib}/libhistory.dylib'"
       s.gsub! "/usr/local/ssl", Formula["openssl"].opt_prefix
-    end
-
-    if build.universal?
-      ENV.universal_binary
-      args << "--enable-universalsdk" << "--with-universal-archs=intel"
     end
 
     if build.with? "sqlite"

--- a/Formula/r3.rb
+++ b/Formula/r3.rb
@@ -13,7 +13,6 @@ class R3 < Formula
     sha256 "26bd4bc4114b54d57d9f39bd00f15914f03eea7407fbcc50df4c1925b412a879" => :mavericks
   end
 
-  option :universal
   option "with-graphviz", "Enable Graphviz functions"
 
   depends_on "autoconf" => :build
@@ -25,8 +24,6 @@ class R3 < Formula
   depends_on "jemalloc" => :recommended
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./autogen.sh"
 
     args = %W[

--- a/Formula/rabbitmq-c.rb
+++ b/Formula/rabbitmq-c.rb
@@ -13,7 +13,6 @@ class RabbitmqC < Formula
     sha256 "f4e4d641af6559ee49beec28a7620af68e643ac26429c5f031953e8d79c8b0b6" => :mavericks
   end
 
-  option :universal
   option "without-tools", "Build without command-line tools"
 
   depends_on "pkg-config" => :build
@@ -22,7 +21,6 @@ class RabbitmqC < Formula
   depends_on "openssl"
 
   def install
-    ENV.universal_binary if build.universal?
     args = std_cmake_args
     args << "-DBUILD_EXAMPLES=OFF"
     args << "-DBUILD_TESTS=OFF"

--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -26,7 +26,6 @@ class Readline < Formula
   EOS
 
   def install
-    ENV.universal_binary
     system "./configure", "--prefix=#{prefix}", "--enable-multibyte"
     system "make", "install"
   end

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -15,7 +15,6 @@ class Ruby < Formula
     depends_on "autoconf" => :build
   end
 
-  option :universal
   option "with-suffix", "Suffix commands with '24'"
   option "with-doc", "Install documentation"
 
@@ -40,11 +39,6 @@ class Ruby < Formula
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
-
-    if build.universal?
-      ENV.universal_binary
-      args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
-    end
 
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--disable-install-doc" if build.without? "doc"

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -25,8 +25,6 @@ class SaneBackends < Formula
     sha256 "37f8e076bdddbdc868076456c308d21fbbef40ab647297f69bf5ca4b88a07688" => :mavericks
   end
 
-  option :universal
-
   depends_on "jpeg"
   depends_on "libtiff"
   depends_on "libusb-compat"
@@ -34,7 +32,6 @@ class SaneBackends < Formula
   depends_on "net-snmp"
 
   def install
-    ENV.universal_binary if build.universal?
     ENV.deparallelize # Makefile does not seem to be parallel-safe
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -22,7 +22,6 @@ class Sdl < Formula
 
   option "with-x11", "Compile with support for X11 video driver"
   option "with-test", "Compile and install the tests"
-  option :universal
 
   deprecated_option "with-x11-driver" => "with-x11"
   deprecated_option "with-tests" => "with-test"
@@ -59,8 +58,6 @@ class Sdl < Formula
     # are installed to the same prefix. Consequently SDL stuff cannot be
     # keg-only but I doubt that will be needed.
     inreplace %w[sdl.pc.in sdl-config.in], "@prefix@", HOMEBREW_PREFIX
-
-    ENV.universal_binary if build.universal?
 
     system "./autogen.sh" if build.head? || build.with?("x11")
 

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -21,7 +21,6 @@ class Sdl2 < Formula
   end
 
   option "with-test", "Compile and install the tests"
-  option :universal
 
   # https://github.com/mistydemeo/tigerbrew/issues/361
   if MacOS.version <= :snow_leopard
@@ -36,8 +35,6 @@ class Sdl2 < Formula
     # are installed to the same prefix. Consequently SDL stuff cannot be
     # keg-only but I doubt that will be needed.
     inreplace %w[sdl2.pc.in sdl2-config.in], "@prefix@", HOMEBREW_PREFIX
-
-    ENV.universal_binary if build.universal?
 
     system "./autogen.sh" if build.head? || build.devel?
 

--- a/Formula/sdl2_gfx.rb
+++ b/Formula/sdl2_gfx.rb
@@ -12,12 +12,9 @@ class Sdl2Gfx < Formula
     sha256 "e7888e8bbdbda56ec2941b53a74482d1d74c3e321b632af1099d909d209497cd" => :mavericks
   end
 
-  option :universal
-
   depends_on "sdl2"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-sdltest"

--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -12,8 +12,6 @@ class Sdl2Image < Formula
     sha256 "f5aaf7b8c035d662c696fa818ac4d82f33108ae1874f88e471368b29938ae20f" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl2"
   depends_on "jpeg" => :recommended
@@ -22,8 +20,6 @@ class Sdl2Image < Formula
   depends_on "webp" => :recommended
 
   def install
-    ENV.universal_binary if build.universal?
-
     inreplace "SDL2_image.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -13,8 +13,6 @@ class Sdl2Mixer < Formula
     sha256 "88f7ef2099f2261534cb4f3e33d65132243b36fb4a6efa648fcbba34ec6c0b77" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl2"
   depends_on "flac" => :optional
@@ -25,7 +23,6 @@ class Sdl2Mixer < Formula
   depends_on "libvorbis" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     ENV["SMPEG_CONFIG"] = "#{Formula["smpeg2"].bin}/smpeg2-config" if build.with? "smpeg2"

--- a/Formula/sdl2_net.rb
+++ b/Formula/sdl2_net.rb
@@ -12,13 +12,10 @@ class Sdl2Net < Formula
     sha256 "ebabcb8f4df6fdee7855a6e19080aea42d9909205b287312015179bb9b3f472a" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl2"
 
   def install
-    ENV.universal_binary if build.universal?
     inreplace "SDL2_net.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/sdl2_ttf.rb
+++ b/Formula/sdl2_ttf.rb
@@ -12,14 +12,11 @@ class Sdl2Ttf < Formula
     sha256 "3b2dafa7edea6a2173c9ae17bb6a1cc5137a9004ffc44b6443bc885456adbb1b" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl2"
   depends_on "freetype"
 
   def install
-    ENV.universal_binary if build.universal?
     inreplace "SDL2_ttf.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -12,8 +12,6 @@ class SdlImage < Formula
     sha256 "6d6105e20e0b8c11cddc1b0b1eda7184c50ec4e69ad71f85980b146a54adb431" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "jpeg" => :recommended
@@ -30,7 +28,6 @@ class SdlImage < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     inreplace "SDL_image.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     args = %W[

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -12,8 +12,6 @@ class SdlMixer < Formula
     sha256 "559377bb70595dc716d1f0c703e986ea4bc30666085812756230b00194b97d87" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "flac" => :optional
@@ -24,8 +22,6 @@ class SdlMixer < Formula
 
   def install
     inreplace "SDL_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
-
-    ENV.universal_binary if build.universal?
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/sdl_net.rb
+++ b/Formula/sdl_net.rb
@@ -12,13 +12,10 @@ class SdlNet < Formula
     sha256 "99f9035f95e548ea81eb11ac9c06ae5eab8d2797ea9ca03ac074fe30bb357748" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--disable-sdltest"
     system "make", "install"

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -22,8 +22,6 @@ class SdlSound < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "flac" => :optional
@@ -34,8 +32,6 @@ class SdlSound < Formula
   depends_on "physfs" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     if build.head?
       inreplace "bootstrap", "/usr/bin/glibtoolize", "#{Formula["libtool"].opt_bin}/glibtoolize"
       system "./bootstrap"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -14,8 +14,6 @@ class SdlTtf < Formula
     sha256 "909f446963645f9634ae76e5f5eb3f3045e6872108a8c124b690bb3c53bb8630" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "freetype"
@@ -28,7 +26,6 @@ class SdlTtf < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     inreplace "SDL_ttf.pc.in", "@prefix@", HOMEBREW_PREFIX
 
     system "./configure", "--disable-debug",

--- a/Formula/sound-touch.rb
+++ b/Formula/sound-touch.rb
@@ -13,7 +13,6 @@ class SoundTouch < Formula
   end
 
   option "with-integer-samples", "Build using integer samples? (default is float)"
-  option :universal
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -27,8 +26,6 @@ class SoundTouch < Formula
       --prefix=#{prefix}
     ]
     args << "--enable-integer-samples" if build.with? "integer-samples"
-
-    ENV.universal_binary if build.universal?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -11,14 +11,11 @@ class Speex < Formula
     sha256 "a0b3c91782b8242508adac3ebc0cd86688e75b043ea0d84f4ef7ac9940f8a21b" => :yosemite
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libogg" => :recommended
 
   def install
     ENV.deparallelize
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -16,7 +16,6 @@ class Subversion < Formula
   deprecated_option "perl" => "with-perl"
   deprecated_option "ruby" => "with-ruby"
 
-  option :universal
   option "with-java", "Build Java bindings"
   option "with-perl", "Build Perl bindings"
   option "with-ruby", "Build Ruby bindings"
@@ -77,8 +76,6 @@ class Subversion < Formula
       # Passing 0 as the `unique` kwarg turns this behaviour off.
       inreplace "SConstruct", "unique=1", "unique=0"
 
-      ENV.universal_binary if build.universal?
-
       # scons ignores our compiler and flags unless explicitly passed
       args = %W[
         PREFIX=#{serf_prefix} GSSAPI=/usr CC=#{ENV.cc}
@@ -95,17 +92,7 @@ class Subversion < Formula
       # Java support doesn't build correctly in parallel:
       # https://github.com/Homebrew/homebrew/issues/20415
       ENV.deparallelize
-
-      unless build.universal?
-        opoo "A non-Universal Java build was requested."
-        puts <<-EOS.undent
-        To use Java bindings with various Java IDEs, you might need a universal build:
-          `brew install subversion --universal --java`
-        EOS
-      end
     end
-
-    ENV.universal_binary if build.universal?
 
     # Use existing system zlib
     # Use dep-provided other libraries
@@ -135,13 +122,6 @@ class Subversion < Formula
       args << "RUBY=/usr/bin/ruby"
     end
 
-    # If Python is built universally, then extensions built with that Python
-    # are too. This default behaviour is not desired when building an extension
-    # for a single architecture.
-    if build.with?("python") && (which "python").universal? && !build.universal?
-      ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
-    end
-
     # The system Python is built with llvm-gcc, so we override this
     # variable to prevent failures due to incompatible CFLAGS
     ENV["ac_cv_python_compile"] = ENV.cc
@@ -168,9 +148,7 @@ class Subversion < Formula
       # In theory SWIG can be built in parallel, in practice...
       ENV.deparallelize
       # Remove hard-coded ppc target, add appropriate ones
-      if build.universal?
-        arches = Hardware::CPU.universal_archs.as_arch_flags
-      elsif MacOS.version <= :leopard
+      if MacOS.version <= :leopard
         arches = "-arch #{Hardware::CPU.arch_32_bit}"
       else
         arches = "-arch #{Hardware::CPU.arch_64_bit}"

--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -10,12 +10,9 @@ class Swig < Formula
     sha256 "3443dbf17f78be0cecb5419772c71bb418caa91763590072224c196a57317717" => :yosemite
   end
 
-  option :universal
-
   depends_on "pcre"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"

--- a/Formula/szip.rb
+++ b/Formula/szip.rb
@@ -13,10 +13,7 @@ class Szip < Formula
     sha256 "df5cfb198d5fbdc45bf9e386ffcf25535b995ca32477afe03ca2d277443ef022" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/ta-lib.rb
+++ b/Formula/ta-lib.rb
@@ -14,10 +14,7 @@ class TaLib < Formula
     sha256 "d4c5bf3efdaed633acf74d8039d723fd828e52982ebc864a48e09c2e71506311" => :mountain_lion
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/tinyxml.rb
+++ b/Formula/tinyxml.rb
@@ -13,8 +13,6 @@ class Tinyxml < Formula
     sha256 "2db8d34dafd503a2982dd9ca5ffb4a2a2740e0eb78195933cb121dd7b7836728" => :mountain_lion
   end
 
-  option :universal
-
   depends_on "cmake" => :build
 
   # The first two patches are taken from the debian packaging of tinyxml.
@@ -39,7 +37,6 @@ class Tinyxml < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
     system "cmake", ".", *std_cmake_args
     system "make", "install"
     (lib+"pkgconfig/tinyxml.pc").write pc_file

--- a/Formula/udis86.rb
+++ b/Formula/udis86.rb
@@ -12,10 +12,7 @@ class Udis86 < Formula
     sha256 "84b56e3d62695b2c39c2c450d94fcd258439baedbcd68980a19b685f2e2b95c9" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}",
                           "--enable-shared"
     system "make"

--- a/Formula/uhd.rb
+++ b/Formula/uhd.rb
@@ -12,8 +12,6 @@ class Uhd < Formula
     sha256 "37a83dbf239ce5949230ab6ae1e6776bb927b5d26f566c74286c08cc5f73c7eb" => :yosemite
   end
 
-  option :universal
-
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "libusb"
@@ -27,13 +25,6 @@ class Uhd < Formula
   end
 
   def install
-    args = std_cmake_args
-
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
 
     resource("Mako").stage do
@@ -41,7 +32,7 @@ class Uhd < Formula
     end
 
     mkdir "host/build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "test"
       system "make", "install"

--- a/Formula/with-readline.rb
+++ b/Formula/with-readline.rb
@@ -12,8 +12,6 @@ class WithReadline < Formula
     sha256 "05cd5dac85256b656838e839a81cd5abdc22caa3d916e7316f7ce517d17f6059" => :yosemite
   end
 
-  option :universal
-
   depends_on "readline"
 
   def install

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -64,7 +64,6 @@ class Wxmac < Formula
     end
   end
 
-  option :universal
   option "with-stl", "use standard C++ classes for everything"
   option "with-static", "build static libraries"
 
@@ -106,11 +105,6 @@ class Wxmac < Formula
       # This is the default option, but be explicit
       "--disable-monolithic",
     ]
-
-    if build.universal?
-      ENV.universal_binary
-      args << "--enable-universal_binary=#{Hardware::CPU.universal_archs.join(",")}"
-    end
 
     args << "--enable-stl" if build.with? "stl"
 

--- a/Formula/wxpython.rb
+++ b/Formula/wxpython.rb
@@ -26,8 +26,6 @@ class Wxpython < Formula
     sha256 "41ec8003758d804b8c426ce654a87f2d9f4be3be40fcbcb3d5686e3ecabaddbc" => :mavericks
   end
 
-  option :universal
-
   if MacOS.version <= :snow_leopard
     depends_on :python
     depends_on FrameworkPythonRequirement
@@ -36,12 +34,7 @@ class Wxpython < Formula
 
   def install
     ENV["WXWIN"] = buildpath
-
-    if build.universal?
-      ENV.universal_binary
-    else
-      ENV.append_to_cflags "-arch #{MacOS.preferred_arch}"
-    end
+    ENV.append_to_cflags "-arch #{MacOS.preferred_arch}"
 
     # wxPython is hardcoded to install headers in wx's prefix;
     # set it to use wxPython's prefix instead

--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -13,7 +13,6 @@ class XalanC < Formula
   end
 
   option "with-docs", "Install HTML docs"
-  option :universal
 
   if build.with? "docs"
     depends_on "doxygen" => :build
@@ -26,7 +25,6 @@ class XalanC < Formula
 
   def install
     ENV.deparallelize # See https://issues.apache.org/jira/browse/XALANC-696
-    ENV.universal_binary if build.universal?
     ENV["XALANCROOT"] = "#{buildpath}/c"
     ENV["XALAN_LOCALE_SYSTEM"] = "inmem"
     ENV["XALAN_LOCALE"] = "en_US"

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -12,10 +12,7 @@ class XercesC < Formula
     sha256 "c7d461ebe0429d9a19e7e017af14a11435fc4f93ed83d2515b161e0f40c058b0" => :mavericks
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -14,10 +14,7 @@ class Xz < Formula
     sha256 "82eef73a78db1c46ed8482c357f6ad1797a62f4c9124410b362efe885082892c" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -13,7 +13,6 @@ class YamlCpp < Formula
   end
 
   option :cxx11
-  option :universal
   option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
@@ -26,7 +25,6 @@ class YamlCpp < Formula
 
   def install
     ENV.cxx11 if build.cxx11?
-    ENV.universal_binary if build.universal?
     args = std_cmake_args
     if build.with? "static-lib"
       args << "-DBUILD_SHARED_LIBS=OFF"

--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -21,14 +21,10 @@ class Ykclient < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "help2man" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "autoreconf", "-iv" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/ykneomgr.rb
+++ b/Formula/ykneomgr.rb
@@ -20,15 +20,11 @@ class Ykneomgr < Formula
     depends_on "gengetopt" => :build
   end
 
-  option :universal
-
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
   depends_on "libzip"
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "make", "autoreconf" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/ykpers.rb
+++ b/Formula/ykpers.rb
@@ -12,14 +12,11 @@ class Ykpers < Formula
     sha256 "708fcea4a38578c8dabe046c07d8705bb8d1874c8b389c46e2edd6bc4f8b1d5c" => :mavericks
   end
 
-  option :universal
-
   depends_on "pkg-config" => :build
   depends_on "libyubikey"
   depends_on "json-c" => :recommended
 
   def install
-    ENV.universal_binary if build.universal?
     libyubikey_prefix = Formula["libyubikey"].opt_prefix
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is based on #9641, where I have fixed the comments by @ilovezfs. It removes the universal option from 147 formulas, but does not touch the 17 formulas that are `wine` dependencies (as they need to be vendored into the wine formula before universal is removed from them).