### PR TITLE
overmind 1.0.4 (new formula)

### DIFF
--- a/Formula/overmind.rb
+++ b/Formula/overmind.rb
@@ -1,0 +1,24 @@
+class Overmind < Formula
+  desc "Process manager for Procfile-based applications and tmux"
+  homepage "https://github.com/DarthSim/overmind"
+  url "https://github.com/DarthSim/overmind/archive/v1.0.4.tar.gz"
+  sha256 "6a2219044fbd68757f1d1551f6750dc639b10cf9d0eab036dda25f1a0879bfe1"
+  head "https://github.com/DarthSim/overmind.git"
+
+  depends_on "go" => :build
+  depends_on "tmux"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/DarthSim/overmind").install buildpath.children
+    system "go", "build", "-o", "#{bin}/overmind", "-v", "github.com/DarthSim/overmind"
+  end
+
+  test do
+    expected_message = "overmind: open ./Procfile: no such file or directory"
+    assert_match expected_message, shell_output("#{bin}/overmind start 2>&1", 1)
+    (testpath/"Procfile").write("test: echo 'test message'")
+    expected_message = "inappropriate ioctl for device"
+    assert_match expected_message, shell_output("#{bin}/overmind start")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Process manager for Procfile-based applications and tmux, is big brother of [hivemind](https://github.com/DarthSim/hivemind), which was added early.

I have an issue with a test. In hivemind test, I use output testing. See [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/hivemind.rb#L24-L25) for more details. 

But I can't write the same test for overmind because tmux failed when running not in TTY with error `inappropriate ioctl for device`. For workaround I use simple test like in [tmux formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tmux.rb#L57).

Is it OK?