### PR TITLE
gradle: Support installing from 'devel' and use overridable JAVA_HOME

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -4,6 +4,12 @@ class Gradle < Formula
   url "https://services.gradle.org/distributions/gradle-4.0.1-all.zip"
   sha256 "8a8005633be0ca38a206f2590445685683452a0b98a5d8ffd5b8413be09bf998"
 
+  devel do
+    url "https://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip"
+    version "4.1-rc-1"
+    sha256 "eb504c25abae8ee43e01a56f6873137d74ce68c43b8b1fe89dc0562e6b81ca51"
+  end
+
   bottle :unneeded
 
   option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
@@ -11,9 +17,10 @@ class Gradle < Formula
   depends_on :java => "1.7+"
 
   def install
+    rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
     libexec.install %w[docs media samples src] if build.with? "all"
-    bin.install_symlink libexec/"bin/gradle"
+    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Changes:
* Support 'devel' installation
* Use 'gradle' wrapper generated with overridable JAVA_HOME
* Remove Windows *.bat files
