### PR TITLE
Build V8 with libcxx instead of libstdc++, fixes #14230

### DIFF
--- a/Formula/v8@3.15.rb
+++ b/Formula/v8@3.15.rb
@@ -3,6 +3,7 @@ class V8AT315 < Formula
   homepage "https://github.com/v8/v8/wiki"
   url "https://github.com/v8/v8-git-mirror/archive/3.15.11.18.tar.gz"
   sha256 "93a4945a550e5718d474113d9769a3c010ba21e3764df8f22932903cd106314d"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/v8@3.15.rb
+++ b/Formula/v8@3.15.rb
@@ -19,6 +19,9 @@ class V8AT315 < Formula
   end
 
   def install
+    # Bully GYP into correctly linking with c++11
+    ENV.cxx11
+    ENV["GYP_DEFINES"] = "clang=1 mac_deployment_target=#{MacOS.version}"
     (buildpath/"build/gyp").install resource("gyp")
 
     # fix up libv8.dylib install_name


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/14230 for details.

V8 3.15 uses an old version of `gyp` to build, which defaults to the legacy libstdc++. This leads to compatibility problems with applications build with clang + libcxx (default on Mavericks and up).

By setting `-mmacosx-version-min=10.9` clang will build against the libcxx instead.