### PR TITLE
pcap_dnsproxy: fix case sensitivity problem of configuration path

### DIFF
--- a/Formula/pcap_dnsproxy.rb
+++ b/Formula/pcap_dnsproxy.rb
@@ -21,23 +21,23 @@ class PcapDnsproxy < Formula
     (buildpath/"Source/Dependency/OpenSSL").install_symlink Formula["openssl@1.1"].opt_lib/"libcrypto.a" => "LibCrypto_macOS.a"
     xcodebuild "-project", "./Source/Pcap_DNSProxy.xcodeproj", "-target", "Pcap_DNSProxy", "-configuration", "Release", "SYMROOT=build"
     bin.install "Source/build/Release/Pcap_DNSProxy"
-    (etc/"pcap_DNSproxy").install Dir["Source/Auxiliary/ExampleConfig/*.{ini,txt}"]
+    (etc/"pcap_dnsproxy").install Dir["Source/Auxiliary/ExampleConfig/*.{ini,txt}"]
     prefix.install "Source/Auxiliary/ExampleConfig/pcap_dnsproxy.service.plist"
   end
 
-  plist_options :startup => true, :manual => "sudo #{HOMEBREW_PREFIX}/opt/pcap_dnsproxy/bin/Pcap_DNSProxy -c #{HOMEBREW_PREFIX}/etc/pcap_DNSproxy/"
+  plist_options :startup => true, :manual => "sudo #{HOMEBREW_PREFIX}/opt/pcap_dnsproxy/bin/Pcap_DNSProxy -c #{HOMEBREW_PREFIX}/etc/pcap_dnsproxy/"
 
   test do
-    (testpath/"pcap_DNSproxy").mkpath
-    cp Dir[etc/"pcap_DNSproxy/*"], testpath/"pcap_DNSproxy/"
+    (testpath/"pcap_dnsproxy").mkpath
+    cp Dir[etc/"pcap_dnsproxy/*"], testpath/"pcap_dnsproxy/"
 
-    inreplace testpath/"pcap_DNSproxy/Config.ini" do |s|
+    inreplace testpath/"pcap_dnsproxy/Config.ini" do |s|
       s.gsub! /^Direct Request.*/, "Direct Request = IPv4 + IPv6"
       s.gsub! /^Operation Mode.*/, "Operation Mode = Proxy"
       s.gsub! /^Listen Port.*/, "Listen Port = 9999"
     end
 
-    pid = fork { exec bin/"Pcap_DNSProxy", "-c", testpath/"pcap_DNSproxy/" }
+    pid = fork { exec bin/"Pcap_DNSProxy", "-c", testpath/"pcap_dnsproxy/" }
     begin
       system "dig", "google.com", "@127.0.0.1", "-p", "9999", "+short"
     ensure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix case sensitivity problem (change all paths to lowercase), this problem will make pcap_dnsproxy cannot find out the configuration location in a case sensitive file system. Please visit this [issue](https://github.com/chengr28/Pcap_DNSProxy/issues/238) to get more information, thanks a lot.
