### PR TITLE
Bump proof-general-4.4 to revision 1

### DIFF
--- a/Formula/proof-general.rb
+++ b/Formula/proof-general.rb
@@ -3,6 +3,7 @@ class ProofGeneral < Formula
   homepage "https://proofgeneral.github.io"
   url "https://github.com/ProofGeneral/PG/archive/v4.4.tar.gz"
   sha256 "1ba236d81768a87afa0287f49d4b2223097bc61d180468cbd997d46ab6132e7e"
+  revision 1
   head "https://github.com/ProofGeneral/PG.git"
 
   bottle do


### PR DESCRIPTION
This will allow the formula to be rebottled against the recent emacs-25.2 release

Fixes #12834

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
