### PR TITLE
add formula for ttnctl (The Things Network CLI)

### DIFF
--- a/Formula/ttnctl.rb
+++ b/Formula/ttnctl.rb
@@ -1,0 +1,16 @@
+class Ttnctl < Formula
+  desc "The Things Network Control Utility"
+  homepage "https://www.thethingsnetwork.org/docs/network/cli/"
+  url "https://ttnreleases.blob.core.windows.net/release/v2.5.3/ttnctl-darwin-amd64.tar.gz"
+  version "2.5.3"
+  sha256 "c913ff2db1e49d30539057a707d31443bd95d484d3433545cac5b09b7a915f75"
+
+  def install
+    bin.install "ttnctl-darwin-amd64"
+    mv "#{bin}/ttnctl-darwin-amd64", "#{bin}/ttnctl"
+  end
+
+  test do
+    system "#{bin}/ttnctl", "version"
+  end
+end


### PR DESCRIPTION
This adds a new formula for the CLI of [The Things Network](https://www.thethingsnetwork.org/).
The binary can currently only be downloaded through the [CLI homepage](https://www.thethingsnetwork.org/docs/network/cli/).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
