### PR TITLE
Fix `$CHILD_STATUS` issue

### DIFF
--- a/Formula/app-engine-java.rb
+++ b/Formula/app-engine-java.rb
@@ -23,6 +23,6 @@ class AppEngineJava < Formula
       Signal.trap "INT", "IGNORE"
       Process.kill "INT", 0
     end
-    assert_equal(130, $CHILD_STATUS.exitstatus, "Dev App Server exited with unexpected status code")
+    assert_equal(130, $?.exitstatus, "Dev App Server exited with unexpected status code")
   end
 end

--- a/Formula/checkstyle.rb
+++ b/Formula/checkstyle.rb
@@ -18,6 +18,6 @@ class Checkstyle < Formula
     output = `#{bin}/checkstyle -c /sun_checks.xml #{path}`
     errors = output.lines.select { |line| line.start_with?("[ERROR] #{path}") }
     assert_match "#{path}:1:17: '{' is not preceded with whitespace.", errors.join(" ")
-    assert_equal errors.size, $CHILD_STATUS.exitstatus
+    assert_equal errors.size, $?.exitstatus
   end
 end

--- a/Formula/chibi-scheme.rb
+++ b/Formula/chibi-scheme.rb
@@ -27,6 +27,6 @@ class ChibiScheme < Formula
   test do
     output = `#{bin}/chibi-scheme -mchibi -e "(for-each write '(0 1 2 3 4 5 6 7 8 9))"`
     assert_equal "0123456789", output
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -93,6 +93,6 @@ class Ddclient < Formula
       Process.kill "TERM", pid
       Process.wait
     end
-    $CHILD_STATUS.success?
+    $?.success?
   end
 end

--- a/Formula/elixir.rb
+++ b/Formula/elixir.rb
@@ -6,7 +6,7 @@ class Erlang18Requirement < Requirement
     erl = which("erl")
     next unless erl
     `#{erl} -noshell -eval 'io:fwrite("~s", [erlang:system_info(otp_release) >= "18"])' -s erlang halt | grep -q '^true'`
-    next unless $CHILD_STATUS.exitstatus.zero?
+    next unless $?.exitstatus.zero?
     erl
   end
 

--- a/Formula/euler-py.rb
+++ b/Formula/euler-py.rb
@@ -42,6 +42,6 @@ class EulerPy < Formula
       stdin.close
       assert_match 'Successfully created "001.py".', stdout.read
     end
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -60,9 +60,9 @@ class Freerdp < Formula
 
   test do
     success = `#{bin}/xfreerdp --version` # not using system as expected non-zero exit code
-    details = $CHILD_STATUS
+    details = $?
     if !success && details.exitstatus != 128
-      raise "Unexpected exit code #{$CHILD_STATUS} while running xfreerdp"
+      raise "Unexpected exit code #{$?} while running xfreerdp"
     end
   end
 end

--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -71,7 +71,7 @@ class Gnutls < Formula
         openssl_io.close_write
       end
 
-      $CHILD_STATUS.success?
+      $?.success?
     end
 
     openssldir = etc/"openssl"

--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -43,6 +43,6 @@ class Hashpump < Formula
       -a '&waffle=liege' -k 14`
     assert_match /0e41270260895979317fff3898ab85668953aaa2/, output
     assert_match /&waffle=liege/, output
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/html2text.rb
+++ b/Formula/html2text.rb
@@ -44,6 +44,6 @@ class Html2text < Formula
 
     output = `#{bin}/html2text #{path}`.strip
     assert_equal "Hello World", output
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -75,7 +75,7 @@ class Io < Formula
       system "cmake", "..", *std_cmake_args
       system "make"
       output = `./_build/binaries/io ../libs/iovm/tests/correctness/run.io`
-      if $CHILD_STATUS.exitstatus.nonzero?
+      if $?.exitstatus.nonzero?
         opoo "Test suite not 100% successful:\n#{output}"
       else
         ohai "Test suite ran successfully:\n#{output}"

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -62,7 +62,7 @@ class Ledger < Formula
       "--output", balance,
       "balance", "--collapse", "equity"
     assert_equal "          $-2,500.00  Equity", balance.read.chomp
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
 
     system "python", pkgshare/"demo.py" if build.with? "python"
   end

--- a/Formula/ledger@2.6.rb
+++ b/Formula/ledger@2.6.rb
@@ -63,7 +63,7 @@ class LedgerAT26 < Formula
       "--output", balance,
       "balance", "--collapse", "equity"
     assert_equal "          $-2,500.00  Equity", balance.read.chomp
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
 
     system "python", "#{share}/ledger/demo.py" if build.with? "python"
   end

--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -54,7 +54,7 @@ class Libressl < Formula
         openssl_io.close_write
       end
 
-      $CHILD_STATUS.success?
+      $?.success?
     end
 
     # LibreSSL install a default pem - We prefer to use macOS for consistency.

--- a/Formula/lwtools.rb
+++ b/Formula/lwtools.rb
@@ -29,13 +29,13 @@ class Lwtools < Formula
 
     # lwobjdump
     dump = `#{bin}/lwobjdump foo.obj`
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
     assert dump.start_with?("SECTION foo")
 
     # lwar
     system "#{bin}/lwar", "--create", "foo.lwa", "foo.obj"
     list = `#{bin}/lwar --list foo.lwa`
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
     assert list.start_with?("foo.obj")
   end
 end

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -162,7 +162,7 @@ class Mesos < Formula
     rescue Timeout::Error
       Process.kill "TERM", agent
     end
