### PR TITLE
libtiff: 4.0.8-2

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -4,7 +4,7 @@ class Libtiff < Formula
   url "http://download.osgeo.org/libtiff/tiff-4.0.8.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.8.tar.gz"
   sha256 "59d7a5a8ccd92059913f246877db95a2918e6c04fb9d43fd74e5c3390dac2910"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -22,16 +22,18 @@ class Libtiff < Formula
   # All of these have been reported upstream & should
   # be fixed in the next release, but please check.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.8-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.8-3.debian.tar.xz"
-    sha256 "8803ef2917ceb80c472e97d85e86f71a20d04cf7de94ebffcc1b3100f51058ce"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.8-4.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.8-4.debian.tar.xz"
+    sha256 "36c008179ae08d6958cd9fcd75f82c082624bf55e2c4e6ca0e1af59ea4d75d9c"
     apply "patches/01-CVE-2015-7554.patch",
           "patches/02-CVE.patch",
           "patches/03-CVE.patch",
           "patches/04-CVE-2016-10095_CVE-2017-9147.patch",
           "patches/05-CVE-2017-9936.patch",
           "patches/06-OOM_in_gtTileContig.patch",
-          "patches/07-CVE-2017-10688.patch"
+          "patches/07-CVE-2017-10688.patch",
+          "patches/08-LZW_compression_regression.patch",
+          "patches/09-CVE-2017-11335.patch"
   end
 
   def install


### PR DESCRIPTION
security update: CVE-2017-11335

Updated debian package build dependency. Included in the new source was a patch
for CVE-2017-11335, and a patch that fixes an LZW regression.

This formula is broken in master.