### PR TITLE
Update DCMTK to the newest snapshot

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -2,9 +2,9 @@ class Dcmtk < Formula
   desc "OFFIS DICOM toolkit command-line utilities"
   homepage "http://dicom.offis.de/dcmtk.php.en"
 
-  # Current snapshot used for stable now.
+  # Current snapshot used for stable now (using - instead of _ in the version field).
   url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20170228.tar.gz"
-  version "3.6.1_20170228"
+  version "3.6.1-20170228"
   sha256 "8de2f2ae70f71455288ec85c96a2579391300c7462f69a4a6398e9ec51779c11"
 
   head "git://git.dcmtk.org/dcmtk.git"

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -3,9 +3,9 @@ class Dcmtk < Formula
   homepage "http://dicom.offis.de/dcmtk.php.en"
 
   # Current snapshot used for stable now.
-  url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20161102.tar.gz"
-  version "3.6.1-20161102"
-  sha256 "657adb3811e0c5c08d8f143a6d878afcd92fac7dcf0d3c89860eecffd5a1a873"
+  url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20170228.tar.gz"
+  version "3.6.1_20170228"
+  sha256 "8de2f2ae70f71455288ec85c96a2579391300c7462f69a4a6398e9ec51779c11"
 
   head "git://git.dcmtk.org/dcmtk.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The audit does not pass:
```
$ brew audit --strict dcmtk
dcmtk:
  * Stable: version 3.6.1_20170228 should not end with an underline and a number
```

But this is expected, since the snapshots are currently being used as stable version, which is indicated in the comment immediately above the diff.