### PR TITLE
percona-server: specifying plugin directory instead of accepting default

### DIFF
--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -57,6 +57,7 @@ class PerconaServer < Formula
 
     args = std_cmake_args + %W[
       -DMYSQL_DATADIR=#{datadir}
+      -DINSTALL_PLUGINDIR=lib/plugin
       -DSYSCONFDIR=#{etc}
       -DINSTALL_MANDIR=#{man}
       -DINSTALL_DOCDIR=#{doc}

--- a/Formula/percona-server@5.5.rb
+++ b/Formula/percona-server@5.5.rb
@@ -41,6 +41,7 @@ class PerconaServerAT55 < Formula
   def install
     args = std_cmake_args + %W[
       -DMYSQL_DATADIR=#{datadir}
+      -DINSTALL_PLUGINDIR=lib/plugin
       -DSYSCONFDIR=#{etc}
       -DINSTALL_MANDIR=#{man}
       -DINSTALL_DOCDIR=#{doc}

--- a/Formula/percona-server@5.6.rb
+++ b/Formula/percona-server@5.6.rb
@@ -43,6 +43,7 @@ class PerconaServerAT56 < Formula
 
     args = std_cmake_args + %W[
       -DMYSQL_DATADIR=#{datadir}
+      -DINSTALL_PLUGINDIR=lib/plugin
       -DSYSCONFDIR=#{etc}
       -DINSTALL_MANDIR=#{man}
       -DINSTALL_DOCDIR=#{doc}


### PR DESCRIPTION
this fixes issue #16373, and is applied to all three percona-server versions

also removed last two -DCMAKE flags in @5.6, as they are duplicated in the main cmake flags.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
