### PR TITLE
unixodbc: depends on GNU libtool

### DIFF
--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -13,6 +13,8 @@ class Unixodbc < Formula
     sha256 "82f217f67f78a6dab125b77558e99f9ee18227f991ab8d842e881e83d0c7d917" => :yosemite
   end
 
+  depends_on "libtool" => :run
+
   keg_only "Shadows system iODBC header files" if MacOS.version < :mavericks
 
   conflicts_with "virtuoso", :because => "Both install `isql` binaries."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
With GNU's libtool, UnixODBC links to that without a specific option. 

>$ otool -L /usr/local/Cellar/unixodbc/2.3.4/lib/libodbcinst.2.dylib
/usr/local/Cellar/unixodbc/2.3.4/lib/libodbcinst.2.dylib:
	/usr/local/opt/unixodbc/lib/libodbcinst.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/local/opt/libtool/lib/libltdl.7.dylib (compatibility version 11.0.0, current version 11.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)

This may have risk at uninstalling only GNU's libtool.