### PR TITLE
emacs 25.3

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -1,9 +1,8 @@
 class Emacs < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://ftp.gnu.org/gnu/emacs/emacs-25.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-25.2.tar.xz"
-  sha256 "59b55194c9979987c5e9f1a1a4ab5406714e80ffcfd415cc6b9222413bc073fa"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-25.3.tar.xz"
+  sha256 "253ac5e7075e594549b83fd9ec116a9dc37294d415e2f21f8ee109829307c00b"
 
   bottle do
     sha256 "b759bd107cb9b227349cb82ddbc3924ffbe8767429db426b980247fd7958b3a5" => :sierra


### PR DESCRIPTION
From the mailing list:

> This is an emergency release to fix a security vulnerability in Emacs.
>
> Enriched Text mode has its support for decoding 'x-display'
> disabled.  This feature allows saving 'display' properties as part
> of text.  Emacs 'display' properties support evaluation of arbitrary
> Lisp forms as part of instantiating the property, so decoding
> 'x-display' is vulnerable to executing arbitrary malicious Lisp code
> included in the text (e.g., sent as part of an email message).
>
> This vulnerability was introduced in Emacs 19.29.  To work around
> that in Emacs versions before 25.3, append the following to your
> ~/.emacs init file:
>
>    (eval-after-load "enriched"
>       '(defun enriched-decode-display-prop (start end &optional param)
>          (list start end)))
>
> Gnus no longer supports "richtext" and "enriched" inline MIME
> objects.  This support was disabled to avoid evaluation of arbitrary
> Lisp code contained in email messages and news articles.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
