### PR TITLE
sbt use github release link directly

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,8 +1,8 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "http://www.scala-sbt.org"
-  url "https://cocl.us/sbt-1.0.1.tgz"
-  sha256 "5b68996a890b4a91efd9d13b9aca5e2b09f78c254c2907b3d548a9a7a73b0e5a"
+  url "https://github.com/sbt/sbt/archive/v1.0.1.zip"
+  sha256 "48c03adba7827f1990866baec88f21a438ca5c584624f95f1befb77d7a31588f"
 
   bottle :unneeded
 


### PR DESCRIPTION
https://62a44.https.cdn.softlayer.net/sbt/1.0.1/sbt-1.0.1.tgz redirected by https://cocl.us/sbt-1.0.1.tgz can not be accessed in my location (Beijing, China).

curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to 62a44.https.cdn.softlayer.net:443

It seems better to use github release download url directly.