### PR TITLE
Update TEE to latest version

### DIFF
--- a/Formula/tee-clc.rb
+++ b/Formula/tee-clc.rb
@@ -1,7 +1,7 @@
 class TeeClc < Formula
-  desc "Microsoft Team Explorer Everywhere 2015 Command Line Client"
+  desc "Microsoft Team Explorer Everywhere Command Line Client"
   homepage "https://www.visualstudio.com/en-us/products/team-explorer-everywhere-vs.aspx"
-  url "https://download.microsoft.com/download/8/F/6/8F68DDC8-4E75-4BEA-951E-C14BFF336E81/TEE-CLC-14.0.3.zip"
+  url "https://github.com/Microsoft/team-explorer-everywhere/releases/download/v14.114.0/TEE-CLC-14.114.0.zip"
   sha256 "615125b71305f2f8d03178d6850ea5088b52b1998bd99ff07eed5c22e29af5eb"
 
   bottle :unneeded

--- a/Formula/tee-clc.rb
+++ b/Formula/tee-clc.rb
@@ -1,8 +1,8 @@
 class TeeClc < Formula
-  desc "Microsoft Team Explorer Everywhere Command Line Client"
+  desc "Microsoft Team Explorer Everywhere command-line Client"
   homepage "https://www.visualstudio.com/en-us/products/team-explorer-everywhere-vs.aspx"
   url "https://github.com/Microsoft/team-explorer-everywhere/releases/download/v14.114.0/TEE-CLC-14.114.0.zip"
-  sha256 "615125b71305f2f8d03178d6850ea5088b52b1998bd99ff07eed5c22e29af5eb"
+  sha256 "22f4670c5e7d95cb23e16f34fcc1854d6d31440688c87ee02b859804bfdaeb21"
 
   bottle :unneeded
 


### PR DESCRIPTION
It looks like the updated versions are being released to GitHub now. See here: https://github.com/Microsoft/team-explorer-everywhere

Not sure how to test this. The version url has changed from Microsoft to GitHub. I pointed it to that new version and updated the description to remove the year.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
