### PR TITLE
latex2html: fix error ":tex is deprecated"

### DIFF
--- a/Formula/latex2html.rb
+++ b/Formula/latex2html.rb
@@ -13,7 +13,6 @@ class Latex2html < Formula
 
   depends_on "netpbm"
   depends_on "ghostscript"
-  depends_on :tex => :optional
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
