### PR TITLE
compose2kube: remove unnecessary `go get`

### DIFF
--- a/Formula/compose2kube.rb
+++ b/Formula/compose2kube.rb
@@ -3,6 +3,7 @@ class Compose2kube < Formula
   homepage "https://github.com/kelseyhightower/compose2kube"
   url "https://github.com/kelseyhightower/compose2kube/archive/0.0.2.tar.gz"
   sha256 "d09b86994949f883c5aa4d041a12f6c5a8989f3755a2fb49a2abac2ad5380c30"
+  revision 1
   head "https://github.com/kelseyhightower/compose2kube.git"
 
   bottle do
@@ -17,7 +18,6 @@ class Compose2kube < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/kelseyhightower/compose2kube").install buildpath.children
     cd "src/github.com/kelseyhightower/compose2kube" do
-      system "go", "get"
       system "go", "build", "-o", bin/"compose2kube"
       prefix.install_metafiles
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?