### PR TITLE
zabbix: depend on openssl

### DIFF
--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -3,6 +3,7 @@ class Zabbix < Formula
   homepage "https://www.zabbix.com/"
   url "https://downloads.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/3.4.1/zabbix-3.4.1.tar.gz"
   sha256 "faaf1a1569ec6b4674d80e707904197c8b568f2b4660f636c28d0c42af471fd4"
+  revision 1
 
   bottle do
     sha256 "1578784f012abb39a5a3ca6fd9ba20b787f7e84f4b1911f9d7aacb033b041e71" => :sierra

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -17,8 +17,8 @@ class Zabbix < Formula
 
   deprecated_option "agent-only" => "without-server-proxy"
 
-  depends_on "pcre"
   depends_on "openssl"
+  depends_on "pcre"
 
   if build.with? "server-proxy"
     depends_on :mysql => :optional

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -17,6 +17,7 @@ class Zabbix < Formula
   deprecated_option "agent-only" => "without-server-proxy"
 
   depends_on "pcre"
+  depends_on "openssl"
 
   if build.with? "server-proxy"
     depends_on :mysql => :optional
@@ -39,6 +40,7 @@ class Zabbix < Formula
       --enable-agent
       --with-iconv=#{MacOS.sdk_path}/usr
       --with-libpcre=#{Formula["pcre"].opt_prefix}
+      --with-openssl=#{Formula["openssl"].opt_prefix}
     ]
 
     if build.with? "server-proxy"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In order to use encryption between the zabbix-agent's and the zabbix server we need to compile the zabbix with OpenSSL (or gnutls or mbedtls). See [Zabbix Documentation: Encryption](https://www.zabbix.com/documentation/3.4/manual/encryption) for more information.