### PR TITLE
fwknop: update path to gnupg binary

### DIFF
--- a/Formula/fwknop.rb
+++ b/Formula/fwknop.rb
@@ -3,6 +3,7 @@ class Fwknop < Formula
   homepage "https://www.cipherdyne.org/fwknop/"
   url "https://github.com/mrash/fwknop/archive/2.6.9.tar.gz"
   sha256 "0a8de8d3e2073ad08f5834d39def6c33fd035809cfddbea252174e7dc06a5a51"
+  revision 1
   head "https://github.com/mrash/fwknop.git"
 
   bottle do
@@ -22,7 +23,7 @@ class Fwknop < Formula
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking", "--disable-silent-rules",
                           "--prefix=#{prefix}", "--with-gpgme", "--sysconfdir=#{etc}",
-                          "--with-gpg=#{Formula["gnupg2"].opt_bin}/gpg2"
+                          "--with-gpg=#{Formula["gnupg"].opt_bin}/gpg"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updated gnupg formula doesn't contain gpg2 symlink anymore.