### PR TITLE
Secure URLs (2 of 3)

### DIFF
--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -1,7 +1,7 @@
 class Libogg < Formula
   desc "Ogg Bitstream Library"
   homepage "https://www.xiph.org/ogg/"
-  url "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
+  url "https://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
   sha256 "e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692"
 
   bottle do

--- a/Formula/libshout.rb
+++ b/Formula/libshout.rb
@@ -1,7 +1,7 @@
 class Libshout < Formula
   desc "Data and connectivity library for the icecast server"
   homepage "http://www.icecast.org/"
-  url "http://downloads.xiph.org/releases/libshout/libshout-2.3.1.tar.gz"
+  url "https://downloads.xiph.org/releases/libshout/libshout-2.3.1.tar.gz"
   sha256 "cf3c5f6b4a5e3fcfbe09fb7024aa88ad4099a9945f7cb037ec06bcee7a23926e"
 
   bottle do

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -1,7 +1,7 @@
 class Libvorbis < Formula
   desc "Vorbis General Audio Compression Codec"
   homepage "http://vorbis.com/"
-  url "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz"
+  url "https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz"
   sha256 "54f94a9527ff0a88477be0a71c0bab09a4c3febe0ed878b24824906cd4b0e1d1"
   revision 1
 

--- a/Formula/libxspf.rb
+++ b/Formula/libxspf.rb
@@ -1,7 +1,7 @@
 class Libxspf < Formula
   desc "C++ library for XSPF playlist reading and writing"
   homepage "https://libspiff.sourceforge.io/"
-  url "http://downloads.xiph.org/releases/xspf/libxspf-1.2.0.tar.bz2"
+  url "https://downloads.xiph.org/releases/xspf/libxspf-1.2.0.tar.bz2"
   sha256 "ba9e93a0066469b074b4022b480004651ad3aa5b4313187fd407d833f79b43a5"
 
   bottle do

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -22,53 +22,53 @@ class Llvm < Formula
   homepage "https://llvm.org/"
 
   stable do
-    url "http://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz"
+    url "https://llvm.org/releases/4.0.1/llvm-4.0.1.src.tar.xz"
     sha256 "da783db1f82d516791179fe103c71706046561f7972b18f0049242dee6712b51"
 
     resource "clang" do
-      url "http://releases.llvm.org/4.0.1/cfe-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/cfe-4.0.1.src.tar.xz"
       sha256 "61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b"
     end
 
     resource "clang-extra-tools" do
-      url "http://releases.llvm.org/4.0.1/clang-tools-extra-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/clang-tools-extra-4.0.1.src.tar.xz"
       sha256 "35d1e64efc108076acbe7392566a52c35df9ec19778eb9eb12245fc7d8b915b6"
     end
 
     resource "compiler-rt" do
-      url "http://releases.llvm.org/4.0.1/compiler-rt-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/compiler-rt-4.0.1.src.tar.xz"
       sha256 "a3c87794334887b93b7a766c507244a7cdcce1d48b2e9249fc9a94f2c3beb440"
     end
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "http://releases.llvm.org/4.0.1/libcxx-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/libcxx-4.0.1.src.tar.xz"
       sha256 "520a1171f272c9ff82f324d5d89accadcec9bc9f3c78de11f5575cdb99accc4c"
     end
 
     resource "libunwind" do
-      url "http://releases.llvm.org/4.0.1/libunwind-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/libunwind-4.0.1.src.tar.xz"
       sha256 "3b072e33b764b4f9b5172698e080886d1f4d606531ab227772a7fc08d6a92555"
     end
 
     resource "lld" do
-      url "http://releases.llvm.org/4.0.1/lld-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/lld-4.0.1.src.tar.xz"
       sha256 "63ce10e533276ca353941ce5ab5cc8e8dcd99dbdd9c4fa49f344a212f29d36ed"
     end
 
     resource "lldb" do
-      url "http://releases.llvm.org/4.0.1/lldb-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/lldb-4.0.1.src.tar.xz"
       sha256 "8432d2dfd86044a0fc21713e0b5c1d98e1d8aad863cf67562879f47f841ac47b"
     end
 
     resource "openmp" do
