### PR TITLE
zookeeper: fix unsafe default log configuration

### DIFF
--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -46,7 +46,7 @@ class Zookeeper < Formula
   def default_log4j_properties
     <<-EOS.undent
       log4j.rootCategory=WARN, zklog
-      log4j.appender.zklog = org.apache.log4j.FileAppender
+      log4j.appender.zklog = org.apache.log4j.RollingFileAppender
       log4j.appender.zklog.File = #{var}/log/zookeeper/zookeeper.log
       log4j.appender.zklog.Append = true
       log4j.appender.zklog.layout = org.apache.log4j.PatternLayout


### PR DESCRIPTION
Change default Zookeeper configuration (log4j) class from [`FileApender`](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/FileAppender.html) to [`RollingFileApender`](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/RollingFileAppender.html).

`FileApender` does not limit the size of the logfile and can potentially grow filling all available space. `RollingFileApender` will limit it to 10MB which is a safer default.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

cc @sparrovv