### PR TITLE
Update osrm-backend

### DIFF
--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -2,7 +2,7 @@ class OsrmBackend < Formula
   desc "High performance routing engine"
   homepage "http://project-osrm.org/"
   url "https://github.com/Project-OSRM/osrm-backend/archive/v5.6.3.tar.gz"
-  sha256 "42875ecdc0cab65fe3bb861f40b17f2dbd71764c030a07a0f0863b8f405eeb0d"
+  sha256 "87c010c9e99e56cda601c357d8ffdea1f5b4bb1bb79275f202ae6247bf3b308a"
   head "https://github.com/Project-OSRM/osrm-backend.git"
 
   bottle do

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -1,7 +1,7 @@
 class OsrmBackend < Formula
   desc "High performance routing engine"
   homepage "http://project-osrm.org/"
-  url "https://github.com/Project-OSRM/osrm-backend/archive/v5.6.0.tar.gz"
+  url "https://github.com/Project-OSRM/osrm-backend/archive/v5.6.3.tar.gz"
   sha256 "42875ecdc0cab65fe3bb861f40b17f2dbd71764c030a07a0f0863b8f405eeb0d"
   head "https://github.com/Project-OSRM/osrm-backend.git"
 
@@ -20,9 +20,9 @@ class OsrmBackend < Formula
   depends_on "libstxxl"
   depends_on "libxml2"
   depends_on "libzip"
-  depends_on "lua@5.1"
-  depends_on "luabind"
+  depends_on "lua"
   depends_on "tbb"
+  depends_on "ccache" => :optional
 
   def install
     mkdir "build" do

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -22,7 +22,6 @@ class OsrmBackend < Formula
   depends_on "libzip"
   depends_on "lua"
   depends_on "tbb"
-  depends_on "ccache" => :optional
 
   def install
     mkdir "build" do


### PR DESCRIPTION
removed dependency on luabind, v.5.6.3

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
