### PR TITLE
Add ammonite for Scala 2.11 / 2.10

### DIFF
--- a/Formula/ammonite-repl@2.10.rb
+++ b/Formula/ammonite-repl@2.10.rb
@@ -1,0 +1,20 @@
+class AmmoniteReplAT210 < Formula
+  desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
+  homepage "https://lihaoyi.github.io/Ammonite/#Ammonite-REPL"
+  url "https://github.com/lihaoyi/Ammonite/releases/download/0.8.2/2.10-0.8.2", :using => :nounzip
+  sha256 "b612e4c642b29dc1b7f652e2150383fe9fa2f57300b7751837bf6150dd32bad0"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    bin.install Dir["*"].shift => "amm"
+  end
+
+  test do
+    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{testpath}"
+    output = shell_output("#{bin}/amm -c 'print(\"hello world!\")'")
+    assert_equal "hello world!", output.lines.last
+  end
+end

--- a/Formula/ammonite-repl@2.11.rb
+++ b/Formula/ammonite-repl@2.11.rb
@@ -1,0 +1,20 @@
+class AmmoniteReplAT211 < Formula
+  desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
+  homepage "https://lihaoyi.github.io/Ammonite/#Ammonite-REPL"
+  url "https://github.com/lihaoyi/Ammonite/releases/download/0.8.2/2.11-0.8.2", :using => :nounzip
+  sha256 "390bd4e8d1c443b3ce66096b9125dbc4f4aa7486a898617a52d2a2654fea6cd2"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    bin.install Dir["*"].shift => "amm"
+  end
+
+  test do
+    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{testpath}"
+    output = shell_output("#{bin}/amm -c 'print(\"hello world!\")'")
+    assert_equal "hello world!", output.lines.last
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Ammonite is cross-published against Scala 2.10/2.11/2.12 (Scala 2.10/2.11/2.12 is binary incompatible). The added Formulae add Scala 2.10/2.11 support for ammonite.