### PR TITLE
kitchen-sync: add option to build with MariaDB

### DIFF
--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -15,10 +15,11 @@ class KitchenSync < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "yaml-cpp" => (MacOS.version <= :mountain_lion ? "c++11" : [])
+  depends_on "yaml-cpp"
 
   depends_on :mysql => :recommended
   depends_on :postgresql => :optional
+  depends_on "mariadb" => :optional
 
   needs :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
