### PR TITLE
geth 1.6.7 (new formula)

### DIFF
--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -13,7 +13,24 @@ class Geth < Formula
   end
 
   test do
-    system "#{bin}/geth", "-h"
     system "#{bin}/geth", "version"
+    (testpath/"genesis.json").write <<-EOS.undent
+    {
+      "config": {
+        "homesteadBlock": 10
+      },
+      "nonce": "0",
+      "difficulty": "0x20000",
+      "mixhash": "0x00000000000000000000000000000000000000647572616c65787365646c6578",
+      "coinbase": "0x0000000000000000000000000000000000000000",
+      "timestamp": "0x00",
+      "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "extraData": "0x",
+      "gasLimit": "0x2FEFD8",
+      "alloc": {}
+    }
+    EOS
+    system "#{bin}/geth", "--datadir", "testchain", "init", "genesis.json"
+    assert File.directory? "testchain/keystore"
   end
 end

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -30,7 +30,7 @@ class Geth < Formula
     }
     EOS
     system "#{bin}/geth", "--datadir", "testchain", "init", "genesis.json"
-    assert_predicate testpath/"testchain/geth/chaindata/000001.log", :exist?, 
+    assert_predicate testpath/"testchain/geth/chaindata/000001.log", :exist?,
                      "Failed to create log file"
   end
 end

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -13,7 +13,6 @@ class Geth < Formula
   end
 
   test do
-    system "#{bin}/geth", "version"
     (testpath/"genesis.json").write <<-EOS.undent
     {
       "config": {
@@ -31,6 +30,6 @@ class Geth < Formula
     }
     EOS
     system "#{bin}/geth", "--datadir", "testchain", "init", "genesis.json"
-    assert File.directory? "testchain/keystore"
+    assert File.file? "testchain/geth/chaindata/000001.log"
   end
 end

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -30,6 +30,7 @@ class Geth < Formula
     }
     EOS
     system "#{bin}/geth", "--datadir", "testchain", "init", "genesis.json"
-    assert File.file? "testchain/geth/chaindata/000001.log"
+    assert_predicate testpath/"testchain/geth/chaindata/000001.log", :exist?, 
+                     "Failed to create log file"
   end
 end

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -6,7 +6,6 @@ class Geth < Formula
   head "https://github.com/ethereum/go-ethereum.git"
 
   depends_on "go" => :build
-  depends_on "cmake" => :build
 
   def install
     system "make", "geth"
@@ -15,5 +14,6 @@ class Geth < Formula
 
   test do
     system "#{bin}/geth", "-h"
+    system "#{bin}/geth", "version"
   end
 end

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -14,20 +14,20 @@ class Geth < Formula
 
   test do
     (testpath/"genesis.json").write <<-EOS.undent
-    {
-      "config": {
-        "homesteadBlock": 10
-      },
-      "nonce": "0",
-      "difficulty": "0x20000",
-      "mixhash": "0x00000000000000000000000000000000000000647572616c65787365646c6578",
-      "coinbase": "0x0000000000000000000000000000000000000000",
-      "timestamp": "0x00",
-      "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "extraData": "0x",
-      "gasLimit": "0x2FEFD8",
-      "alloc": {}
-    }
+      {
+        "config": {
+          "homesteadBlock": 10
+        },
+        "nonce": "0",
+        "difficulty": "0x20000",
+        "mixhash": "0x00000000000000000000000000000000000000647572616c65787365646c6578",
+        "coinbase": "0x0000000000000000000000000000000000000000",
+        "timestamp": "0x00",
+        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "extraData": "0x",
+        "gasLimit": "0x2FEFD8",
+        "alloc": {}
+      }
     EOS
     system "#{bin}/geth", "--datadir", "testchain", "init", "genesis.json"
     assert_predicate testpath/"testchain/geth/chaindata/000001.log", :exist?,

--- a/Formula/geth.rb
+++ b/Formula/geth.rb
@@ -1,0 +1,19 @@
+class Geth < Formula
+  desc "Official Go implementation of the Ethereum protocol"
+  homepage "https://ethereum.github.io/go-ethereum/"
+  url "https://github.com/ethereum/go-ethereum/archive/v1.6.7.tar.gz"
+  sha256 "3e2a75b55ee8f04f238682164a7a255cae7a1f939893c5c97c2adcf48d7d4d49"
+  head "https://github.com/ethereum/go-ethereum.git"
+
+  depends_on "go" => :build
+  depends_on "cmake" => :build
+
+  def install
+    system "make", "geth"
+    bin.install "build/bin/geth"
+  end
+
+  test do
+    system "#{bin}/geth", "-h"
+  end
+end


### PR DESCRIPTION
Add formula for geth. Official golang implementation of the Ethereum
protocol (https://github.com/ethereum/go-ethereum). This formula does
not include other development tools provided by go-ethereum.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
