### PR TITLE
bluepill: fix "bp" is not installed

### DIFF
--- a/Formula/bluepill.rb
+++ b/Formula/bluepill.rb
@@ -21,9 +21,11 @@ class Bluepill < Formula
                "SYMROOT=../",
                "DSTROOT=../dstroot"
     bin.install "dstroot/usr/local/bin/bluepill"
+    bin.install "dstroot/usr/local/bin/bp"
   end
 
   test do
     assert_match "Usage:", shell_output("#{bin}/bluepill -h")
+    assert_match "Usage:", shell_output("#{bin}/bp -h")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[Bluepill](https://github.com/linkedin/bluepill) is need two binaries that `bluepill` and `bp`, but `bp` is not installed currently (install `bluepill` only).

This PR is fix it.