### PR TITLE
gcc 7-20170305 (devel)

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -29,6 +29,11 @@ class Gcc < Formula
     sha256 "807d107ada2e8774a5bf1461d3f8dc636d1135bdfde5a64f03ccabc063a11328" => :yosemite
   end
 
+  devel do
+    url "http://mirrors.concertpass.com/gcc/snapshots/7-20170305/gcc-7-20170305.tar.bz2"
+    sha256 "ea44ed9c765acacf3ae03a33ea386e70af98f51e97f4506c5bc7b54ded56d19e"
+  end
+
   # GCC's Go compiler is not currently supported on macOS.
   # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
   option "with-java", "Build the gcj compiler"


### PR DESCRIPTION
I needed a gcc-7 to test some software, so I found this handy. Maybe others could use it too.

They removed all the java stuff from gcc-7, so some of the build options could be reworked, but I figured that could wait until this becomes the stable version and gcc-6 gets moved off to its own formula.

They don't appear to have a generic download site for the snapshots, so I just grabbed a mirror from their list (https://gcc.gnu.org/mirrors.html).