### PR TITLE
Update sbt java depends_on to 1.8+

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -6,7 +6,7 @@ class Sbt < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8+"
 
   def install
     inreplace "bin/sbt" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

SBT is now built on Scala 2.12 which requires Java 8 - this updates the `depends_on` to reflect this.