### PR TITLE
sane-backends-1.0.27-3: fix bug in make

### DIFF
--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -5,7 +5,7 @@ class SaneBackends < Formula
   mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
-  revision 2
+  revision 3
   head "https://anonscm.debian.org/cgit/sane/sane-backends.git"
 
   bottle do
@@ -29,6 +29,9 @@ class SaneBackends < Formula
                           "--without-gphoto2",
                           "--enable-local-backends",
                           "--with-usb=yes"
+    # Workaround for bug in Makefile.am described here: https://goo.gl/vqzVk5. Remove after next release.
+    # It's already fixed in commit 519ff57, see it here https://goo.gl/Cmp6Br
+    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
`brew audit --strict sane-backends` produces error: `Error: Formula sane-backends has already been loaded`.

We also need to update `wine` after merge of this PR.
