### PR TITLE
qt@5.5: patch Bluetooth API on 10.13

### DIFF
--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -76,11 +76,11 @@ class QtAT55 < Formula
     sha256 "d6d6b41aab16d8fbb1bdd1a9c05c519064258c4d5612d281e7f8661ec8990eaf"
   end
 
-  # Fix QTBUG-62266
+  # Fix QTBUG-62266 and deprecated Bluetooth API
   if MacOS.version >= :high_sierra
     patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0af7ca663c/qt%405.7/QTBUG-62266.patch"
-      sha256 "60471b893eb394db18dacae8bd38727a955742626da641dd980dbb87a8808e9e"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/3ad1b0e172/qt%405.5/high_sierra.patch"
+      sha256 "0959c86ac37c65a7ce4b813ee1e4942425117f76c981d64ff41da782ba7b2efc"
     end
   end
 


### PR DESCRIPTION
Initial patch allowed build to proceed, but was not ultimately successful… (Qt takes sooo loooong to build).

Additional fixes are needed because deprecated Bluetooth APIs were removed in 10.13:
- `CBCentralManagerState` is renamed to `CBManagerState`
- old (unused on recent macOS) code calling `UUID` on a `CBPeripheral` does not compile anymore

#14418 