### PR TITLE
scalaenv: fix url from my namespace to `scalaenv` org.

### DIFF
--- a/Formula/scalaenv.rb
+++ b/Formula/scalaenv.rb
@@ -1,9 +1,9 @@
 class Scalaenv < Formula
   desc "Command-line tool to manage Scala environments"
-  homepage "https://github.com/mazgi/scalaenv"
-  url "https://github.com/mazgi/scalaenv/archive/version/0.0.12.tar.gz"
+  homepage "https://github.com/scalaenv/scalaenv"
+  url "https://github.com/scalaenv/scalaenv/archive/version/0.0.12.tar.gz"
   sha256 "cc6f095c7a76623437030720fc49f786f1711be7c8418b2d4bc27ecec150d5dc"
-  head "https://github.com/mazgi/scalaenv.git"
+  head "https://github.com/scalaenv/scalaenv.git"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
