### PR TITLE
Fix Elvish 0.10 build.

### DIFF
--- a/Formula/elvish.rb
+++ b/Formula/elvish.rb
@@ -1,8 +1,8 @@
 class Elvish < Formula
-  desc "Novel UNIX shell written in Go"
+  desc "Friendly and Expressive Unix shell"
   homepage "https://github.com/elves/elvish"
   url "https://github.com/elves/elvish/archive/0.10.tar.gz"
-  sha256 "1b053abd3f8c3b436712597e5dc7ce44c71737bdc0016cbf773a4e74c712851a"
+  sha256 "94585d0ff4c124b56609e3f2a0b97bb143289400d46d2d4d3c8871c1d90f0727"
   head "https://github.com/elves/elvish.git"
 
   bottle do


### PR DESCRIPTION
The 0.10 tag was force-updated. I thought no one will notice, but Homebrew
picked up the old 0.10 tag.

I also updated the project description.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This build does not pass audit because the SHA256SUM has changed. However, since I represent the upstream I have forgone the process of opening a bug in the upstream repository.