### PR TITLE
librsync: fix homepage

### DIFF
--- a/Formula/librsync.rb
+++ b/Formula/librsync.rb
@@ -1,6 +1,6 @@
 class Librsync < Formula
   desc "Library that implements the rsync remote-delta algorithm"
-  homepage "https://librsync.sourcefrog.net/"
+  homepage "https://librsync.github.io/"
   url "https://github.com/librsync/librsync/archive/v2.0.0.tar.gz"
   sha256 "b5c4dd114289832039397789e42d4ff0d1108ada89ce74f1999398593fae2169"
   revision 1


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Updates librsync's homepage to the new working version as per [issue 99](https://github.com/librsync/librsync/issues/99).