### PR TITLE
swift-protobuf 1.0.0 (new formula)

### DIFF
--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -16,6 +16,9 @@ class ProtobufSwift < Formula
   depends_on "libtool" => :build
   depends_on "protobuf"
 
+  conflicts_with "swift-protobuf",
+    :because => "both install `protoc-gen-swift` binaries"
+
   def install
     system "protoc", "-Iplugin/compiler",
                      "plugin/compiler/google/protobuf/descriptor.proto",

--- a/Formula/swift-protobuf.rb
+++ b/Formula/swift-protobuf.rb
@@ -1,0 +1,36 @@
+class SwiftProtobuf < Formula
+  desc "Plugin and runtime library for using protobuf with Swift"
+  homepage "https://github.com/apple/swift-protobuf"
+  url "https://github.com/apple/swift-protobuf/archive/1.0.0.tar.gz"
+  sha256 "9cb811d608294d7b5fd0dcdc78d5b66b7ac2005ec026db3530f563be4248656a"
+  head "https://github.com/apple/swift-protobuf.git"
+
+  depends_on :xcode => ["8.3", :build]
+  depends_on "protobuf"
+
+  conflicts_with "protobuf-swift",
+    :because => "both install `protoc-gen-swift` binaries"
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc",
+           "-static-stdlib"
+    bin.install ".build/release/protoc-gen-swift"
+    doc.install "Documentation/PLUGIN.md"
+  end
+
+  test do
+    (testpath/"test.proto").write <<~EOS
+      syntax = "proto3";
+      enum Flavor {
+        CHOCOLATE = 0;
+        VANILLA = 1;
+      }
+      message IceCreamCone {
+        int32 scoops = 1;
+        Flavor flavor = 2;
+      }
+    EOS
+    system Formula["protobuf"].opt_bin/"protoc", "test.proto", "--swift_out=."
+    assert_predicate testpath/"test.pb.swift", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apple's swift plugin for protobuf. Notably, this conflicts with `protobuf-swift` which also has a confusingly similar name. Maybe we should prefix name of this formulae with `apple-` to clarify?
