### PR TITLE
elixir: fix always installing erlang19 even if 18 is installed

### DIFF
--- a/Formula/elixir.rb
+++ b/Formula/elixir.rb
@@ -6,7 +6,7 @@ class Erlang18Requirement < Requirement
     erl = which("erl")
     next unless erl
     `#{erl} -noshell -eval 'io:fwrite("~s", [erlang:system_info(otp_release) >= "18"])' -s erlang halt | grep -q '^true'`
-    $?.exitstatus.zero?
+    $?.exitstatus.zero? ? erl : false
   end
 
   def message; <<-EOS.undent

--- a/Formula/elixir.rb
+++ b/Formula/elixir.rb
@@ -6,7 +6,8 @@ class Erlang18Requirement < Requirement
     erl = which("erl")
     next unless erl
     `#{erl} -noshell -eval 'io:fwrite("~s", [erlang:system_info(otp_release) >= "18"])' -s erlang halt | grep -q '^true'`
-    $?.exitstatus.zero? ? erl : false
+    next unless $?.exitstatus.zero?
+    erl
   end
 
   def message; <<-EOS.undent


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/10603

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
