### PR TITLE
apibuilder-cli: new formula

### DIFF
--- a/Formula/apibuilder-cli.rb
+++ b/Formula/apibuilder-cli.rb
@@ -1,0 +1,20 @@
+class ApibuilderCli < Formula
+  desc "Command-line interface to generate clients for api builder"
+  homepage "https://www.apibuilder.io"
+  url "https://github.com/apicollective/apibuilder-cli/archive/0.1.7.tar.gz"
+  sha256 "69a828ebb11270fbc507042d140c54a46ba8050b723fc75f55104f78abc13be9"
+
+  def install
+    system "./install.sh", prefix
+  end
+
+  test do
+    (testpath/"config").write <<-EOS.undent
+      [default]
+      token = abcd1234
+    EOS
+    assert_match "Profile default:", shell_output("#{bin}/read-config --path config")
+    assert_match "**ERROR** Could not find apibuilder configuration directory. Expected at: ~/.apibuilder\n",
+      shell_output("#{bin}/apibuilder", 1)
+  end
+end


### PR DESCRIPTION
Api builder provides simple comprehensive tooling for modern apis.
This cli allows easy generation of clients for apis documented in
Api builder.  https://www.apibuilder.io/

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? 

-----
