### PR TITLE
macvim 8.0-132

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -2,9 +2,9 @@
 class Macvim < Formula
   desc "GUI for vim, made for macOS"
   homepage "https://github.com/macvim-dev/macvim"
-  url "https://github.com/macvim-dev/macvim/archive/snapshot-131.tar.gz"
-  version "8.0-131"
-  sha256 "2b74f294870cb115e516afb856ae40e9626ac96e987bedb1fefa6da0ba978d4c"
+  url "https://github.com/macvim-dev/macvim/archive/snapshot-132.tar.gz"
+  version "8.0-132"
+  sha256 "900ec53ab7156674cf0e02fd792815c35bcb1904580f46b1a41f9c48956341a0"
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do
@@ -91,9 +91,10 @@ class Macvim < Formula
     system "make"
 
     prefix.install "src/MacVim/build/Release/MacVim.app"
-    inreplace "src/MacVim/mvim", %r{^# VIM_APP_DIR=\/Applications$},
-                                 "VIM_APP_DIR=#{prefix}"
-    bin.install "src/MacVim/mvim"
+
+    # mvim needs to be symlinked into MacVim.app's tree to find the Vim binary
+    # https://github.com/macvim-dev/macvim/commit/dc708f3
+    bin.install_symlink prefix/"MacVim.app/Contents/bin/mvim" => "mvim"
 
     # Create MacVim vimdiff, view, ex equivalents
     executables = %w[mvimdiff mview mvimex gvim gvimdiff gview gvimex]


### PR DESCRIPTION
usurper of https://github.com/Homebrew/homebrew-core/pull/13263

This addresses the breaking changes in our configuration that were made to `mvim`.