### PR TITLE
Secure URLs

### DIFF
--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -47,7 +47,7 @@ class ClangFormat < Formula
   depends_on "subversion" => :build
 
   resource "libcxx" do
-    url "https://llvm.org/releases/4.0.0/libcxx-4.0.0.src.tar.xz"
+    url "https://releases.llvm.org/4.0.0/libcxx-4.0.0.src.tar.xz"
     sha256 "4f4d33c4ad69bf9e360eebe6b29b7b19486948b1a41decf89d4adec12473cf96"
   end
 

--- a/Formula/clang-format@3.8.rb
+++ b/Formula/clang-format@3.8.rb
@@ -1,7 +1,7 @@
 class ClangFormatAT38 < Formula
   desc "Formatting tools for C/C++/ObjC/Java/JavaScript/TypeScript"
   homepage "https://clang.llvm.org/docs/ClangFormat.html"
-  url "https://llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz"
+  url "https://releases.llvm.org/3.8.0/llvm-3.8.0.src.tar.xz"
   sha256 "555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46"
 
   bottle do
@@ -18,12 +18,12 @@ class ClangFormatAT38 < Formula
   depends_on "subversion" => :build
 
   resource "clang" do
-    url "https://llvm.org/releases/3.8.0/cfe-3.8.0.src.tar.xz"
+    url "https://releases.llvm.org/3.8.0/cfe-3.8.0.src.tar.xz"
     sha256 "04149236de03cf05232d68eb7cb9c50f03062e339b68f4f8a03b650a11536cf9"
   end
 
   resource "libcxx" do
-    url "https://llvm.org/releases/3.8.0/libcxx-3.8.0.src.tar.xz"
+    url "https://releases.llvm.org/3.8.0/libcxx-3.8.0.src.tar.xz"
     sha256 "36804511b940bc8a7cefc7cb391a6b28f5e3f53f6372965642020db91174237b"
   end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -22,43 +22,43 @@ class Llvm < Formula
   homepage "https://llvm.org/"
 
   stable do
-    url "https://llvm.org/releases/5.0.0/llvm-5.0.0.src.tar.xz"
+    url "https://releases.llvm.org/5.0.0/llvm-5.0.0.src.tar.xz"
     sha256 "e35dcbae6084adcf4abb32514127c5eabd7d63b733852ccdb31e06f1373136da"
 
     resource "clang" do
-      url "https://llvm.org/releases/5.0.0/cfe-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/cfe-5.0.0.src.tar.xz"
       sha256 "019f23c2192df793ac746595e94a403908749f8e0c484b403476d2611dd20970"
     end
 
     resource "clang-extra-tools" do
-      url "https://llvm.org/releases/5.0.0/clang-tools-extra-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/clang-tools-extra-5.0.0.src.tar.xz"
       sha256 "87d078b959c4a6e5ff9fd137c2f477cadb1245f93812512996f73986a6d973c6"
     end
 
     resource "compiler-rt" do
-      url "https://llvm.org/releases/5.0.0/compiler-rt-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/compiler-rt-5.0.0.src.tar.xz"
       sha256 "d5ad5266462134a482b381f1f8115b6cad3473741b3bb7d1acc7f69fd0f0c0b3"
     end
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "https://llvm.org/releases/5.0.0/libcxx-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/libcxx-5.0.0.src.tar.xz"
       sha256 "eae5981e9a21ef0decfcac80a1af584ddb064a32805f95a57c7c83a5eb28c9b1"
     end
 
     resource "libunwind" do
-      url "https://llvm.org/releases/5.0.0/libunwind-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/libunwind-5.0.0.src.tar.xz"
       sha256 "9a70e2333d54f97760623d89512c4831d6af29e78b77a33d824413ce98587f6f"
     end
 
     resource "lld" do
-      url "https://llvm.org/releases/5.0.0/lld-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/lld-5.0.0.src.tar.xz"
       sha256 "399a7920a5278d42c46a7bf7e4191820ec2301457a7d0d4fcc9a4ac05dd53897"
     end
 
     resource "lldb" do
