### PR TITLE
glib 2.52.3- fix pkg-config for linking non-framework libraries

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -89,6 +89,9 @@ class Glib < Formula
               "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib -lintl"
       s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
               "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
+      # correct linking of framework - caused broken links downstream
+      s.gsub! "-Wl,-framework -Wl,CoreFoundation",
+              "-Wl,-framework,CoreFoundation"
     end
 
     (share+"gtk-doc").rmtree


### PR DESCRIPTION
caused problems downstream when linking unix libraries which are not frameworks

See message: https://discourse.brew.sh/t/linking-libraries-problem-caused-by-glib-pkg-config-file/927

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
