### PR TITLE
ntp 4.2.8p10: new formula

### DIFF
--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -10,22 +10,6 @@ class Ntp < Formula
     sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
   end
 
-  head do
-    ## The git repo is broken/ancient, per
-    ## https://github.com/ntp-project/ntp/issues/17 but the others
-    ## aren't much better.
-    ##
-    ## bk://bk.ntp.org/ntp-dev
-    ## (4.3.93) 2016/06/02 Released by Harlan Stenn <stenn@ntp.org>
-
-    # Unsupported syntax?: depends_on cask: "bitkeeper"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-    depends_on "lynx" => :build
-  end
-
   option "with-net-snmp", "Build net-snmp support"
 
   depends_on "openssl"

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -43,7 +43,7 @@ class Ntp < Formula
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
     if build.with?("net-snmp")
-      args <<  "-with-net-snmp-config"
+      args << "-with-net-snmp-config"
     else
       args << "-with-net-snmp-config=no"
     end

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -59,7 +59,11 @@ class Ntp < Formula
       "--with-openssl-libdir=#{Formula["openssl"].lib}",
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
-    args << (build.with?("net-snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no")
+    if build.with?("net-snmp")
+      args <<  "-with-net-snmp-config"
+    else
+      args << "-with-net-snmp-config=no"
+    end
 
     system "./configure", *args
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -1,0 +1,117 @@
+class Ntp < Formula
+  desc "The Network Time Protocol (NTP) Distribution"
+  homepage "https://www.eecis.udel.edu/~mills/ntp/html/"
+  # Arguments could be made for:
+  # http://ntp.org/documentation.html (has more unofficial stuff)
+  # http://ntp.org/  (more the protocol than the distribution)
+  url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
+  version "4.2.8p10"
+  sha256 "ddd2366e64219b9efa0f7438e06800d0db394ac5c88e13c17b70d0dcdf99b99f"
+
+  devel do
+    # http://support.ntp.org/bin/view/Main/SoftwareDevelopment
+    url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
+    sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
+  end
+
+  head do
+    ## The git repo is broken/ancient, per https://github.com/ntp-project/ntp/issues/17
+    ## but the others aren't much better.
+    #
+    ## url "https://github.com/ntp-project/ntp.git"
+    ## Default stable branch: 1a399a03e674da08cfce2cdb847bfb65d65df237, Jan 24 2016
+    ## Non-default "master" branch: 9c75327c3796ff59ac648478cd4da8b205bceb77 Sun Jan 24 12:06:39 2016 +0000
+    #
+    ## bk://bk.ntp.org/ntp-stable
+    ## (4.2.8p10-win-beta1) 2017/03/21 Released by Harlan Stenn <stenn@ntp.org>
+    #
+    ## bk://bk.ntp.org/ntp-dev
+    ## (4.3.93) 2016/06/02 Released by Harlan Stenn <stenn@ntp.org>
+    #
+    ## rsync archive.ntp.org::ntp-dev-src
+    ## (4.3.92) 2016/04/27 Released by Harlan Stenn <stenn@ntp.org>
+
+    # Unsupported syntax?: depends_on cask: "bitkeeper"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "lynx" => :build
+  end
+
+  depends_on "openssl"
+
+  def install
+    # Ensure homebrew perl is in #! lines of installed scripts.
+    ENV["PATH_PERL"] = "/usr/local/bin/perl"
+
+    system "./bootstrap" if build.head?
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-openssl-libdir=#{Formula["openssl"].lib}",
+                          "--with-openssl-incdir=#{Formula["openssl"].include}"
+
+    system "make", "install"
+  end
+
+  def caveats
+    s = <<-EOS.undent
+    By default, OS X ships a broken version of ntpd that by design
+    does not control the system clock, but maintains the network
+    protocol and is intended to write a drift file (which it fails to
+    do under OS X 10.10). The drift file is read by pacemaker(8),
+    which is supposed to call adjtime() in a battery-efficient fashion
+    for laptops.
+
+    Installing this formula implies disabling the system ntpd as well as pacemaker:
+
+    sudo launchctl disable system/com.apple.pacemaker
+    sudo launchctl disable system/org.ntp.ntpd
+    EOS
+    s
+  end
+
+  plist_options :startup => true
+
+  # OS X uses /usr/libexec/ntp-wrapper to wait for appropriate network conditions and then
+  # invoke ntpd with various args. It's not clear that we need to resort to that. It also
+  # runs sntp first, which is definitely unnecessary given ntpd -g.
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_sbin}/ntpd</string>
+        <string>-c</string>
+        <string>/private/etc/ntp-restrict.conf</string>
+        <string>-n</string>
+        <string>-g</string>
+        <string>-p</string>
+        <string>/var/run/ntpd.pid</string>
+        <string>-f</string>
+        <string>/var/db/ntp.drift</string>
+        <string>-l</string>
+        <string>/var/log/ntp.log</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    # It's hard to do anything without network or clock-invasive stuff.
+    # Make sure we can print a usage message.
+    assert_match "usage: ", shell_output("#{sbin}/ntpdate -\? 2>&1", 2)
+  end
+end

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -39,7 +39,10 @@ class Ntp < Formula
     depends_on "lynx" => :build
   end
 
