### PR TITLE
kibana formulae: modernize language/node usage

### DIFF
--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -42,8 +42,7 @@ class Kibana < Formula
 
     # set npm env and fix cache edge case (https://github.com/Homebrew/brew/pull/37#issuecomment-208840366)
     ENV.prepend_path "PATH", prefix/"libexec/node/bin"
-    Pathname.new("#{ENV["HOME"]}/.npmrc").write Language::Node.npm_cache_config
-    system "npm", "install", "--verbose"
+    system "npm", "install", "-ddd", "--build-from-source", "--#{Language::Node.npm_cache_config}"
     system "npm", "run", "build", "--", "--release", "--skip-os-packages", "--skip-archives"
 
     prefix.install Dir["build/kibana-#{version}-#{platform.sub("x64", "x86_64")}/{bin,config,node_modules,optimize,package.json,src,ui_framework,webpackShims}"]

--- a/Formula/kibana@4.4.rb
+++ b/Formula/kibana@4.4.rb
@@ -20,8 +20,7 @@ class KibanaAT44 < Formula
   end
 
   def install
-    resource("node").stage buildpath/"node"
-    cd buildpath/"node" do
+    resource("node").stage do
       system "./configure", "--prefix=#{libexec}/node"
       system "make", "install"
     end
@@ -44,8 +43,7 @@ class KibanaAT44 < Formula
     inreplace buildpath/"tasks/build/archives.js", /(await exec\('zip'.*)/, "// \\1"
 
     ENV.prepend_path "PATH", prefix/"libexec/node/bin"
-    Pathname.new("#{ENV["HOME"]}/.npmrc").write Language::Node.npm_cache_config
-    system "npm", "install"
+    system "npm", "install", "-ddd", "--build-from-source", "--#{Language::Node.npm_cache_config}"
     system "npm", "run", "build"
     mkdir "tar" do
       system "tar", "--strip-components", "1", "-xf", Dir[buildpath/"target/kibana-*-#{platform}.tar.gz"].first


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adopts the changes to language/node from https://github.com/Homebrew/brew/pull/2826 to the `kibana@x` formulae, which doesn't use the high level language/node methods because of their requirement on the node version from their resources bundled into `libexec`. It now:

* has more verbose npm log output
* builds the native addons from source instead of downloading prebuild binaries
* set's the cache config with a command line argument instead of a `.npmrc` file