### PR TITLE
[notmuch] Use gmime from HEAD.

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -3,6 +3,7 @@ class Notmuch < Formula
   homepage "https://notmuchmail.org"
   url "https://notmuchmail.org/releases/notmuch-0.25.tar.gz"
   sha256 "65d28d1f783d02629039f7d15d9a2bada147a7d3809f86fe8d13861b0f6ae60b"
+  revision 1
   head "git://notmuchmail.org/git/notmuch"
 
   bottle do

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -17,6 +17,7 @@ class Notmuch < Formula
   depends_on "pkg-config" => :build
   depends_on "libgpg-error" => :build
   depends_on "glib"
+  depends_on "gmime"
   depends_on "talloc"
   depends_on "xapian"
   depends_on "zlib"
@@ -24,24 +25,12 @@ class Notmuch < Formula
   depends_on :python3 => :optional
   depends_on :ruby => ["1.9", :optional]
 
-  # Currently requires gmime 2.6.x
-  resource "gmime" do
-    url "https://download.gnome.org/sources/gmime/2.6/gmime-2.6.23.tar.xz"
-    sha256 "7149686a71ca42a1390869b6074815106b061aaeaaa8f2ef8c12c191d9a79f6a"
-  end
-
   # Fix SIP issue with python bindings
   # A more comprehensive patch has been submitted upstream
   # https://notmuchmail.org/pipermail/notmuch/2016/022631.html
   patch :DATA
 
   def install
-    resource("gmime").stage do
-      system "./configure", "--prefix=#{prefix}/gmime", "--disable-introspection"
-      system "make", "install"
-      ENV.append_path "PKG_CONFIG_PATH", "#{prefix}/gmime/lib/pkgconfig"
-    end
-
     args = %W[--prefix=#{prefix}]
 
     if build.with? "emacs"


### PR DESCRIPTION
notmuch now supports gmime 3.0: https://notmuchmail.org/news/release-0.25/

And actually building with 2.6.x breaks pkcs7.  When running "notmuch show" for an email with pkcs7, it segfaults with an error "Failed to construct pkcs7 context".

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
