### PR TITLE
gpg-agent: Remove caveats

### DIFF
--- a/Formula/gpg-agent.rb
+++ b/Formula/gpg-agent.rb
@@ -40,12 +40,6 @@ class GpgAgent < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
-      Remember to add "use-standard-socket" to your ~/.gnupg/gpg-agent.conf
-      file.
-    EOS
-  end
-
   test do
     system "#{bin}/gpg-agent", "--help"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since "use-standard-socket" option produces a warning now:
`/Users/oturiak/.gnupg/gpg-agent.conf:1: obsolete option "use-standard-socket" - it has no effect`
removing the caveats section