### PR TITLE
sbt 1.0.0-M5 (devel)

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,7 +1,7 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "http://www.scala-sbt.org"
-  url "https://dl.bintray.com/sbt/native-packages/sbt/0.13.15/sbt-0.13.15.tgz"
+  url "https://github.com/sbt/sbt/releases/download/v0.13.15/sbt-0.13.15.tgz"
   sha256 "b6e073d7c201741dcca92cfdd1dd3cd76c42a47dc9d8c8ead8df7117deed7aef"
 
   devel do

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -5,9 +5,9 @@ class Sbt < Formula
   sha256 "b6e073d7c201741dcca92cfdd1dd3cd76c42a47dc9d8c8ead8df7117deed7aef"
 
   devel do
-    url "https://dl.bintray.com/sbt/native-packages/sbt/1.0.0-M4/sbt-1.0.0-M4.tgz"
-    sha256 "8cb2eaabcbfeceeb65023311b08c980feff80552b22524213c71857ced2f8de7"
-    version "1.0.0-M4"
+    url "https://github.com/sbt/sbt/releases/download/v1.0.0-M5/sbt-1.0.0-M5.tgz"
+    sha256 "06340442a3d6872dbdaceb3cb09e6812838a93da121954cfa8a2e07b1b527c74"
+    version "1.0.0-M5"
   end
 
   bottle :unneeded
@@ -20,21 +20,19 @@ class Sbt < Formula
       s.gsub! "/etc/sbt/sbtopts", "#{etc}/sbtopts"
     end
 
-    inreplace "bin/sbt-launch-lib.bash" do |s|
-      # Upstream issue "Replace realpath with something Mac compatible"
-      # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/149
-      s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
-      s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
-
-      # Workaround for `brew test sbt` failing to detect java -version
-      # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/150
-      if build.stable?
+    if build.stable? # Remove this `inreplace` when stable > 0.13.15
+      inreplace "bin/sbt-launch-lib.bash" do |s|
+        # Upstream issue "Replace realpath with something Mac compatible"
+        # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/149
+        s.gsub! "$(dirname \"$(realpath \"$0\")\")", "#{libexec}/bin"
+        s.gsub! "$(dirname \"$sbt_bin_dir\")", libexec
+        # Workaround for `brew test sbt` failing to detect java -version
+        # Reported 10 Apr 2017 https://github.com/sbt/sbt-launcher-package/issues/150
         s.gsub! "[[ \"$java_version\" > \"8\" ]]", "[[ \"$java_version\" == \"9\" ]]"
       end
     end
 
-    libexec.install "bin"
-    libexec.install "lib" if build.stable? # remove `if` when devel > 1.0.0-M4
+    libexec.install "bin", "lib"
     etc.install "conf/sbtopts"
 
     (bin/"sbt").write <<-EOS.undent
@@ -60,7 +58,6 @@ class Sbt < Formula
   test do
     ENV["_JAVA_OPTIONS"] = "-Dsbt.log.noformat=true"
     ENV.java_cache
-    output = shell_output("#{bin}/sbt sbt-version")
-    assert_match "[info] #{version}", output
+    assert_match "[info] #{version}", shell_output("#{bin}/sbt sbtVersion")
   end
 end


### PR DESCRIPTION
This PR is on top of https://github.com/Homebrew/homebrew-core/pull/12610.

sbt 1.0.0-M5 fixes previously raised issues https://github.com/sbt/sbt-launcher-package/issues/149 and https://github.com/sbt/sbt-launcher-package/issues/150, so the `inreplace` clause is now under `if build.stable?`.

----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
