### PR TITLE
pulseaudio: fix plist

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -80,7 +80,7 @@ class Pulseaudio < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>#{opt_bin}/emacs</string>
+        <string>#{opt_bin}/pulseaudio</string>
         <string>--start</string>
       </array>
       <key>RunAtLoad</key>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@ilovezfs Sorry, I screwed up in #16555 😭 (Apparently copied the plist from emacs.rb).