### PR TITLE
platformio 3.4.0

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "http://platformio.org"
-  url "https://pypi.python.org/packages/97/02/58c93caf59a93999b9b17640b467fca5812a96fae30de6b9acc84d827676/platformio-3.3.0.tar.gz"
-  sha256 "6870d177035bd75472862b57c4c03a910174da5d217e69d5ddd12aa54a43ad64"
+  url "https://files.pythonhosted.org/packages/89/5c/e04c950f9d3663a797e00a0cfabfdd6eceefbe60c8006223752bb16b7958/platformio-3.4.0.tar.gz"
+  sha256 "2311715e98a56964f6f032d22abb883167d34bc64360ccc54be3a3d515452887"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,18 +16,23 @@ class Platformio < Formula
   depends_on :python if MacOS.version <= :snow_leopard
 
   resource "arrow" do
-    url "https://pypi.python.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
+    url "https://files.pythonhosted.org/packages/54/db/76459c4dd3561bbe682619a5c576ff30c42e37c2e01900ed30a501957150/arrow-0.10.0.tar.gz"
     sha256 "805906f09445afc1f0fc80187db8fe07670e3b25cdafa09b8d8ac264a8c0c722"
   end
 
-  resource "python-dateutil" do
-    url "https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
-    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+  resource "bottle" do
+    url "https://files.pythonhosted.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"
+    sha256 "39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355"
   end
 
-  resource "bottle" do
-    url "https://pypi.python.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"
-    sha256 "39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355"
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/dd/0e/1e3b58c861d40a9ca2d7ea4ccf47271d4456ae4294c5998ad817bd1b4396/certifi-2017.4.17.tar.gz"
+    sha256 "f7527ebf7461582ce95f7a9e03dd141ce810d40590834f4ec20cddd54234c10a"
+  end
+
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
   end
 
   resource "click" do
@@ -36,8 +41,13 @@ class Platformio < Formula
   end
 
   resource "colorama" do
-    url "https://files.pythonhosted.org/packages/f0/d0/21c6449df0ca9da74859edc40208b3a57df9aca7323118c913e58d442030/colorama-0.3.7.tar.gz"
-    sha256 "e043c8d32527607223652021ff648fbb394d5e19cba9f1a698670b338c9d782b"
+    url "https://files.pythonhosted.org/packages/e6/76/257b53926889e2835355d74fec73d82662100135293e17d382e2b74d1669/colorama-0.3.9.tar.gz"
+    sha256 "48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/d8/82/28a51052215014efc07feac7330ed758702fc0581347098a81699b5281cb/idna-2.5.tar.gz"
+    sha256 "3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"
   end
 
   resource "lockfile" do
@@ -46,18 +56,33 @@ class Platformio < Formula
   end
 
   resource "pyserial" do
-    url "https://pypi.python.org/packages/8d/88/cf848688ae011085a6da5a470740dafa3a4b105f84a5f79c3b720c19279c/pyserial-3.3.tar.gz"
-    sha256 "2949cddffc2b05683065a3cd2345114b1a49b08df8cb843d69ba99dc3e19edc2"
+    url "https://files.pythonhosted.org/packages/1f/3b/ee6f354bcb1e28a7cd735be98f39ecf80554948284b41e9f7965951befa6/pyserial-3.2.1.tar.gz"
+    sha256 "1eecfe4022240f2eab5af8d414f0504e072ee68377ba63d3b6fe6e66c26f66d1"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
+    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
   end
 
   resource "requests" do
-    url "https://pypi.python.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz"
-    sha256 "5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8"
+    url "https://files.pythonhosted.org/packages/2c/b5/2b6e8ef8dd18203b6399e9f28c7d54f6de7b7549853fe36d575bd31e29a7/requests-2.18.1.tar.gz"
+    sha256 "c6f3bdf4a4323ac7b45d01e04a6f6c20e32a052cd04de81e05103abc049ad9b9"
   end
 
   resource "semantic_version" do
-    url "https://pypi.python.org/packages/72/83/f76958017f3094b072d8e3a72d25c3ed65f754cc607fdb6a7b33d84ab1d5/semantic_version-2.6.0.tar.gz"
+    url "https://files.pythonhosted.org/packages/72/83/f76958017f3094b072d8e3a72d25c3ed65f754cc607fdb6a7b33d84ab1d5/semantic_version-2.6.0.tar.gz"
     sha256 "2a4328680073e9b243667b201119772aefc5fc63ae32398d6afafff07c4f54c0"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
