### PR TITLE
Secure/update sf.net SVN stable URLs

### DIFF
--- a/Formula/exult.rb
+++ b/Formula/exult.rb
@@ -1,7 +1,13 @@
 class Exult < Formula
   desc "Recreation of Ultima 7"
   homepage "https://exult.sourceforge.io/"
-  url "svn://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
+  # TODO: move to: https://github.com/exult/exult
+  if MacOS.version >= :sierra
+    url "https://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
+  else
+    url "http://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
+  end
+
   version "1.4.9rc1+r7520"
   head "https://github.com/exult/exult.git"
 

--- a/Formula/fuego.rb
+++ b/Formula/fuego.rb
@@ -1,7 +1,11 @@
 class Fuego < Formula
   desc "Collection of C++ libraries for the game of Go"
   homepage "https://fuego.sourceforge.io/"
-  url "http://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
+  if MacOS.version >= :sierra
+    url "https://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
+  else
+    url "http://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
+  end
   version "1.1.SVN"
 
   head "https://svn.code.sf.net/p/fuego/code/trunk"

--- a/Formula/lcs.rb
+++ b/Formula/lcs.rb
@@ -1,7 +1,11 @@
 class Lcs < Formula
   desc "Satirical console-based political role-playing/strategy game"
-  homepage "http://sourceforge.net/projects/lcsgame/"
-  url "svn://svn.code.sf.net/p/lcsgame/code/trunk", :revision => "738"
+  homepage "https://sourceforge.net/projects/lcsgame/"
+  if MacOS.version >= :sierra
+    url "https://svn.code.sf.net/p/lcsgame/code/trunk", :revision => "738"
+  else
+    url "http://svn.code.sf.net/p/lcsgame/code/trunk", :revision => "738"
+  end
   version "4.07.4b"
 
   head "https://svn.code.sf.net/p/lcsgame/code/trunk"

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -3,7 +3,11 @@ class Netpbm < Formula
   homepage "https://netpbm.sourceforge.io/"
   # Maintainers: Look at https://sourceforge.net/p/netpbm/code/HEAD/tree/
   # for stable versions and matching revisions.
-  url "http://svn.code.sf.net/p/netpbm/code/stable", :revision => 2885
+  if MacOS.version >= :sierra
+    url "https://svn.code.sf.net/p/netpbm/code/stable", :revision => 2885
+  else
+    url "http://svn.code.sf.net/p/netpbm/code/stable", :revision => 2885
+  end
   version "10.73.07"
   version_scheme 1
 

--- a/Formula/spim.rb
+++ b/Formula/spim.rb
@@ -2,7 +2,11 @@ class Spim < Formula
   desc "MIPS32 simulator"
   homepage "https://spimsimulator.sourceforge.io/"
   # No source code tarball exists
-  url "http://svn.code.sf.net/p/spimsimulator/code", :revision => 681
+  if MacOS.version >= :sierra
+    url "https://svn.code.sf.net/p/spimsimulator/code", :revision => 681
+  else
+    url "http://svn.code.sf.net/p/spimsimulator/code", :revision => 681
+  end
   version "9.1.17"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Migrated from #10843 and #10841, except `exult`, where 
it should be found out what commit ID at <https://github.com/exult/exult.git> belongs to the SVN revision: `url "svn://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520`