### PR TITLE
bison@2.7: %n crash fix for 10.13

### DIFF
--- a/Formula/bison@2.7.rb
+++ b/Formula/bison@2.7.rb
@@ -4,6 +4,7 @@ class BisonAT27 < Formula
   url "https://ftp.gnu.org/gnu/bison/bison-2.7.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/bison/bison-2.7.1.tar.gz"
   sha256 "08e2296b024bab8ea36f3bb3b91d071165b22afda39a17ffc8ff53ade2883431"
+  revision 1
 
   bottle do
     sha256 "c6c60860d585646d15840350b5c9e7b36026bdef84eab99dcd83887c20080d8a" => :high_sierra
@@ -13,6 +14,13 @@ class BisonAT27 < Formula
   end
 
   keg_only :versioned_formula
+
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix crash from the use of %n in dynamic format strings on High Sierra.

Fixes https://github.com/Homebrew/homebrew-core/issues/18591.