### PR TITLE
ode 0.15.2

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -23,6 +23,7 @@ class Ode < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "libccd"
   depends_on :x11 => :optional
 
   def install

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -23,7 +23,6 @@ class Ode < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "libccd"
   depends_on :x11 => :optional
 
   def install

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -1,9 +1,8 @@
 class Ode < Formula
   desc "Library for simulating articulated rigid body dynamics"
   homepage "http://www.ode.org/"
-  url "https://bitbucket.org/odedevs/ode/downloads/ode-0.14.tar.gz"
-  sha256 "a6e22c3713e656d4c8114415089f4aaa685e24fab3a8ad7f3ee54692e5e8d318"
-  revision 1
+  url "https://bitbucket.org/odedevs/ode/downloads/ode-0.15.2.tar.gz"
+  sha256 "bc481ae33f8e139b7beebb18bcb43df5c0251ff9518d82794b393ba1407bae96"
   head "https://bitbucket.org/odedevs/ode/", :using => :hg
 
   bottle do
@@ -15,12 +14,10 @@ class Ode < Formula
 
   option "with-double-precision", "Compile ODE with double precision"
   option "with-shared", "Compile ODE with shared library support"
-  option "with-libccd", "Enable all libccd colliders (except box-cylinder)"
   option "with-x11", "Build the drawstuff library and demos"
 
   deprecated_option "enable-double-precision" => "with-double-precision"
   deprecated_option "enable-shared" => "with-shared"
-  deprecated_option "enable-libccd" => "with-libccd"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -29,10 +26,9 @@ class Ode < Formula
   depends_on :x11 => :optional
 
   def install
-    args = ["--prefix=#{prefix}"]
+    args = ["--prefix=#{prefix}", "--enable-ou", "--enable-libccd"]
     args << "--enable-double-precision" if build.with? "double-precision"
     args << "--enable-shared" if build.with? "shared"
-    args << "--enable-libccd" if build.with? "libccd"
     args << "--with-demos" if build.with? "x11"
 
     inreplace "bootstrap", "libtoolize", "glibtoolize"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR changes to:
* Bump ode to 0.15.2 ([the build error with external libccd is resolved](https://bitbucket.org/odedevs/ode/issues/40/build-error-of-0151-and-0152-with-external#comment-36944296)).
* Always build ode with `--enable-ou --enable-libccd` options, which are [the recommended build options by the upstream](https://bitbucket.org/odedevs/ode/src/97f3a7870c56a953c2bf605f85bc7056bf62130f/bitbucket-pipelines.yml?fileviewer=file-view-default#bitbucket-pipelines.yml-13). This will allow formulae that use ode to pass new audit checks in Homebrew/brew#2482.