### PR TITLE
r 3.4.0 (import from homebrew/science)

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -1,0 +1,86 @@
+class R < Formula
+  desc "Software environment for statistical computing"
+  homepage "https://www.r-project.org/"
+  url "https://cran.rstudio.com/src/base/R-3/R-3.4.1.tar.gz"
+  sha256 "02b1135d15ea969a3582caeb95594a05e830a6debcdb5b85ed2d5836a6a3fc78"
+
+  bottle do
+    sha256 "d0254993416c177d7fa49b9cde95eb8bd262e3a801408b21951cc0f7755e0a0e" => :sierra
+    sha256 "2098376a2d552573a1b0e2ff29c076b05a0161ec276260b5b76a80e87d5cd6c1" => :el_capitan
+    sha256 "be31e78c3df77a46e91500b4809cb7f89bceacabc0c38d1bc3e56beab31bff6e" => :yosemite
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "pcre"
+  depends_on "readline"
+  depends_on "xz"
+  depends_on :fortran
+  depends_on "homebrew/science/openblas" => :optional
+
+  def install
+    # Fix dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? &&
+       MacOS::Xcode.version >= "8.0"
+      ENV["ac_cv_have_decl_clock_gettime"] = "no"
+    end
+
+    args = [
+      "--prefix=#{prefix}",
+      "--enable-memory-profiling",
+      "--without-cairo",
+      "--without-x",
+      "--with-aqua",
+      "--with-lapack",
+      "SED=/usr/bin/sed", # don't remember Homebrew's sed shim
+    ]
+
+    if build.with? "openblas"
+      args << "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas"
+      ENV.append "LDFLAGS", "-L#{Formula["openblas"].opt_lib}"
+    else
+      args << "--with-blas=-framework Accelerate"
+      ENV.append_to_cflags "-D__ACCELERATE__" if ENV.compiler != :clang
+    end
+
+    # Help CRAN packages find gettext and readline
+    ["gettext", "readline"].each do |f|
+      ENV.append "CPPFLAGS", "-I#{Formula[f].opt_include}"
+      ENV.append "LDFLAGS", "-L#{Formula[f].opt_lib}"
+    end
+
+    system "./configure", *args
+    system "make"
+    ENV.deparallelize do
+      system "make", "install"
+    end
+
+    cd "src/nmath/standalone" do
+      system "make"
+      ENV.deparallelize do
+        system "make", "install"
+      end
+    end
+
+    # make Homebrew packages discoverable for R CMD INSTALL
+    inreplace lib/"R/etc/Makeconf" do |s|
+      s.gsub!(/^CPPFLAGS =.*/, "\\0 -I#{HOMEBREW_PREFIX}/include")
+      s.gsub!(/^LDFLAGS =.*/, "\\0 -L#{HOMEBREW_PREFIX}/lib")
+      s.gsub!(/.LDFLAGS =.*/, "\\0 $(LDFLAGS)")
+    end
+  end
+
+  def post_install
+    short_version =
+      `#{bin}/Rscript -e 'cat(as.character(getRversion()[1,1:2]))'`.strip
+    site_library = HOMEBREW_PREFIX/"lib/R/#{short_version}/site-library"
+    site_library.mkpath
+    ln_s site_library, lib/"R/site-library"
+  end
+
+  test do
+    assert_equal "[1] 2", shell_output("#{bin}/Rscript -e 'print(1+1)'").chomp
+  end
+end


### PR DESCRIPTION
We're going to want to tear out a lot of the platform-specific logic, some options and perhaps change the default options too.

CC @ilovezfs @imichka for thoughts and review.

