### PR TITLE
Update recommended launchdns TLD

### DIFF
--- a/Formula/launchdns.rb
+++ b/Formula/launchdns.rb
@@ -4,6 +4,7 @@ class Launchdns < Formula
   url "https://github.com/josh/launchdns/archive/v1.0.3.tar.gz"
   sha256 "c34bab9b4f5c0441d76fefb1ee16cb0279ab435e92986021c7d1d18ee408a5dd"
   head "https://github.com/josh/launchdns.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/launchdns.rb
+++ b/Formula/launchdns.rb
@@ -21,11 +21,11 @@ class Launchdns < Formula
     system "./configure", "--with-launch-h", "--with-launch-h-activate-socket"
     system "make", "install"
 
-    (prefix/"etc/resolver/dev").write("nameserver 127.0.0.1\nport 55353\n")
+    (prefix/"etc/resolver/localhost").write("nameserver 127.0.0.1\nport 55353\n")
   end
 
   def caveats; <<-EOS.undent
-    To have *.dev resolved to 127.0.0.1:
+    To have *.localhost resolved to 127.0.0.1:
       sudo ln -s #{HOMEBREW_PREFIX}/etc/resolver /etc
     EOS
   end


### PR DESCRIPTION
The launchdns formula provides a way to automatically route all DNS queries for a given TLD to the localhost. That TLD is configurable, but homebrew suggests using a `.dev` TLD by default. But there are some [upcoming changes to Chrome will introduce some problems with the default `.dev` configuration](https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/). This should no longer be the default configuration.

I'd suggest recommending `.localhost` as per [draft-west-let-localhost-be-localhost-06](https://tools.ietf.org/html/draft-west-let-localhost-be-localhost-06). I'll be [updating the launchdns README to do the same](https://github.com/josh/launchdns/pull/7).

##

CC: @MikeMcQuaid @mistydemeo