### PR TITLE
kafkacat: fix missing version information

### DIFF
--- a/Formula/kafkacat.rb
+++ b/Formula/kafkacat.rb
@@ -1,8 +1,9 @@
 class Kafkacat < Formula
   desc "Generic command-line non-JVM Apache Kafka producer and consumer"
   homepage "https://github.com/edenhill/kafkacat"
-  url "https://github.com/edenhill/kafkacat.git", :tag => "1.3.0"
-  sha256 "1170daa3ec66f32542872fb8a181f021589dc19d510ebc3b141adccc02d2ae5d"
+  url "https://github.com/edenhill/kafkacat.git",
+      :tag => "1.3.0",
+      :revision => "b79896cceedf81df7873850f38e5e2c4ad3e3e57"
   revision 1
 
   bottle do

--- a/Formula/kafkacat.rb
+++ b/Formula/kafkacat.rb
@@ -1,8 +1,9 @@
 class Kafkacat < Formula
   desc "Generic command-line non-JVM Apache Kafka producer and consumer"
   homepage "https://github.com/edenhill/kafkacat"
-  url "https://github.com/edenhill/kafkacat/archive/1.3.0.tar.gz"
+  url "https://github.com/edenhill/kafkacat.git", :tag => "1.3.0"
   sha256 "1170daa3ec66f32542872fb8a181f021589dc19d510ebc3b141adccc02d2ae5d"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
kafkacat currently requires checking out from git at build time
to show the correct version when running `kafkacat -v`

(see https://github.com/edenhill/kafkacat/issues/92)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@edenhill