### PR TITLE
gdbm 1.13

### DIFF
--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -1,9 +1,9 @@
 class Gdbm < Formula
   desc "GNU database manager"
   homepage "https://www.gnu.org/software/gdbm/"
-  url "https://ftpmirror.gnu.org/gdbm/gdbm-1.12.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/gdbm/gdbm-1.12.tar.gz"
-  sha256 "d97b2166ee867fd6ca5c022efee80702d6f30dd66af0e03ed092285c3af9bcea"
+  url "https://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
+  sha256 "9d252cbd7d793f7b12bcceaddda98d257c14f4d1890d851c386c37207000a253"
 
   bottle do
     cellar :any
@@ -19,6 +19,7 @@ class Gdbm < Formula
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
+      --without-readline
       --prefix=#{prefix}
     ]
 

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -15,6 +15,8 @@ class Gdbm < Formula
 
   option "with-libgdbm-compat", "Build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
 
+  # The --without-readline is to avoid a probable bug introduced in
+  # 1.13.
   def install
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?


-----

The new `configure` flag is a workaround for what I believe is a newly-introduced bug.  The new version of `gdbm` "enhances" the enclosed `gdbmtool` to use `readline` functionality.  The problem (I think) is that upstream's detection of readline on macOS is broken.  Without the new flag, building fails with:
```
libtool: link: clang -g -O2 -o .libs/gdbm_load gdbm_load.o  ./libgdbmapp.a
./.libs/libgdbm.dylib -ldbm
Undefined symbols for architecture x86_64:
  "_history_list", referenced from:
      _input_history_handler in input-rl.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see
invocation)
make[3]: *** [gdbmtool] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```
This happens outside of HB also.  (My hunch: their `configure` script thinks readline is present even if it isn't.)

I've reported this upstream, via email (since they appear to have no obviously functioning public bug tracker).

The version bump contains more than just the enhancement of `gdbmtool`, so I thought it was worth making a PR here.  If they fix the bug, we can remove the flag later.