### PR TITLE
metabase: fix HEAD builds

### DIFF
--- a/Formula/metabase.rb
+++ b/Formula/metabase.rb
@@ -8,6 +8,7 @@ class Metabase < Formula
     url "https://github.com/metabase/metabase.git"
 
     depends_on "node" => :build
+    depends_on "yarn" => :build
     depends_on "leiningen" => :build
   end
 
@@ -17,7 +18,6 @@ class Metabase < Formula
 
   def install
     if build.head?
-      ENV.prepend_path "PATH", "#{Formula["node"].opt_libexec}/npm/bin"
       system "./bin/build"
       libexec.install "target/uberjar/metabase.jar"
     else


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

During the [npm@5 upgrade in the node formula](https://github.com/Homebrew/homebrew-core/commit/ecb2d1e8551d80b5c5de2ac0d00dc071987eac01#diff-d3ef2414308e30df24a517ca9a1324eeR87) the location of npm was changed from `libexec/npm/bin` to just `libexec/bin` and homebrew-npm's path was [updated inside language/node](https://github.com/Homebrew/brew/commit/b6d81359f0a958d27770280900cfb55fbbd62d5e#diff-876a0ba7f64fe71b16f0c695b0e60c02R28). But this core formula, which is directly hardcoding the npm path, was overlooked. This PR fixes the npm path by using language/nodes `setup_npm_environment` method, so that the path to npm is only maintained in one location (inside language/node), which should hopefully prevent similar issues in the future.

Also it looks like HEAD builds are depending on `yarn` now.