### PR TITLE
pkg-config: fix test on 10.13

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -31,6 +31,6 @@ class PkgConfig < Formula
   end
 
   test do
-    system "#{bin}/pkg-config", "--libs", "openssl"
+    system "#{bin}/pkg-config", "--libs", "libpcre"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

/usr/lib/pkgconfig/ no longer has openssl.pc but it does have libpcre.pc