### PR TITLE
profanity: add option --with-python-plugin-support

### DIFF
--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -19,6 +19,8 @@ class Profanity < Formula
     depends_on "libtool" => :build
   end
 
+  option "with-python-plugin-support", "Build with support for python plugins"
+
   depends_on "pkg-config" => :build
   depends_on "ossp-uuid"
   depends_on "libstrophe"
@@ -29,13 +31,19 @@ class Profanity < Formula
   depends_on "libotr" => :recommended
   depends_on "gpgme" => :recommended
   depends_on "terminal-notifier" => :optional
+  # this always uses homebrewed python version
+  depends_on "python" if build.with? "python-plugin-support"
 
   def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
+    args << "--disable-python-plugins" if build.without? "python-plugin-support"
+
     system "./bootstrap.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--disable-python-plugins",
-                          "--prefix=#{prefix}"
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -31,8 +31,7 @@ class Profanity < Formula
   depends_on "libotr" => :recommended
   depends_on "gpgme" => :recommended
   depends_on "terminal-notifier" => :optional
-  # this always uses homebrewed python version
-  depends_on "python" if build.with? "python-plugin-support"
+  depends_on :python if build.with? "python-plugin-support"
 
   def install
     args = %W[


### PR DESCRIPTION
Add option to compile profanity with support for python plugins.
Set dependency to 'python' to always use homebrew version of python.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
