### PR TITLE
emacs: HEAD build no longer requires automake

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -21,7 +21,6 @@ class Emacs < Formula
     url "https://github.com/emacs-mirror/emacs.git"
 
     depends_on "autoconf" => :build
-    depends_on "automake" => :build
     depends_on "gnu-sed" => :build
     depends_on "texinfo" => :build
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As of https://github.com/emacs-mirror/emacs/commit/65faa7bcb59421603ed2b6e961fe4b9ea8cb91b9
