### PR TITLE
sdl2 - add universal build option for i386 arch support

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -20,6 +20,7 @@ class Sdl2 < Formula
     depends_on "libtool" => :build
   end
 
+  option :universal
   option "with-test", "Compile and install the tests"
 
   # https://github.com/mistydemeo/tigerbrew/issues/361
@@ -31,6 +32,8 @@ class Sdl2 < Formula
   end
 
   def install
+    ENV.universal_binary if build.universal?
+
     # we have to do this because most build scripts assume that all sdl modules
     # are installed to the same prefix. Consequently SDL stuff cannot be
     # keg-only but I doubt that will be needed.


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula does not pass the audit. I had to do this locally in order to get MonoGame + SDL2 working - MonoGame is still 32-bit as I understand it, and so even though OS X is 64-bit, it seems critical to me to support 32-bit builds of the libs. Let me know what you think.