### PR TITLE
weechat: fix default SSL/TLS cert path

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -3,6 +3,8 @@ class Weechat < Formula
   homepage "https://www.weechat.org"
   url "https://weechat.org/files/src/weechat-1.8.tar.xz"
   sha256 "b65fc54e965399e31a30448b5f6c8067fcd6ad369e9908ff7c1fd45669c5e017"
+  revision 1
+
   head "https://github.com/weechat/weechat.git"
 
   bottle do
@@ -30,7 +32,11 @@ class Weechat < Formula
   depends_on "curl" => :optional
 
   def install
-    args = std_cmake_args << "-DENABLE_GUILE=OFF"
+    args = std_cmake_args + %W[
+      -DENABLE_GUILE=OFF
+      -DCA_FILE=#{etc}/openssl/cert.pem
+      -DENABLE_JAVASCRIPT=OFF
+    ]
     if build.with? "debug"
       args -= %w[-DCMAKE_BUILD_TYPE=Release]
       args << "-DCMAKE_BUILD_TYPE=Debug"
@@ -42,7 +48,6 @@ class Weechat < Formula
     args << "-DENABLE_ASPELL=OFF" if build.without? "aspell"
     args << "-DENABLE_TCL=OFF" if build.without? "tcl"
     args << "-DENABLE_PYTHON=OFF" if build.without? "python"
-    args << "-DENABLE_JAVASCRIPT=OFF"
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note because weechat uses `$HOME` and Homebrew doesn't touch `$HOME` itself via formulae intentionally if you use SSL/TLS via Weechat & haven't customised your configs any you can simply smash the Weechat home & let it be recreated at run by doing:
```
rm -rf ~/.weechat
```
If you have made modifications to the Weechat home you want to keep you can simply fix the gnutls_ca_file variable in `~/.weechat/weechat.conf`.

Closes https://github.com/Homebrew/homebrew-core/issues/13553.