### PR TITLE
makensis: generate test-script using compiler flags

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -58,15 +58,8 @@ class Makensis < Formula
 
   test do
     system "#{bin}/makensis", "-VERSION"
-    (testpath/"test.nsi").write <<-EOS.undent
-      # name the installer
-      OutFile "test.exe"
-      # default section start; every NSIS script has at least one section.
-      Section
-      # default section end
-      SectionEnd
-    EOS
-    system "#{bin}/makensis", "#{testpath}/test.nsi"
+    args = ["-XOutFile test.exe", "-XSection", "-XSectionEnd"]
+    system "#{bin}/makensis", *args
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR builds the test-script using compiler flags, rather than writing a file to the disk and then compiling it