### PR TITLE
head URL updates/fixes for sf.net domains

### DIFF
--- a/Formula/disktype.rb
+++ b/Formula/disktype.rb
@@ -3,7 +3,7 @@ class Disktype < Formula
   homepage "https://disktype.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/disktype/disktype/9/disktype-9.tar.gz"
   sha256 "b6701254d88412bc5d2db869037745f65f94b900b59184157d072f35832c1111"
-  head ":pserver:anonymous:@disktype.cvs.sourceforge.net:/cvsroot/disktype", :using => :cvs
+  head "https://git.code.sf.net/p/disktype/disktype.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -1,10 +1,10 @@
 class Expat < Formula
   desc "XML 1.0 parser"
-  homepage "https://expat.sourceforge.io"
+  homepage "https://expat.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2"
   mirror "https://fossies.org/linux/www/expat-2.2.0.tar.bz2"
   sha256 "d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff"
-  head ":pserver:anonymous:@expat.cvs.sourceforge.net:/cvsroot/expat", :using => :cvs
+  head "https://github.com/libexpat/libexpat.git"
 
   bottle do
     cellar :any

--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -1,7 +1,7 @@
 class Freetype < Formula
   desc "Software library to render fonts"
   homepage "https://www.freetype.org/"
-  url "https://downloads.sf.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.bz2"
+  url "https://downloads.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.bz2"
   mirror "https://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.bz2"
   sha256 "3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88"
 

--- a/Formula/gmtl.rb
+++ b/Formula/gmtl.rb
@@ -1,14 +1,14 @@
 class Gmtl < Formula
   desc "Lightweight math library"
   homepage "https://ggt.sourceforge.io/"
-  head "https://ggt.svn.sourceforge.net/svnroot/ggt/trunk/"
+  head "https://svn.code.sf.net/p/ggt/code/trunk"
 
   stable do
     url "https://downloads.sourceforge.net/project/ggt/Generic%20Math%20Template%20Library/0.6.1/gmtl-0.6.1.tar.gz"
     sha256 "f7d8e6958d96a326cb732a9d3692a3ff3fd7df240eb1d0921a7c5c77e37fc434"
 
     # Build assumes that Python is a framework, which isn't always true. See:
-    # https://sourceforge.net/tracker/?func=detail&aid=3172856&group_id=43735&atid=437247
+    # https://sourceforge.net/p/ggt/bugs/22/
     # The SConstruct from gmtl's HEAD doesn't need to be patched
     patch :DATA
   end

--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -3,7 +3,7 @@ class Irrlicht < Formula
   homepage "https://irrlicht.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/irrlicht/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip"
   sha256 "f42b280bc608e545b820206fe2a999c55f290de5c7509a02bdbeeccc1bf9e433"
-  head "https://irrlicht.svn.sourceforge.net/svnroot/irrlicht/trunk"
+  head "https://svn.code.sf.net/p/irrlicht/code/trunk"
 
   bottle do
     cellar :any_skip_relocation
@@ -18,7 +18,7 @@ class Irrlicht < Formula
     # Fix "error: cannot initialize a parameter of type
     # 'id<NSApplicationDelegate> _Nullable' with an rvalue of type
     # 'id<NSFileManagerDelegate>'"
-    # Reported 5 Oct 2016 http://irrlicht.sourceforge.net/forum/viewtopic.php?f=7&t=51562
+    # Reported 5 Oct 2016 https://irrlicht.sourceforge.io/forum/viewtopic.php?f=7&t=51562
     inreplace "source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm",
       "[NSApp setDelegate:(id<NSFileManagerDelegate>)",
       "[NSApp setDelegate:(id<NSApplicationDelegate>)"

--- a/Formula/lasi.rb
+++ b/Formula/lasi.rb
@@ -1,10 +1,10 @@
 class Lasi < Formula
   desc "C++ stream output interface for creating Postscript documents"
-  homepage "http://www.unifont.org/lasi/"
+  homepage "https://www.unifont.org/lasi/"
   url "https://downloads.sourceforge.net/project/lasi/lasi/1.1.2%20Source/libLASi-1.1.2.tar.gz"
   sha256 "448c6e52263a1e88ac2a157f775c393aa8b6cd3f17d81fc51e718f18fdff5121"
 
-  head "https://lasi.svn.sourceforge.net/svnroot/lasi/trunk"
+  head "https://svn.code.sf.net/p/lasi/code/trunk"
 
   bottle do
     cellar :any

--- a/Formula/log4c.rb
+++ b/Formula/log4c.rb
@@ -4,7 +4,7 @@ class Log4c < Formula
   url "https://downloads.sourceforge.net/project/log4c/log4c/1.2.4/log4c-1.2.4.tar.gz"
   sha256 "5991020192f52cc40fa852fbf6bbf5bd5db5d5d00aa9905c67f6f0eadeed48ea"
 
-  head ":pserver:anonymous:@log4c.cvs.sourceforge.net:/cvsroot/log4c", :using => :cvs
+  head "https://git.code.sf.net/p/log4c/log4c.git"
 
   bottle do
     sha256 "171a6c3f12f957d5442998f0f02df959aa4376ef543338765930ed4e062ef0ea" => :sierra

