### PR TITLE
wine-2.0.2_3: port changes from sane-backends-1.0.27_3

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -5,8 +5,8 @@
 class Wine < Formula
   desc "Run Windows applications without a copy of Microsoft Windows"
   homepage "https://www.winehq.org/"
+  revision 3
   head "https://source.winehq.org/git/wine.git"
-  revision 2
 
   stable do
     url "https://dl.winehq.org/wine/source/2.0/wine-2.0.2.tar.xz"
@@ -158,9 +158,9 @@ class Wine < Formula
   end
 
   resource "mpg123" do
-    url "https://downloads.sourceforge.net/project/mpg123/mpg123/1.25.4/mpg123-1.25.4.tar.bz2"
-    mirror "https://mpg123.orgis.org/download/mpg123-1.25.4.tar.bz2"
-    sha256 "cdb5620e8aab83f75a27dab3394a44b9cc4017fc77b2954b8425ca416db6b3e7"
+    url "https://downloads.sourceforge.net/project/mpg123/mpg123/1.25.5/mpg123-1.25.5.tar.bz2"
+    mirror "https://mpg123.orgis.org/download/mpg123-1.25.5.tar.bz2"
+    sha256 "358da8602c001e6b25dddd496f50540a419e9922f0efe513e890f266135926b1"
   end
 
   fails_with :clang do
@@ -417,6 +417,10 @@ class Wine < Formula
                                 "--enable-local-backends",
                                 "--with-usb=yes",
                                 *depflags
+          # Remove for > 1.0.27
+          # Workaround for bug in Makefile.am described here: https://lists.alioth.debian.org/pipermail/sane-devel/2017-August/035576.html.
+          # It's already fixed in commit 519ff57. See https://anonscm.debian.org/cgit/sane/sane-backends.git/commit/?id=519ff57bed9391c9c178f660648669f4c77b7d3a.
+          system "make"
           system "make", "install"
         end
       end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
