### PR TITLE
net-snmp: Update workaround for latest macOS (10.13)

### DIFF
--- a/Formula/net-snmp.rb
+++ b/Formula/net-snmp.rb
@@ -42,6 +42,7 @@ class NetSnmp < Formula
     ln_s "darwin13.h", "include/net-snmp/system/darwin14.h"
     ln_s "darwin13.h", "include/net-snmp/system/darwin15.h"
     ln_s "darwin13.h", "include/net-snmp/system/darwin16.h"
+    ln_s "darwin13.h", "include/net-snmp/system/darwin17.h"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This simply continues a fix for an as of yet [unresolved bug](https://sourceforge.net/p/net-snmp/bugs/2504/) where a header is expected to be named the same as the OS of the target triplet (i.e. x86_64-apple-_**darwin##**_). Because the OS increments with the macOS version every year, the header needed must increment every year, as well.

Like the three fixes before it, this will work for now but I have to wonder if overriding the OS version - by passing '--build=x86_64-apple-darwin13' to ./configure, for instance - would be a better longterm option.

Oh well. Until next year...