### PR TITLE
rabbitmq: download packages from Bintray

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -1,14 +1,10 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.12/rabbitmq-server-generic-unix-3.6.12.tar.xz"
+  url "https://dl.bintray.com/rabbitmq/binaries/rabbitmq-server-generic-unix-3.6.12.tar.xz"
   sha256 "1c20bcfbcea922f1ceb14c95d2ad1211add4e1b03ba8491405640c384ea5a8df"
 
   bottle :unneeded
-
-  # Incompatible with Erlang/OTP 20.0
-  # See upstream issue from 23 Jun 2017 https://github.com/rabbitmq/rabbitmq-server/issues/1272
-  depends_on "erlang@19"
 
   def install
     # Install the base files

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -6,6 +6,8 @@ class Rabbitmq < Formula
 
   bottle :unneeded
 
+  depends_on "erlang"
+
   def install
     # Install the base files
     prefix.install Dir["*"]
@@ -15,9 +17,9 @@ class Rabbitmq < Formula
     (var/"log/rabbitmq").mkpath
 
     # Correct SYS_PREFIX for things like rabbitmq-plugins
+    erlang = Formula["erlang"]
     inreplace sbin/"rabbitmq-defaults" do |s|
       s.gsub! "SYS_PREFIX=${RABBITMQ_HOME}", "SYS_PREFIX=#{HOMEBREW_PREFIX}"
-      erlang = Formula["erlang@19"]
       s.gsub! /^ERL_DIR=$/, "ERL_DIR=#{erlang.opt_bin}/"
       s.gsub! "CLEAN_BOOT_FILE=start_clean", "CLEAN_BOOT_FILE=#{erlang.opt_lib/"erlang/bin/start_clean"}"
       s.gsub! "SASL_BOOT_FILE=start_sasl", "SASL_BOOT_FILE=#{erlang.opt_lib/"erlang/bin/start_clean"}"


### PR DESCRIPTION
Currently the package is downloaded from rabbitmq.com/releases.
Team RabbitMQ plans to turn it into a read-only archive and eventually
shut it down. While it's not going to happen any time soon, we try
to not reference or recommend it anywhere. Instead, the users are
encouraged to use [GitHub](https://github.com/rabbitmq/rabbitmq-server/releases), [Bintray](https://bintray.com/rabbitmq/) or [Package Cloud](https://packagecloud.com/rabbitmq/).

Besides that, Bintray offers a CDN and better availability.

While at it, I've noticed that OTP 20 is marked as unsupported.
That's no longer correct: [RabbitMQ officially supports OTP 20
as of 3.6.11](https://groups.google.com/forum/#!searchin/rabbitmq-users/OTP$2020%7Csort:relevance/rabbitmq-users/_imbAavBYjY/ninEKhMYAgAJ).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
