### PR TITLE
Revert "pango: remove x11 option (#13530)"

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -20,23 +20,32 @@ class Pango < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "cairo"
-  depends_on "fontconfig"
+  depends_on :x11 => :optional
   depends_on "glib"
-  depends_on "gobject-introspection"
+  depends_on "cairo"
   depends_on "harfbuzz"
+  depends_on "fontconfig"
+  depends_on "gobject-introspection"
 
   def install
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--with-html-dir=#{share}/doc",
-                          "--enable-introspection=yes",
-                          "--enable-man",
-                          "--enable-static",
-                          "--without-xft"
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-man
+      --with-html-dir=#{share}/doc
+      --enable-introspection=yes
+      --enable-static
+    ]
 
+    if build.with? "x11"
+      args << "--with-xft"
+    else
+      args << "--without-xft"
+    end
+
+    system "./autogen.sh" if build.head?
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
There was no good reason to change the status quo, removing this option in #13530, and as it stands, this option does not break the default builds (hence the *optional* part). As per 'policy', I've left out the change to depend on cairo with x11 if pango is built with x11. But if you're using pango with x11, installing cairo with x11 before pango with x11 works.  Or just specify both when installing.

This reverts commit 083c9d0c65c3f26b0da0983b760a0307302d314b. (The blame on that commit is wrong. @stephengroat didn't write that; @fxcoudert did...)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
