### PR TITLE
qt@5.5: patch for Xcode 9

### DIFF
--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -84,6 +84,14 @@ class QtAT55 < Formula
     end
   end
 
+  # Fix Xcode 9 build errors
+  if DevelopmentTools.clang_build_version >= 900
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/6152bded7d/qt%405.5/xcode9.patch"
+      sha256 "757f377f3fcf753ef6d5b543e6291928d07591c3e3ee8a536a88433aa49d4fbb"
+    end
+  end
+
   def install
     args = %W[
       -prefix #{prefix}


### PR DESCRIPTION
See #14418

Final patch to get qt@5.5 to build on macOS 10.13 with Xcode 9. After fixing the issues related to 10.13 SDK, now we fix errors arising from Xcode 9's clang++ compiler being super strict. I can't really report these issues to upstream Qt because 5.5 is old and unmaintained. Yet we need to fix this mess for formulas that depend on it.