### PR TITLE
mysql & mariadb: Move bind address 127.0.0.1 to my.cnf

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -151,6 +151,9 @@ class Mariadb < Formula
 
     To connect:
         mysql -uroot
+
+    Using brew services will place a plist file at #{ENV["HOME"]}/Library/LaunchAgents/#{plist_name}
+    This plist file overrides the bind address to 127.0.0.1. Edit this plist file if you need to change the server's bind address.
     EOS
   end
 

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -133,6 +133,15 @@ class Mariadb < Formula
       inreplace "#{bin}/#{f}", "$(dirname $0)/wsrep_sst_common",
                                "#{libexec}/wsrep_sst_common"
     end
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -149,11 +158,10 @@ class Mariadb < Formula
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
 
+    MySQL is configured to only allow connections from localhost by default
+
     To connect:
         mysql -uroot
-
-    Using brew services will place a plist file at #{ENV["HOME"]}/Library/LaunchAgents/#{plist_name}
-    This plist file overrides the bind address to 127.0.0.1. Edit this plist file if you need to change the server's bind address.
     EOS
   end
 
@@ -171,7 +179,6 @@ class Mariadb < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
-        <string>--bind-address=127.0.0.1</string>
         <string>--datadir=#{var}/mysql</string>
       </array>
       <key>RunAtLoad</key>

--- a/Formula/mariadb@10.0.rb
+++ b/Formula/mariadb@10.0.rb
@@ -108,6 +108,15 @@ class MariadbAT100 < Formula
     end
 
     bin.install_symlink prefix/"support-files/mysql.server"
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -123,6 +132,8 @@ class MariadbAT100 < Formula
   def caveats; <<-EOS.undent
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         mysql -uroot
@@ -143,7 +154,6 @@ class MariadbAT100 < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
-        <string>--bind-address=127.0.0.1</string>
         <string>--datadir=#{var}/mysql</string>
       </array>
       <key>RunAtLoad</key>

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -143,6 +143,7 @@ class MysqlCluster < Formula
       #{var}/mysql-cluster
     Note that in a production system there are other parameters
     that you would set to tune the configuration.
+    MySQL is configured to only allow connections from localhost by default
 
     Set up databases to run AS YOUR USER ACCOUNT with:
       unset TMPDIR
@@ -176,6 +177,8 @@ class MysqlCluster < Formula
     datadir=#{var}/mysql-cluster/mysqld_data
     basedir=#{opt_prefix}
     port=5000
+    # Only allow connections from localhost
+    bind-address = 127.0.0.1
     EOCNF
   end
 
@@ -301,7 +304,7 @@ class MysqlCluster < Formula
       "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
       pid = fork do
-        exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}"
+        exec bin/"mysqld", "--datadir=#{dir}"
       end
       sleep 2
 

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -113,6 +113,15 @@ class Mysql < Formula
               /^(PATH=".*)(")/,
               "\\1:#{HOMEBREW_PREFIX}/bin\\2"
     bin.install_symlink prefix/"support-files/mysql.server"
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -122,17 +131,6 @@ class Mysql < Formula
       ENV["TMPDIR"] = nil
       system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
         "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
-    end
-
-    # Create my.cnf that binds to 127.0.0.1 by default
-    unless (etc/"my.cnf").exist?
-      s = <<-EOS.undent
-        # Default Homebrew MySQL server config
-        [mysqld]
-        # Only allow connections from localhost
-        bind-address = 127.0.0.1
-      EOS
-      File.write(etc/"my.cnf", s)
     end
   end
 

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -123,6 +123,17 @@ class Mysql < Formula
       system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
         "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
     end
+
+    # Create my.cnf that binds to 127.0.0.1 by default
+    unless (etc/"my.cnf").exist?
+      s = <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost by default
+      bind_address = 127.0.0.1
+      EOS
+      File.write(etc/"my.cnf", s)
+    end
   end
 
   def caveats
