### PR TITLE
gdb: add expat

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -4,6 +4,7 @@ class Gdb < Formula
   url "https://ftp.gnu.org/gnu/gdb/gdb-8.0.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-8.0.1.tar.xz"
   sha256 "3dbd5f93e36ba2815ad0efab030dcd0c7b211d7b353a40a53f4c02d7d56295e3"
+  revision 1
 
   bottle do
     sha256 "e98ad847402592bd48a9b1468fefb2fac32aff1fa19c2681c3cea7fb457baaa0" => :high_sierra
@@ -22,6 +23,7 @@ class Gdb < Formula
   depends_on "pkg-config" => :build
   depends_on "python" => :optional
   depends_on "guile@2.0" => :optional
+  depends_on "expat" => :optional
 
   def install
     args = [
@@ -32,6 +34,10 @@ class Gdb < Formula
 
     args << "--with-guile" if build.with? "guile@2.0"
     args << "--enable-targets=all" if build.with? "all-targets"
+
+    # uses homewbrew expat
+    args << "--with-expat" if build.with? "expat"
+    args << "--with-libexpat-prefix=/usr/local/opt/expat" if build.with? "expat"
 
     if build.with? "python"
       args << "--with-python=#{HOMEBREW_PREFIX}"


### PR DESCRIPTION
debian builds its gdb & gdbserver with expat (XML) support. In order to
remote debug, the client needs expat support as well. This formula
update allows optionally linking against the homebrew expat library.

- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
