### PR TITLE
qt: fix startup failures for QTBUG-58344

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -23,7 +23,7 @@ class Qt < Formula
     # Upstream issue QTBUG-58344 "UI crash upon start" which won't be fixed in qt 5.7, 5.8
     # See https://codereview.qt-project.org/#/c/183183/
     patch do
-      url "https://raw.githubusercontent.com/theirix/formula-patches/qt-58344/qt5/QTBUG-58344.patch"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/qt-58344/qt5/QTBUG-58344.patch"
       sha256 "b5eebbe587ab64b66aea4938c0d2b90a00516d4d5b33d0971d049d919b4fcf9d"
     end
   end

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -23,7 +23,7 @@ class Qt < Formula
     # Upstream issue QTBUG-58344 "UI crash upon start" which won't be fixed in qt 5.7, 5.8
     # See https://codereview.qt-project.org/#/c/183183/
     patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/qt-58344/qt5/QTBUG-58344.patch"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a2c2bea6/qt5/QTBUG-58344.patch"
       sha256 "b5eebbe587ab64b66aea4938c0d2b90a00516d4d5b33d0971d049d919b4fcf9d"
     end
   end

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -19,6 +19,13 @@ class Qt < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/634a19fb/qt5/QTBUG-57656.patch"
       sha256 "a69fc727f4378dbe0cf05ecf6e633769fe7ee6ea52b1630135a05d5adfa23d87"
     end
+
+    # Upstream issue QTBUG-58344 "UI crash upon start" which won't be fixed in qt 5.7, 5.8
+    # See https://codereview.qt-project.org/#/c/183183/
+    patch do
+      url "https://raw.githubusercontent.com/theirix/formula-patches/qt-58344/qt5/QTBUG-58344.patch"
+      sha256 "b5eebbe587ab64b66aea4938c0d2b90a00516d4d5b33d0971d049d919b4fcf9d"
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Qt applications (like djview4) failed to start when using latest QT (5.8, 5.7) due to upstream bug https://bugreports.qt.io/browse/QTBUG-58344 "UI crash upon start" which won't be fixed in qt 5.7, 5.8. Maybe should be removed for qt 5.9 and later versions.

Patch is provided at https://github.com/Homebrew/formula-patches/pull/139