### PR TITLE
bash-completion@2: import from homebrew/versions

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -9,6 +9,7 @@
   "autoconf213": "autoconf@213",
   "autoconf264": "autoconf@264",
   "automake112": "automake@112",
+  "bash-completion2": "bash-completion@2",
   "beanstalk": "beanstalkd",
   "berkeley-db4": "berkeley-db@4",
   "boost155": "boost@1.55",


### PR DESCRIPTION
the actual formula exists in a seperate PR that
updates the version to 2.5 from 2.4

Corresponding PRs: Homebrew/homebrew-core#10594 and Homebrew/homebrew-versions#1539