### PR TITLE
platformio 3.3.0

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -19,7 +19,7 @@ class Platformio < Formula
     url "https://pypi.python.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
     sha256 "805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
   end
-  
+
   resource "python-dateutil" do
     url "https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
     sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -14,11 +14,11 @@ class Platformio < Formula
   end
 
   depends_on :python if MacOS.version <= :snow_leopard
-  
+
   resource "arrow" do
     url "https://pypi.python.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
     sha256 "805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
-  end  
+  end
 
   resource "bottle" do
     url "https://pypi.python.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -19,6 +19,11 @@ class Platformio < Formula
     url "https://pypi.python.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
     sha256 "805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
   end
+  
+  resource "python-dateutil" do
+    url "https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
+    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+  end
 
   resource "bottle" do
     url "https://pypi.python.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/01/29/5720a510593527335710a6f0219d7e7cff177d799cfeb61a74e2a2e94f84/platformio-3.2.1.tar.gz"
-  sha256 "fad4b32bc68f44ac0df7582d2965be456012bd79bb6c220797155d220c503d17"
+  url "https://pypi.python.org/packages/97/02/58c93caf59a93999b9b17640b467fca5812a96fae30de6b9acc84d827676/platformio-3.3.0.tar.gz"
+  sha256 "6870d177035bd75472862b57c4c03a910174da5d217e69d5ddd12aa54a43ad64"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,8 +16,8 @@ class Platformio < Formula
   depends_on :python if MacOS.version <= :snow_leopard
 
   resource "bottle" do
-    url "https://pypi.python.org/packages/7e/b5/a8404cf922bdedb63b41e9b6f3ae64c93f99cf1accdf0fc265ae75f063a2/bottle-0.12.10.tar.gz"
-    sha256 "1308133647adc2d266f0ba5fea6684ba955cbf5e8133590cf0314c8beb814ff4"
+    url "https://pypi.python.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"
+    sha256 "39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355"
   end
 
   resource "click" do
@@ -36,13 +36,13 @@ class Platformio < Formula
   end
 
   resource "pyserial" do
-    url "https://pypi.python.org/packages/1f/3b/ee6f354bcb1e28a7cd735be98f39ecf80554948284b41e9f7965951befa6/pyserial-3.2.1.tar.gz"
-    sha256 "1eecfe4022240f2eab5af8d414f0504e072ee68377ba63d3b6fe6e66c26f66d1"
+    url "https://pypi.python.org/packages/8d/88/cf848688ae011085a6da5a470740dafa3a4b105f84a5f79c3b720c19279c/pyserial-3.3.tar.gz"
+    sha256 "2949cddffc2b05683065a3cd2345114b1a49b08df8cb843d69ba99dc3e19edc2"
   end
 
   resource "requests" do
-    url "https://files.pythonhosted.org/packages/2e/ad/e627446492cc374c284e82381215dcd9a0a87c4f6e90e9789afefe6da0ad/requests-2.11.1.tar.gz"
-    sha256 "5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133"
+    url "https://pypi.python.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz"
+    sha256 "5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8"
   end
 
   resource "semantic_version" do

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -14,6 +14,11 @@ class Platformio < Formula
   end
 
   depends_on :python if MacOS.version <= :snow_leopard
+  
+  resource "arrow" do
+    url "https://pypi.python.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
+    sha256 "805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
+  end  
 
   resource "bottle" do
     url "https://pypi.python.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"


