### PR TITLE
djview4: fix failure on latest qt

### DIFF
--- a/Formula/djview4.rb
+++ b/Formula/djview4.rb
@@ -16,7 +16,8 @@ class Djview4 < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "djvulibre"
-  depends_on "qt"
+  # avoid bug QTBUG-58344 on qt 5.7 and 5.8. version 5.9 would be fine
+  depends_on "qt@5.5"
 
   def install
     inreplace "src/djview.pro", "10.6", MacOS.version


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

djview4 failed to start when using latest QT (5.8, 5.7) due to https://bugreports.qt.io/browse/QTBUG-58344 . Temporarily fallback to qt 5.5 until qt 5.9 would be released.