+    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/96/d9/40e4e515d3e17ed0adbbde1078e8518f8c4e3628496b56eb8f026a02b9e4/urllib3-1.21.1.tar.gz"
+    sha256 "b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"
   end
 
   def install
@@ -67,5 +92,6 @@ class Platformio < Formula
   test do
     system bin/"platformio"
     system bin/"pio"
+    system bin/"piodebuggdb", "--help"
   end
 end


### PR DESCRIPTION
# Release Notes

* [PIO Unified Debugger](http://docs.platformio.org/page/plus/debugging.html)

  - "1-click" solution, zero configuration
  - Support for 100+ embedded boards
  - Multiple architectures and development platforms
  - Windows, MacOS, Linux (+ARMv6-8)
  - Built-in into [PlatformIO IDE for Atom](http://docs.platformio.org/page/ide/atom.html) and [PlatformIO IDE for VScode](http://docs.platformio.org/page/ide/vscode.html)
  - Integration with [Eclipse](http://docs.platformio.org/page/ide/eclipse.html) and [Sublime Text](http://docs.platformio.org/page/ide/sublimetext.html)

* Filter [PIO Unit Testing](http://docs.platformio.org/page/plus/unit-testing.html) tests using a new ``test_filter`` option in [Project Configuration File "platformio.ini"](http://docs.platformio.org/page/projectconf.html) or [platformio test --filter](http://docs.platformio.org/page/userguide/cmd_test.html#cmdoption-platformio-test-f) command ([issue #934](https://github.com/platformio/platformio-core/issues/934))
* Custom ``test_transport`` for [PIO Unit Testing](http://docs.platformio.org/page/plus/unit-testing.html) Engine
* Configure Serial Port Monitor in [Project Configuration File "platformio.ini"](http://docs.platformio.org/page/projectconf.html) ([issue #787](https://github.com/platformio/platformio-core/issues/787))
* New [monitor](http://docs.platformio.org/page/userguide/cmd_run.html#cmdoption-platformio-run-t) target which allows to launch Serial Monitor automatically after successful "build" or "upload" operations ([issue #788](https://github.com/platformio/platformio-core/issues/788))
* Project generator for [VIM](http://docs.platformio.org/page/ide/vim.html)
* Multi-line support for the different options in [Project Configuration File "platformio.ini"](http://docs.platformio.org/page/projectconf.html), such as: ``build_flags``, ``build_unflags``, etc. ([issue #889](https://github.com/platformio/platformio-core/issues/889))
* Handle dynamic ``SRC_FILTER`` environment variable from [library.json extra script](http://docs.platformio.org/page/librarymanager/config.html#extrascript)
* Notify about multiple installations of PIO Core ([issue #961](https://github.com/platformio/platformio-core/issues/961))
* Improved auto-detecting of mbed-enabled media disks
* Automatically update Git-submodules for development platforms and libraries that were installed from repository
* Add support for ``.*cc`` extension ([issue #939](https://github.com/platformio/platformio-core/issues/939))
* Handle ``env_default`` in [Project Configuration File "platformio.ini"](http://docs.platformio.org/page/projectconf.html) when re-initializing a project ([issue #950](https://github.com/platformio/platformio-core/issues/950))
* Use root directory for PIO Home when path contains non-ascii characters ([issue #951](https://github.com/platformio/platformio-core/issues/951), [issue #952](https://github.com/platformio/platformio-core/issues/952))
* Don't warn about known ``boards_dir`` option ([pull #949](https://github.com/platformio/platformio-core/pull/949))
* Escape non-valid file name characters when installing a new package (library) ([issue #985](https://github.com/platformio/platformio-core/issues/985))
* Fixed infinite dependency installing when repository consists of multiple libraries ([issue #935](https://github.com/platformio/platformio-core/issues/935))
* Fixed linter error "unity.h does not exist" for Unit Testing ([issue #947](https://github.com/platformio/platformio-core/issues/947))
* Fixed issue when [Library Dependency Finder (LDF)](http://docs.platformio.org/page/librarymanager/ldf.html) does not handle custom ``src_dir`` ([issue #942](https://github.com/platformio/platformio-core/issues/942))
* Fixed cloning a package (library) from a private Git repository with custom user name and SSH port ([issue #925](https://github.com/platformio/platformio-core/issues/925))