### PR TITLE
openssh: drop ldns dependency temporarily

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -17,8 +17,6 @@ class Openssh < Formula
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
   depends_on "openssl"
-  depends_on "ldns" => :optional
-  depends_on "pkg-config" => :build if build.with? "ldns"
 
   # Both these patches are applied by Apple.
   patch do
@@ -43,18 +41,12 @@ class Openssh < Formula
     # We introduce this issue with patching, it's not an upstream bug.
     inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
 
-    args = %W[
-      --with-libedit
-      --with-kerberos5
-      --prefix=#{prefix}
-      --sysconfdir=#{etc}/ssh
-      --with-pam
-      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
-    ]
-
-    args << "--with-ldns" if build.with? "ldns"
-
-    system "./configure", *args
+    system "./configure", "--with-libedit",
+                          "--with-kerberos5",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}/ssh",
+                          "--with-pam",
+                          "--with-ssl-dir=#{Formula["openssl"].opt_prefix}"
     system "make"
     system "make", "install"
 

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -1,8 +1,8 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-  url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
-  mirror "https://www.mirrorservice.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
+  url "https://www.mirrorservice.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
+  mirror "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.5p1.tar.gz"
   version "7.5p1"
   sha256 "9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0"
   revision 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We need to decide what to do here in future. Worst-case scenario is that this waits to return until the migration to OpenSSL@1.1 has been completed.

Closes https://github.com/Homebrew/homebrew-core/issues/13132.