### PR TITLE
ntl: invert library flags in test

### DIFF
--- a/Formula/ntl.rb
+++ b/Formula/ntl.rb
@@ -42,8 +42,8 @@ class Ntl < Formula
       -I#{include}
       -L#{gmp.opt_lib}
       -L#{lib}
-      -lgmp
       -lntl
+      -lgmp
     ]
     system ENV.cxx, "square.cc", "-o", "square", *flags
     assert_equal "4611686018427387904", pipe_output("./square", "2147483648")


### PR DESCRIPTION
Fixes build error of the test in Linuxbrew:
/home/linuxbrew/.linuxbrew/Cellar/ntl/10.4.0/lib/libntl.a(lip.o):
In function redc': /tmp/ntl-20170709-39012-9xndg8/ntl-10.4.0/src/lip.cpp:5012: undefined reference to__gmpn_addmul_1'
/tmp/ntl-20170709-39012-9xndg8/ntl-10.4.0/src/lip.cpp:5024: undefined reference to `__gmpn_sub_n'

This changes nothing for the mac build, it is just to
keep both versions as much in sync as possible.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
