### PR TITLE
cmark-gfm 0.27.1.gfm.0 (new formula)

### DIFF
--- a/Formula/cmark-gfm.rb
+++ b/Formula/cmark-gfm.rb
@@ -1,0 +1,26 @@
+class CmarkGfm < Formula
+  desc "C implementation of GitHub Flavored Markdown"
+  homepage "https://github.com/github/cmark"
+  url "https://github.com/github/cmark/archive/0.27.1.gfm.0.tar.gz"
+  version "0.27.1.gfm.0"
+  sha256 "71644ba7503816e4ba695d7c88b3ddeeefd934ab7bb8707982922a402631730b"
+
+  depends_on "cmake" => :build
+  depends_on :python3 => :build
+
+  conflicts_with "cmark", :because => "both install a `cmark.h` header"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "test"
+      system "make", "install"
+    end
+  end
+
+  test do
+    output = pipe_output("#{bin}/cmark-gfm --extension autolink", "https://brew.sh")
+    assert_equal '<p><a href="https://brew.sh">https://brew.sh</a></p>', output.chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Official C implementation of GFM, forked from cmark (expect the "not canonical repository" audit error).