### PR TITLE
libpng 1.6.30

### DIFF
--- a/Formula/libpng.rb
+++ b/Formula/libpng.rb
@@ -1,9 +1,9 @@
 class Libpng < Formula
   desc "Library for manipulating PNG images"
   homepage "http://www.libpng.org/pub/png/libpng.html"
-  url "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.29.tar.xz"
-  mirror "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.29/libpng-1.6.29.tar.xz"
-  sha256 "4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239"
+  url "https://download.sourceforge.net/libpng/libpng-1.6.30.tar.xz"
+  mirror "ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.30.tar.xz"
+  sha256 "267c332ffff70cc599d3929207869f698798f1df143aa5f9597b007c14353666"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Switching to URLs currently listed on the home page
<https://web.archive.org/web/20170707222014/http://www.libpng.org/pub/png/libpng.html>.