### PR TITLE
gdb: fix Add python3 linkage support

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -15,12 +15,16 @@ class Gdb < Formula
   deprecated_option "with-guile" => "with-guile@2.0"
 
   option "with-python", "Use the Homebrew version of Python; by default system Python is used"
+  option "with-python3", "Use the Homebrew version of Python 3 instead of 2.x"
   option "with-version-suffix", "Add a version suffix to program"
   option "with-all-targets", "Build with support for all targets"
 
   depends_on "pkg-config" => :build
   depends_on "python" => :optional
+  depends_on "python3" => :optional
   depends_on "guile@2.0" => :optional
+
+  patch :p1, :DATA if build.with? "python3"
 
   def install
     args = [
@@ -34,6 +38,8 @@ class Gdb < Formula
 
     if build.with? "python"
       args << "--with-python=#{HOMEBREW_PREFIX}"
+    elsif build.with? "python3"
+      args << "--with-python=#{HOMEBREW_PREFIX}/bin/python3"
     else
       args << "--with-python=/usr"
     end
@@ -67,3 +73,32 @@ class Gdb < Formula
     system bin/"gdb", bin/"gdb", "-configuration"
   end
 end
+__END__
+diff --git a/gdb/configure-origin b/gdb/configure
+--- a/gdb/configure-origin
++++ b/gdb/configure
+@@ -9858,21 +9858,21 @@ fi
+     # We have a python program to use, but it may be too old.
+     # Don't flag an error for --with-python=auto (the default).
+     have_python_config=yes
+-    python_includes=`${python_prog} ${srcdir}/python/python-config.py --includes`
++    python_includes=`${python_prog}-config --includes`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then
+         as_fn_error "failure running python-config --includes" "$LINENO" 5
+       fi
+     fi
+-    python_libs=`${python_prog} ${srcdir}/python/python-config.py --ldflags`
++    python_libs=`${python_prog}-config --ldflags`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then
+         as_fn_error "failure running python-config --ldflags" "$LINENO" 5
+       fi
+     fi
+-    python_prefix=`${python_prog} ${srcdir}/python/python-config.py --exec-prefix`
++    python_prefix=`${python_prog}-config --exec-prefix`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Description:
I've made a patch to configure process and make it possible to compile gdb against python3. When launched with python3, `gdb/python/python-config.py` in the source file generates some flags that clang may not recognize. I tried to patch it but with no luck. So instead I choose the `python3-config` that comes with python, it works.

The difference of their output:
```
$ python3 python/python-config.py --ldflags
-L/usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/config-3.6m-darwin -ldl -framework CoreFoundation -lpython3.6m -Wl,-stack_size,1000000 -framework CoreFoundation Python.framework/Versions/3.6/Python

$ python3-config --ldflags
-L/usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/config-3.6m-darwin -lpython3.6m -ldl -framework CoreFoundation
```
