### PR TITLE
igraph: migrate from homebrew/science

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -1,0 +1,38 @@
+class Igraph < Formula
+  desc "Network analysis package"
+  homepage "http://igraph.org"
+  url "http://igraph.org/nightly/get/c/igraph-0.7.1.tar.gz"
+  sha256 "d978030e27369bf698f3816ab70aa9141e9baf81c56cc4f55efbe5489b46b0df"
+  revision 6
+
+  depends_on "glpk"
+  depends_on "gmp"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--with-external-blas",
+                          "--with-external-lapack",
+                          "--with-external-glpk"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <igraph.h>
+      int main(void) {
+        igraph_integer_t diameter;
+        igraph_t graph;
+        igraph_rng_seed(igraph_rng_default(), 42);
+        igraph_erdos_renyi_game(&graph, IGRAPH_ERDOS_RENYI_GNP, 1000, 5.0/1000, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS);
+        igraph_diameter(&graph, &diameter, 0, 0, 0, IGRAPH_UNDIRECTED, 1);
+        printf("Diameter = %d\\n", (int) diameter);
+        igraph_destroy(&graph);
+      }
+      EOS
+    system ENV.cc, "test.c", "-I#{include}/igraph", "-L#{lib}",
+                   "-ligraph", "-o", "test"
+    assert_match "Diameter = 9", shell_output("./test")
+  end
+end


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/15619

```
install events in the last 100 days for igraph
================================================================================================
1 | homebrew/science/igraph                                                      | 759 |  94.17%
2 | homebrew/science/igraph --with-arpack --with-gmp                             |  26 |   3.23%
3 | homebrew/science/igraph --with-gmp                                           |  21 |   2.61%
================================================================================================
Total                                                                            | 806 |    100%
================================================================================================
```