### PR TITLE
swift 3.1

### DIFF
--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -2,45 +2,47 @@ class Swift < Formula
   desc "High-performance system programming language"
   homepage "https://github.com/apple/swift"
 
+  # This formula is expected to have broken/missing linkage to
+  # both UIKit.framework and AssetsLibrary.framework. This is
+  # simply due to the nature of Swift's SDK Overlays.
   stable do
-    url "https://github.com/apple/swift/archive/swift-3.0.2-RELEASE.tar.gz"
-    sha256 "e69764cb3d83d7209f21c2af448ae39e6612df28e37b7a3ceffa9c24f19ca0cc"
-
-    resource "cmark" do
-      url "https://github.com/apple/swift-cmark/archive/swift-3.0.2-RELEASE.tar.gz"
-      sha256 "40fc49d2f1c4075030b43f706193c1e6323e741ac5b029d2c627fd2f86da1cb4"
-    end
+    url "https://github.com/apple/swift/archive/swift-3.1-RELEASE.tar.gz"
+    sha256 "bc8f4fc1cb5e9cddcdca4208dc5db89696d6ab507e739d498519a0262bd453c0"
 
     resource "clang" do
-      url "https://github.com/apple/swift-clang/archive/swift-3.0.2-RELEASE.tar.gz"
-      sha256 "8c9026b6f7543fc4ad2efef412da8ab186dbbcb089e8558e27b9994243faff99"
+      url "https://github.com/apple/swift-clang/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "bb4543904e82f433a6a65612c9c4d8218dc5358f8097318f4f7fd6af145dd1f5"
+    end
+
+    resource "cmark" do
+      url "https://github.com/apple/swift-cmark/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "f0906c6048cdc93c85106090a878dea7ca3b6d862091f82fe8073e273d3fc011"
+    end
+
+    resource "compiler-rt" do
+      url "https://github.com/apple/swift-compiler-rt/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "d1d4eec2649f9c02007f666975b41bb0174713384c80665f15e7f34345049d96"
+    end
+
+    resource "llbuild" do
+      url "https://github.com/apple/swift-llbuild/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "578c0d28fc74df52c77dd6c1bfc91e45f0d9d2349e82855ae2f9715d1b25ac36"
     end
 
     resource "llvm" do
-      url "https://github.com/apple/swift-llvm/archive/swift-3.0.2-RELEASE.tar.gz"
-      sha256 "194f66f522aa349061ae682bab18fa3fffe146da30e30f2d9f4b811fd544f8eb"
+      url "https://github.com/apple/swift-llvm/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "5f99110ac0fcd70b7fabf02989cfd0e7f1f1b6368b80d69f1506ce1fdc38c83e"
+    end
+
+    resource "swiftpm" do
+      url "https://github.com/apple/swift-package-manager/archive/swift-3.1-RELEASE.tar.gz"
+      sha256 "54e66ff2fbe06011207e07a75807b9c0d317355c655c1d74580411e705f2b824"
     end
   end
 
   bottle do
     sha256 "99aad195f9e873da1510b7660bf064719081f1e645d43488177f5ed984e841dd" => :sierra
     sha256 "aedb8c8af6aa435da8d83c1461da1cca2d9d9369a61304aa425053a59eab1e87" => :el_capitan
-  end
-
-  head do
-    url "https://github.com/apple/swift.git"
-
-    resource "cmark" do
-      url "https://github.com/apple/swift-cmark.git"
-    end
-
-    resource "clang" do
-      url "https://github.com/apple/swift-clang.git", :branch => "stable"
-    end
-
-    resource "llvm" do
-      url "https://github.com/apple/swift-llvm.git", :branch => "stable"
-    end
   end
 
   keg_only :provided_by_osx, "Apple's CLT package contains Swift."
@@ -50,7 +52,7 @@ class Swift < Formula
 
   # Depends on latest version of Xcode
   # https://github.com/apple/swift#system-requirements
-  depends_on :xcode => ["8.0", :build]
+  depends_on :xcode => ["8.3", :build]
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
@@ -63,39 +65,51 @@ class Swift < Formula
     workspace = buildpath.parent
     build = workspace/"build"
 
