### PR TITLE
yarn: set installation method to 'brew'

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -19,6 +19,7 @@ class Yarn < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
+    inreplace "#{libexec}/lib/node_modules/yarn/package.json", '"installationMethod": "tar"', '"installationMethod": "brew"'
   end
 
   test do


### PR DESCRIPTION
fixes #10540
helps with https://github.com/yarnpkg/yarn/issues/2517

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
