### PR TITLE
migrate 3.0.1 (new formula)

### DIFF
--- a/Formula/migrate.rb
+++ b/Formula/migrate.rb
@@ -1,0 +1,34 @@
+require "language/go"
+
+class Migrate < Formula
+  desc "Go CLI for database migrations"
+  homepage "https://github.com/mattes/migrate"
+  url "https://github.com/mattes/migrate/archive/v3.0.1.tar.gz"
+  sha256 "c3847f260e283929db8a39d8a0273db2f6c2d96ab3aee2dba7053a83f4b61e22"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/lib/pq" do
+    url "https://github.com/lib/pq.git",
+        :revision => "8837942c3e09574accbc5f150e2c5e057189cace"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    Language::Go.stage_deps resources, buildpath/"src"
+    (buildpath/"src/github.com/mattes").mkpath
+    ln_s buildpath, buildpath/"src/github.com/mattes/migrate"
+
+    cd buildpath/"src/github.com/mattes/migrate/cli" do
+      system "go", "build", "-tags", "'postgres'",
+             "-o", "./migrate", "."
+
+      bin.install "migrate"
+    end
+  end
+
+  test do
+    system bin/"migrate", "-version"
+  end
+end


### PR DESCRIPTION
Signed-off-by: mkozjak <kozjakm1@gmail.com>

- [✓] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✓] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```migrate``` is a Golang command line interface tool for the https://github.com/mattes/migrate library.

It pulls source from the stable release tarball, uses brew go to install from source, and installs the migrate binary to /usr/local/bin/ via formula's ```bin.install``` function.

Resolves mattes/migrate#156.