### PR TITLE
httping: use https in test on El Cap and above

### DIFF
--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -25,6 +25,10 @@ class Httping < Formula
   end
 
   test do
-    system bin/"httping", "-c", "2", "-g", "http://brew.sh"
+    if MacOS.version >= :el_capitan
+      system bin/"httping", "-c", "2", "-g", "https://brew.sh/"
+    else
+      system bin/"httping", "-c", "2", "-g", "http://brew.sh/"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

HTTPS test seems to consistently fail on Yosemite:
https://bot.brew.sh/job/Homebrew%20Core/18803/version=yosemite/console
