### PR TITLE
djvulibre: use secure head, remove 404 mirror

### DIFF
--- a/Formula/djvulibre.rb
+++ b/Formula/djvulibre.rb
@@ -2,7 +2,6 @@ class Djvulibre < Formula
   desc "DjVu viewer"
   homepage "https://djvu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/djvu/DjVuLibre/3.5.27/djvulibre-3.5.27.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/djvulibre/djvulibre_3.5.27.orig.tar.gz"
   sha256 "e69668252565603875fb88500cde02bf93d12d48a3884e472696c896e81f505f"
 
   bottle do
@@ -14,7 +13,7 @@ class Djvulibre < Formula
   end
 
   head do
-    url "git://git.code.sf.net/p/djvu/djvulibre-git"
+    url "https://git.code.sf.net/p/djvu/djvulibre-git.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
Will fail when building a dependency of a dependent: `evince`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Will fail when building a dependency of a dependent: `evince`