### PR TITLE
terminally-tetris 1.0.0 (new formula)

### DIFF
--- a/Formula/terminally-tetris.rb
+++ b/Formula/terminally-tetris.rb
@@ -1,0 +1,24 @@
+class TerminallyTetris < Formula
+  desc "Play Tetris in the Terminal"
+  homepage "https://github.com/thecardkid/terminally-tetris"
+  url "https://github.com/thecardkid/terminally-tetris/archive/v1.0.0.tar.gz"
+  sha256 "213f8a7581e69d3284291187eb887a1c0822fe699d53a7768f0fea777bc1427b"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "make"
+    bin.install "build/ttetris"
+    man.mkpath
+    man1.install "man/ttetris.1"
+  end
+
+  test do
+    output = shell_output(bin/"ttetris help")
+    assert_match "Terminally-Tetris' key bindings", output
+
+    # invalid argument
+    output = shell_output(bin/"ttetris save")
+    assert_match "Did not recognize argument. See man page for help.", output
+  end
+end


### PR DESCRIPTION
Adding a new formula that allows tetris to be played in the terminal.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
