### PR TITLE
azure-cli: fix cxxstdlib warnings

### DIFF
--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -24,6 +24,9 @@ class AzureCli < Formula
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
     (bash_completion/"azure").write Utils.popen_read("#{bin}/azure --completion")
+
+    # fix cxxstdlib warnings caused by installed (but not used) prebuild binaries for fibers
+    rm_rf Dir[libexec/"lib/node_modules/azure-cli/node_modules/fibers/bin/*-{46,48}"]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes cxxstdlib warnings caused by installed (but not used) prebuild binaries for fibers (native addon dependency of azure-cli).

Refs: https://github.com/Homebrew/homebrew-core/pull/17284#issuecomment-325182238

cc @ilovezfs 
