### PR TITLE
Fix libbladerf and darkstat

### DIFF
--- a/Formula/darkstat.rb
+++ b/Formula/darkstat.rb
@@ -19,6 +19,11 @@ class Darkstat < Formula
   end
 
   def install
+    # Fix clockid_t redefinition on Sierra and later
+    if MacOS.version >= :sierra
+      inreplace "now.c", "__MACH__", "__TOTO__"
+    end
+
     system "autoreconf", "-iv" if build.head?
     system "./configure", "--disable-debug", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/darkstat.rb
+++ b/Formula/darkstat.rb
@@ -20,7 +20,7 @@ class Darkstat < Formula
 
   def install
     # Fix clockid_t redefinition on Sierra and later
-    if MacOS.version >= :sierra
+    if MacOS.version >= :el_capitan
       inreplace "now.c", "__MACH__", "__TOTO__"
     end
 

--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -15,6 +15,11 @@ class Libbladerf < Formula
   depends_on "cmake" => :build
   depends_on "libusb"
 
+  patch do
+    url "https://github.com/Nuand/bladeRF/commit/b6f6267.diff"
+    sha256 "c9b80e04e7e6c7b6ddc6ce3944650d6ae9ad30f4187857a84632993fb9ccc39d"
+  end
+
   def install
     mkdir "host/build" do
       system "cmake", "..", *std_cmake_args


### PR DESCRIPTION
Add two more Sierra bottles #6408 by fixing `clockid_t` issues.