### PR TITLE
pixman: Re-enable MMX builds

### DIFF
--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -3,6 +3,7 @@ class Pixman < Formula
   homepage "https://cairographics.org/"
   url "https://cairographics.org/releases/pixman-0.34.0.tar.gz"
   sha256 "21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e"
+  revision 1
 
   bottle do
     cellar :any
@@ -19,7 +20,6 @@ class Pixman < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-gtk",
-                          "--disable-mmx", # MMX assembler fails with Xcode 7
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
The build failures caused with clang builds with MMX enabled was [fixed
upstream](https://cgit.freedesktop.org/pixman/commit/pixman/pixman-mmx.c?id=d24b415f3e2753a588759d028b811e1ce38fea6c) and released in 0.34.0.

Signed-off-by: Tim Sheridan <tghs@tghs.net>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?