### PR TITLE
libvpx: add VP9 in description

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -1,5 +1,5 @@
 class Libvpx < Formula
-  desc "VP8 video codec"
+  desc "VP8/VP9 video codec"
   homepage "https://www.webmproject.org/code/"
   url "https://github.com/webmproject/libvpx/archive/v1.6.1.tar.gz"
   sha256 "cda8bb6f0e4848c018177d3a576fa83ed96d762554d7010fe4cfb9d70c22e588"


### PR DESCRIPTION
add VP9 in the description of the libvpx formula

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
