### PR TITLE
dnsmasq: use 10.11 bottle on 10.12

### DIFF
--- a/Formula/dnsmasq.rb
+++ b/Formula/dnsmasq.rb
@@ -3,6 +3,7 @@ class Dnsmasq < Formula
   homepage "http://www.thekelleys.org.uk/dnsmasq/doc.html"
   url "http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.77.tar.gz"
   sha256 "ae97a68c4e64f07633f31249eb03190d673bdb444a05796a3a2d3f521bfe9d38"
+  revision 1
 
   bottle do
     sha256 "b0b61da17a54a80fd7b6d492bb652e42d568d5d98a3ed2aef3861a4b899c4214" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The 10.12 bottle is currently not working correctly.

See https://github.com/Homebrew/homebrew-core/issues/14463.