### PR TITLE
Patches for qt@5.5 and qt@5.7 on 10.13

### DIFF
--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -76,6 +76,14 @@ class QtAT55 < Formula
     sha256 "d6d6b41aab16d8fbb1bdd1a9c05c519064258c4d5612d281e7f8661ec8990eaf"
   end
 
+  # Fix QTBUG-62266
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0af7ca663c/qt%405.7/QTBUG-62266.patch"
+      sha256 "60471b893eb394db18dacae8bd38727a955742626da641dd980dbb87a8808e9e"
+    end
+  end
+
   def install
     args = %W[
       -prefix #{prefix}

--- a/Formula/qt@5.7.rb
+++ b/Formula/qt@5.7.rb
@@ -53,6 +53,14 @@ class QtAT57 < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
 
+  # Fix QTBUG-62266
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0af7ca663c/qt%405.7/QTBUG-62266.patch"
+      sha256 "60471b893eb394db18dacae8bd38727a955742626da641dd980dbb87a8808e9e"
+    end
+  end
+
   def install
     args = %W[
       -verbose


### PR DESCRIPTION
These both fail due to [QTBUG-62266](https://bugreports.qt.io/browse/QTBUG-62266) (see https://github.com/Homebrew/homebrew-core/issues/14418#issuecomment-324082915), for which a fix is known. Let's use upstream's patch, adapted because the same code has moved to another source file in these older versions.