### PR TITLE
basex: add java installation dependency

### DIFF
--- a/Formula/basex.rb
+++ b/Formula/basex.rb
@@ -13,6 +13,8 @@ class Basex < Formula
 
   bottle :unneeded
 
+  depends_on :java => "1.7+"
+
   def install
     rm Dir["bin/*.bat"]
     rm_rf "repo"


### PR DESCRIPTION
BaseX is a Java application, but is missing an install dependency.

Due to upstream [installation requirements](http://docs.basex.org/wiki/Startup#Requirements) Java 1.7 or greater is mandatory.