### PR TITLE
watchman: fix build dep on libtool

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -16,6 +16,7 @@ class Watchman < Formula
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pcre"
 
   def install


### PR DESCRIPTION
in https://github.com/facebook/watchman/issues/486 folks have reported that `brew install --HEAD watchman` fails due to libtool being missing.  Adding an explicit build dep fixes this for me locally.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
