### PR TITLE
fix: include manpages for open-sp

### DIFF
--- a/Formula/open-sp.rb
+++ b/Formula/open-sp.rb
@@ -12,14 +12,35 @@ class OpenSp < Formula
     sha256 "d7b79be390f3c2b2a823e1156d896200db397dffb6cb6e6712d27539e05ca18b" => :yosemite
   end
 
+  depends_on "docbook" => :build
+  depends_on "ghostscript" => :build
+  depends_on "xmlto" => :build
+
   def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
-                          "--disable-doc-build",
                           "--enable-http",
-                          "--enable-default-catalog=#{etc}/sgml/catalog",
-                          "--enable-default-search-path=#{HOMEBREW_PREFIX}/share/sgml"
+                          "--enable-default-catalog=#{etc}/sgml/catalog"
+
     system "make", "pkgdatadir=#{share}/sgml/opensp", "install"
+  end
+
+  test do
+    (testpath/"eg.sgml").write <<-EOS.undent
+      <!DOCTYPE TESTDOC [
+
+      <!ELEMENT TESTDOC - - (TESTELEMENT)+>
+      <!ELEMENT TESTELEMENT - - (#PCDATA)>
+
+      ]>
+      <TESTDOC>
+        <TESTELEMENT>Hello</TESTELEMENT>
+      </TESTDOC>
+    EOS
+
+    system "#{bin}/onsgmls", "--warning=type-valid", "eg.sgml"
   end
 end


### PR DESCRIPTION
Remove the `--disable-doc-build` option and fix the things that were
preventing the doc build from working, namely some build-time
dependencies and some fixes to system IDs in the Doctypes of the
documentation XML.

This gives us manpages, which were previously not being generated, and
the rest of the docs

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
