### PR TITLE
sip: use includes from /System or brewed python instead of Xcode

### DIFF
--- a/Formula/sip.rb
+++ b/Formula/sip.rb
@@ -3,7 +3,7 @@ class Sip < Formula
   homepage "https://www.riverbankcomputing.com/software/sip/intro"
   url "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.19.3/sip-4.19.3.tar.gz"
   sha256 "740df844f80cc45dcc9b23294a92492923bc403ce88e68c35783f27c177c4b74"
-  revision 2
+  revision 3
   head "https://www.riverbankcomputing.com/hg/sip", :using => :hg
 
   bottle do
@@ -30,7 +30,8 @@ class Sip < Formula
     end
 
     Language::Python.each_python(build) do |python, version|
-      # Note the binary `sip` is the same for python 2.x and 3.x
+      # Avoid picking up /Application/Xcode.app paths
+      ENV.delete("SDKROOT")
       system python, "configure.py",
                      "--deployment-target=#{MacOS.version}",
                      "--destdir=#{lib}/python#{version}/site-packages",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? *Except for the "Formula name conflicts with caskroom/cask/sip", which is not a regression*

-----

Addresses https://github.com/Homebrew/homebrew-core/pull/18155#issuecomment-330148493. This should prevent `sip` tests from failing when Xcode version changes affect the MacOSX SDK version number/path. And as a salutary effect, it'll make `sip` work under more user configurations.

The default `sip` build bakes in include paths to `/Applications/Xcode.app/.../SDKs/MacOSX10.XXX` in its `lib/python*/site-packages/sipconfig.py` file. This means that it's broken if you install it from a bottle and do not have Xcode installed at the default location, or if you move Xcode after installing it. And it'll break when the MacOSX SDK version increments, as it did with Xcode 9.

This PR changes `sip` to use the paths from `/System/Library/Frameworks` or the brewed Python 2.7 (if installed), removing the `/Applications/Xcode.app/.../SDKs` dependency, for the 2.6/2.7 Pythons.

Note: This PR does not change paths used by Python 3, which means `python3` version bumps will still require a `sip` revision bump. And `sip` builds done against a brewed Python 2 will still have paths to the kegs built in, so `python` revision bumps will still require rebuilds for users who installed `sip` from source against a brewed `python`. I think those concerns are out of scope for this change, though. Or maybe this should go all the way and try to change all `sip`'s path to use `opt_prefix`? I don't know if that would be legit, though, since I don't know if Python preserves the relevant compatibility across minor versions.