### PR TITLE
duplicity: bring back typing dependency

### DIFF
--- a/Formula/duplicity.rb
+++ b/Formula/duplicity.rb
@@ -5,6 +5,7 @@ class Duplicity < Formula
   homepage "http://www.nongnu.org/duplicity/"
   url "https://code.launchpad.net/duplicity/0.7-series/0.7.14/+download/duplicity-0.7.14.tar.gz"
   sha256 "7a3eb74a2a36b004b10add2970b37cfbac0bd693d79513e6311c8e4b8c3dd73e"
+  revision 1
 
   bottle do
     cellar :any
@@ -22,7 +23,7 @@ class Duplicity < Formula
   # Generated with homebrew-pypi-poet from
   # for i in azure-storage boto dropbox fasteners kerberos mega.py
   # paramiko pexpect pycrypto pycryptopp python-swiftclient python-keystoneclient
-  # requests requests-oauthlib; do poet -r $i >> resources; done
+  # requests requests-oauthlib typing; do poet -r $i >> resources; done
   # Additional dependencies of requests[security] should also be installed:
   #   ndg-httpsclient, pyOpenSSL
   # pyrax was dropped because it has pinned dependencies & is deprecated.

--- a/Formula/duplicity.rb
+++ b/Formula/duplicity.rb
@@ -299,6 +299,11 @@ class Duplicity < Formula
     sha256 "c8a373b90487b7a1b52ebaa3ca5059315bf68d9ebe15b2203c2fa675bd7e1e7e"
   end
 
+  resource "typing" do
+    url "https://files.pythonhosted.org/packages/ca/38/16ba8d542e609997fdcd0214628421c971f8c395084085354b11ff4ac9c3/typing-3.6.2.tar.gz"
+    sha256 "d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849"
+  end
+
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz"
     sha256 "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"


### PR DESCRIPTION
The `typing` python package was removed from the list of dependencies on
https://github.com/Homebrew/homebrew-core/commit/b2d8b6c9c0b8f3359eded9517abe7f2a61ad5ac2,
however the removal of this package breaks at least the Dropbox backend
support (didn't test others).

This is the error you get if trying to sync with a Dropbox backend:

```
UnsupportedBackendScheme: scheme not supported in url: dpbx:///<directory>
```

Executing `duplicity` with `--verbosity 9` reveals the following
information:

```
Import of duplicity.backends.dpbxbackend Failed: No module named typing
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
