### PR TITLE
add instructions for auto-activating pyenv in shell

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -21,6 +21,12 @@ class Pyenv < Formula
     end
   end
 
+  def caveats; <<-EOS.undent
+    To enable auto-activation, add the following to your profile:
+      eval "$(pyenv init -)"
+    EOS
+  end
+
   test do
     shell_output("eval \"$(#{bin}/pyenv init -)\" && pyenv versions")
   end


### PR DESCRIPTION
Without this, the user has to `eval "$(pyenv init -)"` before
every pyenv command, which is rarely desirable. The pyenv official
instructions recommend adding this to your shell's profile.
