### PR TITLE
restore mirror

### DIFF
--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -2,6 +2,7 @@ class Freetds < Formula
   desc "Libraries to talk to Microsoft SQL Server and Sybase databases"
   homepage "http://www.freetds.org/"
   url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.39.tar.bz2"
+  mirror "https://fossies.org/linux/privat/freetds-1.00.39.tar.bz2"
   sha256 "534f3fc5d2f3b397009a37e57b75e9c0baf70bab92a80b1cbaefde849fdfd3e9"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I get `Formula has other versions so create an alias named freetds@1.00` but the alias already exists.

-----

commit#6ded0182cee2f5861fbd67360c1145e62c813b1c deleted the mirror but the official site is dead as usual.