### PR TITLE
libgcrypt 1.8.0

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -1,9 +1,9 @@
 class Libgcrypt < Formula
   desc "Cryptographic library based on the code from GnuPG"
   homepage "https://directory.fsf.org/wiki/Libgcrypt"
-  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.7.8.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.7.8.tar.bz2"
-  sha256 "948276ea47e6ba0244f36a17b51dcdd52cfd1e664b0a1ac3bc82134fb6cec199"
+  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.0.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.8.0.tar.bz2"
+  sha256 "23e49697b87cc4173b03b4757c8df4314e3149058fa18bdc4f82098f103d891b"
 
   bottle do
     cellar :any
@@ -27,7 +27,8 @@ class Libgcrypt < Formula
                           "--enable-static",
                           "--prefix=#{prefix}",
                           "--disable-asm",
-                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}"
+                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}",
+                          "--disable-jent-support" # Requires ENV.O0, which is unpleasant.
 
     # Parallel builds work, but only when run as separate steps
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes between version 1.7.0 and 1.8.0:
===================================================

 * New interfaces:

   - New cipher mode XTS
   - New hash function Blake-2
   - New function gcry_mpi_point_copy.
   - New function gcry_get_config.
   - GCRYCTL_REINIT_SYSCALL_CLAMP allows to init nPth after Libgcrypt.
   - New gobal configuration file /etc/gcrypt/random.conf.

 * Extended interfaces:

   - GCRYCTL_PRINT_CONFIG does now also print build information for
     libgpg-error and the used compiler version.
   - GCRY_CIPHER_MODE_CFB8 is now supported.
   - Add Stribog OIDs.  [also in 1.7.4]

 * Performance:

   - A jitter based entropy collector is now used in addition to the
     other entropy collectors.
   - Optimized gcry_md_hash_buffers for SHA-256 and SHA-512.
   - More ARMv8/AArch32 improvements for AES, GCM, SHA-256, and SHA-1.
     [also in 1.7.4]
   - Add ARMv8/AArch32 assembly implementation for Twofish and
     Camellia.  [also in 1.7.4]
   - Add bulk processing implementation for ARMv8/AArch32.
     [also in 1.7.4]
   - Improve the DRBG performance and sync the code with the Linux
     version.  [also in 1.7.4]

 * Internal changes:

   - Libgpg-error 1.25 is now required.  This avoids stalling of nPth
     threads due to contention on internal Libgcrypt locks (e.g. the
     random pool lock).
   - The system call clamp of libgpg-error is now used to wrap the
     blocking read of /dev/random.  This allows other nPth threads to
     run while Libgcrypt is gathering entropy.
   - When secure memory is requested by the MPI functions or by
     gcry_xmalloc_secure, they do not anymore lead to a fatal error if
     the secure memory pool is used up.  Instead new pools are
     allocated as needed.  These new pools are not protected against
     being swapped out (mlock can't be used).  However, these days
     this is considered a minor issue and can easily be mitigated by
     using encrypted swap space.  [also in 1.7.4]

 * Bug fixes:

   - Fix AES CTR self-check detected failure in the SSSE3 based
     implementation.  [also in 1.7.6]
   - Remove gratuitous select before the getrandom syscall.
     [also in 1.7.6]
   - Fix regression in mlock detection.  [bug#2870] [also in 1.7.5]
   - Fix GOST 28147 CryptoPro-B S-box.   [also in 1.7.4]
   - Fix error code handling of mlock calls.  [also in 1.7.4]
   - Fix possible timing attack on EdDSA session key. [also in 1.7.7]
   - Fix long standing bug in secure memory implementation which could
     lead to a segv on free. [bug#3027] [also in 1.7.7]
   - Mitigate a flush+reload side-channel attack on RSA secret keys
     dubbed "Sliding right into disaster".  For details see
     <https://eprint.iacr.org/2017/627>.  [CVE-2017-7526] [also in 1.7.8]
```