### PR TITLE
Replace `shell_profile` calls in formulae

### DIFF
--- a/Formula/gnupg@1.4.rb
+++ b/Formula/gnupg@1.4.rb
@@ -52,7 +52,7 @@ class GnupgAT14 < Formula
       brew install gnupg
 
     If you really need to use these tools without the "1" suffix you can
-    add a "gpgbin" directory to your PATH from your #{shell_profile} like:
+    add a "gpgbin" directory to your PATH from your #{Utils::Shell.profile} like:
 
         PATH="#{opt_libexec}/gpgbin:$PATH"
 

--- a/Formula/lesspipe.rb
+++ b/Formula/lesspipe.rb
@@ -25,19 +25,20 @@ class Lesspipe < Formula
     system "make", "install"
   end
 
+  def caveats
+    <<-EOS
+      Append the following to your #{Utils::Shell.profile}:
+      export LESSOPEN="|#{HOMEBREW_PREFIX}/bin/lesspipe.sh %s" LESS_ADVANCED_PREPROCESSOR=1
+    EOS
+  end
+
   test do
     touch "file1.txt"
     touch "file2.txt"
-    system "tar", "-cvzf", "homebrew.tar.gz", "file1.txt", "file2.txt"
+    system "tar", "cvzf", "homebrew.tar.gz", "file1.txt", "file2.txt"
 
     assert File.exist?("homebrew.tar.gz")
-    assert_match /file2.txt/, shell_output("tar tvzf homebrew.tar.gz | #{bin}/tarcolor")
-  end
-
-  def caveats
-    <<-EOS
-      Append the following to your #{shell_profile}:
-      export LESSOPEN="|#{HOMEBREW_PREFIX}/bin/lesspipe.sh %s" LESS_ADVANCED_PREPROCESSOR=1
-    EOS
+    assert_match "file2.txt",
+      pipe_output("#{bin}/tarcolor", shell_output("tar tvzf homebrew.tar.gz"), 0)
   end
 end

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -21,7 +21,7 @@ class Nvm < Formula
 
       mkdir ~/.nvm
 
-    Add the following to #{shell_profile} or your desired shell
+    Add the following to #{Utils::Shell.profile} or your desired shell
     configuration file:
 
       export NVM_DIR="$HOME/.nvm"
@@ -37,8 +37,8 @@ class Nvm < Formula
 
   test do
     output = pipe_output("NODE_VERSION=homebrewtest #{prefix}/nvm-exec 2>&1")
-    assert_no_match /No such file or directory/, output
-    assert_no_match /nvm: command not found/, output
+    assert_no_match(/No such file or directory/, output)
+    assert_no_match(/nvm: command not found/, output)
     assert_match "N/A: version \"homebrewtest -> N/A\" is not yet installed", output
   end
 end

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -68,12 +68,14 @@ class Perl < Formula
 
     You can set that up like this:
       PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
-      echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> #{shell_profile}
+      echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> #{Utils::Shell.profile}
     EOS
   end
 
   test do
-    (testpath/"test.pl").write "print 'Perl is not an acronym, but JAPH is a Perl acronym!';"
+    (testpath/"test.pl").write <<-EOS.undent
+      print 'Perl is not an acronym, but JAPH is a Perl acronym!';
+    EOS
     system "#{bin}/perl", "test.pl"
   end
 end

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -31,7 +31,7 @@ class Piknik < Formula
   end
 
   def caveats; <<-EOS.undent
-    In order to get convenient shell aliases, put something like this in #{shell_profile}:
+    In order to get convenient shell aliases, put something like this in #{Utils::Shell.profile}:
       . #{etc}/profile.d/piknik.sh
     EOS
   end

--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -353,7 +353,7 @@ class Python < Formula
   def caveats; <<-EOS.undent
     This formula installs a python2 executable to #{HOMEBREW_PREFIX}/bin.
     If you wish to have this formula's python executable in your PATH then add
-    the following to #{shell_profile}:
+    the following to #{Utils::Shell.profile}:
       export PATH="#{opt_libexec}/bin:$PATH"
 
     Pip and setuptools have been installed. To update them


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I got some exceptions while loading formulae in no-compat mode, since `shell_profile` is now defined in `compat/utils.rb`.