```
mikebook # brew formula-analytics --days-ago=365 homebrew/science/r
install events in the last 365 days for homebrew/science/r
==================================================================================================
 1 | homebrew/science/r                                                        |  94,223 |  86.95%
 2 | homebrew/science/r --with-openblas                                        |  10,335 |   9.54%
 3 | homebrew/science/r --with-x11                                             |   1,787 |   1.65%
 4 | homebrew/science/r --with-openblas --with-x11                             |     305 |   0.28%
 5 | homebrew/science/r --with-openblas --with-pango --with-valgrind --with-x1 |     252 |   0.23%
 6 | homebrew/science/r --with-openblas --with-pango --with-x11                |     248 |   0.23%
 7 | homebrew/science/r --with-openblas --with-pango                           |     221 |   0.20%
 8 | homebrew/science/r --without-tcltk                                        |     125 |   0.12%
 9 | homebrew/science/r --without-tcltk --with-openblas                        |     119 |   0.11%
10 | homebrew/science/r --with-pango --with-x11                                |      88 |   0.08%
11 | homebrew/science/r --with-openblas --with-pango --with-valgrind           |      84 |   0.08%
12 | homebrew/science/r --with-pango                                           |      71 |   0.07%
13 | homebrew/science/r --without-accelerate                                   |      71 |   0.07%
14 | homebrew/science/r --with-openblas --with-valgrind                        |      59 |   0.05%
15 | homebrew/science/r --HEAD                                                 |      40 |   0.04%
16 | homebrew/science/r --with-librmath-only                                   |      40 |   0.04%
17 | homebrew/science/r --with-parallel-studio --without-accelerate --without- |      36 |   0.03%
18 | homebrew/science/r --with-valgrind                                        |      35 |   0.03%
19 | homebrew/science/r --HEAD --with-x11                                      |      21 |   0.02%
20 | homebrew/science/r --with-parallel-studio --without-tcltk                 |      16 |   0.01%
21 | homebrew/science/r --with-pango --with-valgrind                           |      14 |   0.01%
22 | homebrew/science/r --with-openblas --with-valgrind --with-x11             |      12 |   0.01%
23 | homebrew/science/r --without-tcltk --with-openblas --with-valgrind        |      12 |   0.01%
24 | homebrew/science/r --with-pango --with-valgrind --with-x11                |      11 |   0.01%
25 | homebrew/science/r --HEAD --with-openblas --with-pango --with-x11         |      10 |   0.01%
26 | homebrew/science/r --without-accelerate --with-openblas --with-pango --wi |      10 |   0.01%
27 | homebrew/science/r --without-test                                         |       9 |   0.01%
28 | homebrew/science/r --with-librmath-only --with-openblas --with-pango --wi |       8 |   0.01%
29 | homebrew/science/r --with-valgrind --with-x11                             |       8 |   0.01%
30 | homebrew/science/r --without-tcltk --with-valgrind                        |       8 |   0.01%
31 | homebrew/science/r --with-parallel-studio --without-tcltk --with-openblas |       7 |   0.01%
32 | homebrew/science/r --HEAD --with-openblas --with-x11                      |       6 |   0.01%
33 | homebrew/science/r --without-tcltk --with-openblas --with-pango           |       6 |   0.01%
34 | homebrew/science/r --HEAD --with-openblas --with-pango                    |       5 |   0.00%
35 | homebrew/science/r --with-librmath-only --with-openblas --with-pango --wi |       5 |   0.00%
36 | homebrew/science/r --without-accelerate --with-openblas --with-x11        |       5 |   0.00%
37 | homebrew/science/r --without-tcltk --with-openblas --with-pango --with-x1 |       5 |   0.00%
38 | homebrew/science/r --without-tcltk --with-x11                             |       5 |   0.00%
39 | homebrew/science/r --with-valgrind --with-openblas                        |       4 |   0.00%
40 | homebrew/science/r --HEAD --without-test --without-tcltk                  |       3 |   0.00%
41 | homebrew/science/r --with-parallel-studio --without-accelerate --without- |       3 |   0.00%
42 | homebrew/science/r --without-accelerate --without-test                    |       3 |   0.00%
43 | homebrew/science/r --HEAD --with-openblas                                 |       2 |   0.00%
44 | homebrew/science/r --HEAD --without-accelerate --without-test --without-t |       2 |   0.00%
45 | homebrew/science/r --with-librmath-only --with-openblas                   |       2 |   0.00%
46 | homebrew/science/r --with-mkl --with-icc --without-tcltk --with-openblas  |       2 |   0.00%
47 | homebrew/science/r --with-openblas --with-valgrind --with-pango           |       2 |   0.00%
48 | homebrew/science/r --with-pango --with-openblas --with-valgrind           |       2 |   0.00%
49 | homebrew/science/r --with-pango --with-valgrind --with-openblas           |       2 |   0.00%
50 | homebrew/science/r --with-x11 --with-openblas --with-pango --with-valgrin |       2 |   0.00%
51 | homebrew/science/r --without-accelerate --with-librmath-only              |       2 |   0.00%
52 | homebrew/science/r --without-accelerate --with-openblas                   |       2 |   0.00%
53 | homebrew/science/r --without-accelerate --with-x11                        |       2 |   0.00%
54 | homebrew/science/r --without-tcltk --with-openblas --with-pango --with-va |       2 |   0.00%
55 | homebrew/science/r --without-test --without-tcltk                         |       2 |   0.00%
56 | homebrew/science/r --HEAD --with-openblas --with-pango --with-valgrind -- |       1 |   0.00%
57 | homebrew/science/r --with-openblas --with-x11 --with-valgrind --with-pang |       1 |   0.00%
58 | homebrew/science/r --with-valgrind --with-openblas --with-pango           |       1 |   0.00%
59 | homebrew/science/r --with-x11 --with-valgrind --with-pango --with-openbla |       1 |   0.00%
60 | homebrew/science/r --without-accelerate --without-tcltk                   |       1 |   0.00%
61 | homebrew/science/r --without-check --with-openblas --with-pango --with-x1 |       1 |   0.00%
62 | homebrew/science/r --without-tcltk --with-librmath-only                   |       1 |   0.00%
63 | homebrew/science/r --without-tcltk --with-openblas --with-x11             |       1 |   0.00%
64 | homebrew/science/r --without-test --with-openblas --with-valgrind         |       1 |   0.00%
==================================================================================================
Total                                                                          | 108,370 |    100%
==================================================================================================

```