### PR TITLE
readline: restore universal

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -5,7 +5,7 @@ class Readline < Formula
   mirror "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
   version "7.0.3"
   sha256 "750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -33,6 +33,7 @@ class Readline < Formula
   EOS
 
   def install
+    ENV.universal_binary
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This reverts commit ae391d59dc47007786c561fd04592fba40820d05.

Having a universal version of libreadline is useful when linking against macOS system files, many of which are still universal binaries. For example, building C extensions for the system versions of Ruby or Python fails with a non-universal readline build.

This PR was motivated by https://github.com/thoughtbot/gitsh/issues/287, which reported that the [gitsh formula][1] had suddenly stopped working. I discovered #10907 had changed the default build architecture of readline, which is what was causing the formula to fail.

As an alternative to merging this PR, I could include ruby as a dependency in the gitsh formula; the ruby formula is non-universal, so it has no problem with a non-universal readline library. I thought it was worthwhile trying this PR first, since gitsh is unlikely to be the only program affected by the readline formula's architecture change.

[1]: https://github.com/thoughtbot/homebrew-formulae/blob/master/Formula/gitsh.rb