### PR TITLE
collectd: Enable write-riemann based on libriemann-client

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -15,6 +15,9 @@ class Collectd < Formula
 
   head do
     url "https://github.com/collectd/collectd.git"
+
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
   end
 
   option "with-java", "Enable Java support"
@@ -26,8 +29,6 @@ class Collectd < Formula
   deprecated_option "debug" => "with-debug"
 
   depends_on "pkg-config" => :build
-  depends_on "automake" => :build
-  depends_on "autoconf" => :build
   depends_on "libtool" => :build
   depends_on "riemann-client" => :optional
   depends_on :java => :optional

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -15,22 +15,21 @@ class Collectd < Formula
 
   head do
     url "https://github.com/collectd/collectd.git"
-
-    depends_on "libtool" => :build
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
   end
 
   option "with-java", "Enable Java support"
   option "with-python", "Enable Python support"
-  option "with-protobuf-c", "Enable write_riemann via protobuf-c support"
+  option "with-riemann-client", "Enable write_riemann support"
   option "with-debug", "Enable debug support"
 
   deprecated_option "java" => "with-java"
   deprecated_option "debug" => "with-debug"
 
   depends_on "pkg-config" => :build
-  depends_on "protobuf-c" => :optional
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "libtool" => :build
+  depends_on "riemann-client" => :optional
   depends_on :java => :optional
   depends_on :python => :optional
   depends_on "net-snmp"
@@ -53,7 +52,7 @@ class Collectd < Formula
 
     args << "--disable-java" if build.without? "java"
     args << "--enable-python" if build.with? "python"
-    args << "--enable-write_riemann" if build.with? "protobuf-c"
+    args << "--enable-write_riemann" if build.with? "riemann-client"
     args << "--enable-debug" if build.with? "debug"
 
     system "./build.sh" if build.head?


### PR DESCRIPTION
The plugin uses the riemann-c-client library since commit d55584214206 (https://github.com/collectd/collectd/commit/d555842142065378f041c2ea29e808386c463a16). Therefore adjusting the dependencies for '--enable-write_riemann' to include riemann-client and libtool. 

Secondary making sure that automake, autoconf are always present when build is attempted since configure script is requiring this. Which means it is applicable for head and stable scenario.