### PR TITLE
tcl-tk 8.7a1 (devel)

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -1,10 +1,20 @@
 class TclTk < Formula
   desc "Tool Command Language"
   homepage "https://www.tcl.tk/"
-  url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tcl8.6.7-src.tar.gz"
-  mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7-src.tar.gz"
-  version "8.6.7"
-  sha256 "7c6b8f84e37332423cfe5bae503440d88450da8cc1243496249faa5268026ba5"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tcl8.6.7-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.7-src.tar.gz"
+    version "8.6.7"
+    sha256 "7c6b8f84e37332423cfe5bae503440d88450da8cc1243496249faa5268026ba5"
+
+    resource "tk" do
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tk8.6.7-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk8.6.7-src.tar.gz"
+      version "8.6.7"
+      sha256 "061de2a354f9b7c7d04de3984c90c9bc6dd3a1b8377bb45509f1ad8a8d6337aa"
+    end
+  end
 
   bottle do
     sha256 "0a21606596e11bc27ae105548906cc161e0e8bd1ccd0546c1df0441ae2ab1a43" => :sierra
@@ -12,18 +22,24 @@ class TclTk < Formula
     sha256 "4a3b7d78452c33e84d8c55eaf71bb758e25f0aa9e16112cdd6646ba458304baf" => :yosemite
   end
 
+  devel do
+    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.7a1/tcl8.7a1-src.tar.gz"
+    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_7/tk8.7a1-src.tar.gz"
+    version "8.7a1"
+    sha256 "2bbd4e0bbdebeaf5dc6cc823d0805afb45c764292f6667d9ce2b9fcf5399e0dc"
+
+    resource "tk" do
+      url "https://downloads.sourceforge.net/project/tcl/Tcl/8.7a1/tk8.7a1-src.tar.gz"
+      mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_7/tk8.7a1-src.tar.gz"
+      sha256 "131e4bae43a15dff0324c0479358bb42cfd7b8de0e1ca8d93c9207643c7144dd"
+    end
+  end
+
   keg_only :provided_by_osx,
     "tk installs some X11 headers and macOS provides an (older) Tcl/Tk"
 
   option "without-tcllib", "Don't build tcllib (utility modules)"
   option "without-tk", "Don't build the Tk (window toolkit)"
-
-  resource "tk" do
-    url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.7/tk8.6.7-src.tar.gz"
-    mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk8.6.7-src.tar.gz"
-    version "8.6.7"
-    sha256 "061de2a354f9b7c7d04de3984c90c9bc6dd3a1b8377bb45509f1ad8a8d6337aa"
-  end
 
   resource "tcllib" do
     url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.18/tcllib-1.18.tar.gz"
@@ -43,7 +59,7 @@ class TclTk < Formula
       system "make"
       system "make", "install"
       system "make", "install-private-headers"
-      ln_s bin/"tclsh8.6", bin/"tclsh"
+      ln_s bin/"tclsh#{version.to_f}", bin/"tclsh"
     end
 
     if build.with? "tk"
@@ -56,7 +72,7 @@ class TclTk < Formula
           system "make"
           system "make", "install"
           system "make", "install-private-headers"
-          ln_s bin/"wish8.6", bin/"wish"
+          ln_s bin/"wish#{version.to_f}", bin/"wish"
         end
       end
     end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `devel` version back to Tcl/Tk, since 8.7a1 is out.

There's a gotcha in the installation process. The formula does a `ln_s bin/"tclsh8.6", bin/"tclsh"` to get a non-versioned `tclsh` command. But with this version bump, the major/minor suffix changes to `8.7`, so the `stable` and `devel` versions need to link different files. I got it working with a class variable, like `@@major_minor_version = "8.6"`, but that technique is a no-no (and `brew audit --strict` complains about it accordingly). Any suggestions on how to do this correctly?

Also, the test fails locally for me, with what looks like an internal error in the `minitest` framework. Any ideas what might be causing this? This is on Sierra 10.12.6.

```
$ brew test tcl-tk
Testing tcl-tk
==> /usr/local/Cellar/tcl-tk/8.7a1/bin/tclsh
Error: tcl-tk: failed
undefined method `assertions' for #<Formulary::FormulaNamespace16be1d04c46876002c7043a69f8e93c9::TclTk:0x007fddc791b070>
/Library/Ruby/Gems/2.0.0/gems/minitest-5.9.0/lib/minitest/assertions.rb:135:in `assert'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/test/unit/assertions.rb:38:in `assert'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/test/unit/assertions.rb:187:in `assert_equal'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/tcl-tk.rb:92:in `block in <class:TclTk>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1641:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:834:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1640:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:14:in `block in mktemp'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `block in run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:13:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1634:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:28:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:27:in `<main>'
```

I get the same error when doing `brew test tcl-tk` with the stable version installed, so I don't think it was introduced by this change.