### PR TITLE
ffmpeg: enable Apple VideoToolbox hardware encoder

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -158,6 +158,7 @@ class Ffmpeg < Formula
     args << "--enable-libzimg" if build.with? "zimg"
     args << "--enable-libzmq" if build.with? "zeromq"
     args << "--enable-opencl" if MacOS.version > :lion
+    args << "--enable-videotoolbox" if MacOS.version >= :mountain_lion
     args << "--enable-openssl" if build.with? "openssl"
 
     if build.with? "xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Utilizes the framework [introduced][ml_new] in macOS Mountain Lion. Adds a H.264 hardware encoder (h264_videotoolbox) which, together with h264_vda, should allow for full hardware-accelerated H.264 transcoding.

One can check that VideoToolbox support is enabled with `ffmpeg -hwaccels` and `ffmpeg -codecs | grep videotoolbox`.

[ml_new]: https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_8.html#//apple_ref/doc/uid/TP40011634-SW12