### PR TITLE
ck 0.6.0 (new formula)

### DIFF
--- a/Formula/ck.rb
+++ b/Formula/ck.rb
@@ -1,0 +1,26 @@
+class Ck < Formula
+  desc "Concurrency primitives and non-blocking data structures library"
+  homepage "http://concurrencykit.org/"
+  url "http://concurrencykit.org/releases/ck-0.6.0.tar.gz"
+  sha256 "d7e27dd0a679e45632951e672f8288228f32310dfed2d5855e9573a9cf0d62df"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+    #include <ck_spinlock.h>
+    int main() {
+      ck_spinlock_t spinlock;
+      ck_spinlock_init(&spinlock);
+      return 0;
+    }
+    EOS
+    system ENV.cc, "-I#{include}", "-L#{lib}", "-lck",
+           testpath/"test.c", "-o", testpath/"test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Concurrent Kit is used to add multi-threading support to the Crystal
language runtime. It'll soon be required to build crystal, hence this PR.

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
