### PR TITLE
corsixth: fix 'extra blank line detected'

### DIFF
--- a/Formula/corsixth.rb
+++ b/Formula/corsixth.rb
@@ -21,7 +21,6 @@ class Corsixth < Formula
     sha256 "879015e727a6decec4d24f65d810890caa766107339e81f1e6c6b96a70e1b944" => :yosemite
   end
 
-
   depends_on "cmake" => :build
   depends_on :xcode => :build
   depends_on "ffmpeg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- To find things to fix, I ran `brew audit --strict` across everything and it found this issue with `corsixth`: "* C: 24: col 1: Extra blank line detected.".

(Also, :wave:. It's my first PR for you!)