### PR TITLE
use bash_profile instead of bashrc.

### DIFF
--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -19,11 +19,11 @@ class Chruby < Formula
   end
 
   def caveats; <<-EOS.undent
-    Add the following to the ~/.bashrc or ~/.zshrc file:
+    Add the following to the ~/.bash_profile or ~/.zshrc file:
       source #{opt_share}/chruby/chruby.sh
 
     To enable auto-switching of Rubies specified by .ruby-version files,
-    add the following to ~/.bashrc or ~/.zshrc:
+    add the following to ~/.bash_profile or ~/.zshrc:
       source #{opt_share}/chruby/auto.sh
     EOS
   end


### PR DESCRIPTION
.bash_profile is executed for login shells / .bashrc is executed for interactive non-login shells.

On OS X, Terminal by default runs a login shell every time.

Therefore - formula should advise to users that bash_profile is the way to go

Source : https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
