### PR TITLE
tcl-tk: fix for #12114 and #12808. Reenabled the `--with-x11` option.…

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -21,6 +21,10 @@ class TclTk < Formula
   option "with-threads", "Build with multithreading support"
   option "without-tcllib", "Don't build tcllib (utility modules)"
   option "without-tk", "Don't build the Tk (window toolkit)"
+  option "with-x11", "Build X11-based Tk instead of Aqua-based Tk"
+
+  depends_on :x11 => :optional
+  depends_on "pkg-config" => :build if build.with? "x11"
 
   resource "tk" do
     url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tk8.6.6-src.tar.gz"
@@ -54,7 +58,13 @@ class TclTk < Formula
         args = ["--prefix=#{prefix}", "--mandir=#{man}", "--with-tcl=#{lib}"]
         args << "--enable-threads" if build.with? "threads"
         args << "--enable-64bit" if MacOS.prefer_64_bit?
-        args << "--enable-aqua=yes" << "--without-x"
+        
+        if build.with? "x11"
+          args << "--with-x"
+        else
+          args << "--enable-aqua=yes"
+          args << "--without-x"
+        end
 
         cd "unix" do
           system "./configure", *args


### PR DESCRIPTION
… Without --with-x11 `brew test python` and `brew test python3` fail, and some formulae (eg pymol) break

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#### Fix for the python crashes described in #12114 and #12808.

- To reproduce on Sierra:
    - `brew install python --with-tcl-tk`
    - All of the following produce a low-level crash (eg `SIGABRT`, `abort trap 6`, etc)
        - `brew test python`
        - `python -m Tkinter`
        - `brew install pymol && pymol`

- To fix:
    - Using the version of the `tcl-tk` forula in this PR, do
        - `brew remove python`
        - `brew remove tcl-tk`
        - `brew install tcl-tk --with-x11`
        - `brew install python --with-tcl-tk`
    - Now `tkinter` and related software should work normally

The Aqua build of `tcl-tk` seems to break `tkinter` in various ways. This causes `brew test` to fail for both the `python` and 'python3' formulas. More relevantly, a broken `tkinter` in turn breaks the executables installed by certain formulae, such as `pymol`.

Following the suggestion of @cowsandmilk, I have unremoved the `--with-x11` option in the `tcl-tk` formula. Building `tcl-with` using the `--with-x11` option and then rebuilding my pythons fixed the bug for me, so I figured I'd share the fix with everyone via a PR.