### PR TITLE
skinny 2.3.8

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.7/skinny-2.3.7.tar.gz"
-  sha256 "ce5421354d0518c4e10fba06d63ee8737634bcee73bdafee4fd4dcc5cc737805"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.8/skinny-2.3.8.tar.gz"
+  sha256 "ad455cd92d06978c2bbf2d327c9ce277191bf53bdfc2e9f77bbb0f94f177c6cd"
 
   bottle :unneeded
   depends_on :java => "1.7+"


### PR DESCRIPTION
This pull request upgrades `skinny` formula. https://github.com/skinny-framework/skinny-framework/releases/tag/2.3.8

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew uninstall skinny
Uninstalling /usr/local/Cellar/skinny/2.3.7... (461 files, 61.5MB)
x:homebrew-core kazuhirosera$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.3.8/skinny-2.3.8.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/410b1436-6f1b-11e7-804c-45864a633668?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20170722%2Fus-east-1%2Fs3%2
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.3.8: 449 files, 60.9MB, built in 39 seconds

$ brew audit --strict skinny
$
```
