### PR TITLE
nano: apply upstream fix for configure's word boundary regex logic

### DIFF
--- a/Formula/nano.rb
+++ b/Formula/nano.rb
@@ -1,6 +1,7 @@
 class Nano < Formula
   desc "Free (GNU) replacement for the Pico text editor"
   homepage "https://www.nano-editor.org/"
+  revision 1
 
   stable do
     url "https://www.nano-editor.org/dist/v2.8/nano-2.8.0.tar.gz"
@@ -12,6 +13,14 @@ class Nano < Formula
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/45f1329/nano/configure-ignore-reg-enhanced-test.diff"
       sha256 "20e988cd2406da8009c3f5f9ddde206d14e8586bd744bb7bf75326ba59eba653"
+    end
+
+    # Remove for > 2.8.0
+    # Fix "Bad regex '[[:<:]]dnl.*': Invalid character class name"
+    # Upstream commit from 3 Apr 2017 https://git.savannah.gnu.org/cgit/nano.git/patch/?id=8f2b5bbf3d1b23007aedc9f07f224da91f0ec479
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a03b730/nano/configure-fix-up-word-boundary-regex-logic.diff"
+      sha256 "9f158ed8d6fa0276c7bcaea567b65acf883b95c2b7d374e6285b2aefb99669ed"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #12136.