### PR TITLE
makensis: Add advanced logging option

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -12,6 +12,9 @@ class Makensis < Formula
     sha256 "4e7ee251f0e53b7cc3b254f6d7ee5a247f18287327f25dbba586ee75a43084fb" => :yosemite
   end
 
+  # From http://nsis.sourceforge.net/Special_Builds#Advanced_logging
+  option "with-advanced-logging", "Enable advanced logging of all installer actions"
+
   # Build makensis so installers can handle strings > 1024 characters
   # From https://nsis.sourceforge.io/Special_Builds#Large_strings
   # Upstream RFE to make this default the default behavior is
@@ -46,6 +49,7 @@ class Makensis < Formula
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
     args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu",
             "VERSION=#{version}"]
+    args << "NSIS_CONFIG_LOG=yes" if build.with? "advanced-logging"
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     scons "makensis", *args
     bin.install "build/urelease/makensis/makensis"


### PR DESCRIPTION
Following @rhwood's option for large string builds, I thought it's only natural to add another for advanced logging. Both options are available as officially maintained [Special Builds](http://nsis.sourceforge.net/Special_Builds) and can be combined.

PS: I wanted to maintain the order given on that website, thought that makes sense (not that it has any impact at all)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
