### PR TITLE
makensis: Add optional support for large strings

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -45,11 +45,12 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    if build.with? "large-strings"
-      scons "NSIS_MAX_STRLEN=8192", "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
-    else
-      scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
-    end
+    args = %W[STRIP=0]
+    args << "SKIPUTILS=NSIS Menu"
+    args << "ZLIB_W32=#{@zlib_path}"
+    args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
+    args << "makensis"
+    scons *args
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")
   end

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -68,12 +68,12 @@ index a344456..37c575b 100755
 +import os
 +
  Import('defenv')
-
+ 
  ### Configuration options
 @@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
  env = Environment()
  cfg.Update(env)
-
+ 
 +defenv['CC'] = os.environ['CC']
 +defenv['CXX'] = os.environ['CXX']
 +

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -45,9 +45,8 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    args = %W[STRIP=0]
+    args = %W[STRIP=0 ZLIB_W32=#{@zlib_path}]
     args << "SKIPUTILS=NSIS Menu"
-    args << "ZLIB_W32=#{@zlib_path}"
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     args << "makensis"
     scons *args

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -45,11 +45,9 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    args = %W[STRIP=0 ZLIB_W32=#{@zlib_path}]
-    args << "SKIPUTILS=NSIS Menu"
+    args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu"] 
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
-    args << "makensis"
-    scons *args
+    scons "makensis", *args
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")
   end

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -12,6 +12,9 @@ class Makensis < Formula
     sha256 "5c116395f0a53447856051885ef9c606e60ab8925cb9ec97a21cf72c2c90097d" => :yosemite
   end
 
+  # From http://nsis.sourceforge.net/Special_Builds#Large_strings
+  option "with-large-strings", "Enable strings up to 8192 characters instead of default 1024"
+
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
 
@@ -42,7 +45,11 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
+    if build.with? "large-strings"
+      scons "NSIS_MAX_STRLEN=8192", "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
+    else
+      scons "STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu", "makensis"
+    end
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")
   end
@@ -61,12 +68,12 @@ index a344456..37c575b 100755
 +import os
 +
  Import('defenv')
- 
+
  ### Configuration options
 @@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
  env = Environment()
  cfg.Update(env)
- 
+
 +defenv['CC'] = os.environ['CC']
 +defenv['CXX'] = os.environ['CXX']
 +

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -48,7 +48,7 @@ class Makensis < Formula
     end
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu"] 
+    args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu"]
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     scons "makensis", *args
     bin.install "build/urelease/makensis/makensis"

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -12,7 +12,10 @@ class Makensis < Formula
     sha256 "5c116395f0a53447856051885ef9c606e60ab8925cb9ec97a21cf72c2c90097d" => :yosemite
   end
 
+  # Build makensis so installers can handle strings > 1024 characters
   # From http://nsis.sourceforge.net/Special_Builds#Large_strings
+  # Upstream RFE to make this default the default behavior is
+  # https://sourceforge.net/p/nsis/feature-requests/542/
   option "with-large-strings", "Enable strings up to 8192 characters instead of default 1024"
 
   depends_on "mingw-w64" => :build

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -13,7 +13,7 @@ class Makensis < Formula
   end
 
   # Build makensis so installers can handle strings > 1024 characters
-  # From http://nsis.sourceforge.net/Special_Builds#Large_strings
+  # From https://nsis.sourceforge.io/Special_Builds#Large_strings
   # Upstream RFE to make this default the default behavior is
   # https://sourceforge.net/p/nsis/feature-requests/542/
   option "with-large-strings", "Enable strings up to 8192 characters instead of default 1024"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Adds optional support to create the ["Large Strings" special build](http://nsis.sourceforge.net/Special_Builds#Large_strings) for the current version of makensis.