### PR TITLE
Remove defunct `conflicts_with` in mariadb connector

### DIFF
--- a/Formula/mariadb-connector-c.rb
+++ b/Formula/mariadb-connector-c.rb
@@ -14,7 +14,7 @@ class MariadbConnectorC < Formula
   depends_on "cmake" => :build
   depends_on "openssl"
 
-  conflicts_with "mysql", "mariadb", "percona-server",
+  conflicts_with "mysql", "percona-server",
                  :because => "both install plugins"
 
   def install

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -26,11 +26,7 @@ class Mariadb < Formula
 
   conflicts_with "mysql", "mysql-cluster", "percona-server",
     :because => "mariadb, mysql, and percona install the same binaries."
-  conflicts_with "mysql-connector-c",
-    :because => "both install MySQL client libraries"
   conflicts_with "mytop", :because => "both install `mytop` binaries"
-  conflicts_with "mariadb-connector-c",
-    :because => "both install plugins"
 
   def install
     # Set basedir and ldata so that mysql_install_db can find the server


### PR DESCRIPTION
# Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?

Yes, though I chose to fork+clone the repo rather than using `brew edit`. I hope that's OK.

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

The search `is:pr is:open mariadb` currently returns zero results.

- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

Yes, but I think I should specify a relative path, rather than just the name of the formula?

```
brew install --build-from-source ./Formula/mariadb-connector-c.rb 
```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Yes, `brew audit --strict mariadb-connector-c` exited with status code 0.

It's really impressive the tooling y'all have built to make contributions easier! ❤️ 

# Reasons

**According to new information from Sergei Golubchik, Chief Architect
of MariaDB, these packages should not conflict.**

> I suspect that now mariadb and mariadb-connector-c will not conflict anymore, so they can (but not should) be safely installed side by side. But please double check that (and do complain if they still conflict).
> https://jira.mariadb.org/browse/MDEV-13370?focusedCommentId=99175&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-99175

**I am not a MariaDB expert, I am just passing along this information
in hopes that it is helpful to homebrew.**

By the rules of Homebrew, I was required to pass along this information
in the form of a pull request. This does not imply that:

1. I know what I'm doing
2. These packages are guaranteed not to conflict

I'm just passing along Sergei's instructions the only way I am allowed to.

