### PR TITLE
midnight-commander: fix compilation on 10.13

### DIFF
--- a/Formula/midnight-commander.rb
+++ b/Formula/midnight-commander.rb
@@ -33,6 +33,10 @@ class MidnightCommander < Formula
       --enable-vfs-sftp
     ]
 
+    # Fix compilation bug on macOS 10.13 by pretending we don't have utimensat()
+    # https://github.com/MidnightCommander/mc/pull/130
+    ENV["ac_cv_func_utimensat"] = "no" if MacOS.version >= :high_sierra
+
     args << "--disable-nls" if build.without? "nls"
 
     system "./configure", *args


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/14418 : `midnight-commander` [fails to build](https://gist.github.com/anonymous/b2dbd533a416b4b9316f959b84a8f747) on macOS 10.13 with:

```
file.c:668:23: error: no member named 'st_atim' in 'struct stat'
    (*times)[0] = sb->st_atim;
                  ~~  ^
file.c:669:23: error: no member named 'st_mtim' in 'struct stat'
    (*times)[1] = sb->st_mtim;
                  ~~  ^
```

I reported the bug and a patch to fix it: https://github.com/MidnightCommander/mc/pull/130
Here it is simpler to work around it.