### PR TITLE
Update j2objc formula to follow formula rules

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -1,9 +1,8 @@
 class Gradle < Formula
   desc "Build system based on the Groovy language"
   homepage "https://www.gradle.org/"
-  url "https://services.gradle.org/distributions/gradle-3.5-all.zip"
-  sha256 "d84bf6b6113da081d0082bcb63bd8547824c6967fe68704d1e3a6fde822b7212"
-
+  url "https://services.gradle.org/distributions-snapshots/gradle-4.0-20170426102539+0000-bin.zip"
+  sha256 "4e502f1c152c0df787e7cd8fcb043c3d03a8c65cf1d8ae46c9475ddbc80ceebb"
   bottle :unneeded
 
   option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"

--- a/Formula/j2objc.rb
+++ b/Formula/j2objc.rb
@@ -1,0 +1,41 @@
+## TODO Prebuilt version, to be updated for build from source
+
+class J2objc < Formula
+  desc "Java to iOS Objective-C translation tool and runtime. (Prebuilt)"
+  homepage "http://j2objc.org"
+  url "https://github.com/google/j2objc/archive/1.3.1.zip"
+  sha256 "bd05db67fb233dfe7b58cefc899afb8f35099eae0e4b8a6486a398472fb2fac3"
+
+  def shim_script(target)
+    <<-EOS.undent
+    #!/bin/bash
+    export J2OBJC_HOME=#{libexec}
+    "#{libexec}/#{target}" "$@"
+    EOS
+  end
+
+  def install
+    libexec.install %w[lib include]
+    man.install Dir["man/*"]
+    libexec.install "j2objc"
+    libexec.install "j2objcc"
+    libexec.install "cycle_finder"
+    (bin+"j2objc").write shim_script("j2objc")
+    (bin+"j2objcc").write shim_script("j2objcc")
+    (bin+"cycle_finder").write shim_script("cycle_finder")
+# bin.install_symlink libexec/"j2objc"
+# bin.install_symlink libexec/"j2objcc"
+# bin.install_symlink libexec/"cycle_finder"
+# system "./configure", "--disable-debug",
+#                      "--disable-dependency-tracking",
+#                      "--disable-silent-rules",
+#                      "--prefix=#{prefix}"
+# system "make", "install"
+  end
+
+  test do
+    # system "false"
+  end
+end
+# Documents : https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md
+#             http://www.rubydoc.info/github/Homebrew/brew/master/Formula


### PR DESCRIPTION
J2ObjC is an open-source command-line tool from Google that translates Java source code to Objective-C for the iOS (iPhone/iPad) platform. This tool enables Java source to be part of an iOS application's build, as no editing of the generated files is necessary.
It takes very long to build from source, so the default option shall be prebuilt. (1.6GB)
https://github.com/google/j2objc

- [v ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ v] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ v] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
