### PR TITLE
wine: add option to disable fc-cache run at post-install

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -62,8 +62,12 @@ class Fontconfig < Formula
   end
 
   def post_install
-    ohai "Regenerating font cache, this may take a while"
-    system "#{bin}/fc-cache", "-frv"
+    if ENV["HOMEBREW_FONTCONFIG_CACHE_SKIP"] = "yes"
+      ohai "HOMEBREW_FONTCONFIG_CACHE_SKIP set to 'yes', skipping font cache update"
+    else
+      ohai "Regenerating font cache, this may take a while"
+      system "#{bin}/fc-cache", "-frv"
+    end
   end
 
   test do

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -491,8 +491,12 @@ class Wine < Formula
 
   def post_install
     # For fontconfig
-    ohai "Regenerating font cache, this may take a while"
-    system "#{libexec}/bin/fc-cache", "-frv"
+    if ENV["HOMEBREW_FONTCONFIG_CACHE_SKIP"] = "yes"
+      ohai "HOMEBREW_FONTCONFIG_CACHE_SKIP set to 'yes', skipping font cache update"
+    else
+      ohai "Regenerating font cache, this may take a while"
+      system "#{libexec}/bin/fc-cache", "-frv"
+    end
 
     # For net-snmp
     (var/"db/net-snmp_vendored_wine").mkpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

First of all thanks for the new self-contained `wine` formula, I'm migrating from the wine-devel cask as we speak.

One concern with it, which I noticed on the first install: The infamous fontconfig cache regeneration is taking place as a post-install task and this may be a problem when installing the formula on CI machines. These are headless and certainly not GUI, so fonts should not matter. The regeneration process however takes several minutes (~2-5), which reduces the useful time to run the actual build and adds an uncomfortable wait to each CI session.

I had committed a patch to address this problem to the MSYS2 project here: Alexpux/MINGW-packages@fdea2f9
It solved the problem properly.

Current patch is just an initial proposal and any advice for finding the best solution is much welcome.

Patch also contains an unrelated audit fix [UPDATE: moved to #10952), plus leaves this other audit error unfixed:
```
resource "openssl": The URL https://dl.bintray.com/homebrew/mirror/openssl-1.0.2k.tar.gz is not reachable (HTTP status code 404)
```