### PR TITLE
grafana: fix build with yarn 1.0

### DIFF
--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -23,7 +23,8 @@ class Grafana < Formula
 
     cd grafana_path do
       system "go", "run", "build.go", "build"
-      system "yarn", "install"
+
+      system "yarn", "install", "--ignore-engines"
 
       args = ["build"]
       # Avoid PhantomJS error "unrecognized selector sent to instance"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upgrade to yarn 1.0 has broken the ability to build `grafana` against latest `node` from source, because yarn 1.0 has enabled/fixed strict top level engine checks.

```
[1/5] Validating package.json...
error grafana@4.4.3: The engine "node" is incompatible with this module. Expected version "4.x".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Refs: https://github.com/Homebrew/brew/pull/2962

The PR adds a workaround which restores the ability to build `grafana` against the latest `node` version ~~(and fixes the warning about not being able to find `node-gyp`)~~.