### PR TITLE
gitlab-runner: renamed from gitlab-ci-multi-runner (10.0.0)

### DIFF
--- a/Aliases/gitlab-ci-multi-runner
+++ b/Aliases/gitlab-ci-multi-runner
@@ -1,0 +1,1 @@
+../Formula/gitlab-runner.rb

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -4,8 +4,8 @@ class GitlabRunner < Formula
   desc "The official GitLab CI runner written in Go"
   homepage "https://gitlab.com/gitlab-org/gitlab-runner"
   url "https://gitlab.com/gitlab-org/gitlab-runner.git",
-      :tag => "v9.5.0",
-      :revision => "413da38a72634601bf435f6215d6669cd5a4e40e"
+      :tag => "v10.0.0",
+      :revision => "2055cfdc9ab6a2ba5aa3a84fe14372cd214e08db"
   head "https://gitlab.com/gitlab-org/gitlab-runner.git"
 
   bottle do
@@ -25,17 +25,17 @@ class GitlabRunner < Formula
   end
 
   resource "prebuilt-x86_64.tar.xz" do
-    url "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v9.5.0/docker/prebuilt-x86_64.tar.xz",
+    url "https://gitlab-runner-downloads.s3.amazonaws.com/v10.0.0/docker/prebuilt-x86_64.tar.xz",
         :using => :nounzip
-    version "9.5.0"
-    sha256 "b771f522bb628d694fde2933fd293d4e4bfd1facf9b9650ecc940f8e6f817717"
+    version "10.0.0"
+    sha256 "9c88e6f924f14ab6802103436bb6419cc4da1c46a77f39a1bc40349abfbf2e8f"
   end
 
   resource "prebuilt-arm.tar.xz" do
-    url "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v9.5.0/docker/prebuilt-arm.tar.xz",
+    url "https://gitlab-runner-downloads.s3.amazonaws.com/v10.0.0/docker/prebuilt-arm.tar.xz",
         :using => :nounzip
-    version "9.5.0"
-    sha256 "12d3106afeec6eacba9771e6c08ec851c002160b0c37b6a03516f035473a9746"
+    version "10.0.0"
+    sha256 "9c56f8a58eaec81ed0da6242177672fef28ea49b784abd8e78e69b5d67cde3a7"
   end
 
   def install

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -1,12 +1,12 @@
 require "language/go"
 
-class GitlabCiMultiRunner < Formula
+class GitlabRunner < Formula
   desc "The official GitLab CI runner written in Go"
-  homepage "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner"
-  url "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git",
+  homepage "https://gitlab.com/gitlab-org/gitlab-runner"
+  url "https://gitlab.com/gitlab-org/gitlab-runner.git",
       :tag => "v9.5.0",
       :revision => "413da38a72634601bf435f6215d6669cd5a4e40e"
-  head "https://gitlab.com/gitlab-org/gitlab-ci-multi-runner.git"
+  head "https://gitlab.com/gitlab-org/gitlab-runner.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -40,7 +40,7 @@ class GitlabCiMultiRunner < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/gitlab.com/gitlab-org/gitlab-ci-multi-runner"
+    dir = buildpath/"src/gitlab.com/gitlab-org/gitlab-runner"
     dir.install buildpath.children
     ENV.prepend_create_path "PATH", buildpath/"bin"
     Language::Go.stage_deps resources, buildpath/"src"
@@ -58,25 +58,24 @@ class GitlabCiMultiRunner < Formula
                            "prebuilt-x86_64.tar.xz",
                            "prebuilt-arm.tar.xz"
 
-      proj = "gitlab.com/gitlab-org/gitlab-ci-multi-runner"
+      proj = "gitlab.com/gitlab-org/gitlab-runner"
       commit = Utils.popen_read("git", "rev-parse", "--short", "HEAD").chomp
       branch = version.to_s.split(".")[0..1].join("-") + "-stable"
       built = Time.new.strftime("%Y-%m-%dT%H:%M:%S%:z")
       system "go", "build", "-ldflags", <<-EOS.undent
-             -X #{proj}/common.NAME=gitlab-ci-multi-runner
+             -X #{proj}/common.NAME=gitlab-runner
              -X #{proj}/common.VERSION=#{version}
              -X #{proj}/common.REVISION=#{commit}
              -X #{proj}/common.BRANCH=#{branch}
              -X #{proj}/common.BUILT=#{built}
       EOS
 
-      bin.install "gitlab-ci-multi-runner"
-      bin.install_symlink bin/"gitlab-ci-multi-runner" => "gitlab-runner"
+      bin.install "gitlab-runner"
       prefix.install_metafiles
     end
   end
 
-  plist_options :manual => "gitlab-ci-multi-runner start"
+  plist_options :manual => "gitlab-runner start"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>
@@ -91,7 +90,7 @@ class GitlabCiMultiRunner < Formula
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
         <array>
-          <string>#{opt_bin}/gitlab-ci-multi-runner</string>
+          <string>#{opt_bin}/gitlab-runner</string>
           <string>run</string>
           <string>--working-directory</string>
           <string>#{ENV["HOME"]}</string>

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -48,6 +48,7 @@
   "gcc5": "gcc@5",
   "gcc6": "gcc@6",
   "geode": "apache-geode",
+  "gitlab-ci-multi-runner": "gitlab-runner",
   "giflib5": "giflib@5",
   "giflib@5": "giflib",
   "glfw2": "glfw@2",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Recently, we (at GitLab) renamed our runner to `gitlab-runner` ([source](https://about.gitlab.com/2017/09/22/gitlab-10-0-released/#new-gitlab-runner-repository)). It's now hosted at https://gitlab.com/gitlab-org/gitlab-runner/.

This PR renames the runner formula and bumps it to the most recent `10.0.0` version.

cc @tmaczukin @To1ne