### PR TITLE
mame & rom-tools 0.183

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -1,9 +1,9 @@
 class Mame < Formula
   desc "Multiple Arcade Machine Emulator"
   homepage "http://mamedev.org/"
-  url "https://github.com/mamedev/mame/archive/mame0179.tar.gz"
-  version "0.179"
-  sha256 "d1616ef32b884c3e7913378ebf5282b6f846f895f419eb92a9068770581e081b"
+  url "https://github.com/mamedev/mame/archive/mame0183.tar.gz"
+  version "0.183"
+  sha256 "c12b3051f2f11331a38f557eac7f3074166e48155133b2f3e7cc323df56ce8b0"
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -36,7 +36,7 @@ class Mame < Formula
                    "USE_SYSTEM_LIB_ZLIB=1",
                    "USE_SYSTEM_LIB_JPEG=1",
                    "USE_SYSTEM_LIB_FLAC=1",
-                   "USE_SYSTEM_LIB_LUA=", # lua53 not available yet
+                   "USE_SYSTEM_LIB_LUA=", # Homebrew's lua@5.3 can't build with MAME yet.
                    "USE_SYSTEM_LIB_PORTMIDI=1",
                    "USE_SYSTEM_LIB_PORTAUDIO=1"
     bin.install "mame64" => "mame"

--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -1,9 +1,9 @@
 class RomTools < Formula
   desc "Tools for Multiple Arcade Machine Emulator"
   homepage "http://mamedev.org/"
-  url "https://github.com/mamedev/mame/archive/mame0179.tar.gz"
-  version "0.179"
-  sha256 "d1616ef32b884c3e7913378ebf5282b6f846f895f419eb92a9068770581e081b"
+  url "https://github.com/mamedev/mame/archive/mame0183.tar.gz"
+  version "0.183"
+  sha256 "c12b3051f2f11331a38f557eac7f3074166e48155133b2f3e7cc323df56ce8b0"
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -20,16 +20,15 @@ class RomTools < Formula
   depends_on "portmidi"
 
   def install
-    inreplace "scripts/src/main.lua", /(targetsuffix) "\w+"/, '\1 ""'
     inreplace "scripts/src/osd/sdl.lua", "--static", ""
-    system "make", "TARGET=ldplayer", "TOOLS=1",
+    system "make", "TOOLS=1",
                    "PTR64=#{MacOS.prefer_64_bit? ? 1 : 0}", # for old Macs
                    "USE_LIBSDL=1",
                    "USE_SYSTEM_LIB_ZLIB=1",
                    "USE_SYSTEM_LIB_FLAC=1",
                    "USE_SYSTEM_LIB_PORTMIDI=1"
     bin.install %w[
-      aueffectutil castool chdman floptool imgtool jedutil ldplayer ldresample
+      aueffectutil castool chdman floptool imgtool jedutil ldresample
       ldverify nltool nlwav pngcmp regrep romcmp src2html srcclean unidasm
     ]
     bin.install "split" => "rom-split"
@@ -44,7 +43,6 @@ class RomTools < Formula
     system "#{bin}/floptool"
     system "#{bin}/imgtool", "listformats"
     system "#{bin}/jedutil", "-viewlist"
-    system "#{bin}/ldplayer", "-help"
     assert_match "linear equation", shell_output("#{bin}/ldresample 2>&1", 1)
     assert_match "avifile.avi", shell_output("#{bin}/ldverify 2>&1", 1)
     system "#{bin}/nltool", "--help"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

* ~~Add option to build MAME's tools inside the MAME formula.~~
* Update lua@5.3's comments.
* Change rom-tools build's main target, where ldplayer target is not longer exist.
