### PR TITLE
libbitcoin-blockchain 3.3.0 (new formula)

### DIFF
--- a/Formula/libbitcoin-blockchain.rb
+++ b/Formula/libbitcoin-blockchain.rb
@@ -1,0 +1,69 @@
+class LibbitcoinBlockchain < Formula
+  desc "Bitcoin Blockchain Library"
+  homepage "https://github.com/libbitcoin/libbitcoin-blockchain"
+  url "https://github.com/libbitcoin/libbitcoin-blockchain/archive/v3.3.0.tar.gz"
+  sha256 "c97762f37e30b0d41b5f9d70499dbf9ca70096924410e98a15781e4cb5c39966"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libbitcoin"
+
+  resource "libbitcoin-consensus" do
+    url "https://github.com/libbitcoin/libbitcoin-consensus/archive/v3.3.0.tar.gz"
+    sha256 "ae581f7c42a52fb6f4a233300f76f2a2d03a22eee6d4bfe22b233e9b52f029b4"
+  end
+
+  resource "libbitcoin-database" do
+    url "https://github.com/libbitcoin/libbitcoin-database/archive/v3.3.0.tar.gz"
+    sha256 "b4d98199ac4629a9857c1eb8819fe8166525bf2dca9ed790a9bbe5dc9c9e9186"
+  end
+
+  def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_create_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
+
+    resource("libbitcoin-consensus").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    resource("libbitcoin-database").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <bitcoin/blockchain.hpp>
+      int main() {
+        static const auto default_block_hash = libbitcoin::hash_literal("14508459b221041eab257d2baaa7459775ba748246c8403609eb708f0e57e74b");
+        const auto block = std::make_shared<const libbitcoin::message::block>();
+        libbitcoin::blockchain::block_entry instance(block);
+        assert(instance.block() == block);
+        assert(instance.hash() == default_block_hash);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp",
+                    "-I#{libexec}/include",
+                    "-L#{lib}", "-L#{libexec}/lib",
+                    "-lbitcoin", "-lbitcoin-blockchain", "-lboost_system",
+                    "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This formula is for libbitcoin-blockchain. Along with libbitcoin-blockchain, it also builds its dependencies libbitcoin-consensus and libbitcoin-database. The formula includes a small test. The eventual goal is to submit a formula for libbitcoin-server, which includes libbitcoin-blockchain in its dependency chain.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
