### PR TITLE
bento4 1.5.0-615 (new formula)

### DIFF
--- a/Formula/bento4.rb
+++ b/Formula/bento4.rb
@@ -1,0 +1,21 @@
+class Bento4 < Formula
+  desc "Full-featured MP4 format and MPEG DASH library and tools"
+  homepage "https://www.bento4.com/"
+  url "https://github.com/axiomatic-systems/Bento4/archive/v1.5.0-615.tar.gz"
+  version "1.5.0-615"
+  sha256 "109d48b75e7ba34d5a0cb98346c098d9e0d29d58b6bc27b90014dbc558a491a4"
+
+  conflicts_with "gpac", :because => "both install `mp42ts` binaries"
+
+  def install
+    cd "Build/Targets/any-gnu-gcc" do
+      system "make", "AP4_BUILD_CONFIG=Release"
+      bin.install Dir["Release/*"].select { |f| File.executable?(f) }
+    end
+  end
+
+  test do
+    system "#{bin}/mp4mux", "--track", test_fixtures("test.m4a"), "out.mp4"
+    assert_predicate testpath/"out.mp4", :exist?, "Failed to create out.mp4!"
+  end
+end


### PR DESCRIPTION
Adds a formula for the bento4 set of tools to (re)mux or edit MP4
file.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Please bear with me – this is my first formula and it's taken me long enough to figure this out. Some things that I haven't been able to consider due to my lack of experience with the program, build tools and Homebrew in particular:

- I had to use the standard `make` way to build these tools (from the `any-gnu-gcc` directory), although it supplies Cmake and a macOS-specific configuration – but I couldn't figure out how to build with this.
- I did not copy any header files or libraries, although this might be useful for programmatic use of the library.
- The formula provides `mp42ts` whereas `gpac` provides `MP4TS` (capitals). I guess this conflicts, so I excluded it.
- I only considered the release `.tar.gz`, although I think building from source would be possible
