### PR TITLE
Retain fits.sh and fits-ngserver.sh commands that other applications expect

### DIFF
--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -3,6 +3,7 @@ class Fits < Formula
   homepage "https://projects.iq.harvard.edu/fits"
   url "https://github.com/harvard-lts/fits/archive/1.1.0.tar.gz"
   sha256 "57ba2ee001c2c113a1cae84d1c8f8e9a49e21fc39307abe2bd97de0a2c1689c0"
+  revision 1
 
   bottle do
     cellar :any
@@ -35,8 +36,7 @@ class Fits < Formula
     # fits-env.sh is a helper script that sets up environment
     # variables, so we want to tuck this away in libexec
     libexec.install "fits-env.sh"
-    bin.install "fits.sh"
-    bin.install "fits-ngserver.sh"
+    bin.install "fits.sh", "fits-ngserver.sh"
     bin.install_symlink bin/"fits.sh" => "fits"
     bin.install_symlink bin/"fits-ngserver.sh" => "fits-ngserver"
   end

--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -35,8 +35,10 @@ class Fits < Formula
     # fits-env.sh is a helper script that sets up environment
     # variables, so we want to tuck this away in libexec
     libexec.install "fits-env.sh"
-    bin.install "fits.sh" => "fits"
-    bin.install "fits-ngserver.sh" => "fits-ngserver"
+    bin.install "fits.sh"
+    bin.install "fits-ngserver.sh"
+    bin.install_symlink bin/"fits.sh" => "fits"
+    bin.install_symlink bin/"fits-ngserver.sh" => "fits-ngserver"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Developed with generous guidance from @dunn.

Rather than renaming `fits.sh` and `fits-ngserver.sh` to `fits` and `fits-ngserver`, respectively, create `fits` and `fits-ngserver` symlinks. This prevents issues with dependencies on the `fits.sh` and `fits-ngserver.sh` commands in other software, such as [Hyrax](https://github.com/projecthydra-labs/hyrax).