### PR TITLE
git-town 4.0.0

### DIFF
--- a/Formula/git-town.rb
+++ b/Formula/git-town.rb
@@ -1,15 +1,17 @@
 class GitTown < Formula
   desc "High-level command-line interface for Git"
   homepage "http://www.git-town.com"
-  url "https://github.com/Originate/git-town/archive/v3.1.0.tar.gz"
-  sha256 "3a7227e99a1d5824d191769866c28a8d4fc6b4b0ac4cef278fc5cf9c1f033327"
+  url "https://github.com/Originate/git-town/archive/v4.0.0.tar.gz"
+  sha256 "4145a77ee7fe1f4579d04dfcc0a4658a21db4e07e80d7dd79328162f12797193"
 
-  bottle :unneeded
+  depends_on "go" => :build
+  depends_on :macos => :el_capitan
 
   def install
-    libexec.install Dir["src/*"]
-    bin.write_exec_script Dir["#{libexec}/git-*"]
-    man1.install Dir["man/man1/*"]
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/Originate").mkpath
+    ln_sf buildpath, buildpath/"src/github.com/Originate/git-town"
+    system "go", "build", "-o", bin/"git-town"
   end
 
   test do


### PR DESCRIPTION
depends on go
no longer bottle unneeded
drop support for Yosemite and below
don't install outdated man files