### PR TITLE
ipython@5: add ipykernel and man1 page

### DIFF
--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -170,14 +170,17 @@ class IpythonAT5 < Formula
     end
 
     # install kernel
-    system libexec/"bin/ipython", "kernel", "install", "--prefix", buildpath
-    inreplace buildpath/"share/jupyter/kernels/python2/kernel.json", "]", <<-EOS.undent
+    system libexec/"bin/ipython", "kernel", "install", "--prefix", share
+    inreplace share/"share/jupyter/kernels/python2/kernel.json", "]", <<-EOS.undent
       ],
       "env": {
         "PYTHONPATH": "#{ENV["PYTHONPATH"]}"
       }
     EOS
-    (etc/"jupyter/kernels/python2").install Dir[buildpath/"share/jupyter/kernels/python2/*"]
+  end
+
+  def post_install
+    (etc/"jupyter/kernels/python2").install Dir[share/"share/jupyter/kernels/python2/*"]
   end
 
   test do

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -187,6 +187,6 @@ class IpythonAT5 < Formula
     assert_equal "4", shell_output("#{bin}/ipython -c 'print 2+2'").chomp
 
     system bin/"ipython", "kernel", "install", "--prefix", testpath
-    assert File.exist?(testpath/"share/jupyter/kernels/python2/kernel.json"), "Failed to install kernel"
+    assert_predicate testpath/"share/jupyter/kernels/python2/kernel.json", :exist?, "Failed to install kernel"
   end
 end

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -5,6 +5,7 @@ class IpythonAT5 < Formula
   homepage "https://ipython.org/"
   url "https://files.pythonhosted.org/packages/21/86/58d06db0c82af66c2d47faead027c3ce775cfbf9bc9d2f13f85d95f0a162/ipython-5.4.1.tar.gz"
   sha256 "afaa92343c20cf4296728161521d84f606d8817f963beaf7198e63dfede897fb"
+  revision 1
   head "https://github.com/ipython/ipython.git", :branch => "5.x"
 
   bottle do
@@ -23,9 +24,19 @@ class IpythonAT5 < Formula
     sha256 "8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
   end
 
+  resource "backports_abc" do
+    url "https://files.pythonhosted.org/packages/68/3c/1317a9113c377d1e33711ca8de1e80afbaf4a3c950dd0edfaf61f9bfe6d8/backports_abc-0.5.tar.gz"
+    sha256 "033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde"
+  end
+
   resource "backports.shutil_get_terminal_size" do
     url "https://files.pythonhosted.org/packages/ec/9c/368086faa9c016efce5da3e0e13ba392c9db79e3ab740b763fe28620b18b/backports.shutil_get_terminal_size-1.0.0.tar.gz"
     sha256 "713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80"
+  end
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/dd/0e/1e3b58c861d40a9ca2d7ea4ccf47271d4456ae4294c5998ad817bd1b4396/certifi-2017.4.17.tar.gz"
+    sha256 "f7527ebf7461582ce95f7a9e03dd141ce810d40590834f4ec20cddd54234c10a"
   end
 
   resource "decorator" do
@@ -38,14 +49,29 @@ class IpythonAT5 < Formula
     sha256 "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
   end
 
+  resource "ipykernel" do
+    url "https://files.pythonhosted.org/packages/0c/41/67e16b243b78b49f4b1650d045b63be187c27d20a76f0f7b8e61e0fcb966/ipykernel-4.6.1.tar.gz"
+    sha256 "2e1825aca4e2585b5adb7953ea16e53f53a62159ed49952a564b1e23507205db"
+  end
+
   resource "ipython_genutils" do
     url "https://files.pythonhosted.org/packages/e8/69/fbeffffc05236398ebfcfb512b6d2511c622871dca1746361006da310399/ipython_genutils-0.2.0.tar.gz"
     sha256 "eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
   end
 
+  resource "jupyter_client" do
+    url "https://files.pythonhosted.org/packages/d4/51/09da9a18cd858b28cee596a628660a8cbf9830bdd89fe94361bfe18a0bb4/jupyter_client-5.1.0.tar.gz"
+    sha256 "08756b021765c97bc5665390700a4255c2df31666ead8bff116b368d09912aba"
+  end
+
+  resource "jupyter_core" do
+    url "https://files.pythonhosted.org/packages/2f/39/5138f975100ce14d150938df48a83cd852a3fd8e24b1244f4113848e69e2/jupyter_core-4.3.0.tar.gz"
+    sha256 "a96b129e1641425bf057c3d46f4f44adce747a7d60107e8ad771045c36514d40"
+  end
+
   resource "pathlib2" do
-    url "https://files.pythonhosted.org/packages/ab/d8/ac7489d50146f29d0a14f65545698f4545d8a6b739b24b05859942048b56/pathlib2-2.2.1.tar.gz"
-    sha256 "ce9007df617ef6b7bd8a31cd2089ed0c1fed1f7c23cf2bf1ba140b3dd563175d"
+    url "https://files.pythonhosted.org/packages/a1/14/df0deb867c2733f7d857523c10942b3d6612a1b222502fdffa9439943dfb/pathlib2-2.3.0.tar.gz"
+    sha256 "d32550b75a818b289bd4c1f96b60c89957811da205afcceab75bc8b4857ea5b3"
   end
 
   resource "pexpect" do
