### PR TITLE
brainfuck 2.7.1 (new formula)

### DIFF
--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -1,25 +1,19 @@
 class Brainfuck < Formula
-  desc "Interpreter for brainfuck written in C"
+  desc "Interpreter for the brainfuck language"
   homepage "https://github.com/fabianishere/brainfuck"
   url "https://github.com/fabianishere/brainfuck/archive/2.7.1.tar.gz"
   sha256 "06534de715dbc614f08407000c2ec6d497770069a2d7c84defd421b137313d71"
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Extend the interpreter with a debug command"
-  option "with-examples", "Install brainfuck example programs"
-  option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
 
   def install
-    args = std_cmake_args
-    args << "-DBUILD_SHARED_LIB=ON"
+    args = std_cmake_args + %w[-DBUILD_SHARED_LIB=ON -DBUILD_STATIC_LIB=ON -DINSTALL_EXAMPLES=ON]
     args << "-DENABLE_DEBUG=ON" if build.with? "debug"
-    args << "-DINSTALL_EXAMPLES=ON" if build.with? "examples"
-    args << "-DBUILD_STATIC_LIB=OFF" if build.without? "static-lib"
 
     system "cmake", ".", *args
-    system "make"
     system "make", "install"
   end
 

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -3,7 +3,6 @@ class Brainfuck < Formula
   homepage "https://github.com/fabianishere/brainfuck"
   url "https://github.com/fabianishere/brainfuck/archive/2.7.1.tar.gz"
   sha256 "06534de715dbc614f08407000c2ec6d497770069a2d7c84defd421b137313d71"
-
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"
@@ -25,6 +24,7 @@ class Brainfuck < Formula
   end
 
   test do
-    system "#{bin}/brainfuck", "-e", "++++++++[>++++++++<-]>+.+.+."
+    output = shell_output("#{bin}/brainfuck -e '++++++++[>++++++++<-]>+.+.+.'")
+    assert_equal "ABC", output.chomp
   end
 end

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -5,7 +5,7 @@ class Brainfuck < Formula
   sha256 "06534de715dbc614f08407000c2ec6d497770069a2d7c84defd421b137313d71"
   head "https://github.com/fabianishere/brainfuck.git"
 
-  option "with-debug", "Compile interpreter with debug support"
+  option "with-debug", "Extend the interpreter with a debug command"
   option "with-examples", "Install brainfuck example programs"
   option "with-static-lib", "Build a static library"
 

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -6,11 +6,13 @@ class Brainfuck < Formula
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"
+  option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
 
   def install
     args = std_cmake_args
+    args << "-DBUILD_SHARED_LIB=ON"
     args << "-DENABLE_DEBUG=ON" if build.with? "debug"
 
     system "cmake", ".", *args
@@ -22,6 +24,6 @@ class Brainfuck < Formula
   end
 
   test do
-    system "#{bin}/brainfuck #{doc}/examples/hello.bf"
+    system "#{bin}/brainfuck", "#{doc}/examples/hello.bf"
   end
 end

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -1,5 +1,5 @@
 class Brainfuck < Formula
-  desc "Interpreter for brainfuck written in C."
+  desc "Interpreter for brainfuck written in C"
   homepage "https://github.com/fabianishere/brainfuck"
   url "https://github.com/fabianishere/brainfuck/archive/2.7.0.tar.gz"
   sha256 "aaa14203aeece4e9627c8eb707c5c630020d22a6d4465c35595dbbc854ddddd7"

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -2,11 +2,12 @@ class Brainfuck < Formula
   desc "Interpreter for brainfuck written in C"
   homepage "https://github.com/fabianishere/brainfuck"
   url "https://github.com/fabianishere/brainfuck/archive/2.7.1.tar.gz"
-  sha256 "528d57d823f3ee4bdcdc3315f99fed69d2e23aec34682fb6670d02f5dec0b40f"
+  sha256 "06534de715dbc614f08407000c2ec6d497770069a2d7c84defd421b137313d71"
 
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"
+  option "with-examples", "Install brainfuck example programs"
   option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
@@ -15,21 +16,15 @@ class Brainfuck < Formula
     args = std_cmake_args
     args << "-DBUILD_SHARED_LIB=ON"
     args << "-DENABLE_DEBUG=ON" if build.with? "debug"
+    args << "-DINSTALL_EXAMPLES=ON" if build.with? "examples"
+    args << "-DBUILD_STATIC_LIB=OFF" if build.without? "static-lib"
 
     system "cmake", ".", *args
     system "make"
-    bin.install "brainfuck"
-    man1.install "man/brainfuck.1"
-    lib.install "libbrainfuck.dylib"
-    if build.with? "static-lib"
-      lib.install "libbrainfuck.a"
-    else # upstream uses this static library in the build process
-      rm "libbrainfuck.a"
-    end
-    pkgshare.install "examples"
+    system "make", "install"
   end
 
   test do
