### PR TITLE
w3m: switch to openssl@1.1 and apply Debian patches

### DIFF
--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,8 +1,23 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "https://w3m.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
-  sha256 "e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3"
+  revision 1
+  head "https://github.com/tats/w3m.git"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
+    sha256 "e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3"
+
+    # Upstream is effectively Debian https://github.com/tats/w3m at this point.
+    # The patches fix a pile of CVEs and provides openssl@1.1 compatibility.
+    patch do
+      url "http://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-34.debian.tar.xz"
+      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-34.debian.tar.xz"
+      sha256 "bed288bdc1ba4b8560724fd5dc77d7c95bcabd545ec330c42491cae3e3b09b7e"
+      apply "patches/010_upstream.patch",
+            "patches/020_debian.patch"
+    end
+  end
 
   bottle do
     sha256 "31d0388967c3a448cc0c27571e3976cbcf79bad9986000adcff74428afff587a" => :sierra
@@ -13,16 +28,12 @@ class W3m < Formula
 
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
-  depends_on "openssl"
-
-  patch :DATA
+  depends_on "openssl@1.1"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-image",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}"
-    # Race condition in build reported in:
-    # https://github.com/Homebrew/homebrew/issues/12854
-    ENV.deparallelize
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-image",
+                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
   end
 
@@ -30,22 +41,3 @@ class W3m < Formula
     assert_match /DuckDuckGo/, shell_output("#{bin}/w3m -dump https://duckduckgo.com")
   end
 end
-
-__END__
-diff --git a/main.c b/main.c
-index b421943..865c744 100644
---- a/main.c
-+++ b/main.c
-@@ -833,7 +833,12 @@ main(int argc, char **argv, char **envp)
-     mySignal(SIGPIPE, SigPipe);
- #endif
- 
-+#if GC_VERSION_MAJOR >= 7 && GC_VERSION_MINOR >= 2
-+    orig_GC_warn_proc = GC_get_warn_proc();
-+    GC_set_warn_proc(wrap_GC_warn_proc);
-+#else
-     orig_GC_warn_proc = GC_set_warn_proc(wrap_GC_warn_proc);
-+#endif
-     err_msg = Strnew();
-     if (load_argc == 0) {
- 	/* no URL specified */


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The reason for switching is so that `dasht` can use `wget`.

also add head spec and reparallelize the build