### PR TITLE
doxygen: add mirror

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -6,6 +6,7 @@ class Doxygen < Formula
 
   stable do
     url "https://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/doxygen/doxygen_1.8.13.orig.tar.gz"
     sha256 "af667887bd7a87dc0dbf9ac8d86c96b552dfb8ca9c790ed1cbffaa6131573f6b"
 
     # Remove for > 1.8.13


### PR DESCRIPTION
The cert on *.stack.nl just expired. I have emailed the maintainer directly.

<img width="482" alt="screen shot 2017-07-07 at 5 09 58 pm" src="https://user-images.githubusercontent.com/4149852/27977080-36ef2d4c-6337-11e7-881c-f6bb2913e0dd.png">

Meanwhile, I'm adding a mirror from Debian.