### PR TITLE
jvm-mon 0.3 (new formula)

### DIFF
--- a/Formula/jvm-mon.rb
+++ b/Formula/jvm-mon.rb
@@ -1,0 +1,19 @@
+class JvmMon < Formula
+  desc "Console-based JVM monitoring"
+  homepage "https://github.com/ajermakovics/jvm-mon"
+  url "https://github.com/ajermakovics/jvm-mon/releases/download/0.3/jvm-mon-0.3.tar.gz"
+  sha256 "9b5dd3d280cb52b6e2a9a491451da2ee41c65c770002adadb61b02aa6690c940"
+
+  depends_on :java => "1.8+"
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"bin/jvm-mon"
+    system "unzip", "-j", libexec/"lib/j2v8_macosx_x86_64-4.6.0.jar", "libj2v8_macosx_x86_64.dylib", "-d", libexec
+  end
+
+  test do
+    system "echo q | #{bin}/jvm-mon"
+  end
+end

--- a/Formula/jvm-mon.rb
+++ b/Formula/jvm-mon.rb
@@ -4,6 +4,8 @@ class JvmMon < Formula
   url "https://github.com/ajermakovics/jvm-mon/releases/download/0.3/jvm-mon-0.3.tar.gz"
   sha256 "9b5dd3d280cb52b6e2a9a491451da2ee41c65c770002adadb61b02aa6690c940"
 
+  bottle :unneeded
+
   depends_on :java => "1.8+"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a new formula for [jvm-mon](https://github.com/ajermakovics/jvm-mon) - Console based JVM monitoring tool
