### PR TITLE
ipython: add ipykernel and man1 page

### DIFF
--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -157,6 +157,6 @@ class Ipython < Formula
     assert_equal "4", shell_output("#{bin}/ipython -c 'print(2+2)'").chomp
 
     system bin/"ipython", "kernel", "install", "--prefix", testpath
-    assert File.exist?(testpath/"share/jupyter/kernels/python3/kernel.json"), "Failed to install kernel"
+    assert_predicate testpath/"share/jupyter/kernels/python3/kernel.json", :exist?, "Failed to install kernel"
   end
 end

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -5,6 +5,7 @@ class Ipython < Formula
   homepage "https://ipython.org/"
   url "https://files.pythonhosted.org/packages/79/63/b671fc2bf0051739e87a7478a207bbeb45cfae3c328d38ccdd063d9e0074/ipython-6.1.0.tar.gz"
   sha256 "5c53e8ee4d4bec27879982b9f3b4aa2d6e3cfd7b26782d250fa117f85bb29814"
+  revision 1
   head "https://github.com/ipython/ipython.git"
 
   bottle do
@@ -26,6 +27,11 @@ class Ipython < Formula
     sha256 "953d6bf082b100f43229cf547f4f97f97e970f5ad645ee7601d55ff87afdfe76"
   end
 
+  resource "ipykernel" do
+    url "https://files.pythonhosted.org/packages/0c/41/67e16b243b78b49f4b1650d045b63be187c27d20a76f0f7b8e61e0fcb966/ipykernel-4.6.1.tar.gz"
+    sha256 "2e1825aca4e2585b5adb7953ea16e53f53a62159ed49952a564b1e23507205db"
+  end
+
   resource "ipython_genutils" do
     url "https://files.pythonhosted.org/packages/e8/69/fbeffffc05236398ebfcfb512b6d2511c622871dca1746361006da310399/ipython_genutils-0.2.0.tar.gz"
     sha256 "eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
@@ -34,6 +40,16 @@ class Ipython < Formula
   resource "jedi" do
     url "https://files.pythonhosted.org/packages/80/b9/4e9b0b999deeec8a91cb84e567380853a842e6c387c9d39b8fc9a49953fa/jedi-0.10.2.tar.gz"
     sha256 "7abb618cac6470ebbd142e59c23daec5e6e063bfcecc8a43a037d2ab57276f4e"
+  end
+
+  resource "jupyter_client" do
+    url "https://files.pythonhosted.org/packages/d4/51/09da9a18cd858b28cee596a628660a8cbf9830bdd89fe94361bfe18a0bb4/jupyter_client-5.1.0.tar.gz"
+    sha256 "08756b021765c97bc5665390700a4255c2df31666ead8bff116b368d09912aba"
+  end
+
+  resource "jupyter_core" do
+    url "https://files.pythonhosted.org/packages/2f/39/5138f975100ce14d150938df48a83cd852a3fd8e24b1244f4113848e69e2/jupyter_core-4.3.0.tar.gz"
+    sha256 "a96b129e1641425bf057c3d46f4f44adce747a7d60107e8ad771045c36514d40"
   end
 
   resource "pexpect" do
@@ -52,13 +68,23 @@ class Ipython < Formula
   end
 
   resource "ptyprocess" do
-    url "https://files.pythonhosted.org/packages/db/d7/b465161910f3d1cef593c5e002bff67e0384898f597f1a7fdc8db4c02bf6/ptyprocess-0.5.1.tar.gz"
-    sha256 "0530ce63a9295bfae7bd06edc02b6aa935619f486f0f1dc0972f516265ee81a6"
+    url "https://files.pythonhosted.org/packages/51/83/5d07dc35534640b06f9d9f1a1d2bc2513fb9cc7595a1b0e28ae5477056ce/ptyprocess-0.5.2.tar.gz"
+    sha256 "e64193f0047ad603b71f202332ab5527c5e52aa7c8b609704fc28c0dc20c4365"
   end
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/71/2a/2e4e77803a8bd6408a2903340ac498cb0a2181811af7c9ec92cb70b0308a/Pygments-2.2.0.tar.gz"
     sha256 "dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
+    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+  end
+
+  resource "pyzmq" do
+    url "https://files.pythonhosted.org/packages/af/37/8e0bf3800823bc247c36715a52e924e8f8fd5d1432f04b44b8cd7a5d7e55/pyzmq-16.0.2.tar.gz"
+    sha256 "0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d"
   end
 
   resource "simplegeneric" do
@@ -69,6 +95,11 @@ class Ipython < Formula
   resource "six" do
     url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
     sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  resource "tornado" do
