### PR TITLE
lftp: %n crash fix for 10.13

### DIFF
--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -15,6 +15,15 @@ class Lftp < Formula
   depends_on "openssl"
   depends_on "libidn"
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Repurposed patch, credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/edf0ee1e2cf/devel/m4/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fix crash from the usage of %n in
dynamic format strings on High Sierra

Fixes build of `lftp` on `10.13` using `Xcode 9 beta 2`.

Part of addressing #14418 

cc @ilovezfs