### PR TITLE
z3: add debugging options

### DIFF
--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -13,6 +13,8 @@ class Z3 < Formula
   end
 
   option "without-python", "Build without python 2 support"
+  option "with-debug", "Build in debug mode"
+  option "with-trace", "Build with support for tracing"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
 
@@ -22,7 +24,14 @@ class Z3 < Formula
     end
 
     Language::Python.each_python(build) do |python, version|
-      system python, "scripts/mk_make.py", "--prefix=#{prefix}", "--python", "--pypkgdir=#{lib}/python#{version}/site-packages", "--staticlib"
+      args = ["--prefix=#{prefix}",
+              "--python",
+              "--pypkgdir=#{lib}/python#{version}/site-packages",
+              "--staticlib"]
+      args << "--trace" if build.with? "trace"
+      args << "--debug" if build.with? "debug"
+
+      system python, "scripts/mk_make.py", *args
       cd "build" do
         system "make"
         system "make", "install"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This doesn't build for me yet using the new `--with-debug` option from
the formula but I'm not sure what's wrong. I get an error at link time
only from the Homebrew build, even though it works in a manual build
(using clang). The error is a missing instance for a templated function:

```
Undefined symbols for architecture x86_64:
  "lean::indexed_vector<unsigned int>::is_OK() const", referenced from:
        lean::lu<double,
	double>::find_error_of_yB_indexed(lean::indexed_vector<double>
	const&, vector<int, true, unsigned int> const&,
	lean::lp_settings const&) in lp.a(lu_instances.o)
	      lean::lu<double,
	      double>::add_delta_to_solution_indexed(lean::indexed_vector<double>&)
	      in lp.a(lu_instances.o)
```

I really don't understand why this function isn't in `lu_instances.o`.
In the Homebrew interactive build I get:

```
bash-3.2$ strings util/lp/lu_instances.o | sort -u | grep is_OK
m_ii.is_OK()
m_y_copy.is_OK()
y.is_OK()
```

whereas with the manual build I get:

```
$ strings util/lp/lu_instances.o | sort -u | grep is_OK
_ZNK4lean14indexed_vectorI8rationalE5is_OKEv
_ZNK4lean14indexed_vectorIdE5is_OKEv
_ZNK4lean14indexed_vectorIjE5is_OKEv
is_OK
m_ii.is_OK()
m_y_copy.is_OK()
y.is_OK()
```

Any ideas on what environment differences might cause this?