### PR TITLE
libswiften: fix build with SCons 3.0 and with Boost 1.65.1

### DIFF
--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -26,6 +26,17 @@ class Libswiften < Formula
   depends_on "lua" => :recommended
 
   def install
+    inreplace "Sluift/main.cpp", "#include <string>",
+                                 "#include <iostream>\n#include <string>"
+
+    inreplace "BuildTools/SCons/SConstruct",
+              /(\["BOOST_SIGNALS_NO_DEPRECATION_WARNING")\]/,
+              "\\1, \"__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0\"]"
+
+    system "2to3", "--write", "--fix=print", "SConstruct",
+           "BuildTools/SCons/SConstruct", "3rdParty/LibIDN/SConscript",
+           "Slimber/SConscript", "Sluift/SConscript", "Swift/SConscript"
+
     boost = Formula["boost"]
     libidn = Formula["libidn"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

and fix a missing header include.