### PR TITLE
qemu: build with ncurses

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -1,10 +1,11 @@
 class Qemu < Formula
   desc "x86 and PowerPC Emulator"
-  homepage "http://www.qemu.org/"
-  url "http://download.qemu.org/qemu-2.9.0.tar.bz2"
+  homepage "https://www.qemu.org/"
+  url "https://download.qemu.org/qemu-2.9.0.tar.bz2"
   sha256 "00bfb217b1bb03c7a6c3261b819cfccbfb5a58e3e2ceff546327d271773c6c14"
+  revision 1
 
-  head "git://git.qemu-project.org/qemu.git"
+  head "https://git.qemu.org/git/qemu.git"
 
   bottle do
     sha256 "8afbc041c76c72bbb49b593a1eacca35203bd051949a6c9d357987992abc0a7c" => :sierra
@@ -17,6 +18,7 @@ class Qemu < Formula
   depends_on "jpeg"
   depends_on "gnutls"
   depends_on "glib"
+  depends_on "ncurses"
   depends_on "pixman"
   depends_on "libpng" => :recommended
   depends_on "vde" => :optional
@@ -34,10 +36,10 @@ class Qemu < Formula
     cause "qemu requires a compiler with support for the __thread specifier"
   end
 
-  # 3.2MB working disc-image file hosted on upstream's servers for people to use to test qemu functionality.
-  resource "armtest" do
-    url "http://download.qemu.org/arm-test-0.2.tar.gz"
-    sha256 "4b4c2dce4c055f0a2adb93d571987a3d40c96c6cbfd9244d19b9708ce5aea454"
+  # 820K floppy disk image file of FreeDOS 1.2, used to test QEMU
+  resource "test-image" do
+    url "https://dl.bintray.com/homebrew/mirror/FD12FLOPPY.zip"
+    sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 
   def install
@@ -57,6 +59,8 @@ class Qemu < Formula
       --host-cc=#{ENV.cc}
       --disable-bsd-user
       --disable-guest-agent
+      --enable-curses
+      --extra-cflags=-DNCURSES_WIDECHAR=1
     ]
 
     # Cocoa and SDL2/GTK+ UIs cannot both be enabled at once.
@@ -77,7 +81,7 @@ class Qemu < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/qemu-system-i386 --version")
-    resource("armtest").stage testpath
-    assert_match "file format: raw", shell_output("#{bin}/qemu-img info arm_root.img")
+    resource("test-image").stage testpath
+    assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
   end
 end


### PR DESCRIPTION
Added ncurses option for qemu, tested it and no issue with that.
The extra cflags is for the detection of Wide Chars (https://trac.macports.org/ticket/53929)

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
