### PR TITLE
mariadb: force use of bundled pcre

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -54,6 +54,7 @@ class Mariadb < Formula
       -DINSTALL_DOCDIR=share/doc/#{name}
       -DINSTALL_INFODIR=share/info
       -DINSTALL_MYSQLSHAREDIR=share/mysql
+      -DWITH_PCRE=bundled
       -DWITH_SSL=yes
       -DDEFAULT_CHARSET=utf8
       -DDEFAULT_COLLATION=utf8_general_ci


### PR DESCRIPTION
The automatic detection of pcre fails on 10.13, so we force it to use the bundled mariadb (which it should do anyway).