### PR TITLE
git: fix with-brewed-openssl option

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -86,7 +86,13 @@ class Git < Formula
       CFLAGS=#{ENV.cflags}
       LDFLAGS=#{ENV.ldflags}
     ]
-    args << "NO_OPENSSL=1" << "APPLE_COMMON_CRYPTO=1" if build.without? "brewed-openssl"
+
+    if build.with? "brewed-openssl"
+      openssl_prefix = Formula["openssl"].opt_prefix
+      args += %W[NO_APPLE_COMMON_CRYPTO=1 OPENSSLDIR=#{openssl_prefix}]
+    else
+      args += %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
+    end
 
     system "make", "install", *args
 


### PR DESCRIPTION
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
 - fails with `Dependency subversion should not use option with-perl`

-----
This fixes the `--with-brewed-openssl` option, without the additional args it is a no-op.

Audit also erroneously flags `depends_on "go" => :build if build.with? "persistent-https"` with `Dependency go should not use option persistent-https`.

Probably fixes: https://github.com/Homebrew/homebrew-core/issues/12870