### PR TITLE
cabal-install 2.0.0.0 and agda 2.5.3-alpha1

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -5,15 +5,16 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
-  revision 1
 
   stable do
-    url "https://hackage.haskell.org/package/Agda-2.5.2/Agda-2.5.2.tar.gz"
-    sha256 "d812cec3bf7f03c4b27248572475c7e060154102771a8434cc11ba89f5691439"
+    url "https://github.com/agda/agda.git",
+        :revision => "e3f598313ceac6de8903f9e5693efb30435691fc"
+    version "2.5.3-alpha1"
 
     resource "stdlib" do
-      url "https://github.com/agda/agda-stdlib/archive/v0.13.tar.gz"
-      sha256 "e7cffc2b8b168c3584b6d1e760d2b49850835444e4777caa69eb29b3677ef8bb"
+      url "https://github.com/agda/agda-stdlib.git",
+          :revision => "c47a1516aaf40892f97b14e3fd1f2bd0c628cadc"
+      version "2.5.3-alpha1"
     end
   end
 
@@ -31,17 +32,17 @@ class Agda < Formula
     end
   end
 
-  deprecated_option "without-malonzo" => "without-ghc@8.0"
-  deprecated_option "without-ghc" => "without-ghc@8.0"
+  deprecated_option "without-malonzo" => "without-ghc"
+  deprecated_option "without-ghc@8.0" => "without-ghc"
 
   option "without-stdlib", "Don't install the Agda standard library"
-  option "without-ghc@8.0", "Disable the GHC backend"
+  option "without-ghc", "Disable the GHC backend"
 
-  depends_on "ghc@8.0" => :recommended
-  if build.with? "ghc@8.0"
+  depends_on "ghc" => :recommended
+  if build.with? "ghc"
     depends_on "cabal-install"
   else
-    depends_on "ghc@8.0" => :build
+    depends_on "ghc" => :build
     depends_on "cabal-install" => :build
   end
 
@@ -167,8 +168,7 @@ class Agda < Formula
     system bin/"agda", "--js", simpletest
 
     # test the GHC backend
-    if build.with? "ghc@8.0"
-      ENV.prepend_path "PATH", Formula["ghc@8.0"].opt_bin
+    if build.with? "ghc"
       cabal_sandbox do
         cabal_install "text", "ieee754"
         dbpath = Dir["#{testpath}/.cabal-sandbox/*-packages.conf.d"].first

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -1,10 +1,9 @@
 class CabalInstall < Formula
   desc "Command-line interface for Cabal and Hackage"
   homepage "https://www.haskell.org/cabal/"
-  url "https://hackage.haskell.org/package/cabal-install-1.24.0.2/cabal-install-1.24.0.2.tar.gz"
-  sha256 "2ac8819238a0e57fff9c3c857e97b8705b1b5fef2e46cd2829e85d96e2a00fe0"
-  revision 4
-  head "https://github.com/haskell/cabal.git", :branch => "1.24"
+  url "https://hackage.haskell.org/package/cabal-install-2.0.0.0/cabal-install-2.0.0.0.tar.gz"
+  sha256 "5f370bac2f18f0d96f525e33d723f248e50d73f452076d49425a752bba062b2d"
+  head "https://github.com/haskell/cabal.git", :branch => "2.0"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +12,7 @@ class CabalInstall < Formula
     sha256 "85096c8636875906aae069a2e46dba78c393715381ca2ecfe44848e88354fe84" => :yosemite
   end
 
-  depends_on "ghc@8.0"
+  depends_on "ghc"
 
   fails_with :clang if MacOS.version <= :lion # Same as ghc.rb
 
@@ -26,7 +25,6 @@ class CabalInstall < Formula
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["ghc@8.0"].opt_bin
     system "#{bin}/cabal", "--config-file=#{testpath}/config", "info", "cabal"
   end
 end


### PR DESCRIPTION
depend on ghc instead of ghc@8.0