### PR TITLE
dosbox: fix debugger build by adding dependency on ncurses

### DIFF
--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -24,6 +24,7 @@ class Dosbox < Formula
   depends_on "sdl_net"
   depends_on "sdl_sound"
   depends_on "libpng"
+  depends_on "ncurses" if build.with?("debugger")
 
   conflicts_with "dosbox-x", :because => "both install `dosbox` binaries"
 


### PR DESCRIPTION
The DosBox debugger depends on ncurses. Without adding this dependency, the
build include curses.h from MacOSX SDK, and error with "member access into
incomplete type 'WINDOW'".

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
