### PR TITLE
Mercurial 4.2

### DIFF
--- a/Formula/git-remote-hg.rb
+++ b/Formula/git-remote-hg.rb
@@ -1,4 +1,6 @@
 class GitRemoteHg < Formula
+  include Language::Python::Virtualenv
+
   desc "Transparent bidirectional bridge between Git and Mercurial"
   homepage "https://github.com/felipec/git-remote-hg"
   url "https://github.com/felipec/git-remote-hg/archive/v0.3.tar.gz"
@@ -16,8 +18,15 @@ class GitRemoteHg < Formula
   depends_on :hg
   depends_on :python if MacOS.version <= :snow_leopard
 
+  resource "hg" do
+    url "https://mercurial-scm.org/release/mercurial-4.1.3.tar.gz"
+    sha256 "103d2ae187d5c94110c0e86ccc3b46f55fcd8e21c78d1c209bac7b59a73e86d8"
+  end
+
   def install
-    inreplace "git-remote-hg", "python2", "python"
+    venv = virtualenv_create(libexec)
+    venv.pip_install resource("hg")
+    inreplace "git-remote-hg", /#!.*/, "#!#{libexec}/bin/python"
     system "make", "install", "prefix=#{prefix}"
   end
 

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -3,8 +3,8 @@
 class Mercurial < Formula
   desc "Scalable distributed version control system"
   homepage "https://mercurial-scm.org/"
-  url "https://mercurial-scm.org/release/mercurial-4.1.3.tar.gz"
-  sha256 "103d2ae187d5c94110c0e86ccc3b46f55fcd8e21c78d1c209bac7b59a73e86d8"
+  url "https://mercurial-scm.org/release/mercurial-4.2.tar.gz"
+  sha256 "23a412308fc9c2b354a0e91a89588a4af2af061b47da80bc4233ccb0cceef47d"
 
   bottle do
     sha256 "e49e2540768bbd66225f9723f579c27b1d028586eab078981c3b2ec7710ec18d" => :sierra

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -25,6 +25,14 @@ class Mercurial < Formula
       bin.install "chg"
     end
 
+    # Configure a nicer default pager
+    (buildpath/"hgrc").write <<-EOS.undent
+      [pager]
+      pager = less -FRX
+    EOS
+
+    (etc/"mercurial").install "hgrc"
+
     # Install man pages, which come pre-built in source releases
     man1.install "doc/hg.1"
     man5.install "doc/hgignore.5", "doc/hgrc.5"


### PR DESCRIPTION
This updates mercurial to version 4.2.

This version moved the pager extension into core, which means we need to configure a default pager lest it use `more` (which is guaranteed to be there by POSIX, unlike `less`). To make sure that the transition is seamless, I've installed an hgrc file into a location that mercurial will search on startup. If people already have a pager configured in an hgrc file in their home directory, that configuration will take precedence over the one I'm installing.
