### PR TITLE
profanity: build with Python plugin support

### DIFF
--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -19,8 +19,6 @@ class Profanity < Formula
     depends_on "libtool" => :build
   end
 
-  option "without-python", "Build without Python plugin support"
-
   depends_on "pkg-config" => :build
   depends_on "ossp-uuid"
   depends_on "libstrophe"
@@ -30,19 +28,13 @@ class Profanity < Formula
   depends_on "gnutls"
   depends_on "libotr" => :recommended
   depends_on "gpgme" => :recommended
-  depends_on :python => :recommended
   depends_on "terminal-notifier" => :optional
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --prefix=#{prefix}
-    ]
-    args << "--disable-python-plugins" if build.without? :python
-
     system "./bootstrap.sh" if build.head?
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -19,6 +19,8 @@ class Profanity < Formula
     depends_on "libtool" => :build
   end
 
+  option "without-python", "Build without Python plugin support"
+
   depends_on "pkg-config" => :build
   depends_on "ossp-uuid"
   depends_on "libstrophe"
@@ -28,14 +30,19 @@ class Profanity < Formula
   depends_on "gnutls"
   depends_on "libotr" => :recommended
   depends_on "gpgme" => :recommended
+  depends_on :python => :recommended
   depends_on "terminal-notifier" => :optional
 
   def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
+    args << "--disable-python-plugins" if build.without? :python
+
     system "./bootstrap.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--disable-python-plugins",
-                          "--prefix=#{prefix}"
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There's really no good reason to build Profanity *without* support for Python plugins? #12861 also tried to add this support to the formula but had various minor issues, which I believe this pull request has addressed.