### PR TITLE
colortail: Fix patch

### DIFF
--- a/Formula/colortail.rb
+++ b/Formula/colortail.rb
@@ -19,7 +19,7 @@ class Colortail < Formula
 
   # Upstream PR to fix the build on ML
   patch do
-    url "https://github.com/joakim666/colortail/pull/12.diff"
+    url "https://github.com/joakim666/colortail/commit/36dd0437bb364fd1493934bdb618cc102a29d0a5.diff"
     sha256 "2bb9963f6fc586c8faff3b51a48896cf09c68c4229c39c6ae978a59cb58d0fd7"
   end
 


### PR DESCRIPTION
The current patch URL 404's, preventing from-source builds.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

```
==> Downloading from https://patch-diff.githubusercontent.com/raw/joakim666/colortail/pull/12.diff
/usr/bin/curl --remote-time --location --user-agent Homebrew/1.1.12-24-gd84655efb (Macintosh; Intel macOS 10.11.6) curl/7.43.0 --fail https://patch-diff.githubusercontent.com/raw/joakim666/colortail/pull/12.diff -C 0 -o /Users/rhogg/Library/Caches/Homebrew/colortail--patch-2bb9963f6fc586c8faff3b51a48896cf09c68c4229c39c6ae978a59cb58d0fd7.diff.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "colortail--patch"
Download failed: https://github.com/joakim666/colortail/pull/12.diff
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----