### PR TITLE
gst-plugins-bad: add optional dependency on fdk-aac

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -27,6 +27,7 @@ class GstPluginsBad < Formula
   depends_on "dirac" => :optional
   depends_on "faac" => :optional
   depends_on "faad2" => :optional
+  depends_on "fdk-aac" => :optional
   depends_on "gnutls" => :optional
   depends_on "gtk+3" => :optional
   depends_on "libdvdread" => :optional


### PR DESCRIPTION
This can be used to enable the compilation of the GStreamer AAC encoder
and decoder based on the fdk-aac library.

- [yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [yes] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
