### PR TITLE
go@1.4: build from commit, drop CGO support, simplify formula

### DIFF
--- a/Formula/go@1.4.rb
+++ b/Formula/go@1.4.rb
@@ -1,10 +1,9 @@
 class GoAT14 < Formula
   desc "Go programming environment (1.4)"
   homepage "https://golang.org"
-  url "https://storage.googleapis.com/golang/go1.4.3.src.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/go-1.4/go1.4.3.src.tar.gz"
-  version "1.4.3"
-  sha256 "9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959"
+  url "https://github.com/golang/go.git",
+      :revision => "d76c7d5a31ffaba3134f16981abd5f891fa2d805"
+  version "1.4.3-20170922"
 
   bottle do
     sha256 "310b4c2b5d3a63e7d16dbac1f3d1283600171db07ec469a4b2521a313a4a8040" => :sierra
@@ -16,22 +15,10 @@ class GoAT14 < Formula
 
   option "with-cc-all", "Build with cross-compilers and runtime support for all supported platforms"
   option "with-cc-common", "Build with cross-compilers and runtime support for darwin, linux and windows"
-  option "without-cgo", "Build without cgo"
-  option "without-godoc", "godoc will not be installed for you"
-  option "without-vet", "vet will not be installed for you"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
         :branch => "release-branch.go1.4"
-  end
-
-  # fix build on macOS Sierra by adding compatibility for new gettimeofday behavior
-  # patch derived from backported fixes to the go 1.4 release branch
-  if MacOS.version == "10.12"
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/29ef8e9/go%401.4/go%401.4-Sierra-build.patch"
-      sha256 "49c3f57432b2b3037af737c900a01822cff0a1cb440947db8507e636f6430a33"
-    end
   end
 
   def install
@@ -66,7 +53,7 @@ class GoAT14 < Formula
           ENV["GOROOT_FINAL"] = libexec
           ENV["GOOS"]         = os
           ENV["GOARCH"]       = arch
-          ENV["CGO_ENABLED"]  = "0" if build.without?("cgo")
+          ENV["CGO_ENABLED"]  = "0"
           ohai "Building go for #{arch}-#{os}"
           system "./make.bash", "--no-clean"
         end
@@ -78,26 +65,20 @@ class GoAT14 < Formula
     (bin/"go").write_env_script(libexec/"bin/go", :PATH => "#{libexec}/bin:$PATH")
     bin.install_symlink libexec/"bin/gofmt"
 
-    if build.with?("godoc") || build.with?("vet")
-      ENV.prepend_path "PATH", libexec/"bin"
-      ENV["GOPATH"] = buildpath
-      (buildpath/"src/golang.org/x/tools").install resource("gotools")
+    ENV.prepend_path "PATH", libexec/"bin"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/golang.org/x/tools").install resource("gotools")
 
-      if build.with? "godoc"
-        cd "src/golang.org/x/tools/cmd/godoc/" do
-          system "go", "build"
-          (libexec/"bin").install "godoc"
-        end
-        bin.install_symlink libexec/"bin/godoc"
-      end
+    cd "src/golang.org/x/tools/cmd/godoc/" do
+      system "go", "build"
+      (libexec/"bin").install "godoc"
+    end
+    bin.install_symlink libexec/"bin/godoc"
 
-      if build.with? "vet"
-        cd "src/golang.org/x/tools/cmd/vet/" do
-          system "go", "build"
-          # This is where Go puts vet natively; not in the bin.
-          (libexec/"pkg/tool/darwin_amd64/").install "vet"
-        end
-      end
+    cd "src/golang.org/x/tools/cmd/vet/" do
+      system "go", "build"
+      # This is where Go puts vet natively; not in the bin.
+      (libexec/"pkg/tool/darwin_amd64/").install "vet"
     end
   end
 
@@ -123,14 +104,9 @@ class GoAT14 < Formula
     system "#{bin}/go", "fmt", "hello.go"
     assert_equal "Hello World\n", shell_output("#{bin}/go run hello.go")
 
-    if build.with? "godoc"
-      assert File.exist?(libexec/"bin/godoc")
-      assert File.executable?(libexec/"bin/godoc")
-    end
-
-    if build.with? "vet"
-      assert File.exist?(libexec/"pkg/tool/darwin_amd64/vet")
-      assert File.executable?(libexec/"pkg/tool/darwin_amd64/vet")
-    end
+    assert_predicate libexec/"bin/godoc", :exist?, "godoc does not exist!"
+    assert_predicate libexec/"bin/godoc", :executable?, "godoc is not executable!"
+    assert_predicate libexec/"pkg/tool/darwin_amd64/vet", :exist?, "vet does not exist!"
+    assert_predicate libexec/"pkg/tool/darwin_amd64/vet", :executable?, "vet is not executable!"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> Does your build pass `brew audit --strict <formula>`

No, because:
```
Error: undefined method `hash_type' for nil:NilClass
/usr/local/Homebrew/Library/Homebrew/checksum.rb:16:in `=='
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:733:in `block in audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:730:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:730:in `audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1069:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1062:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1062:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:108:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:104:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:104:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
```
Insert bemused look here.

But:

* Makes the tools mandatory
* Builds from the latest commit
* Drops the now redundant patch
* Drops CGO support following upstream's lead

Closes https://github.com/Homebrew/homebrew-core/issues/18465.