### PR TITLE
glew: patches should be stable-only

### DIFF
--- a/Formula/glew.rb
+++ b/Formula/glew.rb
@@ -1,9 +1,27 @@
 class Glew < Formula
   desc "OpenGL Extension Wrangler Library"
   homepage "https://glew.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/glew/glew/2.0.0/glew-2.0.0.tgz"
-  sha256 "c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764"
   head "https://github.com/nigels-com/glew.git"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/glew/glew/2.0.0/glew-2.0.0.tgz"
+    sha256 "c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764"
+
+    patch do
+      url "https://github.com/nigels-com/glew/commit/925722f.patch"
+      sha256 "6f36179dc42f1bbf5dd5bfe525457e4988749b56ee68180482c3a82b999792ed"
+    end
+
+    patch do
+      url "https://github.com/nigels-com/glew/commit/e7bf0f70.patch"
+      sha256 "ccab4b2e2edafe9b96bf277891061dbfb1b0dd0f1de75d574c653d7c49ce9c5c"
+    end
+
+    patch do
+      url "https://github.com/nigels-com/glew/commit/298528cd.patch"
+      sha256 "3d9dad811b74ec9502f096393f18f16e4d29891df786ff55d91f4e2301d4d773"
+    end
+  end
 
   bottle do
     cellar :any
@@ -14,16 +32,6 @@ class Glew < Formula
   end
 
   depends_on "cmake" => :build
-
-  patch do
-    url "https://github.com/nigels-com/glew/commit/925722f.patch"
-    sha256 "6f36179dc42f1bbf5dd5bfe525457e4988749b56ee68180482c3a82b999792ed"
-  end
-
-  patch do
-    url "https://github.com/nigels-com/glew/pull/143.patch"
-    sha256 "7761252b504e869e66edfe1615b8eef40311b9eebd6268ae164d4c83af1b31e0"
-  end
 
   def install
     cd "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The PR was merged so I picked up the commits instead of the PR. Essentially just a cosmetic change though. The actual point was to stop patching `HEAD`, which was obviously failing.