### PR TITLE
tcptraceroute: pcap_version fix for 10.12.4+

### DIFF
--- a/Formula/tcptraceroute.rb
+++ b/Formula/tcptraceroute.rb
@@ -1,9 +1,21 @@
 class Tcptraceroute < Formula
   desc "Traceroute implementation using TCP packets"
   homepage "https://github.com/mct/tcptraceroute"
-  url "https://github.com/mct/tcptraceroute/archive/tcptraceroute-1.5beta7.tar.gz"
-  version "1.5beta7"
-  sha256 "57fd2e444935bc5be8682c302994ba218a7c738c3a6cae00593a866cd85be8e7"
+  revision 1
+  head "https://github.com/mct/tcptraceroute.git"
+
+  stable do
+    url "https://github.com/mct/tcptraceroute/archive/tcptraceroute-1.5beta7.tar.gz"
+    version "1.5beta7"
+    sha256 "57fd2e444935bc5be8682c302994ba218a7c738c3a6cae00593a866cd85be8e7"
+
+    # Call `pcap_lib_version()` rather than access `pcap_version` directly
+    # upstream issue: https://github.com/mct/tcptraceroute/issues/5
+    patch do
+      url "https://github.com/mct/tcptraceroute/commit/3772409867b3c5591c50d69f0abacf780c3a555f.patch"
+      sha256 "e7f118f0da011e1f879b8582d17f6f5515d5db491a61d7c71c6f8f71b3cdea0d"
+    end
+  end
 
   bottle do
     cellar :any
@@ -28,5 +40,10 @@ class Tcptraceroute < Formula
     `sudo tcptraceroute`.
     You should be certain that you trust any software you grant root privileges.
     EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/tcptraceroute --help 2>&1", 1)
+    assert_match "Usage: tcptraceroute", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Integrates a fix for libpcap linking in 10.12.4+, and introduces a test so we can tell when things break. Test can't be more complex than just a usage however, as executing the tool's function requires root.