### PR TITLE
Updated sshguard formula to use new config file, Sierra unified logging.

### DIFF
--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -75,6 +75,6 @@ class Sshguard < Formula
   end
 
   test do
-    assert_match "SSHGuard #{version.to_s}", shell_output("#{sbin}/sshguard -v 2>&1")
+    assert_match "SSHGuard #{version}", shell_output("#{sbin}/sshguard -v 2>&1")
   end
 end

--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -23,7 +23,7 @@ class Sshguard < Formula
     inreplace "examples/sshguard.conf" do |s|
       s.gsub! /^#BACKEND=.*$/, "BACKEND=\"#{libexec}/sshg-fw-#{firewall}\""
       if MacOS.version >= :sierra
-        s.gsub! %r{^#LOGREADER="/usr\/bin\/log}, "LOGREADER=\"/usr/bin/log"
+        s.gsub! %r{^#LOGREADER="/usr/bin/log}, "LOGREADER=\"/usr/bin/log"
       else
         s.gsub! /^#FILES.*$/, "FILES=#{log_path}"
       end
@@ -75,6 +75,6 @@ class Sshguard < Formula
   end
 
   test do
-    assert_match "SSHGuard #{version.to_s}", shell_output("#{sbin}/sshguard -v 2>&1", 0)
+    assert_match "SSHGuard #{version.to_s}", shell_output("#{sbin}/sshguard -v 2>&1")
   end
 end

--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -12,18 +12,14 @@ class Sshguard < Formula
     sha256 "20918ad422229e3d3fec35af56916d396963014b95341206bd1e905a3f553384" => :yosemite
   end
 
-  depends_on "automake" => :build
-  depends_on "autoconf" => :build
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}"
     system "make", "install"
-    mkdir "etc"
-    cp "examples/sshguard.conf.sample", "etc/sshguard.conf"
-    inreplace "etc/sshguard.conf" do |s|
+    cp "examples/sshguard.conf.sample", "examples/sshguard.conf"
+    inreplace "examples/sshguard.conf" do |s|
       s.gsub! /^#BACKEND=.*$/, "BACKEND=\"#{libexec}/sshg-fw-#{firewall}\""
       if MacOS.version >= :sierra
         s.gsub! %r{^#LOGREADER="/usr\/bin\/log}, "LOGREADER=\"/usr/bin/log"
@@ -31,7 +27,7 @@ class Sshguard < Formula
         s.gsub! /^#FILES.*$/, "FILES=#{log_path}"
       end
     end
-    etc.install "etc/sshguard.conf"
+    etc.install "examples/sshguard.conf"
   end
 
   def firewall
@@ -78,6 +74,6 @@ class Sshguard < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{sbin}/sshguard -v 2>&1", 78)
+    assert_match "SSHGuard #{version.to_s}", shell_output("#{sbin}/sshguard -v 2>&1", 0)
   end
 end

--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -4,6 +4,7 @@ class Sshguard < Formula
   url "https://downloads.sourceforge.net/project/sshguard/sshguard/2.0.0/sshguard-2.0.0.tar.gz"
   sha256 "e87c6c4a6dddf06f440ea76464eb6197869c0293f0a60ffa51f8a6a0d7b0cb06"
   version_scheme 1
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
SSHguard v2 requires a config file that does not get installed with make install. This commit creates that file and configures it for ipfw/pf and specifies the proper logfile, or a LOGREADER to use macOS unified logging for Sierra. Also removes some configure flags that are no longer valid.