### PR TITLE
azure-cli: improve handling of third-party python3

### DIFF
--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -480,7 +480,11 @@ class AzureCli < Formula
     (bin/"az").write <<-EOS.undent
       #!/usr/bin/env bash
       export PYTHONPATH="#{ENV["PYTHONPATH"]}"
-      python#{xy} -m azure.cli \"$@\"
+      if command -v python#{xy} >/dev/null 2>&1; then
+        python#{xy} -m azure.cli \"$@\"
+      else
+        python3 -m azure.cli \"$@\"
+      fi
     EOS
 
     bash_completion.install "az.completion" => "az"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For users who have installed Python 3 through some other method (without Homebrew), `python3` Homebrew package fails to link with the following error message:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/idle3
Target /usr/local/bin/idle3
already exists. You may want to remove it:
  rm '/usr/local/bin/idle3'
 
To force the link and overwrite all conflicting files:
  brew link --overwrite python3
```

If a user didn't run the link command above, they would see this error:
```
$ az
/usr/local/bin/az: line 3: python3.6: command not found
```

In this PR, we attempt to use the version of Python if it has been linked successfully.
If not, we fall back to simply `python3`.