### PR TITLE
xsv 0.10.3 (new formula)

### DIFF
--- a/Formula/xsv.rb
+++ b/Formula/xsv.rb
@@ -1,0 +1,20 @@
+class Xsv < Formula
+  desc "Fast CSV toolkit written in Rust."
+  homepage "https://github.com/BurntSushi/xsv"
+  url "https://github.com/BurntSushi/xsv/archive/0.10.3.tar.gz"
+  sha256 "856addb2067724319b85c76619a41745e90ba0bf3d42221594154479dc4419b1"
+  head "https://github.com/BurntSushi/xsv.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--release"
+
+    bin.install "target/release/xsv"
+  end
+
+  test do
+    (testpath/"test.csv").write("first header,second header")
+    system "#{bin}/xsv", "stats", "test.csv"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a formula for [xsv](https://github.com/BurntSushi/xsv). It was adapted from [ripgrep.rb](https://github.com/Homebrew/homebrew-core/blob/7fe2d5b58fa2790920cb57ea6dfb7c18253e1f06/Formula/ripgrep.rb).