### PR TITLE
youtube-dl: fix crash

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -11,6 +11,9 @@ class YoutubeDl < Formula
 
   bottle :unneeded
 
+  depends_on "libav"
+  depends_on "ffmpeg"
+
   def install
     system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"


### PR DESCRIPTION
fix youtube-dl exception "ValueError: insecure string pickle". this
seems to stem from missing dependencies ffmpeg and libav.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
