### PR TITLE
boost@1.57: remove `env :userpaths`

### DIFF
--- a/Formula/boost@1.57.rb
+++ b/Formula/boost@1.57.rb
@@ -29,8 +29,6 @@ class BoostAT157 < Formula
 
   needs :cxx11 if build.cxx11?
 
-  env :userpaths
-
   def install
     # https://svn.boost.org/trac/boost/ticket/8841
     if build.with?("mpi") && build.with?("single")


### PR DESCRIPTION
Splitting #10586 into three for the CI