### PR TITLE
pgloader: remove pgloader resource block

### DIFF
--- a/Formula/pgloader.rb
+++ b/Formula/pgloader.rb
@@ -3,6 +3,7 @@ class Pgloader < Formula
   homepage "https://github.com/dimitri/pgloader"
   url "https://github.com/dimitri/pgloader/archive/v3.4.1.tar.gz"
   sha256 "3ac4d03706057a35e1d4d0e63571b84be7d0d07ea09e015d90e242200488fe82"
+  revision 1
   head "https://github.com/dimitri/pgloader.git"
 
   bottle do
@@ -227,11 +228,6 @@ class Pgloader < Formula
   resource "parse-number" do
     url "https://beta.quicklisp.org/archive/parse-number/2014-08-26/parse-number-1.4.tgz"
     sha256 "90ae04cd1a43fe186d07e5f805faa6cc8a00d1134dd9d99b56e31fa2f5811279"
-  end
-
-  resource "pgloader" do
-    url "https://beta.quicklisp.org/archive/pgloader/2016-12-04/pgloader-3.3.2.tgz"
-    sha256 "1b0fd097932f980942c46ac7ec4211e2c4646577bc598a088b5f53b9a5393fe6"
   end
 
   resource "postmodern" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

which was overwriting 3.4.1 with an old version.

Fixes https://github.com/Homebrew/homebrew-core/issues/18101.

CC @yoghi