### PR TITLE
freetds: fix brew audit warning

### DIFF
--- a/Aliases/freetds@1.00
+++ b/Aliases/freetds@1.00
@@ -1,0 +1,1 @@
+../Formula/freetds.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
``` brew audit freetds ``` gave the warning: 
``` 
  * Formula has other versions so create an alias:
      cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Aliases
      ln -s ../Formula/freetds.rb freetds@1.00
 ```

This PR resolves that warning. 