### PR TITLE
spdylay: adjust test

### DIFF
--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -36,6 +36,6 @@ class Spdylay < Formula
   end
 
   test do
-    system "#{bin}/spdycat", "-ns", "https://nghttp2.org"
+    system "#{bin}/spdycat", "-ns", "https://cloudflare.com/"
   end
 end


### PR DESCRIPTION
Current test fails with:

```
Server did not advertise SPDY protocol.
error:140920E3:SSL routines:ssl3_get_server_hello:parse tlsext
```