### PR TITLE
rust: fix test by adding `rustc` to `PATH`

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -120,6 +120,7 @@ class Rust < Formula
     system "#{bin}/rustc", "hello.rs"
     assert_equal "Hello World!\n", `./hello`
     system "#{bin}/cargo", "new", "hello_world", "--bin"
+    ENV.prepend_path "PATH", bin
     assert_equal "Hello, world!",
                  (testpath/"hello_world").cd { `#{bin}/cargo run`.split("\n").last }
   end


### PR DESCRIPTION
The specific error that I was seeing:
```shell-session
$ /usr/local/Cellar/rust/1.18.0_1/bin/cargo run --verbose
error: could not execute process `rustc -vV` (never executed)

Caused by:
  No such file or directory (os error 2)
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
  (Rebuilding isn’t necessary if I’m only updating the test, right?)
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
