### PR TITLE
plplot: fix cmake error when building `--with-fortran`

### DIFF
--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -3,7 +3,6 @@ class Plplot < Formula
   homepage "https://plplot.sourceforge.io"
   url "https://downloads.sourceforge.net/project/plplot/plplot/5.12.0%20Source/plplot-5.12.0.tar.gz"
   sha256 "8dc5da5ef80e4e19993d4c3ef2a84a24cc0e44a5dade83201fca7160a6d352ce"
-  revision 1
 
   bottle do
     sha256 "983bfc816485426b63a65d2afb52f6945acb4ccfdbe7044909055d4c2f9aeb94" => :sierra

--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -3,6 +3,7 @@ class Plplot < Formula
   homepage "https://plplot.sourceforge.io"
   url "https://downloads.sourceforge.net/project/plplot/plplot/5.12.0%20Source/plplot-5.12.0.tar.gz"
   sha256 "8dc5da5ef80e4e19993d4c3ef2a84a24cc0e44a5dade83201fca7160a6d352ce"
+  revision 1
 
   bottle do
     sha256 "983bfc816485426b63a65d2afb52f6945acb4ccfdbe7044909055d4c2f9aeb94" => :sierra
@@ -19,6 +20,10 @@ class Plplot < Formula
   depends_on :x11 => :optional
   depends_on :fortran => :optional
   depends_on :java => :optional
+
+  # Patch reported upstream. Fixes 5.12 cmake issue in cmake/modules/pkg-config.cmake that gets
+  # triggered when passing `--with-fortran`
+  patch :DATA
 
   def install
     args = std_cmake_args
@@ -69,3 +74,18 @@ class Plplot < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git i/cmake/modules/pkg-config.cmake w/cmake/modules/pkg-config.cmake
+index 2b46dbe..7ecc789 100644
+--- i/cmake/modules/pkg-config.cmake
++++ w/cmake/modules/pkg-config.cmake
+@@ -230,7 +230,7 @@ function(pkg_config_link_flags link_flags_out link_flags_in)
+     "/System/Library/Frameworks/([^ ]*)\\.framework"
+     "-framework \\1"
+     link_flags
+-    ${link_flags}
++    "${link_flags}"
+     )
+     #message("(frameworks) link_flags = ${link_flags}")
+   endif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
 Reported upstream at https://sourceforge.net/p/plplot/bugs/186/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