### PR DESCRIPTION
# PlatformIO 3.3.0
* PlatformIO Library Registry statistics with new [pio lib stats](http://docs.platformio.org/page/userguide/lib/cmd_stats.html) command

  - Recently updated and added libraries
  - Recent and popular keywords
  - Featured libraries (today, week, month)

* List built-in libraries based on development platforms with a new [pio lib builtin](http://docs.platformio.org/page/userguide/lib/cmd_builtin.html) command
* Show detailed info about a library using [pio lib show](http://docs.platformio.org/page/userguide/lib/cmd_show.html) command ([issue #430](https://github.com/platformio/platformio-core/issues/430))
* List supported frameworks, SDKs with a new [pio platform frameworks](http://docs.platformio.org/en/latest/userguide/platforms/cmd_frameworks.htmll) command
* Visual Studio Code extension for PlatformIO ([issue #619](https://github.com/platformio/platformio-core/issues/619))
* Added new options ``--no-reset``, ``--monitor-rts`` and ``--monitor-dtr`` to [pio test](http://docs.platformio.org/en/latest/userguide/cmd_test.html) command (allows to avoid automatic board's auto-reset when gathering test results)
* Added support for templated methods in ``*.ino to *.cpp`` converter ([pull #858](https://github.com/platformio/platformio-core/pull/858))
* Package version as "Repository URL" in manifest of development version (``"version": "https://github.com/user/repo.git"``)
* Produce less noisy output when ``-s/--silent`` options are used for [platformio init](http://docs.platformio.org/page/userguide/cmd_init.html) and [platformio run](http://docs.platformio.org/page/userguide/cmd_run.html) commands ([issue #850](https://github.com/platformio/platformio-core/issues/850))
* Use C++11 by default for CLion IDE based projects ([pull #873](https://github.com/platformio/platformio-core/pull/873))
* Escape project path when Glob matching is used
* Do not overwrite project configuration variables when system environment variables are set
* Handle dependencies when installing non-registry package/library (VCS, archive, local folder) ([issue #913](https://github.com/platformio/platformio-core/issues/913))
* Fixed package installing with VCS branch for Python 2.7.3 ([issue #885](https://github.com/platformio/platformio-core/issues/885))


-------

* Development platform [Atmel AVR](https://github.com/platformio/platform-atmelavr)

  + New boards: EnviroDIY Mayfly, The Things Uno, SparkFun Qduino Mini, SparkFun ATmega128RFA1 Dev Board, SparkFun Serial 7-Segment Display, Generic ATTiny2313 and ATTiny4313
  + Set fuse bits with new target named ``fuses`` ([issue #865](https://github.com/platformio/platformio-core/issues/865))
  + Updated Arduino Core to 1.6.17
  + Fixed ISO C99 warning for EnviroDIY Mayfly board
  + Fixed firmware uploading to Arduino Leonardo

* Development platform [Atmel SAM](https://github.com/platformio/platform-atmelsam)

  + Added support for Adafruit Circuit Playground Express, Arduino MKRZero, Atmel ATSAMW25-XPRO boards
  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137
  + Updated Arduino SAM & SAMD Core to 1.6.11

* Development platform [Espressif 32](https://github.com/platformio/platform-espressif32)

  + Added support for Simba & Pumbaa Frameworks
  + Added new boards: Node32s, Hornbill ESP32 Dev, Hornbill ESP32 Minim
  + Updated Arduino Core
  + Updated ESP-IDF framework to the latest v2.0 Release Candidate 1
  + New ESP IDF examples: BLE, Coap Server, Peripherals UART, Storage SDCard

* Development platform [Freescale Kinetis](https://github.com/platformio/platform-freescalekinetis)

  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137

* Development platform [Lattice iCE40](https://github.com/platformio/platform-lattice_ice40)

  + Improved path management for Windows
  + Custom uploader using ``$UPLOAD`` build variable ([issue #6](https://github.com/platformio/platform-lattice_ice40/issues/6))
  + Updated toolchain-icestorm to 1.10.0 (added -C option to "time" target)
  + Updated toolchain-iverilog to 1.1.0  (loaed all vlib/\*.v files in "iverilog" builder)

* Development platform [Linux ARM](https://github.com/platformio/platform-linux_arm)

  + Added support for Samsung ARTIK boards (520, 530, 710, 1020) and ARTIK SDK ([issue #353](https://github.com/platformio/platformio-core/issues/353))

* Development platform [Nordic nRF51](https://github.com/platformio/platform-nordicnrf51)

  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137

* Development platform [NXP LPC](https://github.com/platformio/platform-nxplpc)

  + Added support for LPCXpresso4337 and y5 LPC11U35 mbug boards
  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137

* Development platform [Silicon Labs EFM32](https://github.com/platformio/platform-siliconlabsefm32)

  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137

* Development platform [ST STM32](https://github.com/platformio/platform-ststm32)

  + Added support for new boards: Espotel LoRa Module, NAMote72, MTS Dragonfly, ST Nucleo F303ZE, u-blox EVK-ODIN-W2, MultiTech xDot
  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137

* Development platform [Teensy](https://github.com/platformio/platform-teensy)

  + Added support for ARM mbed events library
  + Updated ARM mbed OS to 5.3.6/rev137
  + Updated Arduino Core to v1.35

* Development platform [TI TIVA](https://github.com/platformio/platform-titiva)

  + Updated Energia Core to 1.0.2