### PR TITLE
Wireshark update to 2.4, enable Qt5 by default, correctly mark dependencies

### DIFF
--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -1,9 +1,9 @@
 class Wireshark < Formula
   desc "Graphical network analyzer and capture tool"
   homepage "https://www.wireshark.org"
-  url "https://www.wireshark.org/download/src/all-versions/wireshark-2.2.8.tar.bz2"
-  mirror "https://1.eu.dl.wireshark.org/src/wireshark-2.2.8.tar.bz2"
-  sha256 "ecf02c148c9ab6e809026ad5743fe9be1739a9840ef6fece6837a7ddfbdf7edc"
+  url "https://www.wireshark.org/download/src/all-versions/wireshark-2.4.0.tar.xz"
+  mirror "https://1.eu.dl.wireshark.org/src/wireshark-2.4.0.tar.xz"
+  sha256 "890bb41b826ff04e98fb089446ab37e5871e16205278bfeffc2a7c7364de3b04"
   head "https://code.wireshark.org/review/wireshark", :using => :git
 
   bottle do
@@ -38,7 +38,19 @@ class Wireshark < Formula
   depends_on "spandsp" => :optional
   depends_on "gnome-icon-theme" if build.with? "gtk+3"
 
+  # Fix build due to missing source file (will be fixed in 2.4.1)
+  resource "udpdump.pod" do
+    url "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;hb=v2.4.0;f=doc/udpdump.pod"
+    sha256 "4f2a6f7c0f39793c9bf14db5563fc284275a342677aeaef02d91a3980a5c37d1"
+  end
+
   def install
