### PR TITLE
octave: bring back java

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -26,12 +26,13 @@ class Octave < Formula
   # Complete list of dependecies at https://wiki.octave.org/Building
   depends_on "gnu-sed" => :build # https://lists.gnu.org/archive/html/octave-maintainers/2016-09/msg00193.html
   depends_on "pkg-config" => :build
+  depends_on :java => ["1.6+", :build, :recommended]
   depends_on :fortran
   depends_on "arpack"
   depends_on "epstool"
   depends_on "fftw"
-  depends_on "fltk"
   depends_on "fig2dev"
+  depends_on "fltk"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "ghostscript"
@@ -40,7 +41,6 @@ class Octave < Formula
   depends_on "gnuplot"
   depends_on "graphicsmagick"
   depends_on "hdf5"
-  depends_on :java => ["1.6+", :build, :recommended]
   depends_on "libsndfile"
   depends_on "libtool" => :run
   depends_on "pcre"

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -94,8 +94,6 @@ class Octave < Formula
     system "./configure", *args
     system "make", "all"
     system "make", "install"
-
-    prefix.install "test/fntests.log" if File.exist? "test/fntests.log"
   end
 
   test do

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -49,7 +49,7 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "readline"
-  depends_on "sundials" # new dependency for octave > 4.2.1
+  depends_on "sundials" if build.head?
   depends_on "suite-sparse"
   depends_on "veclibfort"
 

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -40,7 +40,7 @@ class Octave < Formula
   depends_on "gnuplot"
   depends_on "graphicsmagick"
   depends_on "hdf5"
-  depends_on :java => ["1.6+", :optional]
+  depends_on :java => ["1.6+", :build, :recommended]
   depends_on "libsndfile"
   depends_on "libtool" => :run
   depends_on "pcre"

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,7 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-4.2.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/octave/octave-4.2.1.tar.gz"
   sha256 "80c28f6398576b50faca0e602defb9598d6f7308b0903724442c2a35a605333b"
-  revision 4
+  revision 5
 
   bottle do
     sha256 "8df6402ed13b6c6339221ab7ddfb7c69cda4c7e2074afca44e6df26e4c22dcb3" => :sierra
@@ -22,13 +22,16 @@ class Octave < Formula
     depends_on "librsvg" => :build
   end
 
+  # Complete list of dependecies at https://wiki.octave.org/Building
   depends_on "gnu-sed" => :build # https://lists.gnu.org/archive/html/octave-maintainers/2016-09/msg00193.html
   depends_on "pkg-config" => :build
   depends_on :fortran
   depends_on "arpack"
+  depends_on "curl"
   depends_on "epstool"
   depends_on "fftw"
   depends_on "fltk"
+  depends_on "fig2dev"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "ghostscript"
@@ -37,6 +40,7 @@ class Octave < Formula
   depends_on "gnuplot"
   depends_on "graphicsmagick"
   depends_on "hdf5"
+  depends_on :java => ["1.6+", :optional]
   depends_on "libsndfile"
   depends_on "libtool" => :run
   depends_on "pcre"
@@ -45,6 +49,7 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "readline"
+  depends_on "sundials" # new dependency for octave > 4.2.1
   depends_on "suite-sparse"
   depends_on "veclibfort"
 
@@ -66,29 +71,38 @@ class Octave < Formula
     # cause linking problems.
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
 
+    args = %W[ --prefix=#{prefix}
+               --disable-dependency-tracking
+               --disable-silent-rules
+               --enable-link-all-dependencies
+               --enable-shared
+               --disable-static
+               --disable-docs
+               --without-OSMesa
+               --without-qt
+               --with-hdf5-includedir=#{Formula["hdf5"].opt_include}
+               --with-hdf5-libdir=#{Formula["hdf5"].opt_lib}
+               --with-x=no
+               --with-blas=-L#{Formula["veclibfort"].opt_lib}\ -lvecLibFort
+               --with-portaudio
+               --with-sndfile]
+
+    args << "--disable-java" if build.without? "java"
+
     system "./bootstrap" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--enable-link-all-dependencies",
-                          "--enable-shared",
-                          "--disable-static",
-                          "--disable-docs",
-                          "--disable-java",
-                          "--without-OSMesa",
-                          "--without-qt",
-                          "--with-x=no",
-                          "--with-blas=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort",
-                          "--with-portaudio",
-                          "--with-sndfile"
+    system "./configure", *args
     system "make", "all"
+    system "make", "check" # Run octave's test suite
     system "make", "install"
+
+    prefix.install "test/fntests.log" if File.exist? "test/fntests.log"
   end
 
   test do
