### PR TITLE
bazel: update patch checksum for 10.10 fix

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -18,7 +18,7 @@ class Bazel < Formula
   # See https://github.com/bazelbuild/bazel/issues/3279
   patch do
     url "https://github.com/bazelbuild/bazel/pull/3281.patch?full_index=1"
-    sha256 "2584b81dfe0115281ece11a3dd5dbfe07233700fc904c81a58c0bcaf0f48c275"
+    sha256 "704dff309fa2f6ee5304f72fcbe6d2576326e1bb8e1e41385dc02d773ee35665"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/bazelbuild/bazel/pull/3281 has been refreshed so the checksum for the PR patch needs to be updated.