### PR TITLE
boost@1.60: remove `env :userpaths`

### DIFF
--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -27,8 +27,6 @@ class BoostAT160 < Formula
     sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
   end
 
-  env :userpaths
-
   option "with-icu4c", "Build regexp engine with icu support"
   option "without-single", "Disable building single-threading variant"
   option "without-static", "Disable building static library variant"


### PR DESCRIPTION
Splitting #10586 into three for the CI