### PR TITLE
elvish: fix install with vendored golang library

### DIFF
--- a/Formula/elvish.rb
+++ b/Formula/elvish.rb
@@ -16,9 +16,10 @@ class Elvish < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/elves").mkpath
-    ln_sf buildpath, buildpath/"src/github.com/elves/elvish"
-    system "go", "build", "-o", bin/"elvish"
+    (buildpath/"src/github.com/elves/elvish").install buildpath.children
+    cd "src/github.com/elves/elvish" do
+      system "go", "build", "-o", bin/"elvish"
+    end
   end
 
   test do


### PR DESCRIPTION
Previously `brew reinstall --HEAD elvish` failed with:

```
==> Reinstalling elvish 
==> Using the sandbox
==> Cloning https://github.com/elves/elvish.git
Cloning into '/Users/taazadi1/Library/Caches/Homebrew/elvish--git'...
remote: Counting objects: 669, done.
remote: Compressing objects: 100% (520/520), done.
remote: Total 669 (delta 149), reused 467 (delta 134), pack-reused 0
Receiving objects: 100% (669/669), 963.90 KiB | 791.00 KiB/s, done.
Resolving deltas: 100% (149/149), done.
==> Checking out branch master
==> go build -o /usr/local/Cellar/elvish/HEAD-c30495c/bin/elvish
Last 15 lines from /Users/taazadi1/Library/Logs/Homebrew/elvish/01.go:
2017-08-02 12:19:18 +0200

go
build
-o
/usr/local/Cellar/elvish/HEAD-c30495c/bin/elvish

main.go:21:2: cannot find package "github.com/boltdb/bolt" in any of:
 /usr/local/Cellar/go/1.8.3/libexec/src/github.com/boltdb/bolt (from $GOROOT)
 /private/tmp/elvish-20170802-90084-10kep2c/src/github.com/boltdb/bolt (from $GOPATH)
```