### PR TITLE
kops: update checksum

### DIFF
--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -2,7 +2,7 @@ class Kops < Formula
   desc "Production Grade K8s Installation, Upgrades, and Management"
   homepage "https://github.com/kubernetes/kops"
   url "https://github.com/kubernetes/kops/archive/1.6.0.tar.gz"
-  sha256 "39ef8382d7557c4eacf9678feae42f473f2a9c436f4a518dfcf6a630eea6c2ce"
+  sha256 "483da291fc5a7a72c151e15ab586e6106f807564894669070705d2e1762e5595"
   head "https://github.com/kubernetes/kops.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Checksum changed due to Git keyword expansion of `$Format:%h$` in
combination with the backend GitHub upgrade of the Git version leading
to the following difference in the source archive tarball:

```
Josephs-MacBook-Pro:tmp joe$ diff A/kops-1.6.0/vendor/k8s.io/kubernetes/pkg/version/base.go B/kops-1.6.0/vendor/k8s.io/kubernetes/pkg/version/base.go
54c54
<     gitVersion   string = "v0.0.0-master+f69a313"
---
>     gitVersion   string = "v0.0.0-master+f69a313ce"
Josephs-MacBook-Pro:tmp joe$ diff A/kops-1.6.0/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/version/base.go B/kops-1.6.0/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/version/base.go
54c54
<     gitVersion   string = "v0.0.0-master+f69a313"
---
>     gitVersion   string = "v0.0.0-master+f69a313ce"
```

In the actual file in the repository, this appears as
```
gitVersion string = "v0.0.0-master+$Format:%h$"
```

See
https://github.com/kubernetes/kops/issues/2630
https://github.com/kubernetes/kubernetes/issues/46443

This PR should trigger https://github.com/Homebrew/brew/pull/2601.

Closes #13900.