### PR TITLE
the_silver_searcher: fix aclocal's args

### DIFF
--- a/Formula/the_silver_searcher.rb
+++ b/Formula/the_silver_searcher.rb
@@ -21,7 +21,7 @@ class TheSilverSearcher < Formula
 
   def install
     # Stable tarball does not include pre-generated configure script
-    system "aclocal", "-I #{HOMEBREW_PREFIX}/share/aclocal"
+    system "aclocal", "-I", "#{HOMEBREW_PREFIX}/share/aclocal"
     system "autoconf"
     system "autoheader"
     system "automake", "--add-missing"

--- a/Formula/the_silver_searcher.rb
+++ b/Formula/the_silver_searcher.rb
@@ -14,17 +14,13 @@ class TheSilverSearcher < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-
   depends_on "pkg-config" => :build
   depends_on "pcre"
   depends_on "xz" => :recommended
 
   def install
     # Stable tarball does not include pre-generated configure script
-    system "aclocal", "-I", "#{HOMEBREW_PREFIX}/share/aclocal"
-    system "autoconf"
-    system "autoheader"
-    system "automake", "--add-missing"
+    system "autoreconf", "-fiv"
 
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[gist-logs](https://gist.github.com/anonymous/949e8a7cc05041003bcbe2f059b4fd4a)
failed on
```
aclocal
-I /data/home/okhowang/.linuxbrew/share/aclocal

aclocal: couldn't open directory ` /data/home/okhowang/.linuxbrew/share/aclocal': No such file or directory
```