### PR TITLE
install chg along with mercurial

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -18,6 +18,14 @@ class Mercurial < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "install-bin"
+
+    # Install chg (see https://www.mercurial-scm.org/wiki/CHg)
+    cd "contrib/chg" do
+      system "make", "PREFIX=#{prefix}", "HGPATH=#{bin}/hg", \
+             "HG=#{bin}/hg"
+      bin.install "chg"
+    end
+
     # Install man pages, which come pre-built in source releases
     man1.install "doc/hg.1"
     man5.install "doc/hgignore.5", "doc/hgrc.5"


### PR DESCRIPTION
- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This makes the mercurial formula install `chg` (see https://www.mercurial-scm.org/wiki/CHg for more details; tl;dr: `chg` is a tiny C binary that communicates with a background python process, using it avoids needing to pay the python startup cost every time you invoke `hg`).

It's not distributed along with the regular `hg` binary because it's considered experimental by the mercurial developers. However, since a user needs to manually add an alias for `chg` to `hg` or use `chg` directly I don't think it's harmful to build and distribute `chg` by default.