### PR TITLE
vim: add gettext option

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -130,7 +130,7 @@ class Vim < Formula
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal (testpath/"test.txt").read.strip, "hello world"
+      assert_equal "hello world"， (testpath/"test.txt").read.strip
     end
     if build.with? "python3"
       (testpath/"commands.vim").write <<-EOS.undent
@@ -138,7 +138,7 @@ class Vim < Formula
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal (testpath/"test.txt").read.strip, "hello python3"
+      assert_equal "hello python3"， (testpath/"test.txt").read.strip
     end
     if build.with? "gettext"
       assert_match "+gettext", shell_output("#{bin}/vim --version")

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -124,21 +124,20 @@ class Vim < Formula
   end
 
   test do
-    if build.with?("python") && build.without?("python3")
-      (testpath/"commands.vim").write <<-EOS.undent
-        :python import vim; vim.current.buffer[0] = 'hello world'
-        :wq
-      EOS
-      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python.txt"
-      assert_equal "hello world", File.read("test-python.txt").chomp
-    end
     if build.with? "python3"
       (testpath/"commands.vim").write <<-EOS.undent
         :python3 import vim; vim.current.buffer[0] = 'hello python3'
         :wq
       EOS
-      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python3.txt"
-      assert_equal "hello python3", File.read("test-python3.txt").chomp
+      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
+      assert_equal "hello python3", File.read("test.txt").chomp
+    elsif build.with? "python"
+      (testpath/"commands.vim").write <<-EOS.undent
+        :python import vim; vim.current.buffer[0] = 'hello world'
+        :wq
+      EOS
+      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
+      assert_equal "hello world", File.read("test.txt").chomp
     end
     if build.with? "gettext"
       assert_match "+gettext", shell_output("#{bin}/vim --version")

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -129,16 +129,16 @@ class Vim < Formula
         :python import vim; vim.current.buffer[0] = 'hello world'
         :wq
       EOS
-      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal "hello world"， (testpath/"test.txt").read.strip
+      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python.txt"
+      assert_equal "hello world", File.read("test-python.txt").strip
     end
     if build.with? "python3"
       (testpath/"commands.vim").write <<-EOS.undent
         :python3 import vim; vim.current.buffer[0] = 'hello python3'
         :wq
       EOS
-      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal "hello python3"， (testpath/"test.txt").read.strip
+      system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python3.txt"
+      assert_equal "hello python3", File.read("test-python3.txt").strip
     end
     if build.with? "gettext"
       assert_match "+gettext", shell_output("#{bin}/vim --version")

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -73,14 +73,14 @@ class Vim < Formula
       opts -= %w[--enable-pythoninterp]
     end
 
-    if !build.with? "nls"
-      opts << "--disable-nls"
-    else
+    if build.with? "nls"
       gettext = Formula["gettext"]
       ENV.append "CPPFLAGS", "-I#{gettext.include}"
       ENV.append "LDFLAGS", "-L#{gettext.lib}"
       ENV.append "PATH", gettext.bin
       opts << "MSGFMT=#{gettext.bin}/msgfmt"
+    else
+      opts << "--disable-nls"
     end
 
     opts << "--enable-gui=no"

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -11,11 +11,10 @@ class Vim < Formula
     sha256 "144d5c2d2e13f3b5d0f5bcf7a7e28523fa71277738959b587b9b95dea7e27295" => :yosemite
   end
 
-  deprecated_option "disable-nls" => "without-nls"
   deprecated_option "override-system-vi" => "with-override-system-vi"
 
   option "with-override-system-vi", "Override system vi"
-  option "without-nls", "Build vim without National Language Support (translated messages, keymaps)"
+  option "with-nls", "Build vim with National Language Support (translated messages, keymaps)"
   option "with-client-server", "Enable client/server mode"
 
   LANGUAGES_OPTIONAL = %w[lua python3 tcl].freeze
@@ -74,7 +73,7 @@ class Vim < Formula
       opts -= %w[--enable-pythoninterp]
     end
 
-    if build.without? "nls"
+    if !build.with? "nls"
       opts << "--disable-nls"
     else
       gettext = Formula["gettext"]

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -126,7 +126,7 @@ class Vim < Formula
   end
 
   test do
-    if build.with? "python" and build.without? "python3"
+    if (build.with? "python") && (build.without? "python3")
       (testpath/"commands.vim").write <<-EOS.undent
         :python import vim; vim.current.buffer[0] = 'hello world'
         :wq

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -73,15 +73,7 @@ class Vim < Formula
       opts -= %w[--enable-pythoninterp]
     end
 
