### PR TITLE
gcore: drop universal, add test

### DIFF
--- a/Formula/gcore.rb
+++ b/Formula/gcore.rb
@@ -3,6 +3,7 @@ class Gcore < Formula
   homepage "https://osxbook.com/book/bonus/chapter8/core/"
   url "https://osxbook.com/book/bonus/chapter8/core/download/gcore-1.3.tar.gz"
   sha256 "6b58095c80189bb5848a4178f282102024bbd7b985f9543021a3bf1c1a36aa2a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,9 +14,14 @@ class Gcore < Formula
     sha256 "6479ee2516b07716c506155dee9e9d6be8484ae5f8ac044945644eb22db49a3b" => :mavericks
   end
 
+  keg_only :provided_by_osx if MacOS.version >= :sierra
+
   def install
-    ENV.universal_binary
     system "make"
     bin.install "gcore"
+  end
+
+  test do
+    assert_match "<pid>", shell_output("#{bin}/gcore 2>&1", 22)
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Drop universal
- Bump revision
- Since Sierra, there is a `gcore` provided by macOS in `/usr/bin`
- Provide a rudimentary test