### PR TITLE
libbitcoin-node 3.3.0 (new formula)

### DIFF
--- a/Aliases/bn
+++ b/Aliases/bn
@@ -1,0 +1,1 @@
+../Formula/libbitcoin-node.rb

--- a/Formula/libbitcoin-node.rb
+++ b/Formula/libbitcoin-node.rb
@@ -1,0 +1,56 @@
+class LibbitcoinNode < Formula
+  desc "Bitcoin Full Node"
+  homepage "https://github.com/libbitcoin/libbitcoin-node"
+  url "https://github.com/libbitcoin/libbitcoin-node/archive/v3.3.0.tar.gz"
+  sha256 "51298e2346d629215171af14b01d61cfabe93ddaa8069595a80b8b9f88224f7b"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libbitcoin-blockchain"
+
+  resource "libbitcoin-network" do
+    url "https://github.com/libbitcoin/libbitcoin-network/archive/v3.3.0.tar.gz"
+    sha256 "cab9142d2b94019c824365c0b39d7e31dbc9aaeb98c6b4bf22ce32b829395c19"
+  end
+
+  def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin-blockchain"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_create_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
+
+    resource("libbitcoin-network").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <bitcoin/node.hpp>
+      int main() {
+        libbitcoin::node::settings configuration;
+        assert(configuration.sync_peers == 0u);
+        assert(configuration.sync_timeout_seconds == 5u);
+        assert(configuration.refresh_transactions == true);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp",
+                    "-I#{libexec}/include",
+                    "-I" + Formula["libbitcoin-blockchain"].opt_libexec/"include",
+                    "-lbitcoin", "-lbitcoin-node", "-lboost_system",
+                    "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This is [libbitcoin-node](https://github.com/libbitcoin/libbitcoin-node). It is a dependency of libbitcoin-server, which I plan to create a formula for. It builds libbitcoin-network as a resource. It also depends on libbitcoin-database, which is a resource defined by libbitcoin-blockchain, and secp256k1, which is a resource defined by libbitcoin.

The formula includes a small test that exercises an include installed by libbitcoin-node. Even though libbitcoin-node installs a binary, it starts up a Bitcoin node, which isn't really suitable for trying to run tests.

Since the installed binary is called `bn`, this pull request also includes a `bn` alias.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
