### PR TITLE
fstar: Fix forwarding of args to fstar.exe wrapper

### DIFF
--- a/Formula/fstar.rb
+++ b/Formula/fstar.rb
@@ -41,7 +41,7 @@ class Fstar < Formula
     (libexec/"bin").install "bin/fstar.exe"
     (bin/"fstar.exe").write <<-EOS.undent
       #!/bin/sh
-      #{libexec}/bin/fstar.exe --fstar_home #{prefix} $@
+      #{libexec}/bin/fstar.exe --fstar_home #{prefix} "$@"
     EOS
 
     (libexec/"ulib").install Dir["ulib/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In the wrapper for fstar.exe, $@ expands words within each argument - "$@" is required to treat each parameter as its own argument and forward arguments as-is (otherwise an argument with spaces is expanded).

See [bash Special Parameters](https://www.gnu.org/software/bash/manual/bashref.html#Special-Parameters).