### PR TITLE
mono-libgdiplus 5.4

### DIFF
--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -1,5 +1,5 @@
 class MonoLibgdiplus < Formula
-  desc "C-based implementation of GDI+ API http://www.mono-project.com/"
+  desc "Provides a GDI+-compatible API on non-Windows operating systems"
   homepage "http://www.mono-project.com/docs/gui/libgdiplus/"
   url "https://github.com/mono/libgdiplus/archive/910ba3a126d2639861fb7feb3f12941526e99be8.tar.gz"
   sha256 "af9892feff6fcc40fafe637f466c3d4c06c220c705107fa4a33e47cb3539f07a"

--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -1,0 +1,49 @@
+class MonoLibgdiplus < Formula
+  desc "C-based implementation of GDI+ API http://www.mono-project.com/"
+  homepage "http://www.mono-project.com/docs/gui/libgdiplus/"
+  url "https://github.com/mono/libgdiplus/archive/910ba3a126d2639861fb7feb3f12941526e99be8.tar.gz"
+  sha256 "af9892feff6fcc40fafe637f466c3d4c06c220c705107fa4a33e47cb3539f07a"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "libpng"
+  depends_on "freetype"
+  depends_on "fontconfig"
+  depends_on "pixman"
+  depends_on "glib"
+  depends_on "gettext"
+  depends_on "jpeg"
+  depends_on "libtiff"
+  depends_on "libexif"
+  depends_on "giflib"
+
+  def install
+    system "./autogen.sh", "--disable-debug",
+                           "--disable-dependency-tracking",
+                           "--disable-silent-rules",
+                           "--without-x11",
+                           "--disable-tests",
+                           "--prefix=#{prefix}"
+    system "make"
+    cd "tests" do
+      system "make", "testbits"
+      system "./testbits"
+    end
+    system "make", "install"
+  end
+
+  test do
+    # Since there are no headers to install (due to the libs nature as part of mono)
+    # The test just tries to include libgdiplus in the compile step, which should
+    # fail if it is not present
+    (testpath/"test.c").write <<-EOS.undent
+      int main() {
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lgdiplus", "-o", "test"
+  end
+end

--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -1,8 +1,8 @@
 class MonoLibgdiplus < Formula
   desc "Provides a GDI+-compatible API on non-Windows operating systems"
   homepage "http://www.mono-project.com/docs/gui/libgdiplus/"
-  url "https://github.com/mono/libgdiplus/archive/910ba3a126d2639861fb7feb3f12941526e99be8.tar.gz"
-  sha256 "af9892feff6fcc40fafe637f466c3d4c06c220c705107fa4a33e47cb3539f07a"
+  url "https://github.com/mono/libgdiplus/archive/5.4.tar.gz"
+  sha256 "ce31da0c6952c8fd160813dfa9bf4a9a871bfe7284e9e3abff9a8ee689acfe58"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -21,7 +21,8 @@ class MonoLibgdiplus < Formula
   depends_on "giflib"
 
   def install
-    system "./autogen.sh", "--disable-debug",
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-debug",
                            "--disable-dependency-tracking",
                            "--disable-silent-rules",
                            "--without-x11",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libgdiplus is the library used by Mono for its graphics. It is a missing dependency for the Mono formula. 

Previous efforts to get this into brew have stalled because the upstream repository did not contain a fix which allowed bypassing the dependency libgdiplus has on X11. This was fixed a while ago (mono/libgdiplus#46), so all should be good now to get this into homebrew.

Let me know if you need anything else.

See also #4202 (@medains), Homebrew/legacy-homebrew#45404 (@haf)