### PR TITLE
xerces-c 3.2.0

### DIFF
--- a/Formula/blahtexml.rb
+++ b/Formula/blahtexml.rb
@@ -3,6 +3,7 @@ class Blahtexml < Formula
   homepage "http://gva.noekeon.org/blahtexml/"
   url "http://gva.noekeon.org/blahtexml/blahtexml-0.9-src.tar.gz"
   sha256 "c5145b02bdf03cd95b7b136de63286819e696639824961d7408bec4591bc3737"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,7 @@ class Blahtexml < Formula
   option "without-blahtexml", "Build only blahtex, not blahtexml"
 
   depends_on "xerces-c" if build.with? "blahtexml"
+  needs :cxx11 if build.with? "blahtexml"
 
   # Add missing unistd.h includes, taken from MacPorts
   patch :p0 do
@@ -30,6 +32,8 @@ class Blahtexml < Formula
   end
 
   def install
+    ENV.cxx11 if build.with? "blahtexml"
+
     system "make", "blahtex-mac"
     bin.install "blahtex"
     if build.with? "blahtexml"

--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -3,6 +3,7 @@ class Dbxml < Formula
   homepage "https://www.oracle.com/us/products/database/berkeley-db/xml/overview/index.html"
   url "http://download.oracle.com/berkeley-db/dbxml-6.1.4.tar.gz"
   sha256 "a8fc8f5e0c3b6e42741fa4dfc3b878c982ff8f5e5f14843f6a7e20d22e64251a"
+  revision 1
 
   bottle do
     rebuild 1
@@ -16,7 +17,17 @@ class Dbxml < Formula
   depends_on "xqilla"
   depends_on "berkeley-db"
 
+  needs :cxx11
+
+  # No public bug tracker or mailing list to submit this to, unfortunately.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/dbxml/c%2B%2B11.patch"
+    sha256 "98d518934072d86c15780f10ceee493ca34bba5bc788fd9db1981a78234b0dc4"
+  end
+
   def install
+    ENV.cxx11
+
     inreplace "dbxml/configure" do |s|
       s.gsub! "lib/libdb-*.la | sed -e 's\/.*db-\\\(.*\\\).la", "lib/libdb-*.a | sed -e 's/.*db-\\(.*\\).a"
       s.gsub! "lib/libdb-*.la", "lib/libdb-*.a"

--- a/Formula/enigma.rb
+++ b/Formula/enigma.rb
@@ -3,7 +3,7 @@ class Enigma < Formula
   homepage "http://www.nongnu.org/enigma/"
   url "https://downloads.sourceforge.net/project/enigma-game/Release%201.21/enigma-1.21.tar.gz"
   sha256 "d872cf067d8eb560d3bb1cb17245814bc56ac3953ae1f12e2229c8eb6f82ce01"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "5a788728bde916cc18f8a4c1cfe9323d2aacdfac416096ac082fb37d0c2ee93a" => :high_sierra
@@ -31,7 +31,17 @@ class Enigma < Formula
   depends_on "gettext"
   depends_on "enet"
 
+  needs :cxx11
+
+  # See https://github.com/Enigma-Game/Enigma/pull/8
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/enigma/c%2B%2B11.patch"
+    sha256 "5870bb761dbba508e998fc653b7b05a130f9afe84180fa21667e7c2271ccb677"
+  end
+
   def install
+    ENV.cxx11
+
     system "./autogen.sh" if build.head?
 
     inreplace "configure" do |s|

--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -3,6 +3,7 @@ class Opensaml < Formula
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/Home"
   url "https://shibboleth.net/downloads/c++-opensaml/2.6.0/opensaml-2.6.0.tar.gz"
   sha256 "8c8e7d1d7b045cda330dd49ea1972a3306ebefbf42cc65b8f612d66828352179"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,7 +21,11 @@ class Opensaml < Formula
   depends_on "xml-tooling-c"
   depends_on "openssl"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
+
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
   end

