### PR TITLE
treefrog: remove unused oci option

### DIFF
--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -11,7 +11,6 @@ class Treefrog < Formula
   end
 
   option "with-mysql", "enable --with-mysql option for Qt build"
-  option "with-oci", "enable --with-oci option for Qt build"
   option "with-postgresql", "enable --with-postgresql option for Qt build"
   option "with-qt5", "build and link with QtGui module"
 
@@ -19,7 +18,6 @@ class Treefrog < Formula
   depends_on :xcode => [:build, "8.0"]
 
   qt5_build_options = []
-  qt5_build_options << "with-oci" if build.with?("oci") && ENV["ORACLE_HOME"]
   qt5_build_options << "with-mysql" if build.with?("mysql")
   qt5_build_options << "with-postgresql" if build.with?("postgresql")
   depends_on "qt5" => qt5_build_options


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Correction according for commit https://github.com/Homebrew/homebrew-core/commit/6999067302ab3cdb6ffb58ec875619311ebbafe3