### PR TITLE
Use https://deb.debian.org for all Debian mirrors

### DIFF
--- a/Formula/abcde.rb
+++ b/Formula/abcde.rb
@@ -2,7 +2,7 @@ class Abcde < Formula
   desc "Better CD Encoder"
   homepage "https://abcde.einval.com"
   url "https://abcde.einval.com/download/abcde-2.8.1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/abcde/abcde_2.8.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/a/abcde/abcde_2.8.1.orig.tar.gz"
   sha256 "e49c71d7ddcd312dcc819c3be203abd3d09d286500ee777cde434c7881962b39"
   revision 1
   head "https://git.einval.com/git/abcde.git"

--- a/Formula/aiccu.rb
+++ b/Formula/aiccu.rb
@@ -2,8 +2,7 @@ class Aiccu < Formula
   desc "Automatic IPv6 Connectivity Client Utility"
   homepage "https://www.sixxs.net/tools/aiccu/"
   # Upstream 402s when passed a non-standard User-Agent such as Homebrew's
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/aiccu/aiccu_20070115.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/aiccu/aiccu_20070115.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/a/aiccu/aiccu_20070115.orig.tar.gz"
   version "20070115"
   sha256 "d23cf50a16fa842242c97683c3c1c1089a7a4964e3eaba97ad1f17110fdfe3cc"
 

--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -3,8 +3,7 @@ class Analog < Formula
   homepage "https://tracker.debian.org/pkg/analog"
   # The previous long-time homepage and url are stone-cold dead. Using Debian instead.
   # homepage "http://analog.cx"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
   sha256 "31c0e2bedd0968f9d4657db233b20427d8c497be98194daf19d6f859d7f6fcca"
   revision 1
 

--- a/Formula/apachetop.rb
+++ b/Formula/apachetop.rb
@@ -1,8 +1,7 @@
 class Apachetop < Formula
   desc "Top-like display of Apache log"
   homepage "http://freecode.com/projects/apachetop"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz"
   sha256 "850062414517055eab2440b788b503d45ebe9b290d4b2e027a5f887ad70f3f29"
 
   bottle do

--- a/Formula/audiofile.rb
+++ b/Formula/audiofile.rb
@@ -10,8 +10,7 @@ class Audiofile < Formula
     # Fixes CVE-2015-7747. Fixed upstream but doesn't apply cleanly.
     # https://github.com/mpruett/audiofile/commit/b62c902dd258125cac86cd2df21fc898035a43d3
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
+      url "https://deb.debian.org/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
       sha256 "0620675a52bdb40b775980cc1820e308df329348bb847f9a4a8361b3799fa241"
       apply "patches/03_CVE-2015-7747.patch"
     end
@@ -54,8 +53,7 @@ class Audiofile < Formula
   # https://github.com/mpruett/audiofile/issues/41
   # https://github.com/mpruett/audiofile/pull/42
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/a/audiofile/audiofile_0.3.6-4.debian.tar.xz"
     sha256 "0620675a52bdb40b775980cc1820e308df329348bb847f9a4a8361b3799fa241"
     apply "patches/04_clamp-index-values-to-fix-index-overflow-in-IMA.cpp.patch",
           "patches/05_Always-check-the-number-of-coefficients.patch",

--- a/Formula/autossh.rb
+++ b/Formula/autossh.rb
@@ -2,7 +2,7 @@ class Autossh < Formula
   desc "Automatically restart SSH sessions and tunnels"
   homepage "http://www.harding.motd.ca/autossh/"
   url "http://www.harding.motd.ca/autossh/autossh-1.4e.tgz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/a/autossh/autossh_1.4e.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/a/autossh/autossh_1.4e.orig.tar.gz"
   sha256 "9e8e10a59d7619176f4b986e256f776097a364d1be012781ea52e08d04679156"
 
   bottle do

--- a/Formula/babl.rb
+++ b/Formula/babl.rb
@@ -2,7 +2,7 @@ class Babl < Formula
   desc "Dynamic, any-to-any, pixel format translation library"
   homepage "http://www.gegl.org/babl/"
   url "https://download.gimp.org/pub/babl/0.1/babl-0.1.28.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/b/babl/babl_0.1.28.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/b/babl/babl_0.1.28.orig.tar.bz2"
   sha256 "63f3ed23e72a857a0e6df53d9d968a325024177b01edbe314a0c98b499eb8603"
 
   bottle do

--- a/Formula/bokken.rb
+++ b/Formula/bokken.rb
@@ -22,13 +22,13 @@ class Bokken < Formula
   depends_on "radare2"
 
   resource "distorm64" do
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/distorm64/distorm64_1.7.30.orig.tar.gz"
+    url "https://deb.debian.org/debian/pool/main/d/distorm64/distorm64_1.7.30.orig.tar.gz"
     sha256 "98b218e5a436226c5fb30d3b27fcc435128b4e28557c44257ed2ba66bb1a9cf1"
   end
 
   resource "pyew" do
     # Upstream only provides binary packages so pull from Debian.
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/pyew/pyew_2.0.orig.tar.gz"
+    url "https://deb.debian.org/debian/pool/main/p/pyew/pyew_2.0.orig.tar.gz"
     sha256 "64a4dfb1850efbe2c9b06108697651f9ff25223fd132eec66c6fe84d5ecc17ae"
   end
 

--- a/Formula/bzrtools.rb
+++ b/Formula/bzrtools.rb
@@ -2,7 +2,7 @@ class Bzrtools < Formula
   desc "Bazaar plugin that supplies useful additional utilities"
   homepage "http://wiki.bazaar.canonical.com/BzrTools"
   url "https://launchpad.net/bzrtools/stable/2.6.0/+download/bzrtools-2.6.0.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/b/bzrtools/bzrtools_2.6.0.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/b/bzrtools/bzrtools_2.6.0.orig.tar.gz"
   sha256 "8b17fbba61dafc8dbefe1917a2ce084a8adc7650dee60add340615270dfb7f58"
 
   bottle :unneeded

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -1,8 +1,7 @@
 class Castxml < Formula
   desc "C-family Abstract Syntax Tree XML Output"
   homepage "https://github.com/CastXML/CastXML"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20161215.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20161215.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20161215.orig.tar.xz"
   version "0.1+git20161215"
   sha256 "6710486f72ea32020d30e04ff9d6e629a94b79d4fb10b834f93d3f87ebd9c091"
   revision 1

--- a/Formula/ccrypt.rb
+++ b/Formula/ccrypt.rb
@@ -2,7 +2,7 @@ class Ccrypt < Formula
   desc "Encrypt and decrypt files and streams"
   homepage "https://ccrypt.sourceforge.io/"
   url "https://ccrypt.sourceforge.io/download/ccrypt-1.10.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/ccrypt/ccrypt_1.10.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/ccrypt/ccrypt_1.10.orig.tar.gz"
   sha256 "87d66da2170facabf6f2fc073586ae2c7320d4689980cfca415c74688e499ba0"
 
   bottle do

--- a/Formula/ccze.rb
+++ b/Formula/ccze.rb
@@ -1,8 +1,7 @@
 class Ccze < Formula
   desc "Robust and modular log colorizer"
   homepage "https://packages.debian.org/wheezy/ccze"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
   sha256 "8263a11183fd356a033b6572958d5a6bb56bfd2dba801ed0bff276cfae528aa3"
   revision 1
 

--- a/Formula/cd-discid.rb
+++ b/Formula/cd-discid.rb
@@ -6,7 +6,7 @@ class CdDiscid < Formula
 
   stable do
     url "http://linukz.org/download/cd-discid-1.4.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/cd-discid/cd-discid_1.4.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/c/cd-discid/cd-discid_1.4.orig.tar.gz"
     sha256 "ffd68cd406309e764be6af4d5cbcc309e132c13f3597c6a4570a1f218edd2c63"
 
     # macOS fix; see https://github.com/Homebrew/homebrew/issues/46267

--- a/Formula/cmatrix.rb
+++ b/Formula/cmatrix.rb
@@ -2,7 +2,7 @@ class Cmatrix < Formula
   desc "Console Matrix"
   homepage "https://www.asty.org/cmatrix/"
   url "https://www.asty.org/cmatrix/dist/cmatrix-1.2a.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/cmatrix/cmatrix_1.2a.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/cmatrix/cmatrix_1.2a.orig.tar.gz"
   sha256 "1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c"
 
   bottle do

--- a/Formula/corkscrew.rb
+++ b/Formula/corkscrew.rb
@@ -1,8 +1,7 @@
 class Corkscrew < Formula
   desc "Tunnel SSH through HTTP proxies"
   homepage "https://packages.debian.org/sid/corkscrew"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
   sha256 "0d0fcbb41cba4a81c4ab494459472086f377f9edb78a2e2238ed19b58956b0be"
 
   bottle do

