### PR TITLE
znc: use HOMEBREW_PREFIX for modules

### DIFF
--- a/Formula/znc.rb
+++ b/Formula/znc.rb
@@ -37,7 +37,10 @@ class Znc < Formula
     ENV.append "CXXFLAGS", "-std=c++11"
     ENV.append "CXXFLAGS", "-stdlib=libc++" if ENV.compiler == :clang
 
-    args = ["--prefix=#{prefix}"]
+    args = [
+      "--prefix=#{prefix}",
+      "--with-module-prefix=#{HOMEBREW_PREFIX/"lib/znc"}",
+    ]
     args << "--enable-debug" if build.with? "debug"
 
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Using this instead of znc's own isolated prefix (the current behaviour) allows ZNC to find modules installed by other formulae, e.g. [alyssais/znc/znc-playback](https://github.com/alyssais/homebrew-znc/blob/master/Formula/znc-playback.rb). This [seems](https://github.com/Homebrew/homebrew-core/search?utf8=✓&q=HOMEBREW_PREFIX+modules&type=) to be consistent with other packages with module systems.