### PR TITLE
mpw 2.6-cli-1 (update)

### DIFF
--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -3,9 +3,9 @@ class Mpw < Formula
   homepage "https://ssl.masterpasswordapp.com/"
 
   stable do
-    url "https://ssl.masterpasswordapp.com/mpw-2.6-cli-1-0-g895df637.tar.gz"
-    sha256 "1b7992dcab2538cfd403ccb8645d69ae419dfedbb03b38515508af3e814c8164"
-    version "2.6-cli-1"
+    url "https://ssl.masterpasswordapp.com/mpw-2.6-cli-2-0-g30fdb54e.tar.gz"
+    sha256 "c206e512d193a154814a7c5d1faa8dc89e3fa0817b059bd6d957a61dc8ee1e68"
+    version "2.6-cli-2"
   end
 
   bottle do
@@ -23,12 +23,10 @@ class Mpw < Formula
 
   option "without-json-c", "Disable JSON configuration support."
   option "without-ncurses", "Disable colorized identicon support."
-  option "without-libxml2", "Disable test-case parsing support."
 
   depends_on "libsodium"
   depends_on "json-c" => :recommended
   depends_on "ncurses" => :recommended
-  depends_on "libxml2" => :build
 
   def install
     cd "platform-independent/cli-c" if build.head?
@@ -44,31 +42,22 @@ class Mpw < Formula
     else
       ENV["mpw_color"] = "0"
     end
-    if build.with? "libxml2"
-      ENV["mpw_xml"] = "1"
-    else
-      ENV["mpw_xml"] = "0"
-    end
 
     # Targets
-    if build.with? "libxml2"
-      ENV["targets"] = "mpw mpw-tests"
-    else
-      ENV["targets"] = "mpw"
-    end
+    ENV["targets"] = "mpw"
 
     # Build
     system "./build"
 
     # Test
-    system "./mpw-tests" if build.with? "libxml2"
+    system "./mpw-cli-tests"
 
     # Install
     bin.install "mpw"
   end
 
   test do
-    # The URL's package provides a test script for the mpw binary but I'm not sure how to run it from the `test` block.
-    # system "./mpw-cli-tests"
+    assert_equal "Jejr5[RepuSosp",
+      shell_output("#{bin}/mpw -q -Fnone -u 'Robert Lee Mitchell' -M 'banana colored duckling' -tlong -c1 -a3 'masterpasswordapp.com'").strip
   end
 end

--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -1,12 +1,10 @@
 class Mpw < Formula
   desc "Stateless/deterministic password and identity manager"
   homepage "https://ssl.masterpasswordapp.com/"
-
-  stable do
-    url "https://ssl.masterpasswordapp.com/mpw-2.6-cli-2-0-g30fdb54e.tar.gz"
-    sha256 "c206e512d193a154814a7c5d1faa8dc89e3fa0817b059bd6d957a61dc8ee1e68"
-    version "2.6-cli-2"
-  end
+  url "https://ssl.masterpasswordapp.com/mpw-2.6-cli-2-0-g30fdb54e.tar.gz"
+  version "2.6-cli-2"
+  sha256 "c206e512d193a154814a7c5d1faa8dc89e3fa0817b059bd6d957a61dc8ee1e68"
+  head "https://github.com/Lyndir/MasterPassword.git"
 
   bottle do
     cellar :any
@@ -17,12 +15,8 @@ class Mpw < Formula
     sha256 "290586cc77c94562e08977227209e16b9b821cb84e068bcf748b2e0ce07bdb0f" => :mavericks
   end
 
-  head do
-    url "https://github.com/Lyndir/MasterPassword.git"
-  end
-
-  option "without-json-c", "Disable JSON configuration support."
-  option "without-ncurses", "Disable colorized identicon support."
+  option "without-json-c", "Disable JSON configuration support"
+  option "without-ncurses", "Disable colorized identicon support"
 
   depends_on "libsodium"
   depends_on "json-c" => :recommended
@@ -31,28 +25,12 @@ class Mpw < Formula
   def install
     cd "platform-independent/cli-c" if build.head?
 
-    # Features
-    if build.with? "json-c"
-      ENV["mpw_json"] = "1"
-    else
-      ENV["mpw_json"] = "0"
-    end
-    if build.with? "ncurses"
-      ENV["mpw_color"] = "1"
-    else
-      ENV["mpw_color"] = "0"
-    end
-
-    # Targets
     ENV["targets"] = "mpw"
+    ENV["mpw_json"] = build.with?("json-c") ? "1" : "0"
+    ENV["mpw_color"] = build.with?("ncurses") ? "1" : "0"
 
-    # Build
     system "./build"
-
-    # Test
     system "./mpw-cli-tests"
-
-    # Install
     bin.install "mpw"
   end
 


### PR DESCRIPTION
Also adds support for --HEAD and mpw's new toggleable feature support
for JSON configuration, XML test cases and colorized output using curses

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
