### PR TITLE
cdecl 3.0.1 (updated formula)

### DIFF
--- a/Formula/cdecl.rb
+++ b/Formula/cdecl.rb
@@ -4,6 +4,14 @@ class Cdecl < Formula
   url "https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-3.0.1/cdecl-3.0.1.tar.gz"
   sha256 "68437d334f1392f2e0555ae65cc9de5e13d8f9d13f9363e893c90d9654e11e37"
 
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "1d424613881cf9109d824664fc77fc947f2968b9850d448db4b02c6f0a562b5c" => :sierra
+    sha256 "4f0e990d88823aa9f3d1dcea71ffa442c13640ce82cc9da41f90a1be5ef457dc" => :el_capitan
+    sha256 "e8f53a0e5b3649f0c691c60380b9c77af573387240f3479a41550583fcc4e22c" => :yosemite
+    sha256 "b1e1618d0f1bcbb801c669c314c36c72e47e8829950a8bf0899d0517f3036ccc" => :mavericks
+  end
+
   def install
     ENV.deparallelize # must ensure parser.h builds first
 

--- a/Formula/cdecl.rb
+++ b/Formula/cdecl.rb
@@ -1,36 +1,20 @@
 class Cdecl < Formula
-  desc "Turn English phrases to C or C++ declarations"
-  homepage "https://cdecl.org/"
-  url "https://cdecl.org/files/cdecl-blocks-2.5.tar.gz"
-  sha256 "9ee6402be7e4f5bb5e6ee60c6b9ea3862935bf070e6cecd0ab0842305406f3ac"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "1d424613881cf9109d824664fc77fc947f2968b9850d448db4b02c6f0a562b5c" => :sierra
-    sha256 "4f0e990d88823aa9f3d1dcea71ffa442c13640ce82cc9da41f90a1be5ef457dc" => :el_capitan
-    sha256 "e8f53a0e5b3649f0c691c60380b9c77af573387240f3479a41550583fcc4e22c" => :yosemite
-    sha256 "b1e1618d0f1bcbb801c669c314c36c72e47e8829950a8bf0899d0517f3036ccc" => :mavericks
-  end
+  desc "Compose and decipher C (or C++) type declarations or casts."
+  homepage "https://github.com/paul-j-lucas/cdecl"
+  url "https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-3.0.1/cdecl-3.0.1.tar.gz"
+  sha256 "68437d334f1392f2e0555ae65cc9de5e13d8f9d13f9363e893c90d9654e11e37"
 
   def install
-    # Fix namespace clash with Lion's getline
-    inreplace "cdecl.c", "getline", "cdecl_getline"
+    ENV.deparallelize # must ensure parser.h builds first
 
-    bin.mkpath
-    man1.mkpath
-
-    ENV.append "CFLAGS", "-DBSD -DUSE_READLINE -std=gnu89"
-
-    system "make", "CC=#{ENV.cc}",
-                   "CFLAGS=#{ENV.cflags}",
-                   "LIBS=-lreadline",
-                   "BINDIR=#{bin}",
-                   "MANDIR=#{man1}",
-                   "install"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
   end
 
   test do
-    assert_equal "declare a as pointer to int",
-                 shell_output("#{bin}/cdecl explain int *a").strip
+    assert_equal "declare p as pointer to int",
+                 shell_output("#{bin}/cdecl explain 'int *p'").strip
   end
 end


### PR DESCRIPTION
Cdecl hasn't seen a major update since 1996.  This all-new version updates it
to support C through C11 and C++ through C++14 and greatly improves error
messages.

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
