### PR TITLE
make: depend on guile@2.0 instead of guile

### DIFF
--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -13,7 +13,9 @@ class Make < Formula
 
   option "with-default-names", "Do not prepend 'g' to the binary"
 
-  depends_on "guile" => :optional
+  deprecated_option "with-guile" => "with-guile@2.0"
+
+  depends_on "guile@2.0" => :optional
 
   def install
     args = %W[
@@ -21,7 +23,7 @@ class Make < Formula
       --prefix=#{prefix}
     ]
 
-    args << "--with-guile" if build.with? "guile"
+    args << "--with-guile" if build.with? "guile@2.0"
     args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the --with-guile option, which fails with Guile 2.2.x