### PR TITLE
osmium-tool 1.6.1 (new formula)

### DIFF
--- a/Formula/osmium-tool.rb
+++ b/Formula/osmium-tool.rb
@@ -1,0 +1,37 @@
+class OsmiumTool < Formula
+  desc "Libosmium-based command-line tool for processing OpenStreetMap data"
+  homepage "http://osmcode.org/osmium-tool/"
+  url "https://github.com/osmcode/osmium-tool/archive/v1.6.1.tar.gz"
+  sha256 "75523396b3fe51ff585a59251144bd61c93609df0703b7119fe6e16fd4ddb0fa"
+
+  depends_on "cmake" => :build
+  depends_on "libosmium" => :build
+  depends_on "boost"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.osm").write <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <osm version="0.6" generator="handwritten">
+        <node id="1" lat="0.001" lon="0.001" user="Dummy User" uid="1" version="1" changeset="1" timestamp="2015-11-01T19:00:00Z"></node>
+        <node id="2" lat="0.002" lon="0.002" user="Dummy User" uid="1" version="1" changeset="1" timestamp="2015-11-01T19:00:00Z"></node>
+        <way id="1" user="Dummy User" uid="1" version="1" changeset="1" timestamp="2015-11-01T19:00:00Z">
+          <nd ref="1"/>
+          <nd ref="2"/>
+          <tag k="name" v="line"/>
+        </way>
+        <relation id="1" user="Dummy User" uid="1" version="1" changeset="1" timestamp="2015-11-01T19:00:00Z">
+          <member type="node" ref="1" role=""/>
+          <member type="way" ref="1" role=""/>
+        </relation>
+      </osm>
+    EOS
+    output = shell_output("#{bin}/osmium fileinfo test.osm")
+    assert_match /Compression.+generator=handwritten/m, output
+    system bin/"osmium", "tags-filter", "test.osm", "w/name=line", "-f", "osm"
+  end
+end


### PR DESCRIPTION
This is a highly useful command-line tool to work with OpenStreetMap files. Basically it is the interface to the libosmium library that is already in the homebrew. Made and quite frequently updated by the same author. The official website: http://osmcode.org/osmium-tool/

Version 1.6.0 requires libosmium 1.12.0 (see #11899).