### PR TITLE
emacs: fix --with-imagemagick using imagemagick@6

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -39,7 +39,7 @@ class Emacs < Formula
   depends_on "dbus" => :optional
   depends_on "gnutls" => :optional
   depends_on "librsvg" => :optional
-  depends_on "imagemagick" => :optional
+  depends_on "imagemagick@6" => :optional
   depends_on "mailutils" => :optional
 
   def install

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -71,11 +71,15 @@ class Emacs < Formula
       args << "--without-gnutls"
     end
 
+    # Note that if ./configure is passed --with-imagemagick but can't find the
+    # library it does not fail but imagemagick support will not be available.
+    # See: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=24455
     if build.with? "imagemagick@6"
       args << "--with-imagemagick"
     else
       args << "--without-imagemagick"
     end
+
     args << "--with-modules" if build.with? "modules"
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-pop" if build.with? "mailutils"

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -34,6 +34,7 @@ class Emacs < Formula
   deprecated_option "cocoa" => "with-cocoa"
   deprecated_option "keep-ctags" => "with-ctags"
   deprecated_option "with-d-bus" => "with-dbus"
+  deprecated_option "imagemagick" => "imagemagick@6"
 
   depends_on "pkg-config" => :build
   depends_on "dbus" => :optional

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -40,6 +40,8 @@ class Emacs < Formula
   depends_on "dbus" => :optional
   depends_on "gnutls" => :optional
   depends_on "librsvg" => :optional
+  # Emacs does not support ImageMagick 7:
+  # Reported on 2017-03-04: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=25967
   depends_on "imagemagick@6" => :optional
   depends_on "mailutils" => :optional
 

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -71,7 +71,11 @@ class Emacs < Formula
       args << "--without-gnutls"
     end
 
-    args << "--with-imagemagick" if build.with? "imagemagick"
+    if build.with? "imagemagick@6"
+      args << "--with-imagemagick"
+    else
+      args << "--without-imagemagick"
+    end
     args << "--with-modules" if build.with? "modules"
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-pop" if build.with? "mailutils"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now `brew install --with-cocoa --with-imagemagick@6 emacs` installs Emacs with support for imagemagick.

Closes #10453