### PR TITLE
mosh: Rename from mobile-shell

### DIFF
--- a/Aliases/mobile-shell
+++ b/Aliases/mobile-shell
@@ -1,0 +1,1 @@
+../Formula/mosh.rb

--- a/Aliases/mosh
+++ b/Aliases/mosh
@@ -1,1 +1,0 @@
-../Formula/mobile-shell.rb

--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -1,4 +1,4 @@
-class MobileShell < Formula
+class Mosh < Formula
   desc "Remote terminal application"
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.3.2.tar.gz"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -107,6 +107,7 @@
   "mariadb100": "mariadb@10.0",
   "maven31": "maven@3.1",
   "maven32": "maven@3.2",
+  "mobile-shell": "mosh",
   "mongo-c": "mongo-c-driver",
   "mongodb26": "mongodb@2.6",
   "mongodb30": "mongodb@3.0",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Renaming `mobile-shell` to `mosh` to be consistent with actual package name.
See: https://mosh.org/