### PR TITLE
ori: fix build with SCons 3.0 and depend on boost@1.60

### DIFF
--- a/Formula/ori.rb
+++ b/Formula/ori.rb
@@ -14,12 +14,15 @@ class Ori < Formula
 
   depends_on "pkg-config" => :build
   depends_on "scons" => :build
-  depends_on "boost"
+  depends_on "boost@1.60"
   depends_on "libevent"
   depends_on "openssl"
   depends_on :osxfuse
 
   def install
+    system "2to3", "--write", "--fix=print", "SConstruct",
+           "liboriutil/SConscript"
+
     scons "BUILDTYPE=RELEASE"
     scons "install", "PREFIX=#{prefix}"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?