### PR TITLE
mimic 1.2.0.2 (new formula)

### DIFF
--- a/Formula/mimic.rb
+++ b/Formula/mimic.rb
@@ -1,0 +1,29 @@
+class Mimic < Formula
+  desc "Lightweight text-to-speech engine based on CMU Flite"
+  homepage "https://mimic.mycroft.ai"
+  url "https://github.com/MycroftAI/mimic/archive/1.2.0.2.tar.gz"
+  sha256 "6adcc9911b09d6e9513add41ad9dfc0893ece277f556419869520a0f0708c102"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "icu4c"
+  depends_on "portaudio"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--enable-shared",
+                          "--enable-static",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"mimic", "-t", "Hello, Homebrew!", "test.wav"
+    assert (testpath/"test.wav").exist?
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a formula for [Mimic](https://mimic.mycroft.ai/), the TTS engine used by the [Mycroft](https://mycroft.ai/) AI assistant project.

The formula passes `brew audit --strict`, but fails `brew audit --strict --new-formula` due to one error:
```
mimic:
  * Dependency 'icu4c' may be unnecessary as it is provided by macOS; try to build this formula without it.
Error: 1 problem in 1 formula
```

I tried to build the formula without the `icu4c` keg-only dependency, but it failed to compile; so, please consider it for inclusion despite the audit output.

Although a partial implementation of ICU is provided by OS X, it does not include all functionality and does not include headers required to compile against the Apple-distributed version of the library. (It may even be worth removing this warning entirely from `brew audit --new-formula`?)