### PR TITLE
aha: fix manpage install

### DIFF
--- a/Formula/aha.rb
+++ b/Formula/aha.rb
@@ -3,6 +3,7 @@ class Aha < Formula
   homepage "https://github.com/theZiz/aha"
   url "https://github.com/theZiz/aha/archive/0.4.10.5.tar.gz"
   sha256 "b2cd7a1a0f7b3a70c37446d7157b4b58e2939535cdd71112a2228b2e78f7e620"
+  revision 1
   head "https://github.com/theZiz/aha.git"
 
   bottle do
@@ -13,7 +14,9 @@ class Aha < Formula
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "MANDIR=share/man"
+    system "make"
+    bin.install "aha"
+    man1.install "aha.1"
   end
 
   test do

--- a/Formula/aha.rb
+++ b/Formula/aha.rb
@@ -13,7 +13,7 @@ class Aha < Formula
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "MANDIR=#{man}"
+    system "make", "install", "PREFIX=#{prefix}", "MANDIR=share/man"
   end
 
   test do

--- a/Formula/aha.rb
+++ b/Formula/aha.rb
@@ -1,9 +1,8 @@
 class Aha < Formula
   desc "ANSI HTML adapter"
   homepage "https://github.com/theZiz/aha"
-  url "https://github.com/theZiz/aha/archive/0.4.10.5.tar.gz"
-  sha256 "b2cd7a1a0f7b3a70c37446d7157b4b58e2939535cdd71112a2228b2e78f7e620"
-  revision 1
+  url "https://github.com/theZiz/aha/archive/0.4.10.6.tar.gz"
+  sha256 "747e939787dca7a9620869fefc17b60f5e29f0ea3965548d15dc9b2a1f31c3f6"
   head "https://github.com/theZiz/aha.git"
 
   bottle do
@@ -14,9 +13,7 @@ class Aha < Formula
   end
 
   def install
-    system "make"
-    bin.install "aha"
-    man1.install "aha.1"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
Aha's [Makefile] treats `MANDIR` as a relative path from `PREFIX` rather
than an absolute path as given by `man` in `Formula#install`. Changed to
using the expected [manpage prefix].

[Makefile]: https://github.com/theZiz/aha/blob/4df28c96900b73a7073635184673ea631297e27a/Makefile#L20-L21
[manpage prefix]: https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#manuals

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
