### PR TITLE
micro: fixing formula to work correctly when reinstalling from HEAD

### DIFF
--- a/Formula/micro.rb
+++ b/Formula/micro.rb
@@ -102,7 +102,7 @@ class Micro < Formula
     mkdir_p buildpath/"src/github.com/zyedidia"
     ln_s buildpath, buildpath/"src/github.com/zyedidia/micro"
     Language::Go.stage_deps resources, buildpath/"src"
-    system "make", "build-quick"
+    system "make", "runtime", "build"
     bin.install "micro"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

when attempting to run `brew reinstall micro` to reinstall the current version of `HEAD`, the existing brew formula fails to build due to changes in dependencies and not correctly updating the runtime.go file to account for asset changes.

Original Install Log: https://gist.github.com/samdmarshall/853bc356e5b402345c7f441fb199be75
Fixed Install Log: https://gist.github.com/samdmarshall/b966b5944d90334b7e291b551b922b30


The core problem here is that the `quick-build` target in the makefile does not cause `go` to check the dependency graph, which was fixed by changing `quick-build` to `build`. This presented an additional problem of not having built the runtime.go file out correctly, so an additional target (`runtime`) as added prior to `build` to fix this issue.