### PR TITLE
Fix crash from the usage of %n in dynamic format strings on High Sierra

### DIFF
--- a/Formula/bison.rb
+++ b/Formula/bison.rb
@@ -15,6 +15,15 @@ class Bison < Formula
 
   keg_only :provided_by_osx, "some formulae require a newer version of bison"
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/14451f57e89/devel/bison/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -62,6 +62,15 @@ class Coreutils < Formula
   conflicts_with "idutils", :because => "both install `gid` and `gid.1`"
   conflicts_with "aardvark_shell_utils", :because => "both install `realpath` binaries"
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b832494a90b/sysutils/coreutils/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     # Work around unremovable, nested dirs bug that affects lots of
     # GNU projects. See:

--- a/Formula/gzip.rb
+++ b/Formula/gzip.rb
@@ -12,6 +12,15 @@ class Gzip < Formula
     sha256 "e240320b82c71f8367a696558a4863469b52fcb0ca8245ba0f0c83483f126507" => :yosemite
   end
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/bc289fc24ab/archivers/gzip/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/m4.rb
+++ b/Formula/m4.rb
@@ -14,6 +14,15 @@ class M4 < Formula
 
   keg_only :provided_by_osx
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/edf0ee1e2cf/devel/m4/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"

--- a/Formula/nano.rb
+++ b/Formula/nano.rb
@@ -20,6 +20,15 @@ class Nano < Formula
   depends_on "gettext"
   depends_on "ncurses"
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug",


### PR DESCRIPTION
Fix crash from the usage of %n in dynamic format strings on High Sierra

This should provide a fix for some of the issues mentioned in #14418.

cc @ilovezfs