### PR TITLE
chromaprint : add "fftw" option

### DIFF
--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -3,18 +3,15 @@ class Chromaprint < Formula
   homepage "https://acoustid.org/chromaprint"
   url "https://github.com/acoustid/chromaprint/releases/download/v1.4.2/chromaprint-1.4.2.tar.gz"
   sha256 "989609a7e841dd75b34ee793bd1d049ce99a8f0d444b3cea39d57c3e5d26b4d4"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "d3a2316c7cedb13dac47582732166a1be94895398741d45190daaf64a740c307" => :sierra
-    sha256 "b6d54f06b28a2d2d9868ee5977ff4f8fb65a7356e0aa9d76b299850642f8e72d" => :el_capitan
-    sha256 "e93bfcd661dc4b27765ea083585776e53a440343268d1a4a0c1cbdfb60698126" => :yosemite
-  end
+  revision 1
 
   depends_on "cmake" => :build
+  depends_on "fftw" => :optional
 
   def install
-    system "cmake", ".", *std_cmake_args
+    args = std_cmake_args
+    args << "-DFFT_LIB=fftw3" if build.with? "fftw"
+    system "cmake", ".", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
With new option
>$ otool -L /usr/local/Cellar/chromaprint/1.4.2_1/lib/libchromaprint.1.4.2.dylib
/usr/local/Cellar/chromaprint/1.4.2_1/lib/libchromaprint.1.4.2.dylib:
	/usr/local/opt/chromaprint/lib/libchromaprint.1.dylib (compatibility version 1.0.0, current version 1.4.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)
	/usr/local/opt/fftw/lib/libfftw3.3.dylib (compatibility version 9.0.0, current version 9.6.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
