### PR TITLE
Add --with-xquartz option to pkg-config

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -13,6 +13,8 @@ class PkgConfig < Formula
     sha256 "d9ccc19f1a55919408a1b27260b0404aa36dc6782a4a5964e6fd8409abf3b830" => :yosemite
   end
 
+  option "with-xquartz", "Build against XQuarts libraries"
+
   def install
     pc_path = %W[
       #{HOMEBREW_PREFIX}/lib/pkgconfig
@@ -21,6 +23,8 @@ class PkgConfig < Formula
       /usr/lib/pkgconfig
       #{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}
     ].uniq.join(File::PATH_SEPARATOR)
+
+    pc_path << File::PATH_SEPARATOR + "/opt/X11/lib/pkgconfig" if build.with? "xquartz"
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
I need this feature myself but perhaps there is a more general use case, so I'd like to suggest to make this an official option. 

Our systems need to be able to link against libraries that are shipped with `XQuartz`. Currently we do so by setting `PKG_CONFIG_PATH` however having it properly built-in is much more reliable than having to set variables where-ever `pkg-config` may get called.

Thanks for considering :)