### PR TITLE
stern: Fix installation failure with --HEAD

### DIFF
--- a/Formula/stern.rb
+++ b/Formula/stern.rb
@@ -4,7 +4,7 @@ class Stern < Formula
   url "https://github.com/wercker/stern/archive/1.4.0.tar.gz"
   sha256 "32c65ad4710bb84ab187443f78d1016c9e76b18ef7396c841571bf2ce9907b2b"
 
-  head "https://github.com/wercker/stern",
+  head "https://github.com/wercker/stern.git",
     :shallow => false
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, installing stern with --HEAD fails. This PR fixes that.

```
$ brew reinstall stern --HEAD
==> Reinstalling stern
==> Using the sandbox
==> Downloading https://github.com/wercker/stern
######################################################################## 100.0%
Warning: Cannot verify integrity of stern-HEAD
A checksum was not provided for this resource
For your reference the SHA256 is: 65c479b75ae9e9866fe2c97c0b73cf450696770c6dc4881167501a70b92ce452
==> govendor sync
Last 15 lines from /Users/ksuda/Library/Logs/Homebrew/stern/01.govendor:
2017-04-12 11:49:09 +0900

govendor
sync

Error: Vendor file at "vendor" not found.
govendor sync
        Ensures the contents of the vendor folder matches the vendor file.
        Options:
                -n           dry run, print out action only
                -insecure    allow downloading over insecure connection

READ THIS: http://docs.brew.sh/Troubleshooting.html

$ file $(brew --cache)/stern-HEAD
/Users/ksuda/Library/Caches/Homebrew/stern-HEAD: HTML document text
```