### PR TITLE
gwyddion 2.49

### DIFF
--- a/Formula/gwyddion.rb
+++ b/Formula/gwyddion.rb
@@ -1,8 +1,8 @@
 class Gwyddion < Formula
   desc "Scanning Probe Microscopy visualization and analysis tool"
   homepage "http://gwyddion.net/"
-  url "http://gwyddion.net/download/2.48/gwyddion-2.48.tar.gz"
-  sha256 "45f4f1f987172845c4bc0e9de52e4e229a98e94d386625d654bafc2e1cadda10"
+  url "http://gwyddion.net/download/2.49/gwyddion-2.49.tar.gz"
+  sha256 "48446bc2c6680d61c16b3f637e57e09f4de631c6b80bc2b20f424f66cc896c1c"
 
   bottle do
     sha256 "5d6b2bd0c51c46ddd92c5fded33a32fb229ab464130c581612854f0430770b4d" => :sierra
@@ -23,11 +23,9 @@ class Gwyddion < Formula
   depends_on "gtksourceview" if build.with? "python"
 
   def install
-    # Don't explicitly link against libpython. Will be patched in the next release:
-    # <https://sourceforge.net/p/gwyddion/mailman/message/35815736/>
-    inreplace "modules/pygwy/Makefile.in", /\$\(no_undefined\) \$\(PYTHON_LDFLAGS\)/, ""
     system "./configure", "--disable-dependency-tracking",
                           "--disable-desktop-file-update",
+                          "--enable-module-bundling=no",
                           "--prefix=#{prefix}",
                           "--with-html-dir=#{doc}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Removes the replacements that were required for the last version. Gwyddion 2.49 added bundling of modules (shared objects) for faster loading, which is not yet working on macOS (see [here](https://sourceforge.net/p/gwyddion/mailman/message/35998191/)).