### PR TITLE
freealut: new working https url for stable source

### DIFF
--- a/Formula/freealut.rb
+++ b/Formula/freealut.rb
@@ -1,7 +1,7 @@
 class Freealut < Formula
   desc "Implementation of OpenAL's ALUT standard"
   homepage "https://github.com/vancegroup/freealut"
-  url "http://connect.creativelabs.com/openal/Downloads/ALUT/freealut-1.1.0.tar.gz"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   sha256 "60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
 


### PR DESCRIPTION
the old stable url is dead, part of tracker issue #10839