### PR TITLE
stdman 2017-02-14

### DIFF
--- a/Formula/stdman.rb
+++ b/Formula/stdman.rb
@@ -1,8 +1,11 @@
 class Stdman < Formula
-  desc "Formatted C++11/14 stdlib man pages from cppreference.com"
+  desc "Formatted C++11/14/17 stdlib man pages from cppreference.com"
   homepage "https://github.com/jeaye/stdman"
-  url "https://github.com/jeaye/stdman/archive/v0.2.tar.gz"
-  sha256 "9591835b0f57f88698d7c46ef645064a4af646644535cf2a052152656d73329a"
+  url "https://github.com/jeaye/stdman.git",
+    :revision => "61d5fbd2c831f82b29ffd247ee73539b456ba0d6"
+  version "2017-02-14"
+  version_scheme 1
+  head "https://github.com/jeaye/stdman.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Also versioning was changed, because it makes more sense to sync versions with cpprefrence archive updates rather than with repo's tags because author of original repo doesn't seem to care much about updates.

And url:revision is now used instead of url:sha, because there are no releases, see first line.
Minor edit for description, because it now has pages for C++17 too (try `man std::variant`)

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
