### PR TITLE
yarn 1.0.1

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -1,13 +1,13 @@
 class Yarn < Formula
   desc "JavaScript package manager"
   homepage "https://yarnpkg.com/"
-  url "https://yarnpkg.com/downloads/0.27.5/yarn-v0.27.5.tar.gz"
-  sha256 "f0f3510246ee74eb660ea06930dcded7b684eac2593aa979a7add84b72517968"
+  url "https://yarnpkg.com/downloads/1.0.1/yarn-v1.0.1.tar.gz"
+  sha256 "6b00b5e0a7074a512d39d2d91ba6262dde911d452617939ca4be4a700dd77cf1"
   revision 1
 
   devel do
-    url "https://yarnpkg.com/downloads/1.0.0/yarn-v1.0.0.tar.gz"
-    sha256 "0f3d47e35f391507edda1c87a3014b86c2eb32aaec00d0a4b1e7413bec63787d"
+    url "https://yarnpkg.com/downloads/1.0.1/yarn-v1.0.1.tar.gz"
+    sha256 "6b00b5e0a7074a512d39d2d91ba6262dde911d452617939ca4be4a700dd77cf1"
   end
 
   bottle :unneeded

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,12 +3,6 @@ class Yarn < Formula
   homepage "https://yarnpkg.com/"
   url "https://yarnpkg.com/downloads/1.0.1/yarn-v1.0.1.tar.gz"
   sha256 "6b00b5e0a7074a512d39d2d91ba6262dde911d452617939ca4be4a700dd77cf1"
-  revision 1
-
-  devel do
-    url "https://yarnpkg.com/downloads/1.0.1/yarn-v1.0.1.tar.gz"
-    sha256 "6b00b5e0a7074a512d39d2d91ba6262dde911d452617939ca4be4a700dd77cf1"
-  end
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We just bumped the 1.0.1 release to stable, here's the PR! The strict audit fails with the following message:

```
yarn:
  * stable and devel versions are identical
  * 'revision 1' should be removed
```

Should I just remove the `devel` codepath?