### PR TITLE
mlton: Add --HEAD build target

### DIFF
--- a/Formula/mlton.rb
+++ b/Formula/mlton.rb
@@ -1,9 +1,19 @@
 class Mlton < Formula
   desc "Whole-program, optimizing compiler for Standard ML"
   homepage "http://mlton.org"
-  url "https://downloads.sourceforge.net/project/mlton/mlton/20130715/mlton-20130715.src.tgz"
   version "20130715"
-  sha256 "215857ad11d44f8d94c27f75e74017aa44b2c9703304bcec9e38c20433143d6c"
+  head "https://github.com/MLton/mlton.git"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/mlton/mlton/20130715/mlton-20130715.src.tgz"
+    sha256 "215857ad11d44f8d94c27f75e74017aa44b2c9703304bcec9e38c20433143d6c"
+
+    # Configure GMP location via Makefile (https://github.com/MLton/mlton/pull/136)
+    patch do
+      url "https://github.com/MLton/mlton/commit/6e79342cdcf2e15193d95fcd3a46d164b783aed4.diff"
+      sha256 "2d44891eaf3fdecd3b0f6de2bdece463c71c425100fbac2d00196ad159e5c707"
+    end
+  end
 
   bottle do
     cellar :any
@@ -19,12 +29,6 @@ class Mlton < Formula
   resource "bootstrap" do
     url "https://downloads.sourceforge.net/project/mlton/mlton/20130715/mlton-20130715-3.amd64-darwin.gmp-static.tgz"
     sha256 "7e865cd3d1e48ade3de9b7532a31e94af050ee45f38a2bc87b7b2c45ab91e8e1"
-  end
-
-  # Configure GMP location via Makefile (https://github.com/MLton/mlton/pull/136)
-  patch do
-    url "https://github.com/MLton/mlton/commit/6e79342cdcf2e15193d95fcd3a46d164b783aed4.diff"
-    sha256 "2d44891eaf3fdecd3b0f6de2bdece463c71c425100fbac2d00196ad159e5c707"
   end
 
   def install

--- a/Formula/mlton.rb
+++ b/Formula/mlton.rb
@@ -1,11 +1,11 @@
 class Mlton < Formula
   desc "Whole-program, optimizing compiler for Standard ML"
   homepage "http://mlton.org"
-  version "20130715"
   head "https://github.com/MLton/mlton.git"
 
   stable do
     url "https://downloads.sourceforge.net/project/mlton/mlton/20130715/mlton-20130715.src.tgz"
+    version "20130715"
     sha256 "215857ad11d44f8d94c27f75e74017aa44b2c9703304bcec9e38c20433143d6c"
 
     # Configure GMP location via Makefile (https://github.com/MLton/mlton/pull/136)


### PR DESCRIPTION
After the most recent changes to the mlton formula (see
Homebrew/legacy-homebrew#48694), mlton basically supports building from
HEAD for free.

The only tricky change here is that the patch block is only needed for
the stable (because the patch has been merged already on HEAD).

I don't think the idea behind this change is unwelcome, but if it is I'm open
to suggestions.

/cc @MatthewFluet and @apjanke, who were involved in the previous PR.