### PR TITLE
git: migrate to pcre2

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -21,8 +21,9 @@ class Git < Formula
   deprecated_option "with-brewed-openssl" => "with-openssl"
   deprecated_option "with-brewed-curl" => "with-curl"
   deprecated_option "with-brewed-svn" => "with-subversion"
+  deprecated_option "with-pcre" => "with-pcre2"
 
-  depends_on "pcre" => :optional
+  depends_on "pcre2" => :optional
   depends_on "gettext" => :optional
   depends_on "openssl" => :optional
   depends_on "curl" => :optional
@@ -80,13 +81,12 @@ class Git < Formula
     end
 
     ENV["BLK_SHA1"] = "1" if build.with? "blk-sha1"
-
-    if build.with? "pcre"
-      ENV["USE_LIBPCRE"] = "1"
-      ENV["LIBPCREDIR"] = Formula["pcre"].opt_prefix
-    end
-
     ENV["NO_GETTEXT"] = "1" if build.without? "gettext"
+
+    if build.with? "pcre2"
+      ENV["USE_LIBPCRE2"] = "1"
+      ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
+    end
 
     args = %W[
       prefix=#{prefix}


### PR DESCRIPTION
As per latest git release notes (see https://github.com/Homebrew/homebrew-core/pull/16411#issuecomment-320465006), migrating from `pcre` to `pcre2`.