### PR TITLE
new formulae: glproto

### DIFF
--- a/Formula/glproto.rb
+++ b/Formula/glproto.rb
@@ -1,0 +1,17 @@
+class Glproto < Formula
+  desc "X11 OpenGL extension wire protocol"
+  homepage "https://wiki.freedesktop.org/xorg"
+  url "https://www.x.org/releases/individual/proto/glproto-1.4.17.tar.bz2"
+  sha256 "adaa94bded310a2bfcbb9deb4d751d965fcfe6fb3a2f6d242e2df2d6589dbe40"
+
+  depends_on :x11
+  depends_on "pkg-config" => :optional
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There is nothing to test because this formulae is header-only.
<details><summary>brew audit --strict glproto</summary>

```
$ brew audit --strict glproto
glproto:
  * A `test do` test block should be added
  * pkg-config dependency should be
      depends_on "pkg-config" => :build
    Or if it is indeed a runtime dependency
      depends_on "pkg-config" => :run
Error: 2 problems in 1 formula
```
</details>