### PR TITLE
jhipster update dependencies to require Yarn and Java 8

### DIFF
--- a/Formula/jhipster.rb
+++ b/Formula/jhipster.rb
@@ -5,6 +5,7 @@ class Jhipster < Formula
   homepage "https://jhipster.github.io/"
   url "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-4.5.2.tgz"
   sha256 "5df0edbbdb685df5ae598b53fb2def43b6c23bb75d44763a63cda69567395954"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/jhipster.rb
+++ b/Formula/jhipster.rb
@@ -14,6 +14,8 @@ class Jhipster < Formula
   end
 
   depends_on "node"
+  depends_on "yarn"
+  depends_on :java => "1.8+"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
