### PR TITLE
Fixes coreutils MANPATH instruction

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -112,7 +112,7 @@ class Coreutils < Formula
     Additionally, you can access their man pages with normal names if you add
     the "gnuman" directory to your MANPATH from your bashrc as well:
 
-        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+        MANPATH="#{opt_libexec}/gnuman:$(eval "$(: ${MANPATH:=}; /usr/libexec/path_helper -s)"; echo "$MANPATH")"
 
     EOS
   end


### PR DESCRIPTION
to use /usr/libexec/path_helper, which respects entries in /etc/manpaths
and /etc/manpaths.d/ as well as current value of $MANPATH environment.

Previous instruction was encouraging an incorrect $MANPATH setup since
the default login shell did not have MANPATH set for a very long time
(since macOS 10.2 or so, not 10.10.2).

Resolves #14273.

See also: https://github.com/netj/bpm/blob/bb0fd5f2421ef0805e85be7c4cc96ea677c1abf1/plugin/environment#L17-L25

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
