### PR TITLE
Remove quantum depth options

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -12,9 +12,6 @@ class Graphicsmagick < Formula
     sha256 "2a2fb1a9ec819dba12881897baebe47210da0ce65157900bd076d50276d406da" => :yosemite
   end
 
-  option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
-  option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit (default)"
-  option "with-quantum-depth-32", "Compile with a quantum depth of 32 bit"
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-svg", "Compile without svg support"
   option "with-perl", "Build PerlMagick; provides the Graphics::Magick module"
@@ -39,12 +36,6 @@ class Graphicsmagick < Formula
   end
 
   def install
-    quantum_depth = [8, 16, 32].select { |n| build.with? "quantum-depth-#{n}" }
-    if quantum_depth.length > 1
-      odie "graphicsmagick: --with-quantum-depth-N options are mutually exclusive"
-    end
-    quantum_depth = quantum_depth.first || 16 # user choice or default
-
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
@@ -53,7 +44,7 @@ class Graphicsmagick < Formula
       --with-modules
       --without-lzma
       --disable-openmp
-      --with-quantum-depth=#{quantum_depth}
+      --with-quantum-depth=16
     ]
 
     args << "--without-gslib" if build.without? "ghostscript"

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -20,9 +20,6 @@ class Imagemagick < Formula
   option "with-opencl", "Compile with OpenCL support"
   option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
-  option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
-  option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit"
-  option "with-quantum-depth-32", "Compile with a quantum depth of 32 bit"
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-modules", "Disable support for dynamically loadable modules"
   option "without-threads", "Disable threads support"
@@ -112,15 +109,6 @@ class Imagemagick < Formula
     args << "--with-fontconfig=yes" if build.with? "fontconfig"
     args << "--with-freetype=yes" if build.with? "freetype"
     args << "--enable-zero-configuration" if build.with? "zero-configuration"
-
-    if build.with? "quantum-depth-32"
-      quantum_depth = 32
-    elsif build.with?("quantum-depth-16") || build.with?("perl")
-      quantum_depth = 16
-    elsif build.with? "quantum-depth-8"
-      quantum_depth = 8
-    end
-    args << "--with-quantum-depth=#{quantum_depth}" if quantum_depth
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -21,9 +21,6 @@ class ImagemagickAT6 < Formula
   option "with-opencl", "Compile with OpenCL support"
   option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
-  option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"
-  option "with-quantum-depth-16", "Compile with a quantum depth of 16 bit"
-  option "with-quantum-depth-32", "Compile with a quantum depth of 32 bit"
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-modules", "Disable support for dynamically loadable modules"
   option "without-threads", "Disable threads support"
@@ -112,15 +109,6 @@ class ImagemagickAT6 < Formula
     args << "--with-fontconfig=yes" if build.with? "fontconfig"
     args << "--with-freetype=yes" if build.with? "freetype"
     args << "--enable-zero-configuration" if build.with? "zero-configuration"
-
-    if build.with? "quantum-depth-32"
-      quantum_depth = 32
-    elsif build.with?("quantum-depth-16") || build.with?("perl")
-      quantum_depth = 16
-    elsif build.with? "quantum-depth-8"
-      quantum_depth = 8
-    end
-    args << "--with-quantum-depth=#{quantum_depth}" if quantum_depth
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"

--- a/Formula/negfix8.rb
+++ b/Formula/negfix8.rb
@@ -6,7 +6,7 @@ class Negfix8 < Formula
 
   bottle :unneeded
 
-  depends_on "imagemagick" => "with-quantum-depth-16"
+  depends_on "imagemagick"
 
   def install
     bin.install "negfix8"

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -51,14 +51,6 @@ class Octave < Formula
   # Dependencies use Fortran, leading to spurious messages about GCC
   cxxstdlib_check :skip
 
-  # If GraphicsMagick was built from source, it is possible that it was
-  # done to change quantum depth. If so, our Octave bottles are no good.
-  # https://github.com/Homebrew/homebrew-science/issues/2737
-  def pour_bottle?
-    Tab.for_name("graphicsmagick").without?("quantum-depth-32") &&
-      Tab.for_name("graphicsmagick").without?("quantum-depth-8")
-  end
-
   def install
     if build.stable?
       # Remove for > 4.2.1


### PR DESCRIPTION
Removing the quantum depth options from `imagemagick` and `graphicsmagick` because analytics show they are almost never used, and they can conflict with other formulas. All now fall back to the existing default of 16 (which is `imagemagick`'s default, but not `graphicsmagick`; it was decided some time ago to switch Homebrew to using this value by default).

- `imagemagick` non-default quantum depth installs account for ~0.1% of installs in the last 100 days
- same for `imagemagick@6`
- for `graphicsmagick` it's about 0.3%