### PR TITLE
mecab-unidic-extended (new formula)

### DIFF
--- a/Formula/mecab-unidic-extended.rb
+++ b/Formula/mecab-unidic-extended.rb
@@ -1,0 +1,32 @@
+class MecabUnidicExtended < Formula
+  desc "Extended morphological analyzer for MeCab"
+  homepage "https://osdn.jp/projects/unidic/"
+  url "https://ja.osdn.net/frs/redir.php?f=%2Funidic%2F58338%2Funidic-mecab_kana-accent-2.1.2_src.zip"
+  sha256 "70793cacda81b403eda71736cc180f3144303623755a612b13e1dffeb6554591"
+
+  depends_on "mecab"
+
+  link_overwrite "lib/mecab/dic"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--with-dicdir=#{lib}/mecab/dic/unidic-extended"
+    system "make", "install"
+  end
+
+  def caveats; <<-EOS.undent
+     To enable mecab-unidic dictionary, add to #{HOMEBREW_PREFIX}/etc/mecabrc:
+       dicdir = #{HOMEBREW_PREFIX}/lib/mecab/dic/unidic-extended
+    EOS
+  end
+
+  test do
+    (testpath/"mecabrc").write <<-EOS.undent
+      dicdir = #{HOMEBREW_PREFIX}/lib/mecab/dic/unidic-extended
+    EOS
+
+    pipe_output("mecab --rcfile=#{testpath}/mecabrc", "すもももももももものうち\n", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This a dictionary for the [mecab](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mecab.rb) morphological analyzer.
This dictionary is similar but distinct from the already existing [mecab-unidic](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mecab-unidic.rb) as it contains more information like kana accents.
