### PR TITLE
consul: fix to remove outdated caveat

### DIFF
--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -29,14 +29,7 @@ class Consul < Formula
       system "make"
       bin.install "bin/consul"
       zsh_completion.install "contrib/zsh-completion/_consul"
-      pkgshare.install "ui" => "web-ui"
     end
-  end
-
-  def caveats; <<-EOS.undent
-    You can activate the UI by running
-    consul with `-ui-dir #{pkgshare}/web-ui`.
-    EOS
   end
 
   plist_options :manual => "consul agent -dev -advertise 127.0.0.1"


### PR DESCRIPTION
The caveat for the `-ui-dir` parameter is no longer correct as since 0.7
and above produce this warning if you try and use it:

```
==> If using Consul version 0.7.0 or later, the web UI is included in the
    binary so use ui to enable it
```

Using -agent -dev implies -ui and so the caveat produces an error trying
to start Consul.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
