### PR TITLE
openfortivpn 1.4.0 (new formula)

### DIFF
--- a/Formula/openfortivpn.rb
+++ b/Formula/openfortivpn.rb
@@ -1,0 +1,21 @@
+class Openfortivpn < Formula
+  desc "Open Fortinet client for PPP+SSL VPN tunnel services"
+  homepage "https://github.com/adrienverge/openfortivpn"
+  url "https://github.com/adrienverge/openfortivpn/archive/v1.4.0.tar.gz"
+  sha256 "3b5ddbf4c0aecc85e9630bb45e012f7e0b0db5a10276f03f8af55326db97d9b4"
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "openssl"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+  test do
+    system bin/"openfortivpn", "--version"
+  end
+end


### PR DESCRIPTION
openfortivpn is a client for PPP+SSL VPN tunnel services. It spawns a pppd
process and operates the communication between the gateway and this process.

It is compatible with Fortinet VPNs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
