### PR TITLE
gnupg 2.1.23

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,9 +1,9 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://www.gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.22.tar.bz2"
-  sha256 "46716faf9e1b92cfca86609f3bfffbf5bb4b6804df90dc853ff7061cfcfb4ad7"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.23.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.1.23.tar.bz2"
+  sha256 "a94476391595e9351f219188767a9d6ea128e83be5ed3226a7890f49aa2d0d77"
 
   bottle do
     sha256 "f0d36cbb12e9039664b4c33f4202a4ff44fb53745cb4d988c7dbca9c9c051acf" => :sierra
@@ -42,6 +42,7 @@ class Gnupg < Formula
       --sysconfdir=#{etc}
       --enable-symcryptrun
       --with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry
+      --enable-all-tests
     ]
 
     args << "--disable-ccid-driver" if build.without? "libusb"
@@ -52,12 +53,6 @@ class Gnupg < Formula
     system "make"
     system "make", "check"
     system "make", "install"
-
-    # Add symlinks from gpg2 to unversioned executables, replacing gpg 1.x.
-    bin.install_symlink "gpg2" => "gpg"
-    bin.install_symlink "gpgv2" => "gpgv"
-    man1.install_symlink "gpg2.1" => "gpg.1"
-    man1.install_symlink "gpgv2.1" => "gpgv.1"
 
     bin.install "tools/gpgsplit" if build.with? "gpgsplit"
     bin.install "tools/gpg-zip" if build.with? "gpg-zip"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


```
Noteworthy changes in version 2.1.23
====================================

  * gpg: "gpg" is now installed as "gpg" and not anymore as "gpg2".
    If needed, the new configure option --enable-gpg-is-gpg2 can be
    used to revert this.

  * gpg: Options --auto-key-retrieve and --auto-key-locate "local,wkd"
    are now used by default.  Note: this enables keyserver and Web Key
    Directory operators to notice when a signature from a locally
    non-available key is being verified for the first time or when
    you intend to encrypt to a mail address without having the key
    locally.  This new behaviour will eventually make key discovery
    much easier and mostly automatic.  Disable this by adding
      no-auto-key-retrieve
      auto-key-locate local
    to your gpg.conf.

  * agent: Option --no-grab is now the default.  The new option --grab
    allows to revert this.

  * gpg: New import option "show-only".

  * gpg: New option --disable-dirmngr to entirely disable network
    access for gpg.

  * gpg,gpgsm: Tweaked DE-VS compliance behaviour.

  * New configure flag --enable-all-tests to run more extensive tests
    during "make check".

  * gpgsm: The keygrip is now always printed in colon mode as
    documented in the man page.

  * Fixed connection timeout problem under Windows.
```