### PR TITLE
bochs: fix configure flags

### DIFF
--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -34,13 +34,16 @@ class Bochs < Formula
       --enable-debugger-gui
       --enable-readline
       --enable-iodebug
-      --enable-xpm
       --enable-show-ips
       --enable-logging
       --enable-usb
       --enable-ne2000
       --enable-cpu-level=6
       --enable-clgd54xx
+      --enable-avx
+      --enable-vmx
+      --enable-smp
+      --enable-long-phy-addres
       --with-term
     ]
 

--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -3,6 +3,7 @@ class Bochs < Formula
   homepage "https://bochs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bochs/bochs/2.6.8/bochs-2.6.8.tar.gz"
   sha256 "79700ef0914a0973f62d9908ff700ef7def62d4a28ed5de418ef61f3576585ce"
+  revision 1
 
   bottle do
     sha256 "6797f2b0af54f4ab18d6e299c1a58b87058a6d4d40605479ff8e9084814cf08b" => :sierra


### PR DESCRIPTION
Makes the configure flags a bit more sane:

 * Removed `--enable-xpm`, as it has no effect unless linking with X11.
 * Added `--enable-avx`, as AVX is quite standard now, and the bochs implementation is solid.
 * Added `--enable-vmx`, same as AVX, standard and solid.
 * Added `--enable-smp`, no cost when there is only one CPU.
 * Added `--enable-long-phy-addres`, so bochs can use more than 4GiB of RAM.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
