### PR TITLE
git-cola: unset PYTHONPATH

### DIFF
--- a/Formula/git-cola.rb
+++ b/Formula/git-cola.rb
@@ -19,6 +19,7 @@ class GitCola < Formula
   depends_on "sphinx-doc" => :build if build.with? "docs"
 
   def install
+    ENV.delete("PYTHONPATH")
     system "make", "PYTHON=python3", "prefix=#{prefix}", "install"
 
     if build.with? "docs"


### PR DESCRIPTION
Otherwise the build fails on macOS 10.13 with:

```
make
PYTHON=python3
prefix=/usr/local/Cellar/git-cola/2.11
install

Failed to import the site module
Your PYTHONPATH points to a site-packages dir for Python 2.x but you are running Python 3.x!
     PYTHONPATH is currently: "/usr/local/lib/python2.7/site-packages"
     You should `unset PYTHONPATH` to fix this.
python3 setup.py build
Failed to import the site module
Your PYTHONPATH points to a site-packages dir for Python 2.x but you are running Python 3.x!
     PYTHONPATH is currently: "/usr/local/lib/python2.7/site-packages"
     You should `unset PYTHONPATH` to fix this.
make: *** [build] Error 1
```