### PR TITLE
dep 0.2.0 (new formula)

### DIFF
--- a/Formula/dep.rb
+++ b/Formula/dep.rb
@@ -1,0 +1,44 @@
+class Dep < Formula
+  desc "Go dependency management tool"
+  homepage "https://github.com/golang/dep"
+  url "https://github.com/golang/dep/archive/v0.2.0.tar.gz"
+  sha256 "f7887b1aae33ea6555eef82b8f597dbd670faf808af2c744e8eade338e51e9c3"
+  head "https://github.com/golang/dep.git"
+
+  depends_on "go"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/golang/dep").install buildpath.children
+    cd "src/github.com/golang/dep" do
+      system "go", "build", "-o", bin/"dep", ".../cmd/dep"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    # Default HOMEBREW_TEMP is /tmp, which is actually a symlink to /private/tmp.
+    # `dep` bails without `.realpath` as it expects $GOPATH to be a "real" path.
+    ENV["GOPATH"] = testpath.realpath
+    project = testpath/"src/github.com/project/testing"
+    (project/"hello.go").write <<-EOS.undent
+      package main
+
+      import "fmt"
+      import "github.com/Masterminds/vcs"
+
+      func main() {
+          fmt.Println("Hello World")
+      }
+    EOS
+    cd project do
+      system bin/"dep", "init"
+      assert_predicate project/"vendor", :exist?, "Failed to init!"
+      inreplace "Gopkg.toml", /(version = ).*/, "\\1\"=1.11.0\""
+      system bin/"dep", "ensure"
+      assert_match "795e20f90", (project/"Gopkg.lock").read
+      output = shell_output("#{bin}/dep status")
+      assert_match %r{github.com/Masterminds/vcs\s+1.11.0\s}, output
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`goose` and `pilosa` should be able to use this.