### PR TITLE
tor 0.3.0.7

### DIFF
--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -1,9 +1,9 @@
 class Tor < Formula
   desc "Anonymizing overlay network for TCP"
   homepage "https://www.torproject.org/"
-  url "https://www.torproject.org/dist/tor-0.3.0.6.tar.gz"
-  mirror "https://tor.eff.org/dist/tor-0.3.0.6.tar.gz"
-  sha256 "a3e512e93cb555601fd207d914d7c5fe981d66d6ebb5821ecdf5dea738c2fb14"
+  url "https://tor.eff.org/dist/tor-0.3.0.7.tar.gz"
+  mirror "https://www.torproject.org/dist/tor-0.3.0.7.tar.gz"
+  sha256 "9640c4448ef3cad7237c68ed6984e705db8fb2b9d6bb74c8815d01bb06527d02"
 
   bottle do
     sha256 "d86ea3617596757b46f6e3861370dae83ebe35665c7894b6728ce29d8ece1c0d" => :sierra


### PR DESCRIPTION
use EFF mirror as primary URL to avoid audit failure