### PR TITLE
Replaced pdns launchd plist and updated config dir location

### DIFF
--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -34,7 +34,6 @@ class Pdns < Formula
   depends_on :postgresql => :optional
 
   def install
-    # FIXME: needs a /var/run dir option
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}/pdns
@@ -93,5 +92,25 @@ class Pdns < Formula
   test do
     output = shell_output("#{sbin}/pdns_server --version 2>&1", 99)
     assert_match "PowerDNS Authoritative Server #{version}", output
+  end
+
+  def caveats
+    <<-EOS.udent
+    pdns_server must be run as root to bind to port 53 in OS X. To work around this
+    you can either change the 'local-port' setting in pdns.conf, (probably not
+    what you want to do), or start pdns_server as root.  This can be accomplished
+    with 'sudo brew services start pdns', but it gives pdns_server too much
+    privilege for the liking of any experienced sysadmin.
+
+    pdns_server has two configuration settings that allow it to drop privilege once
+    it has bound to a privileged port: 'setuid' and 'setgid'.  Both require numeric
+    values to function properly in OS X.
+
+    See https://doc.powerdns.com/md/authoritative/settings/ for a documentation on
+    all pdns_server settings.
+
+    See https://gist.github.com/mprzybylski/2b16a0f7e00762a0444612e1b0dcf78e for
+    useful hints on creating separate, unprivileged, for services like pdns_server.
+    EOS
   end
 end

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -34,9 +34,12 @@ class Pdns < Formula
   depends_on :postgresql => :optional
 
   def install
+    # FIXME: needs a /var/run dir option
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}/pdns
+      --localstatedir=#{var}
+      --with-socketdir=#{var}/run
       --with-lua
       --with-openssl=#{Formula["openssl"].opt_prefix}
       --with-sqlite3
@@ -55,6 +58,7 @@ class Pdns < Formula
 
     system "make", "install"
     (var/"log/pdns").mkpath
+    (var/"run").mkpath
   end
 
   plist_options :manual => "pdns_server start"

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -60,6 +60,26 @@ class Pdns < Formula
     (var/"run").mkpath
   end
 
+  def caveats
+    <<-EOS.undent
+    pdns_server must be run as root to bind to port 53 in OS X. To work around this
+    you can either change the 'local-port' setting in pdns.conf, (probably not
+    what you want to do), or start pdns_server as root.  This can be accomplished
+    with 'sudo brew services start pdns', but it gives pdns_server too much
+    privilege for the liking of any experienced sysadmin.
+
+    pdns_server has two configuration settings that allow it to drop privilege once
+    it has bound to a privileged port: 'setuid' and 'setgid'.  Both require numeric
+    values to function properly in OS X.
+
+    See https://doc.powerdns.com/md/authoritative/settings/ for a documentation on
+    all pdns_server settings.
+
+    See https://gist.github.com/mprzybylski/2b16a0f7e00762a0444612e1b0dcf78e for
+    useful hints on creating separate, unprivileged, for services like pdns_server.
+    EOS
+  end
+
   plist_options :manual => "pdns_server start"
 
   def plist; <<-EOS.undent
@@ -92,25 +112,5 @@ class Pdns < Formula
   test do
     output = shell_output("#{sbin}/pdns_server --version 2>&1", 99)
     assert_match "PowerDNS Authoritative Server #{version}", output
-  end
-
-  def caveats
-    <<-EOS.undent
-    pdns_server must be run as root to bind to port 53 in OS X. To work around this
-    you can either change the 'local-port' setting in pdns.conf, (probably not
-    what you want to do), or start pdns_server as root.  This can be accomplished
-    with 'sudo brew services start pdns', but it gives pdns_server too much
-    privilege for the liking of any experienced sysadmin.
-
-    pdns_server has two configuration settings that allow it to drop privilege once
-    it has bound to a privileged port: 'setuid' and 'setgid'.  Both require numeric
-    values to function properly in OS X.
-
-    See https://doc.powerdns.com/md/authoritative/settings/ for a documentation on
-    all pdns_server settings.
-
-    See https://gist.github.com/mprzybylski/2b16a0f7e00762a0444612e1b0dcf78e for
-    useful hints on creating separate, unprivileged, for services like pdns_server.
-    EOS
   end
 end

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -68,7 +68,7 @@ class Pdns < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>#{sbin}/pdns_server</string>
+        <string>#{opt_sbin}/pdns_server</string>
       </array>
       <key>RunAtLoad</key>
       <true/>

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -33,11 +33,7 @@ class Pdns < Formula
   depends_on "openssl"
   depends_on "sqlite"
   depends_on :postgresql => :optional
