### PR TITLE
ponscripter-sekai: update sdl2_mixer dependency

### DIFF
--- a/Formula/ponscripter-sekai.rb
+++ b/Formula/ponscripter-sekai.rb
@@ -3,6 +3,7 @@ class PonscripterSekai < Formula
   homepage "https://github.com/sekaiproject/ponscripter-fork"
   url "https://github.com/sekaiproject/ponscripter-fork/archive/v0.0.6.tar.gz"
   sha256 "888a417808fd48f8f55da42c113b04d61396a1237b2b0fed2458e804b8ddf426"
+  revision 1
   head "https://github.com/sekaiproject/ponscripter-fork.git"
 
   bottle do
@@ -14,7 +15,7 @@ class PonscripterSekai < Formula
 
   depends_on "sdl2"
   depends_on "sdl2_image"
-  depends_on "sdl2_mixer" => ["with-libvorbis", "with-smpeg2"]
+  depends_on "sdl2_mixer" => "with-smpeg2"
   depends_on "libvorbis"
   depends_on "smpeg2"
   depends_on "freetype"


### PR DESCRIPTION
update sdl2_mixer dependency

Addresses part of #13133 by removing the "with-libvorbis" requirement on the `sdl2_mixer` dep.