### PR TITLE
gnuplot: use latest qt

### DIFF
--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -27,9 +27,8 @@ class Gnuplot < Formula
   deprecated_option "with-x" => "with-x11"
   deprecated_option "pdf" => "with-pdflib-lite"
   deprecated_option "wx" => "with-wxmac"
-  deprecated_option "qt" => "with-qt@5.7"
-  deprecated_option "with-qt" => "with-qt@5.7"
-  deprecated_option "with-qt5" => "with-qt@5.7"
+  deprecated_option "qt" => "with-qt"
+  deprecated_option "with-qt5" => "with-qt"
   deprecated_option "cairo" => "with-cairo"
   deprecated_option "nolua" => "without-lua"
 
@@ -39,11 +38,11 @@ class Gnuplot < Formula
   depends_on "lua" => :recommended
   depends_on "pango" if build.with?("cairo") || build.with?("wxmac")
   depends_on "pdflib-lite" => :optional
-  depends_on "qt@5.7" => :optional
+  depends_on "qt" => :optional
   depends_on "wxmac" => :optional
   depends_on :x11 => :optional
 
-  needs :cxx11 if build.with? "qt@5.7"
+  needs :cxx11 if build.with? "qt"
 
   resource "libcerf" do
     url "http://apps.jcns.fz-juelich.de/src/libcerf/libcerf-1.5.tgz"
@@ -53,7 +52,7 @@ class Gnuplot < Formula
 
   def install
     # Qt5 requires c++11 (and the other backends do not care)
-    ENV.cxx11 if build.with? "qt@5.7"
+    ENV.cxx11 if build.with? "qt"
 
     if build.with? "aquaterm"
       # Add "/Library/Frameworks" to the default framework search path, so that an
@@ -87,7 +86,7 @@ class Gnuplot < Formula
       args << "--without-cairo" if build.without? "cairo"
     end
 
-    if build.with? "qt@5.7"
+    if build.with? "qt"
       args << "--with-qt"
     else
       args << "--with-qt=no"


### PR DESCRIPTION
gnuplot was made to depend on `qt@5.7` in https://github.com/Homebrew/homebrew-core/pull/9318 in order for octave not to depend on two different versions of Qt. Now that octave does not have a `qt@5.7` dependency anymore, we can migrate gnuplot back to latest Qt.