### PR TITLE
osc: add typing dependency

### DIFF
--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -35,6 +35,11 @@ class Osc < Formula
     sha256 "05d94fd9b2dae2fb8e072819a795f0e05d3611b09ea185f68e1630530ec09ae8"
   end
 
+  resource "typing" do
+    url "https://files.pythonhosted.org/packages/17/75/3698d7992a828ad6d7be99c0a888b75ed173a9280e53dbae67326029b60e/typing-3.6.1.tar.gz"
+    sha256 "c36dec260238e7464213dcd50d4b5ef63a507972f5780652e835d0228d0edace"
+  end
+
   def install
     venv = virtualenv_create(libexec)
     venv.pip_install resources.reject { |r| r.name == "M2Crypto" }


### PR DESCRIPTION
Needed for M2Crypto.

Closes #13230.