### PR TITLE
purescript: fix build by constraining protolude to < 0.2

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -31,7 +31,11 @@ class Purescript < Formula
         system "cabal", "get", "purescript-#{version}"
         mv "purescript-#{version}/purescript.cabal", "."
       end
-      install_cabal_package "-f release", :using => ["alex", "happy"]
+
+      # Upstream issue "Build failure with protolude 0.2"
+      # Reported 11 Sep 2017 https://github.com/purescript/purescript/issues/3065
+      install_cabal_package "--constraint", "protolude < 0.2",
+                            "-f release", :using => ["alex", "happy"]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/purescript/purescript/issues/3065