### PR TITLE
qt: add patch for 10.13

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -58,6 +58,15 @@ class Qt < Formula
     sha256 "b18e4715fcef2992f051790d3784a54900508c93350c25b0f2228cb058567142"
   end
 
+  # Patch fixing bugs QTBUG-62266 and QTBUG-62658 on macOS 10.13 High Sierra
+  # https://github.com/Homebrew/homebrew-core/issues/17075
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/45282b5b48/qt/high-sierra.diff"
+      sha256 "d8589d747a9ce0b7b7ddf1b59c4d999bbf8a02261e047a602cff39bea151eb42"
+    end
+  end
+
   def install
     args = %W[
       -verbose


### PR DESCRIPTION
Fixes #17075, allowing Qt to build on macOS 10.13 High Sierra