### PR TITLE
osm2pgsql: fix missing symbols related to Lua

### DIFF
--- a/Formula/osm2pgsql.rb
+++ b/Formula/osm2pgsql.rb
@@ -16,7 +16,7 @@ class Osm2pgsql < Formula
   depends_on "boost"
   depends_on "geos"
   depends_on "proj"
-  depends_on "lua" => :recommended
+  depends_on "lua"
 
   # Compatibility with GEOS 3.6.1
   # Upstream PR from 27 Oct 2016 "Geos36"


### PR DESCRIPTION
Trying to install `osm2pgsql` from source results in following error:

```
Undefined symbols for architecture x86_64:
  "_luaL_loadfilex", referenced from:
      tagtransform::tagtransform(options_t const*) in libosm2pgsql.a(tagtransform.cpp.o)
  "_lua_getglobal", referenced from:
      tagtransform::lua_filter_rel_member_tags(taglist_t const&, std::__1::vector<taglist_t, std::__1::allocator<taglist_t> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*> > const&, int*, int*, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
      tagtransform::check_lua_function_exists(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in libosm2pgsql.a(tagtransform.cpp.o)
      tagtransform::lua_filter_basic_tags(OsmType, taglist_t const&, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
  "_lua_pcallk", referenced from:
      tagtransform::lua_filter_rel_member_tags(taglist_t const&, std::__1::vector<taglist_t, std::__1::allocator<taglist_t> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*> > const&, int*, int*, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
      tagtransform::tagtransform(options_t const*) in libosm2pgsql.a(tagtransform.cpp.o)
      tagtransform::lua_filter_basic_tags(OsmType, taglist_t const&, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
  "_lua_tointegerx", referenced from:
      tagtransform::lua_filter_rel_member_tags(taglist_t const&, std::__1::vector<taglist_t, std::__1::allocator<taglist_t> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const*> > const&, int*, int*, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
      tagtransform::lua_filter_basic_tags(OsmType, taglist_t const&, int*, int*, taglist_t&) in libosm2pgsql.a(tagtransform.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Full build logs: https://gist.github.com/d42e8c7a51bdcc637ac0d937fe45e2f7

Apparently these errors seems to be related to Lua which is an optional dependency and therefore was not built by default. I changed this to a "hard" dependency which fixes this error for me.