### PR TITLE
ipmitool: fix segfault when prompting for password

### DIFF
--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -4,7 +4,7 @@ class Ipmitool < Formula
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,15 +15,21 @@ class Ipmitool < Formula
 
   depends_on "openssl"
 
+  # https://sourceforge.net/p/ipmitool/bugs/433/#89ea and
+  # https://sourceforge.net/p/ipmitool/bugs/436/ (prematurely closed):
+  # Fix segfault when prompting for password
+  # Re-reported 12 July 2017 https://sourceforge.net/p/ipmitool/mailman/message/35942072/
+  patch do
+    url "https://gist.githubusercontent.com/adaugherity/87f1466b3c93d5aed205a636169d1c58/raw/29880afac214c1821e34479dad50dca58a0951ef/ipmitool-getpass-segfault.patch"
+    sha256 "fc1cff11aa4af974a3be191857baeaf5753d853024923b55c720eac56f424038"
+  end
+
   def install
     # Fix ipmi_cfgp.c:33:10: fatal error: 'malloc.h' file not found
     # Upstream issue from 8 Nov 2016 https://sourceforge.net/p/ipmitool/bugs/474/
     inreplace "lib/ipmi_cfgp.c", "#include <malloc.h>", ""
 
-    # https://sourceforge.net/p/ipmitool/bugs/436/
-    ENV.append "CFLAGS", "--std=gnu99"
     args = %W[
-      --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
       --mandir=#{man}


### PR DESCRIPTION
*Actually* fixes #9423.

Also remove the --disable-debug configure option, which it no longer
recognizes.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
