### PR TITLE
octave: remove transfig dependency

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -37,13 +37,14 @@ class Octave < Formula
   depends_on "graphicsmagick"
   depends_on "hdf5"
   depends_on "libsndfile"
+  depends_on "libtool" => :run
   depends_on "pcre"
   depends_on "portaudio"
   depends_on "pstoedit"
   depends_on "qhull"
   depends_on "qrupdate"
+  depends_on "readline"
   depends_on "suite-sparse"
-  depends_on "transfig"
   depends_on "veclibfort"
 
   # Dependencies use Fortran, leading to spurious messages about GCC


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Removing the transfig dependency avoids a recursive X11 requirement.
Also, add libtool and readline undeclared, linked-library dependencies.