### PR TITLE
new blitz repository for head

### DIFF
--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -13,7 +13,7 @@ class Blitz < Formula
   end
 
   head do
-    url "http://blitz.hg.sourceforge.net:8000/hgroot/blitz/blitz", :using => :hg
+    url "https://github.com/blitzpp/blitz.git", :using => :git
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -13,7 +13,7 @@ class Blitz < Formula
   end
 
   head do
-    url "https://github.com/blitzpp/blitz.git", :using => :git
+    url "https://github.com/blitzpp/blitz.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

blitz has moved to a git repository which is more up to date than the mercurial repository.  I have only changed the repository name and removed the requirement for hg