### PR TITLE
rabbitmq: put /usr/sbin in $PATH so we can find sysctl

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -79,7 +79,7 @@ class Rabbitmq < Formula
         <dict>
           <!-- need erl in the path -->
           <key>PATH</key>
-          <string>#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:#{HOMEBREW_PREFIX}/bin</string>
+          <string>#{HOMEBREW_PREFIX}/sbin:/usr/sbin:/usr/bin:/bin:#{HOMEBREW_PREFIX}/bin</string>
           <!-- specify the path to the rabbitmq-env.conf file -->
           <key>CONF_ENV_FILE</key>
           <string>#{etc}/rabbitmq/rabbitmq-env.conf</string>


### PR DESCRIPTION
This lets RabbitMQ find sysctl.  Before this patch, RabbitMQ assumed total
system memory was 1024 MB because it couldn't call sysctl to find the correct
amount.

Before this patch:
```
=WARNING REPORT==== 26-Sep-2017::10:32:02 ===
Failed to get total system memory: 
badarg
[{erlang,list_to_integer,["env: sysctl: No such file or directory"],[]},
 {vm_memory_monitor,sysctl,1,[{file,"src/vm_memory_monitor.erl"},{line,509}]},
 {vm_memory_monitor,get_total_memory_from_os,0,
                    [{file,"src/vm_memory_monitor.erl"},{line,275}]},
 {vm_memory_monitor,set_mem_limits,2,
                    [{file,"src/vm_memory_monitor.erl"},{line,294}]},
 {vm_memory_monitor,init,1,[{file,"src/vm_memory_monitor.erl"},{line,233}]},
 {gen_server,init_it,2,[{file,"gen_server.erl"},{line,365}]},
 {gen_server,init_it,6,[{file,"gen_server.erl"},{line,333}]},
 {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]

=WARNING REPORT==== 26-Sep-2017::10:32:02 ===
Unknown total memory size for your OS {unix,darwin}. Assuming memory size is 1024 MiB (1073741824 bytes).

=INFO REPORT==== 26-Sep-2017::10:32:02 ===
Memory high watermark set to 409 MiB (429496729 bytes) of 1024 MiB (1073741824 bytes) total

=WARNING REPORT==== 26-Sep-2017::10:32:02 ===
Failed to get total system memory: 
badarg
[{erlang,list_to_integer,["env: sysctl: No such file or directory"],[]},
 {vm_memory_monitor,sysctl,1,[{file,"src/vm_memory_monitor.erl"},{line,509}]},
 {vm_memory_monitor,get_total_memory_from_os,0,
                    [{file,"src/vm_memory_monitor.erl"},{line,275}]},
 {rabbit_disk_monitor,enable,1,
                      [{file,"src/rabbit_disk_monitor.erl"},{line,274}]},
 {rabbit_disk_monitor,init,1,
                      [{file,"src/rabbit_disk_monitor.erl"},{line,132}]},
 {gen_server,init_it,2,[{file,"gen_server.erl"},{line,365}]},
 {gen_server,init_it,6,[{file,"gen_server.erl"},{line,333}]},
 {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]

=INFO REPORT==== 26-Sep-2017::10:32:02 ===
ERROR: "Free disk space monitor encountered an error (e.g. failed to parse output from OS tools): ~p, retries left: ~s~n" - [{41962614784,
                                                                                                                              unknown},
                                                                                                                             10]
```

Also before:
```shellsession
% rabbitmqctl eval 'os:getenv("PATH").'
"/usr/local/Cellar/erlang/20.0.5/lib/erlang/erts-9.0.5/bin:/usr/local/Cellar/erlang/20.0.5/lib/erlang/bin:/usr/local/sbin:/usr/bin:/bin:/usr/local/bin"
% rabbitmqctl eval 'os:cmd("which sysctl").'
[]
```

After this patch (I have 16 GB of RAM):
```
=INFO REPORT==== 26-Sep-2017::14:57:44 ===
Memory high watermark set to 6553 MiB (6871947673 bytes) of 16384 MiB (17179869184 bytes) total
```

Also after:
```shellsession
% rabbitmqctl eval 'os:getenv("PATH").'
"/usr/local/Cellar/erlang/20.0.5/lib/erlang/erts-9.0.5/bin:/usr/local/Cellar/erlang/20.0.5/lib/erlang/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin"
% rabbitmqctl eval 'os:cmd("which sysctl").'
"/usr/sbin/sysctl\n"
```

Original report in rabbitmq/rabbitmq-server#1375.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
