### PR TITLE
Pilosa 0.6.0

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Pilosa < Formula
   desc "Distributed bitmap index that queries across data sets"
   homepage "https://www.pilosa.com"
-  url "https://github.com/pilosa/pilosa/archive/v0.5.0.tar.gz"
-  sha256 "ca9cb43f15404e695635e001e26c4e76a309e3e0e9a46198b7e50690a00b4fa7"
+  url "https://github.com/pilosa/pilosa/archive/v0.6.0.tar.gz"
+  sha256 "6121066051ab55f266f2c891edcc66d449aa5786c8622f7f765015806ee6f84f"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -1,8 +1,10 @@
+require "language/go"
+
 class Pilosa < Formula
   desc "Distributed bitmap index that queries across data sets"
   homepage "https://www.pilosa.com"
-  url "https://github.com/pilosa/pilosa/archive/v0.4.0.tar.gz"
-  sha256 "ec615c5d2584e5761ac20c6a6df6139f7018de65934f4c2d05e69cfd35d1d89e"
+  url "https://github.com/pilosa/pilosa/archive/v0.5.0.tar.gz"
+  sha256 "ca9cb43f15404e695635e001e26c4e76a309e3e0e9a46198b7e50690a00b4fa7"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,15 +15,26 @@ class Pilosa < Formula
   end
 
   depends_on "go" => :build
-  depends_on "glide" => :build
+  depends_on "dep" => :build
+
+  go_resource "github.com/rakyll/statik" do
+    url "https://github.com/rakyll/statik.git",
+        :revision => "25d6cab4d68d2a9b7c5965aa381726dd5dd6d7b8"
+  end
 
   def install
-    require "time"
     ENV["GOPATH"] = buildpath
-    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
-    mkdir_p buildpath/"src/github.com/pilosa/"
-    ln_s buildpath, buildpath/"src/github.com/pilosa/pilosa"
-    system "make", "pilosa", "FLAGS=-o #{bin}/pilosa", "VERSION=#{version}"
+    ENV.prepend_path "PATH", "#{buildpath}/bin"
+
+    (buildpath/"src/github.com/pilosa/pilosa").install buildpath.children
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd "src/github.com/rakyll/statik" do
+      system "go", "install"
+    end
+    cd "src/github.com/pilosa/pilosa" do
+      system "make", "generate-statik", "pilosa", "FLAGS=-o #{bin}/pilosa", "VERSION=#{version}"
+    end
   end
 
   plist_options :manual => "pilosa server"
@@ -59,6 +72,7 @@ class Pilosa < Formula
       end
       sleep 0.5
       assert_match("Welcome. Pilosa is running.", shell_output("curl localhost:10101"))
+      assert_match("<!DOCTYPE html>", shell_output("curl --user-agent NotCurl localhost:10101"))
     ensure
       Process.kill "TERM", server
       Process.wait server


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This bumps the version of the Pilosa formula to 0.6.0.
This also includes the additional build instructions to produce the WebUI as detailed in #15311 and #16336.