### PR TITLE
goaccess: Enable on-disk storage for log data

### DIFF
--- a/Formula/goaccess.rb
+++ b/Formula/goaccess.rb
@@ -18,6 +18,7 @@ class Goaccess < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "geoip" => :optional
+  depends_on "tokyo-cabinet"
 
   def install
     system "autoreconf", "-vfi"
@@ -27,6 +28,7 @@ class Goaccess < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --enable-utf8
+      --enable-tcb=btree
     ]
 
     args << "--enable-geoip" if build.with? "geoip"


### PR DESCRIPTION
This changes the GoAccess build parameters, to enable on-disk storage. (If your dataset is larger than will fit in RAM, you need this.)