--- a/Formula/pktanon.rb
+++ b/Formula/pktanon.rb
@@ -3,6 +3,7 @@ class Pktanon < Formula
   homepage "https://www.tm.uka.de/software/pktanon/index.html"
   url "https://www.tm.uka.de/software/pktanon/download/pktanon-1.4.0-dev.tar.gz"
   sha256 "db3f437bcb8ddb40323ddef7a9de25a465c5f6b4cce078202060f661d4b97ba3"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -26,8 +26,11 @@ class ShibbolethSp < Formula
   depends_on "apr-util" => :build
   depends_on "apr" => :build
 
+  needs :cxx11
+
   def install
     ENV.O2 # Os breaks the build
+    ENV.cxx11
     args = %W[
       --disable-debug
       --disable-dependency-tracking

--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -3,6 +3,7 @@ class XalanC < Formula
   homepage "https://xalan.apache.org/xalan-c/"
   url "https://www.apache.org/dyn/closer.cgi?path=xalan/xalan-c/sources/xalan_c-1.11-src.tar.gz"
   sha256 "4f5e7f75733d72e30a2165f9fdb9371831cf6ff0d1997b1fb64cdd5dc2126a28"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,10 +22,22 @@ class XalanC < Formula
   end
   depends_on "xerces-c"
 
+  needs :cxx11
+
   # Fix segfault. See https://issues.apache.org/jira/browse/XALANC-751
-  patch :DATA
+  # Build with char16_t casts.  See https://issues.apache.org/jira/browse/XALANC-773
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/xalan-c/xerces-char16.patch"
+    sha256 "ebd4ded1f6ee002351e082dee1dcd5887809b94c6263bbe4e8e5599f56774ebf"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/xalan-c/locator-system-id.patch"
+    sha256 "7c317c6b99cb5fb44da700e954e6b3e8c5eda07bef667f74a42b0099d038d767"
+  end
 
   def install
+    ENV.cxx11
     ENV.deparallelize # See https://issues.apache.org/jira/browse/XALANC-696
     ENV["XALANCROOT"] = "#{buildpath}/c"
     ENV["XALAN_LOCALE_SYSTEM"] = "inmem"
@@ -82,16 +95,3 @@ class XalanC < Formula
     assert_match "Article: An XSLT test-case\nAuthors: \n* Roger Leigh\n* Open Microscopy Environment", shell_output("#{bin}/Xalan #{testpath}/input.xml #{testpath}/transform.xsl")
   end
 end
-
-__END__
---- a/c/src/xalanc/PlatformSupport/XalanLocator.hpp
-+++ b/c/src/xalanc/PlatformSupport/XalanLocator.hpp
-@@ -91,7 +91,7 @@ public:
-             const XalanDOMChar*     theAlternateId = getEmptyPtr())
-     {
-         return theLocator == 0 ? theAlternateId : (theLocator->getSystemId() ?
--            theLocator->getPublicId() : theAlternateId);
-+            theLocator->getSystemId() : theAlternateId);
-     }
-
-     /**

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -1,8 +1,8 @@
 class XercesC < Formula
   desc "Validating XML parser"
   homepage "https://xerces.apache.org/xerces-c/"
-  url "https://www.apache.org/dyn/closer.cgi?path=xerces/c/3/sources/xerces-c-3.1.4.tar.gz"
-  sha256 "c98eedac4cf8a73b09366ad349cb3ef30640e7a3089d360d40a3dde93f66ecf6"
+  url "https://www.apache.org/dyn/closer.cgi?path=xerces/c/3/sources/xerces-c-3.2.0.tar.gz"
+  sha256 "d3162910ada85612f5b8cc89cdab84d0ad9a852a49577691e54bc7e9fc304e15"
 
   bottle do
     cellar :any
@@ -13,10 +13,19 @@ class XercesC < Formula
     sha256 "c7d461ebe0429d9a19e7e017af14a11435fc4f93ed83d2515b161e0f40c058b0" => :mavericks
   end
 
+  depends_on "cmake" => :build
+
+  needs :cxx11
+
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make", "install"
+    ENV.cxx11
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "ctest", "-V"
+      system "make", "install"
+    end
     # Remove a sample program that conflicts with libmemcached
     # on case-insensitive file systems
     (bin/"MemParse").unlink

--- a/Formula/xml-security-c.rb
+++ b/Formula/xml-security-c.rb
@@ -3,6 +3,7 @@ class XmlSecurityC < Formula
   homepage "https://santuario.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=/santuario/c-library/xml-security-c-1.7.3.tar.gz"
   sha256 "e5226e7319d44f6fd9147a13fb853f5c711b9e75bf60ec273a0ef8a190592583"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,7 +19,17 @@ class XmlSecurityC < Formula
   depends_on "xerces-c"
   depends_on "openssl"
 
+  needs :cxx11
+
+  # See https://issues.apache.org/jira/browse/SANTUARIO-471
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/xml-security-c/c%2B%2B11.patch"
+    sha256 "b8ced4b8b7977d7af0d13972e1a0c6623cbc29804ec9fea1eb588f0869503b1c"
+  end
+
   def install
+    ENV.cxx11
+
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking",
                           "--with-openssl=#{Formula["openssl"].opt_prefix}"
     system "make", "install"

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -3,6 +3,7 @@ class XmlToolingC < Formula
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/XMLTooling-C"
   url "https://shibboleth.net/downloads/c++-opensaml/2.6.0/xmltooling-1.6.0.tar.gz"
   sha256 "25814c49e27cdc97e17d42ca503e325f7e474ca3558a5a6b476e57a8a3c1a20e"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,8 +22,12 @@ class XmlToolingC < Formula
   depends_on "openssl"
   depends_on "curl" => "with-openssl"
 
+  needs :cxx11
+
   def install
     ENV.O2 # Os breaks the build
+    ENV.cxx11
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/xqilla.rb
+++ b/Formula/xqilla.rb
@@ -3,6 +3,7 @@ class Xqilla < Formula
   homepage "https://xqilla.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xqilla/XQilla-2.3.3.tar.gz"
   sha256 "8f76b9b4f966f315acc2a8e104e426d8a76ba4ea3441b0ecfdd1e39195674fd6"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,7 +17,17 @@ class Xqilla < Formula
 
   conflicts_with "zorba", :because => "Both supply xqc.h"
 
+  needs :cxx11
+
+  # See https://sourceforge.net/p/xqilla/bugs/48/
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/xqilla/xerces-containing-node.patch"
+    sha256 "36ffb2dff579e5610ca3be2a962942433127b24a78ca454647059d6d54b8e014"
+  end
+
   def install
+    ENV.cxx11
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--with-xerces=#{HOMEBREW_PREFIX}",
                           "--prefix=#{prefix}"

--- a/Formula/xsd.rb
+++ b/Formula/xsd.rb
@@ -4,6 +4,7 @@ class Xsd < Formula
   url "http://www.codesynthesis.com/download/xsd/4.0/xsd-4.0.0+dep.tar.bz2"
   version "4.0.0"
   sha256 "eca52a9c8f52cdbe2ae4e364e4a909503493a0d51ea388fc6c9734565a859817"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,8 @@ class Xsd < Formula
 
   depends_on "pkg-config" => :build
   depends_on "xerces-c"
+
+  needs :cxx11
 
   # Patches:
   # 1. As of version 4.0.0, Clang fails to compile if the <iostream> header is
@@ -33,6 +36,7 @@ class Xsd < Formula
 
   def install
     ENV.append "LDFLAGS", `pkg-config --libs --static xerces-c`.chomp
+    ENV.cxx11
     system "make", "install", "install_prefix=#{prefix}"
   end
 

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -3,7 +3,7 @@ class Zorba < Formula
   homepage "http://www.zorba.io/"
   url "https://github.com/28msec/zorba/archive/3.1.tar.gz"
   sha256 "05eed935c0ff3626934a5a70724a42410fd93bc96aba1fa4821736210c7f1dd8"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "09f9a818113700df3f5b2721ae73266888fc7fb1c4d15ce5c7644d9851bb11a6" => :high_sierra


### PR DESCRIPTION
- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note, this release switches to cmake, and this automatically enables the use of `char16_t` for unicode strings in place of `uint16_t`.  This means you can use `u"string"` directly which is a nice usability gain, but it does mean that all packages using xerces-c must compile with C++11 enabled.  If this proves to be a problem, we can explicitly disable it until Xcode enables it by default.  I've patched xalan-c (https://issues.apache.org/jira/browse/XALANC-773).