### PR TITLE
gcore: use http for homepage and url

### DIFF
--- a/Formula/gcore.rb
+++ b/Formula/gcore.rb
@@ -1,7 +1,8 @@
 class Gcore < Formula
   desc "Produce a snapshot (core dump) of a running process"
-  homepage "https://osxbook.com/book/bonus/chapter8/core/"
-  url "https://osxbook.com/book/bonus/chapter8/core/download/gcore-1.3.tar.gz"
+  homepage "http://osxbook.com/book/bonus/chapter8/core/"
+  url "http://osxbook.com/book/bonus/chapter8/core/download/gcore-1.3.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/gcore-1.3.tar.gz"
   sha256 "6b58095c80189bb5848a4178f282102024bbd7b985f9543021a3bf1c1a36aa2a"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

as the SSL certificate expired 9 Aug 2017.

Also, mirror to Bintray.