--- a/Formula/cproto.rb
+++ b/Formula/cproto.rb
@@ -2,7 +2,7 @@ class Cproto < Formula
   desc "Generate function prototypes for functions in input files"
   homepage "http://invisible-island.net/cproto"
   url "ftp://invisible-island.net/cproto/cproto-4.7m.tgz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/cproto/cproto_4.7m.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/cproto/cproto_4.7m.orig.tar.gz"
   sha256 "4b482e80f1b492e94f8dcda74d25a7bd0381c870eb500c18e7970ceacdc07c89"
 
   bottle do

--- a/Formula/cxxtest.rb
+++ b/Formula/cxxtest.rb
@@ -2,7 +2,7 @@ class Cxxtest < Formula
   desc "xUnit-style unit testing framework for C++"
   homepage "http://cxxtest.com"
   url "https://github.com/CxxTest/cxxtest/releases/download/4.4/cxxtest-4.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/cxxtest/cxxtest_4.4.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/cxxtest/cxxtest_4.4.orig.tar.gz"
   sha256 "1c154fef91c65dbf1cd4519af7ade70a61d85a923b6e0c0b007dc7f4895cf7d8"
 
   bottle do

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -3,7 +3,7 @@ class Dbus < Formula
   desc "Message bus system, providing inter-application communication"
   homepage "https://wiki.freedesktop.org/www/Software/dbus"
   url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.20.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.20.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dbus/dbus_1.10.20.orig.tar.gz"
   sha256 "e574b9780b5425fde4d973bb596e7ea0f09e00fe2edd662da9016e976c460b48"
 
   bottle do
@@ -14,7 +14,7 @@ class Dbus < Formula
 
   devel do
     url "https://dbus.freedesktop.org/releases/dbus/dbus-1.11.14.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.11.14.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/d/dbus/dbus_1.11.14.orig.tar.gz"
     sha256 "55cfc7fdd2cccb2fce1f75d2132ad4801b5ed6699fc2ce79ed993574adf90c80"
 
     depends_on "coreutils" => :build

--- a/Formula/debianutils.rb
+++ b/Formula/debianutils.rb
@@ -1,8 +1,7 @@
 class Debianutils < Formula
   desc "Miscellaneous utilities specific to Debian"
   homepage "https://packages.debian.org/sid/debianutils"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/debianutils/debianutils_4.8.1.1.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/debianutils/debianutils_4.8.1.1.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/d/debianutils/debianutils_4.8.1.1.tar.xz"
   sha256 "06446cd4c0d309fd31a0682c5c2f07f7613fb867f769414b9cc51f155ad73172"
 
   bottle do

--- a/Formula/delta.rb
+++ b/Formula/delta.rb
@@ -1,8 +1,7 @@
 class Delta < Formula
   desc "Programatically minimize files to isolate features of interest"
   homepage "http://delta.tigris.org/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
   sha256 "38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0"
 
   bottle do

--- a/Formula/dhcpdump.rb
+++ b/Formula/dhcpdump.rb
@@ -2,7 +2,7 @@ class Dhcpdump < Formula
   desc "Monitor DHCP traffic for debugging purposes"
   homepage "http://www.mavetju.org"
   url "http://www.mavetju.org/download/dhcpdump-1.8.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
   sha256 "6d5eb9418162fb738bc56e4c1682ce7f7392dd96e568cc996e44c28de7f77190"
 
   bottle do

--- a/Formula/dhcping.rb
+++ b/Formula/dhcping.rb
@@ -2,7 +2,7 @@ class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
   homepage "http://www.mavetju.org/unix/general.php"
   url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 
   bottle do

--- a/Formula/diffstat.rb
+++ b/Formula/diffstat.rb
@@ -1,8 +1,7 @@
 class Diffstat < Formula
   desc "Produce graph of changes introduced by a diff file"
   homepage "http://invisible-island.net/diffstat/"
-  url "https://mirrors.kernel.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz"
   sha256 "25359e0c27183f997b36c9202583b5dc2df390c20e22a92606af4bf7856a55ee"
 
   bottle do
@@ -26,10 +25,10 @@ class Diffstat < Formula
       --- a/diffstat.rb
       +++ b/diffstat.rb
       @@ -2,9 +2,8 @@
-      -  url 'https://mirrors.kernel.org/debian/pool/main/d/diffstat/diffstat_1.58.orig.tar.gz'
+      -  url 'https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.58.orig.tar.gz'
       -  version '1.58'
       -  sha256 'fad5135199c3b9aea132c5d45874248f4ce0ff35f61abb8d03c3b90258713793'
-      +  url 'https://mirrors.kernel.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz'
+      +  url 'https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz'
       +  sha256 '25359e0c27183f997b36c9202583b5dc2df390c20e22a92606af4bf7856a55ee'
     EOS
     output = `#{bin}/diffstat diff.diff`

--- a/Formula/dirac.rb
+++ b/Formula/dirac.rb
@@ -3,7 +3,7 @@ class Dirac < Formula
   homepage "https://sourceforge.net/projects/dirac/"
   url "https://downloads.sourceforge.net/project/dirac/dirac-codec/Dirac-1.0.2/dirac-1.0.2.tar.gz"
   mirror "https://launchpad.net/ubuntu/+archive/primary/+files/dirac_1.0.2.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dirac/dirac_1.0.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dirac/dirac_1.0.2.orig.tar.gz"
   sha256 "816b16f18d235ff8ccd40d95fc5b4fad61ae47583e86607932929d70bf1f00fd"
 
   bottle do

--- a/Formula/dnstracer.rb
+++ b/Formula/dnstracer.rb
@@ -2,7 +2,7 @@ class Dnstracer < Formula
   desc "Trace a chain of DNS servers to the source"
   homepage "http://www.mavetju.org/unix/dnstracer.php"
   url "http://www.mavetju.org/download/dnstracer-1.9.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
 
   bottle do

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -5,7 +5,7 @@ class Dpkg < Formula
   # dpkg site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
   url "https://dl.bintray.com/homebrew/mirror/dpkg-1.18.24.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dpkg/dpkg_1.18.24.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.18.24.tar.xz"
   sha256 "d853081d3e06bfd46a227056e591f094e42e78fa8a5793b0093bad30b710d7b4"
 
   bottle do

--- a/Formula/dtc.rb
+++ b/Formula/dtc.rb
@@ -1,8 +1,7 @@
 class Dtc < Formula
   desc "Device tree compiler"
   homepage "https://www.devicetree.org/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.0+dfsg.orig.tar.gz"
   version "1.4.0"
   sha256 "f5f9a1aea478ee6dbcece8907fd4551058fe72fc2c2a7be972e3d0b7eec4fa43"
 

--- a/Formula/dvorak7min.rb
+++ b/Formula/dvorak7min.rb
@@ -1,8 +1,7 @@
 class Dvorak7min < Formula
   desc "Dvorak (simplified keyboard layout) typing tutor"
   homepage "http://dvorak7min.sourcearchive.com/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
   version "1.6.1"
   sha256 "4cdef8e4c8c74c28dacd185d1062bfa752a58447772627aded9ac0c87a3b8797"
 

--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -21,8 +21,7 @@ class Exim < Formula
   # Patch applied upstream but doesn't apply cleanly from git.
   # https://github.com/Exim/exim/commit/65e061b76867a9ea7aeeb535341b790b90ae6c21
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/e/exim4/exim4_4.89-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/e/exim4/exim4_4.89-3.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/e/exim4/exim4_4.89-3.debian.tar.xz"
     sha256 "6440231912f6ead8097c94deb90524f9a0d1413447ba9ff3a734c4359e2aff3c"
     apply "patches/79_CVE-2017-1000369.patch"
   end

--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -1,8 +1,7 @@
 class Fakeroot < Formula
   desc "Provide a fake root environment"
   homepage "https://tracker.debian.org/pkg/fakeroot"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
+  url "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.20.2.orig.tar.bz2"
   sha256 "7c0a164d19db3efa9e802e0fc7cdfeff70ec6d26cdbdc4338c9c2823c5ea230c"
 
   bottle do

--- a/Formula/fetch-crl.rb
+++ b/Formula/fetch-crl.rb
@@ -2,7 +2,7 @@ class FetchCrl < Formula
   desc "Retrieve certificate revocation lists (CRLs)"
   homepage "https://wiki.nikhef.nl/grid/FetchCRL3"
   url "https://dist.eugridpma.info/distribution/util/fetch-crl3/fetch-crl-3.0.19.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fetch-crl/fetch-crl_3.0.19.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/f/fetch-crl/fetch-crl_3.0.19.orig.tar.gz"
   sha256 "64d8f573601568554415c9ad853864285313538a90de92b3dcf2d16b92b2bcde"
 
   bottle do

