### PR TITLE
offlineimap: Use Basic UI in LaunchAgent

### DIFF
--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -3,6 +3,7 @@ class Offlineimap < Formula
   homepage "http://offlineimap.org/"
   url "https://github.com/OfflineIMAP/offlineimap/archive/v7.1.1.tar.gz"
   sha256 "a624f8a77eae664dd458be47c5306c28911d4a1f788ff5641d7bb37e01ecb703"
+  revision 1
   head "https://github.com/OfflineIMAP/offlineimap.git"
 
   bottle do

--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -58,6 +58,8 @@ class Offlineimap < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/offlineimap</string>
+          <string>-u</string>
+          <string>basic</string>
         </array>
         <key>StartInterval</key>
         <integer>300</integer>


### PR DESCRIPTION
This allows OfflineIMAP not to hang on a password prompt, which would
otherwise leave the instance hanging with a lock.

See OfflineIMAP/offlineimap#466

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
