### PR TITLE
vips: move GPL-licensed dependencies to :recommended

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -12,7 +12,6 @@ class Vips < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "fftw"
   depends_on "fontconfig"
   depends_on "gettext"
   depends_on "giflib"
@@ -27,8 +26,11 @@ class Vips < Formula
   depends_on "little-cms2"
   depends_on "orc"
   depends_on "pango"
-  depends_on "poppler"
   depends_on "pygobject3"
+
+  depends_on "fftw" => :recommended
+  depends_on "poppler" => :recommended
+
   depends_on "graphicsmagick" => :optional
   depends_on "imagemagick" => :optional
   depends_on "jpeg-turbo" => :optional

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -27,7 +27,6 @@ class Vips < Formula
   depends_on "orc"
   depends_on "pango"
   depends_on "pygobject3"
-
   depends_on "fftw" => :recommended
   depends_on "poppler" => :recommended
 

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -29,7 +29,6 @@ class Vips < Formula
   depends_on "pygobject3"
   depends_on "fftw" => :recommended
   depends_on "poppler" => :recommended
-
   depends_on "graphicsmagick" => :optional
   depends_on "imagemagick" => :optional
   depends_on "jpeg-turbo" => :optional


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, `fftw` and `poppler` are GPL-licensed (and optional) dependencies of `vips` that are currently included as hard dependencies.

As `vips` is used as a shared library, having GPL-licensed dependencies means user code in the same process becomes GPL-licensed, which may not be desired.

This PR moves these two dependencies to `:recommended` status, allowing users to opt out of GPL-licensed code via `--without-fftw` and `--without-poppler` flags.

Using `:recommended` has the benefit that the pre-compiled binaries remain the same for backwards compatibility.

/cc @jcupitt