### PR TITLE
abcde: patch to correctly set md5 utility name

### DIFF
--- a/Formula/abcde.rb
+++ b/Formula/abcde.rb
@@ -4,6 +4,7 @@ class Abcde < Formula
   url "https://abcde.einval.com/download/abcde-2.8.1.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/abcde/abcde_2.8.1.orig.tar.gz"
   sha256 "e49c71d7ddcd312dcc819c3be203abd3d09d286500ee777cde434c7881962b39"
+  revision 1
   head "https://git.einval.com/git/abcde.git"
 
   bottle do
@@ -23,6 +24,11 @@ class Abcde < Formula
   depends_on "glyr" => :optional
 
   def install
+    # Fixes MD5SUM being set to nonexistent md5sum
+    # Reported upstream 2017-03-18 18:03 GMT
+    # https://abcde.einval.com/bugzilla/show_bug.cgi?id=59
+    inreplace "abcde", "OSFLAVOUR=OSX", "MD5SUM=md5\n\tOSFLAVOUR=OSX"
+
     system "make", "install", "prefix=#{prefix}", "sysconfdir=#{etc}"
   end
 


### PR DESCRIPTION
fixes https://github.com/Homebrew/homebrew-core/pull/10563

reported upstream at https://abcde.einval.com/bugzilla/show_bug.cgi?id=59

CC @ilovezfs 

@lsolanka Do you mind checking that this actually fixes the issue?