### PR TITLE
MacVim: Link mvim with brewed ruby & perl

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -151,7 +151,7 @@ class Macvim < Formula
     # Check if MacVim was linked to Ruby version in $PATH
     if build.with? "ruby"
       ruby_ver = `ruby -e 'print(RUBY_VERSION)'`.chomp
-      assert_match "-lruby" + ruby_ver, `#{bin}/mvim --version`
+      assert_match "-lruby." + ruby_ver, `#{bin}/mvim --version`
     end
   end
 end

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -18,6 +18,9 @@ class Macvim < Formula
 
   deprecated_option "override-system-vim" => "with-override-system-vim"
 
+  conflicts_with "vim",
+    :because => "They both override system vim" if build.with? "override-system-vim"
+
   depends_on :xcode => :build
   depends_on "cscope" => :recommended
   depends_on "lua" => :optional

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -28,14 +28,17 @@ class Macvim < Formula
 
   if MacOS.version >= :mavericks
     option "with-custom-python", "Build with a custom Python 2 instead of the Homebrew version."
-    option "with-custom-ruby", "Build with a custom Ruby instead of the Homebrew version."
-    option "with-custom-perl", "Build with a custom Perl instead of the Homebrew version."
   end
+
+  option "with-ruby", "Build with brewed ruby instead of the system version"
+  option "with-perl", "Build with brewed perl instead of the system version"
 
   depends_on :python => :recommended
   depends_on :python3 => :optional
-  depends_on :ruby => "1.8" # Can be compiled against 1.8.x or >= 1.9.3-p385.
-  depends_on :perl => "5.3"
+  depends_on "ruby" => :optional
+  depends_on "perl" => :optional
+  depends_on "homebrew/dupes/ncurses" => :optional
+  depends_on "homebrew/dupes/libiconv" => :optional
 
   def install
     # Avoid "fatal error: 'ruby/config.h' file not found"
@@ -100,7 +103,17 @@ class Macvim < Formula
     system "./configure", *args
     system "make"
 
-    prefix.install "src/MacVim/build/Release/MacVim.app"
+    apppath = "src/MacVim/build/Release/MacVim.app"
+
+    if build.with? "gettext"
+      system "INSTALL_DATA=install " +
+             "FILEMOD=644 " +
+             "LOCALEDIR=../../#{apppath}/Contents/Resources/vim/runtime/lang " +
+             "make -C src/po install"
+    end
+
+    prefix.install apppath
+
     inreplace "src/MacVim/mvim", %r{^# VIM_APP_DIR=\/Applications$},
                                  "VIM_APP_DIR=#{prefix}"
     bin.install "src/MacVim/mvim"

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -14,7 +14,6 @@ class Macvim < Formula
   end
 
   option "with-override-system-vim", "Override system vim"
-  option "with-gettext", "Build MacVim with +gettext."
 
   deprecated_option "override-system-vim" => "with-override-system-vim"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Like what [vim does](https://github.com/Homebrew/homebrew-core/blob/master/Formula/vim.rb#L39) for long time. This requires upstream change https://github.com/macvim-dev/macvim/commit/9d23d58d4c8800b395986fbcdeba4c80e7afe4d7
Tested with `--HEAD`

Also add `gettext` option.
Note: MacVim won't bundle `.po` files by default, you may copy them into `MacVim.app/Contents/Resources/vim/runtime/lang` manually

Also fix tests when built with python3 ;)