### PR TITLE
mpd: add option --with-libao

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -61,6 +61,7 @@ class Mpd < Formula
   depends_on "mad" => :optional
   depends_on "libmodplug" => :optional  # MODPlug decoder
   depends_on "pulseaudio" => :optional
+  depends_on "libao" => :optional       # Output to libao
   if build.with? "upnp"
     depends_on "expat"
     depends_on "libupnp"
@@ -95,6 +96,7 @@ class Mpd < Formula
     args << "--enable-nfs" if build.with? "libnfs"
     args << "--enable-modplug" if build.with? "libmodplug"
     args << "--enable-pulse" if build.with? "pulseaudio"
+    args << "--enable-ao" if build.with? "libao"
     if build.with? "upnp"
       args << "--enable-upnp"
       args << "--enable-expat"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change allows compiling MPD with libao support. The reason for this is that the default CoreAudio output plugin for MPD hasn't been maintained for a long time and can work quite poorly, as it did for me. MacPorts maintainers have switched their MPD installations to libao a few years ago, so now Homebrew would also have the same option.

https://trac.macports.org/ticket/46325
https://trac.macports.org/ticket/46861