### PR TITLE
v8: remove with-icu4c options

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -22,7 +22,6 @@ class V8 < Formula
 
   depends_on :python => :build # gyp doesn't run under 2.6 or lower
   depends_on "readline" => :optional
-  depends_on "icu4c" => :optional
 
   needs :cxx11
 
@@ -75,13 +74,6 @@ class V8 < Formula
     # https://code.google.com/p/v8/issues/detail?id=4511#c3
     ENV.append "GYP_DEFINES", "v8_use_external_startup_data=0"
 
-    if build.with? "icu4c"
-      ENV.append "GYP_DEFINES", "use_system_icu=1"
-      i18nsupport = "i18nsupport=on"
-    else
-      i18nsupport = "i18nsupport=off"
-    end
-
     # fix up libv8.dylib install_name
     # https://github.com/Homebrew/homebrew/issues/36571
     # https://code.google.com/p/v8/issues/detail?id=3871
@@ -99,7 +91,7 @@ class V8 < Formula
     (buildpath/"tools/clang").install resource("clang")
 
     system "make", "native", "library=shared", "snapshot=on",
-                   "console=readline", i18nsupport,
+                   "console=readline", "i18nsupport=off",
                    "strictaliasing=off"
 
     include.install Dir["include/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR removes the optional `icu4c` dependency / `--with-icu4c` option from `v8`, because building against system-icu will be broken after the icu4c 59.1 upgrade in #16720 and it's only [used in <1% of all v8 installs](https://github.com/Homebrew/homebrew-core/pull/16720#issuecomment-322001521).
An alternative would be to apply a small patch to V8 5.1 to fix 59.1 compatibility, but given the low usage of that option and the fact that an upgrade to a more recent V8 version is overdue this doesn't seems worth it.


```
../src/runtime/runtime-i18n.cc:591:3: error: no member named 'Normalizer' in namespace 'icu_59'; did you mean 'UNormalizer2'?
  icu::Normalizer::normalize(input, normalizationForms[form_id], 0, result,
  ^~~~~~~~~~~~~~~
  UNormalizer2
/usr/local/opt/icu4c/include/unicode/unorm2.h:119:29: note: 'UNormalizer2' declared here
typedef struct UNormalizer2 UNormalizer2;  /**< C typedef for struct UNormalizer2. @stable ICU 4.4 */
                            ^
../src/runtime/runtime-i18n.cc:591:8: error: incomplete type 'UNormalizer2' named in nested name specifier
  icu::Normalizer::normalize(input, normalizationForms[form_id], 0, result,
  ~~~~~^~~~~~~~~~~~
/usr/local/opt/icu4c/include/unicode/unorm2.h:118:8: note: forward declaration of 'UNormalizer2'
struct UNormalizer2;
       ^
2 errors generated.
```