### PR TITLE
sslscan: use static vendor of insecure openssl 1.0.2f

### DIFF
--- a/Formula/sslscan.rb
+++ b/Formula/sslscan.rb
@@ -4,6 +4,7 @@ class Sslscan < Formula
   url "https://github.com/rbsec/sslscan/archive/1.11.10-rbsec.tar.gz"
   version "1.11.10"
   sha256 "fbb26fdbf2cf5b2f3f8c88782721b7875f206552cf83201981411e0af9521204"
+  revision 1
   head "https://github.com/rbsec/sslscan.git"
 
   bottle do
@@ -13,14 +14,26 @@ class Sslscan < Formula
     sha256 "0537cb08b5d621601741a9b92d9a0bcec978242b3ca5830711a49a3ebf99036b" => :yosemite
   end
 
-  depends_on "openssl"
+  resource "insecure-openssl" do
+    url "https://github.com/openssl/openssl/archive/OpenSSL_1_0_2f.tar.gz"
+    sha256 "4c9492adcb800ec855f11121bd64ddff390160714d93f95f279a9bd7241c23a6"
+  end
 
   def install
-    system "make"
+    (buildpath/"openssl").install resource("insecure-openssl")
+
+    # prevent sslscan from fetching openssl git
+    inreplace "Makefile", "openssl/Makefile: .openssl.is.fresh",
+                          "openssl/Makefile:"
+
+    ENV.deparallelize do
+      system "make", "static"
+    end
     system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
+    assert_match "static", shell_output("#{bin}/sslscan --version")
     system "#{bin}/sslscan", "google.com"
   end
 end


### PR DESCRIPTION
This is partially based on @hanazuki's work in https://github.com/Homebrew/homebrew-core/pull/10556. 

Given the age of the original PR and the number of additional changes, it seemed to make more sense to open a new PR.

`sslscan` is now built statically, using the old, insecure `openssl 1.0.2f` library, rather than using the https://github.com/PeterMosmans/openssl fork.