-      url "https://llvm.org/releases/5.0.0/lldb-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/lldb-5.0.0.src.tar.xz"
       sha256 "c0a0ca32105e9881d86b7ca886220147e686edc97fdb9f3657c6659dc6568b7d"
     end
 
@@ -71,12 +71,12 @@ class Llvm < Formula
     end
 
     resource "openmp" do
-      url "https://llvm.org/releases/5.0.0/openmp-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/openmp-5.0.0.src.tar.xz"
       sha256 "c0ef081b05e0725a04e8711d9ecea2e90d6c3fbb1622845336d3d095d0a3f7c5"
     end
 
     resource "polly" do
-      url "https://llvm.org/releases/5.0.0/polly-5.0.0.src.tar.xz"
+      url "https://releases.llvm.org/5.0.0/polly-5.0.0.src.tar.xz"
       sha256 "44694254a2b105cec13ce0560f207e8552e6116c181b8d21bda728559cf67042"
     end
   end

--- a/Formula/llvm@3.7.rb
+++ b/Formula/llvm@3.7.rb
@@ -3,32 +3,32 @@ class LlvmAT37 < Formula
   homepage "https://llvm.org/"
 
   stable do
-    url "https://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz"
+    url "https://releases.llvm.org/3.7.1/llvm-3.7.1.src.tar.xz"
     sha256 "be7794ed0cec42d6c682ca8e3517535b54555a3defabec83554dbc74db545ad5"
 
     resource "clang" do
-      url "https://llvm.org/releases/3.7.1/cfe-3.7.1.src.tar.xz"
+      url "https://releases.llvm.org/3.7.1/cfe-3.7.1.src.tar.xz"
       sha256 "56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674"
     end
 
     resource "clang-tools-extra" do
-      url "https://llvm.org/releases/3.7.1/clang-tools-extra-3.7.1.src.tar.xz"
+      url "https://releases.llvm.org/3.7.1/clang-tools-extra-3.7.1.src.tar.xz"
       sha256 "4a91edaccad1ce984c7c49a4a87db186b7f7b21267b2b03bcf4bd7820715bc6b"
     end
 
     resource "polly" do
-      url "https://llvm.org/releases/3.7.1/polly-3.7.1.src.tar.xz"
+      url "https://releases.llvm.org/3.7.1/polly-3.7.1.src.tar.xz"
       sha256 "ce9273ad315e1904fd35dc64ac4375fd592f3c296252ab1d163b9ff593ec3542"
     end
 
     resource "libcxx" do
-      url "https://llvm.org/releases/3.7.1/libcxx-3.7.1.src.tar.xz"
+      url "https://releases.llvm.org/3.7.1/libcxx-3.7.1.src.tar.xz"
       sha256 "357fbd4288ce99733ba06ae2bec6f503413d258aeebaab8b6a791201e6f7f144"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "https://llvm.org/releases/3.7.1/libcxxabi-3.7.1.src.tar.xz"
+        url "https://releases.llvm.org/3.7.1/libcxxabi-3.7.1.src.tar.xz"
         sha256 "a47faaed90f577da8ca3b5f044be9458d354a53fab03003a44085a912b73ab2a"
       end
     end

--- a/Formula/llvm@3.8.rb
+++ b/Formula/llvm@3.8.rb
@@ -3,42 +3,42 @@ class LlvmAT38 < Formula
   homepage "https://llvm.org/"
 
   stable do
-    url "https://llvm.org/releases/3.8.1/llvm-3.8.1.src.tar.xz"
+    url "https://releases.llvm.org/3.8.1/llvm-3.8.1.src.tar.xz"
     sha256 "6e82ce4adb54ff3afc18053d6981b6aed1406751b8742582ed50f04b5ab475f9"
 
     resource "clang" do
-      url "https://llvm.org/releases/3.8.1/cfe-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/cfe-3.8.1.src.tar.xz"
       sha256 "4cd3836dfb4b88b597e075341cae86d61c63ce3963e45c7fe6a8bf59bb382cdf"
     end
 
     resource "clang-tools-extra" do
