### PR TITLE
go: fix Xcode/CLT 8.3-related breakage.

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -1,6 +1,7 @@
 class Go < Formula
   desc "The Go programming language"
   homepage "https://golang.org"
+  revision 1
 
   stable do
     url "https://storage.googleapis.com/golang/go1.8.src.tar.gz"
@@ -12,6 +13,22 @@ class Go < Formula
     resource "gotools" do
       url "https://go.googlesource.com/tools.git",
           :branch => "release-branch.go#{go_version}"
+    end
+
+    # Fixes for https://github.com/golang/go/issues/19734.
+    patch do
+      url "https://github.com/golang/go/commit/84192f27.patch"
+      sha256 "86badcb9318b5399de05520cfdd3c1abbc722a5f8cfcecc008815ff889230620"
+    end
+
+    patch do
+      url "https://github.com/golang/go/commit/3ca0d34f.patch"
+      sha256 "7c3a0ce6cf9bec784729bdca8f1798629690042c69cb4ee8c5e9cafaf73fc693"
+    end
+
+    patch do
+      url "https://github.com/golang/go/commit/2d004301.patch"
+      sha256 "2444a4191fd299b8a6e6eb6a671e7ca53005d0785b85343e5b512d4f093a069a"
     end
   end
 

--- a/Formula/godep.rb
+++ b/Formula/godep.rb
@@ -3,7 +3,8 @@ class Godep < Formula
   homepage "https://godoc.org/github.com/tools/godep"
   url "https://github.com/tools/godep/archive/v79.tar.gz"
   sha256 "3dd2e6c4863077762498af98fa0c8dc5fedffbca6a5c0c4bb42b452c8268383d"
-  revision 1
+  revision 2
+
   head "https://github.com/tools/godep.git"
 
   bottle do
@@ -36,6 +37,7 @@ class Godep < Formula
       }
     EOS
     system bin/"godep", "restore"
-    assert File.exist?("src/golang.org/x/tools/README"), "Failed to find 'src/golang.org/x/tools/README!' file"
+    assert_predicate testpath/"src/golang.org/x/tools/README", :exist?,
+                     "Failed to find 'src/golang.org/x/tools/README!' file"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ref: https://github.com/golang/go/issues/19734.
Closes https://github.com/Homebrew/homebrew-core/issues/11739.