### PR TITLE
Pilosa: Add build step that generates static media assets for WebUI

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -71,6 +71,7 @@ class Pilosa < Formula
       end
       sleep 0.5
       assert_match("Welcome. Pilosa is running.", shell_output("curl localhost:10101"))
+      assert_match("<!DOCTYPE html>", shell_output("curl --user-agent NotCurl localhost:10101"))
     ensure
       Process.kill "TERM", server
       Process.wait server


### PR DESCRIPTION
This uses `statik` to generate Go files containing the static media assets needed to display the [Pilosa WebUI](https://www.pilosa.com/docs/webui/). This allows the WebUI to be accessed by HTTP on port 10101 after invoking `pilosa server`.

This fixes pilosa/general#27.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
