### PR TITLE
gradle-completion 1.2.0 (new formula)

### DIFF
--- a/Formula/gradle-completion.rb
+++ b/Formula/gradle-completion.rb
@@ -1,0 +1,19 @@
+class GradleCompletion < Formula
+  desc "Gradle tab completion for bash and zsh"
+  homepage "https://gradle.org"
+  url "https://github.com/gradle/gradle-completion/archive/v1.2.0.tar.gz"
+  sha256 "47c23526d94ac4fa5862ed9d6e3cd4b4704ecb1f880f60827f0d154a7b75392e"
+  head "https://github.com/gradle/gradle-completion.git"
+
+  bottle :unneeded
+
+  def install
+    bash_completion.install "gradle-completion.bash" => "gradle"
+    zsh_completion.install "_gradle" => "_gradle"
+  end
+
+  test do
+    assert_match "-F _gradle",
+      shell_output("bash -c 'source #{bash_completion}/gradle && complete -p gradle'")
+  end
+end

--- a/Formula/gradle-completion.rb
+++ b/Formula/gradle-completion.rb
@@ -1,6 +1,6 @@
 class GradleCompletion < Formula
-  desc "Gradle tab completion for bash and zsh"
-  homepage "https://gradle.org"
+  desc "Bash and Zsh completion for Gradle"
+  homepage "https://gradle.org/"
   url "https://github.com/gradle/gradle-completion/archive/v1.2.0.tar.gz"
   sha256 "47c23526d94ac4fa5862ed9d6e3cd4b4704ecb1f880f60827f0d154a7b75392e"
   head "https://github.com/gradle/gradle-completion.git"


### PR DESCRIPTION
`gradle-completion` is the official Bash/Zsh completion for
[Gradle](https://gradle.org).

The test requires Bash as its shell in order to pass.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
