### PR TITLE
flif 0.3 (new formula)

### DIFF
--- a/Formula/flif.rb
+++ b/Formula/flif.rb
@@ -1,0 +1,32 @@
+class Flif < Formula
+  desc "Free Loseless Image Format"
+  homepage "http://flif.info/"
+  # When updating, please check if FLIF switched to CMake yet
+  url "https://github.com/FLIF-hub/FLIF/archive/v0.3.tar.gz"
+  sha256 "aa02a62974d78f8109cff21ecb6d805f1d23b05b2db7189cfdf1f0d97ff89498"
+  head "https://github.com/FLIF-hub/FLIF.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "libpng"
+  depends_on "sdl2"
+
+  resource "test_c" do
+    url "https://raw.githubusercontent.com/FLIF-hub/FLIF/dcc2011/tools/test.c"
+    sha256 "a20b625ba0efdb09ad21a8c1c9844f686f636656f0e9bd6c24ad441375223afe"
+  end
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install", "install-dev"
+    doc.install "doc/flif.pdf"
+  end
+
+  test do
+    testpath.install resource("test_c")
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lflif", "-o", "test"
+    system "./test", "dummy.flif"
+    system bin/"flif", "-i", "dummy.flif"
+    system bin/"flif", "-I", test_fixtures("test.png"), "test.flif"
+    system bin/"flif", "-d", "test.flif", "test.png"
+    assert_predicate testpath/"test.png", :exist?, "Failed to decode test.flif"
+  end
+end


### PR DESCRIPTION
It currently has two issues: 
- It has a patch
Upstream Makefile  uses `install -s`, which calls `strip`, which fails, while `strip -x` works fine.
I'm not sure what's the right way to solve this. I looked through install(1), but haven't found anything. If the way I did it is correct, I'd fill an upstream PR.

- Tests are missing
FLIF already has tests in Makefile. I'm not sure what's the proper way to "port" them, because they need some files in repo's `test` dir.
Should I add a resource for them (which would be the same as formula's resource), patch makefile so it doesn't rebuild everything before testing, and then call `make test`?

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
