### PR TITLE
Fix url for libimobiledevice HEAD git repo

### DIFF
--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -14,7 +14,7 @@ class Libimobiledevice < Formula
   end
 
   head do
-    url "https://git.libimobiledevice.org/libimobiledevice.git"
+    url "https://github.com/libimobiledevice/libimobiledevice.git"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Looks like the old git repo is abandoned and current head development of the libimobiledevice is at https://github.com/libimobiledevice/libimobiledevice