### PR TITLE
precomp 0.4.5 (new formula)

### DIFF
--- a/Formula/precomp.rb
+++ b/Formula/precomp.rb
@@ -8,7 +8,7 @@ class Precomp < Formula
   def install
     # HEAD already has that, but current stable version does not compile with clang without that patch
     inreplace "contrib/packmp3/Makefile", "-fsched-spec-load ", ""
-    
+
     # Seems like Yosemite does not like the -s flag
     inreplace "Makefile", " -s ", " "
 

--- a/Formula/precomp.rb
+++ b/Formula/precomp.rb
@@ -8,6 +8,9 @@ class Precomp < Formula
   def install
     # HEAD already has that, but current stable version does not compile with clang without that patch
     inreplace "contrib/packmp3/Makefile", "-fsched-spec-load ", ""
+    
+    # Seems like Yosemite does not like the -s flag
+    inreplace "Makefile", " -s ", " "
 
     system "make"
     bin.install "precomp"

--- a/Formula/precomp.rb
+++ b/Formula/precomp.rb
@@ -1,0 +1,25 @@
+class Precomp < Formula
+  desc "Command-line precompressor to achieve better compression"
+  homepage "http://schnaader.info/precomp.php"
+  url "https://github.com/schnaader/precomp-cpp/archive/v0.4.5.tar.gz"
+  sha256 "39add141554f0186200911ab61838b69f5777956b3dfd37d82bb6923607258dc"
+  head "https://github.com/schnaader/precomp-cpp.git"
+
+  def install
+    # HEAD already has that, but current stable version does not compile with clang without that patch
+    inreplace "contrib/packmp3/Makefile", "-fsched-spec-load ", ""
+
+    system "make"
+    bin.install "precomp"
+  end
+
+  test do
+    cp "#{bin}/precomp", testpath/"precomp"
+    system "gzip", "-1", testpath/"precomp"
+
+    system "#{bin}/precomp", testpath/"precomp.gz"
+    rm testpath/"precomp.gz", :force => true
+    system "#{bin}/precomp", "-r", testpath/"precomp.pcf"
+    system "gzip", "-d", testpath/"precomp.gz"
+  end
+end


### PR DESCRIPTION
Precomp is a command-line precompressor to achieve better compression for some filetypes (e.g. PDF, GZip files, etc.) and is mostly useful in combination with other compressors to compress files even further.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
