### PR TITLE
hdf5 1.10.1 (import from homebrew/science)

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -1,0 +1,81 @@
+class Hdf5 < Formula
+  desc "File format designed to store large amounts of data"
+  homepage "https://www.hdfgroup.org/HDF5"
+  url "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2"
+  sha256 "9c5ce1e33d2463fb1a42dd04daacbc22104e57676e2204e3d66b1ef54b88ebf2"
+
+  bottle do
+    sha256 "cfcd0e27ff297c39b495285fc623a34b1751bdb4993beab94d86f52931bc3448" => :sierra
+    sha256 "a4e677a58a57aaaa4be1dd7fd165b15272ecbf265b7acfa7b89952aea3460467" => :el_capitan
+    sha256 "d9a15be0e5f7091084db292e32a469f9eaff7e3615b429c65f7fde2ef230a8f7" => :yosemite
+  end
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-parallel" => "with-mpi"
+  deprecated_option "enable-cxx" => "with-cxx"
+
+  option :cxx11
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "szip"
+  depends_on :fortran => :optional
+  depends_on :mpi => [:optional, :cc, :cxx, :f90]
+
+  def install
+    ENV.cxx11 if build.cxx11?
+
+    inreplace %w[c++/src/h5c++.in fortran/src/h5fc.in tools/src/misc/h5cc.in],
+      "${libdir}/libhdf5.settings", "#{pkgshare}/libhdf5.settings"
+
+    inreplace "src/Makefile.am", "settingsdir=$(libdir)", "settingsdir=#{pkgshare}"
+
+    system "autoreconf", "-fiv"
+
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-szlib=#{Formula["szip"].opt_prefix}
+      --enable-build-mode=production
+    ]
+
+    if build.with?("cxx") && build.without?("mpi")
+      args << "--enable-cxx"
+    else
+      args << "--disable-cxx"
+    end
+
+    if build.with? "fortran"
+      args << "--enable-fortran"
+    else
+      args << "--disable-fortran"
+    end
+
+    if build.with? "mpi"
+      ENV["CC"] = ENV["MPICC"]
+      ENV["CXX"] = ENV["MPICXX"]
+      ENV["FC"] = ENV["MPIFC"]
+
+      args << "--enable-parallel"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+      #include "hdf5.h"
+      int main()
+      {
+        printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
+        return 0;
+      }
+    EOS
+    system "#{bin}/h5cc", "test.c"
+    assert_equal version.to_s, shell_output("./a.out").chomp
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -26,7 +26,6 @@
   "gromacs": "homebrew/science",
   "gtkwave": "caskroom/cask",
   "hdf@4": "homebrew/science",
-  "hdf5": "homebrew/science",
   "helios": "spotify/public",
   "hexchat": "caskroom/cask",
   "horndis": "caskroom/cask",


### PR DESCRIPTION
We're going to want to tear out a lot of the platform-specific logic, some options and perhaps change the default options too.

CC @ilovezfs @imichka for thoughts and review.

