### PR TITLE
maven@3.0 3.0.5 (new formula)

### DIFF
--- a/Formula/maven@3.0.rb
+++ b/Formula/maven@3.0.rb
@@ -1,7 +1,8 @@
 class MavenAT30 < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
-  url "https://archive.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz"
   sha256 "d98d766be9254222920c1d541efd466ae6502b82a39166c90d65ffd7ea357dd9"
 
   bottle :unneeded

--- a/Formula/maven@3.0.rb
+++ b/Formula/maven@3.0.rb
@@ -1,0 +1,52 @@
+class MavenAT30 < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://archive.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz"
+  sha256 "d98d766be9254222920c1d541efd466ae6502b82a39166c90d65ffd7ea357dd9"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.bat"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    prefix.install_metafiles
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<-EOS.undent
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end


### PR DESCRIPTION
The formula for Maven 3.0 was was not added after the migration from
Homebrew/versions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
