### PR TITLE
ettercap: add patch for CVE-2017-6430

### DIFF
--- a/Formula/ettercap.rb
+++ b/Formula/ettercap.rb
@@ -1,9 +1,20 @@
 class Ettercap < Formula
   desc "Multipurpose sniffer/interceptor/logger for switched LAN"
   homepage "https://ettercap.github.io/ettercap/"
-  url "https://github.com/Ettercap/ettercap/archive/v0.8.2.tar.gz"
-  sha256 "f38514f35bea58bfe6ef1902bfd4761de0379942a9aa3e175fc9348f4eef2c81"
+  revision 1
+
   head "https://github.com/Ettercap/ettercap.git"
+
+  stable do
+    url "https://github.com/Ettercap/ettercap/archive/v0.8.2.tar.gz"
+    sha256 "f38514f35bea58bfe6ef1902bfd4761de0379942a9aa3e175fc9348f4eef2c81"
+
+    # Fixes CVE-2017-6430.
+    patch do
+      url "https://github.com/Ettercap/ettercap/commit/4ad7f85d.patch"
+      sha256 "a53322b8f103d92e3947b947083e548a92e05c0c2814ee870ec21a31eb0035c3"
+    end
+  end
 
   bottle do
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Also patches in `openssl@1.1` support from upstream, which may be a more controversial change in terms of patching, but it is from upstream & Debian have been running with it for a while.

Note this does not actually flip the `@1.1` switch to on here, for the reasons provided, but it does remove one thing from curl's usage tree that isn't ready yet, which is something.

If ILZ hates this I'll drop the patches for everything beside the CVE, but thought I'd see.