### PR TITLE
saltstack 2017.7.1: add dependency on libgit2/pygit2

### DIFF
--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -19,6 +19,7 @@ class Saltstack < Formula
   depends_on "zeromq"
   depends_on "libyaml"
   depends_on "openssl" # For M2Crypto
+  depends_on "libgit2"
 
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/90/61/f820ff0076a2599dd39406dcb858ecb239438c02ce706c8e91131ab9c7f1/Jinja2-2.9.6.tar.gz"
@@ -103,6 +104,11 @@ class Saltstack < Formula
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz"
     sha256 "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+  end
+
+  resource "pygit2" do
+    url "https://files.pythonhosted.org/packages/84/fa/867aec49165bd119b215d997e4d1211875e398d956b26888cd47070145a7/pygit2-0.26.0.tar.gz"
+    sha256 "a7f06d61f25ab644c39e0e9bd4846a6cc4af81ae27f889473e6f0e9511226cb1"
   end
 
   def install

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -5,6 +5,7 @@ class Saltstack < Formula
   homepage "http://www.saltstack.org"
   url "https://files.pythonhosted.org/packages/d2/cd/348817b5b4d0ee160f72744bad39c8b6898df62e3287a4923b8a2cc07716/salt-2017.7.1.tar.gz"
   sha256 "fe868415d0e1162157186f4c5263e9af902b0571870ad2da210e7edf5ff5331d"
+  revision 1
   head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
 
   bottle do

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -21,6 +21,9 @@ class Saltstack < Formula
   depends_on "openssl" # For M2Crypto
   depends_on "libgit2"
 
+  # Saltstack's Git filesystem backend depends on pygit2 which depends on libgit2
+  # pygit2 be the same verison as libgit2 - mismatched versions are incompatible
+
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/90/61/f820ff0076a2599dd39406dcb858ecb239438c02ce706c8e91131ab9c7f1/Jinja2-2.9.6.tar.gz"
     sha256 "ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff"

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -22,7 +22,7 @@ class Saltstack < Formula
   depends_on "openssl" # For M2Crypto
 
   # Saltstack's Git filesystem backend depends on pygit2 which depends on libgit2
-  # pygit2 be the same verison as libgit2 - mismatched versions are incompatible
+  # pygit2 must be the same version as libgit2 - mismatched versions are incompatible
 
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/90/61/f820ff0076a2599dd39406dcb858ecb239438c02ce706c8e91131ab9c7f1/Jinja2-2.9.6.tar.gz"

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -17,9 +17,9 @@ class Saltstack < Formula
   depends_on "swig" => :build
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "zeromq"
+  depends_on "libgit2"
   depends_on "libyaml"
   depends_on "openssl" # For M2Crypto
-  depends_on "libgit2"
 
   # Saltstack's Git filesystem backend depends on pygit2 which depends on libgit2
   # pygit2 be the same verison as libgit2 - mismatched versions are incompatible
@@ -79,6 +79,11 @@ class Saltstack < Formula
     sha256 "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
   end
 
+  resource "pygit2" do
+    url "https://files.pythonhosted.org/packages/84/fa/867aec49165bd119b215d997e4d1211875e398d956b26888cd47070145a7/pygit2-0.26.0.tar.gz"
+    sha256 "a7f06d61f25ab644c39e0e9bd4846a6cc4af81ae27f889473e6f0e9511226cb1"
+  end
+
   resource "pyzmq" do
     url "https://files.pythonhosted.org/packages/af/37/8e0bf3800823bc247c36715a52e924e8f8fd5d1432f04b44b8cd7a5d7e55/pyzmq-16.0.2.tar.gz"
     sha256 "0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d"
@@ -107,11 +112,6 @@ class Saltstack < Formula
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz"
     sha256 "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
-  end
-
-  resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/84/fa/867aec49165bd119b215d997e4d1211875e398d956b26888cd47070145a7/pygit2-0.26.0.tar.gz"
-    sha256 "a7f06d61f25ab644c39e0e9bd4846a6cc4af81ae27f889473e6f0e9511226cb1"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing forumla would build and test fine, but Salt's GitFS functionality would not work due to a missing `pygit2`/`libgit2` dependency. 

Note that `pygit2` will only work with the matching `libgit2` version - in this case, v0.26.0. This normally wouldn't be an issue if `pygit2` and `libgit2` were updated at the same time - Just update the `pygit2` dependency whenever `libgit2` is updated. However, `pygit2`'s development seems to lag behind `libgit2` quite a lot, and therefore the latest version of `pygit2` may not be compatible with the latest version of `libgit2`. 

Unfortunately, I don't know enough about dependency versioning in Homebrew to fix this, so this PR will probably require some amendment until it is ready to be merged. 

I do note that the actual [`gitfs.rb` formula][gitfs] depends on `pygit2`/`libgit2` the same way - I feel like the `gitfs.rb` formula will need to be amended if this PR is also amended. 

[gitfs]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/gitfs.rb