### PR TITLE
faas-cli: use canonical repository URL

### DIFF
--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -1,7 +1,7 @@
 class FaasCli < Formula
   desc "CLI for templating and/or deploying FaaS functions"
   homepage "http://docs.get-faas.com/"
-  url "https://github.com/alexellis/faas-cli.git",
+  url "https://github.com/openfaas/faas-cli.git",
       :tag => "0.4.15",
       :revision => "ae3b137914f8478a4b7bf14db24df6677f9f278f"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Go import path is still the old one.
See https://github.com/openfaas/faas-cli/issues/116.