### PR TITLE
yarn: fix to not use npm to install

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -1,26 +1,20 @@
-require "language/node"
-
 class Yarn < Formula
   desc "JavaScript package manager"
   homepage "https://yarnpkg.com/"
   url "https://yarnpkg.com/downloads/0.21.3/yarn-v0.21.3.tar.gz"
   sha256 "0946a4d1abc106c131b700cc31e5c3aa5f2205eb3bb9d17411f8115354a97d5d"
+  revision 1
   head "https://github.com/yarnpkg/yarn.git"
 
-  bottle do
-    cellar :any_skip_relocation
-    rebuild 2
-    sha256 "9858ac5a34367b65a20ee828cba84ded38ac1bd9920f6c11c28e5d3a896755cf" => :sierra
-    sha256 "de303f2b4ab5fe273082118825b01c3ef64bb4e109fc62d36eeb37d23dfe7b81" => :el_capitan
-    sha256 "9b0b0e12931a58f5ef2a29372a353f46a65d81de492cf919cb9ece34019cd999" => :yosemite
-  end
+  bottle :unneeded
 
   depends_on "node"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
-    inreplace "#{libexec}/lib/node_modules/yarn/package.json", '"installationMethod": "tar"', '"installationMethod": "homebrew"'
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/yarn.js" => "yarn"
+    bin.install_symlink "#{libexec}/bin/yarn.js" => "yarnpkg"
+    inreplace "#{libexec}/package.json", '"installationMethod": "tar"', '"installationMethod": "homebrew"'
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This doesn't pass it's test, and I'm unable to use it locally after install. There seems to be some issue  with the symlink. Instead of following it it's just prepended to the current path. So if I try to run yarn from a deep path:

```sh-session
$ ls -la /usr/local/Cellar/yarn/0.21.3/bin
total 16
drwxr-xr-x  4 simen  admin  136 Mar 31 08:21 .
drwxr-xr-x  8 simen  admin  272 Mar 31 08:21 ..
lrwxr-xr-x  1 simen  admin   19 Mar 31 08:21 yarn -> ../libexec/bin/yarn
lrwxr-xr-x  1 simen  admin   22 Mar 31 08:21 yarnpkg -> ../libexec/bin/yarnpkg
$ ls -la /usr/local/Cellar/yarn/0.21.3/libexec/bin
total 32
drwxr-xr-x   7 simen  admin   238 Feb 27 16:36 .
drwxr-xr-x  10 simen  admin   340 Mar 31 08:21 ..
drwxr-xr-x   4 simen  admin   136 Feb 27 16:36 node-gyp-bin
-rwxr-xr-x   1 simen  admin   906 Feb 27 16:29 yarn
-rw-r--r--   1 simen  admin    34 Feb 27 16:29 yarn.cmd
-rwxr-xr-x   1 simen  admin  1874 Feb 27 16:29 yarn.js
-rwxr-xr-x   1 simen  admin    42 Feb 27 16:29 yarnpkg
$ pwd
/Users/simen
$ /usr/local/Cellar/yarn/0.21.3/libexec/bin/yarn --version
0.21.3
$ /usr/local/Cellar/yarn/0.21.3/bin/yarn --version
module.js:472
    throw err;
    ^

Error: Cannot find module '/Users/libexec/bin/yarn.js'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:423:7)
    at startup (bootstrap_node.js:147:9)
    at bootstrap_node.js:538:3
```

Why does this happen? `brew test` fails because of this. Might be that the old npm solution put up some extra magic symlinks, but I can't find them, beyond the fact that old `libexec/bin` also was a symlink.

(this is using the old install)
```sh-session
$ ls -la /usr/local/Cellar/yarn/0.21.3/libexec/bin
total 16
drwxr-xr-x  4 simen  admin  136 Mar 31 08:33 .
drwxr-xr-x  5 simen  admin  170 Mar 31 08:33 ..
lrwxr-xr-x  1 simen  admin   36 Mar 31 08:33 yarn -> ../lib/node_modules/yarn/bin/yarn.js
lrwxr-xr-x  1 simen  admin   36 Mar 31 08:33 yarnpkg -> ../lib/node_modules/yarn/bin/yarn.js
```

/cc @Daniel15 