### PR TITLE
filebeat: Fix module and es6x missing issue

### DIFF
--- a/Formula/filebeat.rb
+++ b/Formula/filebeat.rb
@@ -3,7 +3,7 @@ class Filebeat < Formula
   homepage "https://www.elastic.co/products/beats/filebeat"
   url "https://github.com/elastic/beats/archive/v5.5.1.tar.gz"
   sha256 "b6c85901b1feb0e184dd56d9012ccda10bf62566ddfbe3d9790c771b73db3a46"
-
+  revision 1
   head "https://github.com/elastic/beats.git"
 
   bottle do
@@ -23,9 +23,10 @@ class Filebeat < Formula
 
     cd gopath/"src/github.com/elastic/beats/filebeat" do
       system "make"
+      system "make", "modules"
       libexec.install "filebeat"
-
-      (etc/"filebeat").install("filebeat.yml", "filebeat.template.json", "filebeat.template-es2x.json")
+      (prefix/"module").install Dir["_meta/module.generated/*"]
+      (etc/"filebeat").install Dir["filebeat.*"]
     end
 
     prefix.install_metafiles gopath/"src/github.com/elastic/beats"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? Yes
- [x] Have you checked that there aren't other open [pull requests] 
(https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? yes
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? yes

-----
