### PR TITLE
libvpx: add VP9 high bit depth support

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -14,6 +14,7 @@ class Libvpx < Formula
   option "with-gcov", "Enable code coverage"
   option "with-visualizer", "Enable post processing visualizer"
   option "with-examples", "Build examples (vpxdec/vpxenc)"
+  option "with-highbitdepth", "Enable high bit depth support for VP9"
 
   deprecated_option "gcov" => "with-gcov"
   deprecated_option "visualizer" => "with-visualizer"
@@ -35,6 +36,7 @@ class Libvpx < Formula
     args << (build.with?("examples") ? "--enable-examples" : "--disable-examples")
     args << "--enable-gcov" if !ENV.compiler == :clang && build.with?("gcov")
     args << "--enable-postproc" << "--enable-postproc-visualizer" if build.with? "visualizer"
+    args << "--enable-vp9-highbitdepth" if build.with? "highbitdepth"
 
     mkdir "macbuild" do
       system "../configure", *args


### PR DESCRIPTION
Adds support for the VP9 high bit depth compile-time option, which in turn enables 10-Bit and 12-Bit and profiles 2/3, respectively.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds support for higher bit depth encoding and new profiles with VP9.

ffmpeg will support those options after building libvpx with this option, then reinstalling ffmpeg.