### PR TITLE
x3270: Make X11 dependency optional

### DIFF
--- a/Formula/x3270.rb
+++ b/Formula/x3270.rb
@@ -10,17 +10,18 @@ class X3270 < Formula
     sha256 "897d18de2b85172e751719687710f20b1717293b10dac669d6eb052e08d4b02a" => :yosemite
   end
 
-  option "with-c3270", "Include c3270 (curses-based version)"
-  option "with-s3270", "Include s3270 (displayless version)"
-  option "with-tcl3270", "Include tcl3270 (integrated with Tcl)"
-  option "with-pr3287", "Include pr3287 (printer emulation)"
+  option "with-x11", "Include x3270 (X11-based version)"
+  option "without-c3270", "Exclude c3270 (curses-based version)"
+  option "without-s3270", "Exclude s3270 (displayless version)"
+  option "without-tcl3270", "Exclude tcl3270 (integrated with Tcl)"
+  option "without-pr3287", "Exclude pr3287 (printer emulation)"
 
-  depends_on :x11
+  depends_on :x11 => :optional
   depends_on "openssl"
 
   def install
     args = ["--prefix=#{prefix}"]
-    args << "--enable-x3270"
+    args << "--enable-x3270" if build.with? "x11"
     args << "--enable-c3270" if build.with? "c3270"
     args << "--enable-s3270" if build.with? "s3270"
     args << "--enable-tcl3270" if build.with? "tcl3270"
@@ -32,6 +33,6 @@ class X3270 < Formula
   end
 
   test do
-    system bin/"x3270", "--version"
+    system bin/"c3270", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
