### PR TITLE
readline: remove no-op --enable-multibyte

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -33,7 +33,7 @@ class Readline < Formula
   EOS
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--enable-multibyte"
+    system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
`--enable-multibyte` is a no-op in readline's `configure` script (it is the default).