### PR TITLE
wine: update libpng

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -105,9 +105,9 @@ class Wine < Formula
   end
 
   resource "libpng" do
-    url "https://download.sourceforge.net/libpng/libpng-1.6.30.tar.xz"
-    mirror "ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.30.tar.xz"
-    sha256 "267c332ffff70cc599d3929207869f698798f1df143aa5f9597b007c14353666"
+    url "https://download.sourceforge.net/libpng/libpng-1.6.31.tar.xz"
+    mirror "ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.31.tar.xz"
+    sha256 "232a602de04916b2b5ce6f901829caf419519e6a16cc9cd7c1c91187d3ee8b41"
   end
 
   resource "freetype" do


### PR DESCRIPTION
No security fix in the libpng update, so not bumping revision