### PR TITLE
python: stop shadowing system python.

### DIFF
--- a/Aliases/python2
+++ b/Aliases/python2
@@ -1,0 +1,1 @@
+../Formula/python.rb

--- a/Aliases/python@2
+++ b/Aliases/python@2
@@ -1,0 +1,1 @@
+../Formula/python.rb

--- a/Aliases/python@3
+++ b/Aliases/python@3
@@ -1,0 +1,1 @@
+../Formula/python3.rb

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -3,7 +3,7 @@ class Fontforge < Formula
   homepage "https://fontforge.github.io"
   url "https://github.com/fontforge/fontforge/archive/20161012.tar.gz"
   sha256 "a5f5c2974eb9109b607e24f06e57696d5861aaebb620fc2c132bdbac6e656351"
-  revision 1
+  revision 2
   head "https://github.com/fontforge/fontforge.git"
 
   bottle do

--- a/Formula/gedit.rb
+++ b/Formula/gedit.rb
@@ -3,6 +3,7 @@ class Gedit < Formula
   homepage "https://wiki.gnome.org/Apps/Gedit"
   url "https://download.gnome.org/sources/gedit/3.22/gedit-3.22.0.tar.xz"
   sha256 "063b5a0b5dcc8f540f6e8c3ea1c22cf8a3a19edffc25315a1b6bc51d462b3f45"
+  revision 1
 
   bottle do
     sha256 "86f0fb0000fca3d5cdf78df96bcf9d12671fdccc7609cde5390b0196477e3496" => :sierra

--- a/Formula/gnome-builder.rb
+++ b/Formula/gnome-builder.rb
@@ -3,7 +3,7 @@ class GnomeBuilder < Formula
   homepage "https://wiki.gnome.org/Apps/Builder"
   url "https://download.gnome.org/sources/gnome-builder/3.24/gnome-builder-3.24.2.tar.xz"
   sha256 "84843a9f4af2e1ee1ebfac44441a2affa2d409df9066e7d11bf1d232ae0c535a"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "75411800654698f175dec305851a03e8bf94c310523878fbf9feb151b47c8dc8" => :sierra

--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -3,6 +3,7 @@ class GobjectIntrospection < Formula
   homepage "https://live.gnome.org/GObjectIntrospection"
   url "https://download.gnome.org/sources/gobject-introspection/1.52/gobject-introspection-1.52.1.tar.xz"
   sha256 "2ed0c38d52fe1aa6fc4def0c868fe481cb87b532fc694756b26d6cfab29faff4"
+  revision 1
 
   bottle do
     sha256 "4e73519510f4e86ed98fa1238695b904530fcd5da8334486c85845d75799b050" => :sierra
@@ -25,7 +26,7 @@ class GobjectIntrospection < Formula
 
   def install
     ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
-    ENV["PYTHON"] = Formula["python"].bin/"python"
+    ENV["PYTHON"] = Formula["python"].opt_bin/"python2"
     inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"
     inreplace "configure" do |s|
       s.change_make_var! "GOBJECT_INTROSPECTION_LIBDIR", "#{HOMEBREW_PREFIX}/lib"

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -5,6 +5,7 @@ class Macvim < Formula
   url "https://github.com/macvim-dev/macvim/archive/snapshot-134.tar.gz"
   version "8.0-134"
   sha256 "5b512d9c02703df7ffcd3f5268e5ac8a21e1e046dca60ec7544791f11b523e0a"
+  revision 1
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do

--- a/Formula/mat.rb
+++ b/Formula/mat.rb
@@ -3,6 +3,7 @@ class Mat < Formula
   homepage "https://mat.boum.org/"
   url "https://mat.boum.org/files/mat-0.5.4.tar.xz"
   sha256 "a928cb2d5ebcafec4563b552096436771598376f8b4dded86a769c278c1314d1"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/mftrace.rb