-      url "http://releases.llvm.org/4.0.1/openmp-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/openmp-4.0.1.src.tar.xz"
       sha256 "ec693b170e0600daa7b372240a06e66341ace790d89eaf4a843e8d56d5f4ada4"
     end
 
     resource "polly" do
-      url "http://releases.llvm.org/4.0.1/polly-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/polly-4.0.1.src.tar.xz"
       sha256 "b443bb9617d776a7d05970e5818aa49aa2adfb2670047be8e9f242f58e84f01a"
     end
   end

--- a/Formula/llvm@3.7.rb
+++ b/Formula/llvm@3.7.rb
@@ -1,34 +1,34 @@
 class LlvmAT37 < Formula
   desc "Next-gen compiler infrastructure"
-  homepage "http://llvm.org/"
+  homepage "https://llvm.org/"
 
   stable do
-    url "http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz"
+    url "https://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz"
     sha256 "be7794ed0cec42d6c682ca8e3517535b54555a3defabec83554dbc74db545ad5"
 
     resource "clang" do
-      url "http://llvm.org/releases/3.7.1/cfe-3.7.1.src.tar.xz"
+      url "https://llvm.org/releases/3.7.1/cfe-3.7.1.src.tar.xz"
       sha256 "56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674"
     end
 
     resource "clang-tools-extra" do
-      url "http://llvm.org/releases/3.7.1/clang-tools-extra-3.7.1.src.tar.xz"
+      url "https://llvm.org/releases/3.7.1/clang-tools-extra-3.7.1.src.tar.xz"
       sha256 "4a91edaccad1ce984c7c49a4a87db186b7f7b21267b2b03bcf4bd7820715bc6b"
     end
 
     resource "polly" do
-      url "http://llvm.org/releases/3.7.1/polly-3.7.1.src.tar.xz"
+      url "https://llvm.org/releases/3.7.1/polly-3.7.1.src.tar.xz"
       sha256 "ce9273ad315e1904fd35dc64ac4375fd592f3c296252ab1d163b9ff593ec3542"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/releases/3.7.1/libcxx-3.7.1.src.tar.xz"
+      url "https://llvm.org/releases/3.7.1/libcxx-3.7.1.src.tar.xz"
       sha256 "357fbd4288ce99733ba06ae2bec6f503413d258aeebaab8b6a791201e6f7f144"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "http://llvm.org/releases/3.7.1/libcxxabi-3.7.1.src.tar.xz"
+        url "https://llvm.org/releases/3.7.1/libcxxabi-3.7.1.src.tar.xz"
         sha256 "a47faaed90f577da8ca3b5f044be9458d354a53fab03003a44085a912b73ab2a"
       end
     end
@@ -42,27 +42,27 @@ class LlvmAT37 < Formula
   end
 
   head do
-    url "http://llvm.org/git/llvm.git", :branch => "release_37"
+    url "https://llvm.org/git/llvm.git", :branch => "release_37"
 
     resource "clang" do
-      url "http://llvm.org/git/clang.git", :branch => "release_37"
+      url "https://llvm.org/git/clang.git", :branch => "release_37"
     end
 
     resource "clang-tools-extra" do
-      url "http://llvm.org/git/clang-tools-extra.git", :branch => "release_37"
+      url "https://llvm.org/git/clang-tools-extra.git", :branch => "release_37"
     end
 
     resource "polly" do
-      url "http://llvm.org/git/polly.git", :branch => "release_37"
+      url "https://llvm.org/git/polly.git", :branch => "release_37"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/git/libcxx.git", :branch => "release_37"
+      url "https://llvm.org/git/libcxx.git", :branch => "release_37"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "http://llvm.org/git/libcxxabi.git", :branch => "release_37"
+        url "https://llvm.org/git/libcxxabi.git", :branch => "release_37"
       end
     end
   end

--- a/Formula/llvm@3.8.rb
+++ b/Formula/llvm@3.8.rb
@@ -1,44 +1,44 @@
 class LlvmAT38 < Formula
   desc "Next-gen compiler infrastructure"
