### PR TITLE
azure-cli 0.10.14

### DIFF
--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -3,9 +3,9 @@ require "language/node"
 class AzureCli < Formula
   desc "Official Azure CLI"
   homepage "https://github.com/azure/azure-xplat-cli"
-  url "https://github.com/Azure/azure-xplat-cli/archive/v0.10.12-May2017.tar.gz"
-  version "0.10.13"
-  sha256 "60194e770b8dca0485db9d4c99f9cd432f7b43096cc5ad0353f52fd5b1b29181"
+  url "https://github.com/Azure/azure-xplat-cli/archive/v0.10.14-June2017.tar.gz"
+  version "0.10.14"
+  sha256 "3a74f8007a53c625c939be21703183130ebc086462674ba66c9c5988f24d3dc4"
   head "https://github.com/azure/azure-xplat-cli.git", :branch => "dev"
 
   bottle do
@@ -21,12 +21,6 @@ class AzureCli < Formula
 
   def install
     rm_rf "bin/windows"
-
-    # Workaround for incorrect file system permissios inside the npm published
-    # easy_table@0.0.1 package, which would break build with npm@5.
-    # See: https://github.com/Azure/azure-xplat-cli/issues/3605
-    inreplace "package.json", '"easy-table": "0.0.1",',
-              '"easy-table": "https://github.com/eldargab/easy-table/archive/v0.0.1.tar.gz",'
 
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates `azure-cli` to v0.10.14 and removes the workaround for the `easy-table@0.0.1` permission issues, which is now fixed by upstream by upgrading the `easy-table` dependency to a more recent version.
