### PR TITLE
sbt 0.13.15

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -21,6 +21,8 @@ class Sbt < Formula
     end
 
     inreplace "bin/sbt-launch-lib.bash" do |s|
+      # Upstream issue "Replace realpath with something Mac compatible"
+      # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/149
       s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
       s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
 

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -24,9 +24,9 @@ class Sbt < Formula
       s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
       s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
 
-      ## See https://github.com/sbt/sbt-launcher-package/issues/150
-      ## This is a workaround for `brew test sbt` failing to detect java -version.
-      if s.include?("[[ \"$java_version\" > \"8\" ]]")
+      # Workaround for `brew test sbt` failing to detect java -version
+      # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/150
+      if build.stable?
         s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"
       end
     end

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -23,6 +23,12 @@ class Sbt < Formula
     inreplace "bin/sbt-launch-lib.bash" do |s|
       s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
       s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
+
+      ## See https://github.com/sbt/sbt-launcher-package/issues/150
+      ## This is a workaround for `brew test sbt` failing to detect java -version.
+      if s.include?("[[ \"$java_version\" > \"8\" ]]")
+        s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"
+      end
     end
 
     libexec.install "bin"

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -26,8 +26,8 @@ class Sbt < Formula
     end
 
     libexec.install "bin"
-    etc.install "conf/sbtopts"
     libexec.install "lib" if build.stable? # remove `if` when devel > 1.0.0-M4
+    etc.install "conf/sbtopts"
 
     (bin/"sbt").write <<-EOS.undent
       #!/bin/sh

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -31,10 +31,7 @@ class Sbt < Formula
 
     libexec.install "bin"
     etc.install "conf/sbtopts"
-    ## if should be removed when devel is > 1.0.0-M4
-    if build.stable?
-      libexec.install "lib"
-    end
+    libexec.install "lib" if build.stable? # remove `if` when devel > 1.0.0-M4
 
     (bin/"sbt").write <<-EOS.undent
       #!/bin/sh

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -23,10 +23,6 @@ class Sbt < Formula
     inreplace "bin/sbt-launch-lib.bash" do |s|
       s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
       s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
-      ## This is required to pass the test
-      if s.include?("[[ \"$java_version\" > \"8\" ]]")
-        s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"
-      end
     end
 
     libexec.install "bin"

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -21,15 +21,9 @@ class Sbt < Formula
     end
 
     inreplace "bin/sbt-launch-lib.bash" do |s|
+      s.gsub! "$(dirname \"$(realpath \"$0\")\")", libexec
+      s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
       s.gsub! "${sbt_home}/bin/sbt-launch.jar", "#{libexec}/sbt-launch.jar"
-      if s.include?("${sbt_bin_dir}/java9-rt-export.jar")
-        s.gsub! "${sbt_bin_dir}/java9-rt-export.jar", "#{libexec}/java9-rt-export.jar"
-      end
-
-      if s.include?("$sbt_home/lib/local-preloaded/")
-        s.gsub! "$sbt_home/lib/local-preloaded/", "#{libexec}/lib/local-preloaded/"
-      end
-
       ## This is required to pass the test
       if s.include?("[[ \"$java_version\" > \"8\" ]]")
         s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -21,20 +21,18 @@ class Sbt < Formula
     end
 
     inreplace "bin/sbt-launch-lib.bash" do |s|
-      s.gsub! "$(dirname \"$(realpath \"$0\")\")", libexec
+      s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
       s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
-      s.gsub! "${sbt_home}/bin/sbt-launch.jar", "#{libexec}/sbt-launch.jar"
       ## This is required to pass the test
       if s.include?("[[ \"$java_version\" > \"8\" ]]")
         s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"
       end
     end
 
-    libexec.install "bin/sbt", "bin/sbt-launch-lib.bash"
-    libexec.install Dir["bin/*.jar"]
+    libexec.install "bin"
     etc.install "conf/sbtopts"
-
-    if File.directory?("lib")
+    ## if should be removed when devel is > 1.0.0-M4
+    if build.stable?
       libexec.install "lib"
     end
 
@@ -44,7 +42,7 @@ class Sbt < Formula
         echo "Use of ~/.sbtconfig is deprecated, please migrate global settings to #{etc}/sbtopts" >&2
         . "$HOME/.sbtconfig"
       fi
-      exec "#{libexec}/sbt" "$@"
+      exec "#{libexec}/bin/sbt" "$@"
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source sbt
==> Using the sandbox
==> Downloading https://dl.bintray.com/sbt/native-packages/sbt/0.13.15/sbt-0.13.15.tgz
Already downloaded: /Users/eugene/Library/Caches/Homebrew/sbt-0.13.15.tgz
==> Caveats
You can use $SBT_OPTS to pass additional JVM options to SBT:
   SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"

This formula is now using the standard lightbend sbt launcher script.
Project specific options should be placed in .sbtopts in the root of your project.
Global settings should be placed in /usr/local/etc/sbtopts
==> Summary
🍺  /usr/local/Cellar/sbt/0.13.15: 377 files, 63.3MB, built in 1 second
$ brew audit --strict sbt
$
```

