### PR TITLE
kafka: fix test

### DIFF
--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -80,6 +80,7 @@ class Kafka < Formula
 
   test do
     ENV["PWD"] = Dir.pwd
+    ENV["CURL_HOME"] = Dir.pwd
     ENV["LOG_DIR"] = "#{testpath}/kafkalog"
 
     (testpath/"kafka").mkpath

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -81,6 +81,7 @@ class Kafka < Formula
   test do
     ENV["PWD"] = Dir.pwd
     ENV["CURL_HOME"] = Dir.pwd
+    puts ENV.inspect
     ENV["LOG_DIR"] = "#{testpath}/kafkalog"
 
     (testpath/"kafka").mkpath

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -79,11 +79,7 @@ class Kafka < Formula
   end
 
   test do
-    ENV["PWD"] = testpath
-    ENV["CURL_HOME"] = testpath
-    ENV["WORKSPACE"] =  testpath
     ENV["LOG_DIR"] = "#{testpath}/kafkalog"
-    puts ENV.inspect
 
     (testpath/"kafka").mkpath
     cp "#{etc}/kafka/zookeeper.properties", testpath/"kafka"
@@ -91,6 +87,7 @@ class Kafka < Formula
     inreplace "#{testpath}/kafka/zookeeper.properties", "#{var}/lib", testpath
     inreplace "#{testpath}/kafka/server.properties", "#{var}/lib", testpath
 
+    puts "hello logs: #{logs}"
     begin
       fork do
         exec "#{bin}/zookeeper-server-start #{testpath}/kafka/zookeeper.properties > #{logs}/test.zookeeper-server-start.log 2>&1"

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -79,6 +79,7 @@ class Kafka < Formula
   end
 
   test do
+    ENV["PWD"] = Dir.pwd
     ENV["LOG_DIR"] = "#{testpath}/kafkalog"
 
     (testpath/"kafka").mkpath

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -87,16 +87,15 @@ class Kafka < Formula
     inreplace "#{testpath}/kafka/zookeeper.properties", "#{var}/lib", testpath
     inreplace "#{testpath}/kafka/server.properties", "#{var}/lib", testpath
 
-    puts "hello logs: #{logs}"
     begin
       fork do
-        exec "#{bin}/zookeeper-server-start #{testpath}/kafka/zookeeper.properties > #{logs}/test.zookeeper-server-start.log 2>&1"
+        exec "#{bin}/zookeeper-server-start #{testpath}/kafka/zookeeper.properties > #{testpath}/test.zookeeper-server-start.log 2>&1"
       end
 
       sleep 15
 
       fork do
-        exec "#{bin}/kafka-server-start #{testpath}/kafka/server.properties > #{logs}/test.kafka-server-start.log 2>&1"
+        exec "#{bin}/kafka-server-start #{testpath}/kafka/server.properties > #{testpath}/test.kafka-server-start.log 2>&1"
       end
 
       sleep 30

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -79,10 +79,11 @@ class Kafka < Formula
   end
 
   test do
-    ENV["PWD"] = Dir.pwd
-    ENV["CURL_HOME"] = Dir.pwd
-    puts ENV.inspect
+    ENV["PWD"] = testpath
+    ENV["CURL_HOME"] = testpath
+    ENV["WORKSPACE"] =  testpath
     ENV["LOG_DIR"] = "#{testpath}/kafkalog"
+    puts ENV.inspect
 
     (testpath/"kafka").mkpath
     cp "#{etc}/kafka/zookeeper.properties", testpath/"kafka"


### PR DESCRIPTION
`logs` can have spaces in it, so just use `testpath` instead.