### PR TITLE
wireguard-tools 0.0.20170517

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -3,8 +3,8 @@ class WireguardTools < Formula
   homepage "https://www.wireguard.io/"
   # Please only update version when the tools have been modified/updated,
   # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20170421.tar.xz"
-  sha256 "03c82af774224cd171d000ee4a519b5e474cc6842ac04967773cf77b26750000"
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20170517.tar.xz"
+  sha256 "7303e973654a3585039f4789e89a562f807f0d6010c7787b9b69ca72aa7a6908"
   head "https://git.zx2c4.com/WireGuard", :using => :git
 
   bottle do


### PR DESCRIPTION
This is a simple though important version bump that adds support the new text-based cross platform IPC.