### PR TITLE
mednafen 0.9.43

### DIFF
--- a/Formula/mednafen.rb
+++ b/Formula/mednafen.rb
@@ -1,8 +1,8 @@
 class Mednafen < Formula
   desc "Multi-system emulator"
   homepage "http://mednafen.fobby.net/"
-  url "https://mednafen.github.io/releases/files/mednafen-0.9.41.tar.xz"
-  sha256 "74736b9b52a7ba6270b67ae8e6c876a887e0e26a00a7d96bdd49af17992aac47"
+  url "https://mednafen.github.io/releases/files/mednafen-0.9.43.tar.xz"
+  sha256 "b8305914cdf297fe6483219fa10c3fa14116fff8eed02f61326a0e32dd350f4d"
 
   bottle do
     sha256 "80e63fcb4a9c17bee872bb7866f567fd1752054e3810db1c19fb9ac0ff904299" => :sierra
@@ -11,25 +11,22 @@ class Mednafen < Formula
   depends_on "pkg-config" => :build
   depends_on "sdl"
   depends_on "libsndfile"
+  depends_on :macos => :sierra # needs clock_gettime
   depends_on "gettext"
 
-  needs :cxx11
-
-  fails_with :clang do
-    build 800
-    cause <<-EOS.undent
-      LLVM miscompiles some loop code with optimization
-      https://llvm.org/bugs/show_bug.cgi?id=15470
-      EOS
-  end
-
   def install
-    ENV.cxx11
+    # Fix run-time crash "Assertion failed: (x == TestLLVM15470_Counter), function
+    # TestLLVM15470_Sub2, file tests.cpp, line 643."
+    # LLVM miscompiles some loop code with optimization
+    # https://llvm.org/bugs/show_bug.cgi?id=15470
+    ENV.O2
+
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end
 
   test do
-    assert_equal version.to_s, shell_output("#{bin}/mednafen -dump_modules_def M >/dev/null || head -n 1 M").chomp
+    cmd = "#{bin}/mednafen -dump_modules_def M >/dev/null || head -n 1 M"
+    assert_equal version.to_s, shell_output(cmd).chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

require Sierra or above since clock_gettime is needed
use ENV.O2 to avoid the loop optimization bug instead of gcc
remove superfluous explicit ENV.cxx11 and needs :cxx11