### PR TITLE
libbitcoin: avoid opportunistic linkage to gmp

### DIFF
--- a/Formula/libbitcoin.rb
+++ b/Formula/libbitcoin.rb
@@ -3,7 +3,7 @@ class Libbitcoin < Formula
   homepage "https://libbitcoin.org/"
   url "https://github.com/libbitcoin/libbitcoin/archive/v3.3.0.tar.gz"
   sha256 "391913a73615afcb42c6a7c4736f23888cfc999a899fc38395ddcbd560251d94"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -29,7 +29,8 @@ class Libbitcoin < Formula
       system "./configure", "--disable-dependency-tracking",
                             "--disable-silent-rules",
                             "--prefix=#{libexec}",
-                            "--enable-module-recovery"
+                            "--enable-module-recovery",
+                            "--with-bignum=no"
       system "make", "install"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Discovered in https://github.com/Homebrew/homebrew-core/pull/17037.
Opportunistic linkage was caused by https://github.com/Homebrew/homebrew-core/pull/17122.