### PR TITLE
netperf: add HEAD option

### DIFF
--- a/Formula/netperf.rb
+++ b/Formula/netperf.rb
@@ -3,6 +3,7 @@ class Netperf < Formula
   homepage "http://netperf.org"
   url "ftp://ftp.netperf.org/netperf/netperf-2.7.0.tar.bz2"
   sha256 "842af17655835c8be7203808c3393e6cb327a8067f3ed1f1053eb78b4e40375a"
+  head "http://www.netperf.org/svn/netperf2/trunk", :using => :svn
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
`--enable-demo` requires HEAD currently to build on OS X. If it's possible to switch to using HEAD automatically if I add a build option to the formula, I'm glad to do it in this PR.