+    url "https://files.pythonhosted.org/packages/df/42/a180ee540e12e2ec1007ac82a42b09dd92e5461e09c98bf465e98646d187/tornado-4.5.1.tar.gz"
+    sha256 "db0904a28253cfe53e7dedc765c71596f3c53bb8a866ae50123320ec1a7b73fd"
   end
 
   resource "traitlets" do
@@ -82,7 +113,16 @@ class Ipython < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    venv = virtualenv_create(libexec, "python3")
+
+    %w[appnope decorator ipython_genutils jedi pexpect pickleshare prompt_toolkit ptyprocess Pygments simplegeneric six traitlets wcwidth].each do |r|
+      venv.pip_install resource(r)
+    end
+    venv.pip_install_and_link buildpath
+
+    %w[jupyter_client jupyter_core python-dateutil pyzmq tornado ipykernel].each do |r|
+      venv.pip_install resource(r)
+    end
   end
 
   test do

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -113,15 +113,41 @@ class Ipython < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
+
+    # install other resources
     ipykernel = resource("ipykernel")
+    (resources - [ipykernel]).each do |r|
+      r.stage do
+        system "python3", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
 
-    venv.pip_install (resources - [ipykernel])
-    venv.pip_install_and_link buildpath
-    venv.pip_install ipykernel
+    # install and link IPython
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
+    system "python3", *Language::Python.setup_install_args(libexec)
+    bin.install libexec/"bin/ipython"
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
 
+    # install IPython man page
     man1.mkpath
     man1.install libexec/"share/man/man1/ipython.1"
+
+    # install IPyKernel
+    ipykernel.stage do
+      system "python3", *Language::Python.setup_install_args(libexec/"vendor")
+    end
+
+    # install kernel
+    system libexec/"bin/ipython", "kernel", "install", "--prefix", buildpath
+    inreplace buildpath/"share/jupyter/kernels/python3/kernel.json", "]", <<-EOS.undent
+      ],
+      "env": {
+        "PYTHONPATH": "#{ENV["PYTHONPATH"]}"
+      }
+    EOS
+    (etc/"jupyter/kernels/python3").install Dir[buildpath/"share/jupyter/kernels/python3/*"]
   end
 
   test do

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -140,17 +140,23 @@ class Ipython < Formula
     end
 
     # install kernel
-    system libexec/"bin/ipython", "kernel", "install", "--prefix", buildpath
-    inreplace buildpath/"share/jupyter/kernels/python3/kernel.json", "]", <<-EOS.undent
+    system libexec/"bin/ipython", "kernel", "install", "--prefix", share
+    inreplace share/"share/jupyter/kernels/python3/kernel.json", "]", <<-EOS.undent
       ],
       "env": {
         "PYTHONPATH": "#{ENV["PYTHONPATH"]}"
       }
     EOS
-    (etc/"jupyter/kernels/python3").install Dir[buildpath/"share/jupyter/kernels/python3/*"]
+  end
+
+  def post_install
+    (etc/"jupyter/kernels/python3").install Dir[share/"share/jupyter/kernels/python3/*"]
   end
 
   test do
     assert_equal "4", shell_output("#{bin}/ipython -c 'print(2+2)'").chomp
+
+    system bin/"ipython", "kernel", "install", "--prefix", testpath
+    assert File.exist?(testpath/"share/jupyter/kernels/python3/kernel.json"), "Failed to install kernel"
   end
 end

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -114,15 +114,11 @@ class Ipython < Formula
 
   def install
     venv = virtualenv_create(libexec, "python3")
+    ipykernel = resource("ipykernel")
 
-    %w[appnope decorator ipython_genutils jedi pexpect pickleshare prompt_toolkit ptyprocess Pygments simplegeneric six traitlets wcwidth].each do |r|
-      venv.pip_install resource(r)
-    end
+    venv.pip_install (resources - [ipykernel])
     venv.pip_install_and_link buildpath
-
-    %w[jupyter_client jupyter_core python-dateutil pyzmq tornado ipykernel].each do |r|
-      venv.pip_install resource(r)
-    end
+    venv.pip_install ipykernel
   end
 
   test do

--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -119,6 +119,9 @@ class Ipython < Formula
     venv.pip_install (resources - [ipykernel])
     venv.pip_install_and_link buildpath
     venv.pip_install ipykernel
+
+    man1.mkpath
+    man1.install libexec/"share/man/man1/ipython.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
IPyKernel is a wrapper around `ipython` that allows [Jupyter](http://jupyter.org/) to talk to it; I'm working on a `jupyter` formula now 😄  IPyKernel needs to be located in the same virtualenv for this communication to work.

As this is the second item in [IPython's list of features](http://ipython.org/), it seems to make sense as part of the default formula.