+    # Disable nghttp2 if requested (remove this for 2.4.1)
+    inreplace "CMakeLists.txt", /(set\(PACKAGELIST.*) NGHTTP2/, '\1' unless build.with?("nghttp2")
+
+    # Install missing udpdump.pod source file in srcdir (remove this for v2.4.1).
+    resource("udpdump.pod").stage(buildpath/"doc")
+
     args = std_cmake_args
     args << "-DENABLE_GNUTLS=ON"
 

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -32,6 +32,10 @@ class Wireshark < Formula
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
   depends_on "libssh" => :optional
+  depends_on "nghttp2" => :optional
+  depends_on "lz4" => :optional
+  depends_on "snappy" => :optional
+  depends_on "spandsp" => :optional
   depends_on "gnome-icon-theme" if build.with? "gtk+3"
 
   def install
@@ -64,6 +68,10 @@ class Wireshark < Formula
     args << "-DENABLE_CARES=" + (build.with?("c-ares") ? "ON" : "OFF")
     args << "-DENABLE_SMI=" + (build.with?("libsmi") ? "ON" : "OFF")
     args << "-DENABLE_LUA=" + (build.with?("lua") ? "ON" : "OFF")
+    args << "-DENABLE_NGHTTP2=" + (build.with?("nghttp2") ? "ON" : "OFF")
+    args << "-DENABLE_LZ4=" + (build.with?("lz4") ? "ON" : "OFF")
+    args << "-DENABLE_SNAPPY=" + (build.with?("snappy") ? "ON" : "OFF")
+    args << "-DENABLE_SPANDSP=" + (build.with?("spandsp") ? "ON" : "OFF")
 
     system "cmake", *args
     system "make"

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -26,7 +26,7 @@ class Wireshark < Formula
   depends_on "geoip" => :recommended
   depends_on "c-ares" => :recommended
   depends_on "libsmi" => :optional
-  depends_on "lua" => :optional
+  depends_on "lua" => :recommended
   depends_on "portaudio" => :optional
   depends_on "qt" => :recommended
   depends_on "gtk+3" => :optional

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -16,7 +16,7 @@ class Wireshark < Formula
 
   option "with-gtk+3", "Build the wireshark command with gtk+3"
   option "with-gtk+", "Build the wireshark command with gtk+"
-  option "with-qt", "Build the wireshark command with Qt (can be used with or without either GTK option)"
+  option "without-qt", "Disable the Wireshark Qt GUI"
   option "with-headers", "Install Wireshark library headers for plug-in development"
 
   depends_on "cmake" => :build
@@ -28,7 +28,7 @@ class Wireshark < Formula
   depends_on "libsmi" => :optional
   depends_on "lua" => :optional
   depends_on "portaudio" => :optional
-  depends_on "qt" => :optional
+  depends_on "qt" => :recommended
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
   depends_on "libssh" => :optional
@@ -71,7 +71,7 @@ class Wireshark < Formula
 
     if build.with? "qt"
       prefix.install bin/"Wireshark.app"
-      bin.install_symlink prefix/"Wireshark.app/Contents/MacOS/Wireshark"
+      bin.install_symlink prefix/"Wireshark.app/Contents/MacOS/Wireshark" => "wireshark"
     end
 
     if build.with? "headers"

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -19,12 +19,10 @@ class Wireshark < Formula
   option "with-qt", "Build the wireshark command with Qt (can be used with or without either GTK option)"
   option "with-headers", "Install Wireshark library headers for plug-in development"
 
-  depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "glib"
   depends_on "gnutls"
   depends_on "libgcrypt"
-  depends_on "dbus"
   depends_on "geoip" => :recommended
   depends_on "c-ares" => :recommended
   depends_on "libsmi" => :optional
@@ -37,7 +35,7 @@ class Wireshark < Formula
 
   def install
     args = std_cmake_args
-    args << "-DENABLE_GNUTLS=ON" << "-DENABLE_GCRYPT=ON"
+    args << "-DENABLE_GNUTLS=ON"
 
     if build.with? "qt"
       args << "-DBUILD_wireshark=ON"
@@ -46,6 +44,7 @@ class Wireshark < Formula
     else
       args << "-DBUILD_wireshark=OFF"
       args << "-DENABLE_APPLICATION_BUNDLE=OFF"
+      args << "-DENABLE_QT5=OFF"
     end
 
     if build.with?("gtk+3") || build.with?("gtk+")
@@ -57,33 +56,13 @@ class Wireshark < Formula
       args << "-DENABLE_PORTAUDIO=OFF"
     end
 
-    if build.with? "geoip"
-      args << "-DENABLE_GEOIP=ON"
-    else
-      args << "-DENABLE_GEOIP=OFF"
-    end
-
-    if build.with? "c-ares"
-      args << "-DENABLE_CARES=ON"
-    else
-      args << "-DENABLE_CARES=OFF"
-    end
-
-    if build.with? "libsmi"
-      args << "-DENABLE_SMI=ON"
-    else
-      args << "-DENABLE_SMI=OFF"
-    end
-
-    if build.with? "lua"
-      args << "-DENABLE_LUA=ON"
-    else
-      args << "-DENABLE_LUA=OFF"
-    end
+    args << "-DENABLE_GEOIP=" + (build.with?("geoip") ? "ON" : "OFF")
+    args << "-DENABLE_CARES=" + (build.with?("c-ares") ? "ON" : "OFF")
+    args << "-DENABLE_SMI=" + (build.with?("libsmi") ? "ON" : "OFF")
+    args << "-DENABLE_LUA=" + (build.with?("lua") ? "ON" : "OFF")
 
     system "cmake", *args
     system "make"
-    ENV.deparallelize # parallel install fails
     system "make", "install"
 
     if build.with? "qt"

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -31,6 +31,7 @@ class Wireshark < Formula
   depends_on "qt" => :optional
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
+  depends_on "libssh" => :optional
   depends_on "gnome-icon-theme" if build.with? "gtk+3"
 
   def install
@@ -55,6 +56,9 @@ class Wireshark < Formula
       args << "-DBUILD_wireshark_gtk=OFF"
       args << "-DENABLE_PORTAUDIO=OFF"
     end
+
+    args << "-DBUILD_sshdump=" + (build.with?("libssh") ? "ON" : "OFF")
+    args << "-DBUILD_ciscodump=" + (build.with?("libssh") ? "ON" : "OFF")
 
     args << "-DENABLE_GEOIP=" + (build.with?("geoip") ? "ON" : "OFF")
     args << "-DENABLE_CARES=" + (build.with?("c-ares") ? "ON" : "OFF")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
A couple of patches to add new optional dependencies for Wireshark 2.4 and enabling Qt GUI by default. Please see the individual commit messages for details. Squash as needed.

Note that the fixups in the last patch will not be necessary after the upcoming 2.4.1 release ([planned for Tuesday 29 August][1]), but I have added them so the build can be tested by CI. (I have already tested each change on 10.11 El Capitan).

Question: should the number of options be reduced if possible? libssh is quite a small dependency. If more configurability is desired, note that gnutls is currently technically optional (and could be marked as such).

 [1]: https://wiki.wireshark.org/Development/Roadmap