### PR TITLE
root: migrate from homebrew/science

### DIFF
--- a/Aliases/root@6
+++ b/Aliases/root@6
@@ -1,0 +1,1 @@
+../Formula/root.rb

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -1,0 +1,100 @@
+class Root < Formula
+  desc "Object oriented framework for large scale data analysis"
+  homepage "https://root.cern.ch"
+  url "https://root.cern.ch/download/root_v6.10.04.source.tar.gz"
+  version "6.10.04"
+  sha256 "461bde21d78608422310f04c599e84ce8dfbdd91caf12c2a54db6c01f8228f5b"
+  head "http://root.cern.ch/git/root.git"
+
+  depends_on "cmake" => :build
+  depends_on "fftw"
+  depends_on "graphviz"
+  depends_on "gsl"
+  depends_on "openssl"
+  depends_on "xrootd"
+  depends_on :fortran
+  depends_on :python => :recommended
+  depends_on :python3 => :optional
+
+  needs :cxx11
+
+  skip_clean "bin"
+
+  def install
+    args = std_cmake_args + %W[
+      -Dgnuinstall=ON
+      -DCMAKE_INSTALL_ELISPDIR=#{share}/emacs/site-lisp/#{name}
+      -Dbuiltin_freetype=ON
+      -Dfftw3=ON
+      -Dfortran=ON
+      -Dmathmore=ON
+      -Dminuit2=ON
+      -Droofit=ON
+      -Dssl=ON
+      -Dxrootd=ON
+    ]
+
+    if build.with?("python3") && build.with?("python")
+      odie "Root: Does not support building both python 2 and 3 wrappers"
+    elsif build.with?("python") || build.with?("python3")
+      python_executable = `which python`.strip if build.with? "python"
+      python_executable = `which python3`.strip if build.with? "python3"
+      python_prefix = `#{python_executable} -c 'import sys;print(sys.prefix)'`.chomp
+      python_include = `#{python_executable} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.chomp
+      python_version = "python" + `#{python_executable} -c 'import sys;print(sys.version[:3])'`.chomp
+
+      # cmake picks up the system's python dylib, even if we have a brewed one
+      if File.exist? "#{python_prefix}/Python"
+        python_library = "#{python_prefix}/Python"
+      elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.a"
+        python_library = "#{python_prefix}/lib/lib#{python_version}.a"
+      elsif File.exist? "#{python_prefix}/lib/lib#{python_version}.dylib"
+        python_library = "#{python_prefix}/lib/lib#{python_version}.dylib"
+      else
+        odie "No libpythonX.Y.{a,dylib} file found!"
+      end
+      args << "-DPYTHON_EXECUTABLE='#{python_executable}'"
+      args << "-DPYTHON_INCLUDE_DIR='#{python_include}'"
+      args << "-DPYTHON_LIBRARY='#{python_library}'"
+    end
+    args << "-Dpython=" + (build.with?("python") ? "ON" : "OFF")
+    args << "-Dpython3=" + (build.with?("python3") ? "ON" : "OFF")
+
+    mkdir "builddir" do
+      system "cmake", "..", *args
+      system "make", "install"
+      chmod 0755, Dir[bin/"*.*sh"]
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    Because ROOT depends on several installation-dependent
+    environment variables to function properly, you should
+    add the following commands to your shell initialization
+    script (.bashrc/.profile/etc.), or call them directly
+    before using ROOT.
+
+    For bash users:
+      . #{HOMEBREW_PREFIX}/bin/thisroot.sh
+    For zsh users:
+      pushd #{HOMEBREW_PREFIX} >/dev/null; . bin/thisroot.sh; popd >/dev/null
+    For csh/tcsh users:
+      source #{HOMEBREW_PREFIX}/bin/thisroot.csh
+    EOS
+  end
+
+  test do
+    (testpath/"test.C").write <<-EOS.undent
+      #include <iostream>
+      void test() {
+        std::cout << "Hello, world!" << std::endl;
+      }
+    EOS
+    (testpath/"test.bash").write <<-EOS.undent
+      . #{bin}/thisroot.sh
+      root -l -b -n -q test.C
+    EOS
+    assert_equal "\nProcessing test.C...\nHello, world!\n",
+                 shell_output("/bin/bash test.bash")
+  end
+end

