### PR TITLE
metricbeat 5.4.3

### DIFF
--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -1,9 +1,8 @@
 class Metricbeat < Formula
   desc "Collect metrics from your systems and services."
   homepage "https://www.elastic.co/products/beats/metricbeat"
-  url "https://github.com/elastic/beats/archive/v5.4.2.tar.gz"
-  sha256 "6a02dffae1b09bc7e2ea673268124bab43c012e8a3b400f53e26c156448f2a99"
-  revision 1
+  url "https://github.com/elastic/beats/archive/v5.4.3.tar.gz"
+  sha256 "a7714383de1a610c7318e8a2751a230b64c8ca243058abd59b1886aabcc3965b"
 
   head "https://github.com/elastic/beats.git"
 


### PR DESCRIPTION
This pull request bumps the version on the Metricbeat formula from version 5.4.2 to version 5.4.3.