### PR TITLE
chunkwm 0.2.29 (new formula)

### DIFF
--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -12,7 +12,7 @@ class Chunkwm < Formula
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
-  option "with-logging", "Redirect stdout and stderr to #{var}/log/chunkwm.log"
+  option "with-logging", "Redirect stdout and stderr to /usr/local/var/log/chunkwm.log"
 
   def install
     # install chunkwm

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -16,7 +16,7 @@ class Chunkwm < Formula
   def install
     # install chunkwm
     system "make", "install"
-    inreplace "#{buildpath}/examples/chunkwmrc", "~/.chunkwm_plugins", "$(brew --prefix chunkwm)/share/plugins"
+    inreplace "#{buildpath}/examples/chunkwmrc", "~/.chunkwm_plugins", "#{opt_pkgshare}/plugins"
     bin.install "#{buildpath}/bin/chunkwm"
     (pkgshare/"examples").install "#{buildpath}/examples/chunkwmrc"
 
@@ -69,7 +69,7 @@ class Chunkwm < Formula
     EOS
   end
 
-  plist_options :manual => "chunkwm"
+  plist_options :startup => false
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
@@ -82,19 +82,19 @@ class Chunkwm < Formula
       <array>
         <string>#{opt_bin}/chunkwm</string>
       </array>
-        <key>EnvironmentVariables</key>
-        <dict>
+      <key>EnvironmentVariables</key>
+      <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        </dict>
+      </dict>
       <key>RunAtLoad</key>
       <true/>
       <key>KeepAlive</key>
       <true/>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/chunkwm/chunkwm.out</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/chunkwm/chunkwm.err</string>
+      <key>StandardOutPath</key>
+      <string>/tmp/chunkwm.out</string>
+      <key>StandardErrorPath</key>
+      <string>/tmp/chunkwm.err</string>
     </dict>
     </plist>
     EOS

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -1,0 +1,108 @@
+class Chunkwm < Formula
+  desc "Tiling window manager for macOS based on plugin architecture"
+  homepage "https://github.com/koekeishiya/chunkwm"
+  url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
+  sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
+
+  head do
+    url "https://github.com/koekeishiya/chunkwm.git"
+  end
+
+  option "without-tiling", "Do not build tiling plugin."
+  option "without-ffm", "Do not build focus-follow-mouse plugin."
+  option "without-border", "Do not build border plugin."
+  option "with-transparency", "Build transparency plugin."
+
+  def install
+    # create plugins and example directories
+    (share/"plugins").mkpath
+    (share/"examples").mkpath
+
+    # install chunkwm
+    system "make", "install"
+    inreplace "#{buildpath}/examples/chunkwmrc", "~/.chunkwm_plugins", "$(brew --prefix chunkwm)/share/plugins"
+    bin.install "#{buildpath}/bin/chunkwm"
+    (share/"examples").install "#{buildpath}/examples/chunkwmrc"
+
+    # install chunkc
+    system "make", "--directory", "src/chunkc"
+    bin.install "#{buildpath}/src/chunkc/bin/chunkc"
+
+    # install tiling plugin
+    if build.with? "tiling"
+      system "make", "install", "--directory", "src/plugins/tiling"
+      (share/"plugins").install "#{buildpath}/plugins/tiling.so"
+      (share/"examples").install "#{buildpath}/src/plugins/tiling/examples/khdrc"
+    end
+
+    # install ffm plugin
+    if build.with? "ffm"
+      system "make", "install", "--directory", "src/plugins/ffm"
+      (share/"plugins").install "#{buildpath}/plugins/ffm.so"
+    end
+
+    # install border plugin
+    if build.with? "border"
+      system "make", "install", "--directory", "src/plugins/border"
+      (share/"plugins").install "#{buildpath}/plugins/border.so"
+    end
+
+    # install transparency plugin
+    if build.with? "transparency"
+      system "make", "install", "--directory", "src/plugins/transparency"
+      (share/"plugins").install "#{buildpath}/plugins/transparency.so"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    Copy the example configuration into your home directory:
+      cp #{share}/examples/chunkwmrc ~/.chunkwmrc
+
+    Opening chunkwm will prompt for Accessibility API permissions. After access has been granted, the application must be restarted.
+      brew services restart chunkwm
+
+    This has to be done after every update to chunkwm, unless you codesign the binary with self-signed certificate before restarting
+      Create code signing certificate named "chunkwm-cert" using Keychain Access.app
+      codesign -fs "chunkwm-cert" #{bin}/chunkwm
+
+    For keybindings install and configure https://github.com/koekeishiya/khd.
+    chunkwm provides an example khd configuration file for easier setup:
+      cp #{share}/examples/khdrc ~/.khdrc
+    EOS
+  end
+
+  plist_options :startup => false
+
+  def plist; <<-EOS.undent
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>com.koekeishiya.chunkwm</string>
+          <key>ProgramArguments</key>
+          <array>
+                <string>#{bin}/chunkwm</string>
+          </array>
+            <key>EnvironmentVariables</key>
+            <dict>
+            <key>PATH</key>
+            <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+            </dict>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>KeepAlive</key>
+          <true/>
+            <key>StandardOutPath</key>
+            <string>/tmp/chunkwm.out</string>
+            <key>StandardErrorPath</key>
+            <string>/tmp/chunkwm.err</string>
+        </dict>
+        </plist>
+    EOS
+  end
+
+  test do
+    system "#{prefix}/chunkwm", "--version"
+  end
+end

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -1,7 +1,7 @@
 class Chunkwm < Formula
   desc "Tiling window manager for macOS based on plugin architecture"
   homepage "https://github.com/koekeishiya/chunkwm"
