### PR TITLE
poppler: update font data to 0.4.8

### DIFF
--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -3,6 +3,7 @@ class Poppler < Formula
   homepage "https://poppler.freedesktop.org/"
   url "https://poppler.freedesktop.org/poppler-0.59.0.tar.xz"
   sha256 "a3d626b24cd14efa9864e12584b22c9c32f51c46417d7c10ca17651f297c9641"
+  revision 1
 
   bottle do
     sha256 "2d1ba2604102e94d36c2cd3d9f86de5c8d0e44955cacb49b4c8606ca96a765d2" => :sierra
@@ -35,8 +36,8 @@ class Poppler < Formula
     :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"
 
   resource "font-data" do
-    url "https://poppler.freedesktop.org/poppler-data-0.4.7.tar.gz"
-    sha256 "e752b0d88a7aba54574152143e7bf76436a7ef51977c55d6bd9a48dccde3a7de"
+    url "https://poppler.freedesktop.org/poppler-data-0.4.8.tar.gz"
+    sha256 "1096a18161f263cccdc6d8a2eb5548c41ff8fcf9a3609243f1b6296abdf72872"
   end
 
   needs :cxx11 if build.with?("qt") || MacOS.version < :mavericks
@@ -44,8 +45,8 @@ class Poppler < Formula
   # Fix clang build failure due to missing user-provided default constructor
   # Reported 4 Sep 2017 https://bugs.freedesktop.org/show_bug.cgi?id=102538
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/3b766b9/poppler/clang.diff"
-    sha256 "5c380a6f769758866eaa61bced5768165959aca457431eb02eeffe2c685dee87"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/656cc7f/poppler/clang.diff"
+    sha256 "b95c454b78c83fc2a7cec276d4014c78aa4de48d247652eb3de3876f78875605"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

and now that our fix for building with clang was merged upstream,
switch over to the upstream commit.