### PR TITLE
tty-clock: fix incorrect description

### DIFF
--- a/Formula/tty-clock.rb
+++ b/Formula/tty-clock.rb
@@ -1,5 +1,5 @@
 class TtyClock < Formula
-  desc "Analog clock in ncurses"
+  desc "Digital clock in ncurses"
   homepage "https://github.com/xorg62/tty-clock"
   url "https://github.com/xorg62/tty-clock/archive/v2.3.tar.gz"
   sha256 "343e119858db7d5622a545e15a3bbfde65c107440700b62f9df0926db8f57984"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`tty-clock` is not an analog clock at all.
See https://github.com/xorg62/tty-clock/issues/12.