-  homepage "http://llvm.org/"
+  homepage "https://llvm.org/"
 
   stable do
-    url "http://llvm.org/releases/3.8.1/llvm-3.8.1.src.tar.xz"
+    url "https://llvm.org/releases/3.8.1/llvm-3.8.1.src.tar.xz"
     sha256 "6e82ce4adb54ff3afc18053d6981b6aed1406751b8742582ed50f04b5ab475f9"
 
     resource "clang" do
-      url "http://llvm.org/releases/3.8.1/cfe-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/cfe-3.8.1.src.tar.xz"
       sha256 "4cd3836dfb4b88b597e075341cae86d61c63ce3963e45c7fe6a8bf59bb382cdf"
     end
 
     resource "clang-tools-extra" do
-      url "http://llvm.org/releases/3.8.1/clang-tools-extra-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/clang-tools-extra-3.8.1.src.tar.xz"
       sha256 "664a5c60220de9c290bf2a5b03d902ab731a4f95fe73a00856175ead494ec396"
     end
 
     resource "polly" do
-      url "http://llvm.org/releases/3.8.1/polly-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/polly-3.8.1.src.tar.xz"
       sha256 "453c27e1581614bb3b6351bf5a2da2939563ea9d1de99c420f85ca8d87b928a2"
     end
 
     resource "lld" do
-      url "http://llvm.org/releases/3.8.1/lld-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/lld-3.8.1.src.tar.xz"
       sha256 "2bd9be8bb18d82f7f59e31ea33b4e58387dbdef0bc11d5c9fcd5ce9a4b16dc00"
     end
 
     resource "openmp" do
-      url "http://llvm.org/releases/3.8.1/openmp-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/openmp-3.8.1.src.tar.xz"
       sha256 "68fcde6ef34e0275884a2de3450a31e931caf1d6fda8606ef14f89c4123617dc"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/releases/3.8.1/libcxx-3.8.1.src.tar.xz"
+      url "https://llvm.org/releases/3.8.1/libcxx-3.8.1.src.tar.xz"
       sha256 "77d7f3784c88096d785bd705fa1bab7031ce184cd91ba8a7008abf55264eeecc"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "http://llvm.org/releases/3.8.1/libcxxabi-3.8.1.src.tar.xz"
+        url "https://llvm.org/releases/3.8.1/libcxxabi-3.8.1.src.tar.xz"
         sha256 "e1b55f7be3fad746bdd3025f43e42d429fb6194aac5919c2be17c4a06314dae1"
       end
     end
@@ -52,35 +52,35 @@ class LlvmAT38 < Formula
   end
 
   head do
-    url "http://llvm.org/git/llvm.git", :branch => "release_38"
+    url "https://llvm.org/git/llvm.git", :branch => "release_38"
 
     resource "clang" do
-      url "http://llvm.org/git/clang.git", :branch => "release_38"
+      url "https://llvm.org/git/clang.git", :branch => "release_38"
     end
 
     resource "clang-tools-extra" do
-      url "http://llvm.org/git/clang-tools-extra.git", :branch => "release_38"
+      url "https://llvm.org/git/clang-tools-extra.git", :branch => "release_38"
     end
 
     resource "polly" do
-      url "http://llvm.org/git/polly.git", :branch => "release_38"
+      url "https://llvm.org/git/polly.git", :branch => "release_38"
     end
 
     resource "lld" do
-      url "http://llvm.org/git/lld.git"
+      url "https://llvm.org/git/lld.git"
     end
 
     resource "openmp" do
-      url "http://llvm.org/git/openmp.git", :branch => "release_38"
+      url "https://llvm.org/git/openmp.git", :branch => "release_38"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/git/libcxx.git", :branch => "release_38"
+      url "https://llvm.org/git/libcxx.git", :branch => "release_38"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "http://llvm.org/git/libcxxabi.git", :branch => "release_38"
+        url "https://llvm.org/git/libcxxabi.git", :branch => "release_38"
       end
     end
   end

--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -19,57 +19,57 @@ end
 
 class LlvmAT39 < Formula
   desc "Next-gen compiler infrastructure"
-  homepage "http://llvm.org/"
+  homepage "https://llvm.org/"
   revision 1
 
   stable do
