### PR TITLE
gnuradio: remove cppunit dependency

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -16,7 +16,6 @@ class Gnuradio < Formula
   depends_on "pkg-config" => :build
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on "boost"
-  depends_on "cppunit"
   depends_on "fftw"
   depends_on "gsl"
   depends_on "zeromq"
@@ -77,9 +76,9 @@ class Gnuradio < Formula
 
     args << "-DENABLE_DEFAULT=OFF"
     enabled_components = %w[gr-analog gr-fft volk gr-filter gnuradio-runtime
-                            gr-blocks testing gr-pager gr-noaa gr-channels
-                            gr-audio gr-fcd gr-vocoder gr-fec gr-digital
-                            gr-dtv gr-atsc gr-trellis gr-zeromq]
+                            gr-blocks gr-pager gr-noaa gr-channels gr-audio
+                            gr-fcd gr-vocoder gr-fec gr-digital gr-dtv gr-atsc
+                            gr-trellis gr-zeromq]
     if build.with? "python"
       enabled_components << "python"
       enabled_components << "gr-utils"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

GNU Radio doesn't build with c++11 but the current CppUnit requires it.
Removing the CppUnit dependency means ENABLE_TESTING must be set OFF.