### PR TITLE
gdal: fix compilation on 10.13

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -128,14 +128,9 @@ class Gdal < Formula
       "--with-grib",
       "--with-pam",
 
-      # Backends supported by macOS.
-      "--with-libiconv-prefix=/usr",
-      "--with-libz=/usr",
-      "--with-png=#{Formula["libpng"].opt_prefix}",
-      "--with-expat=/usr",
-      "--with-curl=/usr/bin/curl-config",
-
       # Default Homebrew backends.
+      "--with-png=#{Formula["libpng"].opt_prefix}",
+      "--with-curl=/usr/bin/curl-config",
       "--with-jpeg=#{HOMEBREW_PREFIX}",
       "--without-jpeg12", # Needs specially configured JPEG and TIFF libraries.
       "--with-gif=#{HOMEBREW_PREFIX}",


### PR DESCRIPTION
Gdal fails to build on 10.13 because our configure options mean we pass `-I/usr/include` to the compiler, and that triggers a bug in the Apple headers (an inconsistency between Xcode and CLT headers, to be precise). The bug was reported to Apple (number 33890461).