### PR TITLE
conjure-up 2.1.5

### DIFF
--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -3,10 +3,8 @@ class ConjureUp < Formula
 
   desc "Big software deployments so easy it's almost magical."
   homepage "http://conjure-up.io"
-  url "https://github.com/conjure-up/conjure-up/archive/2.1.tar.gz"
-  sha256 "4f60e8cbbb7626c55b63928c65255cddad7df720f04ddb87f9888e1c3de1a44d"
-  revision 1
-
+  url "https://github.com/conjure-up/conjure-up/archive/2.1.5.tar.gz"
+  sha256 "df8278ffca2eab81bf02e6fe422e283baaee52b01e8a7b3bad1ca91ffa691af0"
   head "https://github.com/conjure-up/conjure-up.git", :branch => "master"
 
   bottle do
@@ -28,6 +26,21 @@ class ConjureUp < Formula
   depends_on "juju-wait"
   depends_on "jq"
   depends_on "wget"
+
+  resource "ubuntui" do
+    url "https://pypi.python.org/packages/fa/e3/2f3821c455c0207e615280fb6bf2560e952be500e0769b2d24525bbf8ede/ubuntui-0.1.4.tar.gz#"
+    sha256 "d52206d14e0db6072f435bddadc934cbcaabf6d1cb6f758522eaa7fabf210239"
+  end
+
+  resource "macumba" do
+    url "https://pypi.python.org/packages/76/09/07ac27b7a4bd8511ed3c4b0e16b407ba085323779f917da3be9b0b34e9e7/macumba-0.9.3.tar.gz"
+    sha256 "b6b71064f86b6e886b5f23235577b0c1a27df2c3122a65f55a03908cf13a4b06"
+  end
+
+  resource "bundle-placement" do
+    url "https://pypi.python.org/packages/84/d9/4c416af49f210f46034fbcbe3ee195c272643ae5286e963aa31ea86bff99/bundle-placement-0.0.1.tar.gz"
+    sha256 "a73a4d0dff43f815d1055352d21926dbf722329613e8cfa9e630374ca4e03408"
+  end
 
   resource "python-utils" do
     url "https://pypi.python.org/packages/46/e8/60bc82e7bb5d9e326c4691ed73e02a2a0e3ce6bb7adefd8cb2d9d8456b3a/python-utils-2.0.1.tar.gz"


### PR DESCRIPTION
Brings several improvements including:
- Re-using existing models and controllers for MaaS
- Increased input validation to curb some of the more common issues users have
  inputting required data.

Further changes can be viewed at:
- https://github.com/conjure-up/conjure-up/blob/master/CHANGELOG.md

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
