### PR TITLE
alure: patch for 10.13

### DIFF
--- a/Formula/alure.rb
+++ b/Formula/alure.rb
@@ -21,6 +21,15 @@ class Alure < Formula
   depends_on "libvorbis" => :optional
   depends_on "mpg123" => :optional
 
+  # Fix missing unistd include
+  # Reported by email to author on 2017-08-25
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
+      sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
+    end
+  end
+
   def install
     # fix a broken include flags line, which fixes a build error.
     # Not reported upstream.


### PR DESCRIPTION
Missing header include trips compilation on 10.13: https://github.com/Homebrew/homebrew-core/issues/14418