### PR TITLE
alpine: Update alpine URL’s

### DIFF
--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -1,7 +1,7 @@
 class Alpine < Formula
   desc "News and email agent"
-  homepage "http://patches.freeiz.com/alpine/"
-  url "http://patches.freeiz.com/alpine/release/src/alpine-2.21.tar.xz"
+  homepage "http://alpine.freeiz.com/alpine/"
+  url "http://alpine.freeiz.com/alpine/release/src/alpine-2.21.tar.xz"
   sha256 "6030b6881b8168546756ab3a5e43628d8d564539b0476578e287775573a77438"
 
   bottle do


### PR DESCRIPTION
Alpine has move sites (see http://mailman13.u.washington.edu/pipermail/alpine-info/2017-May/007432.html).

This PR updates the references for the homepage and the download URL to reflect the new location.