### PR TITLE
bbftp-client: use mirrors and remove patch

### DIFF
--- a/Formula/bbftp-client.rb
+++ b/Formula/bbftp-client.rb
@@ -1,7 +1,12 @@
 class BbftpClient < Formula
   desc "Secure file transfer software, optimized for large files"
-  homepage "http://doc.in2p3.fr/bbftp/"
-  url "http://doc.in2p3.fr/bbftp/dist/bbftp-client-3.2.1.tar.gz"
+  # http://doc.in2p3.fr/bbftp/ is 404
+  # Contacted bbftp AT in2p3 DOT fr and mirror AT cc.in2p3 DOT fr 18 Sep 2017
+  homepage "https://web.archive.org/web/20170722062740/http://doc.in2p3.fr/bbftp/"
+  # http://doc.in2p3.fr/bbftp/dist/bbftp-client-3.2.1.tar.gz is 404
+  url "http://ftp.riken.jp/net/bbftp/bbftp-client-3.2.1.tar.gz"
+  mirror "ftp://ccpntc11.in2p3.fr/pub/bbftp/bbftp-client-3.2.1.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/bbftp-client-3.2.1.tar.gz"
   sha256 "4000009804d90926ad3c0e770099874084fb49013e8b0770b82678462304456d"
   revision 1
 
@@ -15,11 +20,10 @@ class BbftpClient < Formula
 
   depends_on "openssl"
 
-  # Dirty patch to fix ntohll errors on Yosemite.
-  # Reported upstream on 14/01/2015.
-  patch :DATA if MacOS.version >= :yosemite
-
   def install
+    # Fix ntohll errors; reported 14 Jan 2015.
+    ENV.append_to_cflags "-DHAVE_NTOHLL" if MacOS.version >= :yosemite
+
     cd "bbftpc" do
       system "./configure", "--disable-debug", "--disable-dependency-tracking",
                             "--with-ssl=#{Formula["openssl"].opt_prefix}", "--prefix=#{prefix}"
@@ -31,81 +35,3 @@ class BbftpClient < Formula
     system "#{bin}/bbftp", "-v"
   end
 end
-
-__END__
-
-diff --git a/bbftpc/bbftp_get.c b/bbftpc/bbftp_get.c
-index 96c8d35..b1cd2e3 100644
---- a/bbftpc/bbftp_get.c
-+++ b/bbftpc/bbftp_get.c
-@@ -94,9 +94,9 @@ extern  int     nbport ;
- extern  int     state ;
- extern  int     protocol ;
-
--#ifndef HAVE_NTOHLL
--my64_t ntohll(my64_t v) ;
--#endif
-+// #ifndef HAVE_NTOHLL
-+// my64_t ntohll(my64_t v) ;
-+// #endif
-
- int bbftp_get(char *remotefilename,int  *errcode)
- {
-
-diff --git a/bbftpc/bbftp_put.c b/bbftpc/bbftp_put.c
-index 53c9919..b633ceb 100644
---- a/bbftpc/bbftp_put.c
-+++ b/bbftpc/bbftp_put.c
-@@ -96,9 +96,9 @@ extern  int     state ;
- extern  int     simulation_mode ;
- extern  int     protocol ;
-
--#ifndef HAVE_NTOHLL
--my64_t ntohll(my64_t v) ;
--#endif
-+// #ifndef HAVE_NTOHLL
-+// my64_t ntohll(my64_t v) ;
-+// #endif
-
- int bbftp_put(char *remotefilename,int  *errcode)
- {
-
-diff --git a/bbftpc/bbftp_utils.c b/bbftpc/bbftp_utils.c
-index 40d5f9e..7143903 100644
---- a/bbftpc/bbftp_utils.c
-+++ b/bbftpc/bbftp_utils.c
-@@ -82,20 +82,20 @@ my64_t convertlong(my64_t v) {
-     return tmp64 ;
- }
-
--#ifndef HAVE_NTOHLL
--my64_t ntohll(my64_t v) {
--#ifdef HAVE_BYTESWAP_H
--    return bswap_64(v);
--#else
--    long lo = v & 0xffffffff;
--    long hi = v >> 32U;
--    lo = ntohl(lo);
--    hi = ntohl(hi);
--    return ((my64_t) lo) << 32U | hi;
--#endif
--}
--#define htonll ntohll
--#endif
-+// #ifndef HAVE_NTOHLL
-+// my64_t ntohll(my64_t v) {
-+// #ifdef HAVE_BYTESWAP_H
-+//    return bswap_64(v);
-+// #else
-+//    long lo = v & 0xffffffff;
-+//    long hi = v >> 32U;
-+//    lo = ntohl(lo);
-+//    hi = ntohl(hi);
-+//    return ((my64_t) lo) << 32U | hi;
-+// #endif
-+// }
-+// #define htonll ntohll
-+// #endif
-
- void printmessage(FILE *strm , int flag, int errcode, int tok, char *fmt, ...)
- {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

in favor of a CFLAGS tweak.

Also, mirror to Bintray.