### PR TITLE
watchman: remove erroneous "cellar :any" line

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -3,6 +3,7 @@ class Watchman < Formula
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v4.7.0.tar.gz"
   sha256 "77c7174c59d6be5e17382e414db4907a298ca187747c7fcb2ceb44da3962c6bf"
+  revision 1
   head "https://github.com/facebook/watchman.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
That line seems to have been added by BrewTestBot; not sure why.

watchman definitely depends on HOMEBREW_PREFIX, though, as it uses `$PREFIX/var/run/watchman`.