### PR TITLE
Sdfcli 17.2.0

### DIFF
--- a/Formula/sdfcli.rb
+++ b/Formula/sdfcli.rb
@@ -6,7 +6,7 @@ class Sdfcli < Formula
   desc "NetSuite SDF CLI Tool"
   homepage "https://system.netsuite.com/app/help/helpcenter.nl?fid=chapter_4779302061.html"
   url "https://github.com/limebox/sdf/raw/master/Files/brew/sdfcli-17.2.0.tar.gz"
-  sha256 "ceff6c2d3a4da0fc3a10dcea9721f81df1f83708ea879a6a293d608c6e1c5ed5"
+  sha256 "984155c6ed680c581aa85f0e32e43bc7894db5182b3a372267780b5402f441f3"
 
   depends_on "maven" => "3.5+"
 

--- a/Formula/sdfcli.rb
+++ b/Formula/sdfcli.rb
@@ -1,0 +1,23 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook.html
+#                http://www.rubydoc.info/github/Homebrew/brew/master/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+
+class Sdfcli < Formula
+  desc "NetSuite SDF CLI Tool"
+  homepage "https://system.netsuite.com/app/help/helpcenter.nl?fid=chapter_4779302061.html"
+  url "https://github.com/limebox/sdf/raw/master/Files/brew/sdfcli-17.2.0.tar.gz"
+  sha256 "ceff6c2d3a4da0fc3a10dcea9721f81df1f83708ea879a6a293d608c6e1c5ed5"
+
+  depends_on "maven" => "3.5+"
+
+  def install
+
+    bin.install "sdfcli", "sdfcli-createproject"
+    libexec.install "pom.xml", "com.netsuite.ide.core_2017.2.0.jar"
+
+  end
+
+  test do
+    system "#{bin}/sdfcli"
+  end
+end

--- a/Formula/sdfcli.rb
+++ b/Formula/sdfcli.rb
@@ -1,20 +1,14 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook.html
-#                http://www.rubydoc.info/github/Homebrew/brew/master/Formula
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
-
 class Sdfcli < Formula
   desc "NetSuite SDF CLI Tool"
   homepage "https://system.netsuite.com/app/help/helpcenter.nl?fid=chapter_4779302061.html"
   url "https://github.com/limebox/sdf/raw/master/Files/brew/sdfcli-17.2.0.tar.gz"
   sha256 "984155c6ed680c581aa85f0e32e43bc7894db5182b3a372267780b5402f441f3"
 
-  depends_on "maven" => "3.5+"
+  depends_on "maven" => :build
 
   def install
-
     bin.install "sdfcli", "sdfcli-createproject"
     libexec.install "pom.xml", "com.netsuite.ide.core_2017.2.0.jar"
-
   end
 
   test do


### PR DESCRIPTION
SDFCLI is an application distributed by Oracle-NetSuite. Unfortunately
the installation instructions are locked behind an account access help
center. The product itself is open-source, but worthless without a
NetSuite account. This will let people easily install the tool without
going through the fairly complicated installation instructions.

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
