### PR TITLE
Update Juju devel to 2.2-rc1

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -14,7 +14,6 @@ class Juju < Formula
   devel do
     url "https://launchpad.net/juju/2.2/2.2-rc1/+download/juju-core_2.2-rc1.tar.gz"
     sha256 "3e81cd96c8737805ad0a31c37b7b6c72e1e28a73d28b81defe9c500d51df00bc"
-    version "2.2-rc1"
   end
 
   depends_on "go" => :build

--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -12,9 +12,9 @@ class Juju < Formula
   end
 
   devel do
-    url "https://launchpad.net/juju/2.2/2.2-beta4/+download/juju-core_2.2-beta4.tar.gz"
-    sha256 "592a0f1f47e3a42648d4647a08d159af9d68faf80974ab4171bd4bd22a2200eb"
-    version "2.2-beta4"
+    url "https://launchpad.net/juju/2.2/2.2-rc1/+download/juju-core_2.2-rc1.tar.gz"
+    sha256 "3e81cd96c8737805ad0a31c37b7b6c72e1e28a73d28b81defe9c500d51df00bc"
+    version "2.2-rc1"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates Juju from the beta4 to the RC1 release. 

Upgrades and install tested to be ok. Audit is tossing some notes but I believe it's part of our 1.25 to 2.0 upgrade issues we've had in the past. This PR only updates the beta to RC. 