### PR TITLE
mesos: install "six" resource in libexec/"protobuf"

### DIFF
--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -4,6 +4,7 @@ class Mesos < Formula
   url "https://www.apache.org/dyn/closer.cgi?path=mesos/1.2.0/mesos-1.2.0.tar.gz"
   mirror "https://archive.apache.org/dist/mesos/1.2.0/mesos-1.2.0.tar.gz"
   sha256 "60dfd06cd1eec6f69af4ff77f7a92043fe7ead60bedf5605eecd14ffa7a3fb41"
+  revision 1
 
   bottle do
     sha256 "7f95b0ae80c39d56f8f2e34a93f80c92a9dc9c9edddd61a6d4171c256bb1994e" => :sierra
@@ -129,7 +130,7 @@ class Mesos < Formula
 
     # stage protobuf build dependencies
     ENV.prepend_create_path "PYTHONPATH", buildpath/"protobuf/lib/python2.7/site-packages"
-    %w[six python-dateutil pytz python-gflags google-apputils].each do |r|
+    %w[python-dateutil pytz python-gflags google-apputils].each do |r|
       resource(r).stage do
         system "python", *Language::Python.setup_install_args(buildpath/"protobuf")
       end
@@ -137,9 +138,13 @@ class Mesos < Formula
 
     protobuf_path = libexec/"protobuf/lib/python2.7/site-packages"
     ENV.prepend_create_path "PYTHONPATH", protobuf_path
-    resource("protobuf").stage do
-      ln_s buildpath/"protobuf/lib/python2.7/site-packages/google/apputils", "google/apputils"
-      system "python", *Language::Python.setup_install_args(libexec/"protobuf")
+    %w[six protobuf].each do |r|
+      resource(r).stage do
+        if r == "protobuf"
+          ln_s buildpath/"protobuf/lib/python2.7/site-packages/google/apputils", "google/apputils"
+        end
+        system "python", *Language::Python.setup_install_args(libexec/"protobuf")
+      end
     end
     pth_contents = "import site; site.addsitedir('#{protobuf_path}')\n"
     (lib/"python2.7/site-packages/homebrew-mesos-protobuf.pth").write pth_contents

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -49,6 +49,20 @@ class Mesos < Formula
     sha256 "47959d0651c32102c10ad919b8a0ffe0ae85f44b8457ddcf2bdc0358fb03dc29"
   end
 
+  if DevelopmentTools.clang_build_version >= 802 # does not affect < Xcode 8.3
+    # _scheduler.so segfault when Mesos is built with Xcode 8.3.2
+    # Reported 29 May 2017 https://issues.apache.org/jira/browse/MESOS-7583
+    # The issue does not occur with Xcode 9 beta 3.
+    fails_with :clang do
+      build 802
+      cause "Segmentation fault in _scheduler.so"
+    end
+  end
+
+  # error: 'Megabytes(32).Megabytes::<anonymous>' is not a constant expression
+  # because it refers to an incompletely initialized variable
+  fails_with :gcc => "7"
+
   needs :cxx11
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This prevents "ImportError: No module named six" when Homebrew's Python
is first in the PATH.