### PR TITLE
wabt 0xd (new formula)

### DIFF
--- a/Formula/wabt.rb
+++ b/Formula/wabt.rb
@@ -1,0 +1,18 @@
+class Wabt < Formula
+  desc "Web Assembly Binary Toolkit"
+  homepage "https://github.com/WebAssembly/wabt"
+  url "https://github.com/WebAssembly/wabt/archive/binary_0xd.tar.gz"
+  sha256 "76146aaeb404e1d84607f8dfd1f31062216b4d5053dd14c72b3dc6df3aaaad9e"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", "-DBUILD_TESTS=OFF", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"sample.wast").write("(module (memory 1) (func))")
+    system "#{bin}/wast2wasm", testpath/"sample.wast"
+  end
+end


### PR DESCRIPTION
The Web Assembly Binary Tools or wabt, are required to work with Web
Assembly http://webassembly.org/

Having these tools in your path is a pre-requisite for working
directly with web assembly since you need to compile web assembly text
files, or `.wast`,  into `.wasm` files which is the actual binary format that 
browsers can understand.

Once you have this capability, then higher level tools can be built on
top of them in things like JavaScript, etc....

The versioning is hexidecimal and corresponds to the version of
webassembly that gets output. The current versions are "0xa",
"0xb", "0xc", and "0xd"

This formula uses the latest release, "0xd"

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
