### PR TITLE
tesseract:  Make this formula's dependency on libtiff required when building `--with-opencl`.  

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -3,6 +3,7 @@ class Tesseract < Formula
   homepage "https://github.com/tesseract-ocr/"
   url "https://github.com/tesseract-ocr/tesseract/archive/3.05.00.tar.gz"
   sha256 "3fe83e06d0f73b39f6e92ed9fc7ccba3ef734877b76aa5ddaaa778fac095d996"
+  revision 1
 
   bottle do
     sha256 "d2ec7a1ef8859c28dd0d1e2e5a4bf54224bf971e11863bef693687fb3f166180" => :sierra
@@ -31,7 +32,7 @@ class Tesseract < Formula
   depends_on "pkg-config" => :build
 
   depends_on "leptonica"
-  depends_on "libtiff" => :recommended
+  depends_on "libtiff"
 
   if build.with? "training-tools"
     depends_on "libtool" => :build
@@ -62,6 +63,14 @@ class Tesseract < Formula
   resource "snum" do
     url "https://github.com/USCDataScience/counterfeit-electronics-tesseract/raw/319a6eeacff181dad5c02f3e7a3aff804eaadeca/Training%20Tesseract/snum.traineddata"
     sha256 "36f772980ff17c66a767f584a0d80bf2302a1afa585c01a226c1863afcea1392"
+  end
+
+  # remove on next release, > 3.05.00
+  # upstream fix for building with OpenCL enabled
+  # https://github.com/tesseract-ocr/tesseract/pull/814
+  patch do
+    url "https://github.com/tesseract-ocr/tesseract/commit/b18cad4.patch"
+    sha256 "10c59baa54c3406fcd03f36cd0f1e3cc2ba150f082d14f919274a541b3cff7b2"
   end
 
   def install


### PR DESCRIPTION
Resolves #10380.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

<hr />

Depends on tesseract-ocr/tesseract#739 and the application of the patch or new release resolving it here downstream, hence the lack of a successful local build and audit.  The CI build _should_ pass, though, as `--with-opencl` is not enabled by default and non-default options are not tested.  Please add the 'do not merge' label to this issue  (or at least abide by the intentions associated with that label) until said dependency has been resolved since I, not being a project maintainer, seem unable to do so.  