### PR TITLE
sbt: make Bintray mirror the primary url temporarily

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,9 +1,8 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "http://www.scala-sbt.org"
-  url "https://cocl.us/sbt01316tgz"
-  mirror "https://dl.bintray.com/homebrew/mirror/sbt-0.13.16"
-  version "0.13.16"
+  url "https://dl.bintray.com/homebrew/mirror/sbt-0.13.16"
+  mirror "https://cocl.us/sbt01316tgz"
   sha256 "22729580a581e966259267eda4d937a2aecad86848f8a82fcc716dcae8dc760c"
 
   devel do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow-up to #16471.
Workaround for #16204 and #16342.