### PR TITLE
pumba 0.4.4 (new formula)

### DIFF
--- a/Formula/pumba.rb
+++ b/Formula/pumba.rb
@@ -1,0 +1,28 @@
+class Pumba < Formula
+  desc "Chaos testing tool for Docker"
+  homepage "https://github.com/gaia-adm/pumba"
+  url "https://github.com/gaia-adm/pumba/archive/0.4.4.tar.gz"
+  sha256 "fdf11426752c69e79c2db10e2f57ef41c8b5d3d6815602ed11a95402b5db2d35"
+  head "https://github.com/gaia-adm/pumba.git"
+
+  depends_on "go" => :build
+  depends_on "docker" => :recommended
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+
+    (buildpath/"src/github.com/gaia-adm/pumba").install buildpath.children
+
+    cd "src/github.com/gaia-adm/pumba" do
+      system "go", "build", "-o", bin/"pumba", "-ldflags",
+             "-X main.Version=#{version}"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    output = pipe_output("#{bin}/pumba rm test-container 2>&1")
+    assert_match "Is the docker daemon running?", output
+  end
+end


### PR DESCRIPTION
Pumba chaos testing tool for Docker: emulate container failures and network problems.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It's a replacement for [PR 15332](https://github.com/Homebrew/homebrew-core/pull/15332), I've closed previous **PR** (messed with `git rebase` command) and open a new clean PR with a single file.