### PR TITLE
libidn@2 2.0.2 (new formula)

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -13,6 +13,7 @@ class Curl < Formula
 
   keg_only :provided_by_osx
 
+  option "with-libidn@2", "Build with support for Internationalized Domain Names"
   option "with-rtmpdump", "Build with RTMP support"
   option "with-libssh2", "Build with scp and sftp support"
   option "with-c-ares", "Build with C-Ares async DNS support"
@@ -20,6 +21,8 @@ class Curl < Formula
   option "with-libmetalink", "Build with libmetalink support."
   option "with-nghttp2", "Build with HTTP/2 support (requires OpenSSL)"
 
+  deprecated_option "with-idn" => "with-libidn@2"
+  deprecated_option "with-libidn" => "with-libidn@2"
   deprecated_option "with-rtmp" => "with-rtmpdump"
   deprecated_option "with-ssh" => "with-libssh2"
   deprecated_option "with-ares" => "with-c-ares"
@@ -37,6 +40,7 @@ class Curl < Formula
   depends_on "rtmpdump" => :optional
   depends_on "libssh2" => :optional
   depends_on "c-ares" => :optional
+  depends_on "libidn@2" => :optional
   depends_on "libmetalink" => :optional
   depends_on "nghttp2" => :optional
 
@@ -63,6 +67,7 @@ class Curl < Formula
     end
 
     args << (build.with?("libssh2") ? "--with-libssh2" : "--without-libssh2")
+    args << (build.with?("libidn@2") ? "--with-libidn2" : "--without-libidn2")
     args << (build.with?("libmetalink") ? "--with-libmetalink" : "--without-libmetalink")
     args << (build.with?("gssapi") ? "--with-gssapi" : "--without-gssapi")
     args << (build.with?("rtmpdump") ? "--with-librtmp" : "--without-librtmp")

--- a/Formula/libidn@2.rb
+++ b/Formula/libidn@2.rb
@@ -1,5 +1,5 @@
 class LibidnAT2 < Formula
-  desc "International domain name library"
+  desc "International domain name library (IDNA2008, Punycode and TR46)"
   homepage "https://www.gnu.org/software/libidn/#libidn2"
   url "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.0.1.tar.xz"

--- a/Formula/libidn@2.rb
+++ b/Formula/libidn@2.rb
@@ -1,0 +1,45 @@
+class LibidnAT2 < Formula
+  desc "International domain name library"
+  homepage "https://www.gnu.org/software/libidn/#libidn2"
+  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.0.1.tar.xz"
+  sha256 "85bc255b936068d0cab3ea6c1a07e7c23b84a4cff4d1c345ee97d2f629173f47"
+
+  head do
+    url "https://gitlab.com/libidn/libidn2.git"
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "libtool" => :build
+    depends_on "gettext" => :build
+    depends_on "gengetopt" => :build
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on "libunistring"
+
+  def install
+    system "./bootstrap" if build.head?
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-packager=Homebrew"
+
+    # This is fixed already upstream by:
+    # https://gitlab.com/libidn/libidn2/commit/4caef557
+    # but by using inreplace we can avoid treating this like HEAD.
+    if build.stable?
+      inreplace "Makefile" do |s|
+        s.gsub! "TMPDIR", "ABI_TMPDIR"
+        s.gsub! "TMPFILE", "ABI_TMPFILE"
+      end
+    end
+    system "make", "install"
+  end
+
+  test do
+    ENV["CHARSET"] = "UTF-8"
+    system bin/"idn2", "räksmörgås.se", "blåbærgrød.no"
+  end
+end

--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -5,7 +5,8 @@ class Osc < Formula
   homepage "https://github.com/openSUSE/osc"
   url "https://github.com/openSUSE/osc/archive/0.157.2.tar.gz"
   sha256 "cde6384f069e3b08cc425cf5105251acb77f5f8c9413888b5f4ab89fec068f07"
-  revision 1
+  revision 2
+
   head "https://github.com/openSUSE/osc.git"
 
   bottle do

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -1,5 +1,3 @@
-# NOTE: Configure will fail if using awk 20110810 from dupes.
-# Upstream issue: https://savannah.gnu.org/bugs/index.php?37063
 class Wget < Formula
   desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -20,6 +20,8 @@ class Wget < Formula
     depends_on "gettext"
   end
 
+  deprecated_option "enable-iri" => "with-iri"
+  deprecated_option "with-iri" => "with-libidn@2"
   deprecated_option "enable-debug" => "with-debug"
 
   option "with-debug", "Build with debug support"
@@ -28,6 +30,7 @@ class Wget < Formula
   depends_on "pod2man" => :build if MacOS.version <= :snow_leopard
   depends_on "openssl"
   depends_on "pcre" => :optional
+  depends_on "libidn@2" => :optional
   depends_on "libmetalink" => :optional
   depends_on "gpgme" => :optional
 
@@ -45,6 +48,7 @@ class Wget < Formula
 
     args << "--disable-debug" if build.without? "debug"
     args << "--disable-pcre" if build.without? "pcre"
+    args << "--disable-iri" if build.without? "libidn@2"
     args << "--with-metalink" if build.with? "libmetalink"
     args << "--with-gpgme-prefix=#{Formula["gpgme"].opt_prefix}" if build.with? "gpgme"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New formula for `libidn@2`, which is now stable upstream.

`libidn@2` includes compatibility functions for other projects but I think the way to be most Homebrew-friendly is to introduce this as a new formula for now & migrate things across it as possible rather than inreplacing a bunch of projects to use the correct header:

> This library is backwards (API) compatible with the libidn library. Replacing the idna.h header with idn2.h into a program is sufficient to switch the application from IDNA2003 to IDNA2008 as supported by this library.