### PR TITLE
libvorbis: fix repo url.

### DIFF
--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -13,7 +13,7 @@ class Libvorbis < Formula
   end
 
   head do
-    url "https://svn.xiph.org/trunk/vorbis"
+    url "https://git.xiph.org/vorbis.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
Upstream has migrated from svn to git.xiph.org.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://svn.xiph.org/trunk/vorbis/REPOSITORY_HAS_MOVED