### PR TITLE
elasticsearch 5.4.3

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,8 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.4.2.tar.gz"
-  sha256 "0206124d101a293b34b19cebee83fbf0e2a540f5214aabf133cde0719b896150"
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.4.3.tar.gz"
+  sha256 "0ceaf6a2243e9a6f3519dce62991ccab09a44326d6899688cd09422b8c31c68f"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"


### PR DESCRIPTION
This pull request bumps the version on the Elasticsearch formula from version 5.4.2 to version 5.4.3.