### PR TITLE
avra: apply patch to avoid "abort trap 6" crash

### DIFF
--- a/Formula/avra.rb
+++ b/Formula/avra.rb
@@ -13,6 +13,13 @@ class Avra < Formula
     sha256 "2e208cec5f270c91c9afc0349236a9abb0622e1e8208c67d25c90f017fcecf65" => :mavericks
   end
 
+  # Crashes with 'abort trap 6' unless this fix is applied.
+  # See: https://sourceforge.net/p/avra/patches/16/
+  patch do
+    url "https://gist.githubusercontent.com/adammck/7e4a14f7dd4cc58eea8afa99d1ad9f5d/raw/5cdbfe5ac310a12cae6671502697737d56827b05/avra-fix-osx.patch"
+    sha256 "03493058c351cfce0764a8c2e63c2a7b691601dd836c760048fe47ddb9e91682"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 

--- a/Formula/avra.rb
+++ b/Formula/avra.rb
@@ -3,6 +3,7 @@ class Avra < Formula
   homepage "https://avra.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avra/1.3.0/avra-1.3.0.tar.bz2"
   sha256 "a62cbf8662caf9cc4e75da6c634efce402778639202a65eb2d149002c1049712"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Seems to be [an open bug](https://sourceforge.net/p/avra/bugs/75/) upstream. [The fix](https://sourceforge.net/p/avra/patches/16/) was submitted by one [olal](https://sourceforge.net/u/olalid/profile/) on SF.