### PR TITLE
nodebrew: fix setup_dirs

### DIFF
--- a/Formula/nodebrew.rb
+++ b/Formula/nodebrew.rb
@@ -9,12 +9,14 @@ class Nodebrew < Formula
 
   def install
     bin.install "nodebrew"
-    system "#{bin}/nodebrew", "setup_dirs"
     bash_completion.install "completions/bash/nodebrew-completion" => "nodebrew"
     zsh_completion.install "completions/zsh/_nodebrew"
   end
 
   def caveats; <<-EOS.undent
+    You need to manually run setup_dirs to create directories required by nodebrew:
+      nodebrew setup_dirs
+
     Add path:
       export PATH=$HOME/.nodebrew/current/bin:$PATH
 

--- a/Formula/nodebrew.rb
+++ b/Formula/nodebrew.rb
@@ -15,7 +15,7 @@ class Nodebrew < Formula
 
   def caveats; <<-EOS.undent
     You need to manually run setup_dirs to create directories required by nodebrew:
-      nodebrew setup_dirs
+      #{opt_bin}/nodebrew setup_dirs
 
     Add path:
       export PATH=$HOME/.nodebrew/current/bin:$PATH


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Can't run setup_dirs as part of the install process, as it's creating
directory under a temp folder

See: https://github.com/Homebrew/homebrew-core/pull/13881