### PR TITLE
jsoncpp: fix build failure when ccache is present

### DIFF
--- a/Formula/jsoncpp.rb
+++ b/Formula/jsoncpp.rb
@@ -24,7 +24,8 @@ class Jsoncpp < Formula
                          "-DBUILD_SHARED_LIBS=ON",
                          "-DJSONCPP_WITH_CMAKE_PACKAGE=ON",
                          "-DJSONCPP_WITH_TESTS=OFF",
-                         "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF"
+                         "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF",
+                         "-DCCACHE_FOUND=CCACHE_FOUND-NOTFOUND"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@fxcoudert please confirm this fixes the bug.

Fixes https://github.com/Homebrew/homebrew-core/issues/17589.