### PR TITLE
plplot: make x11 dependency non optional

### DIFF
--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -3,6 +3,7 @@ class Plplot < Formula
   homepage "https://plplot.sourceforge.io"
   url "https://downloads.sourceforge.net/project/plplot/plplot/5.12.0%20Source/plplot-5.12.0.tar.gz"
   sha256 "8dc5da5ef80e4e19993d4c3ef2a84a24cc0e44a5dade83201fca7160a6d352ce"
+  revision 1
 
   bottle do
     sha256 "983bfc816485426b63a65d2afb52f6945acb4ccfdbe7044909055d4c2f9aeb94" => :sierra
@@ -16,7 +17,7 @@ class Plplot < Formula
   depends_on "pango"
   depends_on "freetype"
   depends_on "libtool" => :run
-  depends_on :x11 => :optional
+  depends_on :x11
   depends_on :fortran => :optional
   depends_on :java => :optional
 


### PR DESCRIPTION
Fixes:

homebrew/science/gnudatalanguage:
  * Dependency plplot should not use option with-x11

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
