### PR TITLE
ffmpeg: remove --enable-vda and --with-schroedinger

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -6,7 +6,10 @@ class Ffmpeg < Formula
     url "https://ffmpeg.org/releases/ffmpeg-3.3.4.tar.bz2"
     sha256 "5ef5e9276c311c74ab2e9d301c2d7ee10e1f2cbd758c6f13d6cb9514dffbac7e"
 
+    option "with-schroedinger", "Enable Dirac video format"
+
     depends_on "yasm" => :build
+    depends_on "schroedinger" => :optional
 
     # Upstream commit from 23 Jun 2017 "Add support for LibOpenJPEG v2.2/git"
     # See https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
@@ -41,7 +44,6 @@ class Ffmpeg < Formula
   option "with-openssl", "Enable SSL support"
   option "with-rtmpdump", "Enable RTMP protocol"
   option "with-rubberband", "Enable rubberband library"
-  option "with-schroedinger", "Enable Dirac video format"
   option "with-sdl2", "Enable FFplay media player"
   option "with-snappy", "Enable Snappy library"
   option "with-tools", "Enable additional FFmpeg tools"
@@ -91,7 +93,6 @@ class Ffmpeg < Formula
   depends_on "opus" => :optional
   depends_on "rtmpdump" => :optional
   depends_on "rubberband" => :optional
-  depends_on "schroedinger" => :optional
   depends_on "sdl2" => :optional
   depends_on "snappy" => :optional
   depends_on "speex" => :optional
@@ -181,7 +182,7 @@ class Ffmpeg < Formula
     # A bug in a dispatch header on 10.10, included via CoreFoundation,
     # prevents GCC from building VDA support.
     # See: https://github.com/Homebrew/homebrew/issues/33741
-    if MacOS.version != :yosemite || ENV.compiler == :clang
+    if !build.head? && (MacOS.version != :yosemite || ENV.compiler == :clang)
       args << "--enable-vda"
     else
       args << "--disable-vda"


### PR DESCRIPTION
VDA does not even exist on recent macOS versions anymore and will be removed from ffmpeg soon.

libschroedinger is removed from FFmpeg git and will be removed with FFmpeg 3.4



### Sources

libschroedinger: https://github.com/FFmpeg/FFmpeg/blob/1ef7752d64cbe9af2f27cc65aba3a2ca3831c128/Changelog#L18

vda: http://ffmpeg.org/pipermail/ffmpeg-devel/2017-September/215888.html



Fixes #18381

---- 

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----