### PR TITLE
faust. v2.1.0 (new formula)

### DIFF
--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -5,11 +5,9 @@ class Faust < Formula
   option "with-httpd", "compile httpdlib (requires GNU libmicrohttpd)"
   option "with-dynamic", "compile httpd & osc supports as dynamic libraries"
   option "with-sound2faust", "compile sound to DSP file converter"
-  option "with-test","install test suite"
+  option "with-test", "install test suite"
 
   depends_on "pkg-config" => :run
-  depends_on "libmicrohttpd" =>[:run,"with-httpd"]
-  depends_on "libsndfile" => [:run,"with-sound2faust"]
 
   if build.without? "faust0"
     depends_on "llvm@3.8" => :run
@@ -26,26 +24,34 @@ class Faust < Formula
     sha256 "abb1dee52faf427d232f56f2037ba5e81cb60a9e6684ac10f41da6c5c6df3415"
     head "https://github.com/grame-cncm/faust.git", :branch => "master"
   end
+  if build.with? "httpd"
+    depends_on "libmicrohttpd" =>:run
+  end
+  if build.with? "sound2faust"
+    depends_on "libsndfile" => :run
+  end
 
   def install
     system "make"
     if build.with? "httpd"
-      system "make","httpd"
+      system "make", "httpd"
     end
     if build.with? "dynamic"
-      system "make","dynamic"
+      system "make", "dynamic"
     end
     if build.with? "sound2faust"
-      system "make","sound2faust"
+      system "make", "sound2faust"
     end
     system "make", "install", "PREFIX=#{prefix}"
     if build.with? "test"
-      system "cp -r tests #{prefix}"
+      cp_r "tests", prefix
     end
   end
   test do
-    system "cp -r #{prefix}/tests/architecture-tests #{testpath}"
-    system "cd #{testpath}/architecture-tests &&./testfailure"
-    system "cd #{testpath}/architecture-tests &&./testsuccess osx"
+    cp_r "#{prefix}/tests/architecture-tests", testpath
+    cd "#{testpath}/architecture-tests"
+    system "./testfailure"
+    cd "#{testpath}/architecture-tests"
+    system "./testsuccess", "osx"
   end
 end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,0 +1,29 @@
+class Faust < Formula
+  desc "Functional AUdio STream is language for signal processing and synthesis."
+  homepage "http://faust.grame.fr"
+  option "with-faust0", "install faust 0.x.x not faust 2.x.x"
+  depends_on "pkg-config" => :build
+  if build.without? "faust0"
+    depends_on "llvm@3.8" => :build
+    depends_on "openssl" => :build
+    url "https://github.com/grame-cncm/faust.git", :tag => "v2-1-0"
+    head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
+  else
+    url "https://github.com/grame-cncm/faust.git", :tag => "v0-9-90"
+    head "https://github.com/grame-cncm/faust.git"
+  end
+
+  def install
+    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
+    ENV["CXXFLAGS"] = "-I/usr/local/opt/openssl/include"
+    ENV["PKG_CONFIG_PATH"] = "/usr/local/bin/pkg-config"
+    ENV["PKG_CONFIG_LIBDIR"] += ":/usr/local/opt/openssl/lib/pkgconfig"
+    ENV["PATH"] += ":#{HOMEBREW_PREFIX}/bin"
+
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+  test do
+    system "#{bin}/faust", "-v"
+  end
+end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -28,11 +28,6 @@ class Faust < Formula
   end
 
   def install
-    # ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
-    # ENV["CXXFLAGS"] = "-I/usr/local/opt/openssl/include"
-    # ENV["PKG_CONFIG_PATH"] = "/usr/local/bin/pkg-config"
-    # ENV["PKG_CONFIG_LIBDIR"] += ":/usr/local/opt/openssl/lib/pkgconfig"
-    # ENV["PATH"] += ":#{HOMEBREW_PREFIX}/bin"
     system "make"
     if build.with? "httpd"
       system "make","httpd"
@@ -45,14 +40,11 @@ class Faust < Formula
     end
     system "make", "install", "PREFIX=#{prefix}"
     if build.with? "test"
