### PR TITLE
swig*: use full path to ruby in the test

### DIFF
--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -40,6 +40,6 @@ class Swig < Formula
     system ENV.cc, "-c", "test.c"
     system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
     system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
-    assert_equal "2", shell_output("ruby run.rb").strip
+    assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end
 end

--- a/Formula/swig@2.rb
+++ b/Formula/swig@2.rb
@@ -42,6 +42,6 @@ class SwigAT2 < Formula
     system ENV.cc, "-c", "test.c"
     system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
     system ENV.cc, "-bundle", "-flat_namespace", "-undefined", "suppress", "test.o", "test_wrap.o", "-o", "test.bundle"
-    assert_equal "2", shell_output("ruby run.rb").strip
+    assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end
 end

--- a/Formula/swig@3.04.rb
+++ b/Formula/swig@3.04.rb
@@ -42,6 +42,6 @@ class SwigAT304 < Formula
     system ENV.cc, "-c", "test.c"
     system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
     system ENV.cc, "-bundle", "-flat_namespace", "-undefined", "suppress", "test.o", "test_wrap.o", "-o", "test.bundle"
-    assert_equal "2", shell_output("ruby run.rb").strip
+    assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The test would fail if Ruby 2.4 happened to be installed, since the test
hard codes -I/System/Library/Frameworks/Ruby.framework/Headers.