### PR TITLE
protobuf v3.4.0 sha update

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -2,7 +2,7 @@ class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/google/protobuf/"
   url "https://github.com/google/protobuf/archive/v3.4.0.tar.gz"
-  sha256 "cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f"
+  sha256 "f6600abeee3babfa18591961a0ff21e7db6a6d9ef82418a261ec4fee44ee6d44"
   head "https://github.com/google/protobuf.git"
 
   bottle do


### PR DESCRIPTION
protobuf sha changed https://github.com/google/protobuf/issues/3619#issuecomment-328687408 and the new one is : f6600abeee3babfa18591961a0ff21e7db6a6d9ef82418a261ec4fee44ee6d44

Error: SHA256 mismatch
Expected: cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f
Actual: f6600abeee3babfa18591961a0ff21e7db6a6d9ef82418a261ec4fee44ee6d44

Verified downloading the file from GitHub again.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.

-----