-    assert $CHILD_STATUS.exitstatus, "agent process died, check MESOS-6606-related behavior"
+    assert $?.exitstatus, "agent process died, check MESOS-6606-related behavior"
 
     # Make tests for minimal functionality.
     master = fork do

--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -62,7 +62,7 @@ class MinimalRacket < Formula
 
     # show that the config file isn't malformed
     output = shell_output("'#{bin}/raco' pkg config")
-    assert $CHILD_STATUS.success?
+    assert $?.success?
     assert_match Regexp.new(<<-EOS.undent), output
       ^name:
         #{version}

--- a/Formula/mockserver.rb
+++ b/Formula/mockserver.rb
@@ -34,7 +34,7 @@ class Mockserver < Formula
 
     loop do
       Utils.popen_read("curl", "-s", "http://localhost:#{port}/status", "-X", "PUT")
-      break if $CHILD_STATUS.exitstatus.zero?
+      break if $?.exitstatus.zero?
     end
 
     system "curl", "-s", "http://localhost:#{port}/stop", "-X", "PUT"

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -63,6 +63,6 @@ class Mosquitto < Formula
 
   test do
     quiet_system "#{sbin}/mosquitto", "-h"
-    assert_equal 3, $CHILD_STATUS.exitstatus
+    assert_equal 3, $?.exitstatus
   end
 end

--- a/Formula/msitools.rb
+++ b/Formula/msitools.rb
@@ -63,13 +63,13 @@ class Msitools < Formula
 
     # msidiff: diff two installers
     lines = `#{bin}/msidiff --list installer1.msi installer2.msi 2>/dev/null`.split("\n")
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
     assert_equal "-Program Files/test/test1.txt", lines[-2]
     assert_equal "+Program Files/test/test2.txt", lines[-1]
 
     # msiinfo: show info for an installer
     out = `#{bin}/msiinfo suminfo installer1.msi`
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
     assert_match /Author: BigCo/, out
 
     # msiextract: extract files from an installer

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -79,7 +79,7 @@ class Oauth2Proxy < Formula
       Timeout.timeout(10) do
         loop do
           Utils.popen_read "curl", "-s", "http://127.0.0.1:#{port}"
-          break if $CHILD_STATUS.exitstatus.zero?
+          break if $?.exitstatus.zero?
           sleep 1
         end
       end

--- a/Formula/ohcount.rb
+++ b/Formula/ohcount.rb
@@ -34,7 +34,7 @@ class Ohcount < Formula
     path = testpath/"test.rb"
     path.write "# comment\n puts\n puts\n"
     stats = `#{bin}/ohcount -i #{path}`.split("\n")[-1]
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
     assert_equal ["ruby", "2", "1", "33.3%"], stats.split[0..3]
   end
 end

--- a/Formula/onepass.rb
+++ b/Formula/onepass.rb
@@ -55,6 +55,6 @@ class Onepass < Formula
 
   test do
     assert_equal "123456", `echo "badger" | #{bin}/1pass --no-prompt --path #{share}/tests/1Password.Agilekeychain onetosix`.strip
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -91,7 +91,7 @@ class Openssl < Formula
         openssl_io.close_write
       end
 
-      $CHILD_STATUS.success?
+      $?.success?
     end
 
     openssldir.mkpath

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -83,7 +83,7 @@ class OpensslAT11 < Formula
         openssl_io.close_write
       end
 
-      $CHILD_STATUS.success?
+      $?.success?
     end
 
     openssldir.mkpath

--- a/Formula/parrot.rb
+++ b/Formula/parrot.rb
@@ -62,6 +62,6 @@ class Parrot < Formula
 
     out = `#{bin}/parrot #{path}`
     assert_equal "0123456789", out
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/rakudo-star.rb
+++ b/Formula/rakudo-star.rb
@@ -47,6 +47,6 @@ class RakudoStar < Formula
   test do
     out = `#{bin}/perl6 -e 'loop (my $i = 0; $i < 10; $i++) { print $i }'`
     assert_equal "0123456789", out
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end

--- a/Formula/unrar.rb
+++ b/Formula/unrar.rb
@@ -36,7 +36,7 @@ class Unrar < Formula
 
     rarpath.write data.unpack("m").first
     assert_equal contentpath, `#{bin}/unrar lb #{rarpath}`.strip
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
 
     system "#{bin}/unrar", "x", rarpath, testpath
     assert_equal "Homebrew\n", (testpath/contentpath).read

--- a/Formula/yuicompressor.rb
+++ b/Formula/yuicompressor.rb
@@ -20,6 +20,6 @@ class Yuicompressor < Formula
 
     output = `#{bin}/yuicompressor --nomunge --preserve-semi #{path}`.strip
     assert_equal "var i=1;console.log(i);", output
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal 0, $?.exitstatus
   end
 end


### PR DESCRIPTION
In order to use the `$CHILD_STATUS` variable we'd need to require [`English`](http://ruby-doc.org/stdlib-2.4.0/libdoc/English/rdoc/English.html), otherwise we'll see errors like:

```
$ brew install elixir
Error: undefined method `exitstatus' for nil:NilClass
```

Isolated example:
```ruby
irb(main):001:0> `echo foo`
=> "foo\n"
irb(main):002:0> p $CHILD_STATUS
=> nil
irb(main):003:0> require 'english'
=> true
irb(main):004:0> `echo foo`
=> "foo\n"
irb(main):005:0> p $CHILD_STATUS
=> #<Process::Status: pid 27240 exit 0>
```

This PR is just reverting this change.