### PR TITLE
Clean up rarely used without options

### DIFF
--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -1,7 +1,7 @@
 class Allegro < Formula
   desc "C/C++ multimedia library for cross-platform game development"
   homepage "http://liballeg.org/"
-  url "http://download.gna.org/allegro/allegro/5.2.2/allegro-5.2.2.tar.gz"
+  url "https://github.com/liballeg/allegro5/releases/download/5.2.2.0/allegro-5.2.2.tar.gz"
   sha256 "e285b9e12a7b33488c0e7e139326903b9df10e8fa9adbfcfe2e1105b69ce94fc"
 
   head "https://github.com/liballeg/allegro5.git", :branch => "master"
@@ -14,13 +14,13 @@ class Allegro < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "libvorbis" => :recommended
-  depends_on "freetype" => :recommended
-  depends_on "flac" => :recommended
-  depends_on "physfs" => :recommended
-  depends_on "libogg" => :recommended
-  depends_on "opusfile" => :recommended
-  depends_on "theora" => :recommended
+  depends_on "flac"
+  depends_on "freetype"
+  depends_on "libogg"
+  depends_on "libvorbis"
+  depends_on "opusfile"
+  depends_on "physfs"
+  depends_on "theora"
   depends_on "dumb" => :optional
 
   def install

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -33,27 +33,24 @@ class Audacious < Formula
   depends_on "gettext" => :build
   depends_on "make" => :build
   depends_on "pkg-config" => :build
-
-  depends_on "neon"
+  depends_on "faad2"
+  depends_on "ffmpeg"
+  depends_on "flac"
+  depends_on "fluid-synth"
   depends_on "glib"
+  depends_on "lame"
+  depends_on "libbs2b"
+  depends_on "libcue"
+  depends_on "libnotify"
+  depends_on "libsamplerate"
+  depends_on "libsoxr"
+  depends_on "libvorbis"
+  depends_on "mpg123"
+  depends_on "neon"
+  depends_on "sdl2"
+  depends_on "wavpack"
   depends_on :python if MacOS.version <= :snow_leopard
-
-  depends_on "faad2" => :recommended
-  depends_on "ffmpeg" => :recommended
-  depends_on "flac" => :recommended
-  depends_on "fluid-synth" => :recommended
-  depends_on "lame" => :recommended
-  depends_on "libbs2b" => :recommended
-  depends_on "libcue" => :recommended
-  depends_on "libnotify" => :recommended
-  depends_on "libsamplerate" => :recommended
-  depends_on "libsoxr" => :recommended
-  depends_on "libvorbis" => :recommended
-  depends_on "mpg123" => :recommended
   depends_on "qt" => :recommended
-  depends_on "sdl2" => :recommended
-  depends_on "wavpack" => :recommended
-
   depends_on "gtk+" => :optional
   depends_on "jack" => :optional
   depends_on "libmms" => :optional

--- a/Formula/gd.rb
+++ b/Formula/gd.rb
@@ -28,59 +28,21 @@ class Gd < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "fontconfig" => :recommended
-  depends_on "freetype" => :recommended
-  depends_on "jpeg" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "libtiff" => :recommended
-  depends_on "webp" => :recommended
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "webp"
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --without-x
-      --without-xpm
-    ]
-
-    if build.with? "libpng"
-      args << "--with-png=#{Formula["libpng"].opt_prefix}"
-    else
-      args << "--without-png"
-    end
-
-    if build.with? "fontconfig"
-      args << "--with-fontconfig=#{Formula["fontconfig"].opt_prefix}"
-    else
-      args << "--without-fontconfig"
-    end
-
-    if build.with? "freetype"
-      args << "--with-freetype=#{Formula["freetype"].opt_prefix}"
-    else
-      args << "--without-freetype"
-    end
-
-    if build.with? "jpeg"
-      args << "--with-jpeg=#{Formula["jpeg"].opt_prefix}"
-    else
-      args << "--without-jpeg"
-    end
-
-    if build.with? "libtiff"
-      args << "--with-tiff=#{Formula["libtiff"].opt_prefix}"
-    else
-      args << "--without-tiff"
-    end
-
-    if build.with? "webp"
-      args << "--with-webp=#{Formula["webp"].opt_prefix}"
-    else
-      args << "--without-webp"
-    end
-
     system "./bootstrap.sh" if build.head?
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--with-freetype=#{Formula["freetype"].opt_prefix}",
+                          "--with-png=#{Formula["libpng"].opt_prefix}",
+                          "--without-x",
+                          "--without-xpm"
     system "make", "install"
   end
 

--- a/Formula/mediatomb.rb
+++ b/Formula/mediatomb.rb
@@ -13,13 +13,13 @@ class Mediatomb < Formula
     sha256 "7022f700071652e20eb3d93b3d0b0a9d5f4cf1485cd350d85116fcbdea1ac104" => :mavericks
   end
 
-  depends_on "libexif" => :recommended
-  depends_on "libmagic" => :recommended
-  depends_on "lzlib" => :recommended
-  depends_on "mp4v2" => :recommended
-  depends_on "spidermonkey" => :recommended
-  depends_on "sqlite" => :recommended
-  depends_on "taglib" => :recommended
+  depends_on "libexif"
+  depends_on "libmagic"
+  depends_on "lzlib"
+  depends_on "mp4v2"
+  depends_on "spidermonkey"
+  depends_on "sqlite"
+  depends_on "taglib"
   depends_on "ffmpeg" => :optional
   depends_on "ffmpegthumbnailer" => :optional
   depends_on "id3lib" => :optional
