### PR TITLE
libevent: fix package version

### DIFF
--- a/Formula/libevent.rb
+++ b/Formula/libevent.rb
@@ -1,8 +1,8 @@
 class Libevent < Formula
   desc "Asynchronous event library"
   homepage "http://libevent.org"
-  url "https://github.com/libevent/libevent/archive/release-2.1.8-stable.tar.gz"
-  sha256 "316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d"
+  url "https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz"
+  sha256 "965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2"
 
   bottle do
     cellar :any
@@ -11,10 +11,15 @@ class Libevent < Formula
     sha256 "ef703db1b4cbdab35b89aabe80c225dd9b7a2c3ea14b1eae681478c5b9df15fe" => :yosemite
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
+  head do
+    url "https://github.com/libevent/libevent.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "doxygen" => :build
-  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
 
@@ -22,8 +27,8 @@ class Libevent < Formula
     :because => "both install `event_rpcgen.py` binaries"
 
   def install
+    system "./autogen.sh" if build.head?
     inreplace "Doxyfile", /GENERATE_MAN\s*=\s*NO/, "GENERATE_MAN = YES"
-    system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-debug-mode",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
* use validated release package instead of snapshot (nmathewson/Libevent#151)
* allow building the unreleased git head

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
Yes
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
Yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
Yes (for all 4 combinations)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No, because the sha256 has changed but not the version, which is expected
-----
