### PR TITLE
libunistring: %n crash fix for 10.13

### DIFF
--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -12,6 +12,15 @@ class Libunistring < Formula
     sha256 "e2143b25bf7bdc85ddb00b065cf1f72c665d77a6737563cd81a88420bc72e51f" => :yosemite
   end
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Repurposed patch, credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/edf0ee1e2cf/devel/m4/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>`? (no test)

-----
Fix crash from the usage of %n in
dynamic format strings on High Sierra

Fixes build of `libunistring` on `10.13` using `Xcode 9 beta 2`. (Further tested by successfully building `gnupg`)

Part of addressing #14418

cc @mistydemeo @ilovezfs