### PR TITLE
watchman 4.9.0

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -1,7 +1,7 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/v4.9.0-rc1.tar.gz"
+  url "https://github.com/facebook/watchman/archive/v4.9.0.tar.gz"
   sha256 "3ecfe4a98da790fabcaca553d2f02b6ad9c28a9b0948c03fa5247e9138ed29ec"
   head "https://github.com/facebook/watchman.git"
 

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,7 +2,7 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v4.9.0.tar.gz"
-  sha256 "3ecfe4a98da790fabcaca553d2f02b6ad9c28a9b0948c03fa5247e9138ed29ec"
+  sha256 "1f6402dc70b1d056fffc3748f2fdcecff730d8843bb6936de395b3443ce05322"
   head "https://github.com/facebook/watchman.git"
 
   bottle do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -15,8 +15,8 @@ class Watchman < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
   depends_on "pkg-config" => :build
+  depends_on "openssl"
   depends_on "pcre"
 
   def install

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,7 +2,6 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v4.9.0-rc1.tar.gz"
-  version "4.9.0"
   sha256 "3ecfe4a98da790fabcaca553d2f02b6ad9c28a9b0948c03fa5247e9138ed29ec"
   head "https://github.com/facebook/watchman.git"
 

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -1,9 +1,9 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/v4.7.0.tar.gz"
-  sha256 "77c7174c59d6be5e17382e414db4907a298ca187747c7fcb2ceb44da3962c6bf"
-  revision 1
+  url "https://github.com/facebook/watchman/archive/v4.9.0-rc1.tar.gz"
+  version "4.9.0"
+  sha256 "3ecfe4a98da790fabcaca553d2f02b6ad9c28a9b0948c03fa5247e9138ed29ec"
   head "https://github.com/facebook/watchman.git"
 
   bottle do
@@ -16,6 +16,7 @@ class Watchman < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on "pcre"
 
   def install

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -15,6 +15,7 @@ class Watchman < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "openssl"
   depends_on "pkg-config" => :build
   depends_on "pcre"
 


### PR DESCRIPTION
This is a preliminary PR that checks that 4.9.0-rc1 builds and passes the tests in the brew CI system.
Once this shows green, we'll tag v4.9.0 and update this to match and can proceed to ship it.

We're jumping from 4.7 -> 4.9 because I ran out of bandwidth when wrapping up our internal 4.8 release :-(

Audit reports:

```
$ brew audit --strict watchman
watchman:
  * Stable version URLs should not contain rc1
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----