### PR TITLE
bibtex2html: fix error ':tex is deprecated'

### DIFF
--- a/Formula/bibtex2html.rb
+++ b/Formula/bibtex2html.rb
@@ -15,7 +15,6 @@ class Bibtex2html < Formula
 
   depends_on "ocaml"
   depends_on "hevea"
-  depends_on :tex => :optional
 
   def install
     # See: https://trac.macports.org/ticket/26724


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
