### PR TITLE
stone-soup: Added option to build without Lua

### DIFF
--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -13,7 +13,7 @@ class StoneSoup < Formula
   end
 
   option "with-tiles", "Enable graphic tiles and sound"
-  option "without-lua", "Disable Lua bindings for user scripts"
+  option "without-lua@5.1", "Disable Lua bindings for user scripts"
 
   depends_on "pkg-config" => :build
   depends_on "pcre"
@@ -27,7 +27,7 @@ class StoneSoup < Formula
   end
 
   if build.with? "lua"
-    depends_on "lua@5.1"
+    depends_on "lua@5.1" => :recommended
   end
 
   needs :cxx11

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -16,6 +16,7 @@ class StoneSoup < Formula
   option "without-lua@5.1", "Disable Lua bindings for user scripts"
 
   depends_on "pkg-config" => :build
+  depends_on "lua@5.1" => :recommended
   depends_on "pcre"
 
   if build.with? "tiles"
@@ -24,10 +25,6 @@ class StoneSoup < Formula
     depends_on "sdl2_image"
     depends_on "libpng"
     depends_on "freetype"
-  end
-
-  if build.with? "lua"
-    depends_on "lua@5.1" => :recommended
   end
 
   needs :cxx11

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -13,9 +13,9 @@ class StoneSoup < Formula
   end
 
   option "with-tiles", "Enable graphic tiles and sound"
+  option "without-lua", "Disable Lua bindings for user scripts"
 
   depends_on "pkg-config" => :build
-  depends_on "lua@5.1"
   depends_on "pcre"
 
   if build.with? "tiles"
@@ -24,6 +24,10 @@ class StoneSoup < Formula
     depends_on "sdl2_image"
     depends_on "libpng"
     depends_on "freetype"
+  end
+
+  if build.with? "lua"
+    depends_on "lua@5.1"
   end
 
   needs :cxx11
@@ -37,7 +41,6 @@ class StoneSoup < Formula
         DATADIR=data
         NO_PKGCONFIG=
         BUILD_ZLIB=
-        BUILD_LUA=
         BUILD_SQLITE=yes
         BUILD_FREETYPE=
         BUILD_LIBPNG=
@@ -51,6 +54,12 @@ class StoneSoup < Formula
         inreplace "Makefile", "contrib/install/$(ARCH)/lib/libSDL2main.a", ""
         args << "TILES=y"
         args << "SOUND=y"
+      end
+
+      if build.with? "lua"
+        args << "BUILD_LUA=y"
+      else
+        args << "NO_LUA_BINDINGS=y"
       end
 
       # FSF GCC doesn't support the -rdynamic flag

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -53,7 +53,7 @@ class StoneSoup < Formula
         args << "SOUND=y"
       end
 
-      if build.with? "lua"
+      if build.with? "lua@5.1"
         args << "BUILD_LUA=y"
       else
         args << "NO_LUA_BINDINGS=y"


### PR DESCRIPTION
Formula requires Lua@5.1 which is outdated. Added option to build
without Lua as Lua is only required for specific features.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
