### PR TITLE
media-info 0.7.99 (upstream change without version bump)

### DIFF
--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -4,6 +4,7 @@ class MediaInfo < Formula
   url "https://mediaarea.net/download/binary/mediainfo/0.7.99/MediaInfo_CLI_0.7.99_GNU_FromSource.tar.bz2"
   version "0.7.99"
   sha256 "a365ea634b0188566eec25553a50483283a3a600cf69cd6d707e714ee329cb90"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -3,7 +3,7 @@ class MediaInfo < Formula
   homepage "https://mediaarea.net/"
   url "https://mediaarea.net/download/binary/mediainfo/0.7.99/MediaInfo_CLI_0.7.99_GNU_FromSource.tar.bz2"
   version "0.7.99"
-  sha256 "099c06531bec1ecff18b2ac8626cdd2b64c4652b9aba5d0c869abafdd69e44d5"
+  sha256 "a365ea634b0188566eec25553a50483283a3a600cf69cd6d707e714ee329cb90"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  * Audit warns about sha256 change without version change. Verified with [upstream](https://sourceforge.net/p/mediainfo/discussion/297610/thread/e547907b/#12f7) that this is an intentional change. 

-----