### PR TITLE
ruby: apply upstream gem security fixes

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -1,9 +1,23 @@
 class Ruby < Formula
   desc "Powerful, clean, object-oriented scripting language"
   homepage "https://www.ruby-lang.org/"
-  url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2"
-  sha256 "ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2"
+    sha256 "ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c"
+
+    # https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
+    patch :p0 do
+      url "https://bugs.ruby-lang.org/attachments/download/6692/rubygems-2612-ruby24.patch"
+      sha256 "2512420ec6aad586c6fbe80dfc32e7ec571a0168c90e451ad022b443202ab4a9"
+    end
+
+    patch :p0 do
+      url "https://bugs.ruby-lang.org/attachments/download/6693/rubygems-2613-ruby24.patch"
+      sha256 "6677689d991e07adf26355e4045a3bd9eaeca07694928644c282bd05ec13060d"
+    end
+  end
 
   bottle do
     sha256 "f581f686392b4ca25a08eb674a9ef92ef7ce54b66c7fc63f5e7ed98cc5bb1b9f" => :sierra

--- a/Formula/ruby@2.2.rb
+++ b/Formula/ruby@2.2.rb
@@ -3,6 +3,7 @@ class RubyAT22 < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2"
   sha256 "80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b"
+  revision 1
 
   bottle do
     sha256 "16992fc572462b4377210411cecc78970f49ede5dc57f53441b7ca3dd0919434" => :sierra
@@ -24,6 +25,12 @@ class RubyAT22 < Formula
   depends_on "libyaml"
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
+
+  # https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
+  patch :p0 do
+    url "https://bugs.ruby-lang.org/attachments/download/6690/rubygems-2613-ruby22.patch"
+    sha256 "d0a8c5552ac44d8bc985befaf12288263fa248516b41bede9beb65b48334e6e3"
+  end
 
   def install
     args = %W[

--- a/Formula/ruby@2.3.rb
+++ b/Formula/ruby@2.3.rb
@@ -4,6 +4,7 @@ class RubyAT23 < Formula
 
   url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.xz"
   sha256 "341cd9032e9fd17c452ed8562a8d43f7e45bfe05e411d0d7d627751dd82c578c"
+  revision 1
 
   # Reverts an upstream commit which incorrectly tries to install headers
   # into SDKROOT, if defined
@@ -35,6 +36,12 @@ class RubyAT23 < Formula
   depends_on "libyaml"
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
+
+  # https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
+  patch :p0 do
+    url "https://bugs.ruby-lang.org/attachments/download/6691/rubygems-2613-ruby23.patch"
+    sha256 "510567a43d57ea9c8c7436b14e78d0a4d33380f410443dcf350b9867c9745748"
+  end
 
   def install
     # otherwise `gem` command breaks


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/.

Not really sure what to do with the older Ruby versions; we could try to update the `gem` version shipped with them, we could print a caveat telling people to run `gem update --system`, or we could accept they've been EOL for a while & people should know they are wide open to security problems by using those versions of Ruby.