### PR TITLE
Add HTTP mirrors

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -15,7 +15,6 @@ class Curl < Formula
 
   head do
     url "https://github.com/curl/curl.git"
-    mirror "http://github.com/curl/curl.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -2,6 +2,7 @@ class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
   url "https://www.kernel.org/pub/software/scm/git/git-2.14.1.tar.xz"
+  mirror "http://tux.rainside.sk/pub/software/scm/git/git-2.14.1.tar.xz"
   sha256 "6f724c6d0e9e13114ab35db6f67e1b2c1934b641e89366e6a0e37618231f2cc6"
   head "https://github.com/git/git.git", :shallow => false
 
@@ -40,11 +41,13 @@ class Git < Formula
 
   resource "html" do
     url "https://www.kernel.org/pub/software/scm/git/git-htmldocs-2.14.1.tar.xz"
+    mirror "http://tux.rainside.sk/pub/software/scm/git/git-htmldocs-2.14.1.tar.xz"
     sha256 "9c1970c7f87f37c8b3044e01e0500d84d8bc4eb4dfa5ca881c32c351f20769fb"
   end
 
   resource "man" do
     url "https://www.kernel.org/pub/software/scm/git/git-manpages-2.14.1.tar.xz"
+    mirror "http://tux.rainside.sk/pub/software/scm/git/git-manpages-2.14.1.tar.xz"
     sha256 "7ebce1e0e862af1367e24f14765c7b67f08b63fb01b80949f55479c562d414f2"
   end
 

--- a/Formula/makedepend.rb
+++ b/Formula/makedepend.rb
@@ -2,6 +2,7 @@ class Makedepend < Formula
   desc "Creates dependencies in makefiles"
   homepage "https://x.org/"
   url "https://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.bz2"
+  mirror "http://xorg.mirrors.pair.com/individual/util/makedepend-1.0.5.tar.bz2"
   sha256 "f7a80575f3724ac3d9b19eaeab802892ece7e4b0061dd6425b4b789353e25425"
 
   bottle do
@@ -18,11 +19,13 @@ class Makedepend < Formula
 
   resource "xproto" do
     url "https://xorg.freedesktop.org/releases/individual/proto/xproto-7.0.28.tar.gz"
+    mirror "http://xorg.mirrors.pair.com/individual/proto/xproto-7.0.28.tar.gz"
     sha256 "6cabc8ce3fa2b1a2427871167b62c24d5b08a58bd3e81ed7aaf08f2bf6dbcfed"
   end
 
   resource "xorg-macros" do
     url "https://xorg.freedesktop.org/releases/individual/util/util-macros-1.19.0.tar.bz2"
+    mirror "http://xorg.mirrors.pair.com/individual/util/util-macros-1.19.0.tar.bz2"
     sha256 "2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba"
   end
 

--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -7,6 +7,7 @@ class Openssl < Formula
   url "https://www.openssl.org/source/openssl-1.0.2l.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2l.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2l.tar.gz"
+  mirror "http://artfiles.org/openssl.org/source/openssl-1.0.2l.tar.gz"
   sha256 "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c"
 
   bottle do

--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -3,6 +3,7 @@ class PkgConfig < Formula
   homepage "https://freedesktop.org/wiki/Software/pkg-config/"
   url "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/pkg-config-0.29.2.tar.gz"
+  mirror "http://fco.it.distfiles.macports.org/mirrors/macports-distfiles/pkgconfig/pkg-config-0.29.2.tar.gz"
   sha256 "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591"
 
   bottle do


### PR DESCRIPTION
Add HTTP mirrors for bootstrapping Git and Curl when using an insecure system version (e.g. for older OS X versions).