### PR TITLE
srm 1.2.15 (new formula)

### DIFF
--- a/Formula/srm.rb
+++ b/Formula/srm.rb
@@ -1,0 +1,22 @@
+class Srm < Formula
+  desc "Secure file deletion"
+  homepage "http://srm.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/srm/1.2.15/srm-1.2.15.tar.gz"
+  sha256 "7583c1120e911e292f22b4a1d949b32c23518038afd966d527dae87c61565283"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make"
+    bin.install "src/srm"
+    man1.install "doc/srm.1"
+  end
+
+  test do
+    touch testpath/"test.txt"
+    system bin/"srm", testpath/"test.txt"
+    assert !(testpath/"test.txt").exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

(Mac) OS X shipped with `srm(1)` from the [10.3](https://opensource.apple.com/release/mac-os-x-1039.html) era all the way to [10.11](https://opensource.apple.com/release/os-x-10116.html), but `srm` was somehow dropped when the operating system was renamed macOS...

I still want the peace of mind when deleting a key from disk, though.