### PR TITLE
Fix encfs broken build

### DIFF
--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -23,11 +23,13 @@ class Encfs < Formula
 
   def install
     ENV.cxx11
-    ENV.append "CMAKE_INCLUDE_PATH", "/usr/local/include", ":"
     ENV.append "CMAKE_LIBRARY_PATH", "/usr/local/lib", ":"
 
+    args = std_cmake_args
+    args << "-DFUSE_INCLUDE_DIR=/usr/local"
+
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *args
       system "make", "install"
     end
   end

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -23,6 +23,8 @@ class Encfs < Formula
 
   def install
     ENV.cxx11
+    ENV.append "CMAKE_INCLUDE_PATH", "/usr/local/include", ":"
+    ENV.append "CMAKE_LIBRARY_PATH", "/usr/local/lib", ":"
 
     mkdir "build" do
       system "cmake", "..", *std_cmake_args


### PR DESCRIPTION
This fixes a problem with building encfs:

```
==> Upgrading 1 outdated package, with result:
encfs 1.9.2
==> Upgrading encfs 
==> Downloading https://github.com/vgough/encfs/archive/v1.9.2.tar.gz
Already downloaded: /Users/gerritb/Library/Caches/Homebrew/encfs-1.9.2.tar.gz
==> cmake .. -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/opt/homebrew/Cellar/encfs/1.9.2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_F
Last 15 lines from /Users/gerritb/Library/Logs/Homebrew/encfs/01.cmake:
-- Check for working CXX compiler: /opt/homebrew/Library/Homebrew/shims/super/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /opt/homebrew/Cellar/cmake/3.9.3_1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find FUSE (missing: FUSE_INCLUDE_DIR FUSE_LIBRARIES)
Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.9.3_1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:377 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindFUSE.cmake:29 (find_package_handle_standard_args)
  CMakeLists.txt:63 (find_package)


-- Configuring incomplete, errors occurred!
See also "/tmp/encfs-20170926-13252-10ogldg/encfs-1.9.2/build/CMakeFiles/CMakeOutput.log".

READ THIS: https://docs.brew.sh/Troubleshooting.html

These open issues may also help:
Formulae missing High Sierra bottles https://github.com/Homebrew/homebrew-core/issues/18493

```