### PR TITLE
mruby-cli 0.0.4 (new formula)

### DIFF
--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -1,0 +1,25 @@
+class MrubyCli < Formula
+  desc "Build native command-line applications for Linux, MacOS, and Windows"
+  homepage "https://github.com/hone/mruby-cli"
+  url "https://github.com/hone/mruby-cli/archive/v0.0.4.tar.gz"
+  sha256 "97d889b5980193c562e82b42089b937e675b73950fa0d0c4e46fbe71d16d719f"
+
+  # The mruby-cli build_config.rb assumes that it will be compiled on Linux.
+  # It also automatically cross compiles to MacOS, Linux, and Windows
+  # This patch compiles a single MacOS binary using clang
+  patch do
+    url "https://gist.githubusercontent.com/jeremyjung/ca4f5baa0e6567b96332b6a9281ab37b/raw/84d9dc64fbe02162cab5625243d7e477adb32ab3/mruby-cli_patch.diff"
+    sha256 "4d148001ac180c1942f157829d5a18e553987fc370b5d98d9f1123ce3b21436f"
+  end
+
+  def install
+    ENV["MRUBY_CLI_LOCAL"] = "true"
+    system "rake", "compile"
+    cp "mruby/build/host/bin/mruby-cli", "mruby-cli"
+    bin.install "mruby-cli"
+  end
+
+  test do
+    system "#{bin}/mruby-cli", "-v"
+  end
+end

--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -7,6 +7,7 @@ class MrubyCli < Formula
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"
 
+    # Edit config to skip building Linux and Windows binaries
     rm buildpath/"build_config.rb"
 
     (buildpath/"build_config.rb").write <<-EOS.undent
@@ -22,5 +23,7 @@ class MrubyCli < Formula
 
   test do
     system "#{bin}/mruby-cli", "--setup=brew"
+    assert File.file? "brew/mrblib/brew.rb"
+    assert File.file? "brew/tools/brew/brew.c"
   end
 end

--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -6,30 +6,21 @@ class MrubyCli < Formula
 
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"
-    rewrite_build_config
-    system "rake", "compile"
-    cp "mruby/build/host/bin/mruby-cli", "mruby-cli"
-    bin.install "mruby-cli"
-  end
 
-  # The upstream build_config.rb assumes it will be compiled on Linux.
-  # It also automatically cross compiles to MacOS, Linux, and Windows
-  # This configuration compiles a single MacOS binary using clang
-  def rewrite_build_config
-    build_config = <<-eos
+    rm buildpath/"build_config.rb"
+
+    (buildpath/"build_config.rb").write <<-EOS.undent
       MRuby::Build.new do |conf|
         toolchain :clang
-
         conf.gem File.expand_path(File.dirname(__FILE__))
       end
-    eos
+    EOS
 
-    File.open("build_config.rb", "w") do |f|
-      f.write(build_config)
-    end
+    system "rake", "compile"
+    bin.install "mruby/build/host/bin/mruby-cli"
   end
 
   test do
-    system "#{bin}/mruby-cli", "-v"
+    system "#{bin}/mruby-cli", "--setup=brew"
   end
 end

--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -4,19 +4,29 @@ class MrubyCli < Formula
   url "https://github.com/hone/mruby-cli/archive/v0.0.4.tar.gz"
   sha256 "97d889b5980193c562e82b42089b937e675b73950fa0d0c4e46fbe71d16d719f"
 
-  # The mruby-cli build_config.rb assumes that it will be compiled on Linux.
-  # It also automatically cross compiles to MacOS, Linux, and Windows
-  # This patch compiles a single MacOS binary using clang
-  patch do
-    url "https://gist.githubusercontent.com/jeremyjung/ca4f5baa0e6567b96332b6a9281ab37b/raw/84d9dc64fbe02162cab5625243d7e477adb32ab3/mruby-cli_patch.diff"
-    sha256 "4d148001ac180c1942f157829d5a18e553987fc370b5d98d9f1123ce3b21436f"
-  end
-
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"
+    rewrite_build_config
     system "rake", "compile"
     cp "mruby/build/host/bin/mruby-cli", "mruby-cli"
     bin.install "mruby-cli"
+  end
+
+  # The upstream build_config.rb assumes it will be compiled on Linux.
+  # It also automatically cross compiles to MacOS, Linux, and Windows
+  # This configuration compiles a single MacOS binary using clang
+  def rewrite_build_config
+    build_config = <<-eos
+      MRuby::Build.new do |conf|
+        toolchain :clang
+
+        conf.gem File.expand_path(File.dirname(__FILE__))
+      end
+    eos
+
+    File.open("build_config.rb", "w") do |f|
+      f.write(build_config)
+    end
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Formula is a new addition but requires a patch to build.  The upstream mruby-cli build configuration assumes that the binaries will be built on a Linux machine and it automatically cross compiles to MacOS, Linux, and Windows.  The included patch removes the cross compilation steps so that the binary can be compiled on the user's computer as well as the Brew Test Bot.