### PR TITLE
Remove Leopard-specific patches and dependencies

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -26,7 +26,7 @@ class Cairo < Formula
   keg_only :provided_pre_mountain_lion
 
   depends_on "pkg-config" => :build
-  depends_on :x11 => :optional if MacOS.version > :leopard
+  depends_on :x11 => :optional
   depends_on "freetype"
   depends_on "fontconfig"
   depends_on "libpng"

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -19,8 +19,6 @@ class Cataclysm < Formula
   needs :cxx11
 
   depends_on "gettext"
-  # needs `set_escdelay`, which isn't present in system ncurses before 10.6
-  depends_on "ncurses" if MacOS.version < :snow_leopard
 
   if build.with? "tiles"
     depends_on "sdl2"
@@ -30,10 +28,6 @@ class Cataclysm < Formula
 
   def install
     ENV.cxx11
-
-    # cataclysm tries to #import <curses.h>, but Homebrew ncurses installs no
-    # top-level headers
-    ENV.append_to_cflags "-I#{Formula["ncurses"].include}/ncursesw" if MacOS.version < :snow_leopard
 
     args = %W[
       NATIVE=osx RELEASE=1 OSX_MIN=#{MacOS.version}

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -51,7 +51,6 @@ class Collectd < Formula
       --localstatedir=#{var}
     ]
 
-    args << "--disable-embedded-perl" if MacOS.version <= :leopard
     args << "--disable-java" if build.without? "java"
     args << "--enable-python" if build.with? "python"
     args << "--enable-write_riemann" if build.with? "protobuf-c"

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -35,7 +35,6 @@ class Couchdb < Formula
   depends_on "spidermonkey"
   depends_on "icu4c"
   depends_on "erlang"
-  depends_on "curl" if MacOS.version <= :leopard
 
   resource "geocouch" do
     url "https://github.com/couchbase/geocouch/archive/couchdb1.3.x.tar.gz"

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -69,10 +69,7 @@ class Erlang < Formula
     args << "--enable-native-libs" if build.with? "native-libs"
     args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
     args << "--enable-wx" if build.with? "wxmac"
-
-    if MacOS.version >= :snow_leopard && MacOS::CLT.installed?
-      args << "--with-dynamic-trace=dtrace"
-    end
+    args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
 
     if build.without? "hipe"
       # HIPE doesn't strike me as that reliable on macOS

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -72,10 +72,7 @@ class ErlangAT18 < Formula
     args << "--enable-native-libs" if build.with? "native-libs"
     args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
     args << "--enable-wx" if build.with? "wxmac"
-
-    if MacOS.version >= :snow_leopard && MacOS::CLT.installed?
-      args << "--with-dynamic-trace=dtrace"
-    end
+    args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
 
     if build.without? "hipe"
       # HIPE doesn't strike me as that reliable on macOS

--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -25,7 +25,7 @@ class ImapUw < Formula
               "SSLINCLUDE=#{Formula["openssl"].opt_include}/openssl"
       s.gsub! "SSLLIB=/usr/lib",
               "SSLLIB=#{Formula["openssl"].opt_lib}"
-      s.gsub! "-DMAC_OSX_KLUDGE=1", "" if MacOS.version >= :snow_leopard
+      s.gsub! "-DMAC_OSX_KLUDGE=1", ""
     end
     inreplace "src/osdep/unix/ssl_unix.c", "#include <x509v3.h>\n#include <ssl.h>",
                                            "#include <ssl.h>\n#include <x509v3.h>"

--- a/Formula/libmemcached.rb
+++ b/Formula/libmemcached.rb
@@ -26,8 +26,6 @@ class Libmemcached < Formula
   patch :DATA
 
   def install
-    ENV.append_to_cflags "-undefined dynamic_lookup" if MacOS.version <= :leopard
-
     args = ["--prefix=#{prefix}"]
 
     if build.with? "sasl"

--- a/Formula/libmms.rb
+++ b/Formula/libmms.rb
@@ -16,14 +16,6 @@ class Libmms < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
 
-  # https://trac.macports.org/ticket/27988
-  if MacOS.version <= :leopard
-    patch :p0 do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/1fac7062/libmms/src_mms-common.h.patch"
-      sha256 "773193b878b7c061f05fe76f0ea5d331b8ab3e7b348608fae8cb144139e94798"
-    end
-  end
-
   def install
     ENV.append "LDFLAGS", "-liconv"
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libunwind-headers.rb
+++ b/Formula/libunwind-headers.rb
@@ -16,8 +16,6 @@ class LibunwindHeaders < Formula
     "this formula includes official development headers not installed by Apple"
 
   def install
