### PR TITLE
kubectx: mark kubernetes-cli dependency as recommended

### DIFF
--- a/Formula/kubectx.rb
+++ b/Formula/kubectx.rb
@@ -9,7 +9,7 @@ class Kubectx < Formula
 
   option "with-short-names", "link as \"kctx\" and \"kns\" instead"
 
-  depends_on "kubernetes-cli" => :run
+  depends_on "kubernetes-cli" => [:run, :recommended]
 
   def install
     bin.install "kubectx" => build.with?("short-names") ? "kctx" : "kubectx"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Some users will have kubectl installed via [gcloud][], in which case installing a second installation of kubectl via the homebrew is redundant.

By marking the dependency as recommended, this should allow for installing kubectx with a `--without-kubernetes-cli` option.

[gcloud]: https://cloud.google.com/sdk/
