### PR TITLE
bullet: always build shared libraries

### DIFF
--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -32,12 +32,13 @@ class Bullet < Formula
       args << "-DFRAMEWORK=ON"
       args << "-DCMAKE_INSTALL_PREFIX=#{frameworks}"
       args << "-DCMAKE_INSTALL_NAME_DIR=#{frameworks}"
+      args << "-DBUILD_BULLET2_DEMOS=OFF"
     else
       args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+      args << "-DBUILD_BULLET2_DEMOS=OFF" if build.without? "demo"
     end
 
     args << "-DUSE_DOUBLE_PRECISION=ON" if build.with? "double-precision"
-    args << "-DBUILD_BULLET2_DEMOS=OFF" if build.without? "demo"
 
     # always build and install shared libraries
     system "cmake", *args, "-DBUILD_SHARED_LIBS=ON"

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -58,7 +58,7 @@ class Bullet < Formula
 
   test do
     (testpath/"test.cpp").write <<-EOS.undent
-      #include "bullet/LinearMath/btPolarDecomposition.h"
+      #include "LinearMath/btPolarDecomposition.h"
       int main() {
         btMatrix3x3 I = btMatrix3x3::getIdentity();
         btMatrix3x3 u, h;
@@ -66,7 +66,16 @@ class Bullet < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-L#{lib}", "-lLinearMath", "-lc++", "-o", "test"
+    args = []
+    if build.with? "framework"
+      args << "-framework" << "LinearMath"
+      args << "-F#{frameworks}"
+      args << "-I#{frameworks}/LinearMath.framework/Headers"
+    else
+      args << "-I#{include}/bullet"
+      args << "-L#{lib}" << "-lLinearMath"
+    end
+    system ENV.cc, "test.cpp", *args, "-lc++", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -52,7 +52,6 @@ class Bullet < Formula
 
       # examples and extras only work with static libraries
       prefix.install "examples" if build.with? "demo"
-      prefix.install "Extras" if build.with? "extra"
     end
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Shared libraries can be installed alongside static libraries, so remove the `--with-shared` option and always build them. This will allow formulae that use bullet's shared libraries to pass the new audit checks in https://github.com/Homebrew/brew/pull/2482.