### PR TITLE
Add tests for libogg, libvorbis, and libunistring

### DIFF
--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -22,6 +22,11 @@ class Libogg < Formula
     depends_on "libtool" => :build
   end
 
+  resource("oggfile") do
+    url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
+    sha256 "379071af4fa77bc7dacf892ad81d3f92040a628367d34a451a2cdcc997ef27b0"
+  end
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
@@ -29,5 +34,42 @@ class Libogg < Formula
     system "make"
     ENV.deparallelize
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <ogg/ogg.h>
+      #include <stdio.h>
+
+      int main (void) {
+        ogg_sync_state oy;
+        ogg_stream_state os;
+        ogg_page og;
+        ogg_packet op;
+        char *buffer;
+        int bytes;
+
+        ogg_sync_init (&oy);
+        buffer = ogg_sync_buffer (&oy, 4096);
+        bytes = fread(buffer, 1, 4096, stdin);
+        ogg_sync_wrote (&oy, bytes);
+        if (ogg_sync_pageout (&oy, &og) != 1)
+          return 1;
+        ogg_stream_init (&os, ogg_page_serialno (&og));
+        if (ogg_stream_pagein (&os, &og) < 0)
+          return 1;
+        if (ogg_stream_packetout (&os, &op) != 1)
+         return 1;
+
+        return 0;
+      }
+    EOS
+    testpath.install resource("oggfile")
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-logg",
+                   "-o", "test"
+    # Should work on an OGG file
+    shell_output("./test < Example.ogg")
+    # Expected to fail on a non-OGG file
+    shell_output("./test < #{test_fixtures("test.wav")}", 1)
   end
 end

--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -29,4 +29,24 @@ class Libunistring < Formula
     system "make", "check"
     system "make", "install"
   end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <uniname.h>
+      #include <unistdio.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+      int main (void) {
+        uint32_t s[2] = {};
+        uint8_t buff[12] = {};
+        if (u32_uctomb (s, unicode_name_character ("BEER MUG"), sizeof s) != 1) abort();
+        if (u8_sprintf (buff, "%llU", s) != 4) abort();
+        printf ("%s\\n", buff);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lunistring",
+                   "-o", "test"
+    assert_equal "🍺", shell_output("./test").chomp
+  end
 end

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -23,10 +23,36 @@ class Libvorbis < Formula
   depends_on "pkg-config" => :build
   depends_on "libogg"
 
+  resource("oggfile") do
+    url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
+    sha256 "379071af4fa77bc7dacf892ad81d3f92040a628367d34a451a2cdcc997ef27b0"
+  end
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+      #include <assert.h>
+      #include "vorbis/vorbisfile.h"
+      int main (void) {
+        OggVorbis_File vf;
+        assert (ov_open_callbacks (stdin, &vf, NULL, 0, OV_CALLBACKS_NOCLOSE) >= 0);
+        vorbis_info *vi = ov_info (&vf, -1);
+        printf("Bitstream is %d channel, %ldHz\\n", vi->channels, vi->rate);
+        printf("Encoded by: %s\\n", ov_comment(&vf,-1)->vendor);
+        return 0;
+      }
+    EOS
+    testpath.install resource("oggfile")
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lvorbisfile",
+                   "-o", "test"
+    assert_match "2 channel, 44100Hz\nEncoded by: Xiph.Org libVorbis",
+                 shell_output("./test < Example.ogg")
   end
 end


### PR DESCRIPTION
Our 3 most-used formulas without tests. See #11898 