### PR TITLE
adr-tools 2.1.0 (new formula)

### DIFF
--- a/Formula/adr-tools.rb
+++ b/Formula/adr-tools.rb
@@ -5,11 +5,15 @@ class AdrTools < Formula
   sha256 "1ef028cfeaa1b262a5c62845aa8965be169705370983f9ff73b17ec77bf75f70"
 
   def install
-    inreplace "src/adr-config" do |s|
-      s.sub! "# Config for when running from the source directory.", "#!/bin/bash"
-      s.sub! %q('"$(dirname $0)"'), bin
-      s.sub! %q('"$(dirname $0)"'), prefix
-    end
+    config = buildpath/"src/adr-config"
+
+    # Unlink and re-write to matches homebrew's installation conventions
+    config.unlink
+    config.write <<-EOS.undent
+      #!/bin/bash
+      echo 'adr_bin_dir=\"#{bin}\"'
+      echo 'adr_template_dir=\"#{prefix}\"'
+    EOS
 
     prefix.install Dir["src/*.md"]
     bin.install Dir["src/*"]

--- a/Formula/adr-tools.rb
+++ b/Formula/adr-tools.rb
@@ -4,6 +4,8 @@ class AdrTools < Formula
   url "https://github.com/npryce/adr-tools/archive/2.1.0.tar.gz"
   sha256 "1ef028cfeaa1b262a5c62845aa8965be169705370983f9ff73b17ec77bf75f70"
 
+  bottle :unneeded
+
   def install
     config = buildpath/"src/adr-config"
 

--- a/Formula/adr-tools.rb
+++ b/Formula/adr-tools.rb
@@ -5,17 +5,18 @@ class AdrTools < Formula
   sha256 "1ef028cfeaa1b262a5c62845aa8965be169705370983f9ff73b17ec77bf75f70"
 
   def install
-    # Override adr-config with custom config to point to homebrew dirs
-    system "echo '#!/bin/bash' > src/adr-config"
-    system "echo 'echo adr_bin_dir=\"#{bin}\"' >> src/adr-config"
-    system "echo 'echo adr_template_dir=\"#{prefix}\"' >> src/adr-config"
+    inreplace "src/adr-config" do |s|
+      s.sub! "# Config for when running from the source directory.", "#!/bin/bash"
+      s.sub! %q('"$(dirname $0)"'), bin
+      s.sub! %q('"$(dirname $0)"'), prefix
+    end
 
-    prefix.install Dir["src/*.md"] # Places the base templates in `prefix`
-    bin.install Dir["src/*"]       # Copies the rest to `prefix/bin`
+    prefix.install Dir["src/*.md"]
+    bin.install Dir["src/*"]
   end
 
   test do
-    assert_match(/Run 'adr help COMMAND' for help on a specific command./,
-                 pipe_output("#{bin}/adr help"))
+    assert_match(/0001-record-architecture-decisions.md/, shell_output("#{bin}/adr-init"))
+    assert_match(/0001-record-architecture-decisions.md/, shell_output("#{bin}/adr-list"))
   end
 end

--- a/Formula/adr-tools.rb
+++ b/Formula/adr-tools.rb
@@ -1,0 +1,21 @@
+class AdrTools < Formula
+  desc "CLI tool for working with Architecture Decision Records."
+  homepage "https://github.com/npryce/adr-tools"
+  url "https://github.com/npryce/adr-tools/archive/2.1.0.tar.gz"
+  sha256 "1ef028cfeaa1b262a5c62845aa8965be169705370983f9ff73b17ec77bf75f70"
+
+  def install
+    # Override adr-config with custom config to point to homebrew dirs
+    system "echo '#!/bin/bash' > src/adr-config"
+    system "echo 'echo adr_bin_dir=\"#{bin}\"' >> src/adr-config"
+    system "echo 'echo adr_template_dir=\"#{prefix}\"' >> src/adr-config"
+
+    prefix.install Dir["src/*.md"] # Places the base templates in `prefix`
+    bin.install Dir["src/*"]       # Copies the rest to `prefix/bin`
+  end
+
+  test do
+    assert_match(/Run 'adr help COMMAND' for help on a specific command./,
+                 pipe_output("#{bin}/adr help"))
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add new formula for adr-tools (v2.1.0) - a command-line tools for working with Architecture Decision Records.