### PR TITLE
Upgrade to mono 5.2.0.215, fsharp 4.1.25 and add msbuild d15.3

### DIFF
--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -1,8 +1,8 @@
 class Mono < Formula
   desc "Cross platform, open source .NET development framework"
   homepage "http://www.mono-project.com/"
-  url "https://download.mono-project.com/sources/mono/mono-5.0.1.1.tar.bz2"
-  sha256 "48d6ae71d593cd01bf0f499de569359d45856cda325575e1bacb5fabaa7e9718"
+  url "https://download.mono-project.com/sources/mono/mono-5.2.0.215.tar.bz2"
+  sha256 "8f0cebd3f7b03f68b9bd015706da9c713ed968004612f1ef8350993d8fe850ea"
 
   bottle do
     sha256 "8dab2660d98e8e3bb1fa7f4640db04ef33e4e7fcfb7c3ef8a5c718e5254d80bd" => :sierra
@@ -30,10 +30,15 @@ class Mono < Formula
 
   conflicts_with "xsd", :because => "both install `xsd` binaries"
 
+  resource "msbuild" do
+    url "https://github.com/mono/msbuild.git",
+        :tag => "d15.3"
+      #:revision => "5633e38dd86d5ca588a7a3b9c8e961b5f7bdcf62"
+  end
+
   resource "fsharp" do
-    url "https://github.com/fsharp/fsharp.git",
-        :tag => "4.1.18",
-        :revision => "3245fd24efcc7a54d4314a2897257f68cd194244"
+    url "https://github.com/fsharp/fsharp/archive/4.1.25.tar.gz"
+    sha256 "9c6f06ff77f7e2c3a764af8a85094c6b6c50a2088c5cc7ba52d3f87384a251f1"
   end
 
   def install
@@ -52,6 +57,13 @@ class Mono < Formula
     # mono-gdb.py and mono-sgen-gdb.py are meant to be loaded by gdb, not to be
     # run directly, so we move them out of bin
     libexec.install bin/"mono-gdb.py", bin/"mono-sgen-gdb.py"
+
+    resource("msbuild").stage do
+      ENV.prepend_path "PATH", bin
+      ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
+      system "./cibuild.sh", "--scope", "Compile", "--target", "Mono", "--config", "Release"
+      system "./install-mono-prefix.sh", "#{prefix}"
+    end
 
     # Now build and install fsharp as well
     if build.with? "fsharp"

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -58,6 +58,19 @@ class Mono < Formula
     libexec.install bin/"mono-gdb.py", bin/"mono-sgen-gdb.py"
 
     resource("msbuild").stage do
+      patch_str = <<-EOM
+      tar -xf $__DOTNET_PATH/dotnet.tar
+
+      __SHARED_DIR="shared/Microsoft.NETCore.App/1.0.1"
+      __OPENSSL_PREFIX="/usr/local/opt/openssl/lib"
+      mkdir -p __SHARED_DIR
+      cp $__OPENSSL_PREFIX/libssl.1.0.0.dylib $__SHARED_DIR
+      cp $__OPENSSL_PREFIX/libcrypto.1.0.0.dylib $__SHARED_DIR
+      EOM
+      inreplace "init-tools.sh", "tar -xf $__DOTNET_PATH/dotnet.tar", patch_str
+      #inreplace "init-tools.sh" do |s|
+      #  s.gsub! "tar -xf $__DOTNET_PATH/dotnet.tar", patch_str
+      #end
       ENV.prepend_path "PATH", bin
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
       system "./cibuild.sh", "--scope", "Compile", "--target", "Mono", "--config", "Release"

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -33,7 +33,6 @@ class Mono < Formula
   resource "msbuild" do
     url "https://github.com/mono/msbuild.git",
         :branch => "d15.3"
-      #:revision => "5633e38dd86d5ca588a7a3b9c8e961b5f7bdcf62"
   end
 
   resource "fsharp" do
@@ -62,7 +61,7 @@ class Mono < Formula
       ENV.prepend_path "PATH", bin
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
       system "./cibuild.sh", "--scope", "Compile", "--target", "Mono", "--config", "Release"
-      system "./install-mono-prefix.sh", "#{prefix}"
+      system "./install-mono-prefix.sh", prefix.to_s
     end
 
     # Now build and install fsharp as well

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -27,6 +27,7 @@ class Mono < Formula
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
+  depends_on "openssl" => :build
 
   conflicts_with "xsd", :because => "both install `xsd` binaries"
 

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -32,7 +32,7 @@ class Mono < Formula
 
   resource "msbuild" do
     url "https://github.com/mono/msbuild.git",
-        :tag => "d15.3"
+        :branch => "d15.3"
       #:revision => "5633e38dd86d5ca588a7a3b9c8e961b5f7bdcf62"
   end
 

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -69,9 +69,9 @@ class Mono < Formula
       cp $__OPENSSL_PREFIX/libcrypto.1.0.0.dylib $__SHARED_DIR
       EOM
       inreplace "init-tools.sh", "tar -xf $__DOTNET_PATH/dotnet.tar", patch_str
-      #inreplace "init-tools.sh" do |s|
-      #  s.gsub! "tar -xf $__DOTNET_PATH/dotnet.tar", patch_str
-      #end
+      # inreplace "init-tools.sh" do |s|
+      #   s.gsub! "tar -xf $__DOTNET_PATH/dotnet.tar", patch_str
+      # end
       ENV.prepend_path "PATH", bin
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
       system "./cibuild.sh", "--scope", "Compile", "--target", "Mono", "--config", "Release"


### PR DESCRIPTION
Upgrade mono and fsharp to latest stable/release and add msbuild.

[MSbuild](//github.com/mono/msbuild) is now needed in order to build [newest](https://github.com/fsharp/fsharp/commit/7975efc3989888603a6169238ac0fa4671c2fceb) fsharp releases. 

- mono 5.2.0.215
- fsharp 4.1.25
- msbuild d15.3

-----