--- a/Formula/ffms2.rb
+++ b/Formula/ffms2.rb
@@ -2,7 +2,7 @@ class Ffms2 < Formula
   desc "Libav/ffmpeg based source library and Avisynth plugin"
   homepage "https://github.com/FFMS/ffms2"
   url "https://github.com/FFMS/ffms2/archive/2.23.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/ffms2/ffms2_2.23.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/f/ffms2/ffms2_2.23.orig.tar.gz"
   sha256 "b09b2aa2b1c6f87f94a0a0dd8284b3c791cbe77f0f3df57af99ddebcd15273ed"
 
   bottle do

--- a/Formula/freealut.rb
+++ b/Formula/freealut.rb
@@ -1,8 +1,7 @@
 class Freealut < Formula
   desc "Implementation of OpenAL's ALUT standard"
   homepage "https://github.com/vancegroup/freealut"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   sha256 "60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
 
   bottle do

--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -2,7 +2,7 @@ class Gegl < Formula
   desc "Graph based image processing framework"
   homepage "http://www.gegl.org/"
   url "https://download.gimp.org/pub/gegl/0.3/gegl-0.3.18.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/g/gegl/gegl_0.3.18.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/g/gegl/gegl_0.3.18.orig.tar.bz2"
   sha256 "d7858ef26ede136d14e3de188a9e9c0de7707061a9fb96d7d615fab4958491fb"
 
   bottle do

--- a/Formula/geomview.rb
+++ b/Formula/geomview.rb
@@ -1,7 +1,7 @@
 class Geomview < Formula
   desc "Interactive 3D viewing program"
   homepage "http://www.geomview.org"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/geomview/geomview_1.9.5.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/g/geomview/geomview_1.9.5.orig.tar.gz"
   mirror "https://downloads.sourceforge.net/project/geomview/geomview/1.9.5/geomview-1.9.5.tar.gz"
   sha256 "67edb3005a22ed2bf06f0790303ee3f523011ba069c10db8aef263ac1a1b02c0"
   revision 1

--- a/Formula/gpa.rb
+++ b/Formula/gpa.rb
@@ -2,7 +2,7 @@ class Gpa < Formula
   desc "Graphical user interface for the GnuPG"
   homepage "https://www.gnupg.org/related_software/gpa/"
   url "https://gnupg.org/ftp/gcrypt/gpa/gpa-0.9.10.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/gpa/gpa_0.9.10.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/g/gpa/gpa_0.9.10.orig.tar.bz2"
   sha256 "c3b9cc36fd9916e83524930f99df13b1d5f601f4c0168cb9f5d81422e282b727"
 
   bottle do

--- a/Formula/grace.rb
+++ b/Formula/grace.rb
@@ -1,7 +1,7 @@
 class Grace < Formula
   desc "WYSIWYG 2D plotting tool for X11"
   homepage "http://plasma-gate.weizmann.ac.il/Grace/"
-  url "https://mirrors.kernel.org/debian/pool/main/g/grace/grace_5.1.25.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/g/grace/grace_5.1.25.orig.tar.gz"
   sha256 "751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac"
   revision 1
 

--- a/Formula/grib-api.rb
+++ b/Formula/grib-api.rb
@@ -1,8 +1,7 @@
 class GribApi < Formula
   desc "Encode and decode grib messages (editions 1 and 2)"
   homepage "https://software.ecmwf.int/wiki/display/GRIB/Home"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/grib-api/grib-api_1.19.0.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/g/grib-api/grib-api_1.19.0.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/g/grib-api/grib-api_1.19.0.orig.tar.xz"
   sha256 "c234a0a6d551a79ac77eae86b5effaa82c96dfc16ba6a8e7570067d83f1f6326"
   revision 1
 

--- a/Formula/hexedit.rb
+++ b/Formula/hexedit.rb
@@ -3,7 +3,7 @@ class Hexedit < Formula
   # Homepage/URL down since at least Jan 2016.
   homepage "http://rigaux.org/hexedit.html"
   url "http://rigaux.org/hexedit-1.2.13.src.tgz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/h/hexedit/hexedit_1.2.13.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/h/hexedit/hexedit_1.2.13.orig.tar.gz"
   sha256 "6a126da30a77f5c0b08038aa7a881d910e3b65d13767fb54c58c983963b88dd7"
 
   bottle do

--- a/Formula/html-xml-utils.rb
+++ b/Formula/html-xml-utils.rb
@@ -2,7 +2,7 @@ class HtmlXmlUtils < Formula
   desc "Tools for manipulating HTML and XML files"
   homepage "https://www.w3.org/Tools/HTML-XML-utils/"
   url "https://www.w3.org/Tools/HTML-XML-utils/html-xml-utils-7.1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/h/html-xml-utils/html-xml-utils_7.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/h/html-xml-utils/html-xml-utils_7.1.orig.tar.gz"
   sha256 "ec0efd2263b864bb7e0ae5c59f02c43c5d8aebd0e1c0d2bfce391e665766d56e"
 
   bottle do

--- a/Formula/icon-naming-utils.rb
+++ b/Formula/icon-naming-utils.rb
@@ -4,8 +4,7 @@ class IconNamingUtils < Formula
   # Upstream seem to have enabled by default SSL/TLS across whole domain which
   # is problematic when the cert is for www rather than a wildcard or similar.
   # url "http://tango.freedesktop.org/releases/icon-naming-utils-0.8.90.tar.gz"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
   sha256 "044ab2199ed8c6a55ce36fd4fcd8b8021a5e21f5bab028c0a7cdcf52a5902e1c"
 
   bottle do

--- a/Formula/intercal.rb
+++ b/Formula/intercal.rb
@@ -2,7 +2,7 @@ class Intercal < Formula
   desc "Esoteric, parody programming language"
   homepage "http://catb.org/~esr/intercal/"
   url "http://catb.org/~esr/intercal/intercal-0.30.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/i/intercal/intercal_0.30.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/intercal/intercal_0.30.orig.tar.gz"
   sha256 "b38b62a61a3cb5b0d3ce9f2d09c97bd74796979d532615073025a7fff6be1715"
   revision 1
 

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -2,7 +2,7 @@ class Ipmitool < Formula
   desc "Utility for IPMI control with kernel driver or LAN interface"
   homepage "https://ipmitool.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
   revision 1
 

--- a/Formula/iprint.rb
+++ b/Formula/iprint.rb
@@ -1,8 +1,7 @@
 class Iprint < Formula
   desc "Provides a print_one function"
   homepage "https://www.samba.org/ftp/unpacked/junkcode/i.c"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
   version "1.3-9"
   sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
 
@@ -16,8 +15,7 @@ class Iprint < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
     sha256 "3a1ff260e6d639886c005ece754c2c661c0d3ad7f1f127ddb2943c092e18ab74"
   end
 

--- a/Formula/ircii.rb
+++ b/Formula/ircii.rb
@@ -2,8 +2,8 @@ class Ircii < Formula
   desc "IRC and ICB client"
   homepage "http://www.eterna.com.au/ircii/"
   url "https://ircii.warped.com/ircii-20151120.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ircii/ircii_20151120.orig.tar.bz2"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/ircii/ircii_20151120.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/i/ircii/ircii_20151120.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/i/ircii/ircii_20151120.orig.tar.bz2"
   sha256 "5dfd3fd364a96960e1f57ade4d755474556858653e4ce64265599520378c5f65"
 
   bottle do

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -2,7 +2,7 @@ class Irssi < Formula
   desc "Modular IRC client"
   homepage "https://irssi.org/"
   url "https://github.com/irssi/irssi/releases/download/1.0.3/irssi-1.0.3.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/irsssi_1.0.3.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/i/irsssi_1.0.3.orig.tar.xz"
   sha256 "838220297dcbe7c8c42d01005059779a82f5b7b7e7043db37ad13f5966aff581"
 
   bottle do

--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -8,7 +8,7 @@ class Isl < Formula
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
   url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
   sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
 
   bottle do

--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -2,7 +2,7 @@ class Ispell < Formula
   desc "International Ispell"
   homepage "https://lasr.cs.ucla.edu/geoff/ispell.html"
   url "https://www.cs.hmc.edu/~geoff/tars/ispell-3.4.00.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/i/ispell/ispell_3.4.00.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/ispell/ispell_3.4.00.orig.tar.gz"
   sha256 "5dc42e458635f218032d3ae929528e5587b1e7247564f0e9f9d77d5ccab7aec2"
 
   bottle do

