### PR TITLE
mono: only build 32-bit binaries

### DIFF
--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -28,6 +28,9 @@ class MonoLibgdiplus < Formula
   depends_on "pixman"
 
   def install
+    # Mono 64-bit isn't fully supported, so let's build a 32-bit one!
+    ENV.m32
+
     system "autoreconf", "-fiv"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -38,6 +38,9 @@ class Mono < Formula
   end
 
   def install
+    # Mono 64-bit isn't fully supported, so let's build a 32-bit one!
+    ENV.m32
+
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
@@ -45,7 +48,7 @@ class Mono < Formula
       --enable-nls=no
     ]
 
-    args << "--build=" + (MacOS.prefer_64_bit? ? "x86_64": "i686") + "-apple-darwin"
+    args << "--build=i686-apple-darwin"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates mono and (some) direct dependencies to build 32-bit binaries. As discussed in #14684, [64-bit Mono is not fully supported on macOS](http://www.mono-project.com/docs/about-mono/supported-platforms/osx/#32-and-64-bit-support).

I’m not fully across the other dependencies’ requirements for linking, so this may well require further evaluation to not be a breaking change.