### PR TITLE
Drop universal support

### DIFF
--- a/Formula/boost-python@1.59.rb
+++ b/Formula/boost-python@1.59.rb
@@ -41,8 +41,6 @@ class BoostPythonAT159 < Formula
             "threading=multi,single",
             "link=shared,static"]
 
-    args << "address-model=32_64" << "architecture=x86" << "pch=off" if build.universal?
-
     # Build in C++11 mode if boost was built in C++11 mode.
     # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
     # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.

--- a/Formula/nacl.rb
+++ b/Formula/nacl.rb
@@ -27,16 +27,13 @@ class Nacl < Formula
 
     system "./do" # This takes a while since it builds *everything*
 
-    # NaCL has an odd compilation model (software by djb, who'da thunk it?)
-    # and installs the resulting binaries in a directory like:
+    # NaCL has an odd compilation model and installs the resulting
+    # binaries in a directory like:
     #    <nacl source>/build/<hostname>/lib/<arch>/libnacl.a
     #    <nacl source>/build/<hostname>/include/<arch>/crypto_box.h
-    # etc. Each of these is optimized for the specific hardware it's
-    # compiled on.
     #
     # It also builds both x86 and x86_64 copies if your compiler can
-    # handle it. Here we only install one copy, based on if you're a
-    # 64bit system or not. A --universal could come later though I guess.
+    # handle it, but we install only one.
     archstr = Hardware::CPU.is_64_bit? ? "amd64" : "x86"
 
     # Don't include cpucycles.h

--- a/Formula/ruby@1.8.rb
+++ b/Formula/ruby@1.8.rb
@@ -50,11 +50,6 @@ class RubyAT18 < Formula
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
 
-    if build.universal?
-      ENV.universal_binary
-      args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
-    end
-
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--enable-install-doc" if build.with? "doc"
 

--- a/Formula/ruby@1.9.rb
+++ b/Formula/ruby@1.9.rb
@@ -32,11 +32,6 @@ class RubyAT19 < Formula
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
 
-    if build.universal?
-      ENV.universal_binary
-      args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
-    end
-
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--with-out-ext=tk" if build.without? "tcltk"
     args << "--disable-install-doc" if build.without? "doc"

--- a/Formula/ruby@2.0.rb
+++ b/Formula/ruby@2.0.rb
@@ -33,11 +33,6 @@ class RubyAT20 < Formula
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
 
-    if build.universal?
-      ENV.universal_binary
-      args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
-    end
-
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--with-out-ext=tk" if build.without? "tcltk"
     args << "--disable-install-doc" if build.without? "doc"

--- a/Formula/ruby@2.1.rb
+++ b/Formula/ruby@2.1.rb
@@ -34,11 +34,6 @@ class RubyAT21 < Formula
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
 
-    if build.universal?
-      ENV.universal_binary
-      args << "--with-arch=#{Hardware::CPU.universal_archs.join(",")}"
-    end
-
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
     args << "--with-out-ext=tk" if build.without? "tcltk"
     args << "--disable-install-doc" if build.without? "doc"


### PR DESCRIPTION
Universal builds for these are not actually used by users.

```
install events in the last 30 days for subversion@1.8
1 | subversion@1.8                                                                                                | 139 |  82.74%
2 | subversion@1.8 --with-java                                                                                    |  28 |  16.67%
3 | subversion@1.8 --with-java --with-perl --with-ruby --with-gpg-agent --with-python                             |   1 |   0.60%

install events in the last 30 days for boost-python@1.59
1 | boost-python@1.59                                                                                             | 147 | 100.00%

install events in the last 30 days for ruby@1.8
1 | ruby@1.8                                                                                                       | 33 |  97.06%
2 | ruby@1.8 --with-doc --with-tcltk --with-gdbm                                                                   |  1 |   2.94%

install events in the last 30 days for ruby@1.9
1 | ruby@1.9                                                                                                      | 155 |  98.73%
2 | ruby@1.9 --with-doc --with-tcltk --with-gdbm                                                                  |   2 |   1.27%

install events in the last 30 days for ruby@2.0
1 | ruby@2.0                                                                                                       | 44 |  97.78%
2 | ruby@2.0 --with-doc --with-tcltk --with-gdbm --with-libffi                                                     |  1 |   2.22%

install events in the last 30 days for ruby@2.1
1 | ruby@2.1                                                                                                      | 324 |  99.69%
2 | ruby@2.1 --with-doc --with-tcltk --with-gdbm --with-gmp --with-libffi                                         |   1 |   0.31%
```