--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -16,8 +16,7 @@ class Jbig2dec < Formula
 
   # These are all upstream already, remove on next release.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.1.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.1.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/j/jbig2dec/jbig2dec_0.13-4.1.debian.tar.xz"
     sha256 "41114245b7410a03196c5f7def10efa78c9da12b4bac9d21d6fbe96ded4232dd"
     apply "patches/020160518~1369359.patch",
           "patches/020161212~e698d5c.patch",

--- a/Formula/jbigkit.rb
+++ b/Formula/jbigkit.rb
@@ -2,7 +2,7 @@ class Jbigkit < Formula
   desc "JBIG1 data compression standard implementation"
   homepage "https://www.cl.cam.ac.uk/~mgk25/jbigkit/"
   url "https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/jbigkit-2.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/j/jbigkit/jbigkit_2.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/j/jbigkit/jbigkit_2.1.orig.tar.gz"
   sha256 "de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"
 
   head "https://www.cl.cam.ac.uk/~mgk25/git/jbigkit",

--- a/Formula/jed.rb
+++ b/Formula/jed.rb
@@ -2,7 +2,7 @@ class Jed < Formula
   desc "Powerful editor for programmers"
   homepage "http://www.jedsoft.org/jed/"
   url "http://www.jedsoft.org/releases/jed/jed-0.99-19.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/j/jed/jed_0.99.19.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/j/jed/jed_0.99.19.orig.tar.gz"
   sha256 "5eed5fede7a95f18b33b7b32cb71be9d509c6babc1483dd5c58b1a169f2bdf52"
 
   bottle do

--- a/Formula/jhead.rb
+++ b/Formula/jhead.rb
@@ -20,8 +20,7 @@ class Jhead < Formula
   patch :DATA
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
     sha256 "d2553bb7e7e47c33fa1136841e4b5bfbad6b92edce1dcad639ab5d74ace606aa"
     apply "patches/31_CVE-2016-3822"
   end

--- a/Formula/jnettop.rb
+++ b/Formula/jnettop.rb
@@ -3,8 +3,7 @@ class Jnettop < Formula
   # http://jnettop.kubs.info/ is offline
   homepage "https://packages.debian.org/sid/net/jnettop"
   # http://jnettop.kubs.info/dist/jnettop-0.13.0.tar.gz is offline
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jnettop/jnettop_0.13.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jnettop/jnettop_0.13.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/j/jnettop/jnettop_0.13.0.orig.tar.gz"
   sha256 "e987a1a9325595c8a0543ab61cf3b6d781b4faf72dd0e0e0c70b2cc2ceb5a5a0"
 
   bottle do

--- a/Formula/jpegoptim.rb
+++ b/Formula/jpegoptim.rb
@@ -2,7 +2,7 @@ class Jpegoptim < Formula
   desc "Utility to optimize JPEG files"
   homepage "https://github.com/tjko/jpegoptim"
   url "https://github.com/tjko/jpegoptim/archive/RELEASE.1.4.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/j/jpegoptim/jpegoptim_1.4.4.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/j/jpegoptim/jpegoptim_1.4.4.orig.tar.gz"
   sha256 "bc6b018ae8c3eb12d07596693d54243e214780a2a2303a6578747d3671f45da3"
   head "https://github.com/tjko/jpegoptim.git"
 

--- a/Formula/jxrlib.rb
+++ b/Formula/jxrlib.rb
@@ -1,8 +1,7 @@
 class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
   homepage "https://jxrlib.codeplex.com/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   sha256 "c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303"
   head "https://git01.codeplex.com/jxrlib", :using => :git
 

--- a/Formula/lbdb.rb
+++ b/Formula/lbdb.rb
@@ -2,7 +2,7 @@ class Lbdb < Formula
   desc "Little brother's database for the mutt mail reader"
   homepage "https://www.spinnaker.de/lbdb/"
   url "https://www.spinnaker.de/debian/lbdb_0.42.1.tar.xz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/l/lbdb/lbdb_0.42.1.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/l/lbdb/lbdb_0.42.1.tar.xz"
   sha256 "fe03bfc922b06febd8da261003070e335680d7fdf9ebd513c04a92a37731df2d"
 
   bottle do

--- a/Formula/lcrack.rb
+++ b/Formula/lcrack.rb
@@ -1,8 +1,7 @@
 class Lcrack < Formula
   desc "Generic password cracker"
   homepage "https://packages.debian.org/sid/lcrack"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
   version "20040914"
   sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
 

--- a/Formula/ldapvi.rb
+++ b/Formula/ldapvi.rb
@@ -2,7 +2,7 @@ class Ldapvi < Formula
   desc "Update LDAP entries with a text editor"
   homepage "http://www.lichteblau.com/ldapvi/"
   url "http://www.lichteblau.com/download/ldapvi-1.7.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/ldapvi/ldapvi_1.7.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/l/ldapvi/ldapvi_1.7.orig.tar.gz"
   sha256 "6f62e92d20ff2ac0d06125024a914b8622e5b8a0a0c2d390bf3e7990cbd2e153"
   revision 3
 
@@ -25,8 +25,7 @@ class Ldapvi < Formula
   # http://www.lichteblau.com/git/?p=ldapvi.git;a=commit;h=256ced029c235687bfafdffd07be7d47bf7af39b
   # http://www.lichteblau.com/git/?p=ldapvi.git;a=commit;h=a2717927f297ff9bc6752f281d4eecab8bd34aad
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/ldapvi/ldapvi_1.7-10.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/ldapvi/ldapvi_1.7-10.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/l/ldapvi/ldapvi_1.7-10.debian.tar.xz"
     sha256 "93be20cf717228d01272eab5940337399b344bb262dc8bc9a59428ca604eb6cb"
     apply "patches/05_getline-conflict",
           "patches/06_fix-vim-modeline"

--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -1,8 +1,7 @@
 class Libewf < Formula
   desc "Library for support of the Expert Witness Compression Format"
   homepage "https://github.com/libyal/libewf"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libe/libewf/libewf_20140608.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libe/libewf/libewf_20140608.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libe/libewf/libewf_20140608.orig.tar.gz"
   version "20140608"
   sha256 "d14030ce6122727935fbd676d0876808da1e112721f3cb108564a4d9bf73da71"
   revision 1

--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -1,8 +1,7 @@
 class Libffi < Formula
   desc "Portable Foreign Function Interface library"
   homepage "https://sourceware.org/libffi/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
   mirror "ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz"
   sha256 "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"
 

--- a/Formula/libgpg-error.rb
+++ b/Formula/libgpg-error.rb
@@ -2,7 +2,7 @@ class LibgpgError < Formula
   desc "Common error values for all GnuPG components"
   homepage "https://www.gnupg.org/related_software/libgpg-error/"
   url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/libg/libgpg-error/libgpg-error_1.27.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/libg/libgpg-error/libgpg-error_1.27.orig.tar.bz2"
   sha256 "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2"
 
   bottle do

--- a/Formula/libicns.rb
+++ b/Formula/libicns.rb
@@ -2,7 +2,7 @@ class Libicns < Formula
   desc "Library for manipulation of the macOS .icns resource format"
   homepage "https://icns.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
   sha256 "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
   revision 3
 

--- a/Formula/libkate.rb
+++ b/Formula/libkate.rb
@@ -2,7 +2,7 @@ class Libkate < Formula
   desc "Overlay codec for multiplexed audio/video in Ogg"
   homepage "https://code.google.com/archive/p/libkate/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libkate/libkate-0.4.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libk/libkate/libkate_0.4.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libk/libkate/libkate_0.4.1.orig.tar.gz"
   sha256 "c40e81d5866c3d4bf744e76ce0068d8f388f0e25f7e258ce0c8e76d7adc87b68"
   revision 1
 

--- a/Formula/liblockfile.rb
+++ b/Formula/liblockfile.rb
@@ -1,8 +1,7 @@
 class Liblockfile < Formula
   desc "Library providing functions to lock standard mailboxes"
   homepage "https://tracker.debian.org/pkg/liblockfile"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.09.orig.tar.gz"
   sha256 "16979eba05396365e1d6af7100431ae9d32f9bc063930d1de66298a0695f1b7f"
 
   bottle do

--- a/Formula/libmwaw.rb
+++ b/Formula/libmwaw.rb
@@ -17,8 +17,7 @@ class Libmwaw < Formula
   # Fixed upstream, will be in the next release.
   # https://sourceforge.net/p/libmwaw/libmwaw/ci/68b3b74569881248bfb6cbb4266177cc253b292f/
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libm/libmwaw/libmwaw_0.3.11-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libm/libmwaw/libmwaw_0.3.11-3.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/libm/libmwaw/libmwaw_0.3.11-3.debian.tar.xz"
     sha256 "5377a0fb979c595b4b66076b57be980724d0afc9681a4e10c1566ac6cfc26886"
     apply "patches/CVE-2017-9433.diff"
   end

