### PR TITLE
xmrig 2.3.1 (new formula)

### DIFF
--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -1,0 +1,32 @@
+class Xmrig < Formula
+  desc "Monero (XMR) CPU miner"
+  homepage "https://github.com/xmrig/xmrig"
+  url "https://github.com/xmrig/xmrig/archive/v2.3.1.tar.gz"
+  sha256 "99be5e69732bf2720f3f34a1beb14ba06d440431bc55d308307fdbd1f877f6e5"
+
+  depends_on "cmake" => :build
+  depends_on "libuv"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", "-DUV_LIBRARY=#{Formula["libuv"].opt_lib}/libuv.a", *std_cmake_args
+      system "make"
+      bin.install "xmrig"
+    end
+  end
+
+  test do
+    test_server="donotexist.localhost:65535"
+    timeout=10
+    require "open3"
+    Open3.popen2e("#{bin}/xmrig", "--no-color", "--max-cpu-usage=1", "--print-time=1", "--threads=1", "--retries=1", "--url=#{test_server}") do |stdin, stdouts, _wait_thr|
+      start_time=Time.now
+      stdin.close_write
+
+      stdouts.each do |line|
+        assert (Time.now-start_time <= timeout), "No server connect after timeout"
+        break if line.include? "\] \[#{test_server}\] DNS error: \"unknown node or service\""
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a follow up of the original PR #16576 which address most of the issues raised and updated to the newer release. For those which have not been addressed, here are the explanations.
https://github.com/Homebrew/homebrew-core/pull/16576#discussion_r132222609
Checked the `build` directory after `make`, `xmrig` is the only result, no man page.

https://github.com/Homebrew/homebrew-core/pull/16576#discussion_r132222709
I wished I could think of some test case as well, but as it just run non-stop otherwise (and use the build machine to mine XMR), I'd rather check its version, or I could check something more on the `-v` output?