@@ -74,14 +74,7 @@ class Mediatomb < Formula
   end
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-    ]
-
-    args << "--disable-libmp4v2" if build.without? "mp4v2"
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end
 

--- a/Formula/mgba.rb
+++ b/Formula/mgba.rb
@@ -22,16 +22,14 @@ class Mgba < Formula
     sha256 "49dec7dc507d9048599cdd75379cff76789c0e6eb65a7a5c6da5451381008f7b" => :yosemite
   end
 
-  deprecated_option "with-qt5" => "with-qt"
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "ffmpeg" => :recommended
-  depends_on "imagemagick" => :recommended
-  depends_on "libepoxy" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "libzip" => :recommended
-  depends_on "qt" => :recommended
+  depends_on "ffmpeg"
+  depends_on "imagemagick"
+  depends_on "libepoxy"
+  depends_on "libpng"
+  depends_on "libzip"
+  depends_on "qt"
   depends_on "sdl2"
 
   def install
@@ -42,22 +40,13 @@ class Mgba < Formula
       s.gsub! "Applications", "."
     end
 
-    cmake_args = []
-    cmake_args << "-DUSE_EPOXY=OFF"  if build.without? "libepoxy"
-    cmake_args << "-DUSE_MAGICK=OFF" if build.without? "imagemagick"
-    cmake_args << "-DUSE_FFMPEG=OFF" if build.without? "ffmpeg"
-    cmake_args << "-DUSE_PNG=OFF"    if build.without? "libpng"
-    cmake_args << "-DUSE_LIBZIP=OFF" if build.without? "libzip"
-    cmake_args << "-DBUILD_QT=OFF"   if build.without? "qt"
-
-    system "cmake", ".", *cmake_args, *std_cmake_args
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
-    if build.with? "qt"
-      # Replace SDL frontend binary with a script for running Qt frontend
-      # -DBUILD_SDL=OFF would be easier, but disable joystick support in Qt frontend
-      rm "#{bin}/mgba"
-      bin.write_exec_script "#{prefix}/mGBA.app/Contents/MacOS/mGBA"
-    end
+
+    # Replace SDL frontend binary with a script for running Qt frontend
+    # -DBUILD_SDL=OFF would be easier, but disable joystick support in Qt frontend
+    rm bin/"mgba"
+    bin.write_exec_script "#{prefix}/mGBA.app/Contents/MacOS/mGBA"
   end
 
   test do

--- a/Formula/residualvm.rb
+++ b/Formula/residualvm.rb
@@ -11,29 +11,19 @@ class Residualvm < Formula
     sha256 "b1aa19050c3ee60834ebcf49f40dc1ec90d246e4d0ca70343218e0f08c3b5e96" => :yosemite
   end
 
-  option "with-all-engines", "Enable all engines (including broken or unsupported)"
-  option "with-safedisc", "Enable SafeDisc decryption for Myst III"
-
+  depends_on "faad2"
+  depends_on "flac"
+  depends_on "fluid-synth"
+  depends_on "freetype"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libvorbis"
+  depends_on "mad"
   depends_on "sdl"
-  depends_on "libvorbis" => :recommended
-  depends_on "mad" => :recommended
-  depends_on "flac" => :recommended
-  depends_on "libmpeg2" => :optional
-  depends_on "jpeg" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "theora" => :recommended
-  depends_on "faad2" => :recommended
-  depends_on "fluid-synth" => :recommended
-  depends_on "freetype" => :recommended
+  depends_on "theora"
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --enable-release
-    ]
-    args << "--enable-all-engines" if build.with? "all-engines"
-    args << "--enable-safedisc" if build.with? "safedisc"
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--enable-release"
     system "make"
     system "make", "install"
     (share+"icons").rmtree

--- a/Formula/scummvm.rb
+++ b/Formula/scummvm.rb
@@ -11,27 +11,19 @@ class Scummvm < Formula
     sha256 "213a1905e6d46cfe685e0cf25f0d7bb164bace5abbaff9497f4c1e40f794240d" => :yosemite
   end
 
-  option "with-all-engines", "Enable all engines (including broken or unsupported)"
-
+  depends_on "faad2"
+  depends_on "flac"
+  depends_on "fluid-synth"
+  depends_on "freetype"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libvorbis"
+  depends_on "mad"
   depends_on "sdl2"
-  depends_on "libvorbis" => :recommended
-  depends_on "mad" => :recommended
-  depends_on "flac" => :recommended
-  depends_on "libmpeg2" => :optional
-  depends_on "jpeg" => :recommended
-  depends_on "libpng" => :recommended
-  depends_on "theora" => :recommended
-  depends_on "faad2" => :recommended
-  depends_on "fluid-synth" => :recommended
-  depends_on "freetype" => :recommended
+  depends_on "theora"
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --enable-release
-    ]
-    args << "--enable-all-engines" if build.with? "all-engines"
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--enable-release"
     system "make"
     system "make", "install"
     (share+"pixmaps").rmtree


### PR DESCRIPTION
Cleaning up some of the formulas that:
- have many `:recommended` deps
- for which the `--without` option is never used (2 installs in 100 days at most)

Because these are untested anyway, and sometimes make our formulas longer/more complex.