### PR TITLE
ssdeep 2.14

### DIFF
--- a/Formula/ssdeep.rb
+++ b/Formula/ssdeep.rb
@@ -1,17 +1,8 @@
 class Ssdeep < Formula
   desc "Recursive piecewise hashing tool"
-  homepage "https://ssdeep.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz"
-  sha256 "6e4ca94457cb50ff3343d4dd585473817a461a55a666da1c5a74667924f0f8c5"
-
-  bottle do
-    cellar :any
-    sha256 "fa344811991146d2d53fd6d66399e8f3bb05c53bf5baadb190e5ff0ddf91d9e5" => :sierra
-    sha256 "1cfc5e0f2bda54443383d58583d9d23279820201350cb5d97ba37b4e7b14a17a" => :el_capitan
-    sha256 "e01ebfb4bfb63ff3fa3f491c5b8bbf28055c70ccb1440ddacd4a2e31f84fe41d" => :yosemite
-    sha256 "fb7b2a4b78b97b348f5a385bc58fb2ccfb285677a04f4ac73caffd2e4bf34921" => :mavericks
-    sha256 "0077b7bb0348eb0b66e8cd575dd687e2dd82237beab1e2cd2f56ccb741614071" => :mountain_lion
-  end
+  homepage "https://ssdeep-project.github.io/ssdeep/"
+  url "https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14/ssdeep-2.14.tar.gz"
+  sha256 "3aad00b51adf8f0086b37198e50dc779d2313b7d9df09a96bce73c5376dcdd36"
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
@@ -21,7 +12,7 @@ class Ssdeep < Formula
   test do
     expected = <<-EOS.undent
       ssdeep,1.1--blocksize:hash:hash,filename
-      192:15Jsxlk/azhE79EEfpm0sfQ+CfQoDfpw3RtU:15JsPz+7OEBCYLYYB7,"#{include}/fuzzy.h"
+      192:1xJsxlk/aMhud9Eqfpm0sfQ+CfQoDfpw3RtU:1xJsPMIdOqBCYLYYB7,"#{include}/fuzzy.h"
     EOS
     assert_equal expected, shell_output("#{bin}/ssdeep #{include}/fuzzy.h")
   end


### PR DESCRIPTION
Update ssdeep to version 2.14. There is a new distribution site on GitHub,
https://ssdeep-project.github.io/ssdeep/index.html, and a new maintainer
for project. Official announcement from the old maintainer,
https://twitter.com/jessekornblum/status/907623191937409024

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
