### PR TITLE
znc: add python3 modpython support

### DIFF
--- a/Formula/znc.rb
+++ b/Formula/znc.rb
@@ -20,12 +20,14 @@ class Znc < Formula
 
   option "with-debug", "Compile ZNC with debug support"
   option "with-icu4c", "Build with icu4c for charset support"
+  option "with-python3", "Build with mod_python support, allowing Python ZNC modules"
 
   deprecated_option "enable-debug" => "with-debug"
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "icu4c" => :optional
+  depends_on "python3" => :optional
 
   needs :cxx11
 
@@ -39,6 +41,7 @@ class Znc < Formula
 
     args = ["--prefix=#{prefix}"]
     args << "--enable-debug" if build.with? "debug"
+    args << "--enable-python" if build.with? "python3"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
This updates the ZNC formula to support building modpython, allowing for
Python ZNC modules to be used at runtime.

- [✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
