### PR TITLE
immortal: fixed formula to enable passing version on compile time

### DIFF
--- a/Formula/immortal.rb
+++ b/Formula/immortal.rb
@@ -1,3 +1,5 @@
+require "language/go"
+
 class Immortal < Formula
   desc "OS agnostic (*nix) cross-platform supervisor"
   homepage "https://immortal.run/"
@@ -14,11 +16,51 @@ class Immortal < Formula
 
   depends_on "go" => :build
 
+  go_resource "gopkg.in/yaml.v2" do
+    url "https://github.com/go-yaml/yaml.git",
+        :revision => "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
+  end
+
+  go_resource "github.com/nbari/violetear" do
+    url "https://github.com/nbari/violetear.git",
+        :revision => "502d8b0480c0d356d94b16b22ad222deec81e6cc"
+  end
+
+  go_resource "github.com/immortal/logrotate" do
+    url "https://github.com/immortal/logrotate.git",
+        :revision => "3691ab555939319a80a8833983faedb8b76d9cc6"
+  end
+
+  go_resource "github.com/immortal/multiwriter" do
+    url "https://github.com/immortal/multiwriter.git",
+        :revision => "2555774a03ac1d12b5bb4392858959ee50f78884"
+  end
+
+  go_resource "github.com/immortal/natcasesort" do
+    url "https://github.com/immortal/natcasesort.git",
+        :revision => "69368b73881a69041466dd2b4fc0373f8e47db15"
+  end
+
+  go_resource "github.com/immortal/xtime" do
+    url "https://github.com/immortal/xtime.git",
+        :revision => "fb1aca1146ea82769e8433f5bb22f373765e7ecc"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/immortal/immortal").install buildpath.children
+    Language::Go.stage_deps resources, buildpath/"src"
     cd "src/github.com/immortal/immortal" do
-      system "make", "install", "DESTDIR=#{prefix}"
+      ldflags = "-s -w -X main.version=#{version}"
+      system "go", "build", "-ldflags", ldflags, "-o", "immortal", "cmd/immortal/main.go"
+      system "go", "build", "-ldflags", ldflags, "-o", "immortalctl", "cmd/immortalctl/main.go"
+      system "go", "build", "-ldflags", ldflags, "-o", "immortaldir", "cmd/immortaldir/main.go"
+      bin.install "immortal"
+      bin.install "immortalctl"
+      bin.install "immortaldir"
+      man8.install "man/immortal.8"
+      man8.install "man/immortalctl.8"
+      man8.install "man/immortaldir.8"
     end
   end
 


### PR DESCRIPTION
	modified:   immortal.rb

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
