### PR TITLE
gnupg 2.2.1

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,9 +1,9 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.0.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.2.0.tar.bz2"
-  sha256 "d4514a0be0f7a1ff263193330019eb4b53c82f0f5e230af3c14df371271a45e6"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.2.1.tar.bz2"
+  sha256 "34d70cd65b9c95f3f2f90a9f5c1e0b6a0fe039a8d685e2d66d69c33d1cbf62fb"
 
   bottle do
     sha256 "06c0af8086036fe3de3c034ee56a07404aee2294d0d739339c708771acd5a516" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes in version 2.2.1
===================================

  * gpg: Fix formatting of the user id in batch mode key generation
    if only "name-email" is given.

  * gpgv: Fix annoying "not suitable for" warnings.

  * wks: Convey only the newest user id to the provider.  This is the
    case if different names are used with the same addr-spec.

  * wks: Create a complying user id for provider policy mailbox-only.

  * wks: Add workaround for posteo.de.

  * scd: Fix the use of large ECC keys with an OpenPGP card.

  * dirmngr: Use system provided root certificates if no specific HKP
    certificates are configured.  If build with GNUTLS, this was
    already the case.
```