@@ -130,11 +141,11 @@ class Mysql < Formula
     We've installed your MySQL database without a root password. To secure it run:
         mysql_secure_installation
 
+    We've installed a default server config which only allows connections from localhost.
+    You'll find that config here: #{etc}/my.cnf
+
     To connect run:
         mysql -uroot
-
-    Using brew services will place a plist file at #{ENV["HOME"]}/Library/LaunchAgents/#{plist_name}
-    This plist file overrides the bind address to 127.0.0.1. Edit this plist file if you need to change the server's bind address.
     EOS
     if my_cnf = ["/etc/my.cnf", "/etc/mysql/my.cnf"].find { |x| File.exist? x }
       s += <<-EOS.undent
@@ -160,7 +171,6 @@ class Mysql < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
-        <string>--bind-address=127.0.0.1</string>
         <string>--datadir=#{datadir}</string>
       </array>
       <key>RunAtLoad</key>

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -132,6 +132,9 @@ class Mysql < Formula
 
     To connect run:
         mysql -uroot
+
+    Using brew services will place a plist file at #{ENV["HOME"]}/Library/LaunchAgents/#{plist_name}
+    This plist file overrides the bind address to 127.0.0.1. Edit this plist file if you need to change the server's bind address.
     EOS
     if my_cnf = ["/etc/my.cnf", "/etc/mysql/my.cnf"].find { |x| File.exist? x }
       s += <<-EOS.undent

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -130,7 +130,7 @@ class Mysql < Formula
       # Default Homebrew MySQL server config
       [mysqld]
       # Only allow connections from localhost by default
-      bind_address = 127.0.0.1
+      bind-address = 127.0.0.1
       EOS
       File.write(etc/"my.cnf", s)
     end

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -127,10 +127,10 @@ class Mysql < Formula
     # Create my.cnf that binds to 127.0.0.1 by default
     unless (etc/"my.cnf").exist?
       s = <<-EOS.undent
-      # Default Homebrew MySQL server config
-      [mysqld]
-      # Only allow connections from localhost by default
-      bind-address = 127.0.0.1
+        # Default Homebrew MySQL server config
+        [mysqld]
+        # Only allow connections from localhost
+        bind-address = 127.0.0.1
       EOS
       File.write(etc/"my.cnf", s)
     end
@@ -141,8 +141,7 @@ class Mysql < Formula
     We've installed your MySQL database without a root password. To secure it run:
         mysql_secure_installation
 
-    We've installed a default server config which only allows connections from localhost.
-    You'll find that config here: #{etc}/my.cnf
+    MySQL is configured to only allow connections from localhost by default
 
     To connect run:
         mysql -uroot

--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -107,6 +107,15 @@ class MysqlAT55 < Formula
 
     libexec.install bin/"mysqlaccess"
     libexec.install bin/"mysqlaccess.conf"
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -122,6 +131,8 @@ class MysqlAT55 < Formula
   def caveats; <<-EOS.undent
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         #{opt_bin}/mysql -uroot
@@ -142,7 +153,6 @@ class MysqlAT55 < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
-        <string>--bind-address=127.0.0.1</string>
         <string>--datadir=#{datadir}</string>
       </array>
       <key>RunAtLoad</key>
@@ -162,7 +172,7 @@ class MysqlAT55 < Formula
       "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
       pid = fork do
-        exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}"
+        exec bin/"mysqld", "--datadir=#{dir}"
       end
       sleep 2
 

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -107,6 +107,15 @@ class MysqlAT56 < Formula
 
     libexec.install bin/"mysqlaccess"
     libexec.install bin/"mysqlaccess.conf"
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -122,6 +131,8 @@ class MysqlAT56 < Formula
   def caveats; <<-EOS.undent
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         mysql -uroot
@@ -142,7 +153,6 @@ class MysqlAT56 < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
-        <string>--bind-address=127.0.0.1</string>
         <string>--datadir=#{datadir}</string>
       </array>
       <key>RunAtLoad</key>
