### PR TITLE
mpd: add option --with-upnp

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -26,6 +26,7 @@ class Mpd < Formula
   option "with-opus", "Build with opus support (for Opus encoding and decoding)"
   option "with-libmodplug", "Build with modplug support (for decoding modules supported by MODPlug)"
   option "with-pulseaudio", "Build with PulseAudio support (for sending audio output to a PulseAudio sound server)"
+  option "with-upnp", "Build with upnp database plugin support"
 
   deprecated_option "with-vorbis" => "with-libvorbis"
 
@@ -60,6 +61,10 @@ class Mpd < Formula
   depends_on "mad" => :optional
   depends_on "libmodplug" => :optional  # MODPlug decoder
   depends_on "pulseaudio" => :optional
+  if build.with? "upnp"
+    depends_on "expat"
+    depends_on "libupnp"
+  end
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -92,6 +97,11 @@ class Mpd < Formula
     args << "--enable-nfs" if build.with? "libnfs"
     args << "--enable-modplug" if build.with? "libmodplug"
     args << "--enable-pulse" if build.with? "pulseaudio"
+    if build.with? "upnp"
+      args << "--enable-upnp"
+      args << "--enable-expat"
+      args << "--with-expat=/usr/local/opt/expat"
+    end
 
     system "./configure", *args
     system "make"

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -100,7 +100,6 @@ class Mpd < Formula
     if build.with? "upnp"
       args << "--enable-upnp"
       args << "--enable-expat"
-      args << "--with-expat=/usr/local/opt/expat"
     end
 
     system "./configure", *args


### PR DESCRIPTION
Add option to compile mpd with support for upnp database plugin.
Add conditional requirements of 'expat' and 'libupnp'

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
