### PR TITLE
Add maven devel version. Add maven java version requirement.

### DIFF
--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -6,7 +6,6 @@ class Maven < Formula
     url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
     mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
     sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
-    version "3.3.9"
   end
 
   devel do

--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -1,13 +1,24 @@
 class Maven < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
-  mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
-  sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+    sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
+    version "3.3.9"
+  end
+
+  devel do
+    url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.5.0-alpha-1/binaries/apache-maven-3.5.0-alpha-1-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/maven/maven-3/3.5.0-alpha-1/binaries/apache-maven-3.5.0-alpha-1-bin.tar.gz"
+    sha256 "7421b3737729ea4e3865c33af6fbf4e50f9820b477d46eaff9492ad940785cd7"
+    version "3.5.0-alpha-1"
+  end
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.7+"
 
   conflicts_with "mvnvm", :because => "also installs a 'mvn' executable"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Implementation of #10524 

```
brew info maven
maven: stable 3.3.9, devel 3.5.0-alpha-1
Java-based project management
https://maven.apache.org/
Conflicts with: mvnvm
/usr/local/Cellar/maven/3.3.9 (94 files, 9.6MB)
  Built from source on 2015-11-23 at 15:53:18
/usr/local/Cellar/maven/3.5.0-alpha-1 (100 files, 9.6MB) *
  Built from source on 2017-03-02 at 14:24:47
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/maven.rb
==> Requirements
Required: java >= 1.7 ✔
```

```
brew audit --strict maven
Error: Error while running RuboCop
```
