### PR TITLE
[hub] Add fish completion

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -48,6 +48,8 @@ class Hub < Formula
     if build.with? "completions"
       bash_completion.install "etc/hub.bash_completion.sh"
       zsh_completion.install "etc/hub.zsh_completion" => "_hub"
+      # TODO: Remove the conditional when hub 2.3.0 is released.
+      fish_completion.install "etc/hub.fish_completion" => "hub.fish" unless build.stable?
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This links the completions for the fish shell that are added in hub 2.3.0. However, that version is still a pre-release state, so this will only work when using `--HEAD`. I guess we should wait with merging this till 2.3.0 proper is released? /cc @mislav