### PR TITLE
testssl 2.8

### DIFF
--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -1,9 +1,8 @@
 class Testssl < Formula
   desc "Tool which checks for the support of TLS/SSL ciphers and flaws"
   homepage "https://testssl.sh/"
-  url "https://github.com/drwetter/testssl.sh/archive/v2.8rc3.tar.gz"
-  version "2.8rc3"
-  sha256 "e36a60acc0aa09191ff2f86762cd07925630df82498d48d81d86e3b7402a3312"
+  url "https://github.com/drwetter/testssl.sh/archive/v2.8.tar.gz"
+  sha256 "2e4588bfcd5f4e6b30b2e250d51b39e4209131a5366f1e75354aaa4a5ee6a22d"
 
   head "https://github.com/drwetter/testssl.sh.git"
 


### PR DESCRIPTION
This also removes the version clause from the recipe as hinted on by `brew
audit --strict`:

```
 testssl:
  * Stable: version 2.8 is redundant with version scanned from URL
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
