### PR TITLE
lapack: depend on cmake instead of vendoring it

### DIFF
--- a/Formula/lapack.rb
+++ b/Formula/lapack.rb
@@ -3,6 +3,7 @@ class Lapack < Formula
   homepage "http://www.netlib.org/lapack/"
   url "http://www.netlib.org/lapack/lapack-3.7.0.tgz"
   sha256 "ed967e4307e986474ab02eb810eed1d1adc73f5e1e3bc78fb009f6fe766db3be"
+  revision 1
   head "https://github.com/Reference-LAPACK/lapack.git"
 
   bottle do
@@ -13,30 +14,11 @@ class Lapack < Formula
 
   keg_only :provided_by_osx
 
+  depends_on "cmake" => :build
   depends_on :fortran
   depends_on "gcc"
 
-  # cmake 3.7 and later misdetect the Fortran compiler
-  # https://github.com/Reference-LAPACK/lapack/issues/139
-  # When the issue is fixes, replace with cmake dependency
-  resource "cmake" do
-    url "https://cmake.org/files/v3.6/cmake-3.6.3.tar.gz"
-    sha256 "7d73ee4fae572eb2d7cd3feb48971aea903bb30a20ea5ae8b4da826d8ccad5fe"
-  end
-
   def install
-    # Build, install, and use cmake 3.6
-    resource("cmake").stage do
-      system "./bootstrap", "--prefix=#{buildpath}/cmake",
-                            "--no-system-libs",
-                            "--parallel=#{ENV.make_jobs}",
-                            "--system-zlib",
-                            "--system-bzip2"
-      system "make"
-      system "make", "install"
-    end
-    ENV.prepend_path "PATH", buildpath/"cmake/bin"
-
     mkdir "build" do
       system "cmake", "..",
                       "-DBUILD_SHARED_LIBS:BOOL=ON",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

vendoring CMake 3.6.3 is no longer necessary now that the CMake
-lto_library bug is fixed.

See
https://github.com/Homebrew/homebrew-core/pull/12198
https://github.com/Reference-LAPACK/lapack/issues/139

CC @fxcoudert