### PR TITLE
freeling: vendor boost with icu4c and c++11

### DIFF
--- a/Formula/freeling.rb
+++ b/Formula/freeling.rb
@@ -3,7 +3,7 @@ class Freeling < Formula
   homepage "http://nlp.lsi.upc.edu/freeling/"
   url "https://github.com/TALP-UPC/FreeLing/releases/download/4.0/FreeLing-4.0.tar.gz"
   sha256 "c79d21c5af215105ba16eb69ee75b589bf7d41abce86feaa40757513e33c6ecf"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any
@@ -15,18 +15,67 @@ class Freeling < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "boost" => "with-icu4c"
   depends_on "icu4c"
 
   conflicts_with "hunspell", :because => "both install 'analyze' binary"
 
+  resource "boost" do
+    url "https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.bz2"
+    sha256 "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332"
+  end
+
   def install
+    resource("boost").stage do
+      # Force boost to compile with the desired compiler
+      open("user-config.jam", "a") do |file|
+        file.write "using darwin : : #{ENV.cxx} ;\n"
+      end
+
+      bootstrap_args = %W[
+        --without-icu
+        --prefix=#{libexec}/boost
+        --libdir=#{libexec}/boost/lib
+        --with-icu=#{Formula["icu4c"].opt_prefix}
+        --with-libraries=program_options,regex,system,thread
+      ]
+
+      args = %W[
+        --prefix=#{libexec}/boost
+        --libdir=#{libexec}/boost/lib
+        -d2
+        -j#{ENV.make_jobs}
+        --ignore-site-config
+        --layout=tagged
+        --user-config=user-config.jam
+        install
+        threading=multi
+        link=shared
+        optimization=space
+        variant=release
+        cxxflags=-std=c++11
+      ]
+
+      if ENV.compiler == :clang
+        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+      end
+
+      system "./bootstrap.sh", *bootstrap_args
+      system "./b2", "headers"
+      system "./b2", *args
+    end
+
+    (libexec/"boost/lib").each_child do |dylib|
+      MachO::Tools.change_dylib_id(dylib.to_s, dylib.to_s)
+    end
+
     icu4c = Formula["icu4c"]
     libtool = Formula["libtool"]
     ENV.append "LDFLAGS", "-L#{libtool.lib}"
     ENV.append "LDFLAGS", "-L#{icu4c.lib}"
+    ENV.append "LDFLAGS", "-L#{libexec}/boost/lib"
     ENV.append "CPPFLAGS", "-I#{libtool.include}"
     ENV.append "CPPFLAGS", "-I#{icu4c.include}"
+    ENV.append "CPPFLAGS", "-I#{libexec}/boost/include"
 
     system "autoreconf", "--install"
     system "./configure", "--prefix=#{prefix}", "--enable-boost-locale"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Only needs the program_options, regex, system and thread libraries.

Avoids `depends_on "boost" => ["c++11", "with-icu4c"]`.
See https://github.com/Homebrew/homebrew-core/issues/13133.