### PR TITLE
Update Atlassian-cli to 6.2.0

### DIFF
--- a/Formula/atlassian-cli.rb
+++ b/Formula/atlassian-cli.rb
@@ -1,9 +1,9 @@
 class AtlassianCli < Formula
   desc "Command-line interface clients for Atlassian products"
   homepage "https://bobswift.atlassian.net/wiki/pages/viewpage.action?pageId=1966101"
-  url "https://bobswift.atlassian.net/wiki/download/attachments/16285777/atlassian-cli-5.7.0-distribution.zip"
-  version "5.7.0"
-  sha256 "7d1af9dd7b5fe0fa35ba13f24d5d98fa49e0146bbae2181c43d845f3bf93ad2f"
+  url "https://bobswift.atlassian.net/wiki/download/attachments/16285777/atlassian-cli-6.2.0-distribution.zip"
+  version "6.2.0"
+  sha256 "e6c2cfaa8c00419de9e509bb740ad891cf4f425405402a43d2dd2c9d89bbc68f"
 
   bottle :unneeded
 

--- a/Formula/atlassian-cli.rb
+++ b/Formula/atlassian-cli.rb
@@ -7,7 +7,7 @@ class AtlassianCli < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   def install
     Dir.glob("*.sh") do |f|


### PR DESCRIPTION
Atlassian Cloud JIRA requires 6.x to connect, now. Updating formula to most recent package. ref: https://bobswift.atlassian.net/wiki/display/ACLI/Downloads

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
