### PR TITLE
boost: fix env: userpaths deprecated

### DIFF
--- a/Formula/boost@1.55.rb
+++ b/Formula/boost@1.55.rb
@@ -39,8 +39,6 @@ class BoostAT155 < Formula
 
   keg_only :versioned_formula
 
-  env :userpaths
-
   option "with-icu", "Build regexp engine with icu support"
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"

--- a/Formula/boost@1.55.rb
+++ b/Formula/boost@1.55.rb
@@ -1,6 +1,6 @@
 class BoostAT155 < Formula
   desc "Collection of portable C++ source libraries"
-  homepage "http://www.boost.org"
+  homepage "https://www.boost.org"
   revision 1
 
   stable do

--- a/Formula/boost@1.57.rb
+++ b/Formula/boost@1.57.rb
@@ -29,8 +29,6 @@ class BoostAT157 < Formula
 
   needs :cxx11 if build.cxx11?
 
-  env :userpaths
-
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
     if build.with?("mpi") && build.with?("single")

--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -27,8 +27,6 @@ class BoostAT160 < Formula
     sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
   end
 
-  env :userpaths
-
   option "with-icu4c", "Build regexp engine with icu support"
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is my first pull request and I am not fully certain how to perform the 4th operation correctly. 

I found the error through running `brew audit --strict` and I thought it was trivial to fix it since it's just a one line change in each of the formulas.

I hope this solves the issue.