### PR TITLE
Remove unused options

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -14,16 +14,13 @@ class Freetype < Formula
 
   keg_only :provided_pre_mountain_lion
 
-  option "without-subpixel", "Disable sub-pixel rendering (a.k.a. LCD rendering, or ClearType)"
-
   depends_on "libpng"
 
   def install
-    if build.with? "subpixel"
-      inreplace "include/freetype/config/ftoption.h",
-          "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */",
-          "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
-    end
+    # Enable sub-pixel rendering (a.k.a. LCD rendering, or ClearType)
+    inreplace "include/freetype/config/ftoption.h",
+        "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */",
+        "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
 
     system "./configure", "--prefix=#{prefix}", "--without-harfbuzz"
     system "make"

--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -18,10 +18,6 @@ class Openssl < Formula
   keg_only :provided_by_osx,
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
 
-  option "without-test", "Skip build-time tests (not recommended)"
-
-  deprecated_option "without-check" => "without-test"
-
   depends_on "makedepend" => :build
 
   def arch_args
@@ -66,8 +62,7 @@ class Openssl < Formula
     system "perl", "./Configure", *(configure_args + arch_args[arch])
     system "make", "depend"
     system "make"
-    system "make", "test" if build.with?("test")
-
+    system "make", "test"
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
   end
 

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -14,16 +14,10 @@ class OpensslAT11 < Formula
 
   keg_only :versioned_formula
 
-  option "without-test", "Skip build-time tests (not recommended)"
-
-  # Only needs 5.10 to run, but needs >5.13.4 to run the testsuite.
+  # Needs Perl > 5.13.4 to run the testsuite.
   # https://github.com/openssl/openssl/blob/4b16fa791d3ad8/README.PERL
   # The MacOS ML tag is same hack as the way we handle most :python deps.
-  if build.with? "test"
-    depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
-  else
-    depends_on :perl => "5.10"
-  end
+  depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
   # SSLv3 & zlib are off by default with 1.1.0 but this may not
@@ -58,7 +52,7 @@ class OpensslAT11 < Formula
     ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
-    system "make", "test" if build.with?("test")
+    system "make", "test"
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
   end
 


### PR DESCRIPTION
- `openssl@1.1` option to avoid tests was used in 0 out of 44,049 installs in the last month
- `openssl`'s `--without-test` was used in 3 out of 240,105 installs
- `freetype`'s `--without-subpixel` was used in 1 out of 141,340 installs