### PR TITLE
Add new Formula: ColorTools

### DIFF
--- a/Formula/colortools.rb
+++ b/Formula/colortools.rb
@@ -1,0 +1,30 @@
+class Colortools < Formula
+  desc "Convert, import and export MacOS Color Picker (NSColorList) palettes"
+  homepage "https://github.com/ramonpoca/ColorTools"
+  url "https://github.com/ramonpoca/ColorTools/archive/0.2.tar.gz"
+  sha256 "87fe9a8ba6edd1bebf697f9f821f15f2073b29825fa18ea68e77f5ccb2a7f3e0"
+
+  def install
+    xcodebuild "SYMROOT=build"
+    bin.install "build/Release/Ase2Clr" => "ase2clr"
+    bin.install "build/Release/Clr2Ase" => "clr2ase"
+    bin.install "build/Release/Clr2Obj" => "clr2obj"
+    bin.install "build/Release/Html2Clr" => "html2clr"
+  end
+
+  test do
+    # "foo --version and foo --help are bad tests. However, a bad test is better
+    # than no test at all"
+    #  - https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md
+    program_should_run_and_print_usage "ase2clr"
+    program_should_run_and_print_usage "clr2ase"
+    program_should_run_and_print_usage "clr2obj"
+    program_should_run_and_print_usage "html2clr"
+  end
+
+  private
+
+  def program_should_run_and_print_usage(cmd)
+    assert_match "Usage:", shell_output("#{bin}/#{cmd} 2>&1 | grep Usage")
+  end
+end


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

(`ase2clr`, `clr2ase`, `clr2obj`, `html2clr`)

Small tools to import and export colors from the Mac OS X ColorPicker palettes (.CLR).

* Adobe Swatch Exchange (.ASE) import and export.
* Hex color list to system palette.
* Simple UIColor category generation from color lists.
* Color search&replace from .xib/.storyboard
