### PR TITLE
Update afsctool.rb: fix "Unable to compress file" issue on Mac OS Sierra

### DIFF
--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -10,7 +10,7 @@ class Afsctool < Formula
     url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.diff?full_index=1"
     sha256 "a541526679eb5d2471b3f257dab6103300d950f7b2f9d49bbfeb9f27dfc48542"
   end
-  
+
   bottle do
     cellar :any_skip_relocation
     sha256 "9b956b7c54385c3001e49f03672054b660e03f06b7831d0825f2bd613daa7cf8" => :sierra

--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -4,9 +4,10 @@ class Afsctool < Formula
   url "https://docs.google.com/uc?export=download&id=0BwQlnXqL939ZQjBQNEhRQUo0aUk"
   version "1.6.4"
   sha256 "bb6a84370526af6ec1cee2c1a7199134806e691d1093f4aef060df080cd3866d"
+  revision 1
 
+  # Fixes Sierra "Unable to compress" issue; reported upstream on 24 July 2017
   patch do
-    # fixes Sierra "Unable to compress" issue
     url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.diff?full_index=1"
     sha256 "a541526679eb5d2471b3f257dab6103300d950f7b2f9d49bbfeb9f27dfc48542"
   end
@@ -21,8 +22,8 @@ class Afsctool < Formula
 
   def install
     cd "afsctool_34" do
-      system ENV.cc, ENV.cflags, "-lz",
-         "-framework", "CoreServices", "-o", "afsctool", "afsctool.c"
+      system ENV.cc, ENV.cflags, "-lz", "afsctool.c",
+                     "-framework", "CoreServices", "-o", "afsctool"
       bin.install "afsctool"
     end
   end

--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -5,6 +5,12 @@ class Afsctool < Formula
   version "1.6.4"
   sha256 "bb6a84370526af6ec1cee2c1a7199134806e691d1093f4aef060df080cd3866d"
 
+  patch do
+    # fixes Sierra "Unable to compress" issue
+    url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.diff?full_index=1"
+    sha256 "a541526679eb5d2471b3f257dab6103300d950f7b2f9d49bbfeb9f27dfc48542"
+  end
+  
   bottle do
     cellar :any_skip_relocation
     sha256 "9b956b7c54385c3001e49f03672054b660e03f06b7831d0825f2bd613daa7cf8" => :sierra


### PR DESCRIPTION
Include a patch to fix "Unable to compress file" issue on Mac OS Sierra.
Checking values of both 17 and 23 in returned type of fsInfo.f_type. Filesystem on Sierra would return 23 while the filesystem on previous Mac OS X would return 17. Both of these values should be accepted to let the compression moving on.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
