### PR TITLE
bitcoin: needs cxx11

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -22,6 +22,8 @@ class Bitcoin < Formula
   depends_on "miniupnpc"
   depends_on "openssl"
 
+  needs :cxx11
+
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I found this using Linuxbrew, but it seems like an upstream problem because it would be equally valid on macOS with an old C compiler. I didn't add `ENV.cxx11`, which most other formulae I've seen using `needs :cxx11` include, because it seems to work fine without it.