### PR TITLE
logstash: fix lack of plist

### DIFF
--- a/Aliases/logstash@5.3
+++ b/Aliases/logstash@5.3
@@ -1,0 +1,1 @@
+../Formula/logstash.rb

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -33,6 +33,37 @@ class Logstash < Formula
     EOS
   end
 
+  plist_options :manual => "logstash"
+
+  def plist; <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <false/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/logstash</string>
+          </array>
+          <key>EnvironmentVariables</key>
+          <dict>
+          </dict>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/logstash.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/logstash.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
   test do
     # workaround https://github.com/elastic/logstash/issues/6378
     mkdir testpath/"config"


### PR DESCRIPTION
Elasticsearch and Kibana both offer out-of-the-box run-as-a-service functionality, so I added it for Logstash.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
