### PR TITLE
libftdi & libusb universal binary build

### DIFF
--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -23,9 +23,16 @@ class Libftdi < Formula
   # https://www.mail-archive.com/libftdi@developer.intra2net.com/msg03013.html
   patch :DATA
 
+  option "universal", "Build universal binary (32-bit & 64-bit)"
+
   def install
+    ENV.universal_binary if build.universal?
+
+    extra_cmake_args = []
+    extra_cmake_args << "-DBUILD_TESTS=OFF" if build.universal?
+
     mkdir "libftdi-build" do
-      system "cmake", "..", "-DLINK_PYTHON_LIBRARY=OFF", *std_cmake_args
+      system "cmake", "..", "-DLINK_PYTHON_LIBRARY=OFF", *extra_cmake_args, *std_cmake_args
       system "make", "install"
       (libexec/"bin").install "examples/find_all"
     end
@@ -38,9 +45,19 @@ class Libftdi < Formula
 end
 __END__
 diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index 8b52745..31ef1c6 100644
+index 8b52745..df0529a 100644
 --- a/python/CMakeLists.txt
 +++ b/python/CMakeLists.txt
+@@ -12,8 +12,8 @@ if ( PYTHON_BINDINGS )
+       set ( SWIG_FOUND TRUE )
+     endif ()
+   endif ()
+-  find_package ( PythonLibs )
+   find_package ( PythonInterp )
++  find_package ( PythonLibs )
+ endif ()
+
+ if ( SWIG_FOUND AND PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND )
 @@ -30,6 +30,8 @@ if ( SWIG_FOUND AND PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND )
 
    if ( LINK_PYTHON_LIBRARY )

--- a/Formula/libusb.rb
+++ b/Formula/libusb.rb
@@ -20,12 +20,15 @@ class Libusb < Formula
     depends_on "libtool" => :build
   end
 
+  option "universal", "Build universal binary (32-bit & 64-bit)"
   option "without-runtime-logging", "Build without runtime logging functionality"
   option "with-default-log-level-debug", "Build with default runtime log level of debug (instead of none)"
 
   deprecated_option "no-runtime-logging" => "without-runtime-logging"
 
   def install
+    ENV.universal_binary if build.universal?
+
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]
     args << "--disable-log" if build.without? "runtime-logging"
     args << "--enable-debug-log" if build.with? "default-log-level-debug"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This adds the --universal option to libftdi & libusb.  It also fixes a build error in libftdi on some machine configurations because it finds Python stuff incorrectly per the CMake documentation for the PythonInterp PythonLibs modules.  I know --universal is deprecated but Wine still needs 32-bit binaries so this makes it much more convenient.