-      url "https://llvm.org/releases/3.8.1/clang-tools-extra-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/clang-tools-extra-3.8.1.src.tar.xz"
       sha256 "664a5c60220de9c290bf2a5b03d902ab731a4f95fe73a00856175ead494ec396"
     end
 
     resource "polly" do
-      url "https://llvm.org/releases/3.8.1/polly-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/polly-3.8.1.src.tar.xz"
       sha256 "453c27e1581614bb3b6351bf5a2da2939563ea9d1de99c420f85ca8d87b928a2"
     end
 
     resource "lld" do
-      url "https://llvm.org/releases/3.8.1/lld-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/lld-3.8.1.src.tar.xz"
       sha256 "2bd9be8bb18d82f7f59e31ea33b4e58387dbdef0bc11d5c9fcd5ce9a4b16dc00"
     end
 
     resource "openmp" do
-      url "https://llvm.org/releases/3.8.1/openmp-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/openmp-3.8.1.src.tar.xz"
       sha256 "68fcde6ef34e0275884a2de3450a31e931caf1d6fda8606ef14f89c4123617dc"
     end
 
     resource "libcxx" do
-      url "https://llvm.org/releases/3.8.1/libcxx-3.8.1.src.tar.xz"
+      url "https://releases.llvm.org/3.8.1/libcxx-3.8.1.src.tar.xz"
       sha256 "77d7f3784c88096d785bd705fa1bab7031ce184cd91ba8a7008abf55264eeecc"
     end
 
     if MacOS.version <= :snow_leopard
       resource "libcxxabi" do
-        url "https://llvm.org/releases/3.8.1/libcxxabi-3.8.1.src.tar.xz"
+        url "https://releases.llvm.org/3.8.1/libcxxabi-3.8.1.src.tar.xz"
         sha256 "e1b55f7be3fad746bdd3025f43e42d429fb6194aac5919c2be17c4a06314dae1"
       end
     end

--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -23,53 +23,53 @@ class LlvmAT39 < Formula
   revision 1
 
   stable do
-    url "https://llvm.org/releases/3.9.1/llvm-3.9.1.src.tar.xz"
+    url "https://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz"
     sha256 "1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee"
 
     resource "clang" do
-      url "https://llvm.org/releases/3.9.1/cfe-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/cfe-3.9.1.src.tar.xz"
       sha256 "e6c4cebb96dee827fa0470af313dff265af391cb6da8d429842ef208c8f25e63"
     end
 
     resource "clang-extra-tools" do
-      url "https://llvm.org/releases/3.9.1/clang-tools-extra-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/clang-tools-extra-3.9.1.src.tar.xz"
       sha256 "29a5b65bdeff7767782d4427c7c64d54c3a8684bc6b217b74a70e575e4813635"
     end
 
     resource "compiler-rt" do
-      url "https://llvm.org/releases/3.9.1/compiler-rt-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/compiler-rt-3.9.1.src.tar.xz"
       sha256 "d30967b1a5fa51a2503474aacc913e69fd05ae862d37bf310088955bdb13ec99"
     end
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "https://llvm.org/releases/3.9.1/libcxx-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/libcxx-3.9.1.src.tar.xz"
       sha256 "25e615e428f60e651ed09ffd79e563864e3f4bc69a9e93ee41505c419d1a7461"
     end
 
     resource "libunwind" do
-      url "https://llvm.org/releases/3.9.1/libunwind-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/libunwind-3.9.1.src.tar.xz"
       sha256 "0b0bc73264d7ab77d384f8a7498729e3c4da8ffee00e1c85ad02a2f85e91f0e6"
     end
 
     resource "lld" do
-      url "https://llvm.org/releases/3.9.1/lld-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/lld-3.9.1.src.tar.xz"
       sha256 "48e128fabb2ddaee64ecb8935f7ac315b6e68106bc48aeaf655d179c65d87f34"
     end
 
     resource "lldb" do
-      url "https://llvm.org/releases/3.9.1/lldb-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/lldb-3.9.1.src.tar.xz"
       sha256 "7e3311b2a1f80f4d3426e09f9459d079cab4d698258667e50a46dccbaaa460fc"
     end
 
     resource "openmp" do
