### PR TITLE
subversion: remove env :userpaths

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -52,11 +52,6 @@ class Subversion < Formula
   patch :DATA
 
   if build.with?("perl") || build.with?("ruby")
-    # If building bindings, allow non-system interpreters
-    # Currently the serf -> scons dependency forces stdenv, so this isn't
-    # strictly necessary
-    env :userpaths
-
     # When building Perl or Ruby bindings, need to use a compiler that
     # recognizes GCC-style switches, since that's what the system languages
     # were compiled against.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`env :userpaths` in formulae is deprecated