### PR TITLE
Switch to downloading sbt 0.13.15 from GitHub Releases

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,7 +1,7 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "http://www.scala-sbt.org"
-  url "https://dl.bintray.com/sbt/native-packages/sbt/0.13.15/sbt-0.13.15.tgz"
+  url "https://github.com/sbt/sbt/releases/download/v0.13.15/sbt-0.13.15.tgz"
   sha256 "b6e073d7c201741dcca92cfdd1dd3cd76c42a47dc9d8c8ead8df7117deed7aef"
 
   devel do


### PR DESCRIPTION
sbt 0.13.15 (added in https://github.com/Homebrew/homebrew-core/pull/12264) includes JAR artifacts needed to run sbt, but it's using too much bandwidth on Bintray. This change switches to GitHub Releases.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
