### PR TITLE
update GitHub tarball sha256 hashes

### DIFF
--- a/Formula/osquery.rb
+++ b/Formula/osquery.rb
@@ -55,7 +55,7 @@ class Osquery < Formula
 
   resource "aws-sdk-cpp" do
     url "https://github.com/aws/aws-sdk-cpp/archive/1.1.20.tar.gz"
-    sha256 "94d3bf8cbb1db18ebdb50fbf20aa48ad1838f1743bbd22ca04adbaad9bc284dc"
+    sha256 "d88e152ab5d9ad838166cb32a6152549ec16a51fb2fcc0802c704ea79c12edcb"
   end
 
   resource "cpp-netlib" do

--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -11,7 +11,7 @@ class Swift < Formula
 
     resource "clang" do
       url "https://github.com/apple/swift-clang/archive/swift-3.1.1-RELEASE.tar.gz"
-      sha256 "ed41f1231bae030a412455491a5244ede53a4761617194b2dda573f5776361ad"
+      sha256 "bf9ec0c157501eea69ea1eb3c4b8bf56058110ec6c6a870d81d53868b67d1b96"
     end
 
     resource "cmark" do
@@ -26,17 +26,17 @@ class Swift < Formula
 
     resource "llbuild" do
       url "https://github.com/apple/swift-llbuild/archive/swift-3.1.1-RELEASE.tar.gz"
-      sha256 "ea59fd6603fe5d71598895832d6eef9314f1af99a72050536e473e9bb08a57df"
+      sha256 "a5b0a69e3785ce483053a7c1d2b2fe3c6ccc81832a930afee7969a9147316165"
     end
 
     resource "llvm" do
       url "https://github.com/apple/swift-llvm/archive/swift-3.1.1-RELEASE.tar.gz"
-      sha256 "fc6ac7c0c6afff344a8d4e5299b7417f414f1499cf374953e06c339d8177fc26"
+      sha256 "385b587b825adae9a9f7e5789e151ae0554e6e62f2f2f81ff3b623ef578b39bc"
     end
 
     resource "swiftpm" do
       url "https://github.com/apple/swift-package-manager/archive/swift-3.1.1-RELEASE.tar.gz"
-      sha256 "5f98dd6fd41170e2f51f85131ca50cba3d50a187ce94b7a1db7a776c2815c778"
+      sha256 "8ba05b5399b266615cf0d2055698dd3f23b57111120e98419f56139301981914"
     end
   end
 


### PR DESCRIPTION
GitHub recently applied an old Git bugfix to their servers (git/git@22f0dcd9634a818a0c83f23ea1a48f2d620c0546), which caused the byte representation of some tarballs to change.

I computed the mapping of old to new tarballs by building two versions of git, with and without that commit, and then computing the archive hash for each case. I used this script (note the "git.with" and "git.without" builds were in my $PATH):

    #!/usr/bin/perl

    sub hash {
      my ($git, $repo, $version) = @_;
      my $prefix = $version;
      $prefix =~ s/^v//;
      $prefix = "$repo-$prefix/";
      my $cmd = "$git -C tmp.git archive --format=tar.gz" .
                " --prefix=" . quotemeta($prefix) .
                " " . quotemeta($version) .
                " | sha256sum";
      my $hash = `$cmd`;
      chomp $hash;
      $hash =~ s/\s*-$//;
      return $hash;
    }

    while (<>) {
      if (m{https://github.com/(.*?)/(.*?)/archive/(.*?).tar.gz}) {
            system(qw(rm -rf tmp.git));
            system(qw(git clone --bare), "https://github.com/$1/$2.git", "tmp.git");
            $? and next; # skip clone failures

            my $old = hash("git.without", $2, $3);
            my $new = hash("git.with", $2, $3);
            if ($old ne $new) {
              print "$old $new $1/$2\n";
              print STDERR "$1/$2\n  $old\n  $new\n";
            }
      }
    }

That script generated 94 entries.  With that output saved to the file "map", I was then able to adjust the hashes in place:

    #!/bin/sh

    git ls-files Formula | xargs perl -i -pe '
      BEGIN {
    	  open(my $fh, "<map");
    	  while (<$fh>) {
    		  my ($from, $to, $repo) = split;
    		  $map{$from} = $to;
    	  }
      }

      s{sha256 "(.*?)"}
      {
    	  my $hash = $1;
    	  if (exists $map{$hash}) {
    		  print STDERR "replacing $hash with $map{$hash}\n";
    		  $hash = $map{$hash};
    	  }
    	  qq(sha256 "$hash")
      }e;
    '

and commit the result. Note that there _aren't_ 94 updates in this commit, because the previous commits had already picked up most of these changes.

/cc @ilovezfs #18044