-    system "#{bin}/brainfuck", "#{doc}/examples/hello.bf"
+    system "#{bin}/brainfuck", "-e", "++++++++[>++++++++<-]>+.+.+."
   end
 end

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -2,7 +2,7 @@ class Brainfuck < Formula
   desc "Interpreter for brainfuck written in C"
   homepage "https://github.com/fabianishere/brainfuck"
   url "https://github.com/fabianishere/brainfuck/archive/2.7.0.tar.gz"
-  sha256 "aaa14203aeece4e9627c8eb707c5c630020d22a6d4465c35595dbbc854ddddd7"
+  sha256 "445e00ef848f8b9a3ac101872ac08046b32b3477520ff06804d0ede5c3654c63"
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -1,0 +1,27 @@
+class Brainfuck < Formula
+  desc "Interpreter for brainfuck written in C."
+  homepage "https://github.com/fabianishere/brainfuck"
+  url "https://github.com/fabianishere/brainfuck/archive/2.7.0.tar.gz"
+  sha256 "aaa14203aeece4e9627c8eb707c5c630020d22a6d4465c35595dbbc854ddddd7"
+  head "https://github.com/fabianishere/brainfuck.git"
+
+  option "with-debug", "Compile interpreter with debug support"
+
+  depends_on "cmake" => :build
+
+  def install
+    args = std_cmake_args
+    args << "-DENABLE_DEBUG=ON" if build.with? "debug"
+
+    system "cmake", ".", *args
+    system "make"
+    bin.install "brainfuck"
+    man1.install "man/brainfuck.1"
+    lib.install "libbrainfuck.a"
+    doc.install "examples"
+  end
+
+  test do
+    system "#{bin}/brainfuck | cat"
+  end
+end

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -6,13 +6,11 @@ class Brainfuck < Formula
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"
-  option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
 
   def install
     args = std_cmake_args
-    args << "-DBUILD_SHARED_LIB=ON"
     args << "-DENABLE_DEBUG=ON" if build.with? "debug"
 
     system "cmake", ".", *args
@@ -20,7 +18,7 @@ class Brainfuck < Formula
     bin.install "brainfuck"
     man1.install "man/brainfuck.1"
     lib.install "libbrainfuck.a"
-    doc.install "examples"
+    pkgshare.install "examples"
   end
 
   test do

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -22,6 +22,6 @@ class Brainfuck < Formula
   end
 
   test do
-    system "#{bin}/brainfuck | cat"
+    system "#{bin}/brainfuck #{doc}/examples/hello.bf"
   end
 end

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -1,23 +1,31 @@
 class Brainfuck < Formula
   desc "Interpreter for brainfuck written in C"
   homepage "https://github.com/fabianishere/brainfuck"
-  url "https://github.com/fabianishere/brainfuck/archive/2.7.0.tar.gz"
-  sha256 "445e00ef848f8b9a3ac101872ac08046b32b3477520ff06804d0ede5c3654c63"
+  url "https://github.com/fabianishere/brainfuck/archive/2.7.1.tar.gz"
+  sha256 "528d57d823f3ee4bdcdc3315f99fed69d2e23aec34682fb6670d02f5dec0b40f"
+
   head "https://github.com/fabianishere/brainfuck.git"
 
   option "with-debug", "Compile interpreter with debug support"
+  option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
 
   def install
     args = std_cmake_args
+    args << "-DBUILD_SHARED_LIB=ON"
     args << "-DENABLE_DEBUG=ON" if build.with? "debug"
 
     system "cmake", ".", *args
     system "make"
     bin.install "brainfuck"
     man1.install "man/brainfuck.1"
-    lib.install "libbrainfuck.a"
+    lib.install "libbrainfuck.dylib"
+    if build.with? "static-lib"
+      lib.install "libbrainfuck.a"
+    else # upstream uses this static library in the build process
+      rm "libbrainfuck.a"
+    end
     pkgshare.install "examples"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with brew install --build-from-source <formula>, where <formula> is the name of the formula you're submitting?
- [x] Does your build pass brew audit --strict <formula> (after doing brew install <formula>)?


Excuse me for the explicit name, but a formula named "thefuck" also exists. If it's not okay then there exist a couple of commonly used censored variants of the name "brainfuck" as well. 

As stated in the commit message, homebrew-legacy had this formula, but removed it due to build issues on macOS. The only problem was the inclusion of the `fmemopen` library however, a library which is not available on (most) BSD systems, but whose functionality can often easily be replaced. Therefore, the formula should build fine on macOS from now on. 