### PR TITLE
libvbucket: add a comma after the last parameter of a multiline method call

### DIFF
--- a/Formula/libvbucket.rb
+++ b/Formula/libvbucket.rb
@@ -27,7 +27,7 @@ class Libvbucket < Formula
       "hashAlgorithm" => "CRC",
       "numReplicas" => 2,
       "serverList" => ["server1:11211", "server2:11210", "server3:11211"],
-      "vBucketMap" => [[0, 1, 2], [1, 2, 0], [2, 1, -1], [1, 2, 0]]
+      "vBucketMap" => [[0, 1, 2], [1, 2, 0], [2, 1, -1], [1, 2, 0]],
     )
 
     expected = <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