--- a/Formula/libquicktime.rb
+++ b/Formula/libquicktime.rb
@@ -29,8 +29,7 @@ class Libquicktime < Formula
 
   # Fix CVE-2016-2399. Applied upstream on March 6th 2017.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-10.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-10.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-10.debian.tar.xz"
     sha256 "550cc827c675aeb37727f6daaa311b649246dc9f952e830f0796c25af1137340"
     apply "patches/CVE-2016-2399.patch"
   end

--- a/Formula/libresample.rb
+++ b/Formula/libresample.rb
@@ -1,7 +1,7 @@
 class Libresample < Formula
   desc "Audio resampling C library"
   homepage "https://ccrma.stanford.edu/~jos/resample/Available_Software.html"
-  url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libr/libresample/libresample_0.1.3.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libr/libresample/libresample_0.1.3.orig.tar.gz"
   sha256 "20222a84e3b4246c36b8a0b74834bb5674026ffdb8b9093a76aaf01560ad4815"
 
   bottle do

--- a/Formula/libsoxr.rb
+++ b/Formula/libsoxr.rb
@@ -2,7 +2,7 @@ class Libsoxr < Formula
   desc "High quality, one-dimensional sample-rate conversion library"
   homepage "https://sourceforge.net/projects/soxr/"
   url "https://downloads.sourceforge.net/project/soxr/soxr-0.1.2-Source.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.2.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.2.orig.tar.xz"
   sha256 "54e6f434f1c491388cd92f0e3c47f1ade082cc24327bdc43762f7d1eefe0c275"
 
   bottle do

--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -22,8 +22,7 @@ class Libtiff < Formula
   # All of these have been reported upstream & should
   # be fixed in the next release, but please check.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.8-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.8-3.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/t/tiff/tiff_4.0.8-3.debian.tar.xz"
     sha256 "8803ef2917ceb80c472e97d85e86f71a20d04cf7de94ebffcc1b3100f51058ce"
     apply "patches/01-CVE-2015-7554.patch",
           "patches/02-CVE.patch",

--- a/Formula/libusb.rb
+++ b/Formula/libusb.rb
@@ -2,7 +2,7 @@ class Libusb < Formula
   desc "Library for USB device access"
   homepage "http://libusb.info"
   url "https://github.com/libusb/libusb/releases/download/v1.0.21/libusb-1.0.21.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/libu/libusb-1.0/libusb-1.0_1.0.21.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0_1.0.21.orig.tar.bz2"
   sha256 "7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b"
 
   bottle do

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -11,8 +11,7 @@ class Libxml2 < Formula
     # All patches upstream already. Remove whenever 2.9.5 is released.
     # Fixes CVE-2016-4658, CVE-2016-5131.
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.2.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.2.debian.tar.xz"
+      url "https://deb.debian.org/debian/pool/main/libx/libxml2/libxml2_2.9.4+dfsg1-2.2.debian.tar.xz"
       sha256 "c038bba02a56164cef7728509ba3c8f1856018573769ee9ffcc48c565e90bdc9"
       apply "patches/0003-Fix-NULL-pointer-deref-in-XPointer-range-to.patch",
             "patches/0004-Fix-comparison-with-root-node-in-xmlXPathCmpNodes.patch",

--- a/Formula/libyaml.rb
+++ b/Formula/libyaml.rb
@@ -2,7 +2,7 @@ class Libyaml < Formula
   desc "YAML Parser"
   homepage "http://pyyaml.org/wiki/LibYAML"
   url "http://pyyaml.org/download/libyaml/yaml-0.1.7.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/liby/libyaml/libyaml_0.1.7.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/liby/libyaml/libyaml_0.1.7.orig.tar.gz"
   sha256 "8088e457264a98ba451a90b8661fcb4f9d6f478f7265d48322a196cec2480729"
 
   bottle do

--- a/Formula/logcheck.rb
+++ b/Formula/logcheck.rb
@@ -1,8 +1,7 @@
 class Logcheck < Formula
   desc "Mail anomalies in the system logfiles to the administrator"
   homepage "https://logcheck.alioth.debian.org/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.18.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.18.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.18.tar.xz"
   sha256 "077b9149ccd2b747b52785afa89da844f3d072c017c9e719925dec6acb9a9af4"
 
   bottle do

--- a/Formula/lsh.rb
+++ b/Formula/lsh.rb
@@ -20,8 +20,7 @@ class Lsh < Formula
   depends_on "gmp"
 
   resource "liboop" do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
+    url "https://deb.debian.org/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
     sha256 "34d83c6e0f09ee15cb2bc3131e219747c3b612bb57cf7d25318ab90da9a2d97c"
   end
 

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -4,7 +4,7 @@ class LuaAT51 < Formula
   desc "Powerful, lightweight programming language (v5.1.5)"
   homepage "https://www.lua.org/"
   url "https://www.lua.org/ftp/lua-5.1.5.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
   sha256 "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
   revision 4
 

--- a/Formula/mdf2iso.rb
+++ b/Formula/mdf2iso.rb
@@ -1,8 +1,7 @@
 class Mdf2iso < Formula
   desc "Tool to convert MDF (Alcohol 120% images) images to ISO images"
   homepage "https://packages.debian.org/sid/mdf2iso"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
   sha256 "906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7"
 
   bottle do

--- a/Formula/minbif.rb
+++ b/Formula/minbif.rb
@@ -1,8 +1,7 @@
 class Minbif < Formula
   desc "IRC-to-other-IM-networks gateway using Pidgin library"
   homepage "https://symlink.me/projects/minbif/wiki/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
   version "1.0.5-20150505"
   sha256 "4e264fce518a0281de9fc3d44450677c5fa91097a0597ef7a0d2a688ee66d40b"
   revision 1

--- a/Formula/minimodem.rb
+++ b/Formula/minimodem.rb
@@ -2,7 +2,7 @@ class Minimodem < Formula
   desc "General-purpose software audio FSK modem"
   homepage "http://www.whence.com/minimodem/"
   url "http://www.whence.com/minimodem/minimodem-0.24.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minimodem/minimodem_0.24.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/m/minimodem/minimodem_0.24.orig.tar.gz"
   sha256 "f8cca4db8e3f284d67f843054d6bb4d88a3db5e77b26192410e41e9a06f4378e"
 
   bottle do

--- a/Formula/mkcue.rb
+++ b/Formula/mkcue.rb
@@ -1,8 +1,7 @@
 class Mkcue < Formula
   desc "Generate a CUE sheet from a CD"
   homepage "https://packages.debian.org/sid/mkcue"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
   version "1"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
 

--- a/Formula/mmv.rb
+++ b/Formula/mmv.rb
@@ -1,8 +1,7 @@
 class Mmv < Formula
   desc "Move, copy, append, and link multiple files"
   homepage "https://packages.debian.org/unstable/utils/mmv"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
   sha256 "0399c027ea1e51fd607266c1e33573866d4db89f64a74be8b4a1d2d1ff1fdeef"
 
   bottle do
@@ -15,7 +14,7 @@ class Mmv < Formula
   end
 
   patch do
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
     sha256 "9ad3e3d47510f816b4a18bae04ea75913588eec92248182f85dd09bc5ad2df13"
   end
 

--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -1,8 +1,7 @@
 class Monkeysphere < Formula
   desc "Use the OpenPGP web of trust to verify ssh connections"
   homepage "http://web.monkeysphere.info/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
   sha256 "911a2f1622ddb81151b0f41cf569ccf2154d10a09b2f446dbe98fac7279fe74b"
   head "git://git.monkeysphere.info/monkeysphere"
 

--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -2,7 +2,7 @@ class Mpfr < Formula
   desc "C library for multiple-precision floating-point computations"
   homepage "http://www.mpfr.org/"
   # Upstream is down a lot, so use mirrors
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mpfr4/mpfr4_3.1.5.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/m/mpfr4/mpfr4_3.1.5.orig.tar.xz"
   mirror "https://ftp.gnu.org/gnu/mpfr/mpfr-3.1.5.tar.xz"
   sha256 "015fde82b3979fbe5f83501986d328331ba8ddf008c1ff3da3c238f49ca062bc"
 

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -2,8 +2,7 @@ class Mytop < Formula
   desc "Top-like query monitor for MySQL"
   homepage "http://www.mysqlfanboy.com/mytop-3/"
   url "http://www.mysqlfanboy.com/mytop-3/mytop-1.9.1.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
   revision 3
 
