### PR TITLE
gopass 1.3.0 (new formula)

### DIFF
--- a/Formula/gopass.rb
+++ b/Formula/gopass.rb
@@ -1,0 +1,51 @@
+class Gopass < Formula
+  desc "The slightly more awesome Standard Unix Password Manager for Teams"
+  homepage "https://www.justwatch.com/gopass"
+  url "https://www.justwatch.com/gopass/releases/1.3.0/gopass-1.3.0.tar.gz"
+  sha256 "1546546d6e9db9347e276b18a3c900c5359cf463058244ed4fc25d44d87f6f1b"
+  head "https://github.com/justwatchcom/gopass.git"
+
+  depends_on "go" => :build
+  depends_on :gpg => :run
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/justwatchcom/gopass").install buildpath.children
+
+    cd "src/github.com/justwatchcom/gopass" do
+      prefix.install_metafiles
+      ENV["PREFIX"] = prefix
+      system "make", "install"
+    end
+
+    output = Utils.popen_read("#{bin}/gopass completion bash")
+    (bash_completion/"gopass-completion").write output
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gopass version")
+
+    (testpath/"batch.gpg").write <<-EOS.undent
+      Key-Type: RSA
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Name-Real: Testing
+      Name-Email: testing@foo.bar
+      Expire-Date: 1d
+      %no-protection
+      %commit
+    EOS
+    begin
+      system Formula["gnupg"].opt_bin/"gpg", "--batch", "--gen-key", "batch.gpg"
+
+      system bin/"gopass", "init", "--nogit", "testing@foo.bar"
+      system bin/"gopass", "generate", "Email/other@foo.bar", "15"
+      assert File.exist?(".password-store/Email/other@foo.bar.gpg")
+    ensure
+      system Formula["gnupg"].opt_bin/"gpgconf", "--kill", "gpg-agent"
+      system Formula["gnupg"].opt_bin/"gpgconf", "--homedir", "keyrings/live",
+                                                 "--kill", "gpg-agent"
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

(Was previously #13196, managed to orphan that PR so I can't push changes to it so opened a new one.)

Adds gopass 1.2.0 as a new formula. Cribbed from the [upstream project's tap](https://github.com/justwatchcom/homebrew-gopass), because it's useful to have available in core. There's also a [discourse thread asking for this Formula to be added](https://discourse.brew.sh/t/missing-formula-gopass/618).

Feedback from previous PR addressed, most notably there are now proper tests that exercise the tool.