### PR TITLE
iperf: fix for 10.13

### DIFF
--- a/Formula/iperf.rb
+++ b/Formula/iperf.rb
@@ -16,6 +16,13 @@ class Iperf < Formula
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
+
+    # Otherwise this definition confuses system headers on 10.13
+    # https://github.com/Homebrew/homebrew-core/issues/14418#issuecomment-324082915
+    if MacOS.version >= :high_sierra
+      inreplace "config.h", "#define bool int", ""
+    end
+
     system "make", "install"
   end
 


### PR DESCRIPTION
`iperf` fails to build on 10.13, because its configure defines `bool` as `int`, which the C++ headers don't like (see https://github.com/Homebrew/homebrew-core/issues/14418#issuecomment-324082915). The simplest way to fix it is to remove the `#define` after configure is run.

Unfortunately, [`iperf` website](http://iperf.sourceforge.net) says:

> This is the old, deprecated Iperf site. Please use Iperf3.

so I can't report upstream — and it would never be fixed anyway. Even more unfortunately, this deprecated `iperf` has 1,698 installs per month (compared to 2,018 for `iperf3`). So I'm reluctant to remove it.