### PR TITLE
strongswan: enable curve25519 plugin

### DIFF
--- a/Formula/strongswan.rb
+++ b/Formula/strongswan.rb
@@ -3,6 +3,7 @@ class Strongswan < Formula
   homepage "https://www.strongswan.org"
   url "https://download.strongswan.org/strongswan-5.5.3.tar.bz2"
   sha256 "c5ea54b199174708de11af9b8f4ecf28b5b0743d4bc0e380e741f25b28c0f8d4"
+  revision 1
 
   bottle do
     sha256 "1f94fb9fbd97fb9d85203f23c14127c641f9652bd996d78d8893739fb14a6df7" => :sierra

--- a/Formula/strongswan.rb
+++ b/Formula/strongswan.rb
@@ -37,6 +37,7 @@ class Strongswan < Formula
       --enable-charon
       --enable-cmd
       --enable-constraints
+      --enable-curve25519
       --enable-eap-gtc
       --enable-eap-identity
       --enable-eap-md5


### PR DESCRIPTION
It's enabled in the default build (i.e. without `--disable-defaults`) and
the hard-coded default IKE proposal includes the _curve25519_ DH group
since strongSwan 5.5.2. So without that plugin the negotiation will fail,
unless the proposal is manually changed in the config.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
