### PR TITLE
faas-cli 0.3 (new formula)

### DIFF
--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -1,0 +1,66 @@
+class FaasCli < Formula
+  desc "CLI for templating and/or deploying FaaS functions"
+  homepage "http://docs.get-faas.com/"
+  url "https://github.com/alexellis/faas-cli/archive/0.3.tar.gz"
+  sha256 "d4db7ddb0ea1dadf469c3da9893b004874d19570d09457e8cf86e5aef0df00f5"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["XC_OS"] = "darwin"
+    ENV["XC_ARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/alexellis/faas-cli").install buildpath.children
+    cd "src/github.com/alexellis/faas-cli" do
+      system "go", "build", "-o", bin/"faas-cli"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    require "socket"
+
+    server = TCPServer.new("localhost", 0)
+    port = server.addr[1]
+    pid = fork do
+      loop do
+        socket = server.accept
+        response = "OK"
+        socket.print "HTTP/1.1 200 OK\r\n" \
+                    "Content-Length: #{response.bytesize}\r\n" \
+                    "Connection: close\r\n"
+        socket.print "\r\n"
+        socket.print response
+        socket.close
+      end
+    end
+
+    (testpath/"test.yml").write <<-EOF.undent
+      provider:
+        name: faas
+        gateway: http://localhost:#{port}
+        network: "func_functions"
+
+      functions:
+        dummy_function:
+          lang: python
+          handler: ./dummy_function
+          image: dummy_image
+    EOF
+
+    expected = <<-EOS.undent
+      Deploying: dummy_function.
+      Removing old service.
+      200 OK
+      URL: http://localhost:#{port}/function/dummy_function
+    EOS
+
+    begin
+      output = shell_output("#{bin}/faas-cli -action deploy -yaml test.yml")
+      assert_equal expected, output.chomp
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
`faas-cli` is the official client for the [FaaS framework](https://github.com/alexellis/faas/).

**Note** it throws an error for the notability audit (`--new-formula`) as the client has been given its own repo, the [main repo](https://github.com/alexellis/faas/) has 107 watchers, 2184 stars and 133 forks at the moment. 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