@@ -64,13 +90,23 @@ class IpythonAT5 < Formula
   end
 
   resource "ptyprocess" do
-    url "https://files.pythonhosted.org/packages/db/d7/b465161910f3d1cef593c5e002bff67e0384898f597f1a7fdc8db4c02bf6/ptyprocess-0.5.1.tar.gz"
-    sha256 "0530ce63a9295bfae7bd06edc02b6aa935619f486f0f1dc0972f516265ee81a6"
+    url "https://files.pythonhosted.org/packages/51/83/5d07dc35534640b06f9d9f1a1d2bc2513fb9cc7595a1b0e28ae5477056ce/ptyprocess-0.5.2.tar.gz"
+    sha256 "e64193f0047ad603b71f202332ab5527c5e52aa7c8b609704fc28c0dc20c4365"
   end
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/71/2a/2e4e77803a8bd6408a2903340ac498cb0a2181811af7c9ec92cb70b0308a/Pygments-2.2.0.tar.gz"
     sha256 "dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
+    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+  end
+
+  resource "pyzmq" do
+    url "https://files.pythonhosted.org/packages/af/37/8e0bf3800823bc247c36715a52e924e8f8fd5d1432f04b44b8cd7a5d7e55/pyzmq-16.0.2.tar.gz"
+    sha256 "0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d"
   end
 
   resource "scandir" do
@@ -83,9 +119,19 @@ class IpythonAT5 < Formula
     sha256 "dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
   end
 
+  resource "singledispatch" do
+    url "https://files.pythonhosted.org/packages/d9/e9/513ad8dc17210db12cb14f2d4d190d618fb87dd38814203ea71c87ba5b68/singledispatch-3.4.0.3.tar.gz"
+    sha256 "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"
+  end
+
   resource "six" do
     url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
     sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  resource "tornado" do
+    url "https://files.pythonhosted.org/packages/df/42/a180ee540e12e2ec1007ac82a42b09dd92e5461e09c98bf465e98646d187/tornado-4.5.1.tar.gz"
+    sha256 "db0904a28253cfe53e7dedc765c71596f3c53bb8a866ae50123320ec1a7b73fd"
   end
 
   resource "traitlets" do
@@ -99,7 +145,16 @@ class IpythonAT5 < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    venv = virtualenv_create(libexec)
+
+    %w[appnope backports.shutil_get_terminal_size decorator enum34 ipython_genutils pathlib2 pexpect pickleshare prompt_toolkit ptyprocess Pygments scandir simplegeneric six traitlets wcwidth].each do |r|
+      venv.pip_install resource(r)
+    end
+    venv.pip_install_and_link buildpath
+
+    %w[backports_abc certifi jupyter_client jupyter_core python-dateutil pyzmq singledispatch tornado ipykernel].each do |r|
+      venv.pip_install resource(r)
+    end
   end
 
   test do

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -151,6 +151,9 @@ class IpythonAT5 < Formula
     venv.pip_install (resources - [ipykernel])
     venv.pip_install_and_link buildpath
     venv.pip_install ipykernel
+
+    man1.mkpath
+    man1.install libexec/"share/man/man1/ipython.1"
   end
 
   test do

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -187,6 +187,6 @@ class IpythonAT5 < Formula
     assert_equal "4", shell_output("#{bin}/ipython -c 'print 2+2'").chomp
 
     system bin/"ipython", "kernel", "install", "--prefix", testpath
-    assert File.exists?(testpath/"share/jupyter/kernels/python2/kernel.json"), "Failed to install kernel"    
+    assert File.exist?(testpath/"share/jupyter/kernels/python2/kernel.json"), "Failed to install kernel"
   end
 end

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -185,5 +185,8 @@ class IpythonAT5 < Formula
 
   test do
     assert_equal "4", shell_output("#{bin}/ipython -c 'print 2+2'").chomp
+
+    system bin/"ipython", "kernel", "install", "--prefix", testpath
+    assert File.exists?(testpath/"share/jupyter/kernels/python2/kernel.json"), "Failed to install kernel"    
   end
 end

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -146,15 +146,11 @@ class IpythonAT5 < Formula
 
   def install
     venv = virtualenv_create(libexec)
+    ipykernel = resource("ipykernel")
 
-    %w[appnope backports.shutil_get_terminal_size decorator enum34 ipython_genutils pathlib2 pexpect pickleshare prompt_toolkit ptyprocess Pygments scandir simplegeneric six traitlets wcwidth].each do |r|
-      venv.pip_install resource(r)
-    end
+    venv.pip_install (resources - [ipykernel])
     venv.pip_install_and_link buildpath
-
-    %w[backports_abc certifi jupyter_client jupyter_core python-dateutil pyzmq singledispatch tornado ipykernel].each do |r|
-      venv.pip_install resource(r)
-    end
+    venv.pip_install ipykernel
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
IPyKernel is a wrapper around `ipython@5` that allows [Jupyter](http://jupyter.org/) to talk to it; I'm working on a `jupyter` formula now 😄  IPyKernel needs to be located in the same virtualenv for this communication to work.

As this is the second item in [IPython's list of features](http://ipython.org/), it seems to make sense as part of the default formula.