### PR TITLE
elasticsearch: 5.3.0

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.2.tar.gz"
-  sha256 "cf88930695794a8949342d386f028548bd10b26ecc8c4b422a94ea674faf8ac9"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.tar.gz"
+  sha256 "effd922973e9f4fe25565e0a194a4b534c08b22849f03cb9fea13c311401e21b"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"


### PR DESCRIPTION
This pull request bumps the Elasticsearch version from 5.2.2 to 5.3.0.