### PR TITLE
psql: fix allow intuitive connection by adding createdb

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -94,11 +94,13 @@ class Postgresql < Formula
   end
 
   def post_install
+    require "open3"
     (var/"log").mkpath
     (var/"postgres").mkpath
     unless File.exist? "#{var}/postgres/PG_VERSION"
       system "#{bin}/initdb", "#{var}/postgres"
     end
+    _stdout, _stderr, _status = Open3.capture3("createdb")
   end
 
   def caveats; <<-EOS.undent

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -94,13 +94,14 @@ class Postgresql < Formula
   end
 
   def post_install
-    require "open3"
     (var/"log").mkpath
     (var/"postgres").mkpath
     unless File.exist? "#{var}/postgres/PG_VERSION"
       system "#{bin}/initdb", "#{var}/postgres"
+      system "brew", "services", "start", "postgresql"
+      system "createdb"
+      system "brew", "services", "stop", "postgresql"
     end
-    _stdout, _stderr, _status = Open3.capture3("createdb")
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
Fixes #7682.
Using `initdb` is necessary for creation of a filesystem like folder for `postgresql`. However, running `psql` after installing postgresql results in a fatal error, i.e. `database "user" does not exist`. Running `createdb` fixes the error, as it creates a database with the name of the user. Also, simply running `system "createdb"` may lead to displaying an error if the user already had the database in his system. So, calling creadb through open3 executes the command, and does not display the mentioned error which is not required to be displayed to the user.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
