### PR TITLE
Fix wget formula by adding Python 3 dependency

### DIFF
--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -26,6 +26,7 @@ class Wget < Formula
 
   option "with-debug", "Build with debug support"
 
+  depends_on "python3" => :build
   depends_on "pkg-config" => :build
   depends_on "pod2man" => :build if MacOS.version <= :snow_leopard
   depends_on "openssl"
@@ -37,6 +38,7 @@ class Wget < Formula
     # Fixes undefined symbols _iconv, _iconv_close, _iconv_open
     # Reported 10 Jun 2016: https://savannah.gnu.org/bugs/index.php?48193
     ENV.append "LDFLAGS", "-liconv"
+    ENV.store "PYTHON", Formula["python3"].opt_bin/"python3"
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`wget` version 1.19.1's `configure.ac` contains the lines:

```
dnl
dnl Find python3
dnl
AM_PATH_PYTHON([3.0],,[:])
AM_CONDITIONAL([HAVE_PYTHON3], [test "$PYTHON" != :])
```

Without listing `python3` as a dependency in Homebrew, `./configure` for `wget` fails.