### PR TITLE
re2c 0.16

### DIFF
--- a/Formula/re2c.rb
+++ b/Formula/re2c.rb
@@ -1,8 +1,9 @@
 class Re2c < Formula
   desc "Generate C-based recognizers from regular expressions"
   homepage "http://re2c.org"
-  url "https://downloads.sourceforge.net/project/re2c/0.15.3/re2c-0.15.3.tar.gz"
-  sha256 "f9d2a96c60a8c60d9c6c70e10590cbceaf0776d3115e7b3b35c7d7240cc1613b"
+  url "https://github.com/skvadrik/re2c/releases/download/0.16/re2c-0.16.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/re2c/0.16/re2c-0.16.tar.gz"
+  sha256 "48c12564297641cceb5ff05aead57f28118db6277f31e2262437feba89069e84"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From the re2c home page:

> Note that re2c is hosted both on github and on sourceforge for redundancy. Currently github serves as main repository, bugtracker and binary hosting. Sourceforge is used as backup repository and to host mail (so please don’t send bugs or feedback to sourceforge).
