### PR TITLE
getdns 1.1.1, remove devel, use head do block

### DIFF
--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -13,9 +13,9 @@ class Getdns < Formula
   head do
     url "https://github.com/getdnsapi/getdns.git", :branch => "develop"
 
-    depends_on "libtool" => :build
     depends_on "autoconf" => :build
     depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   depends_on "openssl"

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -10,11 +10,6 @@ class Getdns < Formula
     sha256 "f9259f55b25aa8c20a880c90c63fbbbc2a33da2b68a617799d43d0ae7abcacb1" => :yosemite
   end
 
-  devel do
-    url "https://getdnsapi.net/releases/getdns-1-1-1rc1/getdns-1.1.1rc1.tar.gz"
-    sha256 "f63340b1d05410b875217c6abd7066586fc55a811db4ae90ffd01d2240e05e57"
-  end
-
   depends_on "openssl"
   depends_on "unbound" => :recommended
   depends_on "libidn" => :recommended

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -1,8 +1,8 @@
 class Getdns < Formula
   desc "Modern asynchronous DNS API"
   homepage "https://getdnsapi.net"
-  url "https://getdnsapi.net/releases/getdns-1-1-0/getdns-1.1.0.tar.gz"
-  sha256 "aa47bca275b97f623dc6799cee97d3465fa46521d94bd9892e08e8d5d88f09c3"
+  url "https://getdnsapi.net/releases/getdns-1-1-1/getdns-1.1.1.tar.gz"
+  sha256 "fa414c30d5f2d2b2453b5cec77362b4cc0f44d440be5893233748d82bd6a1a56"
 
   bottle do
     sha256 "91fccbcb1ea628fefa2848fccc318953dfc71d34ffeff44adbf596352ceac16b" => :sierra

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -10,13 +10,6 @@ class Getdns < Formula
     sha256 "f9259f55b25aa8c20a880c90c63fbbbc2a33da2b68a617799d43d0ae7abcacb1" => :yosemite
   end
 
-  depends_on "openssl"
-  depends_on "unbound" => :recommended
-  depends_on "libidn" => :recommended
-  depends_on "libevent" => :recommended
-  depends_on "libuv" => :optional
-  depends_on "libev" => :optional
-
   head do
     url "https://github.com/getdnsapi/getdns.git", :branch => "develop"
 
@@ -24,6 +17,13 @@ class Getdns < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
+
+  depends_on "openssl"
+  depends_on "unbound" => :recommended
+  depends_on "libidn" => :recommended
+  depends_on "libevent" => :recommended
+  depends_on "libuv" => :optional
+  depends_on "libev" => :optional
 
   def install
     if build.head?

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -3,7 +3,6 @@ class Getdns < Formula
   homepage "https://getdnsapi.net"
   url "https://getdnsapi.net/releases/getdns-1-1-0/getdns-1.1.0.tar.gz"
   sha256 "aa47bca275b97f623dc6799cee97d3465fa46521d94bd9892e08e8d5d88f09c3"
-  head "https://github.com/getdnsapi/getdns.git", :branch => "develop"
 
   bottle do
     sha256 "91fccbcb1ea628fefa2848fccc318953dfc71d34ffeff44adbf596352ceac16b" => :sierra
@@ -23,7 +22,9 @@ class Getdns < Formula
   depends_on "libuv" => :optional
   depends_on "libev" => :optional
 
-  if build.head?
+  head do
+    url "https://github.com/getdnsapi/getdns.git", :branch => "develop"
+
     depends_on "libtool"
     depends_on "autoconf"
     depends_on "automake"

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -25,9 +25,9 @@ class Getdns < Formula
   head do
     url "https://github.com/getdnsapi/getdns.git", :branch => "develop"
 
-    depends_on "libtool"
-    depends_on "autoconf"
-    depends_on "automake"
+    depends_on "libtool" => :build
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
   end
 
   def install


### PR DESCRIPTION
## getdns 1.1.1

See [getdns v1.1.1 release notes](https://getdnsapi.net/releases/getdns-1-1-1/).

## getdns remove devel for now

There currently is no release candidate.

## getdns use head do with url

As [mentioned in the formula cookbook](http://docs.brew.sh/Formula-Cookbook.html), blocks are preferred over conditionals.