### PR TITLE
chronograf (new formula)

### DIFF
--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -1,0 +1,82 @@
+require "language/node"
+
+class Chronograf < Formula
+  desc "Open source monitoring and visualization UI for the TICK stack."
+  homepage "https://docs.influxdata.com/chronograf/latest/"
+  url "https://github.com/influxdata/chronograf.git",
+      :tag => "1.3.0",
+      :revision => "99099e8a5c160f7fa436c1b8a4dedfa5fb6e0c2f"
+
+  head "https://github.com/influxdata/chronograf.git"
+
+  depends_on "go" => :build
+  depends_on "node" => :build
+  depends_on "yarn" => :build
+  depends_on "influxdb" => :recommended
+  depends_on "kapacitor" => :recommended
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    chronograf_path = buildpath/"src/github.com/influxdata/chronograf"
+    chronograf_path.install buildpath.children
+
+    cd chronograf_path do
+      system "make", "dep"
+      cd "ui" do
+        system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+        system "npm", "run", "build"
+        touch ".jssrc"
+      end
+      system "make", ".bindata"
+      system "make", "chronograf"
+      bin.install "chronograf"
+    end
+  end
+
+  plist_options :manual => "chronograf"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/chronograf</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/chronograf.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/chronograf.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    begin
+      pid = fork do
+        exec "#{bin}/chronograf"
+      end
+      sleep 1
+      output = shell_output("curl -s 0.0.0.0:8888/chronograf/v1/")
+      sleep 1
+      assert_match %r{/chronograf/v1/layouts}, output
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is essentially a reopening of https://github.com/Homebrew/homebrew-core/pull/7800 now that Chronograf released its first stable, open source version 1.3.0. This formula also works now.

Chronograf is a time series monitoring/visualization project which seamlessly integrates with the TICK stack ([Telegraf](https://github.com/Homebrew/homebrew-core/blob/master/Formula/telegraf.rb), [InfluxDB](https://github.com/Homebrew/homebrew-core/blob/master/Formula/influxdb.rb), and [Kapacitor](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kapacitor.rb)). Currently available via [homebrew-cask](https://github.com/caskroom/homebrew-cask/blob/master/Casks/chronograf.rb), it recently underwent a significant rewrite and was [open-sourced](https://www.influxdata.com/announcing-the-new-chronograf-a-ui-for-the-tick-stack-and-a-complete-open-source-monitoring-solution/).

Now that Chronograf can be built directly from the source, I'd like to move the formula to homebrew-core. I've opened a new PR on the homebrew-cask tap to remove and redirect that formula to homebrew-core (see https://github.com/caskroom/homebrew-cask/pull/33891). Note, there also used to be a Chronograf formula on the homebrew-binary tap that was migrated to the homebrew-cask tap (see https://github.com/Homebrew/homebrew-binary/pull/356).

Thanks for the review! Let me know if there are any questions.