### PR TITLE
rnp 3.99.18 (new formula)

### DIFF
--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -1,0 +1,40 @@
+class Rnp < Formula
+  desc "The Ribose fork of NetPGP."
+  homepage "https://github.com/riboseinc/rnp"
+  url "https://github.com/riboseinc/rnp/archive/3.99.18.tar.gz"
+  sha256 "b61ae76934d4d125660530bf700478b8e4b1bb40e75a4d60efdb549ec864c506"
+  head "https://github.com/riboseinc/rnp.git", :using => :git
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "openssl"
+
+  def install
+    # Generate the configure/Make files. Ideally this won't be necessary
+    # in the future.
+
+    mkdir "m4"
+    system "autoreconf", "-ivf"
+
+    # Configure, make, and install.
+
+    openssl = Formula["openssl"]
+
+    ENV["CFLAGS"]  = "-I#{openssl.opt_include}"
+    ENV["LDFLAGS"] = "-L#{openssl.opt_lib}"
+
+    args = %W[
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --with-openssl=#{openssl.opt_prefix}
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/netpgp", "--version"
+  end
+end

--- a/Formula/rnp.rb
+++ b/Formula/rnp.rb
@@ -21,8 +21,8 @@ class Rnp < Formula
 
     openssl = Formula["openssl"]
 
-    ENV["CFLAGS"]  = "-I#{openssl.opt_include}"
-    ENV["LDFLAGS"] = "-L#{openssl.opt_lib}"
+    ENV.append "CFLAGS", "-I#{openssl.opt_include}"
+    ENV.append "LDFLAGS", "-L#{openssl.opt_lib}"
 
     args = %W[
       --prefix=#{prefix}
@@ -35,6 +35,6 @@ class Rnp < Formula
   end
 
   test do
-    system "#{bin}/netpgp", "--version"
+    system bin/"netpgp", "--version"
   end
 end


### PR DESCRIPTION
This formula installs the latest rnp (https://github.com/riboseinc/rnp), a fork of the NetPGP package from NetBSD that runs on macOS and Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
