### PR TITLE
mobile-shell 1.3.2

### DIFF
--- a/Formula/mobile-shell.rb
+++ b/Formula/mobile-shell.rb
@@ -1,9 +1,8 @@
 class MobileShell < Formula
   desc "Remote terminal application"
   homepage "https://mosh.org"
-  url "https://mosh.org/mosh-1.3.0.tar.gz"
-  sha256 "320e12f461e55d71566597976bd9440ba6c5265fa68fbf614c6f1c8401f93376"
-  revision 1
+  url "https://mosh.org/mosh-1.3.2.tar.gz"
+  sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
 
   bottle do
     sha256 "092d47a9a6836e66597775dadca0bc78c57b04879cf6c392f7514605d8c53a50" => :sierra
@@ -24,17 +23,9 @@ class MobileShell < Formula
 
   depends_on "pkg-config" => :build
   depends_on "protobuf"
-  depends_on :perl => "5.14" if MacOS.version <= :mountain_lion
   depends_on "tmux" => :build if build.with?("test") || build.bottle?
 
   def install
-    # Remove for > 1.3.0
-    # Upstream commit from 29 Apr 2017 "Disable unicode-later-combining.test for now"
-    # See https://github.com/mobile-shell/mosh/commit/df4dbe0d6c9c3ac7a6a102f315090c9b7aa75ad6
-    if build.stable?
-      inreplace "src/tests/Makefile.in", /^\tunicode-later-combining.test \\$\n/, ""
-    end
-
     # teach mosh to locate mosh-client without referring
     # PATH to support launching outside shell e.g. via launcher
     inreplace "scripts/mosh.pl", "'mosh-client", "\'#{bin}/mosh-client"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ancient Perl support was restored upstream in https://github.com/mobile-shell/mosh/pull/825 & then https://github.com/mobile-shell/mosh/pull/866. Should support every macOS version of `perl` right back to Leopard, which Homebrew no longer supports anyway.