### PR TITLE
duti: fix for 10.13

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -17,11 +17,10 @@ class Duti < Formula
   depends_on "autoconf" => :build
 
   # Add hardcoded SDK path for El Capitan or later.
-  # See https://github.com/moretension/duti/pull/20.
   if MacOS.version >= :el_capitan
     patch do
-      url "https://github.com/moretension/duti/pull/20.patch?full_index=1"
-      sha256 "2dee8e25f7c53a9fa4cbd756ad06b308e7eabb385cf589aba02bc7f50ae76c3e"
+      url "https://github.com/moretension/duti/commit/7dbcae8.patch?full_index=1"
+      sha256 "09ea9bec926f38beb217c597fc224fc19c972e44835783a57fe8a54450cb8fb6"
     end
   end
 
@@ -32,6 +31,7 @@ class Duti < Formula
   end
 
   test do
-    system "#{bin}/duti", "-x", "txt"
+    assert_match "com.apple.TextEdit", shell_output("#{bin}/duti -l public.text"),
+                 "TextEdit not found among the handlers for public.text"
   end
 end


### PR DESCRIPTION
- Recognize `darwin17.*` (like what's been done for the past two years);
- Use a better test.

---

It's time for a decision. moretension/duti has been unmaintained for the past three years, but it still absolutely works (with a trivial patch each year), and there are still [more than a few bottle downloads](https://bintray.com/homebrew/bottles/duti#statistics): 531 in the past month, 4563 in the past year. Do we trash it or fix it?

I guess the decision will be 💀, but it doesn't hurt to ask.

---

**UPDATE.** [Patch merged by upstream](https://github.com/moretension/duti/pull/20). So duti should hold out for at least another year.