-      ohai "test"
       system "cp -r tests #{prefix}"
-
     end
   end
   test do
     system "cp -r #{prefix}/tests/architecture-tests #{testpath}"
-    # system "cp test.sh #{bin}/faust-test.sh"
     system "cd #{testpath}/architecture-tests &&./testfailure"
     system "cd #{testpath}/architecture-tests &&./testsuccess osx"
   end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,0 +1,29 @@
+class Faust < Formula
+  desc "Functional AUdio STream is language for signal processing and synthesis."
+  homepage "http://faust.grame.fr"
+  option "with-faust0", "install faust 0.x.x not faust 2.x.x"
+  if build.without? "faust0"
+
+    depends_on "llvm@3.8" => :build
+    depends_on "openssl" => :build
+    url "https://github.com/grame-cncm/faust.git", :tag => "v2-1-0"
+    head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
+  else
+    url "https://github.com/grame-cncm/faust.git", :tag => "v0-9-90"
+    head "https://github.com/grame-cncm/faust.git"
+  end
+
+  def install
+    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
+    ENV["CXXFLAGS"] = "-I/usr/local/opt/openssl/include"
+    ENV["PKG_CONFIG_PATH"] = "/usr/local/bin/pkg-config"
+    ENV["PKG_CONFIG_LIBDIR"] += ":/usr/local/opt/openssl/lib/pkgconfig"
+    ENV["PATH"] += ":#{HOMEBREW_PREFIX}/bin"
+
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+  test do
+    system "#{bin}/faust", "-v"
+  end
+end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -2,12 +2,13 @@ class Faust < Formula
   desc "Functional AUdio STream is language for signal processing and synthesis."
   homepage "http://faust.grame.fr"
   option "with-faust0", "install faust 0.x.x not faust 2.x.x.(don't require llvm and openssl.)"
-  option "with-httpd", "compile httpdlib (requires GNU libmicrohttpd)"
-  option "with-dynamic", "compile httpd & osc supports as dynamic libraries"
-  option "with-sound2faust", "compile sound to DSP file converter"
-  option "with-test", "install test suite"
+  option "without-httpd", "don't compile httpdlib (requires GNU libmicrohttpd)"
+  option "without-dynamic", "don't compile httpd & osc supports as dynamic libraries"
+  option "without-sound2faust", "don't compile sound to DSP file converter"
+  option "without-test", "don't install test suite"
 
   depends_on "pkg-config" => :run
+
 
   if build.without? "faust0"
     depends_on "llvm@3.8" => :run
@@ -15,15 +16,20 @@ class Faust < Formula
     url "https://github.com/grame-cncm/faust/archive/v2-1-0.tar.gz"
     sha256 "9bd0b02020a6d9130ac3e2b11ad7cbfc03883769eb87dcb76251c80c40488494"
     head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
-  else
     if build.devel?
-      url "https://github.com/grame-cncm/faust.git", :branch => "master-dev"
-    else
-      url "https://github.com/grame-cncm/faust/archive/v0-9-90.tar.gz"
+      odie "Faust2 has no devel-release. If you want it, use --head option."
     end
-    sha256 "abb1dee52faf427d232f56f2037ba5e81cb60a9e6684ac10f41da6c5c6df3415"
+  else
+    devel do
+      url "https://github.com/grame-cncm/faust.git", :branch => "master-dev"
+    end
+    stable do
+      url "https://github.com/grame-cncm/faust/archive/v0-9-90.tar.gz"
+      sha256 "abb1dee52faf427d232f56f2037ba5e81cb60a9e6684ac10f41da6c5c6df3415"
+    end
     head "https://github.com/grame-cncm/faust.git", :branch => "master"
   end
+
   if build.with? "httpd"
     depends_on "libmicrohttpd" =>:run
   end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,29 +1,59 @@
 class Faust < Formula
   desc "Functional AUdio STream is language for signal processing and synthesis."
   homepage "http://faust.grame.fr"
