### PR TITLE
Drop universal from non wine-related formulas

### DIFF
--- a/Formula/libmaxminddb.rb
+++ b/Formula/libmaxminddb.rb
@@ -20,13 +20,9 @@ class Libmaxminddb < Formula
     depends_on "libtool" => :build
   end
 
-  option :universal
-
   depends_on "geoipupdate" => :optional
 
   def install
-    ENV.universal_binary if build.universal?
-
     system "./bootstrap" if build.head?
 
     system "./configure", "--disable-debug",

--- a/Formula/libtasn1.rb
+++ b/Formula/libtasn1.rb
@@ -12,10 +12,7 @@ class Libtasn1 < Formula
     sha256 "e506e5613818094ab8029cbf94b51068e7f1d1683bcc5bc6b06c84eb9be2576d" => :yosemite
   end
 
-  option :universal
-
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking",
                           "--disable-silent-rules"
     system "make", "install"

--- a/Formula/sdl_gfx.rb
+++ b/Formula/sdl_gfx.rb
@@ -12,12 +12,9 @@ class SdlGfx < Formula
     sha256 "aa06ebfac9112febe86ec4a933d807ae88e87329498a71678bd52be51748d9dc" => :mavericks
   end
 
-  option :universal
-
   depends_on "sdl"
 
   def install
-    ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-sdltest"


### PR DESCRIPTION
3 formulas that are not wine dependencies were forgotten in the previous patches for `ENV.universal_binary` removal.

Well, `libtasn1` actually is a dependency of wine optional dependency `libgsm`, but `libgsm` itself is not built as universal, so…