### PR TITLE
Antigen branch update (HEAD)

### DIFF
--- a/Formula/antigen.rb
+++ b/Formula/antigen.rb
@@ -3,7 +3,7 @@ class Antigen < Formula
   homepage "http://antigen.sharats.me/"
   url "https://github.com/zsh-users/antigen/releases/download/v1.4.1/v1.4.1.tar.gz"
   sha256 "a2f30020ff8414341d855e33b6dfdc4827cd2079e1f7297ef65cd9a380e66cd8"
-  head "https://github.com/zsh-users/antigen.git"
+  head "https://github.com/zsh-users/antigen.git", :branch => "develop"
 
   bottle :unneeded
 


### PR DESCRIPTION
Update HEAD to use the branch `develop` rather than `master` to capture the most current release.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The Antigen bleeding edge branch is `develop`. Master is actually several releases behind. I updated  `head` to point to the `develop` branch so the most up-to-date version is available.  