### PR TITLE
libfreenect: build python wrapper

### DIFF
--- a/Formula/libfreenect.rb
+++ b/Formula/libfreenect.rb
@@ -15,10 +15,28 @@ class Libfreenect < Formula
   depends_on "cmake" => :build
   depends_on "libusb"
 
+  HAS_PYTHON2 = true
+  if MacOS.version <= :snow_leopard
+    depends_on :python => :optional
+    HAS_PYTHON2 = build.with? :python
+  end
+
+  depends_on :python3 => :optional
+  HAS_PYTHON3 = build.with? :python3
+
+  if HAS_PYTHON2 || HAS_PYTHON3
+    depends_on "cython" => :build
+    depends_on "numpy"
+  end
+
   def install
+    args = std_cmake_args
+    args << "-DBUILD_OPENNI2_DRIVER=ON"
+    args << "-DBUILD_PYTHON2=#{HAS_PYTHON2 ? "ON" : "OFF"}"
+    args << "-DBUILD_PYTHON3=#{HAS_PYTHON3 ? "ON" : "OFF"}"
+
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args,
-                      "-DBUILD_OPENNI2_DRIVER=ON"
+      system "cmake", "..", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
Optionally builds python2 and python3 bindings, though `brew audit` still produces

```
libfreenect:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/opt/libfreenect/lib/python2.7/site-packages/freenect.so
      /usr/local/opt/libfreenect/lib/python3.6/site-packages/freenect.so
Error: 1 problem in 1 formula
```

and I'm not yet sure how to fix that.  Maybe the upstream build process needs patched?