### PR TITLE
mecab-ipadic-neologd 20170807 (new formula)

### DIFF
--- a/Formula/mecab-ipadic-neologd.rb
+++ b/Formula/mecab-ipadic-neologd.rb
@@ -1,0 +1,34 @@
+class MecabIpadicNeologd < Formula
+  desc "Neologism dictionary for MeCab"
+  homepage "https://github.com/neologd/mecab-ipadic-neologd"
+  url "https://github.com/neologd/mecab-ipadic-neologd/archive/b815a08d0478714007856d53f13551c92e9b0b5c.tar.gz"
+  version "20170807"
+  sha256 "ad134f17eae4469b16eb5506cf5dfb11bae248ccb0f0936afacd9179d1be8e5b"
+
+  depends_on "mecab"
+  depends_on "xz" => :build
+
+  def install
+    args = %W[
+      --prefix #{lib}/mecab/dic/ipadic-neologd
+      --forceyes
+    ]
+
+    mkdir_p "#{lib}/mecab/dic/ipadic-neologd"
+    system "./bin/install-mecab-ipadic-neologd", *args
+  end
+
+  def caveats; <<-EOS.undent
+     To enable mecab-ipadic-neologd dictionary, add to #{HOMEBREW_PREFIX}/etc/mecabrc:
+       dicdir = #{HOMEBREW_PREFIX}/lib/mecab/dic/ipadic-neologd
+    EOS
+  end
+
+  test do
+    (testpath/"mecabrc").write <<-EOS.undent
+      dicdir = #{HOMEBREW_PREFIX}/lib/mecab/dic/ipadic-neologd
+    EOS
+
+    assert_equal "10日\t名詞,固有名詞,一般,*,*,*,10日,トオカ,トオカ\nEOS\n", pipe_output("mecab --rcfile=#{testpath}/mecabrc", "10日\n", 0)
+  end
+end


### PR DESCRIPTION
mecab-ipadic-NEologd is customized system dictionary for MeCab.

This dictionary includes many neologisms (new word), which are extracted from many language resources on the Web.

When you analyze the Web documents, it's better to use this system dictionary and default one (ipadic) together.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
