### PR TITLE
exa: Add without-git option

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -12,11 +12,16 @@ class Exa < Formula
     sha256 "5693b6852ccdf92ec6b71dd671be1980aeefea0c0e86aaf9e3d86058afe42b52" => :yosemite
   end
 
+  option "without-git", "Build without Git support"
+
   depends_on "cmake" => :build
   depends_on "rust" => :build
 
   def install
-    system "make", "install", "PREFIX=#{prefix}"
+    args = ["PREFIX=#{prefix}"]
+    args << "FEATURES=" if build.without? "git"
+
+    system "make", "install", *args
     bash_completion.install "contrib/completions.bash" => "exa"
     zsh_completion.install  "contrib/completions.zsh"  => "_exa"
     fish_completion.install "contrib/completions.fish" => "exa.fish"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`exa` was on the front page of Hacker News today, and some commenters mentioned it would be nice to be able to install it without Git features (and therefore not need to bind to any networking libraries). I believe the original formula supported this installation option, but it seems like that feature was removed in #13676 (not sure if it was intentional) — this PR simply reintroduces it.