### PR TITLE
cnats: fix install directory + update to version 1.6.0

### DIFF
--- a/Formula/cnats.rb
+++ b/Formula/cnats.rb
@@ -1,8 +1,8 @@
 class Cnats < Formula
   desc "C client for the NATS messaging system"
   homepage "https://github.com/nats-io/cnats"
-  url "https://github.com/nats-io/cnats/archive/v1.5.0.tar.gz"
-  sha256 "84ce55250a16cd6a4f1350d8903ea046e6cb5add525b54be6dc65227e7343d3a"
+  url "https://github.com/nats-io/cnats/archive/v1.6.0.tar.gz"
+  sha256 "ce2eb48ac9fa6e89cacb3271f06780a2161c9b7f71dc520e09d4b1b0c4091dd8"
 
   bottle do
     cellar :any
@@ -24,7 +24,7 @@ class Cnats < Formula
 
   test do
     (testpath/"test.c").write <<-EOS.undent
-      #include <nats.h>
+      #include <nats/nats.h>
       #include <stdio.h>
       int main() {
         printf("%s\\n", nats_GetVersion());


### PR DESCRIPTION
In release 1.6.0 we have changed the install of headers to go
into install/include/nats instead of simply install/include.
This PR both updates the url/sha256 to point to release 1.6.0 and
also updates the test section to include `<nats/nats.h>` instead
of `<nats.h>`.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
