### PR TITLE
youtube-dl: skip make step for stable and stop bottling

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -11,8 +11,6 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
-  depends_on "rtmpdump" => :optional
-
   def install
     system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"
@@ -20,10 +18,6 @@ class YoutubeDl < Formula
     bash_completion.install "youtube-dl.bash-completion"
     zsh_completion.install "youtube-dl.zsh" => "_youtube-dl"
     fish_completion.install "youtube-dl.fish"
-  end
-
-  def caveats
-    "To use post-processing options, `brew install ffmpeg` or `brew install libav`."
   end
 
   test do

--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -1,18 +1,10 @@
-# Please only update to versions that are published on PyPi as there are too
-# many releases for us to update to every single one:
-# https://pypi.python.org/pypi/youtube_dl
 class YoutubeDl < Formula
   desc "Download YouTube videos from the command-line"
   homepage "https://rg3.github.io/youtube-dl/"
   url "https://github.com/rg3/youtube-dl/releases/download/2017.03.20/youtube-dl-2017.03.20.tar.gz"
   sha256 "6e4201d7b45da75e9ed04c0393e9b1ce86fad27375337d5e1700549a26597215"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "dcede4ff2da08acf2ee876a9f72127188d1890be66140170f48d97f9418b6ac3" => :sierra
-    sha256 "dcede4ff2da08acf2ee876a9f72127188d1890be66140170f48d97f9418b6ac3" => :el_capitan
-    sha256 "dcede4ff2da08acf2ee876a9f72127188d1890be66140170f48d97f9418b6ac3" => :yosemite
-  end
+  bottle :unneeded
 
   head do
     url "https://github.com/rg3/youtube-dl.git"
@@ -22,7 +14,7 @@ class YoutubeDl < Formula
   depends_on "rtmpdump" => :optional
 
   def install
-    system "make", "PREFIX=#{prefix}"
+    system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"
     man1.install "youtube-dl.1"
     bash_completion.install "youtube-dl.bash-completion"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

- Make artifacts are already included in release tarballs (at least for now);
- Stop bottling (#11281);
- Remove useless comments (all GitHub releases are published on PyPI).
