### PR TITLE
goaccess: fix geoip build options

### DIFF
--- a/Formula/goaccess.rb
+++ b/Formula/goaccess.rb
@@ -12,13 +12,14 @@ class Goaccess < Formula
     sha256 "af9801407d647456b2421673aeefdc5d1bd00446d912126c8bc662cfad437937" => :yosemite
   end
 
-  option "with-geoip", "Enable IP location information using GeoIP"
+  option "with-libmaxminddb", "Enable IP location information using enhanced GeoIP2 databases"
 
-  deprecated_option "enable-geoip" => "with-geoip"
+  deprecated_option "enable-geoip" => "with-libmaxminddb"
+  deprecated_option "with-geoip" => "with-libmaxminddb"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "geoip" => :optional
+  depends_on "libmaxminddb" => :optional
   depends_on "tokyo-cabinet"
 
   def install
@@ -32,7 +33,7 @@ class Goaccess < Formula
       --enable-tcb=btree
     ]
 
-    args << "--enable-geoip" if build.with? "geoip"
+    args << "--enable-geoip=mmdb" if build.with? "libmaxminddb"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with ```brew install --build-from-source <formula>```, where ```<formula>``` is the name of the formula you're submitting?
- [x] Does your build pass ```brew audit --strict <formula>``` (after doing ```brew install <formula>```)?
---------------------------------------------------------------------------
The formula was not doing anything when trying to install with the ```--with-geoip``` option.

The build config options for geoip support in goacces have been updated to match this new format```--enable-geoip=<legacy|mmdb>```

I changed the dependency from ```geoip``` to ```libmaxminddb``` and added the correct build flag.