### PR TITLE
ceres-solver: migrate from homebrew/science

### DIFF
--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -1,0 +1,41 @@
+class CeresSolver < Formula
+  desc "C++ library for large-scale optimization"
+  homepage "http://ceres-solver.org/"
+  url "http://ceres-solver.org/ceres-solver-1.13.0.tar.gz"
+  sha256 "1df490a197634d3aab0a65687decd362912869c85a61090ff66f073c967a7dcd"
+  head "https://ceres-solver.googlesource.com/ceres-solver.git"
+
+  depends_on "cmake" => :run
+  depends_on "eigen"
+  depends_on "gflags"
+  depends_on "glog"
+  depends_on "metis"
+  depends_on "suite-sparse"
+
+  def install
+    system "cmake", ".", *std_cmake_args,
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DEIGEN_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3",
+                    "-DMETIS_LIBRARY=#{Formula["metis"].opt_lib}/libmetis.dylib"
+    system "make"
+    system "make", "install"
+    pkgshare.install "examples", "data"
+    doc.install "docs/html" unless build.head?
+  end
+
+  test do
+    cp pkgshare/"examples/helloworld.cc", testpath
+    (testpath/"CMakeLists.txt").write <<-EOS.undent
+      cmake_minimum_required(VERSION 2.8)
+      project(helloworld)
+      find_package(Ceres REQUIRED)
+      include_directories(${CERES_INCLUDE_DIRS})
+      add_executable(helloworld helloworld.cc)
+      target_link_libraries(helloworld ${CERES_LIBRARIES})
+    EOS
+
+    system "cmake", "-DCeres_DIR=#{share}/Ceres", "."
+    system "make"
+    assert_match "CONVERGENCE", shell_output("./helloworld", 0)
+  end
+end


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/15619

`without-test` option is removed, `suite-sparse` is made mandatory, install is simplified on head where docs aren't built.