### PR TITLE
Update borg.rb

### DIFF
--- a/Formula/borg.rb
+++ b/Formula/borg.rb
@@ -2,7 +2,7 @@ require "language/go"
 
 class Borg < Formula
   desc "Terminal based search engine for bash commands"
-  homepage "https://ok-b.org/"
+  homepage "https://github.com/ok-borg/borg"
   url "https://github.com/ok-borg/borg/archive/v0.0.3.tar.gz"
   sha256 "d90a55b9c25c2b1fa0c662f1f22fa79f19e77479ad10368756ddf2fa9bee21cc"
 


### PR DESCRIPTION
https://ok-b.org/ is not accessible and doesn't seem to be a presentation site for Borg, while the Github repo is giving useful information

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
