### PR TITLE
go 1.9beta2 (devel)

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -22,10 +22,9 @@ class Go < Formula
   end
 
   devel do
-    url "https://storage.googleapis.com/golang/go1.9beta1.src.tar.gz"
-    mirror "https://fossies.org/linux/misc/go1.9beta1.src.tar.gz"
-    version "1.9beta1"
-    sha256 "e42dbd2071aadb28a4d293225b04b6b4215a35a7f04417a0e47ffa38f81d642d"
+    url "https://storage.googleapis.com/golang/go1.9beta2.src.tar.gz"
+    version "1.9beta2"
+    sha256 "4ca11b29e9c3b2ef1db837a80bc3a54a6ba392dc3f7447cb99972f9c96daa8c3"
 
     resource "gotools" do
       url "https://go.googlesource.com/tools.git"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I'm seeing this from `brew audit --strict go`:

```go:
  * Formula has other versions so create a versioned alias:
      cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Aliases
      ln -s ../Formula/go.rb go@1.9beta2
  * Formula has invalid versioned aliases:
      go@1.8
Error: 2 problems in 1 formula
```

Not sure if that's benign or not.