### PR TITLE
azure-cli: fix fs permissions in easy-table dep

### DIFF
--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -20,6 +20,13 @@ class AzureCli < Formula
 
   def install
     rm_rf "bin/windows"
+
+    # Workaround for incorrect file system permissios inside the npm published
+    # easy_table@0.0.1 package, which would break build with npm@5.
+    # See: https://github.com/Azure/azure-xplat-cli/issues/3605
+    inreplace "package.json", "\"easy-table\": \"0.0.1\",",
+              "\"easy-table\": \"https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz\","
+
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
     (bash_completion/"azure").write Utils.popen_read("#{bin}/azure --completion")

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -24,8 +24,8 @@ class AzureCli < Formula
     # Workaround for incorrect file system permissios inside the npm published
     # easy_table@0.0.1 package, which would break build with npm@5.
     # See: https://github.com/Azure/azure-xplat-cli/issues/3605
-    inreplace "package.json", "\"easy-table\": \"0.0.1\",",
-              "\"easy-table\": \"https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz\","
+    inreplace "package.json", '"easy-table": "0.0.1",',
+              '"easy-table": "https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz",'
 
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The easy-table@0.0.1 package published at npm has incorrect file system permissions set (missing +x permission for lib folder). Until npm@4 npm didn't handle file system permissions inside .tgz at all, but npm@5 started to handle them correctly. This breaks the azure-cli build with npm@5.

This is fixed by temporary switching from the npm published version of easy-table@0.0.1 to a github tarball installation of the same version. Looking at [the diff between 0.0.1 and 0.0.3](https://github.com/eldargab/easy-table/compare/v0.0.1...v0.0.3#diff-7704a7bcd1f965e637e6ad0c6696e9e9) I think this is more save than bumping it to 0.0.3 (the first version on npm without file system permission errors) and hope that nothing will break. At least until we get some information about this from upstream azure-cli.