### PR TITLE
grpc: install grpc_cli with tools option

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -3,6 +3,7 @@ class Grpc < Formula
   homepage "http://www.grpc.io/"
   url "https://github.com/grpc/grpc/archive/v1.3.2.tar.gz"
   sha256 "6228fb43e6b11b1dec5aa21e66482bb45013b45cb70c1ca062f4848469d1ab99"
+  revision 1
   head "https://github.com/grpc/grpc.git"
 
   bottle do
@@ -11,17 +12,31 @@ class Grpc < Formula
     sha256 "9ede8a74e121aae5516fb35a84b980c402a71d9fe1338707782a40326f49cd3b" => :yosemite
   end
 
+  option "with-tools", "Build tools"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "c-ares"
   depends_on "openssl"
   depends_on "protobuf"
+  depends_on "gflags" if build.with? "tools"
+
+  resource "gtest" do
+    url "https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
+    sha256 "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8"
+  end
 
   def install
     system "make", "install", "prefix=#{prefix}"
 
     system "make", "install-plugins", "prefix=#{prefix}"
+
+    if build.with? "tools"
+      (buildpath/"third_party/googletest").install resource("gtest")
+      system "make", "grpc_cli", "prefix=#{prefix}"
+      bin.install "bins/opt/grpc_cli"
+    end
   end
 
   test do

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -12,15 +12,13 @@ class Grpc < Formula
     sha256 "9ede8a74e121aae5516fb35a84b980c402a71d9fe1338707782a40326f49cd3b" => :yosemite
   end
 
-  option "with-tools", "Build tools"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "c-ares"
   depends_on "openssl"
   depends_on "protobuf"
-  depends_on "gflags" if build.with? "tools"
+  depends_on "gflags"
 
   resource "gtest" do
     url "https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
@@ -32,11 +30,9 @@ class Grpc < Formula
 
     system "make", "install-plugins", "prefix=#{prefix}"
 
-    if build.with? "tools"
-      (buildpath/"third_party/googletest").install resource("gtest")
-      system "make", "grpc_cli", "prefix=#{prefix}"
-      bin.install "bins/opt/grpc_cli"
-    end
+    (buildpath/"third_party/googletest").install resource("gtest")
+    system "make", "grpc_cli", "prefix=#{prefix}"
+    bin.install "bins/opt/grpc_cli"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR ~~adds a `--with-tools` option to install~~ installs by default the `grpc_cli` tool for inspecting and debugging gRPC services. Instructions for installing this tool are at https://github.com/grpc/grpc/blob/3f8b3977bd22e5d01c287dd70dcb6aefbea5b503/doc/command_line_tool.md#code-location. Since googletest cannot be installed globally, and the instructions assume the user is operating out of a git repo (recommending `git submodule update --init` to install dependencies) I created a resource and installed it into the expected location, similar to the [libphonenumber formula](https://github.com/Homebrew/homebrew-core/blob/b39cdd5b5f0acda2aa9ca2a27af4e1772b9d4611/Formula/libphonenumber.rb#L21-L24).

~~If someone feels like this should be installed by default instead of as an option, I'm fine with that. It does add a dependency on gflags but that seems minor.~~ EDIT: now it's installed by default

/cc @mastahyeti