### PR TITLE
gdb: depend on guile@2.0 instead of guile

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -26,6 +26,7 @@ class Gdb < Formula
   end
 
   deprecated_option "with-brewed-python" => "with-python"
+  deprecated_option "with-guile" => "with-guile@2.0"
 
   option "with-python", "Use the Homebrew version of Python; by default system Python is used"
   option "with-version-suffix", "Add a version suffix to program"
@@ -33,7 +34,7 @@ class Gdb < Formula
 
   depends_on "pkg-config" => :build
   depends_on "python" => :optional
-  depends_on "guile" => :optional
+  depends_on "guile@2.0" => :optional
 
   if MacOS.version >= :sierra
     patch do
@@ -55,7 +56,7 @@ class Gdb < Formula
       "--disable-dependency-tracking",
     ]
 
-    args << "--with-guile" if build.with? "guile"
+    args << "--with-guile" if build.with? "guile@2.0"
     args << "--enable-targets=all" if build.with? "all-targets"
 
     if build.with? "python"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the --with-guile option, which fails with Guile 2.2.x

Issue #12789.