### PR TITLE
opam@2 (new formula)

### DIFF
--- a/Formula/opam@2.rb
+++ b/Formula/opam@2.rb
@@ -1,0 +1,60 @@
+class OpamAT2 < Formula
+  desc "The OCaml package manager v2.0.0 (beta)"
+  homepage "https://opam.ocaml.org"
+  url "https://github.com/ocaml/opam/releases/download/2.0.0-beta3/opam-full-2.0.0-beta3.tar.gz"
+  sha256 "83d61052b29e7c08674852f4d607e5403720c5fd85664c3b340acf9a938fd9e6"
+  head "https://github.com/ocaml/opam.git"
+
+  depends_on "ocaml" => :recommended
+
+  # aspcud has a fairly large buildtime dep tree, and uses gringo,
+  # which requires C++11 and is inconvenient to install pre-10.8
+  if MacOS.version > 10.7
+    depends_on "aspcud" => :recommended
+  else
+    depends_on "aspcud" => :optional
+  end
+
+  needs :cxx11 if build.with? "aspcud"
+
+  def install
+    ENV.deparallelize
+
+    if build.without? "ocaml"
+      system "make", "cold", "CONFIGURE_ARGS=--prefix #{prefix} --mandir #{man}"
+      ENV.prepend_path "PATH", "#{buildpath}/bootstrap/ocaml/bin"
+    else
+      system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
+      system "make", "lib-ext"
+      system "make"
+    end
+    system "make", "man"
+    system "make", "install"
+
+    bash_completion.install "shell/opam_completion.sh"
+    zsh_completion.install "shell/opam_completion_zsh.sh" => "_opam"
+  end
+
+  def caveats; <<-EOS.undent
+    OPAM uses ~/.opam by default for its package database, so you need to
+    initialize it first by running (as a normal user):
+
+    $  opam init
+
+    Run the following to initialize your environment variables:
+
+    $  eval `opam config env`
+
+    To export the needed variables every time, add them to your dotfiles.
+      * On Bash, add them to `~/.bash_profile`.
+      * On Zsh, add them to `~/.zprofile` or `~/.zshrc` instead.
+
+    Documentation and tutorials are available at https://opam.ocaml.org, or
+    via "man opam" and "opam --help".
+    EOS
+  end
+
+  test do
+    system bin/"opam", "--help"
+  end
+end


### PR DESCRIPTION
This adds the `opam@2` version formula for the OCaml package manager that installs the latest opam v2.0.0 beta in order to facilitate install and gather more end-user testing via a [simple reversible workflow](https://gist.github.com/dbuenzli/93771b7a2cfc0bf74005907ba0fc97fc#from-opam-122-to-200betaxx-and-back-with-homebrew-on-macos). The main `opam` formula remains the current stable version 1.2.2.

I hope this satisfies the [acceptable version](http://docs.brew.sh/Versions.html) formulae criterion. I do however note that `brew audit --strict --new-formula opam@2` did complain with:
```
opam@2:
  * Stable version URLs should not contain beta
```
The URL is however a stable, non-vcs produced, tarball (see [here](https://github.com/ocaml/opam/releases/tag/2.0.0-beta3)). It is planned to update this URL with subsequent `beta` and `rc` tarballs (produced in a similar fashion) and eventually replace it with the final version tarball.

/cc @avsm @AltGr 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? Yes modulo the caveat mentioned above.

-----