-  url "https://github.com/koekeishiya/chunkwm.git"
+  url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
   sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
 
   option "without-tiling", "Do not build tiling plugin."
@@ -42,7 +42,7 @@ class Chunkwm < Formula
     # install transparency plugin
     if build.with? "transparency"
       system "make", "install", "--directory", "src/plugins/transparency"
-      (pkg_share/"plugins").install "#{buildpath}/plugins/transparency.so"
+      (pkgshare/"plugins").install "#{buildpath}/plugins/transparency.so"
     end
   end
 
@@ -64,6 +64,8 @@ class Chunkwm < Formula
       cp #{opt_pkgshare}/examples/khdrc ~/.khdrc
     EOS
   end
+
+  plist_options :manual => "chunkwm"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -4,6 +4,10 @@ class Chunkwm < Formula
   url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
   sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
 
+  head do
+    url "https://github.com/koekeishiya/chunkwm.git"
+  end
+
   option "without-tiling", "Do not build tiling plugin."
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -1,12 +1,8 @@
 class Chunkwm < Formula
   desc "Tiling window manager for macOS based on plugin architecture"
   homepage "https://github.com/koekeishiya/chunkwm"
-  url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
+  url "https://github.com/koekeishiya/chunkwm.git"
   sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
-
-  head do
-    url "https://github.com/koekeishiya/chunkwm.git"
-  end
 
   option "without-tiling", "Do not build tiling plugin."
   option "without-ffm", "Do not build focus-follow-mouse plugin."
@@ -14,15 +10,11 @@ class Chunkwm < Formula
   option "with-transparency", "Build transparency plugin."
 
   def install
-    # create plugins and example directories
-    (share/"plugins").mkpath
-    (share/"examples").mkpath
-
     # install chunkwm
     system "make", "install"
     inreplace "#{buildpath}/examples/chunkwmrc", "~/.chunkwm_plugins", "$(brew --prefix chunkwm)/share/plugins"
     bin.install "#{buildpath}/bin/chunkwm"
-    (share/"examples").install "#{buildpath}/examples/chunkwmrc"
+    (pkgshare/"examples").install "#{buildpath}/examples/chunkwmrc"
 
     # install chunkc
     system "make", "--directory", "src/chunkc"
