### PR TITLE
libJudy 1.0.5 (new formula)

### DIFF
--- a/Formula/judy.rb
+++ b/Formula/judy.rb
@@ -1,5 +1,5 @@
 class Judy < Formula
-  desc "C library that implements a spare dynamic array"
+  desc "C library that implements a sparse dynamic array"
   homepage "https://judy.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
   sha256 "d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"

--- a/Formula/judy.rb
+++ b/Formula/judy.rb
@@ -1,0 +1,30 @@
+class Judy < Formula
+  desc "C library that implements a spare dynamic array"
+  homepage "https://judy.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
+  sha256 "d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"
+
+  def install
+    ENV.deparallelize
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <Judy.h>
+      int main() {
+        PPvoid_t judy = NULL;
+        Word_t index = 10;
+        int ret;
+        J1T(ret, judy, index);
+        return ret;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lJudy", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
libJudy was moved to boneyard in 1f39056. This adds a modern
formula for Judy.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
