### PR TITLE
z3: install qprofdiff for HEAD

### DIFF
--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -29,6 +29,13 @@ class Z3 < Formula
       end
     end
 
+    # qprofdiff is not yet part of the source release (it will be as soon as a
+    # version is released after 4.5.0), so we only include it in HEAD builds
+    if build.head?
+      system "make", "-C", "contrib/qprofdiff"
+      bin.install "contrib/qprofdiff/qprofdiff"
+    end
+
     pkgshare.install "examples"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds the ability to install qprofdiff, which reports the difference between two z3 execution traces to debug slow queries.

Currently requires `--HEAD` because the source code for `qprofdiff` is not part of the Z3 release; this has been reported as https://github.com/Z3Prover/z3/issues/1123, and is mentioned in the formula.