### PR TITLE
hugo: Update sha256 due to re-tag.

### DIFF
--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -2,7 +2,7 @@ class Hugo < Formula
   desc "Configurable static site generator"
   homepage "https://gohugo.io/"
   url "https://github.com/spf13/hugo/archive/v0.20.6.tar.gz"
-  sha256 "857655b69fb3e7f174011fd6774501194f1241bbb833256fd63b585b6d7a3cc0"
+  sha256 "692e08b009430d27064821d498f1454152cbfd5f26d019c29002e6fbff8fc387"
   head "https://github.com/spf13/hugo.git"
 
   bottle do


### PR DESCRIPTION
ref #13161.

Not merging until https://github.com/spf13/hugo/issues/3428 confirms that this was intentional.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
