### PR TITLE
minio: Fix to use go1.7 instead of go1.8

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -5,6 +5,7 @@ class Minio < Formula
     :tag => "RELEASE.2017-03-16T21-50-32Z",
     :revision => "6e7d33df203d0c11d014b6625bfd18aada22328a"
   version "20170316215032"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
