### PR TITLE
dcmtk: add dicomdict and openssl options

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -18,13 +18,12 @@ class Dcmtk < Formula
   option "with-docs", "Install development libraries/headers and HTML docs"
   option "with-libiconv", "Build with brewed libiconv. Dcmtk and system libiconv can have problems with utf8."
   option "with-dicomdict", "Build with baked-in DICOM data dictionary."
-  option "without-openssl", "Build without support for OpenSSL."
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "openssl" => :build unless build.without? "openssl"
+  depends_on "openssl" => :recommended
   depends_on "homebrew/dupes/libiconv" => :optional
 
   def install

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -4,6 +4,7 @@ class Dcmtk < Formula
 
   # Current snapshot used for stable now (using - instead of _ in the version field).
   url "http://dicom.offis.de/download/dcmtk/snapshot/dcmtk-3.6.1_20170228.tar.gz"
+  mirror "http://dicom.offis.de/download/dcmtk/snapshot/old/dcmtk-3.6.1_20170228.tar.gz"
   version "3.6.1-20170228"
   sha256 "8de2f2ae70f71455288ec85c96a2579391300c7462f69a4a6398e9ec51779c11"
 

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -17,20 +17,23 @@ class Dcmtk < Formula
 
   option "with-docs", "Install development libraries/headers and HTML docs"
   option "with-libiconv", "Build with brewed libiconv. Dcmtk and system libiconv can have problems with utf8."
+  option "with-dicomdict", "Build with baked-in DICOM data dictionary."
+  option "without-openssl", "Build without support for OpenSSL."
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "openssl"
+  depends_on "openssl" => :build unless build.without? "openssl"
   depends_on "homebrew/dupes/libiconv" => :optional
 
   def install
     ENV.m64 if MacOS.prefer_64_bit?
 
     args = std_cmake_args
-    args << "-DDCMTK_WITH_OPENSSL=YES"
+    args << "-DDCMTK_WITH_OPENSSL=NO" if build.without? "openssl"
     args << "-DDCMTK_WITH_DOXYGEN=YES" if build.with? "docs"
+    args << "-DDCMTK_ENABLE_BUILTIN_DICTIONARY=YES -DDCMTK_ENABLE_EXTERNAL_DICTIONARY=NO" if build.with? "dicomdict"
     args << "-DDCMTK_WITH_ICONV=YES -DLIBICONV_DIR=#{Formula["libiconv"].opt_prefix}" if build.with? "libiconv"
     args << ".."
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Building with OpenSSL is already the default, per http://git.dcmtk.org/?p=dcmtk.git;a=blob;f=CMake/dcmtkPrepare.cmake;h=937fc8815de31a0e252a1c6b8aec5b0910169514;hb=HEAD#l78, so this commit introduces a `without-openssl` option to build DCMTK without it.

Additionally, a `with-dicomdict` is introduced to control the inclusion of a baked-in DICOM dictionary (the default is using an external one).