### PR TITLE
grpc: depend on protobuf

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -15,6 +15,7 @@ class Grpc < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "protobuf"
 
   def install
     system "make", "install", "prefix=#{prefix}"

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -4,6 +4,7 @@ class Grpc < Formula
   url "https://github.com/grpc/grpc.git",
       :tag => "v1.3.0",
       :revision => "3ef2355eaedc07f8900ad98d079448169a2a2a06"
+  revision 1
   head "https://github.com/grpc/grpc.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


See grpc/grpc#10944. `grpc` can't find the `protoc` binary during build time without this `depends_on` clause
