### PR TITLE
bzflag 2.4.10+ (new formula)

### DIFF
--- a/Formula/bzflag.rb
+++ b/Formula/bzflag.rb
@@ -1,0 +1,28 @@
+class Bzflag < Formula
+  desc "3D multi-player tank battle game "
+  homepage "https://bzflag.org"
+  url "https://github.com/BZFlag-Dev/bzflag/archive/868a2be7cba3f2b706876f526cf8ba4c76e461d6.tar.gz"
+  sha256 "17bd397a12b40f09f1d1a785266c9bc6b832153d18dfc87e44a5caaf40f94fc2"
+  head "https://github.com/BZFlag-Dev/bzflag.git", :branch => "2.4"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "c-ares" => :build
+  depends_on "libtool" => :build
+  depends_on "sdl2"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "file", "#{bin}/bzflag"
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've followed the instructions, I think, but I have two questions (which is why I can't check the first box above):
1. There is currently a cask for bzflag 2.4.10, and audit complains about this. How do we handle addition/removal in sync?
2. bzflag 2.4.10 currently does not compile on Mac OS using autotools/gcc/etc (which is why we have the cask, I presume). This PR supports versions starting from the point where CLI compilation was fixed, but there hasn't been an official release. Can it be merged somehow now, or should it wait until there's an official release (the title is 2.4.10+ to reflect this)