### PR TITLE
exult: migrate url to github.com

### DIFF
--- a/Formula/exult.rb
+++ b/Formula/exult.rb
@@ -1,13 +1,7 @@
 class Exult < Formula
   desc "Recreation of Ultima 7"
   homepage "https://exult.sourceforge.io/"
-  # TODO: move to: https://github.com/exult/exult
-  if MacOS.version >= :sierra
-    url "https://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
-  else
-    url "http://svn.code.sf.net/p/exult/code/exult/trunk", :revision => 7520
-  end
-
+  url "https://github.com/exult/exult.git", :revision => "75aff2e97a4867d7810f8907796f58cb11b87a39"
   version "1.4.9rc1+r7520"
   head "https://github.com/exult/exult.git"
 


### PR DESCRIPTION
svn r7520 is git commit 75aff2e97a4867d7810f8907796f58cb11b87a39:
```
r7520 | kirben | 2015-03-20 14:23:05 +0100 (Fri, 20 Mar 2015) | 1 line
Correct typo in documentation for u7shp plugin under Windows.
```
```
commit 75aff2e97a4867d7810f8907796f58cb11b87a39
Author: Travis Howell <kirben@users.sourceforge.net>
Date:   2015-03-20 13:23:05 +0000

    Correct typo in documentation for u7shp plugin under Windows.
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
