### PR TITLE
r: add cairo support

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -21,6 +21,7 @@ class R < Formula
   depends_on :fortran
   depends_on "openblas" => :optional
   depends_on :java => :optional
+  depends_on "cairo" => build.with?("x11") ? ["with-x11"] : []
 
   # needed to preserve executable permissions on files without shebangs
   skip_clean "lib/R/bin"
@@ -38,10 +39,13 @@ class R < Formula
       ENV["ac_cv_have_decl_clock_gettime"] = "no"
     end
 
+    # Fix cairo detection with Quartz-only cairo
+    inreplace ["configure", "m4/cairo.m4"], "cairo-xlib.h", "cairo.h"
+
     args = [
       "--prefix=#{prefix}",
       "--enable-memory-profiling",
-      "--without-cairo",
+      "--with-cairo",
       "--without-x",
       "--with-aqua",
       "--with-lapack",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For some reason in process of migration from `hombrew-science` ([this commit](https://github.com/Homebrew/homebrew-science/commit/9cfc5716887fb07c1bcdf887b5ecceb2d60a5f95)), `--with-cairo` was replaced with `--without-cairo`. That breaks built-in `cairo_pdf` and `cairo_ps` functions because of missing library. Can we have it back?