### PR TITLE
ejdb: improve test compatibility

### DIFF
--- a/Formula/ejdb.rb
+++ b/Formula/ejdb.rb
@@ -58,7 +58,8 @@ class Ejdb < Formula
           uint32_t count;
           TCLIST *res = ejdbqryexecute(coll, q1, &count, 0, NULL);
 
-          for (int i = 0; i < TCLISTNUM(res); ++i) {
+          int i;
+          for (i = 0; i < TCLISTNUM(res); ++i) {
               void *bsdata = TCLISTVALPTR(res, i);
               bson_print_raw(bsdata, 0);
           }
@@ -72,8 +73,7 @@ class Ejdb < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "-I#{include}", "-L#{lib}", "-lejdb",
-           "test.c", "-o", testpath/"test"
+    system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lejdb", "-o", testpath/"test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request fixes two standards compliance issues in the tests for more restrictive compilers like `gcc-4.8`:

1. Fixes "'for' loop initial declarations are only allowed in C99 mode"

2. Also reorders the arguments to `ENV.cc` to avoid linker errors. Since files are searched from left to right to resolve symbols, source files must precede library files.