### PR TITLE
vtk: fix pyqt logic, bump revision from 0 to 2

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -3,6 +3,8 @@ class Vtk < Formula
   homepage "http://www.vtk.org"
   url "http://www.vtk.org/files/release/8.0/VTK-8.0.0.tar.gz"
   sha256 "c7e727706fb689fb6fd764d3b47cac8f4dc03204806ff19a10dfd406c6072a27"
+  revision 2
+
   head "https://github.com/Kitware/VTK.git"
 
   bottle do
@@ -24,17 +26,7 @@ class Vtk < Formula
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
   depends_on "qt" => :optional
-
-  # If --with-qt and --with-python, then we automatically use PyQt, too!
-  if build.with? "qt"
-    if build.with? "python"
-      depends_on "sip"
-      depends_on "pyqt5" => ["with-python", "without-python3"]
-    elsif build.with? "python3"
-      depends_on "sip"   => ["with-python3", "without-python"]
-      depends_on "pyqt5"
-    end
-  end
+  depends_on "pyqt" if build.with? "qt"
 
   needs :cxx11
 
@@ -103,7 +95,7 @@ class Vtk < Formula
         args << "-DSIP_PYQT_DIR='#{Formula["pyqt5"].opt_share}/sip'"
       end
 
-      system "cmake", *args, ".."
+      system "cmake", "..", *args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
since `pyqt` is built with support for both `python` and `python3`,
there is no need for the extra option handling code. `sip` also
builds with both versions and is a required dependency of `pyqt`.

The revision is bumped to 2 rather than 1 since the version in `homebrew/science` was at 1 before the migration.

cc @ilovezfs