### PR TITLE
vorbis-tools: ENV.delete SDKROOT on Yosemite

### DIFF
--- a/Formula/vorbis-tools.rb
+++ b/Formula/vorbis-tools.rb
@@ -19,6 +19,10 @@ class VorbisTools < Formula
   depends_on "flac" => :optional
 
   def install
+    # Fix `brew linkage --test` "Missing libraries: /usr/lib/libnetwork.dylib"
+    # Prevent bogus linkage to the libnetwork.tbd in Xcode 7's SDK
+    ENV.delete("SDKROOT") if MacOS.version == :yosemite
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

fix bogus linkage to a non-existent /usr/lib/libnetwork.dylib