### PR TITLE
hg-flow 0.9.8.2

### DIFF
--- a/Formula/hg-flow.rb
+++ b/Formula/hg-flow.rb
@@ -1,8 +1,8 @@
 class HgFlow < Formula
   desc "Development model for mercurial inspired by git-flow"
   homepage "https://bitbucket.org/yujiewu/hgflow"
-  url "https://bitbucket.org/yujiewu/hgflow/downloads/hgflow-v0.9.8.1.tar.bz2"
-  sha256 "aa49cf68ea8e0002be9ca6478daa7392d89113e985631316cab75e87d62d211c"
+  url "https://bitbucket.org/yujiewu/hgflow/downloads/hgflow-v0.9.8.2.tar.bz2"
+  sha256 "ff62ce57126cf0f932dc9da13d3eaed11db6ebb782580c851b072f4fe58dc399"
   head "https://bitbucket.org/yujiewu/hgflow", :using => :hg, :branch => "develop"
 
   bottle :unneeded


### PR DESCRIPTION
Fixes AttributeError: 'function' object has no attribute 'norepo' (see [this issue](https://bitbucket.org/yujiewu/hgflow/issues/86/attributeerror-function-object-has-no))

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes
```
...
AttributeError: 'function' object has no attribute 'norepo'
```
(see [this issue](https://bitbucket.org/yujiewu/hgflow/issues/86/attributeerror-function-object-has-no))