@@ -162,7 +172,7 @@ class MysqlAT56 < Formula
       "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
       pid = fork do
-        exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}"
+        exec bin/"mysqld", "--datadir=#{dir}"
       end
       sleep 2
 

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -119,11 +119,22 @@ class PerconaServer < Formula
     end
 
     bin.install_symlink prefix/"support-files/mysql.server"
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def caveats; <<-EOS.undent
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         mysql -uroot

--- a/Formula/percona-server@5.5.rb
+++ b/Formula/percona-server@5.5.rb
@@ -104,6 +104,15 @@ class PerconaServerAT55 < Formula
     libexec.mkpath
     mv "#{bin}/mysqlaccess", libexec
     mv "#{bin}/mysqlaccess.conf", libexec
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def caveats; <<-EOS.undent
@@ -124,6 +133,8 @@ class PerconaServerAT55 < Formula
 
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         mysql -uroot

--- a/Formula/percona-server@5.5.rb
+++ b/Formula/percona-server@5.5.rb
@@ -162,4 +162,11 @@ class PerconaServerAT55 < Formula
     </plist>
     EOS
   end
+
+  test do
+    system "/bin/sh", "-n", "#{bin}/mysqld_safe"
+    (prefix/"mysql-test").cd do
+      system "./mysql-test-run.pl", "status", "--vardir=#{testpath}"
+    end
+  end
 end

--- a/Formula/percona-server@5.5.rb
+++ b/Formula/percona-server@5.5.rb
@@ -74,12 +74,6 @@ class PerconaServerAT55 < Formula
     # Compile with readline unless libedit is explicitly chosen
     args << "-DWITH_READLINE=yes" if build.without? "libedit"
 
-    # Make universal for binding to universal applications
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     # Build with local infile loading support
     args << "-DENABLED_LOCAL_INFILE=1" if build.include? "enable-local-infile"
 

--- a/Formula/percona-server@5.6.rb
+++ b/Formula/percona-server@5.6.rb
@@ -117,6 +117,15 @@ class PerconaServerAT56 < Formula
     libexec.mkpath
     mv "#{bin}/mysqlaccess", libexec
     mv "#{bin}/mysqlaccess.conf", libexec
+
+    # Install my.cnf that binds to 127.0.0.1 by default
+    (buildpath/"my.cnf").write <<-EOS.undent
+      # Default Homebrew MySQL server config
+      [mysqld]
+      # Only allow connections from localhost
+      bind-address = 127.0.0.1
+    EOS
+    etc.install "my.cnf"
   end
 
   def post_install
@@ -132,6 +141,8 @@ class PerconaServerAT56 < Formula
   def caveats; <<-EOS.undent
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
+
+    MySQL is configured to only allow connections from localhost by default
 
     To connect:
         mysql -uroot

--- a/Formula/percona-server@5.6.rb
+++ b/Formula/percona-server@5.6.rb
@@ -82,12 +82,6 @@ class PerconaServerAT56 < Formula
     # Build with InnoDB Memcached plugin
     args << "-DWITH_INNODB_MEMCACHED=ON" if build.with? "memcached"
 
-    # Make universal for binding to universal applications
-    if build.universal?
-      ENV.universal_binary
-      args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.universal_archs.as_cmake_arch_flags}"
-    end
-
     # Build with local infile loading support
     args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"
 


### PR DESCRIPTION
#### Summary
Move the 127.0.0.1 bind address into a default `my.cnf` that is created during post install instead of having it as a param in the plist file.

#### Reason
Trying to help people (myself included) not have to spend a lot of time troubleshooting why external hosts can't connect.

#### Misc
Reference issue #12744.

I've updated both MySQL & MariaDB in this same pull request - please let me know if you prefer separate pull requests for each.