### PR TITLE
Escape slashes in HKCU line

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -486,7 +486,7 @@ class Wine < Formula
       s += <<-EOS.undent
 
         By default Wine uses a native Mac driver. To switch to the X11 driver, use
-        regedit to set the "graphics" key under "HKCU\Software\Wine\Drivers" to
+        regedit to set the "graphics" key under "HKCU\/Software\/Wine\/Drivers" to
         "x11" (or use winetricks).
 
         For best results with X11, install the latest version of XQuartz:


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Current:
```
2.4.1 :001 > s = ''
 => "" 
2.4.1 :002 > s += <<-EOS.undent
2.4.1 :003">         By default Wine uses a native Mac driver. To switch to the X11 driver, use
2.4.1 :004">         regedit to set the "graphics" key under "HKCU\Software\Wine\Drivers" to
2.4.1 :005">         "x11" (or use winetricks).
2.4.1 :006">         For best results with X11, install the latest version of XQuartz:
2.4.1 :007">           https://www.xquartz.org/
2.4.1 :008">       EOS
 => "By default Wine uses a native Mac driver. To switch to the X11 driver, use\nregedit to set the \"graphics\" key under \"HKCUSoftwareWineDrivers\" to\n\"x11\" (or use winetricks).\nFor best results with X11, install the latest version of XQuartz:\n  https://www.xquartz.org/\n" 
2.4.1 :009 > s = ''
```
<img width="673" alt="screen shot 2017-07-20 at 11 32 22 pm" src="https://user-images.githubusercontent.com/807580/28419876-c07a025a-6da3-11e7-97b2-21de78e34922.png">


Now:
```
2.4.1 :010 > s += <<-EOS.undent
2.4.1 :011">         By default Wine uses a native Mac driver. To switch to the X11 driver, use
2.4.1 :012">         regedit to set the "graphics" key under "HKCU\/Software\/Wine\/Drivers" to
2.4.1 :013">         "x11" (or use winetricks).
2.4.1 :014">         For best results with X11, install the latest version of XQuartz:
2.4.1 :015">           https://www.xquartz.org/
2.4.1 :016">       EOS
 => "By default Wine uses a native Mac driver. To switch to the X11 driver, use\nregedit to set the \"graphics\" key under \"HKCU/Software/Wine/Drivers\" to\n\"x11\" (or use winetricks).\nFor best results with X11, install the latest version of XQuartz:\n  https://www.xquartz.org/\n"
```