-  option "with-faust0", "install faust 0.x.x not faust 2.x.x"
-  depends_on "pkg-config" => :build
+  option "with-faust0", "install faust 0.x.x not faust 2.x.x.(don't require llvm and openssl.)"
+  option "with-httpd", "compile httpdlib (requires GNU libmicrohttpd)"
+  option "with-dynamic", "compile httpd & osc supports as dynamic libraries"
+  option "with-sound2faust", "compile sound to DSP file converter"
+  option "with-test","install test suite"
+
+  depends_on "pkg-config" => :run
+  depends_on "libmicrohttpd" =>[:run,"with-httpd"]
+  depends_on "libsndfile" => [:run,"with-sound2faust"]
+
   if build.without? "faust0"
-    depends_on "llvm@3.8" => :build
-    depends_on "openssl" => :build
-    url "https://github.com/grame-cncm/faust.git", :tag => "v2-1-0"
+    depends_on "llvm@3.8" => :run
+    depends_on "openssl" => :run
+    url "https://github.com/grame-cncm/faust/archive/v2-1-0.tar.gz"
+    sha256 "9bd0b02020a6d9130ac3e2b11ad7cbfc03883769eb87dcb76251c80c40488494"
     head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
   else
-    url "https://github.com/grame-cncm/faust.git", :tag => "v0-9-90"
-    head "https://github.com/grame-cncm/faust.git"
+    if build.devel?
+      url "https://github.com/grame-cncm/faust.git", :branch => "master-dev"
+    else
+      url "https://github.com/grame-cncm/faust/archive/v0-9-90.tar.gz"
+    end
+    sha256 "abb1dee52faf427d232f56f2037ba5e81cb60a9e6684ac10f41da6c5c6df3415"
+    head "https://github.com/grame-cncm/faust.git", :branch => "master"
   end
 
   def install
-    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
-    ENV["CXXFLAGS"] = "-I/usr/local/opt/openssl/include"
-    ENV["PKG_CONFIG_PATH"] = "/usr/local/bin/pkg-config"
-    ENV["PKG_CONFIG_LIBDIR"] += ":/usr/local/opt/openssl/lib/pkgconfig"
-    ENV["PATH"] += ":#{HOMEBREW_PREFIX}/bin"
-
+    # ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
+    # ENV["CXXFLAGS"] = "-I/usr/local/opt/openssl/include"
+    # ENV["PKG_CONFIG_PATH"] = "/usr/local/bin/pkg-config"
+    # ENV["PKG_CONFIG_LIBDIR"] += ":/usr/local/opt/openssl/lib/pkgconfig"
+    # ENV["PATH"] += ":#{HOMEBREW_PREFIX}/bin"
     system "make"
+    if build.with? "httpd"
+      system "make","httpd"
+    end
+    if build.with? "dynamic"
+      system "make","dynamic"
+    end
+    if build.with? "sound2faust"
+      system "make","sound2faust"
+    end
     system "make", "install", "PREFIX=#{prefix}"
+    if build.with? "test"
+      ohai "test"
+      system "cp -r tests #{prefix}"
+
+    end
   end
   test do
-    system "#{bin}/faust", "-v"
+    system "cp -r #{prefix}/tests/architecture-tests #{testpath}"
+    # system "cp test.sh #{bin}/faust-test.sh"
+    system "cd #{testpath}/architecture-tests &&./testfailure"
+    system "cd #{testpath}/architecture-tests &&./testsuccess osx"
   end
 end

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -6,34 +6,28 @@ class Faust < Formula
   sha256 "9bd0b02020a6d9130ac3e2b11ad7cbfc03883769eb87dcb76251c80c40488494"
   head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
 
-  option "without-httpd", "don't compile httpdlib (requires GNU libmicrohttpd)"
-  option "without-dynamic", "don't compile httpd & osc supports as dynamic libraries"
-  option "without-sound2faust", "don't compile sound to DSP file converter"
-  option "without-test", "don't install test suite"
-  depends_on "pkg-config" => :run
-  depends_on "llvm" => :run
-  depends_on "openssl" => :run
-  if build.with? "httpd"
-    depends_on "libmicrohttpd" =>:run
-  end
-  if build.with? "sound2faust"
-    depends_on "libsndfile" => :run
-  end
+  depends_on "pkg-config" => "build"
+  depends_on "llvm"
+  depends_on "openssl"
+  depends_on "libmicrohttpd"
+  depends_on "libsndfile"
 
   def install