-    system bin/"octave", "--eval", "(22/7 - pi)/pi"
-    # this is supposed to crash octave if there is a problem with veclibfort
-    system bin/"octave", "--eval", "single ([1+i 2+i 3+i]) * single ([ 4+i ; 5+i ; 6+i])"
+    system "#{bin}/octave", "--eval", "(22/7 - pi)/pi"
+    # This is supposed to crash octave if there is a problem with veclibfort
+    system "#{bin}/octave", "--eval", "single ([1+i 2+i 3+i]) * single ([ 4+i ; 5+i ; 6+i])"
+    # Test java bindings: check if javaclasspath is working, return error if not
+    system "#{bin}/octave", "--eval", "try; javaclasspath; catch; quit(1); end;" if build.with? "java"
   end
 end

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -23,7 +23,7 @@ class Octave < Formula
     depends_on "sundials"
   end
 
-  # Complete list of dependecies at https://wiki.octave.org/Building
+  # Complete list of dependencies at https://wiki.octave.org/Building
   depends_on "gnu-sed" => :build # https://lists.gnu.org/archive/html/octave-maintainers/2016-09/msg00193.html
   depends_on "pkg-config" => :build
   depends_on :java => ["1.6+", :build, :recommended]

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -70,38 +70,39 @@ class Octave < Formula
     # cause linking problems.
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
 
-    args = %W[ --prefix=#{prefix}
-               --disable-dependency-tracking
-               --disable-silent-rules
-               --enable-link-all-dependencies
-               --enable-shared
-               --disable-static
-               --disable-docs
-               --without-OSMesa
-               --without-qt
-               --with-hdf5-includedir=#{Formula["hdf5"].opt_include}
-               --with-hdf5-libdir=#{Formula["hdf5"].opt_lib}
-               --with-x=no
-               --with-blas=-L#{Formula["veclibfort"].opt_lib}\ -lvecLibFort
-               --with-portaudio
-               --with-sndfile]
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --enable-link-all-dependencies
+      --enable-shared
+      --disable-static
+      --disable-docs
+      --without-OSMesa
+      --without-qt
+      --with-hdf5-includedir=#{Formula["hdf5"].opt_include}
+      --with-hdf5-libdir=#{Formula["hdf5"].opt_lib}
+      --with-x=no
+      --with-blas=-L#{Formula["veclibfort"].opt_lib}\ -lvecLibFort
+      --with-portaudio
+      --with-sndfile
+    ]
 
     args << "--disable-java" if build.without? "java"
 
     system "./bootstrap" if build.head?
     system "./configure", *args
     system "make", "all"
-    system "make", "check" # Run octave's test suite
     system "make", "install"
 
     prefix.install "test/fntests.log" if File.exist? "test/fntests.log"
   end
 
   test do
-    system "#{bin}/octave", "--eval", "(22/7 - pi)/pi"
+    system bin/"octave", "--eval", "(22/7 - pi)/pi"
     # This is supposed to crash octave if there is a problem with veclibfort
-    system "#{bin}/octave", "--eval", "single ([1+i 2+i 3+i]) * single ([ 4+i ; 5+i ; 6+i])"
+    system bin/"octave", "--eval", "single ([1+i 2+i 3+i]) * single ([ 4+i ; 5+i ; 6+i])"
     # Test java bindings: check if javaclasspath is working, return error if not
-    system "#{bin}/octave", "--eval", "try; javaclasspath; catch; quit(1); end;" if build.with? "java"
+    system bin/"octave", "--eval", "try; javaclasspath; catch; quit(1); end;" if build.with? "java"
   end
 end

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -20,6 +20,7 @@ class Octave < Formula
     depends_on "bison" => :build
     depends_on "icoutils" => :build
     depends_on "librsvg" => :build
+    depends_on "sundials"
   end
 
   # Complete list of dependecies at https://wiki.octave.org/Building
@@ -27,7 +28,6 @@ class Octave < Formula
   depends_on "pkg-config" => :build
   depends_on :fortran
   depends_on "arpack"
-  depends_on "curl"
   depends_on "epstool"
   depends_on "fftw"
   depends_on "fltk"
@@ -49,7 +49,6 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "readline"
-  depends_on "sundials" if build.head?
   depends_on "suite-sparse"
   depends_on "veclibfort"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Changes
* added java as optional dependency
* brought back proper checking of the build
* require `sundials` (necessary for development and future stable branch)
* require `fig2dev` (this might be arguable due to #16193)
* added dependency on curl (or is this standard on all platforms?)

Question:
* what about Linux people? The new way of ignoring accelerate alternatives is incompatible or not?