### PR TITLE
dirmngr: fix patch URL

### DIFF
--- a/Formula/dirmngr.rb
+++ b/Formula/dirmngr.rb
@@ -23,7 +23,7 @@ class Dirmngr < Formula
   patch :p0 do
     # patch by upstream developer to fix an API incompatibility with libgcrypt >=1.6.0
     # causing immediate segfault in dirmngr. see https://bugs.gnupg.org/gnupg/issue1590
-    url "https://bugs.gnupg.org/gnupg/file419/dirmngr-pth-fix.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6965aa5/dirmngr/D186.diff"
     sha256 "0efbcf1e44177b3546fe318761c3386a11310a01c58a170ef60df366e5160beb"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a fix for https://github.com/Homebrew/homebrew-core/issues/12001
The GnuPG bug tracker no longer provides a way to download the raw patch file, therefore the patch file is now put into [Homebrew/formula-patches](https://github.com/Homebrew/formula-patches).

**Note**: this PR is blocked until https://github.com/Homebrew/formula-patches/pull/127 is merged and the URL is updated here.

**TODO**:
- [x] Wait until https://github.com/Homebrew/formula-patches/pull/127 is merged
- [x] Update patch URL in this PR