### PR TITLE
skinny 2.3.6

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.5/skinny-2.3.5.tar.gz"
-  sha256 "aba2495eba4c172726135b23d118b386cc5ddaaa6839b041c13369bc3e34da20"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.6/skinny-2.3.6.tar.gz"
+  sha256 "f58402433b5ede9a6a94e95a9bf651b59f67c3b3ae87c04771b371533b0ad4cd"
 
   bottle :unneeded
 

--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -5,6 +5,7 @@ class Skinny < Formula
   sha256 "f58402433b5ede9a6a94e95a9bf651b59f67c3b3ae87c04771b371533b0ad4cd"
 
   bottle :unneeded
+  depends_on :java => "1.7+"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
skinny 2.3.6 is out. Thank you as always 🙇
https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.6

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.6/skinny-2.3.6.tar.gz
==> Downloading from https://github-cloud.s3.amazonaws.com/releases/13057782/f5457f18-134f-11e7-8dba-b28860985c27.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20170327%2Fus-east-1%2Fs3%2Faws4_request&X-Amz
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.6: 915 files, 98.7MB, built in 35 seconds
$ brew audit --strict skinny
```
