### PR TITLE
skinny 2.4.0

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,11 +1,11 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.3.8/skinny-2.3.8.tar.gz"
-  sha256 "ad455cd92d06978c2bbf2d327c9ce277191bf53bdfc2e9f77bbb0f94f177c6cd"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.4.0/skinny-2.4.0.tar.gz"
+  sha256 "8ee02680f876d603cde2c87057d83e13647eb118ae1c19498ff6e95ce2526051"
 
   bottle :unneeded
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
Skinny 2.4.0 is out. Since this version, we dropped JDK 7 support. Thus, I also updated the depends_on part as well.

https://github.com/skinny-framework/skinny-framework/releases/tag/2.4.0

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.4.0/skinny-2.4.0.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/9e84746a-7545-11e7-99ac-696dba8b096f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20170730%2Fus-east-1%2Fs3%2Fa
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.4.0: 459 files, 61.4MB, built in 25 seconds
$ brew audit --strict skinny
$
```