### PR TITLE
rcs: %n crash fix for 10.13

### DIFF
--- a/Formula/rcs.rb
+++ b/Formula/rcs.rb
@@ -4,6 +4,7 @@ class Rcs < Formula
   url "https://ftp.gnu.org/gnu/rcs/rcs-5.9.4.tar.xz"
   mirror "https://ftpmirror.gnu.org/rcs/rcs-5.9.4.tar.xz"
   sha256 "063d5a0d7da1821754b80c639cdae2c82b535c8ff4131f75dc7bbf0cd63a5dff"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -20,6 +21,13 @@ class Rcs < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/3fff7c990b8df4174045834b9c1210e7736ff5a4/rcs/noreturn.patch"
     sha256 "ac2f5ad1df932361e19c6184d2dfddfbe7664184ac4c24a3224c85707cd4da9f"
+  end
+
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix crash from the use of %n in dynamic format strings on High Sierra.

Fixes https://github.com/Homebrew/homebrew-core/issues/18566.
Fixes https://github.com/Homebrew/homebrew-core/issues/18593.