-    inreplace "include/libunwind.h", "__MAC_10_6", "__MAC_NA" if MacOS.version < :snow_leopard
-
     include.install Dir["include/*"]
     (include/"libunwind").install Dir["src/*.h*"]
     (include/"libunwind/libunwind_priv.h").unlink

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -26,12 +26,6 @@ class Libvirt < Formula
     depends_on "rpcgen" => :build
   end
 
-  if MacOS.version <= :leopard
-    # Definitely needed on Leopard, but not on Snow Leopard.
-    depends_on "readline"
-    depends_on "libxml2"
-  end
-
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -14,8 +14,6 @@ class Libxmlxx < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glibmm"
-  # LibXML++ can't compile agains the version of LibXML shipped with Leopard
-  depends_on "libxml2" if MacOS.version <= :leopard
 
   needs :cxx11
 

--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -13,8 +13,6 @@ class Libxmlxx3 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glibmm"
-  # LibXML++ can't compile agains the version of LibXML shipped with Leopard
-  depends_on "libxml2" if MacOS.version <= :leopard
 
   needs :cxx11
 

--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -13,8 +13,6 @@ class MediaInfo < Formula
   end
 
   depends_on "pkg-config" => :build
-  # fails to build against Leopard's older libcurl
-  depends_on "curl" if MacOS.version < :snow_leopard
 
   def install
     cd "ZenLib/Project/GNU/Library" do

--- a/Formula/mediaconch.rb
+++ b/Formula/mediaconch.rb
@@ -16,8 +16,6 @@ class Mediaconch < Formula
   depends_on "jansson"
   depends_on "libevent"
   depends_on "sqlite"
-  # fails to build against Leopard's older libcurl
-  depends_on "curl" if MacOS.version < :snow_leopard
 
   def install
     cd "ZenLib/Project/GNU/Library" do

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -87,8 +87,6 @@ class Mpd < Formula
     ]
 
     args << "--disable-mad" if build.without? "mad"
-    args << "--disable-curl" if MacOS.version <= :leopard
-
     args << "--enable-zzip" if build.with? "libzzip"
     args << "--enable-lastfm" if build.with? "lastfm"
     args << "--disable-lame-encoder" if build.without? "lame"

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -13,7 +13,6 @@ class Mplayer < Formula
 
   head do
     url "svn://svn.mplayerhq.hu/mplayer/trunk"
-    depends_on "subversion" => :build if MacOS.version <= :leopard
 
     # When building SVN, configure prompts the user to pull FFmpeg from git.
     # Don't do that.

--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -18,7 +18,7 @@ class Nethack < Formula
   skip_clean "libexec/save"
 
   def install
-    # Build everything in-order; no multi builds.
+    # Build everything in-order
     ENV.deparallelize
 
     # Generate makefiles for OS X
@@ -27,10 +27,8 @@ class Nethack < Formula
         hintfile = "macosx10.10"
       elsif MacOS.version >= :lion
         hintfile = "macosx10.7"
-      elsif MacOS.version >= :leopard
-        hintfile = "macosx10.5"
       else
-        hintfile = "macosx"
+        hintfile = "macosx10.5"
       end
 
       inreplace "hints/#{hintfile}",

--- a/Formula/nspr.rb
+++ b/Formula/nspr.rb
@@ -16,7 +16,7 @@ class Nspr < Formula
     cd "nspr" do
       # Fixes a bug with linking against CoreFoundation, needed to work with SpiderMonkey
       # See: https://openradar.appspot.com/7209349
