### PR TITLE
gnupg: fix dependency to pinentry-mac instead of pinentry

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -26,7 +26,7 @@ class Gnupg < Formula
   depends_on "libgcrypt"
   depends_on "libksba"
   depends_on "libassuan"
-  depends_on "pinentry"
+  depends_on "pinentry-mac"
   depends_on "gettext"
   depends_on "adns"
   depends_on "libusb" => :recommended


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
closes #18011