-    url "http://llvm.org/releases/3.9.1/llvm-3.9.1.src.tar.xz"
+    url "https://llvm.org/releases/3.9.1/llvm-3.9.1.src.tar.xz"
     sha256 "1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee"
 
     resource "clang" do
-      url "http://llvm.org/releases/3.9.1/cfe-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/cfe-3.9.1.src.tar.xz"
       sha256 "e6c4cebb96dee827fa0470af313dff265af391cb6da8d429842ef208c8f25e63"
     end
 
     resource "clang-extra-tools" do
-      url "http://llvm.org/releases/3.9.1/clang-tools-extra-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/clang-tools-extra-3.9.1.src.tar.xz"
       sha256 "29a5b65bdeff7767782d4427c7c64d54c3a8684bc6b217b74a70e575e4813635"
     end
 
     resource "compiler-rt" do
-      url "http://llvm.org/releases/3.9.1/compiler-rt-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/compiler-rt-3.9.1.src.tar.xz"
       sha256 "d30967b1a5fa51a2503474aacc913e69fd05ae862d37bf310088955bdb13ec99"
     end
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "http://llvm.org/releases/3.9.1/libcxx-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/libcxx-3.9.1.src.tar.xz"
       sha256 "25e615e428f60e651ed09ffd79e563864e3f4bc69a9e93ee41505c419d1a7461"
     end
 
     resource "libunwind" do
-      url "http://llvm.org/releases/3.9.1/libunwind-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/libunwind-3.9.1.src.tar.xz"
       sha256 "0b0bc73264d7ab77d384f8a7498729e3c4da8ffee00e1c85ad02a2f85e91f0e6"
     end
 
     resource "lld" do
-      url "http://llvm.org/releases/3.9.1/lld-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/lld-3.9.1.src.tar.xz"
       sha256 "48e128fabb2ddaee64ecb8935f7ac315b6e68106bc48aeaf655d179c65d87f34"
     end
 
     resource "lldb" do
-      url "http://llvm.org/releases/3.9.1/lldb-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/lldb-3.9.1.src.tar.xz"
       sha256 "7e3311b2a1f80f4d3426e09f9459d079cab4d698258667e50a46dccbaaa460fc"
     end
 
     resource "openmp" do
-      url "http://llvm.org/releases/3.9.1/openmp-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/openmp-3.9.1.src.tar.xz"
       sha256 "d23b324e422c0d5f3d64bae5f550ff1132c37a070e43c7ca93991676c86c7766"
     end
 
     resource "polly" do
-      url "http://llvm.org/releases/3.9.1/polly-3.9.1.src.tar.xz"
+      url "https://llvm.org/releases/3.9.1/polly-3.9.1.src.tar.xz"
       sha256 "9ba5e61fc7bf8c7435f64e2629e0810c9b1d1b03aa5b5605b780d0e177b4cb46"
     end
   end
@@ -82,42 +82,42 @@ class LlvmAT39 < Formula
   end
 
   head do
-    url "http://llvm.org/git/llvm.git", :branch => "release_39"
+    url "https://llvm.org/git/llvm.git", :branch => "release_39"
 
     resource "clang" do
-      url "http://llvm.org/git/clang.git", :branch => "release_39"
+      url "https://llvm.org/git/clang.git", :branch => "release_39"
     end
 
     resource "clang-extra-tools" do
-      url "http://llvm.org/git/clang-tools-extra.git", :branch => "release_39"
+      url "https://llvm.org/git/clang-tools-extra.git", :branch => "release_39"
     end
 
     resource "compiler-rt" do
-      url "http://llvm.org/git/compiler-rt.git", :branch => "release_39"
+      url "https://llvm.org/git/compiler-rt.git", :branch => "release_39"
     end
 
     resource "libcxx" do
-      url "http://llvm.org/git/libcxx.git", :branch => "release_39"
+      url "https://llvm.org/git/libcxx.git", :branch => "release_39"
     end
 
     resource "libunwind" do
-      url "http://llvm.org/git/libunwind.git", :branch => "release_39"
+      url "https://llvm.org/git/libunwind.git", :branch => "release_39"
     end
 
     resource "lld" do
