### PR TITLE
gst-plugins-bad: fix srtp dependency, fix --disable-sdl

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -38,7 +38,7 @@ class GstPluginsBad < Formula
   depends_on "rtmpdump" => :optional
   depends_on "schroedinger" => :optional
   depends_on "sound-touch" => :optional
-  depends_on "srtp" => :optional
+  depends_on "srtp@1.5" => :optional
   depends_on "libvo-aacenc" => :optional
 
   def install

--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -45,7 +45,7 @@ class GstPluginsBad < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-yadif
-      --disable-sdl
+      --disable-examples
       --disable-debug
       --disable-dependency-tracking
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed that I didn't seem to have the "srtpdec" or "srtpenc" gstreamer pipeline elements, even though I brewed gst-plugins-bad `--with-srtp`. Found another small cleanup while investigating.