### PR TITLE
nlopt 2.4.2: remove unnecessary dependency

### DIFF
--- a/Formula/nlopt.rb
+++ b/Formula/nlopt.rb
@@ -18,8 +18,6 @@ class Nlopt < Formula
     depends_on "swig" => :build
   end
 
-  depends_on "numpy"
-
   def install
     ENV.deparallelize
 


### PR DESCRIPTION
Numpy is simply unnecessary to nlopt.
-----
- [Yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Yes] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Yes] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
