### PR TITLE
tcl-tk: fixes #12114 for python and #12808 for python3 by bumping tcl-tk version

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -91,4 +91,3 @@ class TclTk < Formula
     assert_equal "honk", pipe_output("#{bin}/tclsh", "puts honk\n").chomp
   end
 end
-

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -22,11 +22,17 @@ class TclTk < Formula
     sha256 "c0449527355ede1293309ff674ec02e9df91188f9d85173d134ed388cee0afb3" => :yosemite
   end
 
-  head do
-    url "https://github.com/tcltk/tcl.git", :branch => "core_8_6_7_rc"
+  devel do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tcl8.6.7rc0-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7rc0-src.tar.gz"
+    version "8.6.7rc0"
+    sha256 "97840c0edb8a7d8160714b2317d3e7cb0bb45b88264881939db09c3f323fba97"
 
     resource "tk" do
-      url "https://github.com/tcltk/tk.git", :branch => "core_8_6_7_rc"
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tk8.6.7rc0-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7rc0-src.tar.gz"
+      version "8.6.7rc0"
+      sha256 "edb88456da559237d41db5541890a432fb5c437186fd7b18d14f680dea450f6e"
     end
   end
 

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -1,11 +1,20 @@
 class TclTk < Formula
   desc "Tool Command Language"
   homepage "https://www.tcl.tk/"
-  url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tcl8.6.6-src.tar.gz"
-  mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.6-src.tar.gz"
-  version "8.6.6"
-  sha256 "a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07"
-  revision 2
+
+  stable do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tcl8.6.6-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.6-src.tar.gz"
+    version "8.6.6"
+    sha256 "a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07"
+
+    resource "tk" do
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tk8.6.6-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk8.6.6-src.tar.gz"
+      version "8.6.6"
+      sha256 "d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d"
+    end
+  end
 
   bottle do
     sha256 "00cb0c31a7a9fb3820685bb5a0baee3e8b3d81e2b3b7f021277bbb833a710ee0" => :sierra
@@ -13,18 +22,19 @@ class TclTk < Formula
     sha256 "c0449527355ede1293309ff674ec02e9df91188f9d85173d134ed388cee0afb3" => :yosemite
   end
 
+  head do
+    url "https://github.com/tcltk/tcl.git", :branch => "core_8_6_7_rc"
+
+    resource "tk" do
+      url "https://github.com/tcltk/tk.git", :branch => "core_8_6_7_rc"
+    end
+  end
+
   keg_only :provided_by_osx,
     "tk installs some X11 headers and macOS provides an (older) Tcl/Tk"
 
   option "without-tcllib", "Don't build tcllib (utility modules)"
   option "without-tk", "Don't build the Tk (window toolkit)"
-
-  resource "tk" do
-    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tk8.6.6-src.tar.gz"
-    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk8.6.6-src.tar.gz"
-    version "8.6.6"
-    sha256 "d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d"
-  end
 
   resource "tcllib" do
     url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.18/tcllib-1.18.tar.gz"
@@ -54,7 +64,7 @@ class TclTk < Formula
         cd "unix" do
           system "./configure", *args, "--enable-aqua=yes",
                                 "--without-x", "--with-tcl=#{lib}"
-          system "make", "TK_LIBRARY=#{lib}"
+          system "make"
           system "make", "install"
           system "make", "install-private-headers"
           ln_s bin/"wish8.6", bin/"wish"
@@ -75,3 +85,4 @@ class TclTk < Formula
     assert_equal "honk", pipe_output("#{bin}/tclsh", "puts honk\n").chomp
   end
 end
+

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -1,6 +1,7 @@
 class TclTk < Formula
   desc "Tool Command Language"
   homepage "https://www.tcl.tk/"
+  revision 2
 
   stable do
     url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tcl8.6.6-src.tar.gz"
@@ -25,13 +26,11 @@ class TclTk < Formula
   devel do
     url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tcl8.6.7rc0-src.tar.gz"
     mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7rc0-src.tar.gz"
-    version "8.6.7rc0"
     sha256 "97840c0edb8a7d8160714b2317d3e7cb0bb45b88264881939db09c3f323fba97"
 
     resource "tk" do
       url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tk8.6.7rc0-src.tar.gz"
       mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7rc0-src.tar.gz"
-      version "8.6.7rc0"
       sha256 "edb88456da559237d41db5541890a432fb5c437186fd7b18d14f680dea450f6e"
     end
   end


### PR DESCRIPTION
to a version in which the upstream has fixed the relevant bugs.

Hopefully this is a better attempt at a fix than my last one (#15855).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [mostly] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
 
So apparently all of the trouble that people have been having with `brew python install --with-tcl-tk` and `brew python3 install --with-tcl-tk` (#12114 and #12808) is due to a whole mess of bugs in the upstream that have apparently all been fixed.

However, there's still no official release aside from the version of 8.6.6 that was put out last year. So what I've done is to update the formula so that it pulls from the core_8_6_7_rc branch in which all of the relevant fixes have been applied. After installing tcl-tk with the updated formula and then building python2/3 with `--with-tcl-tk`, `brew test` passes for both pythons, and both of

    python -c 'import Tkinter; root = Tkinter.Tk(); root.mainloop()'
    python3 -c 'import tkinter; root = tkinter.Tk(); root.mainloop()'

open an application window as expected, so everything seems good.

The one remaining hiccup is that `brew audit --strict` is still picking up a single error. This is due to the fact that tk now installs a couple of icon files (`Tk.icns` and `Tk.tiff`) in `/usr/local/opt/tcl-tk/lib` alongside the libraries, and audit really doesn't like that. I looked through the `configure` and `makefile` files in tk, and the installation of the icons into the library appears to be intended behavior on the part of the tcltk devs. How should I fix this?