### PR TITLE
mpv: add options to re-enable optical media support

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -68,6 +68,9 @@ class Mpv < Formula
       --zshdir=#{zsh_completion}
     ]
     args << "--enable-libarchive" if build.with? "libarchive"
+    args << "--enable-libbluray" if build.with? "libbluray"
+    args << "--enable-dvdnav" if build.with? "libdvdnav"
+    args << "--enable-dvdread" if build.with? "libdvdread"
     args << "--enable-pulse" if build.with? "pulseaudio"
 
     system "./bootstrap.py"


### PR DESCRIPTION
Since mpv-player/mpv@77cbb35 optical media libs are disabled by default, so explicit flags needs to be passed to the configure script to build dvd/bd support.