### PR TITLE
readline: Swap the URL and mirror

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -1,8 +1,8 @@
 class Readline < Formula
   desc "Library for command-line editing"
   homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
-  url "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
+  url "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
+  mirror "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
   version "7.0.3"
   sha256 "750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334"
   revision 1
@@ -20,8 +20,8 @@ class Readline < Formula
     003 9e43aa93378c7e9f7001d8174b1beb948deefa6799b6f581673f465b7d9d4780
   ].each_slice(2) do |p, checksum|
     patch :p0 do
-      url "https://ftpmirror.gnu.org/readline/readline-7.0-patches/readline70-#{p}"
-      mirror "https://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-#{p}"
+      url "https://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-#{p}"
+      mirror "https://ftpmirror.gnu.org/readline/readline-7.0-patches/readline70-#{p}"
       sha256 checksum
     end
   end


### PR DESCRIPTION
This a) matches the plaintext reading of the URLs, b) the mirror downgrades from HTTPS to HTTP on redirect, the other URL does not.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
