### PR TITLE
Fix issues discovered during universal removal

### DIFF
--- a/Formula/advancemame.rb
+++ b/Formula/advancemame.rb
@@ -13,6 +13,8 @@ class Advancemame < Formula
   depends_on "sdl"
   depends_on "freetype"
 
+  conflicts_with "advancemenu", :because => "both install `advmenu` binaries"
+
   def install
     ENV.delete "SDKROOT" if MacOS.version == :yosemite
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/advancemenu.rb
+++ b/Formula/advancemenu.rb
@@ -12,6 +12,8 @@ class Advancemenu < Formula
 
   depends_on "sdl"
 
+  conflicts_with "advancemame", :because => "both install `advmenu` binaries"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install", "LDFLAGS=#{ENV.ldflags}", "mandir=#{man}"

--- a/Formula/arx-libertatis.rb
+++ b/Formula/arx-libertatis.rb
@@ -38,6 +38,8 @@ class ArxLibertatis < Formula
   depends_on "sdl"
   depends_on "innoextract" => :recommended
 
+  conflicts_with "rnv", :because => "both install `arx` binaries"
+
   def install
     args = std_cmake_args
 

--- a/Formula/cppunit.rb
+++ b/Formula/cppunit.rb
@@ -1,7 +1,7 @@
 class Cppunit < Formula
   desc "Unit testing framework for C++"
   homepage "https://wiki.freedesktop.org/www/Software/cppunit/"
-  url "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
+  url "https://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz"
   sha256 "3f47d246e3346f2ba4d7c9e882db3ad9ebd3fcbd2e8b732f946e0e3eeb9f429f"
 
   bottle do
@@ -17,5 +17,9 @@ class Cppunit < Formula
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/cppunit-config --version")
   end
 end

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -1,6 +1,6 @@
 class Dosbox < Formula
   desc "DOS Emulator"
-  homepage "http://www.dosbox.com/"
+  homepage "https://www.dosbox.com/"
   url "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74/dosbox-0.74.tar.gz"
   sha256 "13f74916e2d4002bad1978e55727f302ff6df3d9be2f9b0e271501bd0a938e05"
 
@@ -23,6 +23,8 @@ class Dosbox < Formula
   depends_on "sdl_net"
   depends_on "sdl_sound" => ["--with-libogg", "--with-libvorbis"]
   depends_on "libpng"
+
+  conflicts_with "dosbox-x", :because => "both install `dosbox` binaries"
 
   def install
     args = %W[

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -24,6 +24,8 @@ class Dosbox < Formula
   depends_on "sdl_sound" => ["--with-libogg", "--with-libvorbis"]
   depends_on "libpng"
 
+  conflicts_with "dosbox-x", :because => "both install `dosbox` binaries"
+
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -1,6 +1,6 @@
 class GdkPixbuf < Formula
   desc "Toolkit for image loading and pixel buffer manipulation"
-  homepage "http://gtk.org"
+  homepage "https://gtk.org"
   url "https://download.gnome.org/sources/gdk-pixbuf/2.36/gdk-pixbuf-2.36.2.tar.xz"
   sha256 "3a082ad67d68b55970aed0b2034a06618167be98a42d5c70de736756b45d325d"
 

--- a/Formula/libtcod.rb
+++ b/Formula/libtcod.rb
@@ -14,6 +14,8 @@ class Libtcod < Formula
   depends_on "cmake" => :build
   depends_on "sdl"
 
+  conflicts_with "libzip", :because => "both install `zip.h` header"
+
   def install
     # Remove unnecessary X11 check - our SDL doesn't use X11
     inreplace "CMakelists.txt" do |s|

--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -12,6 +12,8 @@ class Libzip < Formula
     sha256 "e5c8a9203db8983a448ab144a7457b069f560354f2a0f6ee677e89dc4b07c21e" => :mavericks
   end
 
+  conflicts_with "libtcod", :because => "both install `zip.h` header"
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -1,8 +1,8 @@
 class Minizip < Formula
   desc "C library for zip/unzip via zLib"
   homepage "http://www.winimage.com/zLibDll/minizip.html"
-  url "http://zlib.net/zlib-1.2.10.tar.gz"
-  sha256 "8d7e9f698ce48787b6e1c67e6bff79e487303e66077e25cb9784ac8835978017"
+  url "http://zlib.net/zlib-1.2.11.tar.gz"
+  sha256 "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 
   bottle do
     cellar :any

--- a/Formula/rnv.rb
+++ b/Formula/rnv.rb
@@ -14,6 +14,8 @@ class Rnv < Formula
 
   depends_on "expat"
 
+  conflicts_with "arx-libertatis", :because => "both install `arx` binaries"
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Issues discovered after individual testing of packages affected by universal removal. @ilovezfs launched them on [Homebrew Testing](https://bot.brew.sh/job/Homebrew%20Testing/), builds 1315 to 1371.