### PR TITLE
tensorflow: add rename and alias

### DIFF
--- a/Aliases/tensorflow
+++ b/Aliases/tensorflow
@@ -1,0 +1,1 @@
+../Formula/libtensorflow.rb

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -159,6 +159,7 @@
   "subversion18": "subversion@1.8",
   "swig2": "swig@2",
   "swig304": "swig@3.04",
+  "tensorflow": "libtensorflow",
   "thrift090": "thrift@0.90",
   "tomcat6": "tomcat@6",
   "tomcat7": "tomcat@7",


### PR DESCRIPTION
There was a `tensorflow` formula in homebrew-science,
which duplicates the `libtensorflow` formula in core.

See https://github.com/Homebrew/homebrew-science/pull/5837

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----