+  option "with-snmp", "Build SNMP support"
+
   depends_on "openssl"
+  depends_on "net-snmp" if build.with? "snmp"
 
   def install
     # Ensure homebrew perl is in #! lines of installed scripts.
@@ -48,12 +51,17 @@ class Ntp < Formula
 
     system "./bootstrap" if build.head?
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--with-openssl-libdir=#{Formula["openssl"].lib}",
-                          "--with-openssl-incdir=#{Formula["openssl"].include}"
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      "--with-openssl-libdir=#{Formula["openssl"].lib}",
+      "--with-openssl-incdir=#{Formula["openssl"].include}",
+    ]
+    args << (build.with?("snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no")
+
+    system "./configure", *args
 
     system "make", "install"
   end

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -39,10 +39,10 @@ class Ntp < Formula
     depends_on "lynx" => :build
   end
 
-  option "with-snmp", "Build SNMP support"
+  option "with-net-snmp", "Build net-snmp support"
 
   depends_on "openssl"
-  depends_on "net-snmp" if build.with? "snmp"
+  depends_on "net-snmp" => :optional
 
   def install
     # Ensure homebrew perl is in #! lines of installed scripts.
@@ -59,7 +59,7 @@ class Ntp < Formula
       "--with-openssl-libdir=#{Formula["openssl"].lib}",
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
-    args << (build.with?("snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no")
+    args << (build.with?("net-snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no")
 
     system "./configure", *args
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -69,8 +69,8 @@ class Ntp < Formula
 
     Installing this formula implies disabling the system ntpd as well as pacemaker:
 
-    sudo launchctl disable system/com.apple.pacemaker
-    sudo launchctl disable system/org.ntp.ntpd
+      sudo launchctl disable system/com.apple.pacemaker
+      sudo launchctl disable system/org.ntp.ntpd
     EOS
     s
   end

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -27,10 +27,10 @@ class Ntp < Formula
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
     args << if build.with?("net-snmp")
-              "-with-net-snmp-config"
-            else
-              "-with-net-snmp-config=no"
-            end
+      "-with-net-snmp-config"
+    else
+      "-with-net-snmp-config=no"
+    end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -4,13 +4,13 @@ class Ntp < Formula
   # Arguments could be made for:
   # http://ntp.org/documentation.html (has more unofficial stuff)
   # http://ntp.org/  (more the protocol than the distribution)
-  url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
+  url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
   version "4.2.8p10"
   sha256 "ddd2366e64219b9efa0f7438e06800d0db394ac5c88e13c17b70d0dcdf99b99f"
 
   devel do
     # http://support.ntp.org/bin/view/Main/SoftwareDevelopment
-    url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
+    url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
     sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
   end
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -26,10 +26,10 @@ class Ntp < Formula
       "--with-openssl-libdir=#{Formula["openssl"].lib}",
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
-    if build.with?("net-snmp")
-      args << "-with-net-snmp-config"
+    args << if build.with?("net-snmp")
+      "-with-net-snmp-config"
     else
-      args << "-with-net-snmp-config=no"
+      "-with-net-snmp-config=no"
     end
 
     system "./configure", *args

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -10,7 +10,7 @@ class Ntp < Formula
     sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
   end
 
-  option "with-net-snmp", "Build net-snmp support"
+  option "with-net-snmp", "Build ntpsnmpd, the SNMP MIB agent for ntpd"
 
   depends_on "openssl"
   depends_on "net-snmp" => :optional

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -27,10 +27,10 @@ class Ntp < Formula
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
     args << if build.with?("net-snmp")
-      "-with-net-snmp-config"
-    else
-      "-with-net-snmp-config=no"
-    end
+              "-with-net-snmp-config"
+            else
+              "-with-net-snmp-config=no"
+            end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -27,9 +27,9 @@ class Ntp < Formula
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
     args << if build.with?("net-snmp")
-      "-with-net-snmp-config"
+      "--with-net-snmp-config"
     else
-      "-with-net-snmp-config=no"
+      "--with-net-snmp-config=no"
     end
 
     system "./configure", *args

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -43,7 +43,8 @@ class Ntp < Formula
 
   def install
     # Ensure homebrew perl is in #! lines of installed scripts.
-    ENV["PATH_PERL"] = "/usr/local/bin/perl"
+    localperl="/usr/local/bin/perl"
+    ENV["PATH_PERL"] = localperl if File.exist? localperl
 
     system "./bootstrap" if build.head?
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -32,10 +32,6 @@ class Ntp < Formula
   depends_on "net-snmp" => :optional
 
   def install
-    # Ensure homebrew perl is in #! lines of installed scripts.
-    localperl="/usr/local/bin/perl"
-    ENV["PATH_PERL"] = localperl if File.exist? localperl
-
     system "./bootstrap" if build.head?
 
     args = [

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -26,10 +26,10 @@ class Ntp < Formula
       "--with-openssl-libdir=#{Formula["openssl"].lib}",
       "--with-openssl-incdir=#{Formula["openssl"].include}",
     ]
-    args << if build.with?("net-snmp")
-      "--with-net-snmp-config"
+    if build.with?("net-snmp")
+      args << "--with-net-snmp-config"
     else
-      "--with-net-snmp-config=no"
+      args << "--with-net-snmp-config=no"
     end
 
     system "./configure", *args

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -66,7 +66,6 @@ class Ntp < Formula
     end
 
     system "./configure", *args
-
     system "make", "install"
   end
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -1,35 +1,22 @@
 class Ntp < Formula
   desc "The Network Time Protocol (NTP) Distribution"
   homepage "https://www.eecis.udel.edu/~mills/ntp/html/"
-  # Arguments could be made for:
-  # http://ntp.org/documentation.html (has more unofficial stuff)
-  # http://ntp.org/  (more the protocol than the distribution)
   url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
   version "4.2.8p10"
   sha256 "ddd2366e64219b9efa0f7438e06800d0db394ac5c88e13c17b70d0dcdf99b99f"
 
   devel do
-    # http://support.ntp.org/bin/view/Main/SoftwareDevelopment
     url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
     sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
   end
 
   head do
-    ## The git repo is broken/ancient, per https://github.com/ntp-project/ntp/issues/17
-    ## but the others aren't much better.
-    #
-    ## url "https://github.com/ntp-project/ntp.git"
-    ## Default stable branch: 1a399a03e674da08cfce2cdb847bfb65d65df237, Jan 24 2016
-    ## Non-default "master" branch: 9c75327c3796ff59ac648478cd4da8b205bceb77 Sun Jan 24 12:06:39 2016 +0000
-    #
-    ## bk://bk.ntp.org/ntp-stable
-    ## (4.2.8p10-win-beta1) 2017/03/21 Released by Harlan Stenn <stenn@ntp.org>
-    #
+    ## The git repo is broken/ancient, per
+    ## https://github.com/ntp-project/ntp/issues/17 but the others
+    ## aren't much better.
+    ##
     ## bk://bk.ntp.org/ntp-dev
     ## (4.3.93) 2016/06/02 Released by Harlan Stenn <stenn@ntp.org>
-    #
-    ## rsync archive.ntp.org::ntp-dev-src
-    ## (4.3.92) 2016/04/27 Released by Harlan Stenn <stenn@ntp.org>
 
     # Unsupported syntax?: depends_on cask: "bitkeeper"
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -122,8 +122,6 @@ class Ntp < Formula
   end
 
   test do
-    # It's hard to do anything without network or clock-invasive stuff.
-    # Make sure we can print a usage message.
-    assert_match "usage: ", shell_output("#{sbin}/ntpdate -\? 2>&1", 2)
+    assert_match "step time server ", shell_output("#{sbin}/ntpdate -bq pool.ntp.org")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

The Network Time Protocol (NTP) Distribution.

-----

This pull request ported over from https://github.com/Homebrew/homebrew-dupes/pull/744 per @MikeMcQuaid 

> I appreciate this is a massive pain and I genuinely apologise for that but during this PR homebrew/dupes has been migrated to homebrew/core so after addressing the feedback could you recreate this there?

----

Addressing comments from the prior PR; I've made all these changes, although I'm not sure it is advisable to do so.

> Can remove all these comments

w/r/t https://github.com/Homebrew/homebrew-dupes/pull/744/files/ae3ce6715c032da50409c99f45f54df5ce01af5d#r109661078 I think it's necessary to keep some of the comments in the `head` section, otherwise it makes no sense that there's no URL there. The alternative, of course, is to remove the head section entirely. I've removed all the remaining such comments.

> Let's remove this; it's fine to use the system Perl here.

For the record, it's not fine on my system. As I've articulated previously in #10133, the result is I get commands that don't work:

```
pb3:~ jhawk$ ntptrace
Usage: DynaLoader::dl_find_symbol(libhandle, symbolname) at /Users/jhawk/perl5/lib/perl5/darwin-thread-multi-2level/XSLoader.pm line 89.
Compilation failed in require at /usr/local/Cellar/ntp/4.2.8p10/share/ntp/lib/NTP/Util.pm line 16.
BEGIN failed--compilation aborted at /usr/local/Cellar/ntp/4.2.8p10/share/ntp/lib/NTP/Util.pm line 24.
Compilation failed in require at /usr/local/sbin/ntptrace line 8.
BEGIN failed--compilation aborted at /usr/local/sbin/ntptrace line 8.
pb3:~ jhawk$ 
```

I guess the answer is that this something I have to resolve locally and Homebrew is not interested in fixing? I guess I need to maintain my own private fork of the formula.

> Turn this into an if/else to make it easier to follow.

```diff
 +    args << (build.with?("snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no") 
```

Huh. Not only do I find the one-line syntax easier to follow, but there are only 3 other formulas that test for this condition (`lldpd`, `nut`, and `powerman`), and all of them use the one-line syntax.

