### PR TITLE
bash-completion: fix man autocompletion

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -6,7 +6,7 @@ class BashCompletion < Formula
   url "https://bash-completion.alioth.debian.org/files/bash-completion-1.3.tar.bz2"
   mirror "http://pkgs.fedoraproject.org/repo/pkgs/bash-completion/bash-completion-1.3.tar.bz2/a1262659b4bbf44dc9e59d034de505ec/bash-completion-1.3.tar.bz2"
   sha256 "8ebe30579f0f3e1a521013bcdd183193605dab353d7a244ff2582fb3a36f7bec"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
@@ -24,6 +24,10 @@ class BashCompletion < Formula
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/c1d87451da3b5b147bed95b2dc783a1b02520ac5/bash-completion/bug-740971.patch"
     sha256 "bd242a35b8664c340add068bcfac74eada41ed26d52dc0f1b39eebe591c2ea97"
   end
+
+  # Backports (a variant of) the following upstream patch to fix man completion:
+  # https://anonscm.debian.org/cgit/bash-completion/bash-completion.git/patch/completions/man?id=fb2d657fac6be93a1c4ffa76018d8042859e0a03
+  patch :DATA
 
   def install
     inreplace "bash_completion" do |s|
@@ -45,3 +49,15 @@ class BashCompletion < Formula
     system "bash", "-c", ". #{etc}/profile.d/bash_completion.sh"
   end
 end
+__END__
+--- a/completions/man
++++ b/completions/man
+@@ -27,7 +27,7 @@
+     fi
+ 
+     uname=$( uname -s )
+-    if [[ $uname == @(Linux|GNU|GNU/*|FreeBSD|Cygwin|CYGWIN_*) ]]; then
++    if [[ $uname == @(Darwin|Linux|GNU|GNU/*|FreeBSD|Cygwin|CYGWIN_*) ]]; then
+         manpath=$( manpath 2>/dev/null || command man --path )
+     else
+         manpath=$MANPATH


### PR DESCRIPTION
This patch is required to lookup items in manpath, it was fixed upstream
in a slightly different way, but the result is equivalent.

Without this patch, `man git<TAB>` fails to complete to items like `git-config` because `$MANPATH` is empty and it only looks for commands instead.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
