### PR TITLE
mk-configure 0.29.1 (new formula)

### DIFF
--- a/Formula/mk-configure.rb
+++ b/Formula/mk-configure.rb
@@ -5,7 +5,6 @@ class MkConfigure < Formula
   sha256 "a675c532f6a857c79dedef2cce4776dda8becfbe7d2126e5f67175aee56c3957"
 
   depends_on "bmake" => :build
-  depends_on "makedepend" => :build
   depends_on "makedepend"
 
   def install
@@ -14,7 +13,7 @@ class MkConfigure < Formula
 
     system "bmake", "all"
     system "bmake", "install"
-    cp "presentation/presentation.pdf", "#{share}/doc/mk-configure/"
+    (share/"doc/mk-configure").install("presentation/presentation.pdf")
   end
 
   test do

--- a/Formula/mk-configure.rb
+++ b/Formula/mk-configure.rb
@@ -4,7 +4,7 @@ class MkConfigure < Formula
   url "https://downloads.sourceforge.net/project/mk-configure/mk-configure/mk-configure-0.29.1/mk-configure-0.29.1.tar.gz"
   sha256 "a675c532f6a857c79dedef2cce4776dda8becfbe7d2126e5f67175aee56c3957"
 
-  depends_on "bmake" => :build
+  depends_on "bmake"
   depends_on "makedepend"
 
   def install

--- a/Formula/mk-configure.rb
+++ b/Formula/mk-configure.rb
@@ -1,0 +1,23 @@
+class MkConfigure < Formula
+  desc "Lightweight replacement for GNU autotools"
+  homepage "https://github.com/cheusov/mk-configure"
+  url "https://downloads.sourceforge.net/project/mk-configure/mk-configure/mk-configure-0.29.1/mk-configure-0.29.1.tar.gz"
+  sha256 "a675c532f6a857c79dedef2cce4776dda8becfbe7d2126e5f67175aee56c3957"
+
+  depends_on "bmake" => :build
+  depends_on "makedepend" => :build
+  depends_on "makedepend"
+
+  def install
+    ENV["PREFIX"] = prefix.to_s
+    ENV["MANDIR"] = man.to_s
+
+    system "bmake", "all"
+    system "bmake", "install"
+    cp "presentation/presentation.pdf", "#{share}/doc/mk-configure/"
+  end
+
+  test do
+    system "#{bin}/mkcmake", "-V", "MAKE_VERSION", "-f", "/dev/null"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I'm aware that mkc_check_common.sh is installed to bin/ directory without executable flag. This is correct because this is a shell source file included by executables with a help of "." (AKA) "source". As you may know "." and "source" commands search for files in PATH directories.