@@ -40,8 +39,7 @@ class Mytop < Formula
   # Pick up some patches from Debian to improve functionality & fix
   # some syntax warnings when using recent versions of Perl.
   patch do
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
     sha256 "9c97b7d2a2d4d169c5f263ce0adb6340b71e3a0afd4cdde94edcead02421489a"
     apply "patches/01_fix_pod.patch",
           "patches/02_remove_db_test.patch",

--- a/Formula/nacl.rb
+++ b/Formula/nacl.rb
@@ -2,7 +2,7 @@ class Nacl < Formula
   desc "Network communication, encryption, decryption, signatures library"
   homepage "https://nacl.cr.yp.to/"
   url "https://hyperelliptic.org/nacl/nacl-20110221.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/nacl/nacl_20110221.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/n/nacl/nacl_20110221.orig.tar.bz2"
   sha256 "4f277f89735c8b0b8a6bbd043b3efb3fa1cc68a9a5da6a076507d067fc3b3bf8"
 
   bottle do

--- a/Formula/netcat6.rb
+++ b/Formula/netcat6.rb
@@ -1,8 +1,7 @@
 class Netcat6 < Formula
   desc "Rewrite of netcat that supports IPv6, plus other improvements"
   homepage "https://www.deepspace6.net/projects/netcat6.html"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
   sha256 "db7462839dd135ff1215911157b666df8512df6f7343a075b2f9a2ef46fe5412"
 
   bottle do

--- a/Formula/netris.rb
+++ b/Formula/netris.rb
@@ -2,7 +2,7 @@ class Netris < Formula
   desc "Networked variant of tetris"
   homepage "https://web.archive.org/web/20071223041235/www.netris.be/"
   url "ftp://ftp.netris.org/pub/netris/netris-0.52.tar.gz"
-  mirror "https://ftp.de.debian.org/debian/pool/main/n/netris/netris_0.52.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/n/netris/netris_0.52.orig.tar.gz"
   sha256 "8bc770ebb2c3ead1611ca7a1a2f3d833e169536c78d53b3fcf49381164ee9706"
 
   bottle do

--- a/Formula/num-utils.rb
+++ b/Formula/num-utils.rb
@@ -2,7 +2,7 @@ class NumUtils < Formula
   desc "Programs for dealing with numbers from the command-line"
   homepage "http://suso.suso.org/programs/num-utils/"
   url "http://suso.suso.org/programs/num-utils/downloads/num-utils-0.5.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
   sha256 "03592760fc7844492163b14ddc9bb4e4d6526e17b468b5317b4a702ea7f6c64e"
 
   bottle do

--- a/Formula/nvi.rb
+++ b/Formula/nvi.rb
@@ -1,8 +1,7 @@
 class Nvi < Formula
   desc "44BSD re-implementation of vi"
   homepage "https://sites.google.com/a/bostic.com/keithbostic/vi/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   sha256 "8bc348889159a34cf268f80720b26f459dbd723b5616107d36739d007e4c978d"
   revision 3
 
@@ -36,8 +35,7 @@ class Nvi < Formula
   # Upstream have been pretty inactive for a while, so we may want to kill this
   # formula at some point unless that changes. We're leaning hard on Debian now.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
     sha256 "306c6059d386a161b9884535f0243134c8c9b5b15648e09e595fd1b349a7b9e1"
     apply "patches/03db4.patch",
           "patches/19include_term_h.patch",

--- a/Formula/omega.rb
+++ b/Formula/omega.rb
@@ -2,7 +2,7 @@ class Omega < Formula
   desc "Packaged search engine for websites, built on top of Xapian"
   homepage "https://xapian.org/"
   url "https://oligarchy.co.uk/xapian/1.4.3/xapian-omega-1.4.3.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/x/xapian-omega/xapian-omega_1.4.3.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/x/xapian-omega/xapian-omega_1.4.3.orig.tar.xz"
   sha256 "2eea0344a0703ba379d845b86d08a9c2e9faf0deb21834d9ea6939b712c6216e"
 
   bottle do

--- a/Formula/openjpeg.rb
+++ b/Formula/openjpeg.rb
@@ -26,8 +26,7 @@ class Openjpeg < Formula
   # https://github.com/uclouvain/openjpeg/issues/862
   # https://github.com/uclouvain/openjpeg/issues/863
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/openjpeg2/openjpeg2_2.1.2-1.1.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/openjpeg2/openjpeg2_2.1.2-1.1.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/o/openjpeg2/openjpeg2_2.1.2-1.1.debian.tar.xz"
     sha256 "b19b15ac6306c19734f0626f974c8863e4dc21a1df849a8ae81008479b5b0daf"
     apply "patches/CVE-2016-9572_CVE-2016-9573.patch"
   end

--- a/Formula/ophcrack.rb
+++ b/Formula/ophcrack.rb
@@ -2,7 +2,7 @@ class Ophcrack < Formula
   desc "Microsoft Windows password cracker using rainbow tables"
   homepage "https://ophcrack.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ophcrack/ophcrack/3.7.0/ophcrack-3.7.0.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/o/ophcrack/ophcrack_3.7.0.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/o/ophcrack/ophcrack_3.7.0.orig.tar.bz2"
   sha256 "9d5615dd8e42a395898423f84e29d94ad0b1d4a28fcb14c89a1e2bb1a0374409"
 
   bottle do

--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -1,8 +1,7 @@
 class OsspUuid < Formula
   desc "ISO-C API and CLI for generating UUIDs"
   homepage "http://www.ossp.org/pkg/lib/uuid/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
   mirror "ftp://ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz"
   sha256 "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"
   revision 2

--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -2,7 +2,7 @@ class Pari < Formula
   desc "Computer algebra system designed for fast computations in number theory"
   homepage "https://pari.math.u-bordeaux.fr/"
   url "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.9.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/pari/pari_2.9.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/p/pari/pari_2.9.2.orig.tar.gz"
   sha256 "9aa24cbbcf4e0b09dcc21cf9b09f2eb08e38ee16ab13651be7274c9b3e46207e"
 
   bottle do

--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -2,7 +2,7 @@ class Pass < Formula
   desc "Password manager"
   homepage "https://www.passwordstore.org/"
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.1.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/password-store/password-store_1.7.1.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/p/password-store/password-store_1.7.1.orig.tar.xz"
   sha256 "f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869"
 
   head "https://git.zx2c4.com/password-store", :using => :git

--- a/Formula/patchutils.rb
+++ b/Formula/patchutils.rb
@@ -2,7 +2,7 @@ class Patchutils < Formula
   desc "Small collection of programs that operate on patch files"
   homepage "http://cyberelk.net/tim/software/patchutils/"
   url "http://cyberelk.net/tim/data/patchutils/stable/patchutils-0.3.4.tar.xz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/patchutils/patchutils_0.3.4.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/p/patchutils/patchutils_0.3.4.orig.tar.xz"
   sha256 "cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876"
 
   bottle do

--- a/Formula/perl@5.14.rb
+++ b/Formula/perl@5.14.rb
@@ -2,7 +2,7 @@ class PerlAT514 < Formula
   desc "Highly capable, feature-rich programming language"
   homepage "https://www.perl.org/"
   url "https://www.cpan.org/src/5.0/perl-5.14.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/perl/perl_5.14.2.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/p/perl/perl_5.14.2.orig.tar.bz2"
   sha256 "803fd44c492fcef79fda456a6f50455766e00ddec2e568a543630f65ff3f44cb"
 
   bottle do

--- a/Formula/pgtune.rb
+++ b/Formula/pgtune.rb
@@ -2,8 +2,8 @@ class Pgtune < Formula
   desc "Tuning wizard for postgresql.conf"
   homepage "http://pgfoundry.org/projects/pgtune"
   url "http://pgfoundry.org/frs/download.php/2449/pgtune-0.9.3.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/pgtune/pgtune_0.9.3.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pgtune/pgtune_0.9.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/p/pgtune/pgtune_0.9.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/p/pgtune/pgtune_0.9.3.orig.tar.gz"
   sha256 "31ac5774766dd9793d8d2d3681d1edb45760897c8eda3afc48b8d59350dee0ea"
 
   # 0.9.3 does not have settings for PostgreSQL 9.x, but the trunk does

--- a/Formula/pipebench.rb
+++ b/Formula/pipebench.rb
@@ -3,8 +3,7 @@ class Pipebench < Formula
   homepage "http://www.habets.pp.se/synscan/programs.php?prog=pipebench"
   # Upstream server behaves oddly: https://github.com/Homebrew/homebrew/issues/40897
   # url "http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
   sha256 "ca764003446222ad9dbd33bbc7d94cdb96fa72608705299b6cc8734cd3562211"
 
   bottle do

