### PR TITLE
testssl: install etc files and set correct path to openssl

### DIFF
--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -4,6 +4,7 @@ class Testssl < Formula
   url "https://github.com/drwetter/testssl.sh/archive/v2.9.5-1.tar.gz"
   version "2.9.5-1"
   sha256 "505ba9400e1a49759ba84d0cf6ae79f3787f111c64a319094de69635b786c72a"
+  revision 1
   head "https://github.com/drwetter/testssl.sh.git"
 
   bottle :unneeded
@@ -11,9 +12,14 @@ class Testssl < Formula
   depends_on "openssl"
 
   def install
-    ENV.prepend_create_path "PATH", Formula["openssl"].opt_prefix.to_s
     bin.install "testssl.sh"
-    bin.env_script_all_files(libexec+"bin", :PATH => ENV["PATH"])
+    man1.install "doc/testssl.1"
+    prefix.install "etc"
+    env = {
+      :PATH => "#{Formula["openssl"].opt_bin}:$PATH",
+      :TESTSSL_INSTALL_DIR => prefix,
+    }
+    bin.env_script_all_files(libexec/"bin", env)
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/18634.