### PR TITLE
bochs 2.6.9

### DIFF
--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -1,8 +1,8 @@
 class Bochs < Formula
   desc "Open source IA-32 (x86) PC emulator written in C++"
   homepage "https://bochs.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/bochs/bochs/2.6.8/bochs-2.6.8.tar.gz"
-  sha256 "79700ef0914a0973f62d9908ff700ef7def62d4a28ed5de418ef61f3576585ce"
+  url "https://downloads.sourceforge.net/project/bochs/bochs/2.6.9/bochs-2.6.9.tar.gz"
+  sha256 "ee5b677fd9b1b9f484b5aeb4614f43df21993088c0c0571187f93acb0866e98c"
   revision 1
 
   bottle do
@@ -38,11 +38,10 @@ class Bochs < Formula
       --enable-show-ips
       --enable-logging
       --enable-usb
-      --enable-ne2000
       --enable-cpu-level=6
       --enable-clgd54xx
       --enable-avx
-      --enable-vmx
+      --enable-vmx=2
       --enable-smp
       --enable-long-phy-addres
       --with-term
@@ -70,6 +69,7 @@ class Bochs < Formula
         error: action=report
         info: action=ignore
         debug: action=ignore
+        display_library: nogui
       EOS
 
     expected = <<-ERR.undent


### PR DESCRIPTION
Update bochs to version 2.6.9 (from 2.6.8). Support for network card
ne2000 is disabled, since it breaks building (`netpacket/netpacket.h`
is not found).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
