### PR TITLE
sbtenv: fix url from my namespace to `sbtenv` org.

### DIFF
--- a/Formula/sbtenv.rb
+++ b/Formula/sbtenv.rb
@@ -1,9 +1,9 @@
 class Sbtenv < Formula
   desc "Command-line tool for managing sbt environments"
-  homepage "https://github.com/mazgi/sbtenv"
-  url "https://github.com/mazgi/sbtenv/archive/version/0.0.12.tar.gz"
+  homepage "https://github.com/sbtenv/sbtenv"
+  url "https://github.com/sbtenv/sbtenv/archive/version/0.0.12.tar.gz"
   sha256 "12b0fe7d66717ccd849ae51cb05a3b12e0080b6c1f9f5b7455a732fa2e5e28a9"
-  head "https://github.com/mazgi/sbtenv.git"
+  head "https://github.com/sbtenv/sbtenv.git"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
