### PR TITLE
elasticsearch 5.2.2

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.1.tar.gz"
-  sha256 "f28bfecbb8896bbcf8c6063a474a2ddee29a262c216f56ff6d524fc898094475"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.2.tar.gz"
+  sha256 "cf88930695794a8949342d386f028548bd10b26ecc8c4b422a94ea674faf8ac9"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"


### PR DESCRIPTION
This pull request bumps the version on the Elasticsearch formula from 5.2.1 to 5.2.2.