### PR TITLE
Apply libgda patches to work with XCode 9

### DIFF
--- a/Formula/libgda.rb
+++ b/Formula/libgda.rb
@@ -32,4 +32,21 @@ class Libgda < Formula
     system "make"
     system "make", "install"
   end
+
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/bai/formula-patches/a089089f6657bec65cad85dd2a4f105027682db6/libgda/0001-Convert-files-to-Unicode.patch"
+      sha256 "2e25ee9ca86b3767485b26b19317e5188641e2dbfa6202bb204b16e332cca3a4"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/bai/formula-patches/e248bb75e2d481d312f31dccf8b5acbfee9adbec/libgda/glib-2.54-ftbfs.patch"
+      sha256 "73f65147b1d7d3b78982c9ac562816e855db1b20d7ff346d9fd1ecb013864afc"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/bai/formula-patches/53ea4e47b0d799227e1de832f7af02038ed1499c/libgda/mysqlpatch.patch"
+      sha256 "3b49117a8671ee6c8a599873a95f692b76720635b1c991f107540a84bc355abc"
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


Fixes libgda builds on XCode 9 / High Sierra

TODO: Update patch URLs when https://github.com/Homebrew/formula-patches/pull/191 is merged.