### PR TITLE
Various: support non-brew Mono where possible.

### DIFF
--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -5,12 +5,7 @@ class ArchiSteamFarm < Formula
   version "2.3.1.4"
   sha256 "73941584b97a8b4820a5c4587e033092873f520ff88dbe9b8da085e72b7525bf"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "7a2e792ce756de3ca77ae63d00073da56b7ba0b599f2583b8e286ba60be63c97" => :sierra
-    sha256 "0054489a26c12f9379ad9f79ac959c07e9b4a6d0a387e08400ad8cb978a602d8" => :el_capitan
-    sha256 "0054489a26c12f9379ad9f79ac959c07e9b4a6d0a387e08400ad8cb978a602d8" => :yosemite
-  end
+  bottle :unneeded
 
   depends_on "mono" => :recommended
 

--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -12,7 +12,7 @@ class ArchiSteamFarm < Formula
     sha256 "0054489a26c12f9379ad9f79ac959c07e9b4a6d0a387e08400ad8cb978a602d8" => :yosemite
   end
 
-  depends_on "mono"
+  depends_on "mono" => :recommended
 
   def install
     libexec.install "ASF.exe"

--- a/Formula/autorest.rb
+++ b/Formula/autorest.rb
@@ -11,7 +11,7 @@ class Autorest < Formula
     sha256 "da1dc0e3a25b005db13ffbb95b145c060162648ad700998e4814a7969e17cbb1" => :yosemite
   end
 
-  depends_on "mono"
+  depends_on "mono" => :recommended
 
   resource "swagger" do
     url "https://raw.githubusercontent.com/Azure/autorest/764d308b3b75ba83cb716708f5cef98e63dde1f7/Samples/petstore/petstore.json"

--- a/Formula/ckan.rb
+++ b/Formula/ckan.rb
@@ -7,7 +7,7 @@ class Ckan < Formula
 
   bottle :unneeded
 
-  depends_on "mono"
+  depends_on "mono" => :recommended
 
   def install
     (libexec/"bin").install "ckan.exe"

--- a/Formula/nuget.rb
+++ b/Formula/nuget.rb
@@ -1,13 +1,13 @@
 class Nuget < Formula
   desc "Package manager for Microsoft development platform including .NET"
   homepage "https://www.nuget.org/"
-  url "https://dist.nuget.org/win-x86-commandline/v4.0.0/NuGet.exe"
-  version "4.0.0"
-  sha256 "cc52f94b2f1ba7cd485e546f8059cada2e9daee2ae27abde54507e9b1661e6d1"
+  url "https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe"
+  version "4.1.0"
+  sha256 "4c1de9b026e0c4ab087302ff75240885742c0faa62bd2554f913bbe1f6cb63a0"
 
   bottle :unneeded
 
-  depends_on "mono"
+  depends_on "mono" => :recommended
 
   def install
     libexec.install "NuGet.exe" => "nuget.exe"
@@ -18,6 +18,7 @@ class Nuget < Formula
   end
 
   test do
-    assert_match "NuGet.Protocol.Core.v3", shell_output("#{bin}/nuget list NuGet.Protocol.Core.v3")
+    output = shell_output("#{bin}/nuget list NuGet.Protocol.Core.v3")
+    assert_match "NuGet.Protocol.Core.v3", output
   end
 end

--- a/Formula/scriptcs.rb
+++ b/Formula/scriptcs.rb
@@ -11,6 +11,7 @@ class Scriptcs < Formula
     sha256 "21891cea519df48979320ba74660002d270fb414181e3f7087505169af15a471" => :yosemite
   end
 
+  # Checks for mozroots during build, can't be only :recommended.
   depends_on "mono"
 
   def install
@@ -28,6 +29,6 @@ class Scriptcs < Formula
   test do
     test_file = "tests.csx"
     (testpath/test_file).write('Console.WriteLine("{0}, {1}!", "Hello", "world");')
-    assert_equal "Hello, world!", `scriptcs #{test_file}`.strip
+    assert_equal "Hello, world!", shell_output("#{bin}/scriptcs #{test_file}").strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Essentially does [this](https://github.com/Homebrew/brew/pull/2626) for everything except one formula without mandating the addition of yet another special requirement. These could be `[:run, :recommended]` but `:run` hasn't yet found a comfortable use really so sticking with the more vanilla `:recommended`.