### PR TITLE
corectl: build with OCaml 4.04.2 from OPAM

### DIFF
--- a/Formula/corectl.rb
+++ b/Formula/corectl.rb
@@ -3,6 +3,7 @@ class Corectl < Formula
   homepage "https://github.com/TheNewNormal/corectl"
   url "https://github.com/TheNewNormal/corectl/archive/v0.7.18.tar.gz"
   sha256 "9bdf7bc8c6a7bd861e2b723c0566d0a093ed5d5caf370a065a1708132b4ab98a"
+  revision 1
   head "https://github.com/TheNewNormal/corectl.git", :branch => "golang"
 
   bottle do
@@ -36,9 +37,18 @@ class Corectl < Formula
 
     cd path do
       system "opam", "init", "--no-setup"
-      system "opam", "install", "uri", "ocamlfind", "qcow-format", "conf-libev", "io-page<2"
 
-      system "make", "tarball", *args
+      # Upstream issue "OCaml 4.05.0 support - cannot build in Homebrew"
+      # Reported 23 Jul 2017 https://github.com/TheNewNormal/corectl/issues/119
+      inreplace "opamroot/compilers/4.04.2/4.04.2/4.04.2.comp",
+        '["./configure"', '["./configure" "-no-graph"'
+      system "opam", "switch", "4.04.2"
+
+      system "opam", "config", "exec", "--", "opam", "install", "uri",
+             "ocamlfind", "qcow-format", "conf-libev", "io-page<2",
+             "mirage-block-unix>2.3.0", "lwt<3.1.0"
+      (opamroot/"system/bin").install_symlink opamroot/"4.04.2/bin/qcow-tool"
+      system "opam", "config", "exec", "--", "make", "tarball", *args
 
       bin.install Dir["bin/*"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

corectl does not build currently with OCaml 4.05.0 CC @AntonioMeireles

straggler from https://github.com/Homebrew/homebrew-core/pull/15674