### PR TITLE
pam_yubico-2.24

### DIFF
--- a/Formula/pam_yubico.rb
+++ b/Formula/pam_yubico.rb
@@ -1,8 +1,8 @@
 class PamYubico < Formula
   desc "Yubico pluggable authentication module"
   homepage "https://developers.yubico.com/yubico-pam/"
-  url "https://developers.yubico.com/yubico-pam/Releases/pam_yubico-2.23.tar.gz"
-  sha256 "bc7193ed10c8fb7a2878088af859a24a7e6a456e1728a914eb5ed47cdff0ecb8"
+  url "https://developers.yubico.com/yubico-pam/Releases/pam_yubico-2.24.tar.gz"
+  sha256 "0326ff676e2b32ed1dda7fb5f1358a22d629d71caad8f8db52138bbf3e95e82d"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The 2.24 release includes a new debug_file flag which redirects the output to the file instead of stdout

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
```
$> brew bump-formula-pr --strict pam_yubico --url=https://developers.yubico.com/yubico-pam/Releases/pam_yubico-2.24.tar.gz --sha256=0326ff676e2b32ed1dda7fb5f1358a22d629d71caad8f8db52138bbf3e95e82d
Already up-to-date.
==> replace "https://developers.yubico.com/yubico-pam/Releases/pam_yubico-2.23.tar.gz" with "https://developers.yubico.com/yubico-pam/Releases/pam_yubico-2.24.tar.gz"
==> replace "bc7193ed10c8fb7a2878088af859a24a7e6a456e1728a914eb5ed47cdff0ecb8" with "0326ff676e2b32ed1dda7fb5f1358a22d629d71caad8f8db52138bbf3e95e82d"
M	Formula/pam_yubico.rb
Switched to a new branch 'pam_yubico-2.24'
[pam_yubico-2.24 f6727214b3] pam_yubico 2.24
 1 file changed, 2 insertions(+), 2 deletions(-)
Error: cannot get remote from 'hub'!
```
in the end I modified changed the file on github and created the PR there.

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
basic version upgrade to get the debug_file feature