### PR TITLE
bitcoin: explicitly set boost libdir

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -26,6 +26,7 @@ class Bitcoin < Formula
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--with-boost-libdir=#{Formula["boost"].opt_lib}",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this, I got an error: (see bitcoin/bitcoin#3219)

> configure: error: Could not find a version of the boost_system library!

With this specified explicitly, the formula builds correctly and `brew test bitcoin` is successful.