### PR TITLE
povray: fix implicit boost build path

### DIFF
--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -39,11 +39,12 @@ class Povray < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --mandir=#{man}
+      --with-boost=#{Formula["boost"].opt_prefix}
       --without-libsdl
       --without-x
     ]
 
-    args << "--with-openexr=#{HOMEBREW_PREFIX}" if build.with? "openexr"
+    args << "--with-openexr=#{Formula["openexr"].opt_prefix}" if build.with? "openexr"
 
     # Adjust some scripts to search for `etc` in HOMEBREW_PREFIX.
     %w[allanim allscene portfolio].each do |script|


### PR DESCRIPTION
Pass an explicit location for boost (same as already done for openexr); the build was not finding it with Homebrew living under `/opt/brew`.

- [x] Have you followed the guidelines for contributing?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with brew install --build-from-source <formula>, where <formula> is the name of the formula you're submitting?
- [x] Does your build pass brew audit --strict <formula> (after doing brew install <formula>)?

_(copy-pasted the checklist because opening the PR with `hub pull-request` doesn't seem to use the template…)_