### PR TITLE
blockhash: use GitHub for homepage

### DIFF
--- a/Formula/blockhash.rb
+++ b/Formula/blockhash.rb
@@ -1,6 +1,6 @@
 class Blockhash < Formula
   desc "Perceptual image hash calculation tool"
-  homepage "http://blockhash.io/"
+  homepage "https://github.com/commonsmachinery/blockhash"
   url "https://github.com/commonsmachinery/blockhash/archive/0.2.1.tar.gz"
   sha256 "549e0f52e7a7545bae7eca801c64c79b95cbe9417975718e262fddaf78b00cca"
   revision 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The blockhash.io domain doesn't resolve.

Reported https://github.com/commonsmachinery/blockhash/issues/22.