### PR TITLE
elasticsearch 2.4.6

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -1,8 +1,8 @@
 class ElasticsearchAT24 < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz"
-  sha256 "87fb4d2bcd7e856f2da6945d27a3cf81672de35d33aaffbdbfb81d68e644ad8f"
+  url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz"
+  sha256 "5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f"
 
   bottle :unneeded
 


### PR DESCRIPTION
This pull request bumps the version on the versioned Elasticsearch 2.4 formula from version 2.4.5. to version 2.4.6.