### PR TITLE
libbitcoin-explorer: bx alias

### DIFF
--- a/Aliases/bx
+++ b/Aliases/bx
@@ -1,0 +1,1 @@
+../Formula/libbitcoin-explorer.rb


### PR DESCRIPTION
The libbitcoin-explorer package installs as "bx", so I've created an alias to make it potentially easier to find.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
