### PR TITLE
rocksdb: depend on jemalloc

### DIFF
--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -3,7 +3,7 @@ class Rocksdb < Formula
   homepage "http://rocksdb.org"
   url "https://github.com/facebook/rocksdb/archive/v5.5.2.tar.gz"
   sha256 "c505d8b4aab235346f5555f00a900a45d4912ba902b49228acbcbc61d50163e7"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,6 +16,7 @@ class Rocksdb < Formula
   depends_on "snappy"
   depends_on "lz4"
   depends_on "gflags"
+  depends_on "jemalloc"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Avoid opportunistic linkage to gperftools (specifically, libtcmalloc) or
to jemalloc by explicitly depending on jemalloc.