### PR TITLE
capnp: add git url for build from HEAD

### DIFF
--- a/Formula/capnp.rb
+++ b/Formula/capnp.rb
@@ -3,6 +3,7 @@ class Capnp < Formula
   homepage "https://capnproto.org/"
   url "https://capnproto.org/capnproto-c++-0.6.1.tar.gz"
   sha256 "8082040cd8c3b93c0e4fc72f2799990c72fdcf21c2b5ecdae6611482a14f1a04"
+  head "https://github.com/capnproto/capnproto.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds URL of git repository to allow builds from HEAD.