### PR TITLE
sbt 1.0.0 + sbt@0.13 0.13.16 (new formula)

### DIFF
--- a/Aliases/sbt@1
+++ b/Aliases/sbt@1
@@ -1,0 +1,1 @@
+../Formula/sbt.rb

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,14 +1,8 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "http://www.scala-sbt.org"
-  url "https://dl.bintray.com/homebrew/mirror/sbt-0.13.16"
-  mirror "https://cocl.us/sbt01316tgz"
-  sha256 "22729580a581e966259267eda4d937a2aecad86848f8a82fcc716dcae8dc760c"
-
-  devel do
-    url "https://github.com/sbt/sbt/releases/download/v1.0.0-RC2/sbt-1.0.0-RC2.tgz"
-    sha256 "4e446c49a473d9ae5001e6ec847c06b76e3d27f34d680ae7bd258709547630d7"
-  end
+  url "https://github.com/sbt/sbt/releases/download/v1.0.0/sbt-1.0.0.tgz"
+  sha256 "9ae04f4972145f2ac56c4deb868c9a5bb8b8b85c5151885dff3b997712645c5a"
 
   bottle :unneeded
 

--- a/Formula/sbt@0.13.rb
+++ b/Formula/sbt@0.13.rb
@@ -1,0 +1,46 @@
+class SbtAT013 < Formula
+  desc "Build tool for Scala projects"
+  homepage "http://www.scala-sbt.org"
+  url "https://dl.bintray.com/homebrew/mirror/sbt-0.13.16"
+  mirror "https://cocl.us/sbt01316tgz"
+  sha256 "22729580a581e966259267eda4d937a2aecad86848f8a82fcc716dcae8dc760c"
+
+  bottle :unneeded
+
+  depends_on :java => "1.6+"
+
+  def install
+    inreplace "bin/sbt" do |s|
+      s.gsub! 'etc_sbt_opts_file="${sbt_home}/conf/sbtopts"', "etc_sbt_opts_file=\"#{etc}/sbtopts\""
+      s.gsub! "/etc/sbt/sbtopts", "#{etc}/sbtopts"
+    end
+
+    libexec.install "bin", "lib"
+    etc.install "conf/sbtopts"
+
+    (bin/"sbt").write <<-EOS.undent
+      #!/bin/sh
+      if [ -f "$HOME/.sbtconfig" ]; then
+        echo "Use of ~/.sbtconfig is deprecated, please migrate global settings to #{etc}/sbtopts" >&2
+        . "$HOME/.sbtconfig"
+      fi
+      exec "#{libexec}/bin/sbt" "$@"
+    EOS
+  end
+
+  def caveats;  <<-EOS.undent
+    You can use $SBT_OPTS to pass additional JVM options to SBT:
+       SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
+
+    This formula uses the standard Lightbend sbt launcher script.
+    Project specific options should be placed in .sbtopts in the root of your project.
+    Global settings should be placed in #{etc}/sbtopts
+    EOS
+  end
+
+  test do
+    ENV["_JAVA_OPTIONS"] = "-Dsbt.log.noformat=true"
+    ENV.java_cache
+    assert_match "[info] #{version}", shell_output("#{bin}/sbt sbtVersion")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR bumps "sbt" formula to sbt 1.0.0, and saves the older stable sbt 0.13 as "sbt@0.13".
