### PR TITLE
Added head version for mruby-cli

### DIFF
--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -3,6 +3,7 @@ class MrubyCli < Formula
   homepage "https://github.com/hone/mruby-cli"
   url "https://github.com/hone/mruby-cli/archive/v0.0.4.tar.gz"
   sha256 "97d889b5980193c562e82b42089b937e675b73950fa0d0c4e46fbe71d16d719f"
+  head "https://github.com/hone/mruby-cli.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[mruby-cli](https://github.com/hone/mruby-cli/releases) didn't have a release for almost two years. Even though there's little development activity there are a few minor features that are available in mruby-cli `master` that aren't present in 0.0.4 release. I've added `head` version, I use it locally, no issues.