--- a/Formula/root@5.rb
+++ b/Formula/root@5.rb
@@ -1,0 +1,88 @@
+class RootAT5 < Formula
+  desc "Object oriented framework for large scale data analysis"
+  homepage "https://root.cern.ch"
+  url "https://root.cern.ch/download/root_v5.34.36.source.tar.gz"
+  version "5.34.36"
+  sha256 "fc868e5f4905544c3f392cc9e895ef5571a08e48682e7fe173bd44c0ba0c7dcd"
+  revision 3
+
+  keg_only :versioned_formula
+
+  if MacOS.version == :sierra
+    # Same as https://root.cern.ch/gitweb/?p=root.git;a=patch;h=b86b8376e0c49d45cd909619bbf058d45398b9a9
+    # but with the change to LICENSE.txt removed to prevent it from failing
+    # Only needed so patch below can apply successfully
+    patch do
+      url "https://gist.githubusercontent.com/ilovezfs/df76b33d0e4da8243508d44e8ce9eda9/raw/fd149d6dafcae4aae5dbbc86e7ea2bef7430274f/gistfile1.txt"
+      sha256 "4214bc69f46c97f4e2d545c3942d8ec158105e4059f25f7f2323671377603e3f"
+    end
+
+    # Patch for macOS Sierra; remove for > 5.34.36
+    # Already fixed in the v5-34-00-patches branch
+    patch do
+      url "https://root.cern.ch/gitweb/?p=root.git;a=patch;h=c06fdeae0b3b4d627aacef2bda9df0acd079626b"
+      sha256 "90b8cbf99d6c1d6f04e0ad1ee0c1afeefa798b67151be63008f0573b5ed8d0f3"
+    end
+  end
+
+  depends_on "fftw"
+  depends_on "gsl"
+  depends_on "openssl"
+  depends_on "xrootd"
+  depends_on :x11 => :optional
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  skip_clean "bin"
+
+  def install
+    args = %W[
+      --all
+      --prefix=#{prefix}
+      --elispdir=#{share}/emacs/site-lisp/#{name}
+      --etcdir=#{prefix}/etc/root
+      --mandir=#{man}
+      --disable-ruby
+      --enable-builtin-freetype
+      --enable-builtin-glew
+      --enable-mathmore
+    ]
+
+    args << "--disable-cocoa" << "--enable-x11" if build.with? "x11"
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+    chmod 0755, Dir[bin/"*.*sh"]
+  end
+
+  def caveats; <<-EOS.undent
+    Because ROOT depends on several installation-dependent
+    environment variables to function properly, you should
+    add the following commands to your shell initialization
+    script (.bashrc/.profile/etc.), or call them directly
+    before using ROOT.
+
+    For bash users:
+      . #{opt_bin}/thisroot.sh
+    For zsh users:
+      pushd #{opt_prefix} >/dev/null; . bin/thisroot.sh; popd >/dev/null
+    For csh/tcsh users:
+      source #{opt_bin}/thisroot.csh
+    EOS
+  end
+
+  test do
+    (testpath/"test.C").write <<-EOS.undent
+      #include <iostream>
+      void test() {
+        std::cout << "Hello, world!" << std::endl;
+      }
+    EOS
+    (testpath/"test.bash").write <<-EOS.undent
+      . #{bin}/thisroot.sh
+      root -l -b -n -q test.C
+    EOS
+    assert_equal "\nProcessing test.C...\nHello, world!\n",
+      `/bin/bash test.bash`
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -141,6 +141,7 @@
   "recipes": "gnome-recipes",
   "redis26": "redis@2.6",
   "redis28": "redis@2.8",
+  "root6": "root",
   "ruby187": "ruby@1.8",
   "ruby193": "ruby@1.9",
   "ruby20": "ruby@2.0",


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/15619

All options made mandatory, except X11 and python.

```
install events in the last 100 days for root6
==========================================================================================================================
 1 | homebrew/science/root6                                                                              | 1,524 |  83.74%
 2 | homebrew/science/root6 --with-fftw                                                                  |    69 |   3.79%
 3 | homebrew/science/root6 --without-python --with-python3                                              |    45 |   2.47%
 4 | homebrew/science/root6 --with-python3                                                               |    43 |   2.36%
 5 | homebrew/science/root6 --with-xrootd --with-fftw                                                    |    40 |   2.20%
 6 | homebrew/science/root6 --with-xrootd                                                                |    22 |   1.21%
 7 | homebrew/science/root6 --HEAD                                                                       |    13 |   0.71%
 8 | homebrew/science/root6 --with-fftw --without-python --with-python3                                  |    13 |   0.71%
 9 | homebrew/science/root6 --with-xrootd --with-fftw --without-python --with-python3                    |    12 |   0.66%
10 | homebrew/science/root6 --with-xrootd --with-fftw --with-python3                                     |    10 |   0.55%
11 | homebrew/science/root6 --with-fftw --with-python3                                                   |     9 |   0.49%
12 | homebrew/science/root6 --without-python                                                             |     4 |   0.22%
13 | homebrew/science/root6 --HEAD --with-fftw                                                           |     2 |   0.11%
14 | homebrew/science/root6 --HEAD --with-fftw --with-python3                                            |     2 |   0.11%
15 | homebrew/science/root6 --HEAD --with-xrootd --with-fftw                                             |     2 |   0.11%
```

```
install events in the last 100 days for root
==========================================================================================================================
1 | homebrew/science/root                                                                                  | 608 |  88.24%
2 | homebrew/science/root --with-fftw --with-x11                                                           |  28 |   4.06%
3 | homebrew/science/root --with-x11                                                                       |  18 |   2.61%
4 | homebrew/science/root --with-fftw                                                                      |  15 |   2.18%
5 | homebrew/science/root --HEAD                                                                           |   9 |   1.31%
6 | homebrew/science/root --with-mysql                                                                     |   6 |   0.87%
7 | homebrew/science/root --HEAD --with-fftw --with-x11                                                    |   3 |   0.44%
8 | homebrew/science/root --without-xrootd --with-fftw --with-x11                                          |   1 |   0.15%
9 | homebrew/science/root --without-xrootd --without-gsl                                                   |   1 |   0.15%
```