-    if !build.head?
-      inreplace "compiler/Makefile.unix", "$(filter $(LLVM_VERSION), 4.0.0)", "$(filter $(LLVM_VERSION), 4.0.0 4.0.1)"
+    unless build.head?
+      inreplace "compiler/Makefile.unix", "else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0))
+    LLVM_VERSION = LLVM_40
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11", "else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0 4.0.1))
+    LLVM_VERSION = LLVM_40
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11
+
+else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 5.0.0))
+    LLVM_VERSION = LLVM_50
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11"
     end
-    system "make"
-    if build.with? "httpd"
-      system "make", "httpd"
-    end
-    if build.with? "dynamic"
-      system "make", "dynamic"
-    end
-    if build.with? "sound2faust"
-      system "make", "sound2faust"
-    end
+    system "make world"
     system "make", "install", "PREFIX=#{prefix}"
     if build.with? "test"
       cp_r "tests", prefix

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,35 +1,18 @@
 class Faust < Formula
   desc "Functional AUdio STream is language for signal processing and synthesis."
   homepage "http://faust.grame.fr"
-  option "with-faust0", "install faust 0.x.x not faust 2.x.x.(don't require llvm and openssl.)"
+
+  url "https://github.com/grame-cncm/faust/archive/v2-1-0.tar.gz"
+  sha256 "9bd0b02020a6d9130ac3e2b11ad7cbfc03883769eb87dcb76251c80c40488494"
+  head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
+
   option "without-httpd", "don't compile httpdlib (requires GNU libmicrohttpd)"
   option "without-dynamic", "don't compile httpd & osc supports as dynamic libraries"
   option "without-sound2faust", "don't compile sound to DSP file converter"
   option "without-test", "don't install test suite"
-
   depends_on "pkg-config" => :run
-
-
-  if build.without? "faust0"
-    depends_on "llvm@3.8" => :run
-    depends_on "openssl" => :run
-    url "https://github.com/grame-cncm/faust/archive/v2-1-0.tar.gz"
-    sha256 "9bd0b02020a6d9130ac3e2b11ad7cbfc03883769eb87dcb76251c80c40488494"
-    head "https://github.com/grame-cncm/faust.git", :branch => "faust2"
-    if build.devel?
-      odie "Faust2 has no devel-release. If you want it, use --head option."
-    end
-  else
-    devel do
-      url "https://github.com/grame-cncm/faust.git", :branch => "master-dev"
-    end
-    stable do
-      url "https://github.com/grame-cncm/faust/archive/v0-9-90.tar.gz"
-      sha256 "abb1dee52faf427d232f56f2037ba5e81cb60a9e6684ac10f41da6c5c6df3415"
-    end
-    head "https://github.com/grame-cncm/faust.git", :branch => "master"
-  end
-
+  depends_on "llvm" => :run
+  depends_on "openssl" => :run
   if build.with? "httpd"
     depends_on "libmicrohttpd" =>:run
   end
@@ -38,6 +21,9 @@ class Faust < Formula
   end
 
   def install
+    if !build.head?
+      inreplace "compiler/Makefile.unix", "$(filter $(LLVM_VERSION), 4.0.0)", "$(filter $(LLVM_VERSION), 4.0.0 4.0.1)"
+    end
     system "make"
     if build.with? "httpd"
       system "make", "httpd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is the [faust](http://faust.grame.fr), functional programming language for signal processing and synthesis.

There are no pre-built binary.
In faust,both of v 0.x.x and v2.x.x are developed and used in parallel, and only the latter have dependency to openssl and llvm.
Is my way of writing in option right?
And also, stable version of faust 2.1.0 depends on llvm ,up to 4.0.0. HEAD version is compatible with latest llvm 4.0.1. So temporarily I chose "llvm@3.8" to dependency. If this is merged and next release will appear, I'll update it into "llvm".
Cheers.

