### PR TITLE
librsvg : rm libgsf option

### DIFF
--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -16,7 +16,6 @@ class Librsvg < Formula
   depends_on "glib"
   depends_on "libcroco"
   depends_on "pango"
-  depends_on "libgsf" => :optional
   depends_on "gtk+3" => :optional
 
   def install
@@ -28,7 +27,6 @@ class Librsvg < Formula
       --enable-pixbuf-loader=yes
       --enable-introspection=yes
     ]
-    args << "--enable-svgz" if build.with? "libgsf"
 
     system "./configure", *args
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
In [change-log of librsvg-2.40.17](http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/librsvg/2.40/librsvg-2.40.17.changes)
>Date:   Fri Oct 21 16:42:07 2016 -0500
    test-display.c: Remove redundant code for zlib decompression
    Same as for rsvg-convert; librsvg can already deal with .svgz by itself.

And librsvg's configure say
>configure: WARNING: unrecognized options: --enable-svgz

Now _svgz_ is enabled constantly . No more `--enable-svgz`  and `libgsf`.