### PR TITLE
ctunnel: fix url

### DIFF
--- a/Formula/ctunnel.rb
+++ b/Formula/ctunnel.rb
@@ -1,7 +1,7 @@
 class Ctunnel < Formula
   desc "Cryptographic or plain tunnels for TCP/UDP connections"
   homepage "https://github.com/alienrobotarmy/ctunnel"
-  url "https://alienrobotarmy.com/ctunnel/0.7/ctunnel-0.7.tar.gz"
+  url "https://www.alienrobotarmy.com/ctunnel/0.7/ctunnel-0.7.tar.gz"
   sha256 "3c90e14af75f7c31372fcdeb8ad24b5f874bfb974aa0906f25a059a2407a358f"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The urls needs www. otherwise https fails.