### PR TITLE
x264 : link to OpenCL Framework correctly

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -4,6 +4,7 @@ class X264 < Formula
   # the latest commit on the stable branch
   url "https://git.videolan.org/git/x264.git", :revision => "97eaef2ab82a46d13ea5e00270712d6475fbe42b"
   version "r2748"
+  revision 1
   head "https://git.videolan.org/git/x264.git"
 
   bottle do
@@ -28,6 +29,8 @@ class X264 < Formula
       --enable-static
       --enable-strip
     ]
+    args <<  "--extra-cflags=-framework OpenCL"
+    args <<  "--extra-ldflags=-framework OpenCL"
     args << "--disable-lsmash" if build.without? "l-smash"
     args << "--bit-depth=10" if build.with? "10-bit"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Before(bottled):
>$ otool -L /usr/local/Cellar/x264/r2748/lib/libx264.148.dylib
/usr/local/Cellar/x264/r2748/lib/libx264.148.dylib:
	/usr/local/opt/x264/lib/libx264.148.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)

After:
>$ otool -L /usr/local/Cellar/x264/r2748/lib/libx264.148.dylib
/usr/local/Cellar/x264/r2748/lib/libx264.148.dylib:
	/usr/local/opt/x264/lib/libx264.148.dylib (compatibility version 0.0.0, current version 0.0.0)
	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)