### PR TITLE
emscripten: fix for python3

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -16,6 +16,14 @@ class Emscripten < Formula
       url "https://github.com/kripken/emscripten-fastcomp-clang/archive/#{emscripten_tag}.tar.gz"
       sha256 "4653e5e5628a7f6731d7a30e0f462cd38e423741b57c360ab40423b5d44b603b"
     end
+
+    # Fix for when /usr/bin/env python resolves to python 3.x.
+    # Submitted upstream on 2017-08-27:
+    # https://github.com/kripken/emscripten/pull/5534
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0ac7cb3/emscripten/emscripten-resolve-symlinks.patch"
+      sha256 "d34cec4c1a33e67465b94993ae836ded727cbe0bb9e2c31e73b4cd22d6995234"
+    end
   end
 
   bottle do
@@ -95,6 +103,7 @@ class Emscripten < Formula
   end
 
   test do
-    system "#{libexec}/llvm/bin/llvm-config", "--version"
+    system bin/"emcc"
+    assert_predicate testpath/".emscripten", :exist?, "Failed to create sample config"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When `/usr/bin/env python` resolves to `python 3.x`, wrapper scripts like `emcc` uses a different loading strategy than python 2.x: they directly call underlying scripts like `emcc.py` from the same directory. Unfortunately, currently they do not resolve symlinks when calculating the directory, so our `#{HOMEBREW_PREFIX}/bin/emcc` symlink can't load `#{libexec}/emcc.py`. This is being addressed in https://github.com/kripken/emscripten/pull/5534.

The test is updated to a much more useful one.

I'm using formula-patches since the PR patch does apply cleanly to the stable tarball.

Also, I don't think this deserves a revision bump, since people seem to be happily using Python 2.7 so far. Guess I'm the first weirdo who both use Python 3.x as default and decided to install this.