### PR TITLE
pyenv realpath C dylib

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -3,10 +3,9 @@ class Pyenv < Formula
   homepage "https://github.com/pyenv/pyenv"
   url "https://github.com/pyenv/pyenv/archive/v1.0.10.tar.gz"
   sha256 "cc071d6a63445dc1f7cefa5961c74768bc3dadf8edab5c5a7e1d63bf536a99b5"
+  revision 1
   version_scheme 1
   head "https://github.com/pyenv/pyenv.git"
-
-  bottle :unneeded
 
   depends_on "autoconf" => [:recommended, :run]
   depends_on "pkg-config" => [:recommended, :run]
@@ -15,6 +14,10 @@ class Pyenv < Formula
 
   def install
     inreplace "libexec/pyenv", "/usr/local", HOMEBREW_PREFIX
+
+    system "src/configure"
+    system "make", "-C", "src"
+
     prefix.install Dir["*"]
     %w[pyenv-install pyenv-uninstall python-build].each do |cmd|
       bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR makes the pyenv formula build the C realpath dylib just like the rbenv formula does. Since this is a dylib it does now require a bottle. At @tdsmith's request CC'ing @yyuu to see if he knows of any reason why this might be a bad idea.