-      url "http://llvm.org/git/lld.git", :branch => "release_39"
+      url "https://llvm.org/git/lld.git", :branch => "release_39"
     end
 
     resource "lldb" do
-      url "http://llvm.org/git/lldb.git", :branch => "release_39"
+      url "https://llvm.org/git/lldb.git", :branch => "release_39"
     end
 
     resource "openmp" do
-      url "http://llvm.org/git/openmp.git", :branch => "release_39"
+      url "https://llvm.org/git/openmp.git", :branch => "release_39"
     end
 
     resource "polly" do
-      url "http://llvm.org/git/polly.git", :branch => "release_39"
+      url "https://llvm.org/git/polly.git", :branch => "release_39"
     end
   end
 
@@ -131,7 +131,7 @@ class LlvmAT39 < Formula
   option "with-shared-libs", "Build shared instead of static libraries"
   option "without-libffi", "Do not use libffi to call external functions"
 
-  depends_on "libffi" => :recommended # http://llvm.org/docs/GettingStarted.html#requirement
+  depends_on "libffi" => :recommended # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
 
   depends_on "ocaml" => :optional

--- a/Formula/mvptree.rb
+++ b/Formula/mvptree.rb
@@ -1,7 +1,7 @@
 class Mvptree < Formula
   desc "Perceptual hash library"
-  homepage "http://www.phash.org"
-  url "http://www.phash.org/releases/mvptree-1.0.tar.gz"
+  homepage "https://www.phash.org/"
+  url "https://www.phash.org/releases/mvptree-1.0.tar.gz"
   sha256 "cbb89e7368785f4823200d4ba81975cdabe77797d736047b1ea14b02e6a61839"
 
   bottle do

--- a/Formula/oggz.rb
+++ b/Formula/oggz.rb
@@ -1,7 +1,7 @@
 class Oggz < Formula
   desc "Command-line tool for manipulating Ogg files"
   homepage "https://www.xiph.org/oggz/"
-  url "http://downloads.xiph.org/releases/liboggz/liboggz-1.1.1.tar.gz"
+  url "https://downloads.xiph.org/releases/liboggz/liboggz-1.1.1.tar.gz"
   sha256 "6bafadb1e0a9ae4ac83304f38621a5621b8e8e32927889e65a98706d213d415a"
 
   bottle do

--- a/Formula/raine.rb
+++ b/Formula/raine.rb
@@ -66,7 +66,7 @@ class Raine < Formula
 
   resource "libpng" do
     url "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.28.tar.xz"
-    mirror "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.28/libpng-1.6.28.tar.xz"
+    mirror "https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.28/libpng-1.6.28.tar.xz"
     sha256 "d8d3ec9de6b5db740fefac702c37ffcf96ae46cb17c18c1544635a3852f78f7a"
   end
 
@@ -81,17 +81,17 @@ class Raine < Formula
   end
 
   resource "libogg" do
-    url "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
+    url "https://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
     sha256 "e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692"
   end
 
   resource "libvorbis" do
-    url "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz"
+    url "https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz"
     sha256 "54f94a9527ff0a88477be0a71c0bab09a4c3febe0ed878b24824906cd4b0e1d1"
   end
 
   resource "flac" do
-    url "http://downloads.xiph.org/releases/flac/flac-1.3.2.tar.xz"
+    url "https://downloads.xiph.org/releases/flac/flac-1.3.2.tar.xz"
     mirror "https://downloads.sourceforge.net/project/flac/flac-src/flac-1.3.2.tar.xz"
     sha256 "91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Known issues:
```
llvm@3.9:
  * Dependency graphviz should not use option dot
raine:
  * Stable resource "libpng": The URL https://downloads.sourceforge.net/project/libpng/libpng16/1.6.28/libpng-1.6.28.tar.xz is not
  * HEAD resource "libpng": The URL https://downloads.sourceforge.net/project/libpng/libpng16/1.6.28/libpng-1.6.28.tar.xz is not re
```

Corrected the `raine` `libpng` URL, still fails in audit, even though the URL is fine.