### PR TITLE
Update ntop 3.0 to work with mariadb flag again

### DIFF
--- a/Formula/ntopng.rb
+++ b/Formula/ntopng.rb
@@ -44,6 +44,10 @@ class Ntopng < Formula
   depends_on "mariadb" => :optional
 
   def install
+    if build.with? "mariadb"
+      inreplace "configure.seed", "mariadb_config", "mysql_config"
+    end
+
     # Prevent "make install" failure "cp: the -H, -L, and -P options may not be
     # specified with the -r option"
     # Reported 2 Jun 2017 https://github.com/ntop/ntopng/issues/1285
@@ -52,7 +56,7 @@ class Ntopng < Formula
     resource("nDPI").stage do
       system "./autogen.sh"
       system "make"
-      (buildpath/"nDPI").install Dir["*"]
+      (buildpath / "nDPI").install Dir["*"]
     end
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
This is the patch suggested by @ilovezfs to fix this error in Homebrew/homebrew-core#1427:
https://github.com/Homebrew/homebrew-core/issues/14278#issuecomment-306396602

install and works fine!

---

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Does your build pass `brew style --strict <formula>`?
-----

This would close: Homebrew/homebrew-core#14278