### PR TITLE
LuaJIT 2.1.0-beta3

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -13,14 +13,8 @@ class Luajit < Formula
   end
 
   devel do
-    url "https://luajit.org/download/LuaJIT-2.1.0-beta2.tar.gz"
-    sha256 "713924ca034b9d99c84a0b7b701794c359ffb54f8e3aa2b84fad52d98384cf47"
-
-    # https://github.com/LuaJIT/LuaJIT/issues/180
-    patch do
-      url "https://github.com/LuaJIT/LuaJIT/commit/5837c2a2fb1ba6651.diff"
-      sha256 "7b5d233fc3a95437bd1c8459ad35bba63825655f47951b6dba1d053df7f98587"
-    end
+    url "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
+    sha256 "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
   end
 
   deprecated_option "enable-debug" => "with-debug"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
* Also removed patch for https://github.com/LuaJIT/LuaJIT/issues/180, as it is no longer an issue (tested with sample code from issue).

* `brew audit --strict luajit` complains that "`devel version should not decrease (from 2.1 to 2.1.0-beta3)`", but I'm not sure this makes sense (as only the url and hash designations were changed from `2.1.0-beta2` to `2.1.0-beta3`)