### PR TITLE
libconfini 1.3-4 (new formula)

### DIFF
--- a/Formula/libconfini.rb
+++ b/Formula/libconfini.rb
@@ -1,0 +1,68 @@
+class Libconfini < Formula
+  desc "Yet another INI parser"
+  homepage "https://github.com/madmurphy/libconfini"
+  url "https://github.com/madmurphy/libconfini/archive/1.3-4.tar.gz"
+  version "1.3-4"
+  sha256 "db2ee05b5974b3df22e1afc37da65b78506b8216c85594232ee7dec56d8a20f8"
+
+  patch :DATA
+
+  depends_on "gettext" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "autoconf" => :build
+  depends_on "intltool" => :build
+  depends_on "glib" => :build
+
+  def install
+    system "sh", "autogen.sh",
+                 "--disable-dependency-tracking",
+                 "--disable-silent-rules",
+                 "--prefix=#{prefix}"
+
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.conf").write <<-EOS.undent
+      [section]
+      foo = bar
+    EOS
+    (testpath/"test.c").write <<-EOS.undent
+      #include <confini.h>
+      #include <stdio.h>
+      
+      int main() {
+        if(load_ini_file("test.conf", INI_DEFAULT_FORMAT, NULL, NULL, NULL))
+          return 1;
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-lconfini", "-o", "test"
+    system "./test"
+  end
+end
+
+__END__
+diff --git a/autogen.sh b/autogen.sh
+index a0ec5ee..18b1018 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -49,7 +49,7 @@ fi
+ }
+ 
+ (grep "^LT_INIT" $srcdir/configure.ac >/dev/null) && {
+-  (libtool --version) < /dev/null > /dev/null 2>&1 || {
++  (glibtool --version) < /dev/null > /dev/null 2>&1 || {
+     echo
+     echo "**Error**: You must have \`libtool' installed."
+     echo "You can get it from: ftp://ftp.gnu.org/pub/gnu/"
+@@ -131,7 +131,7 @@ do
+       if grep "^LT_INIT" configure.ac >/dev/null; then
+ 	if test -z "$NO_LIBTOOLIZE" ; then 
+ 	  echo "Running libtoolize..."
+-	  libtoolize --force --copy
++	  glibtoolize --force --copy
+ 	fi
+       fi
+       echo "Running aclocal $aclocalinclude ..."


### PR DESCRIPTION
This is a C++ library for parsing INI files. In order to build correctly the `autogen.sh` script needs to be patched so that it correctly finds `glibtool` and `glibtoolize`, the test is hardcoded so the script has to be edited manually; hence `brew audit` complains about this.
I already filed an upstream issue [here](https://github.com/madmurphy/libconfini/issues/1).
Patch is included in the formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
