### PR TITLE
gdal 1.11.5: error while building due to typedef redefinition

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -23,6 +23,7 @@ class Gdal < Formula
   option "with-mdb", "Build with Access MDB driver (requires Java 1.6+ JDK/JRE, from Apple or Oracle)."
   option "with-libkml", "Build with Google's libkml driver (requires libkml --HEAD or >= 1.3)"
   option "with-swig-java", "Build the swig java bindings"
+  option "without-python", "Build without python2 support"
 
   deprecated_option "enable-opencl" => "with-opencl"
   deprecated_option "enable-armadillo" => "with-armadillo"
@@ -84,7 +85,6 @@ class Gdal < Formula
     depends_on "swig" => :build
   end
 
-  option "without-python", "Build without python2 support"
   depends_on :python => :optional if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
   depends_on :fortran => :build if build.with?("python") || build.with?("python3")


### PR DESCRIPTION
Installing `gdal` from source (as dependecy of `postgis`) fails due to following error:

```
clang: build/src.macosx-10.12-x86_64-2.7/numpy/core/src/npymath/npy_math.c
In file included from numpy/core/src/npymath/npy_math.c.src:56:
numpy/core/src/npymath/npy_math_private.h:78:3: error: typedef redefinition with different types ('union ieee_double_shape_type' vs 'union ieee_double_shape_type')
} ieee_double_shape_type;
  ^
numpy/core/src/npymath/npy_math_private.h:64:3: note: previous definition is here
} ieee_double_shape_type;
  ^
1 error generated.
In file included from numpy/core/src/npymath/npy_math.c.src:56:
numpy/core/src/npymath/npy_math_private.h:78:3: error: typedef redefinition with different types ('union ieee_double_shape_type' vs 'union ieee_double_shape_type')
} ieee_double_shape_type;
  ^
numpy/core/src/npymath/npy_math_private.h:64:3: note: previous definition is here
} ieee_double_shape_type;
  ^
1 error generated.
error: Command "clang -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/opt/sqlite/include -Inumpy/core/include -Ibuild/src.macosx-10.12-x86_64-2.7/numpy/core/include/numpy -Inumpy/core/src/private -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/include -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/include/python2.7 -Ibuild/src.macosx-10.12-x86_64-2.7/numpy/core/src/private -Ibuild/src.macosx-10.12-x86_64-2.7/numpy/core/src/private -Ibuild/src.macosx-10.12-x86_64-2.7/numpy/core/src/private -Ibuild/src.macosx-10.12-x86_64-2.7/numpy/core/src/private -c build/src.macosx-10.12-x86_64-2.7/numpy/core/src/npymath/npy_math.c -o build/temp.macosx-10.12-x86_64-2.7/build/src.macosx-10.12-x86_64-2.7/numpy/core/src/npymath/npy_math.o" failed with exit status 1
```

For a full log see: https://gist.github.com/c07bf451a9fa43b85073b784cf1826a4

The attached patch fixes this error for me.