### PR TITLE
argyll-cms: fix build on 10.11 with Xcode 8.x

### DIFF
--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -4,7 +4,7 @@ class ArgyllCms < Formula
   url "https://www.argyllcms.com/Argyll_V1.9.2_src.zip"
   version "1.9.2"
   sha256 "4d61ae0b91686dea721d34df2e44eaf36c88da87086fd50ccc4e999a58e9ce90"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -21,6 +21,12 @@ class ArgyllCms < Formula
   conflicts_with "num-utils", :because => "both install `average` binaries"
 
   def install
+    # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
+    # Reported 20 Aug 2017 to graeme AT argyllcms DOT com
+    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      inreplace "numlib/numsup.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH"
+    end
+
     system "sh", "makeall.sh"
     system "./makeinstall.sh"
     rm "bin/License.txt"
@@ -31,5 +37,6 @@ class ArgyllCms < Formula
     system bin/"targen", "-d", "0", "test.ti1"
     system bin/"printtarg", testpath/"test.ti1"
     %w[test.ti1.ps test.ti1.ti1 test.ti1.ti2].each { |f| File.exist? f }
+    assert_match "Calibrate a Display", shell_output("#{bin}/dispcal 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

and add a test that would have triggered the clock_gettime runtime error

Fixes #17034.