### PR TITLE
bc: add libedit build option

### DIFF
--- a/Formula/bc.rb
+++ b/Formula/bc.rb
@@ -16,13 +16,18 @@ class Bc < Formula
   keg_only :provided_by_osx
 
   def install
+    # prevent user BC_ENV_ARGS from interfering with or influencing the
+    # bootstrap phase of the build, particularly
+    # BC_ENV_ARGS="--mathlib=./my_custom_stuff.b"
+    ENV.delete("BC_ENV_ARGS")
     system "./configure",
       "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
       "--prefix=#{prefix}",
       "--infodir=#{info}",
-      "--mandir=#{man}"
+      "--mandir=#{man}",
+      "--with-libedit"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


This also fixes a potential bug when building from source with a BC_ENV_ARGS environment variable set with a --mathlib defined.  The build process uses a bootstrap build of bc without a standard library, and then uses that build to parse the libmath.b file and then embeds the standard library (libmath) inside a new bc executable.  This fails if you have some competing definitions in a mathlib file, so this temporarily blanks the BC_ENV_ARGS environment variable just to be safe.