### PR TITLE
libbitcoin-explorer 3.3.0 (new formula)

### DIFF
--- a/Formula/libbitcoin-explorer.rb
+++ b/Formula/libbitcoin-explorer.rb
@@ -1,5 +1,5 @@
 class LibbitcoinExplorer < Formula
-  desc "Bitcoin Command-line Tool"
+  desc "Bitcoin command-line tool"
   homepage "https://github.com/libbitcoin/libbitcoin-explorer"
   url "https://github.com/libbitcoin/libbitcoin-explorer/archive/v3.3.0.tar.gz"
   sha256 "029dc350497bdaad4d8559f7954405011b9e1b996aa4d4cc124f650e2eca00a6"

--- a/Formula/libbitcoin-explorer.rb
+++ b/Formula/libbitcoin-explorer.rb
@@ -8,22 +8,22 @@ class LibbitcoinExplorer < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "zeromq"
   depends_on "libbitcoin"
+  depends_on "zeromq"
 
   resource "secp256k1" do
     url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.13.tar.gz"
     sha256 "9e48dbc88d0fb5646d40ea12df9375c577f0e77525e49833fb744d3c2a69e727"
   end
 
-  resource "libbitcoin-protocol" do
-    url "https://github.com/libbitcoin/libbitcoin-protocol/archive/v3.3.0.tar.gz"
-    sha256 "7902de78b4c646daf2012e04bb7967784f67a6372a8a8d3c77417dabcc4b617d"
-  end
-
   resource "libbitcoin-network" do
     url "https://github.com/libbitcoin/libbitcoin-network/archive/v3.3.0.tar.gz"
     sha256 "cab9142d2b94019c824365c0b39d7e31dbc9aaeb98c6b4bf22ce32b829395c19"
+  end
+
+  resource "libbitcoin-protocol" do
+    url "https://github.com/libbitcoin/libbitcoin-protocol/archive/v3.3.0.tar.gz"
+    sha256 "7902de78b4c646daf2012e04bb7967784f67a6372a8a8d3c77417dabcc4b617d"
   end
 
   resource "libbitcoin-client" do
@@ -37,13 +37,14 @@ class LibbitcoinExplorer < Formula
       system "./configure", "--disable-dependency-tracking",
                             "--disable-silent-rules",
                             "--prefix=#{libexec}",
-                            "--enable-module-recovery"
+                            "--enable-module-recovery",
+                            "--with-bignum=no"
       system "make", "install"
     end
 
     ENV.prepend_path "PKG_CONFIG_PATH", "#{libexec}/lib/pkgconfig"
 
-    resource("libbitcoin-protocol").stage do
+    resource("libbitcoin-network").stage do
       system "./autogen.sh"
       system "./configure", "--disable-dependency-tracking",
                             "--disable-silent-rules",
@@ -51,7 +52,7 @@ class LibbitcoinExplorer < Formula
       system "make", "install"
     end
 
-    resource("libbitcoin-network").stage do
+    resource("libbitcoin-protocol").stage do
       system "./autogen.sh"
       system "./configure", "--disable-dependency-tracking",
                             "--disable-silent-rules",

--- a/Formula/libbitcoin-explorer.rb
+++ b/Formula/libbitcoin-explorer.rb
@@ -32,6 +32,8 @@ class LibbitcoinExplorer < Formula
   end
 
   def install
+    ENV.prepend_create_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
+
     resource("secp256k1").stage do
       system "./autogen.sh"
       system "./configure", "--disable-dependency-tracking",
@@ -41,8 +43,6 @@ class LibbitcoinExplorer < Formula
                             "--with-bignum=no"
       system "make", "install"
     end
-
-    ENV.prepend_path "PKG_CONFIG_PATH", "#{libexec}/lib/pkgconfig"
 
     resource("libbitcoin-network").stage do
       system "./autogen.sh"

--- a/Formula/libbitcoin-explorer.rb
+++ b/Formula/libbitcoin-explorer.rb
@@ -1,0 +1,92 @@
+class LibbitcoinExplorer < Formula
+  desc "Bitcoin Command-line Tool"
+  homepage "https://github.com/libbitcoin/libbitcoin-explorer"
+  url "https://github.com/libbitcoin/libbitcoin-explorer/archive/v3.3.0.tar.gz"
+  sha256 "029dc350497bdaad4d8559f7954405011b9e1b996aa4d4cc124f650e2eca00a6"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "zeromq"
+  depends_on "libbitcoin"
+
+  resource "secp256k1" do
+    url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.13.tar.gz"
+    sha256 "9e48dbc88d0fb5646d40ea12df9375c577f0e77525e49833fb744d3c2a69e727"
+  end
+
+  resource "libbitcoin-protocol" do
+    url "https://github.com/libbitcoin/libbitcoin-protocol/archive/v3.3.0.tar.gz"
+    sha256 "7902de78b4c646daf2012e04bb7967784f67a6372a8a8d3c77417dabcc4b617d"
+  end
+
+  resource "libbitcoin-network" do
+    url "https://github.com/libbitcoin/libbitcoin-network/archive/v3.3.0.tar.gz"
+    sha256 "cab9142d2b94019c824365c0b39d7e31dbc9aaeb98c6b4bf22ce32b829395c19"
+  end
+
+  resource "libbitcoin-client" do
+    url "https://github.com/libbitcoin/libbitcoin-client/archive/v3.3.0.tar.gz"
+    sha256 "ac22793201a269789a5d10e92333a2f59e887256c87c2e72b20ccd023d618757"
+  end
+
+  def install
+    resource("secp256k1").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}",
+                            "--enable-module-recovery"
+      system "make", "install"
+    end
+
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{libexec}/lib/pkgconfig"
+
+    resource("libbitcoin-protocol").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    resource("libbitcoin-network").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    resource("libbitcoin-client").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    seed = "7aaa07602b34e49dd9fd13267dcc0f368effe0b4ce15d107"
+    expected_private_key = "5b4e3cba38709f0d80aff509c1cc87eea9dad95bb34b09eb0ce3e8dbc083f962"
+    expected_public_key = "023b899a380c81b35647fff5f7e1988c617fe8417a5485217e653cda80bc4670ef"
+    expected_address = "1AxX5HyQi7diPVXUH2ji7x5k6jZTxbkxfW"
+
+    private_key = shell_output("#{bin}/bx ec-new #{seed}").chomp
+    assert_equal expected_private_key, private_key
+
+    public_key = shell_output("#{bin}/bx ec-to-public #{private_key}").chomp
+    assert_equal expected_public_key, public_key
+
+    address = shell_output("#{bin}/bx ec-to-address #{public_key}").chomp
+    assert_equal expected_address, address
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add formula for libbitcoin-explorer, a command-line tool for Bitcoin (https://github.com/libbitcoin/libbitcoin-explorer). The formula specifies secp256k1, libbitcoin-protocol, libbitcoin-network, and libbitcoin-client as resources to build first. These repositories do not meet the required number of forks, watchers, and stars for creating separate formulas.