### PR TITLE
libbitcoin 3.3.0 (new formula)

### DIFF
--- a/Formula/libbitcoin.rb
+++ b/Formula/libbitcoin.rb
@@ -1,0 +1,54 @@
+class Libbitcoin < Formula
+  desc "Bitcoin Cross-Platform C++ Development Toolkit"
+  homepage "https://libbitcoin.org/"
+  url "https://github.com/libbitcoin/libbitcoin/archive/v3.3.0.tar.gz"
+  sha256 "391913a73615afcb42c6a7c4736f23888cfc999a899fc38395ddcbd560251d94"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+
+  resource "secp256k1" do
+    url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.13.tar.gz"
+    sha256 "9e48dbc88d0fb5646d40ea12df9375c577f0e77525e49833fb744d3c2a69e727"
+  end
+
+  def install
+    resource("secp256k1").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}",
+                            "--enable-module-recovery"
+      system "make", "install"
+    end
+
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{libexec}/lib/pkgconfig"
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <bitcoin/bitcoin.hpp>
+      int main() {
+        const auto block = bc::chain::block::genesis_mainnet();
+        const auto& tx = block.transactions().front();
+        const auto& input = tx.inputs().front();
+        const auto script = input.script().to_data(false);
+        std::string message(script.begin() + sizeof(uint64_t), script.end());
+        bc::cout << message << std::endl;
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}",
+                    "-lbitcoin", "-lboost_system", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is [libbitcoin](https://github.com/libbitcoin/libbitcoin), a C++ library for Bitcoin development. There are actually two new formula in this pull request: libbitcoin and libbitcoin-secp256k1.

libbitcoin depends on libbitcoin-secp256k1. The [repo](https://github.com/libbitcoin/secp256k1) is actually a fork of the [one maintained by the Bitcoin Core team](https://github.com/bitcoin-core/secp256k1). While I would have preferred to use the source repo, they have not created a tagged release. The fork, maintained by the libbitcoin team, does have a tagged release. Because of this, I am defining secp256k1 as a resource and building it as part of this formula.