### PR TITLE
giflib 4->5 migration, part 1

### DIFF
--- a/Formula/giflib@4.rb
+++ b/Formula/giflib@4.rb
@@ -1,0 +1,20 @@
+class GiflibAT4 < Formula
+  desc "GIF library using patented LZW algorithm"
+  homepage "https://giflib.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2"
+  sha256 "0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766"
+
+  keg_only :versioned_formula
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-x11",
+                          "--without-x"
+    system "make", "install"
+  end
+
+  test do
+    assert_match /Size: 1x1/, shell_output("#{bin}/gifinfo #{test_fixtures("test.gif")}")
+  end
+end

--- a/Formula/pdf2htmlex.rb
+++ b/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.14.6.tar.gz"
   sha256 "320ac2e1c2ea4a2972970f52809d90073ee00a6c42ef6d9833fb48436222f0e5"
-  revision 12
+  revision 13
 
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 
@@ -26,7 +26,7 @@ class Pdf2htmlex < Formula
   depends_on "libtool" => :run
   depends_on "cairo"
   depends_on "freetype"
-  depends_on "giflib"
+  depends_on "giflib@4"
   depends_on "glib"
   depends_on "pango"
   depends_on "gettext"

--- a/Formula/swftools.rb
+++ b/Formula/swftools.rb
@@ -3,7 +3,7 @@ class Swftools < Formula
   homepage "http://www.swftools.org/"
   url "http://www.swftools.org/swftools-0.9.2.tar.gz"
   sha256 "bf6891bfc6bf535a1a99a485478f7896ebacbe3bbf545ba551298080a26f01f1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "479570fcb99302996b55c361db1a6bb4a3abee611533b854fa350956f6b8cf61" => :sierra
@@ -18,7 +18,7 @@ class Swftools < Formula
   depends_on :x11 if build.with? "xpdf"
   depends_on "jpeg" => :optional
   depends_on "lame" => :optional
-  depends_on "giflib" => :optional
+  depends_on "giflib@4" => :optional
   depends_on "fftw" => :optional
 
   resource "xpdf" do


### PR DESCRIPTION
Creating a new `giflib@4` formula for `swftools`, which depends on that version.