### PR TITLE
expat 2.2.1

### DIFF
--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -1,9 +1,9 @@
 class Expat < Formula
   desc "XML 1.0 parser"
-  homepage "https://expat.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/expat/expat/2.2.0/expat-2.2.0.tar.bz2"
-  mirror "https://fossies.org/linux/www/expat-2.2.0.tar.bz2"
-  sha256 "d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff"
+  homepage "https://libexpat.github.io/"
+  url "https://downloads.sourceforge.net/project/expat/expat/2.2.1/expat-2.2.1.tar.bz2"
+  mirror "https://fossies.org/linux/www/expat-2.2.1.tar.bz2"
+  sha256 "1868cadae4c82a018e361e2b2091de103cd820aaacb0d6cfa49bd2cd83978885"
   head "https://github.com/libexpat/libexpat.git"
 
   bottle do
@@ -15,6 +15,11 @@ class Expat < Formula
   end
 
   keg_only :provided_by_osx, "macOS includes Expat 1.5"
+
+  # Upstream commit from 18 Jun 2017 "configure.ac: Fix mis-detection of
+  # getrandom on Debian GNU/kFreeBSD (#50)"
+  # See https://github.com/libexpat/libexpat/commit/602e6c78ca750c082b72f8cdf4a38839b312959f
+  patch :DATA
 
   def install
     system "./configure", "--prefix=#{prefix}",
@@ -61,3 +66,16 @@ class Expat < Formula
     assert_equal "tag:str|data:Hello, world!|", shell_output("./test")
   end
 end
+
+__END__
+--- a/configure
++++ b/configure
+@@ -16341,7 +16341,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+   }
+
+ _ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
++if ac_fn_c_try_link "$LINENO"; then :
+
+
+ $as_echo "#define HAVE_GETRANDOM 1" >>confdefs.h


### PR DESCRIPTION
Needs https://github.com/libexpat/libexpat/commit/602e6c78ca750c082b72f8cdf4a38839b312959f which fixes https://github.com/libexpat/libexpat/issues/50.