--- a/Formula/raine.rb
+++ b/Formula/raine.rb
@@ -1,6 +1,6 @@
 class Raine < Formula
   desc "680x0 arcade emulator"
-  homepage "http://raine.1emulation.com/"
+  homepage "https://raine.1emulation.com/"
   url "https://github.com/zelurker/raine/archive/0.64.13.tar.gz"
   sha256 "0af13e67744ac81f987687a3f83703bc844897a6a1b828a19d82f96dfe8ab719"
   head "https://github.com/zelurker/raine.git"
@@ -103,7 +103,7 @@ class Raine < Formula
   end
 
   resource "freetype" do
-    url "https://downloads.sf.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.bz2"
+    url "https://downloads.sourceforge.net/project/freetype/freetype2/2.7.1/freetype-2.7.1.tar.bz2"
     mirror "https://download.savannah.gnu.org/releases/freetype/freetype-2.7.1.tar.bz2"
     sha256 "3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88"
   end

--- a/Formula/sdcc.rb
+++ b/Formula/sdcc.rb
@@ -4,7 +4,7 @@ class Sdcc < Formula
   url "https://downloads.sourceforge.net/project/sdcc/sdcc/3.6.0/sdcc-src-3.6.0.tar.bz2"
   sha256 "e85dceb11e01ffefb545ec389da91265130c91953589392dddd2e5ec0b7ca374"
 
-  head "https://sdcc.svn.sourceforge.net/svnroot/sdcc/trunk/sdcc/"
+  head "https://svn.code.sf.net/p/sdcc/code/trunk/sdcc"
 
   bottle do
     sha256 "b5b8e259cf24cf913201fa4db9da37a3a7a7464dd351e9aa2e3ce5deb2221db2" => :sierra

--- a/Formula/teem.rb
+++ b/Formula/teem.rb
@@ -3,7 +3,7 @@ class Teem < Formula
   homepage "https://teem.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
   sha256 "a01386021dfa802b3e7b4defced2f3c8235860d500c1fa2f347483775d4c8def"
-  head "https://teem.svn.sourceforge.net/svnroot/teem/teem/trunk"
+  head "https://svn.code.sf.net/p/teem/code/teem/trunk"
 
   bottle do
     sha256 "31d19cd9e0e4c064fb743c41a286736503e61b1d5e4b81f29140fcebf2cde2c8" => :sierra

--- a/Formula/tpp.rb
+++ b/Formula/tpp.rb
@@ -15,7 +15,7 @@ class Tpp < Formula
   depends_on "figlet" => :optional
 
   resource "ncurses-ruby" do
-    url "https://downloads.sf.net/project/ncurses-ruby.berlios/ncurses-ruby-1.3.1.tar.bz2"
+    url "https://downloads.sourceforge.net/project/ncurses-ruby.berlios/ncurses-ruby-1.3.1.tar.bz2"
     sha256 "dca8ce452e989ce1399cb683184919850f2baf79e6af9d16a7eed6a9ab776ec5"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Only these sf.net byzantine/legacy URLs remain:
```
blitz.rb:    url "http://blitz.hg.sourceforge.net:8000/hgroot/blitz/blitz", :using => :hg
gnuplot.rb:    url ":pserver:anonymous:@gnuplot.cvs.sourceforge.net:/cvsroot/gnuplot", :using => :cvs
id3lib.rb:  head ":pserver:anonymous:@id3lib.cvs.sourceforge.net:/cvsroot/id3lib",
myman.rb:  head ":pserver:anonymous:@myman.cvs.sourceforge.net:/cvsroot/myman", :using => :cvs
par2.rb:  # http://parchive.cvs.sourceforge.net/viewvc/parchive/par2-cmdline/par2creatorsourcefile.cpp?r1=1.4&r2=1.5
slashem.rb:  # Fixed upstream: http://slashem.cvs.sourceforge.net/viewvc/slashem/slashem/configure?r1=1.13&r2=1.14&view=patch
ucon64.rb:  head ":pserver:anonymous:@ucon64.cvs.sourceforge.net:/cvsroot/ucon64", :using => :cvs
```

And these in-comments:
```
libreadline-java.rb:  # https://sourceforge.net/tracker/?func=detail&atid=453822&aid=3566332&group_id=48669
mkclean.rb:  # https://sourceforge.net/tracker/?func=detail&aid=3505611&group_id=68739&atid=522228
mpg321.rb:  # https://sourceforge.net/tracker/?func=detail&aid=3587769&group_id=36274&atid=416544
postgres-xc.rb:    # See https://sourceforge.net/mailarchive/forum.php?thread_name=82E44F89-543A-44F2-8AF8-F6909B5DC561%40uniud.it&forum_name=postgres-xc-bugs
vde.rb:    # https://sourceforge.net/tracker/?func=detail&aid=3501432&group_id=95403&atid=611248
wput.rb:  # https://sourceforge.net/tracker/?func=detail&aid=3481469&group_id=141519&atid=749615
```