### PR TITLE
winetricks: make wine dependency optional

### DIFF
--- a/Formula/winetricks.rb
+++ b/Formula/winetricks.rb
@@ -12,8 +12,8 @@ class Winetricks < Formula
   depends_on "cabextract"
   depends_on "p7zip"
   depends_on "unrar"
-  depends_on "wine" => [:optional, :run]
-  depends_on "zenity" => [:optional, :run]
+  depends_on "wine" => :optional
+  depends_on "zenity" => :optional
 
   def install
     bin.install "src/winetricks"

--- a/Formula/winetricks.rb
+++ b/Formula/winetricks.rb
@@ -12,7 +12,7 @@ class Winetricks < Formula
   depends_on "cabextract"
   depends_on "p7zip"
   depends_on "unrar"
-  depends_on "wine"
+  depends_on "wine" => [:optional, :run]
   depends_on "zenity" => [:optional, :run]
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There is a three casks that provide different branches of wine, so I think dependency on wine from brew should be optional. So those who use wine from caskroom can save 600 MB of disk space. 