### PR TITLE
wine: update (sub)formula for net-snmp

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -401,6 +401,7 @@ class Wine < Formula
         ln_s "darwin13.h", "include/net-snmp/system/darwin14.h"
         ln_s "darwin13.h", "include/net-snmp/system/darwin15.h"
         ln_s "darwin13.h", "include/net-snmp/system/darwin16.h"
+        ln_s "darwin13.h", "include/net-snmp/system/darwin17.h"
 
         system "./configure", "--disable-debugging",
                               "--prefix=#{libexec}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Allows wine build to complete on macOS High Sierra. See PR #15602 for the same change made to the standalone formula for net-snmp.