### PR TITLE
kibana@4.1 4.1.11 + cleanup

### DIFF
--- a/Formula/kibana@4.1.rb
+++ b/Formula/kibana@4.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class KibanaAT41 < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
-  url "https://github.com/elastic/kibana.git", :tag => "v4.1.8", :revision => "e4f4c5bef5fbec91f0890bd08f6a622f6c4648ad"
+  url "https://github.com/elastic/kibana.git", :tag => "v4.1.11", :revision => "c55c5d9acf510bed020a4fdc1c4ca8c81c7b7a1b"
   head "https://github.com/elastic/kibana.git"
 
   bottle do
@@ -15,8 +15,8 @@ class KibanaAT41 < Formula
   keg_only :versioned_formula
 
   resource "node" do
-    url "https://nodejs.org/dist/v4.4.4/node-v4.4.4.tar.gz"
-    sha256 "53c694c203ee18e7cd393612be08c61ed6ab8b2a165260984a99c014d1741414"
+    url "https://nodejs.org/dist/v4.4.7/node-v4.4.7.tar.xz"
+    sha256 "1ef900b9cb3ffb617c433a3247a9d67ff36c9455cbc9c34175bee24bdbfdf731"
   end
 
   def install
@@ -42,9 +42,7 @@ class KibanaAT41 < Formula
 
     ENV.prepend_path "PATH", prefix/"libexec/node/bin"
     Pathname.new("#{ENV["HOME"]}/.npmrc").write Language::Node.npm_cache_config
-    system "npm", "install", "grunt-cli", "bower"
-    system "npm", "install"
-    system "node_modules/.bin/bower", "install"
+    system "npm", "install", "--verbose"
     system "node_modules/.bin/grunt", "build"
 
     mkdir "tar" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates `kibana@4.1` to v4.1.11 (the last version in this release line) and cleans up some redundant npm and bower calls, which are already executed as part of `npm install`.
