### PR TITLE
nodenv: fixes

### DIFF
--- a/Formula/nodenv.rb
+++ b/Formula/nodenv.rb
@@ -20,6 +20,13 @@ class Nodenv < Formula
       system "make", "-C", "src"
     end
 
+    if build.head?
+      # Record exact git revision for `nodenv --version` output
+      git_revision = `git rev-parse --short HEAD`.chomp
+      inreplace "libexec/nodenv---version", /^(version=.+)/,
+                                           "\\1--g#{git_revision}"
+    end
+
     prefix.install "bin", "completions", "libexec"
   end
 

--- a/Formula/nodenv.rb
+++ b/Formula/nodenv.rb
@@ -7,11 +7,20 @@ class Nodenv < Formula
 
   bottle :unneeded
 
+  option "without-bash-extension", "Skip compilation of the dynamic bash extension to speed up nodenv."
+
   depends_on "node-build" => :recommended
 
   def install
     inreplace "libexec/nodenv", "/usr/local", HOMEBREW_PREFIX
-    prefix.install "bin", "libexec", "completions"
+
+    if build.with? "bash-extension"
+      # Compile optional bash extension.
+      system "src/configure"
+      system "make", "-C", "src"
+    end
+
+    prefix.install "bin", "completions", "libexec"
   end
 
   test do

--- a/Formula/nodenv.rb
+++ b/Formula/nodenv.rb
@@ -12,7 +12,14 @@ class Nodenv < Formula
   depends_on "node-build" => :recommended
 
   def install
-    inreplace "libexec/nodenv", "/usr/local", HOMEBREW_PREFIX
+    inreplace "libexec/nodenv" do |s|
+      s.gsub! "/usr/local", HOMEBREW_PREFIX
+      s.gsub! '"${BASH_SOURCE%/*}"/../libexec', libexec
+    end
+
+    %w[--version hooks versions].each do |cmd|
+      inreplace "libexec/nodenv-#{cmd}", "${BASH_SOURCE%/*}", libexec
+    end
 
     if build.with? "bash-extension"
       # Compile optional bash extension.


### PR DESCRIPTION
- fix BASH_SOURCE lookups

   replace the BASH_SOURCE lookups with static (known) libexec path at build
   time.

- fix version number for head builds

   Head builds now stamp the version number based on the git-revision similar
   to git-clone installations.

- fix missing shell-extension option

   Shell extension is now enabled by default, but optional.

   Also, list prefix installed files alphabetically.


There is also a version bump to nodenv forthcoming. Shall I include that in this PR or open separate PR for the version bump?