### PR TITLE
firebase-cli 3.6.1 (new formula)

### DIFF
--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -16,7 +16,7 @@ class FirebaseCli < Formula
 
   test do
     (testpath/"test.exp").write <<-EOS.undent
-      spawn firebase login:ci --no-localhost
+      spawn #{bin}/firebase login:ci --no-localhost
       expect "Paste"
     EOS
     assert_match "authorization code", shell_output("expect -f test.exp")

--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -1,7 +1,7 @@
 require "language/node"
 
 class FirebaseCli < Formula
-  desc "Firebase Command Line Tools"
+  desc "Firebase command-line tools"
   homepage "https://firebase.google.com/docs/cli/"
   url "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.6.1.tgz"
   sha256 "0235f8752d8ab7db647c07a255cfbe0a3db62c75e770595170fb9126ce8456b8"

--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -15,7 +15,10 @@ class FirebaseCli < Formula
   end
 
   test do
-    # other commands require login to use
-    system bin/"firebase", "--help"
+    (testpath/"test.exp").write <<-EOS.undent
+      spawn firebase login:ci --no-localhost
+      expect "Paste"
+    EOS
+    assert_match "authorization code", shell_output("expect -f test.exp")
   end
 end

--- a/Formula/firebase-cli.rb
+++ b/Formula/firebase-cli.rb
@@ -1,0 +1,21 @@
+require "language/node"
+
+class FirebaseCli < Formula
+  desc "Firebase Command Line Tools"
+  homepage "https://firebase.google.com/docs/cli/"
+  url "https://registry.npmjs.org/firebase-tools/-/firebase-tools-3.6.1.tgz"
+  sha256 "0235f8752d8ab7db647c07a255cfbe0a3db62c75e770595170fb9126ce8456b8"
+  head "https://github.com/firebase/firebase-tools.git"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # other commands require login to use
+    system bin/"firebase", "--help"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
`brew audit --strict firebase-cli` seems to be failing for both BrewBot and me; I'm not really sure what's causing the issue:
```
Error: undefined method `[]' for nil:NilClass
Please report this bug:
  http://docs.brew.sh/Troubleshooting.html
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:752:in `block in audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:751:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:751:in `audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1239:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1232:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1232:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:82:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:78:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:78:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:90:in `<main>'
```