### PR TITLE
gnupg 2.1.20: enable larger secure memory

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -4,6 +4,7 @@ class Gnupg < Formula
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.20.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.20.tar.bz2"
   sha256 "24cf9a69369be64a9f6f8cc11a1be33ab7780ad77a6a1b93719438f49f69960d"
+  revision 1
 
   bottle do
     sha256 "da72dd30eff4131ff8177528b5bf03f6e0273e553bdf34e8daa490696e24a92c" => :sierra
@@ -39,6 +40,7 @@ class Gnupg < Formula
       --sbindir=#{bin}
       --sysconfdir=#{etc}
       --enable-symcryptrun
+      --enable-large-secmem
       --with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry
     ]
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

GnuPG 2.1.x includes support for up-to 8k RSA keys via the
`--enable-large-rsa` option.  To make use of this function GnuPG must
be built with the `--enable-large-secmem` option.