### PR TITLE
clojure 1.8.0.119 (new formula)

### DIFF
--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -1,0 +1,30 @@
+class Clojure < Formula
+  desc "The Clojure Programming Language"
+  homepage "https://clojure.org"
+  url "https://download.clojure.org/install/brew/install-clj-1.8.0.119.tar.gz"
+  sha256 "7e272d3ae13d97c8fb6848d6851112e88995958391f40a1787bd82b6222d779e"
+
+  devel do
+    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.125.tar.gz"
+    sha256 "393c2f6025553376aebceaf359af08a9152edb9854ccc099460b06cf8dac1c5f"
+    version "1.9.0-alpha18.125"
+  end
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+  depends_on "rlwrap"
+
+  def install
+    prefix.install Dir["*.jar"]
+    prefix.install "clj.props"
+    inreplace "install-clj", /PREFIX/, prefix
+    bin.install "install-clj"
+    bin.install "clj"
+  end
+
+  test do
+    ENV.java_cache
+    system "#{bin}/clj", "-e", "nil"
+  end
+end

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -1,0 +1,28 @@
+class Clojure < Formula
+  desc "The Clojure Programming Language"
+  homepage "https://clojure.org"
+
+  devel do
+    version "1.9.0-alpha18.116"
+    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.116.tar.gz"
+    sha256 "9a11824797190fb6603c8022dbc6398d7a1ae91fb2da56c0587d39f83a40a060"
+  end
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+  depends_on "rlwrap"
+
+  def install
+    prefix.install "install-clj-1.9.0-alpha18.116.jar"
+    prefix.install "clj.props"
+    inreplace "install-clj", /PREFIX/, prefix
+    bin.install "install-clj"
+    bin.install "clj"
+  end
+
+  test do
+    ENV.java_cache
+    system "#{bin}/clj", "-e", "nil"
+  end
+end

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -1,14 +1,13 @@
 class Clojure < Formula
   desc "The Clojure Programming Language"
   homepage "https://clojure.org"
-  version "1.8.0.119"
   url "https://download.clojure.org/install/brew/install-clj-1.8.0.119.tar.gz"
   sha256 "7e272d3ae13d97c8fb6848d6851112e88995958391f40a1787bd82b6222d779e"
 
   devel do
-    version "1.9.0-alpha18.118"
-    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.118.tar.gz"
-    sha256 "93d59d7283a488b1d2fa21038519033543ca36e2f9ac50ccacf2a8801113cba7"
+    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.120.tar.gz"
+    sha256 "92946dd137c394d954b47513aa87a39578e4a2c893ff3501710072f170b07aca"
+    version "1.9.0-alpha18.120"
   end
 
   bottle :unneeded
@@ -17,7 +16,7 @@ class Clojure < Formula
   depends_on "rlwrap"
 
   def install
-    prefix.install "install-clj-1.9.0-alpha18.118.jar"
+    prefix.install "install-clj-1.9.0-alpha18.120.jar"
     prefix.install "clj.props"
     inreplace "install-clj", /PREFIX/, prefix
     bin.install "install-clj"

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -1,11 +1,14 @@
 class Clojure < Formula
   desc "The Clojure Programming Language"
   homepage "https://clojure.org"
+  version "1.8.0.119"
+  url "https://download.clojure.org/install/brew/install-clj-1.8.0.119.tar.gz"
+  sha256 "7e272d3ae13d97c8fb6848d6851112e88995958391f40a1787bd82b6222d779e"
 
   devel do
-    version "1.9.0-alpha18.116"
-    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.116.tar.gz"
-    sha256 "9a11824797190fb6603c8022dbc6398d7a1ae91fb2da56c0587d39f83a40a060"
+    version "1.9.0-alpha18.118"
+    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.118.tar.gz"
+    sha256 "93d59d7283a488b1d2fa21038519033543ca36e2f9ac50ccacf2a8801113cba7"
   end
 
   bottle :unneeded
@@ -14,7 +17,7 @@ class Clojure < Formula
   depends_on "rlwrap"
 
   def install
-    prefix.install "install-clj-1.9.0-alpha18.116.jar"
+    prefix.install "install-clj-1.9.0-alpha18.118.jar"
     prefix.install "clj.props"
     inreplace "install-clj", /PREFIX/, prefix
     bin.install "install-clj"

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -5,9 +5,9 @@ class Clojure < Formula
   sha256 "7e272d3ae13d97c8fb6848d6851112e88995958391f40a1787bd82b6222d779e"
 
   devel do
-    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.120.tar.gz"
-    sha256 "92946dd137c394d954b47513aa87a39578e4a2c893ff3501710072f170b07aca"
-    version "1.9.0-alpha18.120"
+    url "https://download.clojure.org/install/brew/install-clj-1.9.0-alpha18.125.tar.gz"
+    sha256 "393c2f6025553376aebceaf359af08a9152edb9854ccc099460b06cf8dac1c5f"
+    version "1.9.0-alpha18.125"
   end
 
   bottle :unneeded
@@ -16,7 +16,7 @@ class Clojure < Formula
   depends_on "rlwrap"
 
   def install
-    prefix.install "install-clj-1.9.0-alpha18.120.jar"
+    prefix.install Dir["*.jar"]
     prefix.install "clj.props"
     inreplace "install-clj", /PREFIX/, prefix
     bin.install "install-clj"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

*No - see below for details.*

-----

This is a new formula for Clojure (the language) to install the Clojure repl tool (`clj`). This tool has been created by the Clojure core team (of which I am a member) and released as a stable version for 1.8.0 and a devel version for the upcoming Clojure 1.9.0 release.

There is one audit failure as Clojure is currently in the brew blacklist. I have created a separate PR to remove clojure from the blacklist at https://github.com/Homebrew/brew/pull/3083. Presumably that PR needs to be applied before this formula can be accepted.