### PR TITLE
libqalculate 0.9.12

### DIFF
--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -1,9 +1,8 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
-  homepage "https://qalculate.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/qalculate/libqalculate/libqalculate-0.9.7/libqalculate-0.9.7.tar.gz"
-  sha256 "9a6d97ce3339d104358294242c3ecd5e312446721e93499ff70acc1604607955"
-  revision 1
+  homepage "https://qalculate.github.io/"
+  url "https://github.com/Qalculate/libqalculate/releases/download/v0.9.12/libqalculate-0.9.12.tar.gz"
+  sha256 "4b59ab24e45c3162f02b7e316168ebaf7f0d2911a2164d53b501e8b18a9163d2"
 
   bottle do
     sha256 "8e6dfe4e45213d687961fbc44b77e6900233f7bc9e44449c391cf512a8ab73f6" => :sierra
@@ -11,6 +10,7 @@ class Libqalculate < Formula
     sha256 "4b6de765ce80651675e070e1fb2793cc730b05bf9ba5f6bd5f4ec97476441407" => :yosemite
   end
 
+  depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "cln"
   depends_on "glib"
@@ -19,11 +19,16 @@ class Libqalculate < Formula
   depends_on "readline"
   depends_on "wget"
 
-  # Patches against version 0.9.7, should not be needed in the future
-  patch :DATA
+  # Fix "error: typedef redefinition with different types"
+  # Upstream commit from 9 Jun 2017 "Remove clang build fix"
+  patch do
+    url "https://github.com/Qalculate/libqalculate/commit/63c6b4f.patch"
+    sha256 "47d2f3233d104eb591cb16c34648e163a99a85d240661eacb5a8f3ab5d4fb268"
+  end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -32,31 +37,3 @@ class Libqalculate < Formula
     system "#{bin}/qalc", "-nocurrencies", "(2+2)/4 hours to minutes"
   end
 end
-
-__END__
-diff -ur a/src/defs2doc.cc b/src/defs2doc.cc
---- a/src/defs2doc.cc 2009-12-02 14:24:28.000000000 -0600
-+++ b/src/defs2doc.cc 2012-01-10 18:47:50.000000000 -0600
-@@ -16,7 +16,9 @@
- #include <time.h>
- #include <pthread.h>
- #include <dirent.h>
-+#if !defined(__APPLE__)
- #include <malloc.h>
-+#endif
- #include <stdio.h>
- #include <vector>
- #include <glib.h>
-diff -ur a/src/qalc.cc b/src/qalc.cc
---- a/src/qalc.cc 2010-01-05 09:17:29.000000000 -0600
-+++ b/src/qalc.cc 2012-01-10 18:47:42.000000000 -0600
-@@ -16,7 +16,9 @@
- #include <time.h>
- #include <pthread.h>
- #include <dirent.h>
-+#if !defined(__APPLE__)
- #include <malloc.h>
-+#endif
- #include <stdio.h>
- #include <vector>
- #include <glib.h>


### PR DESCRIPTION
upstream moved to GitHub
depend on intltool at build time
apply patch for typedef redefinition error
remove old patch