### PR TITLE
Enable determinstic archives by default in GNU ar

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -16,6 +16,7 @@ class Binutils < Formula
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
+                          "--enable-deterministic-archives",
                           "--program-prefix=g",
                           "--prefix=#{prefix}",
                           "--infodir=#{info}",

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -1,5 +1,5 @@
 class Binutils < Formula
-  desc "FSF Binutils for native development"
+  desc "FSF/GNU ld, ar, readelf, etc. for native development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.28.tar.gz"


### PR DESCRIPTION
Timestamps and user ids are not really needed in
ar archives, and get in the way of reproducible builds,
so let's make -D the default.

freebsd did it a year ago: https://svnweb.freebsd.org/ports?view=revision&revision=416639

debian did it way back in 2.25-6: https://wiki.debian.org/ReproducibleBuilds/TimestampsInStaticLibraries

Fixes https://github.com/Homebrew/homebrew-core/issues/14859

See also https://reproducible-builds.org/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
