### PR TITLE
autoconf-archive: conflicts with gnome-common

### DIFF
--- a/Formula/autoconf-archive.rb
+++ b/Formula/autoconf-archive.rb
@@ -15,6 +15,9 @@ class AutoconfArchive < Formula
   # autoconf-archive is useless without autoconf
   depends_on "autoconf" => :run
 
+  conflicts_with "gnome-common",
+    :because => "both install certain autoconf macros"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/gnome-common.rb
+++ b/Formula/gnome-common.rb
@@ -12,6 +12,9 @@ class GnomeCommon < Formula
     sha256 "a96e5dedc2888b6caa326da0abd8eb7d3f1426407e8bef82a6ba0f41adb7016a" => :mavericks
   end
 
+  conflicts_with "autoconf-archive",
+    :because => "both install certain autoconf macros"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Open to other suggestions than a hard `conflicts_with` here; the macros from `autoconf-archive` seem to be newer.
 
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
(gnome-common is missing a test. That's a known issue)
