### PR TITLE
ffmpeg: fix "No such file or directory - config.mak"

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -179,15 +179,6 @@ class Ffmpeg < Formula
 
     system "./configure", *args
 
-    if MacOS.prefer_64_bit?
-      inreplace "config.mak" do |s|
-        shflags = s.get_make_var "SHFLAGS"
-        if shflags.gsub!(" -Wl,-read_only_relocs,suppress", "")
-          s.change_make_var! "SHFLAGS", shflags
-        end
-      end
-    end
-
     system "make", "install"
 
     if build.with? "tools"


### PR DESCRIPTION
This is to fix issue #13228 "brew install ffmpeg --HEAD" fails because "config.mak" is not found.

config.mak was checked in order to remove the read_only_relocs flag
when executing on 64 bit machines. The file is no longer created.

The flag check and removal is no longer needed, as the change has been
made in ffmpeg upstream:

https://github.com/FFmpeg/FFmpeg/commit/dff68563d846274cee0a2cd2430d6f1a2cb51eaa

This commit removes the flag check and removal, avoiding the need to
look for config.mak