### PR TITLE
jdnssec-tools: add a comma after the last parameter of a multiline method call

### DIFF
--- a/Formula/jdnssec-tools.rb
+++ b/Formula/jdnssec-tools.rb
@@ -28,7 +28,7 @@ class JdnssecTools < Formula
       NfIRTFadqsmuU9F ddz3JqCcYwEpWbReg6DJOeyu+9oBoIQkPxFyLtIXEPGlQzrynKubn04
       Cx83I6NfzDTraJT3jLHKeW5PVc1ifqKzHz5TXdHHTA7NkJAa0sPcZCoNE 1LpnJI/wcUpRU
       iuQhoLFeT1E432GuPuZ7y+agElGj0NnBxEgnHrhrnZW UbULpRa/il+Cr5Taj988HqX9Xdm
-      6FjcP4Lbuds/44U7U8du224Q8jTrZ 57Yvj4VDQKc=)"
+      6FjcP4Lbuds/44U7U8du224Q8jTrZ 57Yvj4VDQKc=)",
     )
 
     assert_match /D4C3D5552B8679FAEEBC317E5F048B614B2E5F607DC57F1553182D49AB2179F7/,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
