### PR TITLE
gdb: don't install subdirectories shared with binutils

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -69,13 +69,11 @@ class Gdb < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "install"
 
-    # Remove conflicting items with binutils
-    rm_rf include
-    rm_rf lib
-    rm_rf share/"locale"
-    rm_rf share/"info"
+    # Don't install bfd or opcodes, as they are provided by binutils
+    inreplace ["bfd/Makefile", "opcodes/Makefile"], /^install:/, "dontinstall:"
+
+    system "make", "install"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew's gdb package has not installed its documentation for two years.  This fixes that.

I also tried code signing the gdb executable with #6736's `codesign -s -` trick, but unfortunately it seems the resulting ad-hoc signature does not suffice for attaching to another process.