### PR TITLE
Fix style for llvm@3.9 and ruby@2.3

### DIFF
--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -72,13 +72,13 @@ class LlvmAT39 < Formula
       sha256 "9ba5e61fc7bf8c7435f64e2629e0810c9b1d1b03aa5b5605b780d0e177b4cb46"
     end
   end
+
   bottle do
     cellar :any
     sha256 "367c8263a2ddb03b01026144cbacbb59a5c89678f0cd6b66a8ca7e54e3a6f09a" => :sierra
     sha256 "a71eccd058680a69428d42f0f936879c5fd051664acb2ef614c257116dd3d9e4" => :el_capitan
     sha256 "3eb7fd1ce32ce5489c85c209d709b07aed6d720f316cdbe12faca0019ba3b1a7" => :yosemite
   end
-
 
   head do
     url "http://llvm.org/git/llvm.git", :branch => "release_39"

--- a/Formula/ruby@2.3.rb
+++ b/Formula/ruby@2.3.rb
@@ -16,12 +16,12 @@ class RubyAT23 < Formula
       sha256 "929c618f74e89a5e42d899a962d7d2e4af75716523193af42626884eaba1d765"
     end
   end
+
   bottle do
     sha256 "b65c706a4582caedab0f44343dfc516020a97b5adbe26d0f0c983a7cf5b5c08a" => :sierra
     sha256 "394b88d104efd8d58cdfbb870e33914f1e495cc5d8b697189d0318547128a33a" => :el_capitan
     sha256 "052a0d908559db900dd91c425723a1f346d5c5583986ed7b73f395a3c1b5afb3" => :yosemite
   end
-
 
   keg_only :versioned_formula
 


### PR DESCRIPTION
Before:
```sh
$ brew style *.rb
== llvm@3.9.rb ==
C: 82:  1: Extra blank line detected.
== ruby@2.3.rb ==
C: 25:  1: Extra blank line detected.

4091 files inspected, 2 offenses detected
```

After:
```sh
$ brew style llvm\@3.9.rb ruby\@2.3.rb 

2 files inspected, no offenses detected
```