### PR TITLE
openjpeg: add patches for CVE-2016-9572/2016-9573

### DIFF
--- a/Formula/openjpeg.rb
+++ b/Formula/openjpeg.rb
@@ -3,6 +3,7 @@ class Openjpeg < Formula
   homepage "http://www.openjpeg.org/"
   url "https://github.com/uclouvain/openjpeg/archive/v2.1.2.tar.gz"
   sha256 "4ce77b6ef538ef090d9bde1d5eeff8b3069ab56c4906f083475517c2c023dfa7"
+  revision 1
 
   head "https://github.com/uclouvain/openjpeg.git"
 
@@ -21,6 +22,15 @@ class Openjpeg < Formula
   depends_on "little-cms2"
   depends_on "libtiff"
   depends_on "libpng"
+
+  # https://github.com/uclouvain/openjpeg/issues/862
+  # https://github.com/uclouvain/openjpeg/issues/863
+  patch do
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/openjpeg2/openjpeg2_2.1.2-1.1.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/openjpeg2/openjpeg2_2.1.2-1.1.debian.tar.xz"
+    sha256 "b19b15ac6306c19734f0626f974c8863e4dc21a1df849a8ae81008479b5b0daf"
+    apply "patches/CVE-2016-9572_CVE-2016-9573.patch"
+  end
 
   def install
     args = std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
