### PR TITLE
metricbeat: fix missing template

### DIFF
--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -28,6 +28,7 @@ class Metricbeat < Formula
       (etc/"metricbeat").install "metricbeat.yml"
       (etc/"metricbeat").install "metricbeat.template.json"
       (etc/"metricbeat").install "metricbeat.template-es2x.json"
+      (etc/"metricbeat").install "metricbeat.template-es6x.json"
     end
 
     (bin/"metricbeat").write <<-EOS.undent

--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -3,6 +3,7 @@ class Metricbeat < Formula
   homepage "https://www.elastic.co/products/beats/metricbeat"
   url "https://github.com/elastic/beats/archive/v5.4.2.tar.gz"
   sha256 "6a02dffae1b09bc7e2ea673268124bab43c012e8a3b400f53e26c156448f2a99"
+  revision 1
 
   head "https://github.com/elastic/beats.git"
 

--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -26,6 +26,7 @@ class Metricbeat < Formula
       system "make"
       libexec.install "metricbeat"
 
+      (etc/"metricbeat").install "metricbeat.full.yml"
       (etc/"metricbeat").install "metricbeat.yml"
       (etc/"metricbeat").install "metricbeat.template.json"
       (etc/"metricbeat").install "metricbeat.template-es2x.json"


### PR DESCRIPTION
Metricbeat 5.4 adds a new template file, which needs to be installed,
otherwise Metricbeat fails on startup.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