+    toolchain_prefix = "/Swift-#{version}.xctoolchain"
+    install_prefix = "#{toolchain_prefix}/usr"
+
     ln_sf buildpath, "#{workspace}/swift"
     resources.each { |r| r.stage("#{workspace}/#{r.name}") }
 
     mkdir build do
       system "#{buildpath}/utils/build-script",
-        "-R",
-        "--build-subdir=",
-        "--no-llvm-assertions",
-        "--no-swift-assertions",
+        "--release", "--assertions",
         "--no-swift-stdlib-assertions",
+        "--build-subdir=#{build}",
+        "--llbuild", "--swiftpm",
+        "--ios", "--tvos", "--watchos",
         "--",
-        "--workspace=#{workspace}",
-        "--build-args=-j#{ENV.make_jobs}",
-        "--lldb-use-system-debugserver",
-        "--install-prefix=#{prefix}",
-        "--darwin-deployment-version-osx=#{MacOS.version}",
-        "--jobs=#{ENV.make_jobs}"
+        "--workspace=#{workspace}", "--build-args=-j#{ENV.make_jobs}",
+        "--install-destdir=#{prefix}", "--toolchain-prefix=#{toolchain_prefix}",
+        "--install-prefix=#{install_prefix}", "--host-target=macosx-x86_64",
+        "--build-swift-static-stdlib", "--build-swift-dynamic-stdlib",
+        "--build-swift-dynamic-sdk-overlay", "--build-swift-static-sdk-overlay",
+        "--build-swift-stdlib-unittest-extra", "--install-swift",
+        "--swift-install-components=compiler;clang-resource-dir-symlink;"\
+        "clang-builtin-headers-in-clang-resource-dir;stdlib;sdk-overlay;tools;"\
+        "editor-integration;testsuite-tools;toolchain-dev-tools;license;sourcekit-inproc;"\
+        "sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers",
+        "--llvm-install-components=clang;libclang;libclang-headers",
+        "--install-llbuild", "--install-swiftpm"
     end
-    bin.install "#{build}/swift-macosx-x86_64/bin/swift",
-                "#{build}/swift-macosx-x86_64/bin/swift-autolink-extract",
-                "#{build}/swift-macosx-x86_64/bin/swift-demangle",
-                "#{build}/swift-macosx-x86_64/bin/swift-ide-test",
-                "#{build}/swift-macosx-x86_64/bin/swift-llvm-opt",
-                "#{build}/swift-macosx-x86_64/bin/swiftc",
-                "#{build}/swift-macosx-x86_64/bin/sil-extract",
-                "#{build}/swift-macosx-x86_64/bin/sil-opt"
-    (lib/"swift").install "#{build}/swift-macosx-x86_64/lib/swift/macosx/",
-                          "#{build}/swift-macosx-x86_64/lib/swift/shims/"
   end
 
   test do
-    (testpath/"test.swift").write 'print("test")'
-    system "#{bin}/swiftc", "test.swift"
-    assert_equal "test\n", shell_output("./test")
+    (testpath/"test.swift").write <<-EOS.undent
+    let base = 2
+    let exponent_inner = 3
+    let exponent_outer = 4
+    var answer = 1
+
+    for _ in 1...exponent_outer {
+      for _ in 1...exponent_inner {
+        answer *= base
+      }
+    }
+
+    print("(\\(base)^\\(exponent_inner))^\\(exponent_outer) == \\(answer)")
+    EOS
+    output = shell_output("#{prefix}/Swift-#{version}.xctoolchain/usr/bin/swift test.swift")
+    assert_match "(2^3)^4 == 4096\n", output
   end
 end


### PR DESCRIPTION
This includes the addition of a number of somewhat
optional components in an effort to encompass more of the
feature set of the standard release toolchain.

-----

**NOTE:** 
This formula will fail `brew audit`, and this is expected. The missing dylibs mentioned as the reason for failure are a part of the toolchain for compiling for non-macOS targets, such as iOS. The two missing frameworks, UIKit and AssetsLibrary, are simply not components of macOS.

-----
cc @ilovezfs 