-
-  resource "pdns-brew-default-config" do
-    url "https://github.com/mprzybylski/pdns-brew-default-config/archive/0.2.tar.gz"
-    sha256 "5abe291cbd789688504731e08cf098a8b5afda9f1928c20c4c0ba8eef025e6b5"
-  end
+  
   def install
     args = %W[
       --prefix=#{prefix}
@@ -64,16 +60,6 @@ class Pdns < Formula
     system "make", "install"
     (var/"log/pdns").mkpath
     (var/"run").mkpath
-    unless (etc/"pdns/pdns.conf").exist?
-      # install a runnable default config with a flat file backend
-      resource("pdns-brew-default-config").stage do
-        # pdns_server needs to start as root, but should drop privilege once it
-        # binds to port 53
-        # UNPRIV_UID and UNPRIV_GID populate pdns.conf
-        system "cmake", ".", "-DETCDIR=#{etc}", "-DUNPRIV_UID=_sandbox", "-DUNPRIV_GID=_sandbox"
-        system "make", "install"
-      end
-    end
   end
 
   plist_options :startup => true, :manual => "sudo pdns_server"

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -3,6 +3,7 @@ class Pdns < Formula
   homepage "https://www.powerdns.com"
   url "https://downloads.powerdns.com/releases/pdns-4.0.3.tar.bz2"
   sha256 "60fa21550b278b41f58701af31c9f2b121badf271fb9d7642f6d35bfbea8e282"
+  revision 1
 
   bottle do
     rebuild 1
@@ -35,6 +36,7 @@ class Pdns < Formula
   def install
     args = %W[
       --prefix=#{prefix}
+      --sysconfdir=#{etc}/#{name}
       --with-lua
       --with-openssl=#{Formula["openssl"].opt_prefix}
       --with-sqlite3
@@ -52,6 +54,7 @@ class Pdns < Formula
     system "./configure", *args
 
     system "make", "install"
+    mkdir "#{var}/log/#{name}"
   end
 
   plist_options :manual => "pdns_server start"
@@ -61,19 +64,23 @@ class Pdns < Formula
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
     <dict>
-      <key>KeepAlive</key>
-      <true/>
       <key>Label</key>
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>#{opt_bin}/pdns_server</string>
+        <string>#{sbin}/pdns_server</string>
       </array>
-      <key>EnvironmentVariables</key>
-      <key>KeepAlive</key>
+      <key>RunAtLoad</key>
       <true/>
-      <key>SHAuthorizationRight</key>
-      <string>system.preferences</string>
+      <key>KeepAlive</key>
+      <dict>
+        <key>Crashed</key>
+        <true/>
+      </dict>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/#{name}/pdns_server.err</string>
+      <key>StandardOutPath</key>
+      <string>/dev/null</string>
     </dict>
     </plist>
     EOS

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -36,7 +36,7 @@ class Pdns < Formula
   def install
     args = %W[
       --prefix=#{prefix}
-      --sysconfdir=#{etc}/#{name}
+      --sysconfdir=#{etc}/pdns
       --with-lua
       --with-openssl=#{Formula["openssl"].opt_prefix}
       --with-sqlite3
@@ -54,7 +54,7 @@ class Pdns < Formula
     system "./configure", *args
 
     system "make", "install"
-    mkdir "#{var}/log/#{name}"
+    (var/"log/pdns").mkpath
   end
 
   plist_options :manual => "pdns_server start"
@@ -78,7 +78,7 @@ class Pdns < Formula
         <true/>
       </dict>
       <key>StandardErrorPath</key>
-      <string>#{var}/log/#{name}/pdns_server.err</string>
+      <string>#{var}/log/pdns/pdns_server.err</string>
       <key>StandardOutPath</key>
       <string>/dev/null</string>
     </dict>

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -22,10 +22,6 @@ class Pdns < Formula
   end
 
   option "with-postgresql", "Enable the PostgreSQL backend"
-  resource "pdns-brew-default-config" do
-    url "https://github.com/mprzybylski/pdns-brew-default-config/archive/0.2.tar.gz"
-    sha256 "5abe291cbd789688504731e08cf098a8b5afda9f1928c20c4c0ba8eef025e6b5"
-  end
 
   deprecated_option "pgsql" => "with-postgresql"
   deprecated_option "with-pgsql" => "with-postgresql"
@@ -38,6 +34,10 @@ class Pdns < Formula
   depends_on "sqlite"
   depends_on :postgresql => :optional
 
+  resource "pdns-brew-default-config" do
+    url "https://github.com/mprzybylski/pdns-brew-default-config/archive/0.2.tar.gz"
+    sha256 "5abe291cbd789688504731e08cf098a8b5afda9f1928c20c4c0ba8eef025e6b5"
+  end
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -95,7 +95,7 @@ class Pdns < Formula
   end
 
   def caveats
-    <<-EOS.udent
+    <<-EOS.undent
     pdns_server must be run as root to bind to port 53 in OS X. To work around this
     you can either change the 'local-port' setting in pdns.conf, (probably not
     what you want to do), or start pdns_server as root.  This can be accomplished

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -29,7 +29,7 @@ class Pdns < Formula
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "lua"
-  depends_on "openssl"
+  depends_on "openssl"q
   depends_on "sqlite"
   depends_on :postgresql => :optional
 
@@ -62,17 +62,11 @@ class Pdns < Formula
 
   def caveats
     <<-EOS.undent
-    pdns_server must be run as root to bind to port 53 in OS X. To work around this
-    you can either change the 'local-port' setting in pdns.conf, (probably not
-    what you want to do), or start pdns_server as root.  This can be accomplished
-    with 'sudo brew services start pdns', but it gives pdns_server too much
-    privilege for the liking of any experienced sysadmin.
-
     pdns_server has two configuration settings that allow it to drop privilege once
     it has bound to a privileged port: 'setuid' and 'setgid'.  Both require numeric
     values to function properly in OS X.
 
-    See https://doc.powerdns.com/md/authoritative/settings/ for a documentation on
+    See https://doc.powerdns.com/md/authoritative/settings/ for explanations of
     all pdns_server settings.
 
     See https://gist.github.com/mprzybylski/2b16a0f7e00762a0444612e1b0dcf78e for
@@ -80,7 +74,7 @@ class Pdns < Formula
     EOS
   end
 
-  plist_options :manual => "pdns_server start"
+  plist_options :startup => true, :manual => "sudo pdns_server start"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The old launchd plist was woefully broken.  Crafted and successfully tested a new
one that does a better job of following the principle of least astonishment in the
following ways:
* It does not continuously try to restart `pdns_server` in the event of a broken config
* The pdns_server STDERR gets logged to `#{var}/log/#{name}/pdns_server.err` which will
greatly facilitate troubleshooting

Also updated the `configure` args with `--sysconfdir=#{etc}/#{name}`

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
