### PR TITLE
SFML 2.4.2: fix installation of pkg-config files.

### DIFF
--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -27,7 +27,14 @@ class Sfml < Formula
   depends_on :macos => :lion
 
   def install
+    # Install pkg-config files, adding the CMake flag below isn't enough, as
+    # the CMakeLists.txt file currently doesn't consider MacOS X.
+    # This was fixed upstream for the future 2.5.0 release on 2016-12-19 in:
+    # https://github.com/SFML/SFML/commit/5fe5e5d6d7792e37685a437551ffa8ed5161fcc1
+    inreplace "CMakeLists.txt", "if(SFML_OS_LINUX OR SFML_OS_FREEBSD)", "if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)"
+
     args = std_cmake_args
+    args << "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE"
     args << "-DSFML_BUILD_DOC=TRUE" if build.with? "doxygen"
 
     # Always remove the "extlibs" to avoid install_name_tool failure

--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -35,8 +35,7 @@ class Sfml < Formula
               "if(SFML_OS_LINUX OR SFML_OS_FREEBSD)",
               "if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)"
 
-    args = std_cmake_args
-    args << "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE"
+    args = std_cmake_args << "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE"
     args << "-DSFML_BUILD_DOC=TRUE" if build.with? "doxygen"
 
     # Always remove the "extlibs" to avoid install_name_tool failure

--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -31,7 +31,9 @@ class Sfml < Formula
     # the CMakeLists.txt file currently doesn't consider MacOS X.
     # This was fixed upstream for the future 2.5.0 release on 2016-12-19 in:
     # https://github.com/SFML/SFML/commit/5fe5e5d6d7792e37685a437551ffa8ed5161fcc1
-    inreplace "CMakeLists.txt", "if(SFML_OS_LINUX OR SFML_OS_FREEBSD)", "if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)"
+    inreplace "CMakeLists.txt",
+              "if(SFML_OS_LINUX OR SFML_OS_FREEBSD)",
+              "if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)"
 
     args = std_cmake_args
     args << "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE"


### PR DESCRIPTION
SFML 2.4.2 on MacOS X Homebrew doesn't install the pkg-config files that allow pkg-config to understand how to find the libraries. This makes for example software using CMake to find a dependency fail.
The fix is to add '-DSFML_INSTALL_PKGCONFIG_FILES=TRUE' to the CMake build arguments, as well as patch the SFML CMakeLists.txt to also consider the above option on MacOS X systems.
Future releases of SFML will not need the patch, as this has been addressed upstream with https://github.com/SFML/SFML/commit/5fe5e5d6d7792e37685a437551ffa8ed5161fcc1. The CMake build argument will still be needed.