### PR TITLE
bash-completion 2.5

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -1,0 +1,31 @@
+class BashCompletionAT2 < Formula
+  desc "Programmable completion for Bash 4.1+"
+  homepage "https://github.com/scop/bash-completion"
+  url "https://github.com/scop/bash-completion/releases/download/2.5/bash-completion-2.5.tar.xz"
+  sha256 "b0b9540c65532825eca030f1241731383f89b2b65e80f3492c5dd2f0438c95cf"
+  head "https://github.com/scop/bash-completion.git"
+
+  keg_only :versioned_formula
+
+  depends_on "bash"
+
+  def install
+    inreplace "bash_completion", "readlink -f", "readlink"
+
+    system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
+    ENV.deparallelize
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    Add the following to your ~/.bash_profile:
+      if [ -f #{opt_share}/bash-completion/bash_completion ]; then
+        . #{opt_share}/bash-completion/bash_completion
+      fi
+    EOS
+  end
+
+  test do
+    system "test", "-f", "#{share}/bash-completion/bash_completion"
+  end
+end

--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -5,9 +5,9 @@ class BashCompletionAT2 < Formula
   sha256 "b0b9540c65532825eca030f1241731383f89b2b65e80f3492c5dd2f0438c95cf"
   head "https://github.com/scop/bash-completion.git"
 
-  keg_only :versioned_formula
-
   depends_on "bash"
+
+  conflicts_with "bash-completion", :because => "Differing version of same formula"
 
   def install
     inreplace "bash_completion", "readlink -f", "readlink"

--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -19,8 +19,8 @@ class BashCompletionAT2 < Formula
 
   def caveats; <<-EOS.undent
     Add the following to your ~/.bash_profile:
-      if [ -f #{opt_share}/bash-completion/bash_completion ]; then
-        . #{opt_share}/bash-completion/bash_completion
+      if [ -f #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion ]; then
+        . #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion
       fi
     EOS
   end


### PR DESCRIPTION
Based on [homebrew-versions/bash-completion2](https://github.com/Homebrew/homebrew-versions/blob/master/bash-completion2.rb), with the following changes:

* Updated to version 2.5 (homebrew-versions was still on 2.4)
* Fixed description: it claimed to be for Bash 4.0+, but AFAICT 4.1+ has always been required
* Added `depends_on "bash"`, to ensure it’s only installed with Bash 4
* `conflicts_with` replaced with `keg_only :versioned_formula`, as per Homebrew v1.1.8

Additionally, I’ve updated the notice at the top of `bash-completion`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----