### PR TITLE
migrate vips.rb from science to core

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -1,0 +1,52 @@
+class Vips < Formula
+  desc "Image processing library"
+  homepage "https://github.com/jcupitt/libvips"
+  url "https://github.com/jcupitt/libvips/releases/download/v8.5.5/vips-8.5.5.tar.gz"
+  sha256 "0891af4531d6f951a16ca6d03020b73796522d5fcf7c6247f2f04c896ecded28"
+
+  depends_on "pkg-config" => :build
+  depends_on "fftw"
+  depends_on "fontconfig"
+  depends_on "gettext"
+  depends_on "giflib"
+  depends_on "glib"
+  depends_on "gobject-introspection"
+  depends_on "jpeg"
+  depends_on "libexif"
+  depends_on "libgsf"
+  depends_on "libpng"
+  depends_on "librsvg"
+  depends_on "libtiff"
+  depends_on "little-cms2"
+  depends_on "orc"
+  depends_on "pango"
+  depends_on "poppler"
+  depends_on "pygobject3"
+  depends_on "graphicsmagick" => :optional
+  depends_on "imagemagick" => :optional
+  depends_on "jpeg-turbo" => :optional
+  depends_on "mozjpeg" => :optional
+  depends_on "openexr" => :optional
+  depends_on "openslide" => :optional
+  depends_on "webp" => :optional
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+    ]
+
+    if build.with? "graphicsmagick"
+      args << "--with-magick" << "--with-magickpackage=GraphicsMagick"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/vips", "-l"
+    cmd = "#{bin}/vipsheader -f width #{test_fixtures("test.png")}"
+    assert_equal "8", shell_output(cmd).chomp
+  end
+end


### PR DESCRIPTION
vips.rb is currently in homebrew-science.

We've recently done a php binding, but homebrew-php are reluctant to
add a dependency on a non-core formula. They've suggested I should
ask for vips.rb to be moved into homebrew-core:

Homebrew/homebrew-php#3757

This has previously been discussed in this PR:

https://github.com/Homebrew/homebrew-core/pull/11601

This add PR is linked to a delete PR in homebrew-science (see below).

There is no version change or change to any deps.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
