### PR TITLE
GCC 4.8 and earlier are not supported on High Sierra

### DIFF
--- a/Formula/gcc@4.6.rb
+++ b/Formula/gcc@4.6.rb
@@ -51,6 +51,7 @@ class GccAT46 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
+  depends_on MaximumMacOSRequirement => :sierra
   depends_on "gmp@4"
   depends_on "libmpc@0.8"
   depends_on "mpfr@2"

--- a/Formula/gcc@4.7.rb
+++ b/Formula/gcc@4.7.rb
@@ -54,6 +54,7 @@ class GccAT47 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
+  depends_on MaximumMacOSRequirement => :sierra
   depends_on "gmp@4"
   depends_on "libmpc@0.8"
   depends_on "mpfr@2"

--- a/Formula/gcc@4.8.rb
+++ b/Formula/gcc@4.8.rb
@@ -61,6 +61,7 @@ class GccAT48 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
+  depends_on MaximumMacOSRequirement => :sierra
   depends_on "gmp@4"
   depends_on "libmpc@0.8"
   depends_on "mpfr@2"


### PR DESCRIPTION
GCC 4.8 series was originally released in March 2013, and the final release in this series was on June 2015. It does not support High Sierra, and using the Sierra bottle will not help because the issues are at runtime (including processing of system headers).

Thus, marking those 3 old versions as `depends_on MaximumMacOSRequirement => :sierra`