### PR TITLE
fontconfig: include downloadable fonts as of sierra

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -50,11 +50,21 @@ class Fontconfig < Formula
   depends_on "freetype"
 
   def install
+    font_dirs = %w[
+      /System/Library/Fonts
+      /Library/Fonts
+      ~/Library/Fonts
+    ]
+
+    if MacOS.version >= :sierra
+      font_dirs << "/System/Library/Assets/com_apple_MobileAsset_Font3"
+    end
+
     system "autoreconf", "-iv" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--enable-static",
-                          "--with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts",
+                          "--with-add-fonts=#{font_dirs.join(",")}",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
                           "--sysconfdir=#{etc}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Starting with macOS Sierra, [additional fonts](https://support.apple.com/en-us/HT206872#download) can be downloaded via Font Book, and then installed under `/System/Library/Assets/com_apple_MobileAsset_Font3`.