### PR TITLE
ocaml: upgrade to 4.04.2

### DIFF
--- a/Formula/camlp4.rb
+++ b/Formula/camlp4.rb
@@ -4,6 +4,7 @@ class Camlp4 < Formula
   url "https://github.com/ocaml/camlp4/archive/4.04+1.tar.gz"
   version "4.04+1"
   sha256 "6044f24a44053684d1260f19387e59359f59b0605cdbf7295e1de42783e48ff1"
+  revision 1
   head "https://github.com/ocaml/camlp4.git", :branch => "trunk"
 
   bottle do

--- a/Formula/compcert.rb
+++ b/Formula/compcert.rb
@@ -3,7 +3,7 @@ class Compcert < Formula
   homepage "http://compcert.inria.fr"
   url "http://compcert.inria.fr/release/compcert-3.0.1.tgz"
   sha256 "09c7dc18c681231c6e83a963b283b66a9352a9611c9695f4b0c4b7df8c90f935"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/menhir.rb
+++ b/Formula/menhir.rb
@@ -3,6 +3,7 @@ class Menhir < Formula
   homepage "http://cristal.inria.fr/~fpottier/menhir"
   url "http://cristal.inria.fr/~fpottier/menhir/menhir-20170607.tar.gz"
   sha256 "00caa66ed0d1544defda24539f2ca1d37b92120e0575aafc5fcabd8e5364ce61"
+  revision 1
 
   bottle do
     sha256 "2d201c4cceb7b740c458285520e0a0ed2fd6b660e93ab434b53fc4653afff3ed" => :sierra

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -14,8 +14,8 @@
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
-  url "https://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.1.tar.xz"
-  sha256 "222cc494b4eea45011234f2cc6620045ec4d4b539985086381a9a9db289bc285"
+  url "https://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.2.tar.xz"
+  sha256 "d158ed3e9446b300554baeaaa8cca2e9491420b505a9878940205074e2970f2e"
   head "https://caml.inria.fr/svn/ocaml/trunk", :using => :svn
 
   pour_bottle? do

--- a/Formula/ocamlbuild.rb
+++ b/Formula/ocamlbuild.rb
@@ -3,6 +3,7 @@ class Ocamlbuild < Formula
   homepage "https://github.com/ocaml/ocamlbuild"
   url "https://github.com/ocaml/ocamlbuild/archive/0.11.0.tar.gz"
   sha256 "1717edc841c9b98072e410f1b0bc8b84444b4b35ed3b4949ce2bec17c60103ee"
+  revision 1
   head "https://github.com/ocaml/ocamlbuild.git"
 
   bottle do

--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -3,7 +3,7 @@ class Ocamlsdl < Formula
   homepage "https://ocamlsdl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha256 "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any


### PR DESCRIPTION
This is a security update (CVE-2017-9772)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
