### PR TITLE
ripgrep: install proper zsh completion for HEAD

### DIFF
--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -24,7 +24,11 @@ class Ripgrep < Formula
     out_dir = Dir["target/release/build/ripgrep-*/out"].first
     bash_completion.install "#{out_dir}/rg.bash-completion"
     fish_completion.install "#{out_dir}/rg.fish"
-    zsh_completion.install "#{out_dir}/_rg"
+    if build.head?
+      zsh_completion.install "complete/_rg"
+    else
+      zsh_completion.install "#{out_dir}/_rg"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now ripgrep's `build.rs` doesn't generate `_rg` for zsh completion. They've added `complete/_rg` manually. See https://github.com/BurntSushi/ripgrep/commit/2628c8f38ee117d41a340afc87454db037b69933.