### PR TITLE
Aliases/fig2dev: add alias for transfig

### DIFF
--- a/Aliases/fig2dev
+++ b/Aliases/fig2dev
@@ -1,0 +1,1 @@
+../Formula/transfig.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Coq has a dependency on the `fig2dev` binary and I've been confused in the past about where to get it from. This alias should make it easier to find the dependency, which is `transfig`.