### PR TITLE
nyancat: remove formula name from description

### DIFF
--- a/Formula/nyancat.rb
+++ b/Formula/nyancat.rb
@@ -1,5 +1,5 @@
 class Nyancat < Formula
-  desc "Nyancat in your terminal, rendered through ANSI escape sequences."
+  desc "Renders an animated, color, ANSI-text loop of the Poptart Cat"
   homepage "https://github.com/klange/nyancat"
   url "https://github.com/klange/nyancat/archive/1.5.1.tar.gz"
   sha256 "c948c769d230b4e41385173540ae8ab1f36176de689b6e2d6ed3500e9179b50a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?