### PR TITLE
Switch to more recent DUTI fork

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -1,37 +1,20 @@
 class Duti < Formula
   desc "Select default apps for documents and URL schemes on macOS"
-  homepage "https://github.com/moretension/duti/"
-  url "https://github.com/moretension/duti/archive/duti-1.5.3.tar.gz"
-  sha256 "0e71b7398e01aedf9dde0ffe7fd5389cfe82aafae38c078240780e12a445b9fa"
-  head "https://github.com/moretension/duti.git"
-
-  bottle do
-    cellar :any_skip_relocation
-    rebuild 2
-    sha256 "8f34c5664b0a9c05274fd67102fca6c969f7dc966279b2ca0f11906df3d2d03a" => :sierra
-    sha256 "53748f3ad97a48b468326e66d869e20c05fc1f67219ac3ea8a147b558717ee45" => :el_capitan
-    sha256 "c2661fc4e59d5cc941a416bf7abad035af3d15f75e7bca73d2bc29706d89f560" => :yosemite
-    sha256 "e301c36a6809acc2a0dd62fba59eac4820b90cf2cf9df30f46480f7ce736dad3" => :mavericks
-  end
-
-  depends_on "autoconf" => :build
-
-  # Add hardcoded SDK path for El Capitan or later.
-  # See https://github.com/moretension/duti/pull/20.
-  if MacOS.version >= :el_capitan
-    patch do
-      url "https://github.com/moretension/duti/pull/20.patch"
-      sha256 "8fab50d10242f8ebc4be10e9a9e11d3daf91331d438d06f692fb6ebd6cbec2f8"
-    end
-  end
+  homepage "https://github.com/russellhancox/duti"
+  url "https://github.com/russellhancox/duti/archive/master.tar.gz"
+  version "1.7"
+  sha256 "fbfaf180b3f24690e60a406d2dbca90b86e907f719a8ef4e9d38965fc0a44cea"
+  head "https://github.com/russellhancox/duti.git"
 
   def install
-    system "autoreconf", "-vfi"
-    system "./configure", "--prefix=#{prefix}"
-    system "make", "install"
+    bin.mkpath
+    system "make"
+    bin.install "duti"
+    man1.install "duti.1"
   end
 
   test do
     system "#{bin}/duti", "-x", "txt"
   end
+  
 end


### PR DESCRIPTION
 https://github.com/moretension/duti hasn't been updated in three years. Not only is https://github.com/russellhancox/duti more active, switching to this fork also allows us to drop the autoconf dependency and the custom patch for 10.11+ :)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  Warning 1 = 'Stable: Use versioned rather than branch tarballs for stable checksums' - I have no control over the repo, and the versioned branches are all out of date.
  Warning 2 = 'Commented-out dep "cmake" => :build' - No idea why this warning is being thrown out. I removed Cmake from my system and all the install and all tests go just fine.

-----