### PR TITLE
lmdb: add simple lmdb.pc pkg-config file

### DIFF
--- a/Formula/lmdb.rb
+++ b/Formula/lmdb.rb
@@ -8,10 +8,8 @@ class Lmdb < Formula
 
   bottle do
     cellar :any
-    rebuild 1
-    sha256 "31c30590d1d685e7418d45b50b5e636cea5ea5147b472172ff4f809686297892" => :sierra
-    sha256 "655ec022ac655fde5a3c88ca4b71c0c6942a0c758e12262d495d15747fc65ecd" => :el_capitan
-    sha256 "36f056edff5219f3efca010d290f8882d5dd053c10cf8f1d673a7a6477f7b20e" => :yosemite
+    rebuild 2
+    sha256 "2479fecf209528e4a8ea9af3a692c28b32fe775f3ee4b9bf391887ae942cb9e1" => :sierra
   end
 
   def install
@@ -20,6 +18,23 @@ class Lmdb < Formula
       system "make", "test", "SOEXT=.dylib"
       system "make", "install", "SOEXT=.dylib", "prefix=#{prefix}"
     end
+    (buildpath/"lmdb.pc").write(lmdb_pc)
+    (lib/"pkgconfig").install "lmdb.pc"
+  end
+
+  def lmdb_pc; <<-EOS.undent
+    prefix=#{prefix}
+    exec_prefix=#{prefix}
+    libdir=${exec_prefix}/lib
+    includedir=${prefix}/include
+
+    Name: liblmdb
+    Description: Lightning Memory-Mapped Database
+    URL: https://symas.com/products/lightning-memory-mapped-database/
+    Version: #{version}
+    Libs: -L${libdir} -llmdb
+    Cflags: -I${includedir}
+    EOS
   end
 
   test do

--- a/Formula/lmdb.rb
+++ b/Formula/lmdb.rb
@@ -8,8 +8,10 @@ class Lmdb < Formula
 
   bottle do
     cellar :any
-    rebuild 2
-    sha256 "2479fecf209528e4a8ea9af3a692c28b32fe775f3ee4b9bf391887ae942cb9e1" => :sierra
+    rebuild 1
+    sha256 "31c30590d1d685e7418d45b50b5e636cea5ea5147b472172ff4f809686297892" => :sierra
+    sha256 "655ec022ac655fde5a3c88ca4b71c0c6942a0c758e12262d495d15747fc65ecd" => :el_capitan
+    sha256 "36f056edff5219f3efca010d290f8882d5dd053c10cf8f1d673a7a6477f7b20e" => :yosemite
   end
 
   def install
@@ -18,8 +20,7 @@ class Lmdb < Formula
       system "make", "test", "SOEXT=.dylib"
       system "make", "install", "SOEXT=.dylib", "prefix=#{prefix}"
     end
-    (buildpath/"lmdb.pc").write(lmdb_pc)
-    (lib/"pkgconfig").install "lmdb.pc"
+    (lib/"pkgconfig/lmdb.pc").write(lmdb_pc)
   end
 
   def lmdb_pc; <<-EOS.undent


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds a simple pkg-config file for lmdb library, so it can be used with modern build systems without too much hacking.