### PR TITLE
wxmac: fix compilation on High Sierra

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -13,23 +13,30 @@ class Wxmac < Formula
     sha256 "591bffb395156566ef3e55a9a8f2c193bdcde8b941d42cc6e6b41833ceeeaba2" => :yosemite
   end
 
+  # Fix compilation on High Sierra
+  # https://trac.wxwidgets.org/ticket/17929#ticket
+  patch do
+    url "https://github.com/wxWidgets/wxWidgets/commit/9a610eadcfe.patch?full_index=1"
+    sha256 "b445ddf1331b8ec21790b7e3fe3ac6059a2548002e7cbb9bf22b597baf32e3bf"
+  end
+
   devel do
     url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
     sha256 "e082460fb6bf14b7dd6e8ac142598d1d3d0b08a7b5ba402fdbf8711da7e66da8"
 
-    # Fix Issue: Creating wxComboCtrl without wxTE_PROCESS_ENTER style results in an assert.
+    # Creating wxComboCtrl without wxTE_PROCESS_ENTER style results in an assert
     patch do
       url "https://github.com/wxWidgets/wxWidgets/commit/cee3188c1abaa5b222c57b87cc94064e56921db8.patch?full_index=1"
       sha256 "c2389fcb565ec4d488aed2586da15ec72d7fdb8c614f266f8f936d6e4ea10210"
     end
 
-    # Fix Issue: Building under macOS in C++11 mode for i386 architecture (but not amd64) results in an error about narrowing conversion.
+    # Building under macOS in C++11 mode for i386 architecture (but not amd64) results in an error about narrowing conversion
     patch do
       url "https://github.com/wxWidgets/wxWidgets/commit/ee486dba32d02c744ae4007940f41a5b24b8c574.patch?full_index=1"
       sha256 "dd73556b7a91cbfa63e2eafa8bab48ce5308b382d8e26e60b79f61d0520871e3"
     end
 
-    # Fix Issue: Building under macOS in C++11 results in several -Winconsistent-missing-override warnings.
+    # Building under macOS in C++11 results in several -Winconsistent-missing-override warnings
     patch do
       url "https://github.com/wxWidgets/wxWidgets/commit/173ecd77c4280e48541c33bdfe499985852935ba.patch?full_index=1"
       sha256 "200c4fc3e103c7c9aa36ff35335af1a05494bf00a7181b6d6a11f0ffb2e4dc5d"
@@ -46,41 +53,35 @@ class Wxmac < Formula
   def install
     args = [
       "--prefix=#{prefix}",
-      "--enable-unicode",
-      "--enable-std_string",
-      "--enable-display",
-      "--with-opengl",
-      "--with-osx_cocoa",
-      "--with-libjpeg",
-      "--with-libtiff",
-      "--with-libpng",
-      "--with-zlib",
-      "--enable-dnd",
       "--enable-clipboard",
-      "--enable-webkit",
-      "--enable-svg",
-      # On 64-bit, enabling mediactrl leads to wxconfig trying to pull
-      # in a non-existent 64 bit QuickTime framework. This is submitted
-      # upstream and will eventually be fixed, but for now...
-      MacOS.prefer_64_bit? ? "--disable-mediactrl" : "--enable-mediactrl",
-      "--enable-graphics_ctx",
       "--enable-controls",
       "--enable-dataviewctrl",
+      "--enable-display",
+      "--enable-dnd",
+      "--enable-graphics_ctx",
+      "--enable-std_string",
+      "--enable-svg",
+      "--enable-unicode",
+      "--enable-webkit",
       "--with-expat",
+      "--with-libjpeg",
+      "--with-libpng",
+      "--with-libtiff",
+      "--with-opengl",
+      "--with-osx_cocoa",
+      "--with-zlib",
       "--disable-precomp-headers",
-      # need to set with-macosx-version-min to avoid configure defaulting to 10.5
-      "--with-macosx-version-min=#{MacOS.version}",
       # This is the default option, but be explicit
       "--disable-monolithic",
+      # Enabling mediactrl leads to wxconfig trying to pull in a non-existent
+      # 64-bit QuickTime framework: https://trac.wxwidgets.org/ticket/17639
+      "--disable-mediactrl",
+      # Set with-macosx-version-min to avoid configure defaulting to 10.5
+      "--with-macosx-version-min=#{MacOS.version}",
     ]
 
     args << "--enable-stl" if build.with? "stl"
-
-    if build.with? "static"
-      args << "--disable-shared"
-    else
-      args << "--enable-shared"
-    end
+    args << (build.with?("static") ? "--disable-shared" : "--enable-shared")
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Revisiting the need to patch `wxmac`, in a separate PR:

- fix was accepted and will be applied upstream
- fix is simple (one `CFLAGS` addition)… we have plenty of formulas that fiddle with `CFLAGS`
- `wxmac` had 63,260 installs in the last 100 days, 95% as a dependency (erlang being the main user)

Yes, it's unfortunate upstream is not willing to cut a new release for High Sierra. But the risks here are pretty limited and the fix self-contained. And I'd be willing to deal with fallout 😉