### PR TITLE
libbtbb: remove vendored libpcap

### DIFF
--- a/Formula/libbtbb.rb
+++ b/Formula/libbtbb.rb
@@ -16,20 +16,7 @@ class Libbtbb < Formula
   depends_on "cmake" => :build
   depends_on :python if MacOS.version <= :snow_leopard
 
-  # Requires headers macOS doesn't supply.
-  resource "libpcap" do
-    url "http://www.tcpdump.org/release/libpcap-1.8.1.tar.gz"
-    sha256 "673dbc69fdc3f5a86fb5759ab19899039a8e5e6c631749e48dcd9c6f0c83541e"
-  end
-
   def install
-    resource("libpcap").stage do
-      system "./configure", "--prefix=#{libexec}/vendor", "--enable-ipv6"
-      system "make", "install"
-    end
-
-    ENV.prepend_path "PATH", libexec/"vendor/bin"
-    ENV.append_to_cflags "-I#{libexec}/vendor/include"
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As of 2017-03-R2 libpcap is no longer needed.