### PR TITLE
Erlang: apply patch for macOS 10.13 BoringSSL issue.

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -42,6 +42,16 @@ class Erlang < Formula
     sha256 "1ab25110b148ce263d6e68cd5a3b912299b6066cfcd9d2fce416a4e9b7d2543a"
   end
 
+  # Check if this patch can be removed when OTP 20.1 is released.
+  # Erlang will crash on macOS 10.13 any time the crypto lib is used.
+  # The Erlang team has an open PR for the patch but it needs to be applied to
+  # older releases. See https://github.com/erlang/otp/pull/1501 and
+  # https://bugs.erlang.org/browse/ERL-439 for additional information.
+  patch do
+    url "https://github.com/erlang/otp/pull/1501.patch?full_index=1"
+    sha256 "e449d698a82e07eddfd86b5b06a0b4ab8fb4674cb72fc6ab037aa79b096f0a12"
+  end
+
   def install
     # Unset these so that building wx, kernel, compiler and
     # other modules doesn't fail with an unintelligable error.

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -28,6 +28,16 @@ class ErlangAT18 < Formula
   depends_on :java => :optional
   depends_on "wxmac" => :recommended # for GUI apps like observer
 
+  # Check if this patch can be removed when OTP 18.3.5 is released.
+  # Erlang will crash on macOS 10.13 any time the crypto lib is used.
+  # The Erlang team has an open PR for the patch but it needs to be applied to
+  # older releases. See https://github.com/erlang/otp/pull/1501 and
+  # https://bugs.erlang.org/browse/ERL-439 for additional information.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/774ad1f/erlang%4018/boring-ssl-high-sierra.patch"
+    sha256 "7cc1069a2d9418a545e12981c6d5c475e536f58207a1faf4b721cc33692657ac"
+  end
+
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_18.3.tar.gz"
     sha256 "978be100e9016874921b3ad1a65ee46b7b6a1e597b8db2ec4b5ef436d4c9ecc2"

--- a/Formula/erlang@19.rb
+++ b/Formula/erlang@19.rb
@@ -32,6 +32,16 @@ class ErlangAT19 < Formula
   depends_on :java => :optional
   depends_on "wxmac" => :recommended # for GUI apps like observer
 
+  # Check if this patch can be removed when OTP 19.4 is released.
+  # Erlang will crash on macOS 10.13 any time the crypto lib is used.
+  # The Erlang team has an open PR for the patch but it needs to be applied to
+  # older releases. See https://github.com/erlang/otp/pull/1501 and
+  # https://bugs.erlang.org/browse/ERL-439 for additional information.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/1f4a770/erlang%4019/boring-ssl-high-sierra.patch"
+    sha256 "5aae52e7947db400a7798e8cda6e33e30088edf816e842cb09974b92c6b5eba6"
+  end
+
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_19.3.tar.gz"
     mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/erlang/otp_doc_man_19.3.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR applies the patch to erlang and applies a backported version of the patch to erlang@19.

I think we need to apply the patch now because this won't be fixed until the next official release at best, and pretty much _any usage of erlang crypto will crash_  on 10.13.

I have built and tested on 10.12 as well as 10.13 although note that if you are using a fresh install of 10.13 you will need to use the prerelease build of the wxmac dependency (only for 10.13) or to install the dependency from a cask.