### PR TITLE
gspell: revision bump

### DIFF
--- a/Formula/gspell.rb
+++ b/Formula/gspell.rb
@@ -3,6 +3,7 @@ class Gspell < Formula
   homepage "https://wiki.gnome.org/Projects/gspell"
   url "https://download.gnome.org/sources/gspell/1.4/gspell-1.4.1.tar.xz"
   sha256 "442f88fecd7f9e00a6a9d0af2d762744dd3c119217ff11d6739500f75b0f10be"
+  revision 1
 
   bottle do
     sha256 "d018460f00f0b8f369c45995076d1e5d7bab4cc0a5813cc9473c0ca95206c7cf" => :sierra


### PR DESCRIPTION
gspell hardcodes the path to the iso-codes Cellar in its library. It find this path
by querying iso-codes' pkg-config file. This means that whenever
iso-codes is updated, gspell needs a bump to get rebuilt.