### PR TITLE
Updating pgbouncer config documentation location.

### DIFF
--- a/Formula/pgbouncer.rb
+++ b/Formula/pgbouncer.rb
@@ -31,7 +31,7 @@ class Pgbouncer < Formula
   def caveats; <<-EOS.undent
     The config file: #{etc}/pgbouncer.ini is in the "ini" format and you
     will need to edit it for your particular setup. See:
-    http://pgbouncer.projects.postgresql.org/doc/config.html
+    https://pgbouncer.github.io/config.html
 
     The auth_file option should point to the #{etc}/userlist.txt file which
     can be populated by the #{bin}/mkauth.py script.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Looks like pgbouncer updated the location of its documentation. The previous url http://pgbouncer.projects.postgresql.org/doc/config.html, redirects to https://pgbouncer.github.io. Might as well take users to the correct doc page.