### PR TITLE
gnatsd: Fix head's URL

### DIFF
--- a/Formula/gnatsd.rb
+++ b/Formula/gnatsd.rb
@@ -3,7 +3,7 @@ class Gnatsd < Formula
   homepage "https://nats.io"
   url "https://github.com/nats-io/gnatsd/archive/v0.9.6.tar.gz"
   sha256 "18d6d1b014bfd262da101e15ed914e194b51b47e3e1a8ca4e8743c742d65310c"
-  head "https://github.com/apcera/gnatsd.git"
+  head "https://github.com/nats-io/gnatsd.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The `head` URL still references `apcera`, but this was changed
long time ago to `nats-io`. An automatic redirect makes this work,
but I think it is time to update this to the proper repo URL.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
