### PR TITLE
gcc: restore secure head for Sierra and upper

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -15,7 +15,11 @@ class Gcc < Formula
   homepage "https://gcc.gnu.org/"
   revision 1
 
-  head "svn://gcc.gnu.org/svn/gcc/trunk"
+  if MacOS.version >= :sierra
+    head "https://gcc.gnu.org/svn/gcc/trunk", :using => :svn
+  else
+    head "svn://gcc.gnu.org/svn/gcc/trunk"
+  end
 
   stable do
     url "https://ftpmirror.gnu.org/gcc/gcc-6.3.0/gcc-6.3.0.tar.bz2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ref: https://github.com/Homebrew/homebrew-core/issues/11581#issuecomment-290574296

Jenkins should answer if this is the known SVN issue or not. If it is, it should also be fixed in the `gcc@*.rb` formulae.