### PR TITLE
tectonic 0.1.6 (new formula)

### DIFF
--- a/Formula/tectonic.rb
+++ b/Formula/tectonic.rb
@@ -1,0 +1,34 @@
+class Tectonic < Formula
+  desc "Modernized, complete, self-contained TeX/LaTeX engine"
+  homepage "https://tectonic-typesetting.github.io/"
+  url "https://github.com/tectonic-typesetting/tectonic/archive/v0.1.6.tar.gz"
+  sha256 "5c201c979069dfb780040b42d8c516847668bd6d429eabb20f5fb15a3873832c"
+
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "freetype"
+  depends_on "graphite2"
+  depends_on "harfbuzz"
+  depends_on "icu4c"
+  depends_on "libpng"
+  depends_on "openssl"
+  depends_on "zlib" if MacOS.version <= :el_capitan
+
+  def install
+    ENV.cxx11
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version # needed for CLT-only builds
+    ENV["OPENSSL_INCLUDE_DIR"] = Formula["openssl"].opt_include
+    ENV["DEP_OPENSSL_INCLUDE"] = Formula["openssl"].opt_include
+    ENV["OPENSSL_LIB_DIR"] = Formula["openssl"].opt_lib
+
+    system "cargo", "build", "--release"
+    bin.install "target/release/tectonic"
+    pkgshare.install "tests"
+  end
+
+  test do
+    system bin/"tectonic", "-o", testpath, pkgshare/"tests/xenia/paper.tex"
+    assert_predicate testpath/"paper.pdf", :exist?, "Failed to create paper.pdf"
+    assert_match "PDF document", shell_output("file paper.pdf")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Thanks to #14490 getting merged in, we're closer to a functional formula for [Tectonic](https://github.com/tectonic-typesetting/tectonic)! I'm submitting this as a WIP to move Homebrew-specific discussion out of tectonic-typesetting/tectonic#4, but there's a couple of things that need still need to be addressed:

- [ ] Ideally, the `test` block should invoke `tectonic`. Unfortunately, a bunch of rather large TeX packages need to be downloaded in order to process even a minimal (empty) document.
- [x] `brew audit` fails because the `harfbuzz` dependency needs to be installed `with-graphite2`.