### PR TITLE
git-annex: remove foundation < 0.0.10 constraint

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -5,10 +5,27 @@ class GitAnnex < Formula
 
   desc "Manage files with git without checking in file contents"
   homepage "https://git-annex.branchable.com/"
-  url "https://hackage.haskell.org/package/git-annex-6.20170520/git-annex-6.20170520.tar.gz"
-  sha256 "f8cf9b44172ce1914c8be8134795c4197d02960b81a2ba596712cbd35e002717"
   revision 1
   head "git://git-annex.branchable.com/"
+
+  stable do
+    url "https://hackage.haskell.org/package/git-annex-6.20170520/git-annex-6.20170520.tar.gz"
+    sha256 "f8cf9b44172ce1914c8be8134795c4197d02960b81a2ba596712cbd35e002717"
+
+    # Fix "Utility/QuickCheck.hs:38:10: error: Duplicate instance declarations"
+    # Upstream commit from 17 Jun 2017 "Fix build with QuickCheck 2.10."
+    patch do
+      url "http://source.git-annex.branchable.com/?p=source.git;a=patch;h=75cecbbe3fdafdb6652e95ac17cd755c28e67f20"
+      sha256 "2d50b633b29895755c8cbe1b55262866f5c09fe346ee5d552edde5e141730de7"
+    end
+
+    # Fix two "git annex test" failures with QuickCheck 2.10
+    # Upstream commit from 17 Jun 2017 "fix failing quickcheck properties"
+    patch do
+      url "http://source.git-annex.branchable.com/?p=source.git;a=patch;h=da8e84efe997fcbfcf489bc4fa9cc835ed131d3a"
+      sha256 "3ab0dfe93e2f121818cce74dd76653a7acd8c2c97b34529b1684a640cabf79fc"
+    end
+  end
 
   bottle do
     sha256 "ae69e1189101b1e202dd3acfd097d5d2f69818f968639448354a3c0b4a11e220" => :sierra

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -7,6 +7,7 @@ class GitAnnex < Formula
   homepage "https://git-annex.branchable.com/"
   url "https://hackage.haskell.org/package/git-annex-6.20170520/git-annex-6.20170520.tar.gz"
   sha256 "f8cf9b44172ce1914c8be8134795c4197d02960b81a2ba596712cbd35e002717"
+  revision 1
   head "git://git-annex.branchable.com/"
 
   bottle do
@@ -26,13 +27,6 @@ class GitAnnex < Formula
   depends_on "xdot" => :recommended
 
   def install
-    # Workaround for "error: redefinition of enumerator '_CLOCK_REALTIME'" and
-    # other similar errors.
-    # Reported 11 Jun 2017 https://github.com/haskell-foundation/foundation/issues/342
-    if MacOS.version == :el_capitan
-      (buildpath/"cabal.config").write("constraints: foundation < 0.0.10\n")
-    end
-
     install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["s3", "webapp"] do
       # this can be made the default behavior again once git-union-merge builds properly when bottling
       if build.with? "git-union-merge"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

since the El Capitan build failure is fixed as of 0.0.11.