### PR TITLE
redis@3.2 3.2.9 (new formula)

### DIFF
--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -1,0 +1,80 @@
+class RedisAT32 < Formula
+  desc "Persistent key-value database, with built-in net interface"
+  homepage "https://redis.io/"
+  url "http://download.redis.io/releases/redis-3.2.9.tar.gz"
+  sha256 "6eaacfa983b287e440d0839ead20c2231749d5d6b78bbe0e0ffa3a890c59ff26"
+  head "https://github.com/antirez/redis.git", :branch => "3.2"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "cc1fe39dedd78b18fa6342cb9626183f2b2ae7138b11c247d17901506678244d" => :sierra
+    sha256 "da746dba8fe2adaf47d764680c6232270fd08a6697ab1c2cc320bfd67e7dc08f" => :el_capitan
+    sha256 "18f7b5ccb4afdb99f8554f8b013cc2d7fca4ae29fa0807fa591cf6dd6017dca0" => :yosemite
+  end
+
+  keg_only :versioned_formula
+
+  option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"
+
+  def install
+    # Architecture isn't detected correctly on 32bit Snow Leopard without help
+    ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
+
+    args = %W[
+      PREFIX=#{prefix}
+      CC=#{ENV.cc}
+    ]
+    args << "MALLOC=jemalloc" if build.with? "jemalloc"
+    system "make", "install", *args
+
+    %w[run db/redis log].each { |p| (var/p).mkpath }
+
+    # Fix up default conf file to match our paths
+    inreplace "redis.conf" do |s|
+      s.gsub! "/var/run/redis.pid", var/"run/redis.pid"
+      s.gsub! "dir ./", "dir #{var}/db/redis/"
+      s.gsub! "\# bind 127.0.0.1", "bind 127.0.0.1"
+    end
+
+    etc.install "redis.conf"
+    etc.install "sentinel.conf" => "redis-sentinel.conf"
+  end
+
+  plist_options :manual => "redis-server #{HOMEBREW_PREFIX}/etc/redis.conf"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/redis-server</string>
+          <string>#{etc}/redis.conf</string>
+          <string>--daemonize no</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/redis.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/redis.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system bin/"redis-server", "--test-memory", "2"
+    %w[run db/redis log].each { |p| assert (var/p).exist?, "#{var/p} doesn't exist!" }
+  end
+end

--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -5,13 +5,6 @@ class RedisAT32 < Formula
   sha256 "6eaacfa983b287e440d0839ead20c2231749d5d6b78bbe0e0ffa3a890c59ff26"
   head "https://github.com/antirez/redis.git", :branch => "3.2"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "cc1fe39dedd78b18fa6342cb9626183f2b2ae7138b11c247d17901506678244d" => :sierra
-    sha256 "da746dba8fe2adaf47d764680c6232270fd08a6697ab1c2cc320bfd67e7dc08f" => :el_capitan
-    sha256 "18f7b5ccb4afdb99f8554f8b013cc2d7fca4ae29fa0807fa591cf6dd6017dca0" => :yosemite
-  end
-
   keg_only :versioned_formula
 
   option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"


### PR DESCRIPTION
Make Redis 3.2.x available again as it was replaced by 4.0.0 which is not quite stable yet and not mainstream for development

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is my first attempt at making a versioned formula and I am not sure I got everything right. I started with a previous version of the redis.rb formula from when it worked with 3.2.9