### PR TITLE
teensy_loader_cli: Update to "current" version 2.1

### DIFF
--- a/Formula/teensy_loader_cli.rb
+++ b/Formula/teensy_loader_cli.rb
@@ -1,8 +1,9 @@
 class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
-  url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
-  sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
+  url "https://github.com/PaulStoffregen/teensy_loader_cli/archive/2.1.tar.gz"
+  sha256 "5c36fe45b9a3a71ac38848b076cd692bf7ca8826a69941c249daac3a1d95e388"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/teensy_loader_cli.rb
+++ b/Formula/teensy_loader_cli.rb
@@ -4,6 +4,7 @@ class TeensyLoaderCli < Formula
   url "https://github.com/PaulStoffregen/teensy_loader_cli/archive/2.1.tar.gz"
   sha256 "5c36fe45b9a3a71ac38848b076cd692bf7ca8826a69941c249daac3a1d95e388"
   revision 1
+  head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,11 +14,7 @@ class TeensyLoaderCli < Formula
     sha256 "dcd10140babb4d2937ce376c89e9c24a2e8046d2cabdad2cfdbc2542afa14471" => :mavericks
   end
 
-  head do
-    url "https://github.com/PaulStoffregen/teensy_loader_cli.git"
-
-    depends_on "libusb-compat" => :optional
-  end
+  depends_on "libusb-compat" => :optional
 
   def install
     ENV["OS"] = "MACOSX"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

——

`teensy_loader_cli` sits in a weird place, where it possesses _two_ versions 2.1.

The first appears [in the repo at 26 Jun 2014](https://github.com/PaulStoffregen/teensy_loader_cli/commit/cbddcca2ddb5ea3d86d340d09eb9fd4420623578), and is the version which Homebrew appears to have shipped since. It also [erroneously reports itself as version 2.0](https://github.com/PaulStoffregen/teensy_loader_cli/blob/cbddcca2ddb5ea3d86d340d09eb9fd4420623578/teensy_loader_cli.c#L102).

The second is [the repo's `2.1` tagged release](https://github.com/PaulStoffregen/teensy_loader_cli/releases/tag/2.1). The most obvious difference between the two is how the `mcu` flag is formatted. The former accepts an apparent misspelling (`-mmcu`) while the latter uses `--mcu`.

The latter has better support for newer Teensy devices, and is in line with the current binary build supplied [on pjrc's website](https://www.pjrc.com/teensy/loader_cli.html)!

This PR does not currently pass `brew audit --strict` because of the source change with no version change, however on consultation with @mistydemeo I’ve bumped the revision, so this appears to be normal.