### PR TITLE
now-cli 7.0.2 (new formula)

### DIFF
--- a/Formula/now-cli.rb
+++ b/Formula/now-cli.rb
@@ -1,0 +1,17 @@
+class NowCli < Formula
+  desc "The command-line interface for realtime global deployments."
+  homepage "https://zeit.co/now"
+  url "https://github.com/zeit/now-cli/releases/download/7.0.2/now-macos"
+  version "7.0.2"
+  sha256 "5dce15bc8af083bee4647fb1b5f7861f6813bd2e86128a26858627a5c882d1df"
+
+  bottle :unneeded
+
+  def install
+    bin.install "now-macos" => "now"
+  end
+
+  test do
+    system "#{bin}/now", "-v"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For `brew install --build-from-source <formula>` requirement, this is a prebuilt binary, it should works on all recently versions macOS.