### PR TITLE
azure-cli@2.0 0.2.10 (new formula)

### DIFF
--- a/Aliases/az
+++ b/Aliases/az
@@ -1,0 +1,1 @@
+../Formula/azure-cli.rb

--- a/Aliases/azure-cli@2.0
+++ b/Aliases/azure-cli@2.0
@@ -1,0 +1,1 @@
+../Formula/azure-cli.rb

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -1,44 +1,46 @@
-require "language/node"
-
 class AzureCli < Formula
-  desc "Official Azure CLI"
-  homepage "https://github.com/azure/azure-xplat-cli"
-  url "https://github.com/Azure/azure-xplat-cli/archive/v0.10.12-May2017.tar.gz"
-  version "0.10.13"
-  sha256 "60194e770b8dca0485db9d4c99f9cd432f7b43096cc5ad0353f52fd5b1b29181"
-  head "https://github.com/azure/azure-xplat-cli.git", :branch => "dev"
+  include Language::Python::Virtualenv
 
-  bottle do
-    cellar :any_skip_relocation
-    rebuild 1
-    sha256 "3d9cce38a38527dda6131d937e22c5ead62e071b7dfafc49f2f6eb3123bba0aa" => :sierra
-    sha256 "6f892658bd3cb909822027352e8826eefd7c9258d9b3488513526da0995d8af7" => :el_capitan
-    sha256 "a9301281b69223213f638fc92b99a4f8032fd354464adfe30d5031664ad4af75" => :yosemite
-  end
+  desc "Microsoft Azure CLI 2.0"
+  homepage "https://docs.microsoft.com/en-us/cli/azure/overview"
+  url "https://azurecliprod.blob.core.windows.net/releases/azure-cli_packaged_0.2.10.tar.gz"
+  version "2.0.2.10"
+  sha256 "be72ddb0983b3466e868602e68e4d3bf67379fbe080bdaa6aa321c03f9bcce48"
+  head "https://github.com/Azure/azure-cli.git"
 
-  depends_on "node"
-  depends_on :python => :build
+  depends_on :python if MacOS.version <= :snow_leopard
 
   def install
-    rm_rf "bin/windows"
+    virtualenv_create(libexec)
+    bin_dir = libexec/"bin"
 
-    # Workaround for incorrect file system permissios inside the npm published
-    # easy_table@0.0.1 package, which would break build with npm@5.
-    # See: https://github.com/Azure/azure-xplat-cli/issues/3605
-    inreplace "package.json", '"easy-table": "0.0.1",',
-              '"easy-table": "https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz",'
+    components = [
+      buildpath/"src/azure-cli",
+      buildpath/"src/azure-cli-core",
+      buildpath/"src/azure-cli-nspkg",
+      buildpath/"src/azure-cli-command_modules-nspkg",
+    ] + Pathname.glob("src/command_modules/azure-cli-*/")
 
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
-    (bash_completion/"azure").write Utils.popen_read("#{bin}/azure --completion")
+    # Create wheel distribution of included components
+    components.each do |c|
+      c.cd { system bin_dir/"python", "setup.py", "bdist_wheel", "-d", buildpath/"dist" }
+    end
+
+    # Install CLI from wheel distributions
+    system bin_dir/"pip", "install", "azure-cli", "-f", buildpath/"dist"
+
+    # Generate executable
+    (bin/"az").write <<-EOS.undent
+      #!/usr/bin/env bash
+      #{bin_dir}/python -m azure.cli "$@"
+    EOS
+
+    # Install bash completion
+    bash_completion.install "az.completion" => "az"
   end
 
   test do
-    shell_output("#{bin}/azure telemetry --disable")
-    json_text = shell_output("#{bin}/azure account env show AzureCloud --json")
-    azure_cloud = JSON.parse(json_text)
-    assert_equal azure_cloud["name"], "AzureCloud"
-    assert_equal azure_cloud["managementEndpointUrl"], "https://management.core.windows.net"
-    assert_equal azure_cloud["resourceManagerEndpointUrl"], "https://management.azure.com/"
+    version_output = shell_output("#{bin}/az --version")
+    assert_match "azure-cli", version_output
   end
 end

--- a/Formula/azure-cli@1.0.rb
+++ b/Formula/azure-cli@1.0.rb
@@ -1,0 +1,36 @@
+require "language/node"
+
+class AzureCliAT10 < Formula
+  desc "Official Azure CLI"
+  homepage "https://github.com/azure/azure-xplat-cli"
+  url "https://github.com/Azure/azure-xplat-cli/archive/v0.10.12-May2017.tar.gz"
+  version "1.0.10.13"
+  sha256 "60194e770b8dca0485db9d4c99f9cd432f7b43096cc5ad0353f52fd5b1b29181"
+  head "https://github.com/azure/azure-xplat-cli.git", :branch => "dev"
+
+  depends_on "node"
+  depends_on :python => :build
+
+  def install
+    rm_rf "bin/windows"
+
+    # Workaround for incorrect file system permissios inside the npm published
+    # easy_table@0.0.1 package, which would break build with npm@5.
+    # See: https://github.com/Azure/azure-xplat-cli/issues/3605
+    inreplace "package.json", '"easy-table": "0.0.1",',
+              '"easy-table": "https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz",'
+
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    (bash_completion/"azure").write Utils.popen_read("#{bin}/azure --completion")
+  end
+
+  test do
+    shell_output("#{bin}/azure telemetry --disable")
+    json_text = shell_output("#{bin}/azure account env show AzureCloud --json")
+    azure_cloud = JSON.parse(json_text)
+    assert_equal azure_cloud["name"], "AzureCloud"
+    assert_equal azure_cloud["managementEndpointUrl"], "https://management.core.windows.net"
+    assert_equal azure_cloud["resourceManagerEndpointUrl"], "https://management.azure.com/"
+  end
+end


### PR DESCRIPTION
---

**Moved to a third-party Tap:** [antoineco/azure-cli](https://github.com/antoineco/homebrew-azure-cli), **until upstream fixes the blocker described below.**

---

[Azure CLI 2.0](https://github.com/Azure/azure-cli) installed from the [packaged releases](https://github.com/Azure/azure-cli/blob/master/packaged_releases/HISTORY.md) distributed by Microsoft.

**Info**: https://docs.microsoft.com/en-us/cli/azure/overview
**Release notes**: https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli

----

<details>
  <summary>GitHub PR template</summary>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

</details>
