### PR TITLE
bash-completion@2: fix legacy autocompletions path

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -3,6 +3,7 @@ class BashCompletionAT2 < Formula
   homepage "https://github.com/scop/bash-completion"
   url "https://github.com/scop/bash-completion/releases/download/2.6/bash-completion-2.6.tar.xz"
   sha256 "61fb652da0b1674443c34827263fe2335f9ddb12670bff208fc383a8955ca5ef"
+  revision 1
   head "https://github.com/scop/bash-completion.git"
 
   bottle do
@@ -13,11 +14,27 @@ class BashCompletionAT2 < Formula
   end
 
   depends_on "bash"
+  depends_on "coreutils"
+
+  # Temporarily needed as the patch modifies automake files
+  # Remove when patch is removed
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
 
   conflicts_with "bash-completion", :because => "Differing version of same formula"
 
+  # Patch to fix legacy autocompletions path
+  # Upstream issue: https://github.com/scop/bash-completion/issues/127
+  # Upstream PR: https://github.com/scop/bash-completion/pull/132
+  patch do
+    url "https://github.com/scop/bash-completion/commit/01052d3744afe41d4448d1b19dee94ea3a88dd2f.patch?full_index=1"
+    sha256 "e65a6a54d788e94daac35fb1b626b1ab3f20323443602c29baf645b769f3cb64"
+  end
+
   def install
-    inreplace "bash_completion", "readlink -f", "readlink"
+    # Temporarily needed as the patch modifies automake files
+    # Remove when patch is removed
+    system "aclocal"
 
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
     ENV.deparallelize


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Temporary patch to fix a bad legacy autocompletions path (impacts brew autocompletions like git, kubectl, etc). This was broken in version 2.6 of the upstream.

Related issues:
- https://github.com/Homebrew/homebrew-core/issues/15170
- https://github.com/Homebrew/homebrew-core/pull/15118
- https://github.com/scop/bash-completion/issues/127
- https://github.com/scop/bash-completion/issues/131
- https://github.com/scop/bash-completion/pull/132 (source of the patch)

It's worth noting the patch I'm applying as not been accepted by the upstream as of the time of this PR. However, as the issue is actively breaking homebrew installations of `bash-completion@2`, I thought it urgent to get this in.

cc: @ilovezfs 