### PR TITLE
mame: remove Xcode 9 patch

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -25,21 +25,13 @@ class Mame < Formula
   depends_on "portaudio"
   depends_on "utf8proc"
 
-  # Needs compiler and library support C++14.
+  # Need C++ compiler and standard library support C++14.
   needs :cxx14
 
   # jpeg 9 compatibility
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/2b7053a/mame/jpeg9.patch"
     sha256 "be8095e1b519f17ac4b9e6208f2d434e47346d8b4a8faf001b68749aac3efd20"
-  end
-
-  # Patch for Xcode 9: https://github.com/mamedev/mame/issues/2598
-  if DevelopmentTools.clang_build_version >= 900
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/7ab58e7967/mame/xcode9.patch"
-      sha256 "2d7d0ffa9adbee780ce584403f4c2a7386b5edb097321efafc1778fc0200573d"
-    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Seems issue is resolved (on my 10.12 with Xcode 9), is Homebrew/formula-patches' patch needs delete?