--- a/Formula/pmccabe.rb
+++ b/Formula/pmccabe.rb
@@ -1,8 +1,7 @@
 class Pmccabe < Formula
   desc "Calculate McCabe-style cyclomatic complexity for C/C++ code"
   homepage "https://packages.debian.org/sid/pmccabe"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
   sha256 "e490fe7c9368fec3613326265dd44563dc47182d142f579a40eca0e5d20a7028"
 
   bottle do

--- a/Formula/postmark.rb
+++ b/Formula/postmark.rb
@@ -1,8 +1,7 @@
 class Postmark < Formula
   desc "File system benchmark from NetApp"
   homepage "https://packages.debian.org/sid/postmark"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
   sha256 "8a88fd322e1c5f0772df759de73c42aa055b1cd36cbba4ce6ee610ac5a3c47d3"
 
   bottle do

--- a/Formula/prips.rb
+++ b/Formula/prips.rb
@@ -2,7 +2,7 @@ class Prips < Formula
   desc "Print the IP addresses in a given range"
   homepage "https://devel.ringlet.net/sysutils/prips/"
   url "https://devel.ringlet.net/files/sys/prips/prips-1.0.1.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/prips/prips_1.0.1.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/p/prips/prips_1.0.1.orig.tar.xz"
   sha256 "56b5a8de4c8df39dfaf9ffce7fbd5e80cb897f491eb2f7de83930756390f36b6"
 
   bottle do

--- a/Formula/puzzles.rb
+++ b/Formula/puzzles.rb
@@ -1,8 +1,7 @@
 class Puzzles < Formula
   desc "Collection of one-player puzzle games"
   homepage "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/"
-  url "https://mirrors.kernel.org/debian/pool/main/s/sgt-puzzles/sgt-puzzles_20161228.7cae89f.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/sgt-puzzles/sgt-puzzles_20161228.7cae89f.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/s/sgt-puzzles/sgt-puzzles_20161228.7cae89f.orig.tar.gz"
   version "20161228.7cae89f"
   sha256 "96b6915941b8490188652ab5c81bcb3ee42117e6fb7c03eed3e4333fa97ed852"
 

--- a/Formula/raine.rb
+++ b/Formula/raine.rb
@@ -98,7 +98,7 @@ class Raine < Formula
 
   resource "sdl_sound" do
     url "https://icculus.org/SDL_sound/downloads/SDL_sound-1.0.3.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
     sha256 "3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
   end
 

--- a/Formula/rancid.rb
+++ b/Formula/rancid.rb
@@ -2,7 +2,7 @@ class Rancid < Formula
   desc "Really Awesome New Cisco confIg Differ"
   homepage "http://www.shrubbery.net/rancid/"
   url "ftp://ftp.shrubbery.net/pub/rancid/rancid-3.6.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/r/rancid/rancid_3.6.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/r/rancid/rancid_3.6.2.orig.tar.gz"
   sha256 "23751829c9bacdd07f90512271265c0cac279ca2f36ac86be815dd21831c253d"
 
   bottle do

--- a/Formula/rdesktop.rb
+++ b/Formula/rdesktop.rb
@@ -2,7 +2,7 @@ class Rdesktop < Formula
   desc "UNIX client for connecting to Windows Remote Desktop Services"
   homepage "http://www.rdesktop.org/"
   url "https://downloads.sourceforge.net/project/rdesktop/rdesktop/1.8.3/rdesktop-1.8.3.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/r/rdesktop/rdesktop_1.8.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/r/rdesktop/rdesktop_1.8.3.orig.tar.gz"
   sha256 "88b20156b34eff5f1b453f7c724e0a3ff9370a599e69c01dc2bf0b5e650eece4"
 
   bottle do

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -1,8 +1,7 @@
 class Rtmpdump < Formula
   desc "Tool for downloading RTMP streaming media"
   homepage "https://rtmpdump.mplayerhq.hu/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
   version "2.4+20151223"
   sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
 

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -2,7 +2,7 @@ class SaneBackends < Formula
   desc "Backends for scanner access"
   homepage "http://www.sane-project.org/"
   url "https://alioth.debian.org/frs/download.php/file/4224/sane-backends-1.0.27.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   head "https://anonscm.debian.org/cgit/sane/sane-backends.git"

--- a/Formula/schroedinger.rb
+++ b/Formula/schroedinger.rb
@@ -2,7 +2,7 @@ class Schroedinger < Formula
   desc "High-speed implementation of the Dirac codec"
   homepage "https://launchpad.net/schroedinger"
   url "https://launchpad.net/schroedinger/trunk/1.0.11/+download/schroedinger-1.0.11.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/schroedinger/schroedinger_1.0.11.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/schroedinger/schroedinger_1.0.11.orig.tar.gz"
   sha256 "1e572a0735b92aca5746c4528f9bebd35aa0ccf8619b22fa2756137a8cc9f912"
 
   bottle do

--- a/Formula/scrub.rb
+++ b/Formula/scrub.rb
@@ -2,7 +2,7 @@ class Scrub < Formula
   desc "Writes patterns on magnetic media to thwart data recovery"
   homepage "https://code.google.com/archive/p/diskscrub/"
   url "https://github.com/chaos/scrub/releases/download/2.6.1/scrub-2.6.1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/scrub/scrub_2.6.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/scrub/scrub_2.6.1.orig.tar.gz"
   sha256 "43d98d3795bc2de7920efe81ef2c5de4e9ed1f903c35c939a7d65adc416d6cb8"
 
   bottle do

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -2,7 +2,7 @@ class SdlSound < Formula
   desc "Library to decode several popular sound file formats"
   homepage "https://icculus.org/SDL_sound/"
   url "https://icculus.org/SDL_sound/downloads/SDL_sound-1.0.3.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
   sha256 "3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
   revision 1
 

--- a/Formula/stress.rb
+++ b/Formula/stress.rb
@@ -2,7 +2,7 @@ class Stress < Formula
   desc "Tool to impose load on and stress test a computer system"
   homepage "https://people.seas.harvard.edu/~apw/stress/"
   url "https://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
   sha256 "057e4fc2a7706411e1014bf172e4f94b63a12f18412378fca8684ca92408825b"
 
   bottle do

--- a/Formula/sxiv.rb
+++ b/Formula/sxiv.rb
@@ -2,7 +2,7 @@ class Sxiv < Formula
   desc "Simple X Image Viewer"
   homepage "https://github.com/muennich/sxiv"
   url "https://github.com/muennich/sxiv/archive/v1.3.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/s/sxiv/sxiv_1.3.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/sxiv/sxiv_1.3.2.orig.tar.gz"
   sha256 "9f5368de8f0f57e78ebe02cb531a31107a993f2769cec51bcc8d70f5c668b653"
   revision 1
 

--- a/Formula/tcptrack.rb
+++ b/Formula/tcptrack.rb
@@ -1,8 +1,7 @@
 class Tcptrack < Formula
   desc "Monitor status of TCP connections on a network interface"
   homepage "https://linux.die.net/man/1/tcptrack"
-  url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tcptrack/tcptrack_1.4.2.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tcptrack/tcptrack_1.4.2.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/t/tcptrack/tcptrack_1.4.2.orig.tar.gz"
   sha256 "6607b1e1c778c49d3e8795e119065cf66eb2db28b3255dbc56b1612527107049"
 
   bottle do

--- a/Formula/tmpreaper.rb
+++ b/Formula/tmpreaper.rb
@@ -1,8 +1,7 @@
 class Tmpreaper < Formula
   desc "Clean up files in directories based on their age"
   homepage "https://packages.debian.org/sid/tmpreaper"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
   version "1.6.13_nmu1"
   sha256 "c88f05b5d995b9544edb7aaf36ac5ce55c6fac2a4c21444e5dba655ad310b738"
 

--- a/Formula/toilet.rb
+++ b/Formula/toilet.rb
@@ -2,8 +2,7 @@ class Toilet < Formula
   desc "Color-based alternative to figlet (uses libcaca)"
   homepage "http://caca.zoy.org/wiki/toilet"
   url "http://caca.zoy.org/raw-attachment/wiki/toilet/toilet-0.3.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
   sha256 "89d4b530c394313cc3f3a4e07a7394fa82a6091f44df44dfcd0ebcb3300a81de"
 
   bottle do

--- a/Formula/tokyo-cabinet.rb
+++ b/Formula/tokyo-cabinet.rb
@@ -2,7 +2,7 @@ class TokyoCabinet < Formula
   desc "Lightweight database library"
   homepage "http://fallabs.com/tokyocabinet/"
   url "http://fallabs.com/tokyocabinet/tokyocabinet-1.4.48.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tokyocabinet/tokyocabinet_1.4.48.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/t/tokyocabinet/tokyocabinet_1.4.48.orig.tar.gz"
   sha256 "a003f47c39a91e22d76bc4fe68b9b3de0f38851b160bbb1ca07a4f6441de1f90"
 
   bottle do

