### PR TITLE
mpv: add options to enable audio CD playback

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -35,6 +35,7 @@ class Mpv < Formula
   depends_on "rubberband" => :optional
   depends_on "uchardet" => :optional
   depends_on "vapoursynth" => :optional
+  depends_on "libcdio" => :optional
   depends_on :x11 => :optional
 
   depends_on :macos => :mountain_lion
@@ -71,6 +72,7 @@ class Mpv < Formula
     args << "--enable-libbluray" if build.with? "libbluray"
     args << "--enable-dvdnav" if build.with? "libdvdnav"
     args << "--enable-dvdread" if build.with? "libdvdread"
+    args << "--enable-cdda" if build.with? "libcdio"
     args << "--enable-pulse" if build.with? "pulseaudio"
 
     system "./bootstrap.py"


### PR DESCRIPTION
Add libcdio dependency and the option to enable it at compile time (it's not autodetected by default).

Also, a little request: in the latest release, mpv added a JS scripting backend, which needs the small [MuJS](https://github.com/ccxvii/mujs) library to work, absent on homebrew: I'm not positive I'd be able to create the formula from scratch (especially the test block), is there someone willing to take the task?