### PR TITLE
rustup-init 1.3.0 (new formula)

### DIFF
--- a/Aliases/rustup
+++ b/Aliases/rustup
@@ -1,0 +1,1 @@
+../Formula/rustup-init.rb

--- a/Formula/rustup-init.rb
+++ b/Formula/rustup-init.rb
@@ -1,0 +1,33 @@
+class RustupInit < Formula
+  desc "The Rust toolchain installer"
+  homepage "https://github.com/rust-lang-nursery/rustup.rs"
+
+  url "https://github.com/rust-lang-nursery/rustup.rs/archive/1.3.0.tar.gz"
+  sha256 "c0ca06b70104fed8f1de5a6f5ecfd8478e8bc03f15add8d7896b86b3b15e81e3"
+
+  depends_on "rust" => :build
+
+  def install
+    cargo_home = buildpath/"cargo_home"
+    cargo_home.mkpath
+    ENV["CARGO_HOME"] = cargo_home
+
+    system "cargo", "build", "--release", "--verbose"
+
+    bin.install buildpath/"target/release/rustup-init"
+  end
+
+  test do
+    ENV["CARGO_HOME"] = testpath/".cargo"
+    ENV["RUSTUP_HOME"] = testpath/".multirust"
+
+    system bin/"rustup-init", "-y"
+    (testpath/"hello.rs").write <<-EOS.undent
+      fn main() {
+        println!("Hello World!");
+      }
+    EOS
+    system testpath/".cargo/bin/rustc", "hello.rs"
+    assert_equal "Hello World!", shell_output("./hello").chomp
+  end
+end


### PR DESCRIPTION
- [✓] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✓] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

rustup is a multiplexing toolchain installer for rust similar to pyenv, rbenv, etc…

I think this PR addresses the concerns raised in #9617.

It pulls source from the stable release tarball, uses brew rust to install from source, and installs the rustup-init executable into the keg. `rustup-init` installs into `RUSTUP_HOME` which defaults to ~/.multirust.
