### PR TITLE
cmake: use 10.11 bottle on 10.12

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -8,8 +8,7 @@ class Cmake < Formula
   bottle do
     cellar :any_skip_relocation
     sha256 "2ddc58f5d0fa8fc0abab86818c4a3f4901912bb334690b322597c21e39b4199c" => :high_sierra
-    sha256 "58d217a8e6369410036727070c967bd95d36f5b57da6bd4127bdcde657ee745f" => :sierra
-    sha256 "43ed6c8d693f3216d55d21e2ecbe958cffa02a7ea54e96b74172408b0f0ff00d" => :el_capitan
+    sha256 "43ed6c8d693f3216d55d21e2ecbe958cffa02a7ea54e96b74172408b0f0ff00d" => :el_capitan_or_later
   end
 
   option "without-docs", "Don't build man pages"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
futimens and utimensat aren't actually defined on 10.12, though they are defined in the 10.13 SDK, so this hacks around the problem until it's fixed in the build.