### PR TITLE
boxes: allow 64-bit compilation

### DIFF
--- a/Formula/boxes.rb
+++ b/Formula/boxes.rb
@@ -3,6 +3,7 @@ class Boxes < Formula
   homepage "http://boxes.thomasjensen.com/"
   url "https://github.com/ascii-boxes/boxes/archive/v1.1.2.tar.gz"
   sha256 "4d5e536be91b476ee48640bef9122f3114b16fe2da9b9906947308b94682c5fe"
+  revision 1
   head "https://github.com/ascii-boxes/boxes.git"
 
   bottle do
@@ -13,16 +14,13 @@ class Boxes < Formula
     sha256 "4d82f6e37b1e18d48a2198ca4301d901e4a6b55681ed8f0b65dddeee1148221e" => :mavericks
   end
 
-  def install
-    ENV.m32
+  # Patch to fix 64-bit compilation
+  # https://github.com/ascii-boxes/boxes/issues/38
+  patch :DATA
 
+  def install
     # distro uses /usr/share/boxes change to prefix
-    system "make",
-      "GLOBALCONF=#{share}/boxes-config",
-      "CC=#{ENV.cc}",
-      # Force 32 bit compile
-      "CFLAGS_ADDTL=-m32",
-      "LDFLAGS_ADDTL=-m32"
+    system "make", "GLOBALCONF=#{share}/boxes-config", "CC=#{ENV.cc}"
 
     bin.install "src/boxes"
     man1.install "doc/boxes.1"
@@ -33,3 +31,32 @@ class Boxes < Formula
     assert_match "/* test brew */", pipe_output("#{bin}/boxes", "test brew")
   end
 end
+
+__END__
+diff --git a/src/Makefile b/src/Makefile
+index c2656df..db19d29 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -62,7 +62,7 @@ boxes.exe: $(ALL_OBJ)
+ 
+ 
+ flags_unix:
+-	$(eval CFLAGS := -ansi -I. -Iregexp -Wall -W $(CFLAGS_ADDTL))
++	$(eval CFLAGS := -I. -Iregexp -Wall -W $(CFLAGS_ADDTL))
+ 	$(eval LDFLAGS := -Lregexp $(LDFLAGS_ADDTL))
+ 	$(eval BOXES_EXECUTABLE_NAME := boxes)
+ 	$(eval ALL_OBJ := $(GEN_SRC:.c=.o) $(ORIG_NORM:.c=.o))
+
+
+diff --git a/src/parser.y b/src/parser.y
+index c9acfbd..a32ef36 100644
+--- a/src/parser.y
++++ b/src/parser.y
+@@ -27,6 +27,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include "shape.h"
+ #include "boxes.h"
+ #include "tools.h"


### PR DESCRIPTION
Remove `ENV.m32` by patching to allow 64-bit compilation. Patch was sent upstream: https://github.com/ascii-boxes/boxes/issues/38