### PR TITLE
kubernetes-cli: Ensure _kubectl is auto-loaded by zsh compinit

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -36,7 +36,14 @@ class KubernetesCli < Formula
 
       # Install zsh completion
       output = Utils.popen_read("#{bin}/kubectl completion zsh")
-      (zsh_completion/"_kubectl").write output
+      # Note: The explicit header to enable auto-loading by compinit
+      # can be removed after Kubernetes 1.8.0 when kubernetes/kubernetes#50561
+      # becomes available upstream.
+      (zsh_completion/"_kubectl").write <<-EOS.undent
+        #compdef kubectl
+        #{output}
+        _complete kubectl
+      EOS
 
       # Install man pages
       # Leave this step for the end as this dirties the git tree


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
* Adding `#compdef kubectl` allows completion to be auto-loaded by zsh compinit
* Adding `_complete kubectl # 2> /dev/null` allows completion fuction to
  be available upfront

NB: this is based on the [fine set of recommendation](https://github.com/Homebrew/homebrew-core/pull/15727#issuecomment-317857731) by @zmwangx