### PR TITLE
add maven@3.3 based on previous maven

### DIFF
--- a/Formula/maven@3.3.rb
+++ b/Formula/maven@3.3.rb
@@ -1,0 +1,52 @@
+class MavenAT33 < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+  sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.bat"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<-EOS.undent
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? Yes
- [x] Have you checked that there aren't other open [pull requests] (https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? Yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? Yes
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? Yes

-----

The maven recently switched from 3.3.9 to 3.5.0. This formula allows users to install version 3.3.9 again. The contents are based on maven.rb before adding 3.5.0 alpha as a "devel", plus specifying 1.7+ as the Java dependency (which is true starting with maven 3.3). I also remove the conflicts_with as directed by the audit.