### PR TITLE
collectd: Setting libtool deps to :run from :build!

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -26,7 +26,7 @@ class Collectd < Formula
   deprecated_option "debug" => "with-debug"
 
   depends_on "pkg-config" => :build
-  depends_on "libtool" => :build
+  depends_on "libtool" => :run
   depends_on "riemann-client" => :optional
   depends_on :java => :optional
   depends_on :python => :optional


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
In tracking down why my PR ([#15602](https://github.com/Homebrew/homebrew-core/pull/15602)) for net-snmp failed the automated online build stuff, I came across this bug. `otool -L` lists libltdl as a linked lib for the actual collectd binary (found in sbin/) yet libtool was only indicated as a _build_ dependency. I'm guessing the near ubiquity of libtool made it exceedingly rare for collectd to be installed without libtool also being installed. Still, brew happily uninstalled libtool which quickly replicated the missing library error `brew linkage --test collectd` produced from the test failure of my original PR.