### PR TITLE
Hadoop 2.7 (new formula)

### DIFF
--- a/Formula/hadoop@2.7.rb
+++ b/Formula/hadoop@2.7.rb
@@ -7,6 +7,8 @@ class HadoopAT27 < Formula
 
   bottle :unneeded
 
+  keg_only :versioned_formula
+
   depends_on :java => "1.7+"
 
   def install

--- a/Formula/hadoop@2.7.rb
+++ b/Formula/hadoop@2.7.rb
@@ -1,0 +1,44 @@
+class HadoopAT27 < Formula
+  desc "Framework for distributed processing of large data sets"
+  homepage "https://hadoop.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.7.4/hadoop-2.7.4.tar.gz"
+  mirror "https://archive.apache.org/dist/hadoop/common/hadoop-2.7.4/hadoop-2.7.4.tar.gz"
+  sha256 "8f791bfcfa5bb7c7ccd09910d490c02910dda93b19936ec2aedb8930bc5be111"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
+    libexec.install %w[bin sbin libexec share etc]
+    bin.write_exec_script Dir["#{libexec}/bin/*"]
+    sbin.write_exec_script Dir["#{libexec}/sbin/*"]
+    # But don't make rcc visible, it conflicts with Qt
+    (bin/"rcc").unlink
+
+    inreplace "#{libexec}/etc/hadoop/hadoop-env.sh",
+      "export JAVA_HOME=${JAVA_HOME}",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+    inreplace "#{libexec}/etc/hadoop/yarn-env.sh",
+      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+    inreplace "#{libexec}/etc/hadoop/mapred-env.sh",
+      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
+      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
+  end
+
+  def caveats; <<-EOS.undent
+    In Hadoop's config file:
+      #{libexec}/etc/hadoop/hadoop-env.sh,
+      #{libexec}/etc/hadoop/mapred-env.sh and
+      #{libexec}/etc/hadoop/yarn-env.sh
+    $JAVA_HOME has been set to be the output of:
+      /usr/libexec/java_home
+    EOS
+  end
+
+  test do
+    system bin/"hadoop", "fs", "-ls"
+  end
+end


### PR DESCRIPTION
Add new versioned formula for Hadoop 2.7 (`2.7.4`). Hadoop 2.8 (as of `2.8.1`) is [_still_ not recommended for production use yet](https://www.mail-archive.com/general@hadoop.apache.org/msg07541.html), so 2.7 will be used significantly by those needing to communicate with production grade Hadoop clusters for some time to come.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?