### PR TITLE
kubernetes-cli: add man pages

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -37,6 +37,11 @@ class KubernetesCli < Formula
       # Install zsh completion
       output = Utils.popen_read("#{bin}/kubectl completion zsh")
       (zsh_completion/"kubectl").write output
+
+      # Install man pages
+      # Leave step this for the end as this dirties the git tree
+      system "hack/generate-docs.sh"
+      man1.install Dir["docs/man/man1/*.1"]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add man pages for kubectl. Didn't bump revision as I don't think this is worth rebottling. It can get wrapped in with next version bump.