### PR TITLE
yarn: fix global installation prefix

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -5,6 +5,11 @@ class Yarn < Formula
   sha256 "f0f3510246ee74eb660ea06930dcded7b684eac2593aa979a7add84b72517968"
   revision 1
 
+  devel do
+    url "https://yarnpkg.com/downloads/0.28.4/yarn-v0.28.4.tar.gz"
+    sha256 "057ef781107bb5d3e7a2a655d75054fbeb265a249a905375bc25bec10d42b31f"
+  end
+
   bottle :unneeded
 
   depends_on "node" => :recommended

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,7 +3,7 @@ class Yarn < Formula
   homepage "https://yarnpkg.com/"
   url "https://yarnpkg.com/downloads/0.27.5/yarn-v0.27.5.tar.gz"
   sha256 "f0f3510246ee74eb660ea06930dcded7b684eac2593aa979a7add84b72517968"
-  head "https://github.com/yarnpkg/yarn.git"
+  revision 1
 
   bottle :unneeded
 
@@ -11,8 +11,8 @@ class Yarn < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install_symlink "#{libexec}/bin/yarn.js" => "yarn"
-    bin.install_symlink "#{libexec}/bin/yarn.js" => "yarnpkg"
+    (bin/"yarn").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX
+    (bin/"yarnpkg").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX
     inreplace "#{libexec}/package.json", '"installationMethod": "tar"', '"installationMethod": "homebrew"'
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refs: #16083

This PR fixes `yarn`'s global installation prefix by using env wrapper scripts to set the correct PREFIX environment variable pointing to `HOMEBREW_PREFIX`. Previously the yarn global prefix was incorrectly auto-detected as `HOMEBREW_PREFIX/Cellar/node/<version>/bin` and global yarn modules got symlinked next to the node executable in node's own cellar. This has caused 2 issues: modules globally installed with yarn where not put into the users $PATH and it broke native addon installation in yarn depending formulas (see #16083 for for details).

`fsevents` usage in core formulas depending on `yarn` (checked = build tested with a fixed `yarn`)
* [x] `chronograf`: yes, only in build deps
* [x] `grafana`: yes, only in build deps
* [x] `metabase`: yes, only in build deps
* `lumo`: no
