### PR TITLE
faas-cli: fix build ldflags, cli syntax and bump to 0.4.11

### DIFF
--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -2,8 +2,8 @@ class FaasCli < Formula
   desc "CLI for templating and/or deploying FaaS functions"
   homepage "http://docs.get-faas.com/"
   url "https://github.com/alexellis/faas-cli.git",
-      :tag => "0.4.10",
-      :revision => "26cfe469caa297394ffab9cc55c6ffe5d1f135b2"
+      :tag => "0.4.11",
+      :revision => "e0131833325dc900f9f375a240ddb708e657503a"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,7 +21,7 @@ class FaasCli < Formula
     (buildpath/"src/github.com/alexellis/faas-cli").install buildpath.children
     cd "src/github.com/alexellis/faas-cli" do
       commit = Utils.popen_read("git rev-list -1 HEAD").chomp
-      system "go", "build", "-ldflags", "-X main.GitCommit=#{commit}", "-a",
+      system "go", "build", "-ldflags", "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=#{commit}", "-a",
              "-installsuffix", "cgo", "-o", bin/"faas-cli"
       prefix.install_metafiles
     end
@@ -67,8 +67,12 @@ class FaasCli < Formula
     EOS
 
     begin
-      output = shell_output("#{bin}/faas-cli -action deploy -yaml test.yml")
+      output = shell_output("#{bin}/faas-cli deploy -yaml test.yml")
       assert_equal expected, output.chomp
+
+      commit = Utils.popen_read("git rev-list -1 HEAD").chomp
+      output = shell_output("#{bin}/faas-cli version")
+      assert_match commit, output.chomp
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)


### PR DESCRIPTION
This commit fixes the build args to set the `GitCommt` var at build time after it moved from the `main` to `commands` package.

It also updates the  `deploy` test to the new Cobra based syntax and adds a new test that checks that the version has been set correctly.

Also bumps the release to `0.4.11`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
