### PR TITLE
sc-im 0.6.0 (new formula)

### DIFF
--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -1,15 +1,13 @@
 class ScIm < Formula
   desc "Spreadsheet program for the terminal, using ncurses"
   homepage "https://github.com/andmarti1424/sc-im"
-  url "https://github.com/andmarti1424/sc-im/archive/v0.5.0.tar.gz"
-  sha256 "d7a31c5225e02239e925b50b414d7e69d12bc3554f218621823782872ccc5e4d"
+  url "https://github.com/andmarti1424/sc-im/archive/v0.6.0.tar.gz"
+  sha256 "5da644d380ab3752de283b83cce18c3ba12b068d0762c44193c34367a0dcbc38"
   head "https://github.com/andmarti1424/sc-im.git", :branch => "freeze"
 
   depends_on "ncurses"
 
   def install
-    ENV.prepend "LDFLAGS", "-L#{Formula["ncurses"].opt_lib}"
-
     cd "src" do
       system "make", "prefix=#{prefix}"
       system "make", "prefix=#{prefix}", "install"
@@ -22,7 +20,7 @@ class ScIm < Formula
       getnum A1
     EOS
     output = pipe_output(
-      "#{bin}/scim --nocurses --quit_afterload", input, 0
+      "#{bin}/scim --nocurses --quit_afterload 2>/dev/null", input
     )
     assert_equal "nowide 2", output.lines.last.chomp
   end

--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -1,0 +1,29 @@
+class ScIm < Formula
+  desc "Spreadsheet program for the terminal, using ncurses"
+  homepage "https://github.com/andmarti1424/sc-im"
+  url "https://github.com/andmarti1424/sc-im/archive/v0.5.0.tar.gz"
+  sha256 "d7a31c5225e02239e925b50b414d7e69d12bc3554f218621823782872ccc5e4d"
+  head "https://github.com/andmarti1424/sc-im.git", :branch => "freeze"
+
+  depends_on "ncurses"
+
+  def install
+    ENV.prepend "LDFLAGS", "-L#{Formula["ncurses"].opt_lib}"
+
+    cd "src" do
+      system "make", "prefix=#{prefix}"
+      system "make", "prefix=#{prefix}", "install"
+    end
+  end
+
+  test do
+    input = <<-EOS.undent
+      let A1=1+1
+      getnum A1
+    EOS
+    output = pipe_output(
+      "#{bin}/scim --nocurses --quit_afterload", input, 0
+    )
+    assert_equal "nowide 2", output.lines.last.chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Does your submission pass `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

___

This PR is the sequel to the orphaned [PR #12260](https://github.com/Homebrew/homebrew-core/pull/12260).

On top of @jez’s three commits, I have added a simple functional test and upgraded the version to 0.6.0.

Discussions and reviews should be resumed here if needed.

While the formula does pass the strict audit (`brew audit --strict --online sc-im`), it [still doesn’t pass](https://github.com/Homebrew/homebrew-core/pull/12260#issue-220496205) the stricter, `--new-formula` audit.