+++ b/Formula/mftrace.rb
@@ -4,6 +4,7 @@ class Mftrace < Formula
   url "http://lilypond.org/downloads/sources/mftrace/mftrace-1.2.19.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/mftrace-1.2.19.tar.gz"
   sha256 "778126f4220aa31fc91fa8baafd26aaf8be9c5e8fed5c0e92a61de04d32bbdb5"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -3,6 +3,7 @@ class Poppler < Formula
   homepage "https://poppler.freedesktop.org/"
   url "https://poppler.freedesktop.org/poppler-0.56.0.tar.xz"
   sha256 "869dbadf99ed882e776acbdbc06689d8a81872a2963440b1e8516cd7a2577173"
+  revision 1
 
   bottle do
     sha256 "183cfb95cb3f30ee45db2e6b6bef3a9b98bd001b6b03c209a6e3fdd62b15313d" => :sierra

--- a/Formula/pygobject.rb
+++ b/Formula/pygobject.rb
@@ -3,7 +3,7 @@ class Pygobject < Formula
   homepage "https://live.gnome.org/PyGObject"
   url "https://download.gnome.org/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2"
   sha256 "e4bfe017fa845940184c82a4d8949db3414cb29dfc84815fb763697dc85bdcee"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -3,6 +3,7 @@ class Pygobject3 < Formula
   homepage "https://live.gnome.org/PyGObject"
   url "https://download.gnome.org/sources/pygobject/3.24/pygobject-3.24.1.tar.xz"
   sha256 "a628a95aa0909e13fb08230b1b98fc48adef10b220932f76d62f6821b3fdbffd"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -3,6 +3,7 @@ class Vim < Formula
   homepage "https://vim.sourceforge.io/"
   url "https://github.com/vim/vim/archive/v8.0.0728.tar.gz"
   sha256 "85e724aaa5fa14ecef6193529e89de60ee56b6f8779874c8cbee7da9ca56d02b"
+  revision 1
   head "https://github.com/vim/vim.git"
 
   bottle do

--- a/Formula/vim@7.4.rb
+++ b/Formula/vim@7.4.rb
@@ -3,7 +3,7 @@ class VimAT74 < Formula
   homepage "http://www.vim.org/"
   url "https://github.com/vim/vim/archive/v7.4.2367.tar.gz"
   sha256 "a9ae4031ccd73cc60e771e8bf9b3c8b7f10f63a67efce7f61cd694cd8d7cda5c"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "cedecb3829f8f0ee0a7f1a066a6d85684d1abfd05548b4ecdf255a78718efea3" => :sierra
@@ -117,9 +117,9 @@ class VimAT74 < Formula
 
       # Expand the link and get the python exec path
       vim_framework_path = Pathname.new(otool_output).realpath.dirname.to_s.chomp
-      system_framework_path = `python-config --exec-prefix`.chomp
+      python_framework_path = `python2-config --exec-prefix`.chomp
 
-      assert_equal system_framework_path, vim_framework_path
+      assert_equal python_framework_path, vim_framework_path
     end
   end
 end

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -3,6 +3,7 @@ class Vips < Formula
   homepage "https://github.com/jcupitt/libvips"
   url "https://github.com/jcupitt/libvips/releases/download/v8.5.6/vips-8.5.6.tar.gz"
   sha256 "19a77ab200eb0ddfcd8babab130fe43c7730880d1f1fdfbdd8def519af32c4b8"
+  revision 1
 
   bottle do
     sha256 "4a0c68b0f49ce94e76f107a42a2029a2ba389c26034c714f320eaa7b5f929346" => :sierra

--- a/Formula/xdot.rb
+++ b/Formula/xdot.rb
@@ -3,6 +3,7 @@ class Xdot < Formula
   homepage "https://github.com/jrfonseca/xdot.py"
   url "https://files.pythonhosted.org/packages/f5/52/7cec1decf2b07c7749eb997fa5f365781a512722f48e6ad4294e31c94629/xdot-0.7.tar.gz"
   sha256 "d2100c3201d974915d1b89220ce52f380334eb365ab48903573a8135f51d0ee0"
+  revision 1
 
   head "https://github.com/jrfonseca/xdot.py.git"
 


### PR DESCRIPTION
Use the `python2` etc. binaries instead and provide a link to `python` in a directory not in the `PATH` by default. With https://github.com/Homebrew/brew/pull/2897 this requires no formula changes and just bumps for those that hardcode `python`'s full path.
