### PR TITLE
elasticsearch 5.3.2

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.1.tar.gz"
-  sha256 "1c277102bedf58d8e0f029b5eecc415260a4ad49442cf8265d6ed7adc0021269"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.2.tar.gz"
+  sha256 "a94fe46bc90eb271a0d448d20e49cb02526ac032281c683c79a219240280a1e8"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"


### PR DESCRIPTION
This pull request bumps the Elasticsearch version from 5.3.1 to 5.3.2.
