### PR TITLE
neovim 0.2.0 (new formula)

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -1,0 +1,67 @@
+class Neovim < Formula
+  desc "Ambitious Vim-fork focused on extensibility and agility"
+  homepage "https://neovim.io/"
+
+  stable do
+    url "https://github.com/neovim/neovim/archive/v0.2.0.tar.gz"
+    sha256 "72e263f9d23fe60403d53a52d4c95026b0be428c1b9c02b80ab55166ea3f62b5"
+
+    depends_on "luajit" => :build
+  end
+
+  head do
+    url "https://github.com/neovim/neovim.git"
+
+    depends_on "luajit"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "lua@5.1" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "jemalloc"
+  depends_on "libtermkey"
+  depends_on "libuv"
+  depends_on "libvterm"
+  depends_on "msgpack"
+  depends_on "unibilium"
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  resource "lpeg" do
+    url "https://luarocks.org/manifests/gvvaughan/lpeg-1.0.1-1.src.rock", :using => :nounzip
+    sha256 "149be31e0155c4694f77ea7264d9b398dd134eca0d00ff03358d91a6cfb2ea9d"
+  end
+
+  resource "mpack" do
+    url "https://luarocks.org/manifests/tarruda/mpack-1.0.6-0.src.rock", :using => :nounzip
+    sha256 "9068d9d3f407c72a7ea18bc270b0fa90aad60a2f3099fa23d5902dd71ea4cd5f"
+  end
+
+  def install
+    resources.each do |r|
+      r.stage(buildpath/"deps-build/build/src/#{r.name}")
+    end
+
+    ENV.prepend_path "LUA_PATH", "#{buildpath}/deps-build/share/lua/5.1/?.lua"
+    ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
+
+    cd "deps-build" do
+      system "luarocks-5.1", "build", "build/src/lpeg/lpeg-1.0.1-1.src.rock", "--tree=."
+      system "luarocks-5.1", "build", "build/src/mpack/mpack-1.0.6-0.src.rock", "--tree=."
+      system "cmake", "../third-party", "-DUSE_BUNDLED=OFF", *std_cmake_args
+      system "make"
+    end
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.txt").write("Hello World from Vim!!")
+    system bin/"nvim", "--headless", "-i", "NONE", "-u", "NONE",
+                       "+s/Vim/Neovim/g", "+wq", "test.txt"
+    assert_equal "Hello World from Neovim!!", (testpath/"test.txt").read.chomp
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is slightly different from the Formula that currently sits in the neovim/neovim tap since the linux specific code has been removed since `brew audit` complains. The issue in the Neovim tap requesting the move to homebrew-core is here https://github.com/neovim/homebrew-neovim/issues/115 which also contains a few question marks related to inclusion of code from non brew formula. Let me know if you have any feedback.