### PR TITLE
jbig2dec: apply more upstream CVE patches

### DIFF
--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -3,6 +3,7 @@ class Jbig2dec < Formula
   homepage "https://ghostscript.com/jbig2dec.html"
   url "http://downloads.ghostscript.com/public/jbig2dec/jbig2dec-0.13.tar.gz"
   sha256 "5aaca0070992cc2e971e3bb2338ee749495613dcecab4c868fc547b4148f5311"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,12 +16,15 @@ class Jbig2dec < Formula
 
   # These are all upstream already, remove on next release.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.debian.tar.xz"
-    sha256 "c4776c27e4633a7216e02ca6efcc19039ca757e8bd8fe0a7fbfdb07fa4c30d23"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.1.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.1.debian.tar.xz"
+    sha256 "41114245b7410a03196c5f7def10efa78c9da12b4bac9d21d6fbe96ded4232dd"
     apply "patches/020160518~1369359.patch",
           "patches/020161212~e698d5c.patch",
-          "patches/020161214~9d2c4f3.patch"
+          "patches/020161214~9d2c4f3.patch",
+          "patches/020170426~5e57e48.patch",
+          "patches/020170503~b184e78.patch",
+          "patches/020170510~ed6c513.patch"
   end
 
   def install
@@ -29,7 +33,6 @@ class Jbig2dec < Formula
       --prefix=#{prefix}
       --disable-silent-rules
     ]
-
     args << "--without-libpng" if build.without? "libpng"
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Covers CVE-2017-7885, CVE-2017-7975 & CVE-2017-7976.