### PR TITLE
docfx 2.24

### DIFF
--- a/Formula/docfx.rb
+++ b/Formula/docfx.rb
@@ -1,8 +1,8 @@
 class Docfx < Formula
   desc "Tools for building and publishing API documentation for .NET projects"
   homepage "https://dotnet.github.io/docfx/"
-  url "https://github.com/dotnet/docfx/releases/download/v2.23.1/docfx.zip"
-  sha256 "9fdb2e8f050ce9dd8f17415c5c8bb81cea5403e1ac85f7941450dfbefe505104"
+  url "https://github.com/dotnet/docfx/releases/download/v2.24/docfx.zip"
+  sha256 "6f22bd5fa15f0ad1a6125f08b47bf55e0cca1c3022159e5d83077b659f0ec74f"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Note that `brew bump-formula-pr` seems to fail for this formula on my box:

```
chrislong@gMac ~> brew bump-formula-pr --url="https://github.com/dotnet/docfx/releases/download/v2.24/docfx.zip" docfx
==> Downloading https://github.com/dotnet/docfx/releases/download/v2.24/docfx.zip
Already downloaded: /Users/chrislong/Library/Caches/Homebrew/docfx-2.24.zip
Already up-to-date.
==> replace nil with nil
Error: no implicit conversion of nil into String
/usr/local/Homebrew/Library/Homebrew/extend/string.rb:56:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/extend/string.rb:56:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:63:in `block (2 levels) in inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:59:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:59:in `block in inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:26:in `block in inreplace'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:22:in `each'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:22:in `inreplace'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:58:in `inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:243:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
```