### PR TITLE
awscli: fix zsh compdef wrapper and remove windows file

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -23,11 +23,21 @@ class Awscli < Formula
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "awscli"
+    # Remove Windows file
+    inreplace buildpath/"setup.py", "'bin/aws.cmd',", ""
     venv.pip_install_and_link buildpath
     pkgshare.install "awscli/examples"
 
     bash_completion.install "bin/aws_bash_completer"
-    zsh_completion.install "bin/aws_zsh_completer.sh" => "_aws"
+    zsh_completion.install "bin/aws_zsh_completer.sh"
+    (zsh_completion/"_aws").write <<-EOS.undent
+        #compdef aws
+        _aws () {
+          local e
+          e=$(dirname ${funcsourcetrace[1]%:*})/aws_zsh_completer.sh
+          if [[ -f $e ]]; then source $e; fi
+        }
+    EOS
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
Completion for zsh requires explicit sourcing of 'aws_zsh_completer.sh'
and not just linking. Also, remove Windows file during build.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