@@ -31,78 +23,80 @@ class Chunkwm < Formula
     # install tiling plugin
     if build.with? "tiling"
       system "make", "install", "--directory", "src/plugins/tiling"
-      (share/"plugins").install "#{buildpath}/plugins/tiling.so"
-      (share/"examples").install "#{buildpath}/src/plugins/tiling/examples/khdrc"
+      (pkgshare/"plugins").install "#{buildpath}/plugins/tiling.so"
+      (pkgshare/"examples").install "#{buildpath}/src/plugins/tiling/examples/khdrc"
     end
 
     # install ffm plugin
     if build.with? "ffm"
       system "make", "install", "--directory", "src/plugins/ffm"
-      (share/"plugins").install "#{buildpath}/plugins/ffm.so"
+      (pkgshare/"plugins").install "#{buildpath}/plugins/ffm.so"
     end
 
     # install border plugin
     if build.with? "border"
       system "make", "install", "--directory", "src/plugins/border"
-      (share/"plugins").install "#{buildpath}/plugins/border.so"
+      (pkgshare/"plugins").install "#{buildpath}/plugins/border.so"
     end
 
     # install transparency plugin
     if build.with? "transparency"
       system "make", "install", "--directory", "src/plugins/transparency"
-      (share/"plugins").install "#{buildpath}/plugins/transparency.so"
+      (pkg_share/"plugins").install "#{buildpath}/plugins/transparency.so"
     end
   end
 
   def caveats; <<-EOS.undent
     Copy the example configuration into your home directory:
-      cp #{share}/examples/chunkwmrc ~/.chunkwmrc
+      cp #{opt_pkgshare}/examples/chunkwmrc ~/.chunkwmrc
 
-    Opening chunkwm will prompt for Accessibility API permissions. After access has been granted, the application must be restarted.
+    Opening chunkwm will prompt for Accessibility API permissions. After access
+    has been granted, the application must be restarted.
       brew services restart chunkwm
 
-    This has to be done after every update to chunkwm, unless you codesign the binary with self-signed certificate before restarting
+    This has to be done after every update to chunkwm, unless you codesign the
+    binary with self-signed certificate before restarting
       Create code signing certificate named "chunkwm-cert" using Keychain Access.app
-      codesign -fs "chunkwm-cert" #{bin}/chunkwm
+      codesign -fs "chunkwm-cert" #{opt_bin}/chunkwm
 
     For keybindings install and configure https://github.com/koekeishiya/khd.
     chunkwm provides an example khd configuration file for easier setup:
-      cp #{share}/examples/khdrc ~/.khdrc
+      cp #{opt_pkgshare}/examples/khdrc ~/.khdrc
     EOS
   end
 
   plist_options :startup => false
 
   def plist; <<-EOS.undent
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+            <string>#{opt_bin}/chunkwm</string>
+      </array>
+        <key>EnvironmentVariables</key>
         <dict>
-          <key>Label</key>
-          <string>com.koekeishiya.chunkwm</string>
-          <key>ProgramArguments</key>
-          <array>
-                <string>#{bin}/chunkwm</string>
-          </array>
-            <key>EnvironmentVariables</key>
-            <dict>
-            <key>PATH</key>
-            <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-            </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <true/>
-            <key>StandardOutPath</key>
-            <string>/tmp/chunkwm.out</string>
-            <key>StandardErrorPath</key>
-            <string>/tmp/chunkwm.err</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         </dict>
-        </plist>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/chunkwm/chunkwm.out</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/chunkwm/chunkwm.err</string>
+    </dict>
+    </plist>
     EOS
   end
 
   test do
-    system "#{prefix}/chunkwm", "--version"
+    system "#{bin}/chunkwm", "--version"
   end
 end

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -8,6 +8,8 @@ class Chunkwm < Formula
     url "https://github.com/koekeishiya/chunkwm.git"
   end
 
+  depends_on :macos => :sierra
+
   option "without-tiling", "Do not build tiling plugin."
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -10,7 +10,7 @@ class Chunkwm < Formula
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
 
