### PR TITLE
proj: fix allow cmake helpers install

### DIFF
--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -67,6 +67,12 @@ class Proj < Formula
 
   skip_clean :la
 
+  option "with-cmake", "Install the CMake library helpers to allow find_package(PROJ4)"
+
+  if build.with? "cmake"
+    depends_on "cmake" => :build
+  end
+
   def install
     resources.each do |r|
       if r.name == "datumgrid"
@@ -76,9 +82,16 @@ class Proj < Formula
       end
     end
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make", "install"
+    if build.without? "cmake"
+      system "./configure", "--disable-dependency-tracking",
+                            "--prefix=#{prefix}"
+      system "make", "install"
+    else
+      mkdir "proj4-build" do
+        system "cmake", "..", *std_cmake_args
+        system "make", "install"
+      end
+    end
   end
 
   test do

--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -1,5 +1,5 @@
 class Proj < Formula
-  desc "PROJ.4, a Cartographic Projections Library"
+  desc "Cartographic Projections Library by OSGeo"
   homepage "https://trac.osgeo.org/proj/"
   url "http://download.osgeo.org/proj/proj-4.9.3.tar.gz"
   sha256 "6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7"
@@ -12,6 +12,8 @@ class Proj < Formula
   end
 
   option "with-vdatum", "Install vertical datum files (~380 MB)"
+
+  depends_on "cmake" => :build
 
   # The datum grid files are required to support datum shifting
   resource "datumgrid" do
@@ -67,12 +69,6 @@ class Proj < Formula
 
   skip_clean :la
 
-  option "with-cmake", "Install the CMake library helpers to allow find_package(PROJ4)"
-
-  if build.with? "cmake"
-    depends_on "cmake" => :build
-  end
-
   def install
     resources.each do |r|
       if r.name == "datumgrid"
@@ -82,15 +78,9 @@ class Proj < Formula
       end
     end
 
-    if build.without? "cmake"
-      system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{prefix}"
+    mkdir "proj4-build" do
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
-    else
-      mkdir "proj4-build" do
-        system "cmake", "..", *std_cmake_args
-        system "make", "install"
-      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
Not fully there is a warning from before, about the description having the name of the formula in it.
-----

When using the configure, make route, proj4 doesn't install the cmake helper scripts, while using cmake to build it does.

I chose to set it as an option since it adds a dependency on cmake, but it might be that most people are willing to have the cmake helpers installed (a quick google for FindProj shows that many are reimplementing it because it is not installed by default).

