### PR TITLE
mupen64plus: secure homepage

### DIFF
--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -1,6 +1,6 @@
 class Mupen64plus < Formula
   desc "Cross-platform plugin-based N64 emulator"
-  homepage "http://www.mupen64plus.org/"
+  homepage "https://www.mupen64plus.org/"
   url "https://github.com/mupen64plus/mupen64plus-core/releases/download/2.5/mupen64plus-bundle-src-2.5.tar.gz"
   sha256 "9c75b9d826f2d24666175f723a97369b3a6ee159b307f7cc876bbb4facdbba66"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fails to build on Sierra (unrelated to this update):
```
     CXX _obj/Glide64/DepthBufferRender.o
 ../../src/Glide64/3dmath.cpp:274:5: error: use of undeclared identifier '__builtin_ia32_storeups'
     __builtin_ia32_storeups(r[i], destrow);
     ^
 1 error generated.
 make: *** [_obj/Glide64/3dmath.o] Error 1
```