### PR TITLE
xplanetFX 2.6.13

### DIFF
--- a/Formula/xplanetfx.rb
+++ b/Formula/xplanetfx.rb
@@ -1,9 +1,9 @@
 class Xplanetfx < Formula
   desc "Configure, run or daemonize xplanet for HQ Earth wallpapers"
   homepage "http://mein-neues-blog.de/xplanetFX/"
-  url "http://repository.mein-neues-blog.de:9000/archive/xplanetfx-2.6.12_all.tar.gz"
-  version "2.6.12"
-  sha256 "42b84623821032b7f31797d0187e9e0e298282831327fe3fc508dd1d85c493a7"
+  url "http://repository.mein-neues-blog.de:9000/archive/xplanetfx-2.6.13_all.tar.gz"
+  version "2.6.13"
+  sha256 "ab5557555af6b5134b53174023709fff2cd64895f930b474eb695222a23c9feb"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
*** Yes, but it does spit out an error, `Dependency pygtk should not use option with-libglade`, even though xplanetFX does require libglade with pygtk.