### PR TITLE
pilosa: Fix version and time params and brew test

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -20,10 +20,7 @@ class Pilosa < Formula
     ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
     mkdir_p buildpath/"src/github.com/pilosa/"
     ln_s buildpath, buildpath/"src/github.com/pilosa/pilosa"
-    system "glide", "install"
-    system "go", "build", "-o", bin/"pilosa", "-ldflags",
-           "-X github.com/pilosa/pilosa/cmd.Version=#{version}",
-           "github.com/pilosa/pilosa/cmd/pilosa"
+    system "make", "pilosa", "FLAGS=-o #{bin}/pilosa", "VERSION=#{version}"
   end
 
   plist_options :manual => "pilosa server"
@@ -57,7 +54,7 @@ class Pilosa < Formula
   test do
     begin
       server = fork do
-        exec "#{bin}/pilosa", "server", "--bind", "10101"
+        exec "#{bin}/pilosa", "server"
       end
       sleep 0.5
       assert_match("Welcome. Pilosa is running.", shell_output("curl localhost:10101"))


### PR DESCRIPTION
The build parameters for Version and BuildTime were not being passed in
correctly, so the built binary did not contain the version number. Also,
the command invocation used in `brew test` passed an invalid `--bind`
option that wasn't caught by the test.

This patch uses the Makefile to run the build command, which correctly
sets the version and build time, and it removes the invalid `--bind`
option.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