-  depends_on :macos => :sierra
+  depends_on :macos => :el_capitan
 
   def install
     system "make", "install"

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -8,13 +8,13 @@ class Chunkwm < Formula
     url "https://github.com/koekeishiya/chunkwm.git"
   end
 
-  depends_on :macos => :sierra
-
   option "without-tiling", "Do not build tiling plugin."
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
   option "with-logging", "Redirect stdout and stderr to /usr/local/var/log/chunkwm.log"
+
+  depends_on :macos => :sierra
 
   def install
     # install chunkwm

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -90,6 +90,6 @@ class Chunkwm < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/chunkwm --version")
+    assert_match "chunkwm #{version}", shell_output("#{bin}/chunkwm --version")
   end
 end

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -3,50 +3,40 @@ class Chunkwm < Formula
   homepage "https://github.com/koekeishiya/chunkwm"
   url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
   sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
-
-  head do
-    url "https://github.com/koekeishiya/chunkwm.git"
-  end
+  head "https://github.com/koekeishiya/chunkwm.git"
 
   option "without-tiling", "Do not build tiling plugin."
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
-  option "with-logging", "Redirect stdout and stderr to /usr/local/var/log/chunkwm.log"
 
   depends_on :macos => :sierra
 
   def install
-    # install chunkwm
     system "make", "install"
     inreplace "#{buildpath}/examples/chunkwmrc", "~/.chunkwm_plugins", "#{opt_pkgshare}/plugins"
     bin.install "#{buildpath}/bin/chunkwm"
     (pkgshare/"examples").install "#{buildpath}/examples/chunkwmrc"
 
-    # install chunkc
     system "make", "--directory", "src/chunkc"
     bin.install "#{buildpath}/src/chunkc/bin/chunkc"
 
-    # install tiling plugin
     if build.with? "tiling"
       system "make", "install", "--directory", "src/plugins/tiling"
       (pkgshare/"plugins").install "#{buildpath}/plugins/tiling.so"
       (pkgshare/"examples").install "#{buildpath}/src/plugins/tiling/examples/khdrc"
     end
 
-    # install ffm plugin
     if build.with? "ffm"
       system "make", "install", "--directory", "src/plugins/ffm"
       (pkgshare/"plugins").install "#{buildpath}/plugins/ffm.so"
     end
 
-    # install border plugin
     if build.with? "border"
       system "make", "install", "--directory", "src/plugins/border"
       (pkgshare/"plugins").install "#{buildpath}/plugins/border.so"
     end
 
-    # install transparency plugin
     if build.with? "transparency"
       system "make", "install", "--directory", "src/plugins/transparency"
       (pkgshare/"plugins").install "#{buildpath}/plugins/transparency.so"
@@ -65,72 +55,41 @@ class Chunkwm < Formula
     binary with self-signed certificate before restarting
       Create code signing certificate named "chunkwm-cert" using Keychain Access.app
       codesign -fs "chunkwm-cert" #{opt_bin}/chunkwm
-
-    For keybindings install and configure https://github.com/koekeishiya/khd.
-    chunkwm provides an example khd configuration file for easier setup:
-      cp #{opt_pkgshare}/examples/khdrc ~/.khdrc
     EOS
   end
 
-  plist_options :startup => false
+  plist_options :manual => "chunkwm"
 
-  if build.with? "logging"
-    def plist; <<-EOS.undent
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/chunkwm</string>
+      </array>
+      <key>EnvironmentVariables</key>
       <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/chunkwm</string>
-        </array>
-        <key>EnvironmentVariables</key>
-        <dict>
-          <key>PATH</key>
-          <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        </dict>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/chunkwm.log</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/chunkwm.log</string>
+        <key>PATH</key>
+        <string>#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
       </dict>
-      </plist>
-      EOS
-    end
-  else
-    def plist; <<-EOS.undent
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/chunkwm</string>
-        </array>
-        <key>EnvironmentVariables</key>
-        <dict>
-          <key>PATH</key>
-          <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        </dict>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-      </dict>
-      </plist>
-      EOS
-    end
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/chunkwm.log</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/chunkwm.log</string>
+    </dict>
+    </plist>
+  EOS
   end
 
   test do
