### PR TITLE
Libbitcoin - additional dependencies

### DIFF
--- a/Formula/libbitcoin-explorer.rb
+++ b/Formula/libbitcoin-explorer.rb
@@ -3,6 +3,7 @@ class LibbitcoinExplorer < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-explorer"
   url "https://github.com/libbitcoin/libbitcoin-explorer/archive/v3.3.0.tar.gz"
   sha256 "029dc350497bdaad4d8559f7954405011b9e1b996aa4d4cc124f650e2eca00a6"
+  revision 1
 
   bottle do
     sha256 "155216851b832da347cbae3f8b90849830f236cf357504e5063fb2a925b284b2" => :high_sierra
@@ -17,11 +18,6 @@ class LibbitcoinExplorer < Formula
   depends_on "pkg-config" => :build
   depends_on "libbitcoin"
   depends_on "zeromq"
-
-  resource "secp256k1" do
-    url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.13.tar.gz"
-    sha256 "9e48dbc88d0fb5646d40ea12df9375c577f0e77525e49833fb744d3c2a69e727"
-  end
 
   resource "libbitcoin-network" do
     url "https://github.com/libbitcoin/libbitcoin-network/archive/v3.3.0.tar.gz"
@@ -39,17 +35,8 @@ class LibbitcoinExplorer < Formula
   end
 
   def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin"].opt_libexec/"lib/pkgconfig"
     ENV.prepend_create_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
-
-    resource("secp256k1").stage do
-      system "./autogen.sh"
-      system "./configure", "--disable-dependency-tracking",
-                            "--disable-silent-rules",
-                            "--prefix=#{libexec}",
-                            "--enable-module-recovery",
-                            "--with-bignum=no"
-      system "make", "install"
-    end
 
     resource("libbitcoin-network").stage do
       system "./autogen.sh"

--- a/Formula/libbitcoin.rb
+++ b/Formula/libbitcoin.rb
@@ -3,7 +3,7 @@ class Libbitcoin < Formula
   homepage "https://libbitcoin.org/"
   url "https://github.com/libbitcoin/libbitcoin/archive/v3.3.0.tar.gz"
   sha256 "391913a73615afcb42c6a7c4736f23888cfc999a899fc38395ddcbd560251d94"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -18,6 +18,8 @@ class Libbitcoin < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
+  depends_on "libpng"
+  depends_on "qrencode"
 
   resource "secp256k1" do
     url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.13.tar.gz"
@@ -40,7 +42,9 @@ class Libbitcoin < Formula
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--with-png",
+                          "--with-qrencode"
     system "make", "install"
   end
 


### PR DESCRIPTION
* To support additional features in libbitcoin-explorer, libbitcoin needs to be built with qrencode and libpng. I have made them required here to be able to install libbitcoin from a bottle when installing libbitcoin-explorer.
* Instead of having libbitcoin-explorer download and build secp256k1, use the one that's already in libbitcoin's libexec.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
