### PR TITLE
agda: use cabal.config from stackage lts 9.1

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -48,7 +48,18 @@ class Agda < Formula
 
   depends_on :emacs => ["23.4", :recommended]
 
+  # Upstream issue from 4 Sep 2017 "Agda fails to build with happy 1.19.6"
+  # See https://github.com/agda/agda/issues/2731
+  resource "cabal-config" do
+    url "https://www.stackage.org/lts-9.1/cabal.config"
+    version "lts-9.1"
+    sha256 "615e2a56ffd64d169fcc59f02a068d579bf5bdd83b13fd6746e20b8fdc79a738"
+  end
+
   def install
+    buildpath.install resource("cabal-config")
+    inreplace "cabal.config", "             Agda ==2.5.2,\n", ""
+
     # install Agda core
     install_cabal_package :using => ["alex", "happy", "cpphs"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

to prevent a segault and to constrain happy to < 1.19.6.

See https://github.com/agda/agda/issues/2731.

CC @Blaisorblade