### PR TITLE
pyenv: fix missing caveats

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -21,6 +21,13 @@ class Pyenv < Formula
     end
   end
 
+  def caveats; <<-EOS.undent
+    After installation, you'll need to add
+      eval "$(pyenv init -)"
+    to your profile (like ~/.bashrc, ~/.zshrc) manually.
+    EOS
+  end
+
   test do
     shell_output("eval \"$(#{bin}/pyenv init -)\" && pyenv versions")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As shown in <https://github.com/pyenv/pyenv#homebrew-on-mac-os-x>, we need add `eval "$(pyenv init -)"` to our profile manually after the installation. The original formula does not provide such a hint, which makes me confusing when installing it. What I do is just adding caveats about it.

