### PR TITLE
sdl2_mixer: make libvorbis a req. dependency

### DIFF
--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -3,6 +3,7 @@ class Sdl2Mixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.1.tar.gz"
   sha256 "5a24f62a610249d744cbd8d28ee399d8905db7222bf3bdbc8a8b4a76e597695f"
+  revision 1
   head "https://hg.libsdl.org/SDL_mixer", :using => :hg
 
   bottle do
@@ -14,22 +15,37 @@ class Sdl2Mixer < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libvorbis"
   depends_on "sdl2"
   depends_on "flac" => :optional
   depends_on "fluid-synth" => :optional
-  depends_on "smpeg2" => :optional
   depends_on "libmikmod" => :optional
   depends_on "libmodplug" => :optional
-  depends_on "libvorbis" => :optional
+  depends_on "smpeg2" => :optional
 
   def install
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
 
-    ENV["SMPEG_CONFIG"] = "#{Formula["smpeg2"].bin}/smpeg2-config" if build.with? "smpeg2"
+    args = %W[
+      --prefix=#{prefix} --disable-dependency-tracking
+      --enable-music-ogg --disable-music-ogg-shared
+      --disable-music-flac-shared
+      --disable-music-midi-fluidsynth-shared
+      --disable-music-mod-mikmod-shared
+      --disable-music-mod-modplug-shared
+      --disable-music-mp3-smpeg-shared
+    ]
 
-    args = %W[--prefix=#{prefix} --disable-dependency-tracking]
+    args << "--disable-music-flac" if build.without? "flac"
+    args << "--disable-music-midi-fluidsynth" if build.without? "fluid-synth"
     args << "--enable-music-mod-mikmod" if build.with? "libmikmod"
-    args << "--enable-music-mod-modplug" if build.with? "libmodplug"
+    args << "--disable-music-mod-modplug" if build.without? "libmodplug"
+
+    if build.with? "smpeg2"
+      args << "--with-smpeg-prefix=#{Formula["smpeg2"].opt_prefix}"
+    else
+      args << "--disable-music-mp3-smpeg"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
make libvorbis a req. dependency

disable dynamic loading of libraries, prevent opportunistic
linkage at compile time to libraries in the pkg-config path