### PR TITLE
fix sha256 hash for docker-completion v17.04.0-ce

### DIFF
--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -3,7 +3,7 @@ class DockerCompletion < Formula
   homepage "https://github.com/docker/docker"
   url "https://github.com/docker/docker/archive/v17.04.0-ce.tar.gz"
   version "17.04.0"
-  sha256 "b6ee0aa93ecea44e956d3627907e10557b3ec37d13ddfb40e436656e5037c640"
+  sha256 "76e84fbb7b5f1077f424ff40ddd14c98247f5aa3f49ad6412eede5a8cb11a29e"
   head "https://github.com/docker/docker"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
