### PR TITLE
php: import from homebrew/php

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -1,0 +1,374 @@
+class Php < Formula
+  desc "General-purpose scripting language"
+  homepage "https://php.net/"
+  url "https://php.net/get/php-7.2.2.tar.xz/from/this/mirror"
+  sha256 "47d7607d38a1d565fc43ea942c92229a7cd165f156737f210937e375b243cb11"
+  revision 14
+
+  depends_on "pkg-config" => :build
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "curl" if MacOS.version < :lion
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gmp"
+  depends_on "httpd"
+  depends_on "icu4c"
+  depends_on "imap-uw"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "openssl"
+  depends_on "pcre"
+  depends_on "unixodbc"
+  depends_on "webp"
+
+  needs :cxx11
+
+  def install
+    # Ensure that libxml2 will be detected correctly in older MacOS
+    if MacOS.version == :el_capitan || MacOS.version == :sierra
+      ENV["SDKROOT"] = MacOS.sdk_path
+    end
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. "\
+              "To use the PHP apache sapi please change "\
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    config_path = etc/"php/#{php_version}"
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-dtrace
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache-file
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-bz2
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-imap=#{Formula["imap-uw"].opt_prefix}
+      --with-imap-ssl=#{Formula["openssl"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap
+      --with-ldap-sasl
+      --with-libedit
+      --with-libzip
+      --with-mhash
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm
+      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium=#{Formula["libsodium"].opt_prefix}
+      --with-tidy
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-webp-dir=#{Formula["webp"].opt_prefix}
+      --with-xmlrpc
+      --with-xsl
+      --with-zlib
+    ]
+
+    if MacOS.version < :lion
+      args << "--with-curl=#{Formula["curl"].opt_prefix}"
+    else
+      args << "--with-curl"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    inreplace "php.ini-development", "; extension_dir = \"./\"",
+      "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+
+    config_files = {
+      "php.ini-development" => "php.ini",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf" => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{php_version}/
+    EOS
+  end
+
+  def post_install
+    pear_prefix = share/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear"
+    {
+      "php_ini" => etc/"php/#{php_version}/php.ini",
+      "php_dir" => pear_path,
+      "doc_dir" => pear_path/"doc",
+      "ext_dir" => pecl_path/php_basename,
+      "bin_dir" => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir" => pear_path/"cfg",
+      "www_dir" => pear_path/"htdocs",
+      "man_dir" => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin" => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if key =~ /(?<!bin|man)_dir$/
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{php_version}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".")
+  end
+
+  plist_options :startup => true, :manual => "php-fpm"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_sbin}/php-fpm</string>
+          <string>--nodaemonize</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/php-fpm.log</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    assert_match /^Zend OPcache$/, shell_output("#{bin}/php -i"), "Zend OPCache extension not loaded"
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    assert_no_match /^snmp$/, shell_output("#{bin}/php -m"), "SNMP extension doesn't work reliably with Homebrew on High Sierra"
+    begin
+      require "socket"
+
+      server = TCPServer.new(0)
+      port = server.addr[1]
+      server_fpm = TCPServer.new(0)
+      port_fpm = server_fpm.addr[1]
+      server.close
+      server_fpm.close
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!';
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        <FilesMatch \.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -134,6 +134,7 @@
   "percona-server56": "percona-server@5.6",
   "perl514": "perl@5.14",
   "perl518": "perl@5.18",
+  "php72": "php",
   "plt-racket": "racket",
   "polarssl": "mbedtls",
   "postgresql94": "postgresql@9.4",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is still a work in progress and provides a first draft for the php formula that potentially could be included in homebrew-core as suggested in #15619 . This also relates to the next generation work as has been discussed in the php tap #4005 . I wanted to get this to a somewhat working state to get feedback early on to make sure we are moving in the right direction with this.

#### _Compared to the php tap Formula the following changes has been made thus far_
* openssl is now the only ssl library available and you can't select libressl
* libedit is now used over readline (one less dep without losing any funcitonality afaik), this change was originally made since the readline formula was missing symbols and linking failed in the compilation
* All extensions distributed with php-core that currently exists as formulas in the php tap are built by default and included in the main formula
* pear will be built by default to manage any extensions that exist in pecl
* libxml2 is using the macos version and no longer depends on the Formula
* httpd is now required and apache module built by default
* webp support is built by default
* enchant support is removed due to compilation issues until php support version 2.x of enchant
* It is also no longer possible to ...
  * enable debug-symbols
  * build a thread safe binary

#### Goal
The goal is to create 1 formula that build a non-threadsafe and non-debug build of php that includes all SAPIs and the most used extensions.

#### TODO
There's still a substantial todo list to go through which are currently listed in the formula itself but I could move that information in here to make it more easy to review and comment on.

- [x] Opcache default config file is included in extension formula, is it needed ? (assumed No for now)
- [x] ldap extension: I have a vague recollection that this caused some issues that were resolved with exluding it. needs to be checked. *Will build this as a shared module so it can be disabled if needed*
- [x] Need to add tests for all supported SAPIs
- [x] Should we remove --with-pdo-dblib from formula ? (mssql support is long gone and as far as I can tell this is the only purpose and would also exclude a dep, freetds)
- [x] How should the Formula handle the apache module ? Sierra (have not checked high sierra) can't support building it for the OS without manually fiddling with link in the file system) with the bundles tools
- [x] Pecl/Pear config needs to be massaged so that it works without issues when installed

I'm all ears to comments and suggestions from the php community and the core maintainers to get this Formula released in 2018.