### PR TITLE
cryptol: fix incompatibility with sbv >= 5.15

### DIFF
--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -21,7 +21,12 @@ class Cryptol < Formula
   depends_on "z3" => :run
 
   def install
-    install_cabal_package :using => ["alex", "happy"]
+    # Remove sbv constraint for > 2.4.0
+    if build.stable?
+      install_cabal_package "--constraint", "sbv < 5.15", :using => ["alex", "happy"]
+    else
+      install_cabal_package :using => ["alex", "happy"]
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?