--- a/Formula/unac.rb
+++ b/Formula/unac.rb
@@ -1,8 +1,7 @@
 class Unac < Formula
   desc "C library and command that removes accents from a string"
   homepage "https://savannah.nongnu.org/projects/unac"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
   sha256 "29d316e5b74615d49237556929e95e0d68c4b77a0a0cfc346dc61cf0684b90bf"
 
   bottle do
@@ -32,8 +31,7 @@ class Unac < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
     sha256 "13a362f8d682670c71182ab5f0bbf3756295a99fae0d7deb9311e611a43b8111"
   end
 

--- a/Formula/uni2ascii.rb
+++ b/Formula/uni2ascii.rb
@@ -3,8 +3,7 @@ class Uni2ascii < Formula
   # homepage/url: "the website you are looking for is suspended"
   # Switched to Debian mirrors June 2015.
   homepage "https://billposer.org/Software/uni2ascii.html"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
   sha256 "9e24bb6eb2ced0a2945e2dabed5e20c419229a8bf9281c3127fa5993bfa5930e"
 
   bottle do

--- a/Formula/unp.rb
+++ b/Formula/unp.rb
@@ -1,8 +1,7 @@
 class Unp < Formula
   desc "Unpack everything with one command"
   homepage "https://packages.debian.org/source/stable/unp"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
+  url "https://deb.debian.org/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
   version "2.0-pre7-nmu1"
   sha256 "7c2d6f2835a5a59ee2588b66d8015d97accd62e71e38ba90ebd4d71d8fd78227"
 

--- a/Formula/unyaffs.rb
+++ b/Formula/unyaffs.rb
@@ -2,7 +2,7 @@ class Unyaffs < Formula
   desc "Extract files from a YAFFS2 filesystem image"
   homepage "https://github.com/ehlers/unyaffs"
   url "https://github.com/ehlers/unyaffs/archive/0.9.6.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/u/unyaffs/unyaffs_0.9.6.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/u/unyaffs/unyaffs_0.9.6.orig.tar.gz"
   sha256 "33c46419ab5cc5290f3b780f0cc9d93729962799f5eb7cecb9b352b85939fbbf"
 
   head "https://github.com/ehlers/unyaffs.git"

--- a/Formula/unzip.rb
+++ b/Formula/unzip.rb
@@ -18,8 +18,7 @@ class Unzip < Formula
   # Upstream is unmaintained so we use the Debian patchset:
   # https://packages.debian.org/sid/unzip
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unzip/unzip_6.0-21.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unzip/unzip_6.0-21.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/u/unzip/unzip_6.0-21.debian.tar.xz"
     sha256 "8accd9d214630a366476437a3ec1842f2e057fdce16042a7b19ee569c33490a3"
     apply %w[
       patches/01-manpages-in-section-1-not-in-section-1l.patch

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -2,7 +2,7 @@ class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/uriparser/Sources/0.8.4/uriparser-0.8.4.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/u/uriparser/uriparser_0.8.4.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/u/uriparser/uriparser_0.8.4.orig.tar.bz2"
   sha256 "ce7ccda4136974889231e8426a785e7578e66a6283009cfd13f1b24a5e657b23"
 
   bottle do

--- a/Formula/urlview.rb
+++ b/Formula/urlview.rb
@@ -1,8 +1,7 @@
 class Urlview < Formula
   desc "URL extractor/launcher"
   homepage "https://packages.debian.org/sid/misc/urlview"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
   sha256 "746ff540ccf601645f500ee7743f443caf987d6380e61e5249fc15f7a455ed42"
 
   bottle do
@@ -15,8 +14,7 @@ class Urlview < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9-19.diff.gz"
     sha256 "056883c17756f849fb9235596d274fbc5bc0d944fcc072bdbb13d1e828301585"
   end
 

--- a/Formula/webalizer.rb
+++ b/Formula/webalizer.rb
@@ -2,7 +2,7 @@ class Webalizer < Formula
   desc "Web server log file analysis"
   homepage "http://www.webalizer.org"
   url "ftp://ftp.mrunix.net/pub/webalizer/webalizer-2.23-08-src.tgz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
   sha256 "edaddb5aa41cc4a081a1500e3fa96615d4b41bc12086bcedf9938018ce79ed8d"
   revision 1
 

--- a/Formula/when.rb
+++ b/Formula/when.rb
@@ -1,8 +1,7 @@
 class When < Formula
   desc "Tiny personal calendar"
   homepage "http://www.lightandmatter.com/when/when.html"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/when/when_1.1.36.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/when/when_1.1.36.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/w/when/when_1.1.36.orig.tar.gz"
   sha256 "3ff95c1881e8fe25c82943720a81c9b9b3bd4ac002cd8ffc2d25c588fe7d50b1"
   head "https://github.com/bcrowell/when.git"
 

--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -1,8 +1,7 @@
 class Whois < Formula
   desc "Lookup tool for domain names and other internet resources"
   homepage "https://packages.debian.org/sid/whois"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/whois/whois_5.2.16.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/whois/whois_5.2.16.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/w/whois/whois_5.2.16.tar.xz"
   sha256 "e9d208b61ccea96b611e522d30fb753dbefed0d44cfabe346e1928690453fc3a"
   head "https://github.com/rfc1036/whois.git"
 

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -88,7 +88,7 @@ class Wine < Formula
 
   resource "jpeg" do
     url "http://www.ijg.org/files/jpegsrc.v9b.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/libj/libjpeg9/libjpeg9_9b.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/libj/libjpeg9/libjpeg9_9b.orig.tar.gz"
     sha256 "240fd398da741669bf3c90366f58452ea59041cacc741a489b99f2f6a0bad052"
   end
 
@@ -100,7 +100,7 @@ class Wine < Formula
 
   resource "little-cms2" do
     url "https://downloads.sourceforge.net/project/lcms/lcms/2.8/lcms2-2.8.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/l/lcms2/lcms2_2.8.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/l/lcms2/lcms2_2.8.orig.tar.gz"
     sha256 "66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22"
   end
 
@@ -118,7 +118,7 @@ class Wine < Formula
 
   resource "libusb" do
     url "https://github.com/libusb/libusb/releases/download/v1.0.21/libusb-1.0.21.tar.bz2"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/libu/libusb-1.0/libusb-1.0_1.0.21.orig.tar.bz2"
+    mirror "https://deb.debian.org/debian/pool/main/libu/libusb-1.0/libusb-1.0_1.0.21.orig.tar.bz2"
     sha256 "7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b"
   end
 
@@ -157,7 +157,7 @@ class Wine < Formula
 
   resource "sane-backends" do
     url "https://alioth.debian.org/frs/download.php/file/4224/sane-backends-1.0.27.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
     mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
     sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   end

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -2,7 +2,7 @@ class Xapian < Formula
   desc "C++ search engine library with many bindings"
   homepage "https://xapian.org/"
   url "https://oligarchy.co.uk/xapian/1.4.3/xapian-core-1.4.3.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/x/xapian-core/xapian-core_1.4.3.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/x/xapian-core/xapian-core_1.4.3.orig.tar.xz"
   sha256 "7d5295511ca2de70463a29e75f6a2393df5dc1485bf33074b778c66e1721e475"
 
   bottle do


### PR DESCRIPTION
deb.debian.org is a redirector service that will send you to either AWS
CloudFront or Fastly, both of which have official Debian mirrors. The
current choice of mirror appears to be somewhat ad-hoc; switch
everything to deb.debian.org and remove redundant mirror lines.

This commit was generated with

    find Formula -name \*.rb -exec sed -i "s|https\?://mirrors.ocf.berkeley.edu/debian|https://deb.debian.org/debian|" {} +
    find Formula -name \*.rb -exec sed -i "s|https\?://\(www\.\)\?mirrorservice.org/sites/ftp.debian.org/debian|https://deb.debian.org/debian|" {} +
    find Formula -name \*.rb -exec sed -i "s|https\?://mirrors.kernel.org/debian|https://deb.debian.org/debian|" {} +
    find Formula -name \*.rb -exec sed -i "s|https\?://ftp.de.debian.org/debian|https://deb.debian.org/debian|" {} +
    git grep --files-with-match 'url "https://deb.debian.org' | xargs sed -i '/mirror "https:\/\/deb.debian.org/d'

plus manual fixes to ldapvi, mytop, and toilet, which reference multiple
tarballs in the same file and broke my naive regexes.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
