### PR TITLE
Ishiiruka Dolphin 5.0 (new formula)

### DIFF
--- a/Formula/ishiiruka-dolphin.rb
+++ b/Formula/ishiiruka-dolphin.rb
@@ -1,0 +1,49 @@
+class IshiirukaDolphin < Formula
+  desc "Custom Dolphin build with reduced graphic thread cpu usage."
+  homepage "https://github.com/Tinob/Ishiiruka"
+  url "https://github.com/Tinob/Ishiiruka/archive/Stable.tar.gz"
+  version "5.0"
+  sha256 "8a7b46ff645cd0303a5c7aaaf60bf2f8d39ac1c7a0df161d0385d064812f8e02"
+  head "https://github.com/Tinob/Ishiiruka.git"
+
+  option "with-avi-frame-dumps", "AVI Frame dumping support"
+
+  depends_on "cmake" => :build
+  depends_on "pulseaudio" => :recommended
+  depends_on "libao" => :optional unless build.head?
+  depends_on "ffmpeg" if build.with? "avi-frame-dumps"
+
+  if build.head?
+    patch :DATA
+  end
+
+  def install
+    args = ["-DCMAKE_CXX_FLAGS=-std=c++11",
+            "-DCMAKE_EXE_LINKER_FLAGS=-lc++"]
+
+    mkdir "build"
+    chmod_R 0777, "."
+    cd "build"
+    system "cmake", "..", *args, *std_cmake_args
+    system "make"
+    prefix.install "Binaries/Dolphin.app"
+  end
+
+  test do
+    system "#{prefix}/Dolphin.app/Contents/MacOS/Dolphin", "-h"
+  end
+end
+
+__END__
+diff --git a/Source/Core/DolphinWX/Frame.h b/Source/Core/DolphinWX/Frame.h
+index 1004afb..5b2a051
+--- a/Source/Core/DolphinWX/Frame.h
++++ b/Source/Core/DolphinWX/Frame.h
+@@ -8,6 +8,7 @@
+ #include <mutex>
+ #include <string>
+ #include <vector>
++#include <array>
+ #include <wx/bitmap.h>
+ #include <wx/frame.h>
+ #include <wx/image.h>


### PR DESCRIPTION
New formula to build the Ishiiruka Dolphin emulator from source,
Stable release and HEAD.

They don't use tags so it is impossible to retrieve a particular
version for the Stable release, only the latest one.

HEAD needs a patch in file Source/Core/Frame.h to be able to
be built correctly on macOS. I already filed a bug report upstream
here (https://github.com/Tinob/Ishiiruka/issues/76). For the moment
the patch is included in the formula.

All dependencies are included in the source, with the exception
of libav/ffmpeg which is optional, and pulseaudio which is also
optional but recommended since without it everything builds
correctly but I get no sound output in the program.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
