### PR TITLE
jing-trang: fix java dependency

### DIFF
--- a/Formula/jing-trang.rb
+++ b/Formula/jing-trang.rb
@@ -7,7 +7,7 @@ class JingTrang < Formula
   bottle :unneeded
 
   depends_on :ant => :build
-  depends_on :java => "1.6"
+  depends_on :java => "1.6+"
 
   def install
     system "./ant", "jar"


### PR DESCRIPTION
Installation of package jing-trang fails as it explicitely depends on Java 1.6.
It should, however, work as long as Java 1.6 *or greater* is installed.

*Current behaviour:*

```
$ java -version          
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
```

```
$ brew install jing-trang
jing-trang: Java 1.6 is required to install this formula.
JavaRequirement unsatisfied!

You can install with Homebrew-Cask:
  brew cask install java

You can download from:
  https://www.oracle.com/technetwork/java/javase/downloads/index.html
Error: An unsatisfied requirement failed this build.
```

*Behaviour after patch:*

```
$ java -version          
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
```

```
$ brew install jing-trang  
==> Downloading https://github.com/relaxng/jing-trang/archive/V20151127.tar.gz
Already downloaded: /Users/holu/Library/Caches/Homebrew/jing-trang-20151127.tar.gz
==> ./ant jar
🍺  /usr/local/Cellar/jing-trang/20151127: 2,444 files, 25.7MB, built in 8 seconds
```

```
$ brew test jing-trang
Testing jing-trang
==> /usr/local/Cellar/jing-trang/20151127/bin/jing -c test.rnc test.xml
==> /usr/local/Cellar/jing-trang/20151127/bin/trang -I rnc -O rng test.rnc test.rng
```
