### PR TITLE
node: upstream fix for npm init hang

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -3,6 +3,7 @@ class Node < Formula
   homepage "https://nodejs.org/"
   url "https://nodejs.org/dist/v8.1.0/node-v8.1.0.tar.xz"
   sha256 "f2ff20b69b782dee85e887ad06e830590b2250856f6df325ed15a368bb6777fc"
+  revision 1
   head "https://github.com/nodejs/node.git"
 
   bottle do
@@ -40,6 +41,15 @@ class Node < Formula
   resource "npm" do
     url "https://registry.npmjs.org/npm/-/npm-5.0.3.tgz"
     sha256 "de62206d779afcba878b3fb949488c01be99afc42e3c955932e754c2ab9aec73"
+  end
+
+  # Remove for > 8.1.0
+  # Fix "All versions of `npm init` hang on Node 8.1.0"
+  # Upstream PR from 8 Jun 2017 "Revert 'readline: clean up event
+  # listener in onNewListener'"
+  patch do
+    url "https://github.com/nodejs/node/pull/13560.patch"
+    sha256 "036e86cee567059415847850a84bed6f80405b02f98b8ce9a5d921a7c480127e"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/nodejs/node/pull/13560.