### PR TITLE
gnupg2: add gnupg 2.1 versioned formula

### DIFF
--- a/Formula/gnupg2@2.1.rb
+++ b/Formula/gnupg2@2.1.rb
@@ -1,0 +1,95 @@
+class Gnupg2AT21 < Formula
+  desc "GNU Privacy Guard: a free PGP replacement"
+  homepage "https://www.gnupg.org/"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.19.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.19.tar.bz2"
+  sha256 "46cced1f5641ce29cc28250f52fadf6e417e649b3bfdec49a5a0d0b22a639bf0"
+
+  keg_only :versioned_formula
+
+  option "with-gpgsplit", "Additionally install the gpgsplit utility"
+  option "without-libusb", "Disable the internal CCID driver"
+  option "without-test", "Don't verify the build with `make check`"
+
+  deprecated_option "without-libusb-compat" => "without-libusb"
+
+  depends_on "pkg-config" => :build
+  depends_on "sqlite" => :build if MacOS.version == :mavericks
+  depends_on "npth"
+  depends_on "gnutls"
+  depends_on "libgpg-error"
+  depends_on "libgcrypt"
+  depends_on "libksba"
+  depends_on "libassuan"
+  depends_on "pinentry"
+  depends_on "gettext"
+  depends_on "adns"
+  depends_on "libusb" => :recommended
+  depends_on "readline" => :optional
+  depends_on "homebrew/fuse/encfs" => :optional
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --sbindir=#{bin}
+      --sysconfdir=#{etc}
+      --enable-symcryptrun
+      --with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry
+    ]
+
+    args << "--disable-ccid-driver" if build.without? "libusb"
+    args << "--with-readline=#{Formula["readline"].opt_prefix}" if build.with? "readline"
+
+    # Adjust package name to fit our scheme of packaging both gnupg 1.x and
+    # and 2.1.x and gpg-agent separately.
+    inreplace "configure" do |s|
+      s.gsub! "PACKAGE_NAME='gnupg'", "PACKAGE_NAME='gnupg2'"
+      s.gsub! "PACKAGE_TARNAME='gnupg'", "PACKAGE_TARNAME='gnupg2'"
+    end
+
+    system "./configure", *args
+
+    system "make"
+    system "make", "check" if build.with? "test"
+    system "make", "install"
+
+    bin.install "tools/gpgsplit" => "gpgsplit2" if build.with? "gpgsplit"
+
+    # Move man files that conflict with 1.x.
+    mv share/"doc/gnupg2/FAQ", share/"doc/gnupg2/FAQ21"
+    mv share/"doc/gnupg2/examples/gpgconf.conf", share/"doc/gnupg2/examples/gpgconf21.conf"
+    mv share/"info/gnupg.info", share/"info/gnupg21.info"
+    mv man7/"gnupg.7", man7/"gnupg21.7"
+  end
+
+  def post_install
+    (var/"run").mkpath
+  end
+
+  def caveats; <<-EOS.undent
+    Once you run the new gpg2 binary you will find it incredibly
+    difficult to go back to using `gnupg2` from Homebrew/Homebrew.
+    The new 2.1.x moves to a new keychain format that can't be
+    and won't be understood by the 2.0.x branch or lower.
+
+    If you use this `gnupg21` formula for a while and decide
+    you don't like it, you will lose the keys you've imported since.
+    For this reason, we strongly advise that you make a backup
+    of your `~/.gnupg` directory.
+
+    For full details of the changes, please visit:
+      https://www.gnupg.org/faq/whats-new-in-2.1.html
+
+    If you are upgrading to gnupg21 from gnupg2 you should execute:
+      `killall gpg-agent && gpg-agent --daemon`
+    After install. See:
+      https://github.com/Homebrew/homebrew-versions/issues/681
+    EOS
+  end
+
+  test do
+    system bin/"gpgconf"
+  end
+end


### PR DESCRIPTION
This is a port from homebrew/versions with the following changes:

* Updated version from 2.1.18 to 2.1.19
* Removed necessary patches for 2.1.18
* Use `test` option (instead of ignoring it)
* Use `keg_only :versioned_formula` and remove conflicts_with
* Removed SHA256 for bottles (cannot build them locally)

Tested and found to be working on MacOS Sierra 10.12.3 with `--without-test`, see comment below https://github.com/Homebrew/homebrew-core/pull/10498#issuecomment-283540523.