### PR TITLE
kibana@4.4: fix brew audit warning

### DIFF
--- a/Formula/kibana@4.4.rb
+++ b/Formula/kibana@4.4.rb
@@ -45,7 +45,7 @@ class KibanaAT44 < Formula
 
     ENV.prepend_path "PATH", prefix/"libexec/node/bin"
     Pathname.new("#{ENV["HOME"]}/.npmrc").write Language::Node.npm_cache_config
-    system "npm", "install"
+    system "npm", "install", *Language::Node.local_npm_install_args
     system "npm", "run", "build"
     mkdir "tar" do
       system "tar", "--strip-components", "1", "-xf", Dir[buildpath/"target/kibana-*-#{platform}.tar.gz"].first


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
``` brew audit kibana@4.4 ``` gives the following warning:
``` * Use Language::Node for npm install args ```

This change removes that warning. 