### PR TITLE
Pulseaudio : recommend D-bus

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -36,11 +36,13 @@ class Pulseaudio < Formula
   depends_on "libsndfile"
   depends_on "libsoxr"
   depends_on "openssl"
+  depends_on "dbus" => :recommended
   depends_on "speexdsp" => :recommended
   depends_on "glib" => :optional
   depends_on "gconf" => :optional
   depends_on "gtk+3" => :optional
   depends_on "jack" => :optional
+  depends_on "fftw" => :optional
 
   fails_with :clang do
     build 421
@@ -60,6 +62,12 @@ class Pulseaudio < Formula
     ]
 
     args << "--disable-nls" if build.without? "nls"
+    args << "--disable-dbus" if build.without? "dbus"
+    args << "--disable-glib2" if build.without? "glib"
+    args << "--disable-gtk3" if build.without? "gtk+3"
+    args << "--disable-gconf" if build.without? "gconf"
+    args << "--disable-jack" if build.without? "jack"
+    args << "--without-fftw" if build.without? "fftw"
 
     if build.head?
       # autogen.sh runs bootstrap.sh then ./configure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
If **dbus** exists, Pulseaudio's configure detects **dbus** and links up with it.
>$ otool -L /usr/local/Cellar/pulseaudio/10.0_2/lib/libpulse.0.dylib
/usr/local/Cellar/pulseaudio/10.0_2/lib/libpulse.0.dylib:
	/usr/local/opt/pulseaudio/lib/libpulse.0.dylib (compatibility version 21.0.0, current version 21.1.0)
	/usr/local/Cellar/gettext/0.19.8.1/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.5.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/local/Cellar/pulseaudio/10.0_2/lib/pulseaudio/libpulsecommon-10.0.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/dbus/lib/libdbus-1.3.dylib (compatibility version 18.0.0, current version 18.11.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 775.19.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1349.64.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2) 

FFTW is same as D-bus.
>$ otool -L /usr/local/Cellar/pulseaudio/10.0_2/lib/pulse-10.0/modules/module-equalizer-sink.so
/usr/local/Cellar/pulseaudio/10.0_2/lib/pulse-10.0/modules/module-equalizer-sink.so:
	/usr/local/Cellar/gettext/0.19.8.1/lib/libintl.8.dylib (compatibility version 10.0.0, current version 10.5.0)
	/usr/local/Cellar/pulseaudio/10.0_2/lib/pulseaudio/libpulsecore-10.0.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/Cellar/pulseaudio/10.0_2/lib/pulseaudio/libpulsecommon-10.0.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/Cellar/pulseaudio/10.0_2/lib/libpulse.0.dylib (compatibility version 21.0.0, current version 21.1.0)
	/usr/local/opt/dbus/lib/libdbus-1.3.dylib (compatibility version 18.0.0, current version 18.11.0)
	/usr/local/opt/fftw/lib/libfftw3f.3.dylib (compatibility version 9.0.0, current version 9.6.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 775.19.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1349.64.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)