### PR TITLE
stubby 0.1.2 (new formula)

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -1,0 +1,78 @@
+class Stubby < Formula
+  desc "DNS privacy enabled stub resolver service based on getdns"
+  homepage "https://getdnsapi.net/blog/dns-privacy-daemon-stubby/"
+  url "https://github.com/getdnsapi/stubby/archive/v0.1.2.tar.gz"
+  sha256 "bdac5dac5873f34a34db8da2538ab7d4f2bd7ff0315eb53db3d5cca5adedabfc"
+  head "https://github.com/getdnsapi/stubby.git", :branch => "develop"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "getdns"
+
+  def install
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}"
+    system "make", "install"
+  end
+
+  plist_options :startup => true, :manual => "sudo stubby -C #{HOMEBREW_PREFIX}/etc/stubby/stubby.conf"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-/Apple/DTD PLIST 1.0/EN" "http:/www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>KeepAlive</key>
+        <true/>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/stubby</string>
+          <string>-C</string>
+          <string>#{etc}/stubby/stubby.conf</string>
+          <string>-l</string>
+        </array>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/stubby/stubby.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/stubby/stubby.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    (testpath/"stubby_test.conf").write <<-EOS.undent
+      { resolution_type: GETDNS_RESOLUTION_STUB
+      , dns_transport_list: [ GETDNS_TRANSPORT_TLS, GETDNS_TRANSPORT_UDP, GETDNS_TRANSPORT_TCP ]
+      , listen_addresses: [ 127.0.0.1@5553]
+      , idle_timeout: 0
+      , upstream_recursive_servers:
+        [ { address_data: 145.100.185.15},
+          { address_data: 145.100.185.16},
+          { address_data: 185.49.141.37}
+        ]
+      }
+    EOS
+    output = shell_output("#{bin}/stubby -i -C stubby_test.conf")
+    assert_match "bindata for 145.100.185.15", output
+    pid = fork do
+      exec "#{bin}/stubby", "-C", testpath/"stubby_test.conf"
+    end
+    begin
+      sleep 2
+      output = shell_output("dig @127.0.0.1 -p 5553 getdnsapi.net")
+      assert_match "status: NOERROR", output
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
Please only review this pull request (do not merge yet) - it is awaiting the release of 1.1.1 production release this week!  It currently uses a release candidate that contains some fixes to enable the formula to work. I would like to see if this passes the tests before updating it when the 1.1.1 production release is done.

- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
=> fails because uses rc1 release


