### PR TITLE
libbitcoin-server 3.3.0 (new formula)

### DIFF
--- a/Aliases/bs
+++ b/Aliases/bs
@@ -1,0 +1,1 @@
+../Formula/libbitcoin-server.rb

--- a/Formula/libbitcoin-server.rb
+++ b/Formula/libbitcoin-server.rb
@@ -48,8 +48,8 @@ class LibbitcoinServer < Formula
     EOS
     system ENV.cxx, "-std=c++11", "test.cpp",
                     "-I#{libexec}/include",
-                    "-I" + Formula["libbitcoin-blockchain"].opt_libexec/"include",
-                    "-I" + Formula["libbitcoin-node"].opt_libexec/"include",
+                    "-I#{Formula["libbitcoin-blockchain"].opt_libexec}/include",
+                    "-I#{Formula["libbitcoin-node"].opt_libexec}/include",
                     "-lbitcoin", "-lbitcoin-server", "-lboost_system",
                     "-o", "test"
     system "./test"

--- a/Formula/libbitcoin-server.rb
+++ b/Formula/libbitcoin-server.rb
@@ -1,0 +1,57 @@
+class LibbitcoinServer < Formula
+  desc "Bitcoin Full Node and Query Server"
+  homepage "https://github.com/libbitcoin/libbitcoin-server"
+  url "https://github.com/libbitcoin/libbitcoin-server/archive/v3.3.0.tar.gz"
+  sha256 "3066ff98af14574edae3e36b056b847558953e501c9b4f626c0428db9933a0ad"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libbitcoin-node"
+  depends_on "zeromq"
+
+  resource "libbitcoin-protocol" do
+    url "https://github.com/libbitcoin/libbitcoin-protocol/archive/v3.3.0.tar.gz"
+    sha256 "7902de78b4c646daf2012e04bb7967784f67a6372a8a8d3c77417dabcc4b617d"
+  end
+
+  def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin-blockchain"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin-node"].opt_libexec/"lib/pkgconfig"
+    ENV.prepend_create_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
+
+    resource("libbitcoin-protocol").stage do
+      system "./autogen.sh"
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{libexec}"
+      system "make", "install"
+    end
+
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <bitcoin/server.hpp>
+      int main() {
+          libbitcoin::server::message message(true);
+          assert(message.secure() == true);
+          return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp",
+                    "-I#{libexec}/include",
+                    "-I" + Formula["libbitcoin-blockchain"].opt_libexec/"include",
+                    "-I" + Formula["libbitcoin-node"].opt_libexec/"include",
+                    "-lbitcoin", "-lbitcoin-server", "-lboost_system",
+                    "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This is libbitcoin-server, a Bitcoin full node and query server. The formula depends on libbitcoin-node, which is another formula, and libbitcoin-protocol, which is defined as a resource here. The libbitcoin-protocol library, in turn, depends on zeromq, which is why it is specified as a dependency.

Since libbitcoin-server's installed executable is called `bs`, I have created an alias for it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
