### PR TITLE
makensis: Add support for build utils

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -19,7 +19,6 @@ class Makensis < Formula
     sha256 "867cf5c8c0699cc8d3ce570571ef883cd6a2ebf0ac657e5091ed60b4b03ff88b" => :yosemite
   end
 
-  depends_on "cppunit" => :build
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
 

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -22,7 +22,6 @@ class Makensis < Formula
   depends_on "cppunit" => :build
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
-  depends_on "zlib" => :build
 
   resource "zlib-win32" do
     url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -12,6 +12,11 @@ class Makensis < Formula
     end
   end
 
+  resource "zlib-win32" do
+    url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"
+    sha256 "a03fd15af45e91964fb980a30422073bc3f3f58683e9fdafadad3f7db10762b1"
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "e18b6829e0db4cf473b1869cff4a21d3a3a1bd9a82bf267ec9a04b24b60dfbd6" => :sierra
@@ -19,7 +24,10 @@ class Makensis < Formula
     sha256 "867cf5c8c0699cc8d3ce570571ef883cd6a2ebf0ac657e5091ed60b4b03ff88b" => :yosemite
   end
 
+  depends_on "cppunit" => :build
+  depends_on "mingw-w64" => :build
   depends_on "scons" => :build
+  depends_on "zlib" => :build
 
   # scons appears to have no builtin way to override the compiler selection,
   # and the only options supported on macOS are 'gcc' and 'g++'.
@@ -32,8 +40,13 @@ class Makensis < Formula
     # https://sourceforge.net/p/nsis/bugs/1085/
     ENV.libstdcxx if ENV.compiler == :clang
 
+    # requires zlib (win32) to build utils
+    resource("zlib-win32").stage do
+       @zlib_path = Dir.pwd
+    end
+
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    scons "STRIP=0", "SKIPUTILS=all", "makensis"
+    scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "makensis"
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")
   end

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -1,16 +1,9 @@
 class Makensis < Formula
   desc "System to create Windows installers"
   homepage "https://nsis.sourceforge.io/"
-
-  stable do
-    url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-src.tar.bz2"
-    sha256 "604c011593be484e65b2141c50a018f1b28ab28c994268e4ecd377773f3ffba1"
-
-    resource "nsis" do
-      url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01.zip"
-      sha256 "daa17556c8690a34fb13af25c87ced89c79a36a935bf6126253a9d9a5226367c"
-    end
-  end
+  url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-src.tar.bz2"
+  sha256 "604c011593be484e65b2141c50a018f1b28ab28c994268e4ecd377773f3ffba1"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -21,6 +14,11 @@ class Makensis < Formula
 
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
+
+  resource "nsis" do
+    url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01.zip"
+    sha256 "daa17556c8690a34fb13af25c87ced89c79a36a935bf6126253a9d9a5226367c"
+  end
 
   resource "zlib-win32" do
     url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -12,11 +12,6 @@ class Makensis < Formula
     end
   end
 
-  resource "zlib-win32" do
-    url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"
-    sha256 "a03fd15af45e91964fb980a30422073bc3f3f58683e9fdafadad3f7db10762b1"
-  end
-
   bottle do
     cellar :any_skip_relocation
     sha256 "e18b6829e0db4cf473b1869cff4a21d3a3a1bd9a82bf267ec9a04b24b60dfbd6" => :sierra
@@ -28,6 +23,11 @@ class Makensis < Formula
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
   depends_on "zlib" => :build
+
+  resource "zlib-win32" do
+    url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"
+    sha256 "a03fd15af45e91964fb980a30422073bc3f3f58683e9fdafadad3f7db10762b1"
+  end
 
   # scons appears to have no builtin way to override the compiler selection,
   # and the only options supported on macOS are 'gcc' and 'g++'.
@@ -42,7 +42,7 @@ class Makensis < Formula
 
     # requires zlib (win32) to build utils
     resource("zlib-win32").stage do
-       @zlib_path = Dir.pwd
+      @zlib_path = Dir.pwd
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -46,7 +46,7 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "makensis"
+    scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull-request adds support to build NSIS with all [included utils](https://github.com/kichik/nsis/blob/master/SConstruct#L32-L42). One could argue that some of these might not be needed on non-Windows, but the libraries and the UIs are essential IMHO.

To build a complete NSIS package, zlib (Win32) and some additional dependencies have been added to the formula.