-      url "https://llvm.org/releases/3.9.1/openmp-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/openmp-3.9.1.src.tar.xz"
       sha256 "d23b324e422c0d5f3d64bae5f550ff1132c37a070e43c7ca93991676c86c7766"
     end
 
     resource "polly" do
-      url "https://llvm.org/releases/3.9.1/polly-3.9.1.src.tar.xz"
+      url "https://releases.llvm.org/3.9.1/polly-3.9.1.src.tar.xz"
       sha256 "9ba5e61fc7bf8c7435f64e2629e0810c9b1d1b03aa5b5605b780d0e177b4cb46"
     end
   end

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -22,53 +22,53 @@ class LlvmAT4 < Formula
   homepage "https://llvm.org/"
 
   stable do
-    url "https://llvm.org/releases/4.0.1/llvm-4.0.1.src.tar.xz"
+    url "https://releases.llvm.org/4.0.1/llvm-4.0.1.src.tar.xz"
     sha256 "da783db1f82d516791179fe103c71706046561f7972b18f0049242dee6712b51"
 
     resource "clang" do
-      url "https://llvm.org/releases/4.0.1/cfe-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/cfe-4.0.1.src.tar.xz"
       sha256 "61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b"
     end
 
     resource "clang-extra-tools" do
-      url "https://llvm.org/releases/4.0.1/clang-tools-extra-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/clang-tools-extra-4.0.1.src.tar.xz"
       sha256 "35d1e64efc108076acbe7392566a52c35df9ec19778eb9eb12245fc7d8b915b6"
     end
 
     resource "compiler-rt" do
-      url "https://llvm.org/releases/4.0.1/compiler-rt-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/compiler-rt-4.0.1.src.tar.xz"
       sha256 "a3c87794334887b93b7a766c507244a7cdcce1d48b2e9249fc9a94f2c3beb440"
     end
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
-      url "https://llvm.org/releases/4.0.1/libcxx-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/libcxx-4.0.1.src.tar.xz"
       sha256 "520a1171f272c9ff82f324d5d89accadcec9bc9f3c78de11f5575cdb99accc4c"
     end
 
     resource "libunwind" do
-      url "https://llvm.org/releases/4.0.1/libunwind-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/libunwind-4.0.1.src.tar.xz"
       sha256 "3b072e33b764b4f9b5172698e080886d1f4d606531ab227772a7fc08d6a92555"
     end
 
     resource "lld" do
-      url "https://llvm.org/releases/4.0.1/lld-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/lld-4.0.1.src.tar.xz"
       sha256 "63ce10e533276ca353941ce5ab5cc8e8dcd99dbdd9c4fa49f344a212f29d36ed"
     end
 
     resource "lldb" do
-      url "https://llvm.org/releases/4.0.1/lldb-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/lldb-4.0.1.src.tar.xz"
       sha256 "8432d2dfd86044a0fc21713e0b5c1d98e1d8aad863cf67562879f47f841ac47b"
     end
 
     resource "openmp" do
-      url "https://llvm.org/releases/4.0.1/openmp-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/openmp-4.0.1.src.tar.xz"
       sha256 "ec693b170e0600daa7b372240a06e66341ace790d89eaf4a843e8d56d5f4ada4"
     end
 
     resource "polly" do
-      url "https://llvm.org/releases/4.0.1/polly-4.0.1.src.tar.xz"
+      url "https://releases.llvm.org/4.0.1/polly-4.0.1.src.tar.xz"
       sha256 "b443bb9617d776a7d05970e5818aa49aa2adfb2670047be8e9f242f58e84f01a"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The reason for this change is that recently `release.llvm.org`
got HTTPS properly configured, while the old `https://llvm.org/release/`
addresses are being redirected to an HTTP address. This PR makes
sure to use the new addresses, which are the canonical ones anyway.

One existing open, but stale PR for `llvm`.

Some audit issues, of which one is known (graphviz), the other two is probably safe to ignore in the context of this PR:
```
clang-format:
  * Formula has other versions so create an alias named clang-format@2017-06-22..
llvm:
  * Formula has other versions so create an alias named llvm@5.
llvm@3.9:
  * Dependency graphviz should not use option dot
```