-    if build.with? "gettext"
-      gettext = Formula["gettext"]
-      ENV.append "CPPFLAGS", "-I#{gettext.include}"
-      ENV.append "LDFLAGS", "-L#{gettext.lib}"
-      ENV.append_path "PATH", gettext.bin
-    else
-      opts << "--disable-nls"
-    end
-
+    opts << "--disable-nls" if build.without? "gettext"
     opts << "--enable-gui=no"
 
     if build.with? "client-server"

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -77,8 +77,7 @@ class Vim < Formula
       gettext = Formula["gettext"]
       ENV.append "CPPFLAGS", "-I#{gettext.include}"
       ENV.append "LDFLAGS", "-L#{gettext.lib}"
-      ENV.append "PATH", gettext.bin
-      opts << "MSGFMT=#{gettext.bin}/msgfmt"
+      ENV.append_path "PATH", gettext.bin
     else
       opts << "--disable-nls"
     end
@@ -125,13 +124,13 @@ class Vim < Formula
   end
 
   test do
-    if (build.with? "python") && (build.without? "python3")
+    if build.with?("python") && build.without?("python3")
       (testpath/"commands.vim").write <<-EOS.undent
         :python import vim; vim.current.buffer[0] = 'hello world'
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal (testpath/"test.txt").read, "hello world\n"
+      assert_equal (testpath/"test.txt").read.strip, "hello world"
     end
     if build.with? "python3"
       (testpath/"commands.vim").write <<-EOS.undent
@@ -139,10 +138,10 @@ class Vim < Formula
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
-      assert_equal (testpath/"test.txt").read, "hello python3\n"
+      assert_equal (testpath/"test.txt").read.strip, "hello python3"
     end
     if build.with? "gettext"
-      system bin/"vim --version | grep '\\+gettext'"
+      assert_match "+gettext", shell_output("#{bin}/vim --version")
     end
   end
 end

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -130,7 +130,7 @@ class Vim < Formula
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python.txt"
-      assert_equal "hello world", File.read("test-python.txt").strip
+      assert_equal "hello world", File.read("test-python.txt").chomp
     end
     if build.with? "python3"
       (testpath/"commands.vim").write <<-EOS.undent
@@ -138,7 +138,7 @@ class Vim < Formula
         :wq
       EOS
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test-python3.txt"
-      assert_equal "hello python3", File.read("test-python3.txt").strip
+      assert_equal "hello python3", File.read("test-python3.txt").chomp
     end
     if build.with? "gettext"
       assert_match "+gettext", shell_output("#{bin}/vim --version")

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -14,7 +14,7 @@ class Vim < Formula
   deprecated_option "override-system-vi" => "with-override-system-vi"
 
   option "with-override-system-vi", "Override system vi"
-  option "with-nls", "Build vim with National Language Support (translated messages, keymaps)"
+  option "with-gettext", "Build vim with National Language Support (translated messages, keymaps)"
   option "with-client-server", "Enable client/server mode"
 
   LANGUAGES_OPTIONAL = %w[lua python3 tcl].freeze
@@ -41,7 +41,7 @@ class Vim < Formula
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
   depends_on :x11 if build.with? "client-server"
-  depends_on "gettext" if build.with? "nls"
+  depends_on "gettext" => :optional
 
   conflicts_with "ex-vi",
     :because => "vim and ex-vi both install bin/ex and bin/view"
@@ -73,7 +73,7 @@ class Vim < Formula
       opts -= %w[--enable-pythoninterp]
     end
 
-    if build.with? "nls"
+    if build.with? "gettext"
       gettext = Formula["gettext"]
       ENV.append "CPPFLAGS", "-I#{gettext.include}"
       ENV.append "LDFLAGS", "-L#{gettext.lib}"
@@ -141,7 +141,7 @@ class Vim < Formula
       system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
       assert_equal (testpath/"test.txt").read, "hello python3\n"
     end
-    if build.with? "nls"
+    if build.with? "gettext"
       system bin/"vim --version | grep '\\+gettext'"
     end
   end

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -11,8 +11,6 @@ class Vim < Formula
     sha256 "144d5c2d2e13f3b5d0f5bcf7a7e28523fa71277738959b587b9b95dea7e27295" => :yosemite
   end
 
-  deprecated_option "disable-nls" => "without-gettext"
-  deprecated_option "without-nls" => "without-gettext"
   deprecated_option "override-system-vi" => "with-override-system-vi"
 
   option "with-override-system-vi", "Override system vi"

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -11,6 +11,8 @@ class Vim < Formula
     sha256 "144d5c2d2e13f3b5d0f5bcf7a7e28523fa71277738959b587b9b95dea7e27295" => :yosemite
   end
 
+  deprecated_option "disable-nls" => "without-gettext"
+  deprecated_option "without-nls" => "without-gettext"
   deprecated_option "override-system-vi" => "with-override-system-vi"
 
   option "with-override-system-vi", "Override system vi"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

* `vim` must be built with `gettext` support, which requires `GNU gettext`, or NLS won't work
* Also fix test then built with --with-python3