### PR TITLE
openssh: fix sandbox profile location

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -1,11 +1,11 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-
   url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
   mirror "https://www.mirrorservice.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
   version "7.5p1"
   sha256 "9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0"
+  revision 1
 
   bottle do
     sha256 "5b40ddc62eb4356cc446b17af0ceb902e9ab1bb19149b54001a023c1d54da1a3" => :sierra
@@ -31,8 +31,17 @@ class Openssh < Formula
     sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
   end
 
+  resource "com.openssh.sshd.sb" do
+    url "https://opensource.apple.com/source/OpenSSH/OpenSSH-209.50.1/com.openssh.sshd.sb"
+    sha256 "a273f86360ea5da3910cfa4c118be931d10904267605cdd4b2055ced3a829774"
+  end
+
   def install
     ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__"
+
+    # Ensure sandbox profile prefix is correct.
+    # We introduce this issue with patching, it's not an upstream bug.
+    inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
 
     args = %W[
       --with-libedit
@@ -53,9 +62,21 @@ class Openssh < Formula
     # potential to break scripts, so recreate it for now.
     # Debian have done the same thing.
     bin.install_symlink bin/"ssh" => "slogin"
+
+    buildpath.install resource("com.openssh.sshd.sb")
+    (etc/"ssh").install "com.openssh.sshd.sb" => "org.openssh.sshd.sb"
   end
 
   test do
     assert_match "OpenSSH_", shell_output("#{bin}/ssh -V 2>&1")
+
+    begin
+      pid = fork { exec sbin/"sshd", "-D", "-p", "8022" }
+      sleep 2
+      assert_match "sshd", shell_output("lsof -i :8022")
+    ensure
+      Process.kill(9, pid)
+      Process.wait(pid)
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I left a comment in dupes somewhere _months ago_ about how to fix this but nobody filed a PR, and to be fair, neither did I, so I guess I can't blame anyone but myself for leaving this broken for so long eh.

Fixes https://github.com/Homebrew/homebrew-core/issues/12488.