### PR TITLE
offlineimap: Only do quick sync in launchd service

### DIFF
--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -3,7 +3,7 @@ class Offlineimap < Formula
   homepage "http://offlineimap.org/"
   url "https://github.com/OfflineIMAP/offlineimap/archive/v7.1.2.tar.gz"
   sha256 "7203435e34f73e90d1833b72c49a859decf7b5828384a2648ee4b2d1ef3bdc66"
-  revision 1
+  revision 2
   head "https://github.com/OfflineIMAP/offlineimap.git"
 
   bottle do
@@ -68,6 +68,7 @@ class Offlineimap < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/offlineimap</string>
+          <string>-q</string>
           <string>-u</string>
           <string>basic</string>
         </array>

--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -3,7 +3,7 @@ class Offlineimap < Formula
   homepage "http://offlineimap.org/"
   url "https://github.com/OfflineIMAP/offlineimap/archive/v7.1.2.tar.gz"
   sha256 "7203435e34f73e90d1833b72c49a859decf7b5828384a2648ee4b2d1ef3bdc66"
-  revision 2
+  revision 1
   head "https://github.com/OfflineIMAP/offlineimap.git"
 
   bottle do


### PR DESCRIPTION
Non-quick syncs need to inspect flags on all messages on the remote.
This can lead to large amount data being transferred (10s of MiB), and a
longer sync time, for no actual changes.

As the service runs every 5 minutes, the amount of data transferred
quickly adds up, and can be in the multi-GiB mark at the end of the day.

A quick sync, comparatively, is only a few 10s of KiB.

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
