### PR TITLE
timedog: add head spec

### DIFF
--- a/Formula/timedog.rb
+++ b/Formula/timedog.rb
@@ -3,10 +3,15 @@ class Timedog < Formula
   homepage "https://github.com/nlfiedler/timedog"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/timedog/timedog-1.3.zip"
   sha256 "4683f37a28407dabc5c56dc45e6480dd2db460289321edce8980a236cc2787ec"
+  head "https://github.com/nlfiedler/timedog.git"
 
   bottle :unneeded
 
   def install
     bin.install "timedog"
+  end
+
+  test do
+    assert_match "Cannot locate timemachine directory", shell_output("#{bin}/timedog 2>&1", 2)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing timedog formula uses the last tarball available from Google
Code which dates from 2013-05-02.

On the [GitHub repo](https://github.com/nlfiedler/timedog) many changes were made after that date, up to
2015-07-27, which is the date of the last commit.

Though no 'release' tarball is available due to the repo being seemingly
abandoned, it would be valuable to update the brew forumla to the last
available version since it is over two years newer than the currently
used version.