### PR TITLE
curl: add http mirror.

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -2,6 +2,7 @@ class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.54.0.tar.bz2"
+  mirror "http://curl.askapache.com/download/curl-7.54.0.tar.bz2"
   sha256 "f50ebaf43c507fa7cc32be4b8108fa8bbd0f5022e90794388f3c7694a302ff06"
 
   bottle do


### PR DESCRIPTION
This is so old versions of `curl` can be used to download and build a newer version.

Fix as part of https://github.com/Homebrew/brew/pull/2747