-      target_frameworks = (Hardware::CPU.is_32_bit? || MacOS.version <= :leopard) ? "-framework Carbon" : ""
+      target_frameworks = Hardware::CPU.is_32_bit? ? "-framework Carbon" : ""
       inreplace "pr/src/Makefile.in", "-framework CoreServices -framework CoreFoundation", target_frameworks
 
       args = %W[

--- a/Formula/postgres-xc.rb
+++ b/Formula/postgres-xc.rb
@@ -21,7 +21,6 @@ class PostgresXc < Formula
   depends_on :arch => :x86_64
   depends_on "openssl"
   depends_on "readline"
-  depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
   depends_on "ossp-uuid" => :recommended
   depends_on :python => :optional
 

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -22,7 +22,6 @@ class Postgresql < Formula
 
   depends_on "openssl"
   depends_on "readline"
-  depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
 
   option "with-python", "Enable PL/Python2"
   depends_on :python => :optional

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -18,7 +18,6 @@ class PostgresqlAT94 < Formula
 
   depends_on "openssl"
   depends_on "readline"
-  depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
   depends_on :python => :optional
 
   fails_with :clang do

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -20,7 +20,6 @@ class PostgresqlAT95 < Formula
 
   depends_on "openssl"
   depends_on "readline"
-  depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
   depends_on :python => :optional
   depends_on :python3 => :optional
 

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -7,7 +7,6 @@ class Rabbitmq < Formula
   bottle :unneeded
 
   depends_on "erlang"
-  depends_on "simplejson" => :python if MacOS.version <= :leopard
 
   def install
     # Install the base files

--- a/Formula/ranger.rb
+++ b/Formula/ranger.rb
@@ -13,15 +13,7 @@ class Ranger < Formula
     sha256 "224dce8bf10cb4f29a182e00d8a684a388f5dc1544f427149ee85e050c07a833" => :yosemite
   end
 
-  # requires 2.6 or newer; Leopard comes with 2.5
-  depends_on :python if MacOS.version <= :leopard
-
   def install
-    if MacOS.version <= :leopard
-      inreplace %w[ranger.py ranger/ext/rifle.py],
-        "#!/usr/bin/python", "#!#{PythonRequirement.new.which_python}"
-    end
-
     man1.install "doc/ranger.1"
     libexec.install "ranger.py", "ranger"
     bin.install_symlink libexec+"ranger.py" => "ranger"

--- a/Formula/rogue.rb
+++ b/Formula/rogue.rb
@@ -13,7 +13,7 @@ class Rogue < Formula
   end
 
   def install
-    ENV.ncurses_define if MacOS.version >= :snow_leopard
+    ENV.ncurses_define
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -136,12 +136,6 @@ class Subversion < Formula
     if build.with? "perl"
       # In theory SWIG can be built in parallel, in practice...
       ENV.deparallelize
-      # Remove hard-coded ppc target, add appropriate ones
-      if MacOS.version <= :leopard
-        arches = "-arch #{Hardware::CPU.arch_32_bit}"
-      else
-        arches = "-arch #{Hardware::CPU.arch_64_bit}"
-      end
 
       perl_core = Pathname.new(`perl -MConfig -e 'print $Config{archlib}'`)+"CORE"
       unless perl_core.exist?
@@ -150,7 +144,7 @@ class Subversion < Formula
 
       inreplace "Makefile" do |s|
         s.change_make_var! "SWIG_PL_INCLUDES",
-          "$(SWIG_INCLUDES) #{arches} -g -pipe -fno-common -DPERL_DARWIN -fno-strict-aliasing -I/usr/local/include -I#{perl_core}"
+          "$(SWIG_INCLUDES) -arch #{MacOS.preferred_arch} -g -pipe -fno-common -DPERL_DARWIN -fno-strict-aliasing -I/usr/local/include -I#{perl_core}"
       end
       system "make", "swig-pl"
       system "make", "install-swig-pl"

--- a/Formula/subversion@1.8.rb
+++ b/Formula/subversion@1.8.rb
@@ -183,10 +183,8 @@ class SubversionAT18 < Formula
       arches = begin
         if build.universal?
           Hardware::CPU.universal_archs.as_arch_flags
-        elsif MacOS.version <= :leopard
-          "-arch #{Hardware::CPU.arch_32_bit}"
         else
-          "-arch #{Hardware::CPU.arch_64_bit}"
+          "-arch #{MacOS.preferred_arch}"
         end
       end
       perl_core = Pathname.new(`perl -MConfig -e 'print $Config{archlib}'`)+"CORE"

--- a/Formula/transmission.rb
+++ b/Formula/transmission.rb
@@ -14,7 +14,6 @@ class Transmission < Formula
   option "with-nls", "Build with native language support"
 
   depends_on "pkg-config" => :build
-  depends_on "curl" if MacOS.version <= :leopard
   depends_on "libevent"
 
   if build.with? "nls"

--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -13,9 +13,6 @@ class Whois < Formula
   end
 
   def install
-    # autodie was not shipped with the system perl 5.8
-    inreplace "make_version_h.pl", "use autodie;", "" if MacOS.version < :snow_leopard
-
     system "make", "whois", "HAVE_ICONV=1", "whois_LDADD+=-liconv"
     bin.install "whois"
     man1.install "whois.1"


### PR DESCRIPTION
Mac OS X Leopard has been unsupported since June 2011