### PR TITLE
grafana 4.3.2 + drop redundant npm install

### DIFF
--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -1,10 +1,8 @@
-require "language/node"
-
 class Grafana < Formula
   desc "Gorgeous metric visualizations and dashboards for timeseries databases."
   homepage "https://grafana.com"
-  url "https://github.com/grafana/grafana/archive/v4.3.0.tar.gz"
-  sha256 "d81e5fdb7ac702646a4b17343796970c91000ea5ea2036880e0e3e36c7a0a8a5"
+  url "https://github.com/grafana/grafana/archive/v4.3.2.tar.gz"
+  sha256 "02753931d9abb5d94e0695fdb44f5ede0a537cad57a7d60f44125056c04129ab"
 
   head "https://github.com/grafana/grafana.git"
 
@@ -27,7 +25,6 @@ class Grafana < Formula
     cd grafana_path do
       system "go", "run", "build.go", "build"
       system "yarn", "install"
-      system "npm", "install", "grunt-cli", *Language::Node.local_npm_install_args
 
       args = ["build"]
       # Avoid PhantomJS error "unrecognized selector sent to instance"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates grafana to v4.3.2 and drops the redundant usage of `npm install grunt-cli` (and language/node).
Grunt is already installed by yarn, so we do not need to install it a
second time using npm.
This fixes an issue with npm@5 which would screw up the dep tree
(removing all other modules) if you try to execute npm install grunt-cli
on the existing deptree created by yarn. (Refs #14085)