### PR TITLE
sane-backends 1.0.27-1: try to fix usb

### DIFF
--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -5,6 +5,7 @@ class SaneBackends < Formula
   mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
+  revision 1
   head "https://anonscm.debian.org/cgit/sane/sane-backends.git"
 
   bottle do
@@ -15,9 +16,10 @@ class SaneBackends < Formula
 
   depends_on "jpeg"
   depends_on "libtiff"
-  depends_on "libusb-compat"
+  depends_on "libusb"
   depends_on "openssl"
   depends_on "net-snmp"
+  depends_on "pkg-config" => :build
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -25,8 +27,7 @@ class SaneBackends < Formula
                           "--localstatedir=#{var}",
                           "--without-gphoto2",
                           "--enable-local-backends",
-                          "--enable-libusb",
-                          "--disable-latex"
+                          "--with-usb=yes"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
I'm trying to implement suggestions of @paddy-hack (Olaf Meeuwissen) in [thread on sane-devel ](https://lists.alioth.debian.org/pipermail/sane-devel/2017-July/035506.html) started by Thomas.S (schmo-fu). USB scanners are broken since 1.0.25 version of this formula.