### PR TITLE
dmtx-utils 0.7.5

### DIFF
--- a/Formula/dmtx-utils.rb
+++ b/Formula/dmtx-utils.rb
@@ -1,0 +1,35 @@
+class DmtxUtils < Formula
+  desc "Read and write data matrix barcodes"
+  homepage "https://github.com/dmtx/dmtx-utils"
+  url "https://github.com/dmtx/dmtx-utils/archive/v0.7.5.tar.gz"
+  sha256 "6fa365cd321609db40800f6b34a2387c0ac56ef4643f6101ac83cb762f5ce9ef"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "imagemagick"
+  depends_on "libdmtx"
+  depends_on "libtool" => :run
+
+  resource "test_image12" do
+    url "https://raw.githubusercontent.com/dmtx/libdmtx/ca9313f/test/rotate_test/images/test_image12.png"
+    sha256 "683777f43ce2747c8a6c7a3d294f64bdbfee600d719aac60a18fcb36f7fc7242"
+  end
+
+  def install
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    testpath.install resource("test_image12")
+    image = File.read("test_image12.png")
+    assert_equal "9411300724000003", pipe_output("#{bin}/dmtxread", image, 0)
+    system "/bin/dd", "if=/dev/random", "of=in.bin", "bs=512", "count=3"
+    dmtxwrite_output = pipe_output("#{bin}/dmtxwrite", File.read("in.bin"), 0)
+    dmtxread_output = pipe_output("#{bin}/dmtxread", dmtxwrite_output, 0)
+    (testpath/"out.bin").atomic_write dmtxread_output
+    assert_equal (testpath/"in.bin").sha256, (testpath/"out.bin").sha256
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -57,7 +57,6 @@
   "disco": "homebrew/boneyard",
   "discodex": "homebrew/boneyard",
   "djmount": "homebrew/fuse",
-  "dmtx-utils": "homebrew/boneyard",
   "dotwrp": "homebrew/science",
   "drizzle": "homebrew/boneyard",
   "drush": "homebrew/php",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

restore from boneyard
new upstream on GitHub
now works with ImageMagick 7
improved test block

CC @msva @swvanderlaan @tbezemer