### PR TITLE
valabind: patch to support BSD sed

### DIFF
--- a/Formula/valabind.rb
+++ b/Formula/valabind.rb
@@ -1,11 +1,27 @@
 class Valabind < Formula
   desc "Vala bindings for radare, reverse engineering framework"
   homepage "https://radare.org/"
-  url "https://www.radare.org/get/valabind-0.10.0.tar.gz"
-  sha256 "35517455b4869138328513aa24518b46debca67cf969f227336af264b8811c19"
-  revision 3
+  revision 4
 
   head "https://github.com/radare/valabind.git"
+
+  stable do
+    url "https://www.radare.org/get/valabind-0.10.0.tar.gz"
+    sha256 "35517455b4869138328513aa24518b46debca67cf969f227336af264b8811c19"
+    # patch necessary to support vala 0.36.0
+    # remove upon next release
+    patch do
+      url "https://github.com/radare/valabind/commit/f23ff9421c1875d18b1e558596557009b45faa19.patch"
+      sha256 "9fe8f9485e1a4f52c68831670b880efcbbae33c6bc70e67297a00cc1d2fe0d4f"
+    end
+
+    # patch to support BSD sed
+    # remove upon next release
+    patch do
+      url "https://github.com/radare/valabind/commit/03762a0fca7ff4bbfe3e668f70bb75422e05ac07.patch"
+      sha256 "13c5712ed5b081135d1e2df0dd04e1a05856b76de1e0acfef838c2fbc76964c5"
+    end
+  end
 
   bottle do
     cellar :any
@@ -17,13 +33,6 @@ class Valabind < Formula
   depends_on "pkg-config" => :build
   depends_on "swig" => :run
   depends_on "vala"
-
-  # patch necessary to support vala 0.36.0
-  # remove upon next release
-  patch do
-    url "https://github.com/radare/valabind/commit/f23ff9421c1875d18b1e558596557009b45faa19.patch"
-    sha256 "9fe8f9485e1a4f52c68831670b880efcbbae33c6bc70e67297a00cc1d2fe0d4f"
-  end
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This upstream patch is essential for BSD based macOS as it fixes the `sed: illegal option -- r` error showing up when building e.g. `radare2`.