### PR TITLE
cdrtools: remove mirror that wasn't updated

### DIFF
--- a/Formula/cdrtools.rb
+++ b/Formula/cdrtools.rb
@@ -5,7 +5,6 @@ class Cdrtools < Formula
 
   stable do
     url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.01.tar.bz2"
-    mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/c/cd/cdrtools/cdrtools-3.01.tar.bz2"
     mirror "https://fossies.org/linux/misc/cdrtools-3.01.tar.bz2"
     sha256 "ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

mirror is pointing to cdrtools-3.00.tar.gz, not cdrtools-3.01.tar.gz,
but 3.01 was released in 2015