### PR TITLE
git-cinnabar 0.4.0, 0.5.0b1 (devel) (new formula)

### DIFF
--- a/Formula/git-cinnabar.rb
+++ b/Formula/git-cinnabar.rb
@@ -1,0 +1,32 @@
+class GitCinnabar < Formula
+  desc "Git remote helper to interact with mercurial repositories"
+  homepage "https://github.com/glandium/git-cinnabar"
+  url "https://github.com/glandium/git-cinnabar.git",
+      :tag => "0.4.0",
+      :revision => "6d374888ff0287517084c0ec7573963961f6acec"
+  head "https://github.com/glandium/git-cinnabar.git"
+
+  devel do
+    url "https://github.com/glandium/git-cinnabar.git",
+        :tag => "0.5.0b1",
+        :revision => "f4ce4ab5ae70c11f00fbc0964e1edf4da6fe7657"
+    version "0.5.0b1"
+  end
+
+  depends_on :hg
+
+  conflicts_with "git-remote-hg", :because => "both install `git-remote-hg` binaries"
+
+  def install
+    system "make", "helper"
+    prefix.install "cinnabar"
+    bin.install "git-cinnabar", "git-cinnabar-helper", "git-remote-hg"
+    bin.env_script_all_files(libexec, :PYTHONPATH => prefix)
+  end
+
+  test do
+    system "git", "clone", "hg::https://www.mercurial-scm.org/repo/hello"
+    assert_predicate testpath/"hello/hello.c", :exist?,
+                     "hello.c not found in cloned repo"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

git-cinnabar is another git-remote-hg (i.e., an external hg bridge for git), and almost the only one that's still actively maintained.

There's a 0.5.0b2, but it seems to be [buggy](https://github.com/glandium/git-cinnabar/issues/131), so I'm packaging 0.5.0b1 as devel for now.

🔴