### PR TITLE
gcc: remove --without-multilib

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -18,7 +18,6 @@ class Gcc < Formula
 
   option "with-jit", "Build just-in-time compiler"
   option "with-nls", "Build with native language support (localization)"
-  option "without-multilib", "Build without multilib support"
 
   depends_on "gmp"
   depends_on "libmpc"
@@ -93,7 +92,6 @@ class Gcc < Formula
       "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
     ]
 
-    args << "--disable-multilib" if build.without?("multilib")
     args << "--disable-nls" if build.without? "nls"
     args << "--enable-host-shared" if build.with?("jit")
 


### PR DESCRIPTION
9% of GCC installs use the `--without-multilib` option, which skips the build of 32-bit runtimes libraries. These take up 37 MB of disk space, i.e. 13% of a GCC install (287 MB). However, these users don't get bottles, and the GCC build literally takes hours.

After googling, it appears the reason for that is we used to display the following caveat about multilib:

> GCC has been built with multilib support. Notably, OpenMP may not work: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60670 If you need OpenMP support you may want to `brew reinstall gcc --without-multilib`

I removed this caveat sometimes ago, because that bug does not actually manifest itself on Darwin. Thus there is no incompatibility between OpenMP and multilib support. Yet people still use the option for that reason, and miss out on our wonderful bottles.

In light of this, **I propose that we remove the `--without-multilib` option**.

----

```
install events in the last 30 days for gcc
================================================================================
 1 | gcc                                                      | 31,105 |  90.28%
 2 | gcc --without-multilib                                   |  3,096 |   8.99%
 3 | gcc --HEAD                                               |    188 |   0.55%
 4 | gcc --with-jit --with-nls                                |     28 |   0.08%
 5 | gcc --with-nls                                           |     10 |   0.03%
```