### PR TITLE
kubernetes-helm@2.2 (new formula)

### DIFF
--- a/Formula/kubernetes-helm@2.2.rb
+++ b/Formula/kubernetes-helm@2.2.rb
@@ -1,0 +1,43 @@
+class KubernetesHelmAT22 < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/kubernetes/helm.git",
+      :tag => "v2.2.3",
+      :revision => "1402a4d6ec9fb349e17b912e32fe259ca21181e3"
+
+  keg_only :versioned_formula
+
+  depends_on :hg => :build
+  depends_on "go" => :build
+  depends_on "glide" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # Bootstap build
+      system "make", "bootstrap"
+
+      # Make binary
+      system "make", "build"
+      bin.install "bin/helm"
+
+      # Install bash completion
+      bash_completion.install "scripts/completions.bash" => "helm"
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Communication between Helm (the client component) and Tiller (the server component) is tied to major & minor version. The `kubernetes-helm` formula now tracks v2.3. This provides an option for users who aren't ready to upgrade. 