-    system "#{bin}/chunkwm", "--version"
+    assert_match version.to_s, shell_output("#{bin}/chunkwm --version")
   end
 end

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -12,7 +12,7 @@ class Chunkwm < Formula
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
-  option "with-logging", "Redirect stdout and stderr to /tmp/chunkwm.log"
+  option "with-logging", "Redirect stdout and stderr to #{var}/log/chunkwm.log"
 
   def install
     # install chunkwm
@@ -94,9 +94,9 @@ class Chunkwm < Formula
         <key>KeepAlive</key>
         <true/>
         <key>StandardOutPath</key>
-        <string>/tmp/chunkwm.log</string>
+        <string>#{var}/log/chunkwm.log</string>
         <key>StandardErrorPath</key>
-        <string>/tmp/chunkwm.log</string>
+        <string>#{var}/log/chunkwm.log</string>
       </dict>
       </plist>
       EOS

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -74,7 +74,7 @@ class Chunkwm < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-            <string>#{opt_bin}/chunkwm</string>
+        <string>#{opt_bin}/chunkwm</string>
       </array>
         <key>EnvironmentVariables</key>
         <dict>

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -12,6 +12,7 @@ class Chunkwm < Formula
   option "without-ffm", "Do not build focus-follow-mouse plugin."
   option "without-border", "Do not build border plugin."
   option "with-transparency", "Build transparency plugin."
+  option "with-logging", "Redirect stdout and stderr to /tmp/chunkwm.log"
 
   def install
     # install chunkwm
@@ -71,33 +72,60 @@ class Chunkwm < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/chunkwm</string>
-      </array>
-      <key>EnvironmentVariables</key>
+  if build.with? "logging"
+    def plist; <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
       <dict>
-        <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/chunkwm</string>
+        </array>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>PATH</key>
+          <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        </dict>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>StandardOutPath</key>
+        <string>/tmp/chunkwm.log</string>
+        <key>StandardErrorPath</key>
+        <string>/tmp/chunkwm.log</string>
       </dict>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-      <key>StandardOutPath</key>
-      <string>/tmp/chunkwm.out</string>
-      <key>StandardErrorPath</key>
-      <string>/tmp/chunkwm.err</string>
-    </dict>
-    </plist>
-    EOS
+      </plist>
+      EOS
+    end
+  else
+    def plist; <<-EOS.undent
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/chunkwm</string>
+        </array>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>PATH</key>
+          <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        </dict>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+      </dict>
+      </plist>
+      EOS
+    end
   end
 
   test do

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -65,8 +65,6 @@ class Chunkwm < Formula
     EOS
   end
 
-  plist_options :startup => false
-
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Formula/chunkwm.rb
+++ b/Formula/chunkwm.rb
@@ -1,8 +1,8 @@
 class Chunkwm < Formula
   desc "Tiling window manager for macOS based on plugin architecture"
   homepage "https://github.com/koekeishiya/chunkwm"
-  url "https://github.com/koekeishiya/chunkwm/archive/v0.2.28.tar.gz"
-  sha256 "917c6aa09521ff4b7463f731192eea6be6313f0fa4e585f63f85603d0993cf92"
+  url "https://github.com/koekeishiya/chunkwm/archive/v0.2.29.tar.gz"
+  sha256 "6f5913476a5e0e7afab59b79061be4952ab575f9d9d06ed91de6297bd169bd38"
   head "https://github.com/koekeishiya/chunkwm.git"
 
   option "without-tiling", "Do not build tiling plugin."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula adds `chunkwm`, a tiling window manager for macOS.

**Question:** The default `launchctl` configuration redirects `stdout` and `stderr` to files in `/tmp/`, is this okay with `homebrew-core` or should this be changed to some other folder? I couldn't find any information about this in the guidelines.