### PR TITLE
adwaita-icon-theme: renamed from gnome-icon-theme

### DIFF
--- a/Aliases/adwaita-icon-theme
+++ b/Aliases/adwaita-icon-theme
@@ -1,1 +1,0 @@
-../Formula/gnome-icon-theme.rb

--- a/Aliases/gnome-icon-theme
+++ b/Aliases/gnome-icon-theme
@@ -1,0 +1,1 @@
+../Formula/adwaita-icon-theme.rb

--- a/Formula/adwaita-icon-theme.rb
+++ b/Formula/adwaita-icon-theme.rb
@@ -1,4 +1,4 @@
-class GnomeIconTheme < Formula
+class AdwaitaIconTheme < Formula
   desc "Icons for the GNOME project"
   homepage "https://developer.gnome.org"
   url "https://download.gnome.org/sources/adwaita-icon-theme/3.26/adwaita-icon-theme-3.26.0.tar.xz"

--- a/Formula/anjuta.rb
+++ b/Formula/anjuta.rb
@@ -19,7 +19,7 @@ class Anjuta < Formula
   depends_on "gdl"
   depends_on "vte3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "gnutls"
   depends_on "shared-mime-info"
   depends_on "vala" => :recommended

--- a/Formula/baobab.rb
+++ b/Formula/baobab.rb
@@ -18,7 +18,7 @@ class Baobab < Formula
   depends_on "vala" => :build
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/easy-tag.rb
+++ b/Formula/easy-tag.rb
@@ -15,7 +15,7 @@ class EasyTag < Formula
   depends_on "itstool" => :build
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "id3lib"
   depends_on "libid3tag"
   depends_on "taglib"

--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -16,7 +16,7 @@ class Evince < Formula
   depends_on "libxml2"
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "libsecret"
   depends_on "libspectre"
   depends_on "gobject-introspection"

--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -18,7 +18,7 @@ class FileRoller < Formula
   depends_on "libmagic"
   depends_on "libarchive"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
 
   # Add linked-library dependencies
   depends_on "atk"

--- a/Formula/gedit.rb
+++ b/Formula/gedit.rb
@@ -29,7 +29,7 @@ class Gedit < Formula
   depends_on "libpeas"
   depends_on "gtksourceview3"
   depends_on "gsettings-desktop-schemas"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -25,7 +25,7 @@ class Gitg < Formula
   depends_on "libsoup"
   depends_on "gtkspell3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/glade.rb
+++ b/Formula/glade.rb
@@ -3,7 +3,7 @@ class Glade < Formula
   homepage "https://glade.gnome.org/"
   url "https://download.gnome.org/sources/glade/3.20/glade-3.20.0.tar.xz"
   sha256 "82d96dca5dec40ee34e2f41d49c13b4ea50da8f32a3a49ca2da802ff14dc18fe"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -11,6 +11,21 @@ class Glade < Formula
     sha256 "420cee7949561ae0c5ed7d5c7472a83b655d8dc427bdf965b49d7e989c71fe4e" => :el_capitan
     sha256 "8c9c09600f97e65562ac8afc4eebe3a66a8122db850f86aacc65195e4f97ccfd" => :yosemite
   end
+
+  # fixes build error against glib 2.54.x
+  # bugzilla ticket: https://bugzilla.gnome.org/show_bug.cgi?id=782161
+  # patch committed into master on May 4, 2017
+  patch do
+    url "https://github.com/GNOME/glade/commit/8a73d114ca5b4d37a770d0b6b69dd17a366dbcf4.diff?full_index=1"
+    sha256 "4bf7c21985b27fb1198fc5ef19a8447805783f394bcb699200ef2e7e99cc81f2"
+  end
+
+  # remove next five lines when new release is available
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "yelp-tools" => :build
+  depends_on "gnome-common" => :build
 
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
@@ -27,6 +42,8 @@ class Glade < Formula
     # Find our docbook catalog
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
+    # remove next line when new release is available
+    system "autoreconf", "-fi"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/glade.rb
+++ b/Formula/glade.rb
@@ -33,7 +33,7 @@ class Glade < Formula
   depends_on "docbook-xsl" => :build
   depends_on "gettext"
   depends_on "libxml2"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "hicolor-icon-theme"
   depends_on "gtk+3"
   depends_on "gtk-mac-integration"

--- a/Formula/gnome-builder.rb
+++ b/Formula/gnome-builder.rb
@@ -21,7 +21,7 @@ class GnomeBuilder < Formula
   depends_on "libpeas"
   depends_on "gtksourceview3"
   depends_on "hicolor-icon-theme"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "desktop-file-utils"
   depends_on "pcre"
   depends_on "json-glib"

--- a/Formula/gnome-recipes.rb
+++ b/Formula/gnome-recipes.rb
@@ -16,7 +16,7 @@ class GnomeRecipes < Formula
   depends_on "itstool" => :build
   depends_on :python3 => :build
   depends_on "gtk+3"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "libcanberra"
   depends_on "gnome-autoar"
   depends_on "gspell"

--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -21,7 +21,7 @@ class Gnumeric < Formula
   depends_on "gettext"
   depends_on "goffice"
   depends_on "rarian"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "pygobject" if build.with? "python-scripting"
 
   def install

--- a/Formula/homebank.rb
+++ b/Formula/homebank.rb
@@ -14,7 +14,7 @@ class Homebank < Formula
   depends_on "intltool" => :build
   depends_on "gettext"
   depends_on "gtk+3"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "hicolor-icon-theme"
   depends_on "freetype"
   depends_on "fontconfig"

--- a/Formula/latexila.rb
+++ b/Formula/latexila.rb
@@ -18,7 +18,7 @@ class Latexila < Formula
   depends_on "tepl"
   depends_on "libgee"
   depends_on "gobject-introspection"
-  depends_on "gnome-icon-theme"
+  depends_on "adwaita-icon-theme"
   depends_on "gnome-themes-standard" => :optional
   depends_on "libxml2"
   depends_on :python if MacOS.version <= :snow_leopard

--- a/Formula/stoken.rb
+++ b/Formula/stoken.rb
@@ -13,7 +13,7 @@ class Stoken < Formula
 
   depends_on "gtk+3" => :optional
   if build.with? "gtk+3"
-    depends_on "gnome-icon-theme"
+    depends_on "adwaita-icon-theme"
     depends_on "hicolor-icon-theme"
   end
   depends_on "pkg-config" => :build

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -35,7 +35,7 @@ class Wireshark < Formula
   depends_on "qt" => :optional
   depends_on "gtk+3" => :optional
   depends_on "gtk+" => :optional
-  depends_on "gnome-icon-theme" if build.with? "gtk+3"
+  depends_on "adwaita-icon-theme" if build.with? "gtk+3"
 
   def install
     args = std_cmake_args + %w[

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -54,6 +54,7 @@
   "glfw3": "glfw",
   "gmp4": "gmp@4",
   "gmt4": "gmt@4",
+  "gnome-icon-theme": "adwaita-icon-theme",
   "gnupg2": "gnupg",
   "gnuplot4": "gnuplot@4",
   "go-app-engine-32": "app-engine-go-32",


### PR DESCRIPTION
It hasn't been called gnome-icon-theme for years...