### PR TITLE
node@0.12: fix build with Xcode 8.3

### DIFF
--- a/Formula/node@0.12.rb
+++ b/Formula/node@0.12.rb
@@ -32,6 +32,15 @@ class NodeAT012 < Formula
     sha256 "927974142c9a44e9bd879d9e9762e7de379b43c5acfae32b02b44f60e59a9c9c"
   end
 
+  # Fix build failure with >= Xcode 8.3 "../deps/v8/include/v8.h:5800:54: error:
+  # 'CreateHandle' is a protected member of 'v8::HandleScope'"
+  if DevelopmentTools.clang_build_version >= 802
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/1eec325/node%400.12/v8-xcode-8.3.diff"
+      sha256 "55e0c540c96b41be05c42bb65383df5b984dd7386a9e4477b3fc716d4ae75a27"
+    end
+  end
+
   def install
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Homebrew/homebrew-core/pull/14171.

Fixes build failure with >= Apple LLVM version 8.1.0 (clang-802.0.42).

The error is
```
../deps/v8/include/v8.h:5800:54: error: 'CreateHandle' is a protected member of 'v8::HandleScope'
```

Fix suggested by Thomas Rosenstein in https://github.com/nodejs/node-gyp/issues/1160.

CC @DomT4 @chrmoritz