### PR TITLE
skinny 2.3.7

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.6/skinny-2.3.6.tar.gz"
-  sha256 "f58402433b5ede9a6a94e95a9bf651b59f67c3b3ae87c04771b371533b0ad4cd"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.7/skinny-2.3.7.tar.gz"
+  sha256 "ce5421354d0518c4e10fba06d63ee8737634bcee73bdafee4fd4dcc5cc737805"
 
   bottle :unneeded
   depends_on :java => "1.7+"


### PR DESCRIPTION
skinny 2.3.7 is out. Thank you as always 🙇
https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.7

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.7/skinny-2.3.7.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/1e007cfa-3db7-11e7-81cc-65cf34ff9972?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F2017052
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.7: 461 files, 61.5MB, built in 34 seconds

$ gem install rubocop
Successfully installed rubocop-0.48.1
Parsing documentation for rubocop-0.48.1
Installing ri documentation for rubocop-0.48.1
Done installing documentation for rubocop after 13 seconds
1 gem installed
$ brew audit --strict skinny
$
```