### PR TITLE
Set LANG and LC_ALL for Emacs plist

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -130,6 +130,13 @@ class Emacs < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+        <key>LC_ALL</key>
+        <string>en_US.UTF-8</string>
+      </dict>
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/emacs</string>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It will use following locale if LANG or LC_ALL not set, cause copy and paste characters like Chinese incorrect.

```bash
Welcome to the Emacs shell

/ $ locale
LANG=
LC_COLLATE="C"
LC_CTYPE="C"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
/ $ 
```

```
# copy and paste Chinese characters in Emacs
你好
‰Ω†Â•Ω (should be 你好)
```