### PR TITLE
exa 0.4.1 (new formula)

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -1,0 +1,25 @@
+class Exa < Formula
+  desc "Replacement for 'ls' written in Rust."
+  homepage "https://the.exa.website"
+  url "https://github.com/iKevinY/exa/archive/v0.4.1.tar.gz"
+  sha256 "9302a9a99a8d06abd6f1743b4d4c41306697af8e97d3203272cab26a425b5c8b"
+  head "https://github.com/ogham/exa.git"
+
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+  depends_on "libgit2" => :recommended
+
+  def install
+    args = ["--release"]
+    args << "--no-default-features" if build.without? "libgit2"
+
+    system "cargo", "build", *args
+    bin.install "target/release/exa"
+    man1.install "contrib/man/exa.1"
+  end
+
+  test do
+    (testpath/"test.txt").write("")
+    assert_match "test.txt", shell_output("exa")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`exa` already exists as a Cask, but given the fact that it's a command line application, it seems more appropriate for it to be a core formula. The download URL points to my fork of the project because the latest official release (0.4.0) has a bug where the program fails to run on Sierra (see ogham/exa#140). This bug is fixed on `master`, but a newer release was never published, and @ogham hasn't been active on GitHub for several months, so I decided to fork the project in order to publish a new release.

Link to `homebrew-cask` migration PR: caskroom/homebrew-cask#31240