### PR TITLE
joe 4.4

### DIFF
--- a/Formula/joe.rb
+++ b/Formula/joe.rb
@@ -1,8 +1,8 @@
 class Joe < Formula
   desc "Joe's Own Editor (JOE)"
   homepage "https://joe-editor.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/joe-editor/JOE%20sources/joe-4.3/joe-4.3.tar.gz"
-  sha256 "985d6a8f943a06e64165996c24d7fecaeae8c59efb52998a49b3fb4b8a3e26e1"
+  url "https://downloads.sourceforge.net/project/joe-editor/JOE%20sources/joe-4.4/joe-4.4.tar.gz"
+  sha256 "a5704828bbca29acb9e200414fef522c66cdf9ce28150f402d6767da43460979"
 
   bottle do
     sha256 "4c2981014abdb5b86da5427e2fc274d596e3b33539ea27c4fcae58562b1393c2" => :sierra


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

JOE 4.4
Enhancements
Bugs fixed
Fix segfault due to buffer overrun. This happens if a line
with many backslashes appears in the status line context display.
Fix jmacs: ^X ^F and ^X ^B were not working
Build fixes for Solaris
Improve php highlighter: allow numbers in substitution variable names
Unicode tweak: treat private use characters (Co) as printable
Dockerfile highlighter: Add Docker new commands from 1.12,
mark bad strings in arrays
Fix loading external charmaps

