### PR TITLE
cmake: bump revision to make sure the 10.11 bottle is used on 10.12

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -3,6 +3,7 @@ class Cmake < Formula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.9/cmake-3.9.3.tar.gz"
   sha256 "8eaf75e1e932159aae98ab5e7491499545554be62a08cbcbc7c75c84b999f28a"
+  revision 1
   head "https://cmake.org/cmake.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow up to #18371 to make sure anyone who got the bad bottle is
switched over to the 10.11 bottle.