### PR TITLE
trafficserver: Fix --with-experimental-plugins

### DIFF
--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -51,11 +51,6 @@ class Trafficserver < Formula
 
     # Fix wrong username in the generated startup script for bottles.
     inreplace "rc/trafficserver.in", "@pkgsysuser@", "$USER"
-    if build.with? "experimental-plugins"
-      # Disable mysql_remap plugin due to missing symbol compile error:
-      # https://issues.apache.org/jira/browse/TS-3490
-      inreplace "plugins/experimental/Makefile", " mysql_remap", ""
-    end
 
     inreplace "lib/perl/Makefile",
       "Makefile.PL INSTALLDIRS=$(INSTALLDIRS)",


### PR DESCRIPTION
This removes an outdated workaround for building trafficserver with
experimental plugins, which disabled the mysql_remap plugin die to build
problems that have been fixed in later versions.

The workaround broke because of makefile re-organizations.

The trafficserver make system will now automatically compile the
mysql_remap plugin if mysql is installed and skip it otherwise.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
