### PR TITLE
speex: add "speexdsp" option

### DIFF
--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -4,14 +4,14 @@ class Speex < Formula
   url "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
   sha256 "eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
 
-  option "with-sse", "Build with SSE support"
-
   bottle do
     cellar :any
     sha256 "5aa61761fb5426de78297fdc83579515dda1a880f47c925cb3405b7175079b92" => :sierra
     sha256 "056781a4d7c5fe9a05f30160c059352bda0a4f8a759820df7dde7233aa08cba5" => :el_capitan
     sha256 "a0b3c91782b8242508adac3ebc0cd86688e75b043ea0d84f4ef7ac9940f8a21b" => :yosemite
   end
+
+  option "with-sse", "Build with SSE support"
 
   depends_on "pkg-config" => :build
   depends_on "libogg" => :recommended

--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -4,6 +4,8 @@ class Speex < Formula
   url "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
   sha256 "eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
 
+  option "with-sse", "Build with SSE support"
+
   bottle do
     cellar :any
     sha256 "5aa61761fb5426de78297fdc83579515dda1a880f47c925cb3405b7175079b92" => :sierra
@@ -17,14 +19,12 @@ class Speex < Formula
 
   def install
     ENV.deparallelize
-    ENV["SPEEXDSP_CFLAGS"] = "-I#{HOMEBREW_PREFIX}/include/speex" if build.with? "speexdsp"
-    ENV["SPEEXDSP_LIBS"] = "-L#{HOMEBREW_PREFIX}/lib -lspeexdsp" if build.with? "speexdsp"
     args = %W[
       --prefix=#{prefix}
       --disable-debug
       --disable-dependency-tracking
-      --enable-sse
     ]
+    args << "--enable-sse" if build.with? "sse"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -13,11 +13,19 @@ class Speex < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libogg" => :recommended
+  depends_on "speexdsp" => :optional
 
   def install
     ENV.deparallelize
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    ENV["SPEEXDSP_CFLAGS"] = "-I#{HOMEBREW_PREFIX}/include/speex" if build.with? "speexdsp"
+    ENV["SPEEXDSP_LIBS"] = "-L#{HOMEBREW_PREFIX}/lib -lspeexdsp" if build.with? "speexdsp"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-dependency-tracking
+      --enable-sse
+    ]
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
With new option:
>$ otool -L /usr/local/Cellar/speex/1.2.0/bin/speexenc
/usr/local/Cellar/speex/1.2.0/bin/speexenc:
	/usr/local/Cellar/speex/1.2.0/lib/libspeex.1.dylib (compatibility version 7.0.0, current version 7.1.0)
	/usr/local/opt/libogg/lib/libogg.0.dylib (compatibility version 9.0.0, current version 9.2.0)
	/usr/local/opt/speexdsp/lib/libspeexdsp.1.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)

_Speex_'s configure has no option to disable _speexdsp_.

`--enabel-sse`  gives effect to building. It makes to add `-msse` and `-msse2` options in building.
(It is same as _speexdsp_)