```
install events in the last 365 days for homebrew/science/hdf5
==================================================================================================
  1 | homebrew/science/hdf5                                                    | 116,478 |  94.77%
  2 | homebrew/science/hdf5 --with-mpi                                         |   3,022 |   2.46%
  3 | homebrew/science/hdf5 --with-mpi --with-fortran                          |     623 |   0.51%
  4 | homebrew/science/hdf5 --with-fortran                                     |     508 |   0.41%
  5 | homebrew/science/hdf5 --c++11                                            |     426 |   0.35%
  6 | homebrew/science/hdf5 --with-mpi --c++11                                 |     231 |   0.19%
  7 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --with-fortran       |     220 |   0.18%
  8 | homebrew/science/hdf5 --with-fortran2003 --with-fortran                  |     118 |   0.10%
  9 | homebrew/science/hdf5 --with-mpi --c++11 --with-fortran                  |     103 |   0.08%
 10 | homebrew/science/hdf5 --c++11 --with-fortran                             |      76 |   0.06%
 11 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --c++11 --with-fortr |      58 |   0.05%
 12 | homebrew/science/hdf5 --with-fortran2003 --c++11 --with-fortran          |      56 |   0.05%
 13 | homebrew/science/hdf5 --with-threadsafe                                  |      55 |   0.04%
 14 | homebrew/science/hdf5 --c 11                                             |      42 |   0.03%
 15 | homebrew/science/hdf5 --with-test --with-mpi --with-fortran              |      39 |   0.03%
 16 | homebrew/science/hdf5 --universal                                        |      38 |   0.03%
 17 | homebrew/science/hdf5 --with-mpi --without-cxx                           |      33 |   0.03%
 18 | homebrew/science/hdf5 --with-test --with-mpi --c++11 --with-fortran      |      32 |   0.03%
 19 | homebrew/science/hdf5 --with-mpi --c 11                                  |      29 |   0.02%
 20 | homebrew/science/hdf5 --with-test --without-cxx                          |      29 |   0.02%
 21 | homebrew/science/hdf5 --with-test                                        |      25 |   0.02%
 22 | homebrew/science/hdf5 --with-test --with-fortran                         |      25 |   0.02%
 23 | homebrew/science/hdf5 --with-test --with-mpi                             |      24 |   0.02%
 24 | homebrew/science/hdf5 --with-threadsafe --with-unsupported               |      24 |   0.02%
 25 | homebrew/science/hdf5 --with-test --with-fortran2003 --with-mpi --c++11  |      22 |   0.02%
 26 | homebrew/science/hdf5 --with-threadsafe --with-fortran2003 --with-mpi -- |      18 |   0.01%
 27 | homebrew/science/hdf5 --with-mpi --with-unsupported --c++11 --with-fortr |      17 |   0.01%
 28 | homebrew/science/hdf5 --with-threadsafe --with-mpi                       |      17 |   0.01%
 29 | homebrew/science/hdf5 --with-threadsafe --with-fortran2003 --with-fortra |      16 |   0.01%
 30 | homebrew/science/hdf5 --with-threadsafe --with-unsupported --c++11       |      16 |   0.01%
 31 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --with-unsupported - |      15 |   0.01%
 32 | homebrew/science/hdf5 --with-fortran2003                                 |      13 |   0.01%
 33 | homebrew/science/hdf5 --with-mpi --with-unsupported --c++11              |      13 |   0.01%
 34 | homebrew/science/hdf5 --universal --c++11                                |      11 |   0.01%
 35 | homebrew/science/hdf5 --with-mpi --with-unsupported                      |      11 |   0.01%
 36 | homebrew/science/hdf5 --with-threadsafe --c++11                          |      11 |   0.01%
 37 | homebrew/science/hdf5 --with-threadsafe --with-mpi --with-unsupported -- |      11 |   0.01%
 38 | homebrew/science/hdf5 --with-check --with-fortran2003 --with-mpi --c++11 |      10 |   0.01%
 39 | homebrew/science/hdf5 --with-test --with-fortran2003 --with-mpi --with-f |      10 |   0.01%
 40 | homebrew/science/hdf5 --with-threadsafe --with-mpi --with-unsupported -- |      10 |   0.01%
 41 | homebrew/science/hdf5 --with-test --c++11 --with-fortran                 |       9 |   0.01%
 42 | homebrew/science/hdf5 --with-test --with-mpi --without-cxx               |       9 |   0.01%
 43 | homebrew/science/hdf5 --with-fortran2003 --c++11                         |       8 |   0.01%
 44 | homebrew/science/hdf5 --with-test --with-mpi --c++11                     |       8 |   0.01%
 45 | homebrew/science/hdf5 --with-threadsafe --with-fortran                   |       8 |   0.01%
 46 | homebrew/science/hdf5 --with-check --with-fortran2003 --with-mpi --c 11  |       7 |   0.01%
 47 | homebrew/science/hdf5 --with-fortran2003 --with-mpi                      |       7 |   0.01%
 48 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --without-cxx --with |       7 |   0.01%
 49 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --with-un |       7 |   0.01%
 50 | homebrew/science/hdf5 --with-threadsafe --with-mpi --with-fortran        |       7 |   0.01%
 51 | homebrew/science/hdf5 --with-threadsafe --with-mpi --without-cxx --witho |       7 |   0.01%
 52 | homebrew/science/hdf5 --with-unsupported                                 |       7 |   0.01%
 53 | homebrew/science/hdf5 --without-cxx                                      |       7 |   0.01%
 54 | homebrew/science/hdf5 --with-check --with-fortran2003 --with-mpi --with- |       6 |   0.00%
 55 | homebrew/science/hdf5 --with-test --with-mpi --with-unsupported --with-f |       6 |   0.00%
 56 | homebrew/science/hdf5 --with-threadsafe --without-cxx                    |       6 |   0.00%
 57 | homebrew/science/hdf5 --with-threadsafe --without-cxx --without-hl       |       6 |   0.00%
 58 | homebrew/science/hdf5 --universal --with-fortran2003 --with-mpi --c++11  |       5 |   0.00%
 59 | homebrew/science/hdf5 --universal --with-mpi                             |       5 |   0.00%
 60 | homebrew/science/hdf5 --with-check                                       |       5 |   0.00%
 61 | homebrew/science/hdf5 --with-check --with-mpi --with-fortran             |       5 |   0.00%
 62 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --c 11 --with-fortra |       5 |   0.00%
 63 | homebrew/science/hdf5 --with-test --c++11                                |       5 |   0.00%
 64 | homebrew/science/hdf5 --with-test --with-mpi --with-unsupported --c++11  |       5 |   0.00%
 65 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --c++11   |       5 |   0.00%
 66 | homebrew/science/hdf5 --with-threadsafe --with-mpi --c++11 --with-fortra |       5 |   0.00%
 67 | homebrew/science/hdf5 --with-threadsafe --without-cxx --with-unsupported |       5 |   0.00%
 68 | homebrew/science/hdf5 --without-cxx --c++11                              |       5 |   0.00%
 69 | homebrew/science/hdf5 --universal --with-test --with-threadsafe --with-f |       4 |   0.00%
 70 | homebrew/science/hdf5 --universal --with-test --with-threadsafe --with-u |       4 |   0.00%
 71 | homebrew/science/hdf5 --universal --with-threadsafe --with-mpi --c++11 - |       4 |   0.00%
 72 | homebrew/science/hdf5 --with-check --with-mpi --c 11 --with-fortran      |       4 |   0.00%
 73 | homebrew/science/hdf5 --with-fortran2003 --with-unsupported --c++11 --wi |       4 |   0.00%
 74 | homebrew/science/hdf5 --with-mpi --c 11 --with-fortran                   |       4 |   0.00%
 75 | homebrew/science/hdf5 --with-mpi --without-cxx --with-fortran            |       4 |   0.00%
 76 | homebrew/science/hdf5 --with-test --with-fortran2003 --c++11 --with-fort |       4 |   0.00%
 77 | homebrew/science/hdf5 --with-threadsafe --with-mpi --with-unsupported    |       4 |   0.00%
 78 | homebrew/science/hdf5 --with-threadsafe --with-unsupported --c 11        |       4 |   0.00%
 79 | homebrew/science/hdf5 --with-threadsafe --without-hl                     |       4 |   0.00%
 80 | homebrew/science/hdf5 --universal --with-mpi --with-fortran              |       3 |   0.00%
 81 | homebrew/science/hdf5 --universal --with-test --with-threadsafe --with-f |       3 |   0.00%
 82 | homebrew/science/hdf5 --with-check --c++11 --with-fortran                |       3 |   0.00%
 83 | homebrew/science/hdf5 --with-check --with-fortran2003 --c 11 --with-fort |       3 |   0.00%
 84 | homebrew/science/hdf5 --with-check --with-mpi                            |       3 |   0.00%
 85 | homebrew/science/hdf5 --with-check --with-threadsafe                     |       3 |   0.00%
 86 | homebrew/science/hdf5 --with-check --with-threadsafe --with-fortran2003  |       3 |   0.00%
 87 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --without-cxx --c++1 |       3 |   0.00%
 88 | homebrew/science/hdf5 --with-test --with-fortran2003 --with-fortran      |       3 |   0.00%
 89 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --with-fo |       3 |   0.00%
 90 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --with-un |       3 |   0.00%
 91 | homebrew/science/hdf5 --with-threadsafe --c 11                           |       3 |   0.00%
 92 | homebrew/science/hdf5 --with-threadsafe --with-fortran2003 --c++11 --wit |       3 |   0.00%
 93 | homebrew/science/hdf5 --with-threadsafe --without-cxx --without-hl --c++ |       3 |   0.00%
 94 | homebrew/science/hdf5 --with-unsupported --c++11                         |       3 |   0.00%
 95 | homebrew/science/hdf5 --c 11 --with-fortran                              |       2 |   0.00%
 96 | homebrew/science/hdf5 --universal --c 11 --with-fortran                  |       2 |   0.00%
 97 | homebrew/science/hdf5 --universal --c++11 --with-fortran                 |       2 |   0.00%
 98 | homebrew/science/hdf5 --universal --with-fortran                         |       2 |   0.00%
 99 | homebrew/science/hdf5 --universal --with-fortran2003 --c++11             |       2 |   0.00%
100 | homebrew/science/hdf5 --universal --with-fortran2003 --with-mpi --with-f |       2 |   0.00%
101 | homebrew/science/hdf5 --universal --with-test                            |       2 |   0.00%
102 | homebrew/science/hdf5 --universal --with-test --with-fortran             |       2 |   0.00%
103 | homebrew/science/hdf5 --universal --with-test --with-threadsafe --with-f |       2 |   0.00%
104 | homebrew/science/hdf5 --universal --with-threadsafe --with-fortran2003 - |       2 |   0.00%
105 | homebrew/science/hdf5 --with-check --c 11                                |       2 |   0.00%
106 | homebrew/science/hdf5 --with-check --c 11 --with-fortran                 |       2 |   0.00%
107 | homebrew/science/hdf5 --with-check --with-mpi --c++11                    |       2 |   0.00%
108 | homebrew/science/hdf5 --with-check --with-threadsafe --with-fortran2003  |       2 |   0.00%
109 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --with-unsupported - |       2 |   0.00%
110 | homebrew/science/hdf5 --with-mpi --without-hl --c++11 --with-fortran     |       2 |   0.00%
111 | homebrew/science/hdf5 --with-mpi --without-hl --with-fortran             |       2 |   0.00%
112 | homebrew/science/hdf5 --with-test --with-fortran2003 --with-mpi --c++11  |       2 |   0.00%
113 | homebrew/science/hdf5 --with-test --with-mpi --with-unsupported --c++11  |       2 |   0.00%
114 | homebrew/science/hdf5 --with-test --with-mpi --without-cxx --with-fortra |       2 |   0.00%
115 | homebrew/science/hdf5 --with-test --with-mpi --without-hl --with-fortran |       2 |   0.00%
116 | homebrew/science/hdf5 --with-test --with-threadsafe --with-fortran2003 - |       2 |   0.00%
117 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --without |       2 |   0.00%
118 | homebrew/science/hdf5 --with-threadsafe --with-fortran2003 --with-mpi -- |       2 |   0.00%
119 | homebrew/science/hdf5 --with-threadsafe --with-mpi --c 11                |       2 |   0.00%
120 | homebrew/science/hdf5 --with-threadsafe --with-mpi --c++11               |       2 |   0.00%
121 | homebrew/science/hdf5 --with-threadsafe --with-unsupported --with-fortra |       2 |   0.00%
122 | homebrew/science/hdf5 --enable-fortran                                   |       1 |   0.00%
123 | homebrew/science/hdf5 --universal --c 11                                 |       1 |   0.00%
124 | homebrew/science/hdf5 --universal --with-check                           |       1 |   0.00%
125 | homebrew/science/hdf5 --universal --with-check --with-fortran2003 --c 11 |       1 |   0.00%
126 | homebrew/science/hdf5 --universal --with-check --with-fortran2003 --with |       1 |   0.00%
127 | homebrew/science/hdf5 --universal --with-check --with-mpi --with-fortran |       1 |   0.00%
128 | homebrew/science/hdf5 --universal --with-check --with-threadsafe --with- |       1 |   0.00%
129 | homebrew/science/hdf5 --universal --with-check --with-threadsafe --with- |       1 |   0.00%
130 | homebrew/science/hdf5 --universal --with-fortran2003 --c++11 --with-fort |       1 |   0.00%
131 | homebrew/science/hdf5 --universal --with-mpi --c 11 --with-fortran       |       1 |   0.00%
132 | homebrew/science/hdf5 --universal --with-mpi --c++11 --with-fortran      |       1 |   0.00%
133 | homebrew/science/hdf5 --universal --with-test --with-mpi --c++11         |       1 |   0.00%
134 | homebrew/science/hdf5 --universal --with-test --with-threadsafe --with-m |       1 |   0.00%
135 | homebrew/science/hdf5 --universal --with-threadsafe --with-unsupported - |       1 |   0.00%
136 | homebrew/science/hdf5 --universal --without-cxx --with-fortran           |       1 |   0.00%
137 | homebrew/science/hdf5 --with-check --with-fortran                        |       1 |   0.00%
138 | homebrew/science/hdf5 --with-check --with-fortran2003 --with-fortran     |       1 |   0.00%
139 | homebrew/science/hdf5 --with-check --with-mpi --c++11 --with-fortran     |       1 |   0.00%
140 | homebrew/science/hdf5 --with-check --with-threadsafe --with-fortran2003  |       1 |   0.00%
141 | homebrew/science/hdf5 --with-check --with-threadsafe --with-mpi --c 11 - |       1 |   0.00%
142 | homebrew/science/hdf5 --with-check --with-threadsafe --with-mpi --with-f |       1 |   0.00%
143 | homebrew/science/hdf5 --with-fortran --with-mpi                          |       1 |   0.00%
144 | homebrew/science/hdf5 --with-fortran2003 --c 11 --with-fortran           |       1 |   0.00%
145 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --without-cxx        |       1 |   0.00%
146 | homebrew/science/hdf5 --with-fortran2003 --with-mpi --without-mpi --with |       1 |   0.00%
147 | homebrew/science/hdf5 --with-mpi --with-unsupported --with-fortran       |       1 |   0.00%
148 | homebrew/science/hdf5 --with-netcdf                                      |       1 |   0.00%
149 | homebrew/science/hdf5 --with-test --with-mpi --with-unsupported          |       1 |   0.00%
150 | homebrew/science/hdf5 --with-test --with-threadsafe                      |       1 |   0.00%
151 | homebrew/science/hdf5 --with-test --with-threadsafe --with-fortran       |       1 |   0.00%
152 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi           |       1 |   0.00%
153 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --c++11 - |       1 |   0.00%
154 | homebrew/science/hdf5 --with-test --with-threadsafe --with-mpi --without |       1 |   0.00%
155 | homebrew/science/hdf5 --with-test --with-threadsafe --with-unsupported - |       1 |   0.00%
156 | homebrew/science/hdf5 --with-test --with-unsupported --c++11 --with-fort |       1 |   0.00%
157 | homebrew/science/hdf5 --with-threadsafe --c++11 --with-fortran           |       1 |   0.00%
158 | homebrew/science/hdf5 --with-threadsafe --with-fortran2003 --with-mpi -- |       1 |   0.00%
159 | homebrew/science/hdf5 --with-threadsafe --with-mpi --with-unsupported -- |       1 |   0.00%
160 | homebrew/science/hdf5 --with-threadsafe --with-mpi --without-cxx --witho |       1 |   0.00%
161 | homebrew/science/hdf5 --with-threadsafe --with-mpi --without-hl          |       1 |   0.00%
162 | homebrew/science/hdf5 --with-threadsafe --with-mpi --without-hl --c++11  |       1 |   0.00%
163 | homebrew/science/hdf5 --with-threadsafe --with-mpi --without-hl --c++11  |       1 |   0.00%
164 | homebrew/science/hdf5 --with-threadsafe --without-cxx --c 11             |       1 |   0.00%
165 | homebrew/science/hdf5 --with-threadsafe --without-hl --c++11             |       1 |   0.00%
166 | homebrew/science/hdf5 --with-threadsafe --without-hl --without-cxx       |       1 |   0.00%
167 | homebrew/science/hdf5 --with-unsupported --c 11                          |       1 |   0.00%
168 | homebrew/science/hdf5 --with-unsupported --c++11 --with-fortran          |       1 |   0.00%
==================================================================================================
Total                                                                          | 122,902 |    100%
==================================================================================================
```