### PR TITLE
fbi-servefiles 2.4.13 (new formula)

### DIFF
--- a/Formula/fbi-servefiles.rb
+++ b/Formula/fbi-servefiles.rb
@@ -1,6 +1,6 @@
 class FbiServefiles < Formula
   include Language::Python::Virtualenv
-  desc "Serve local files to the Nintendo 3DS via the FBI remote installer"
+  desc "Serve local files to Nintendo 3DS via FBI remote installer"
   homepage "https://github.com/Steveice10/FBI"
   url "https://github.com/Steveice10/FBI/archive/2.4.13.tar.gz"
   sha256 "f03d96a32622fd3b9732ff734d9d65b50d4af445eed8e6eb77fd9641265eb42e"

--- a/Formula/fbi-servefiles.rb
+++ b/Formula/fbi-servefiles.rb
@@ -1,0 +1,49 @@
+class FbiServefiles < Formula
+  include Language::Python::Virtualenv
+  desc "Serve local files to the Nintendo 3DS via the FBI remote installer"
+  homepage "https://github.com/Steveice10/FBI"
+  url "https://github.com/Steveice10/FBI/archive/2.4.13.tar.gz"
+  sha256 "f03d96a32622fd3b9732ff734d9d65b50d4af445eed8e6eb77fd9641265eb42e"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  def install
+    venv = virtualenv_create(libexec)
+    venv.pip_install_and_link buildpath/"servefiles"
+  end
+
+  test do
+    require "socket"
+
+    def test_socket
+      server = TCPServer.new(5000)
+      client = server.accept
+      client.puts "\n"
+      client_response = client.gets
+      client.close
+      server.close
+      client_response
+    end
+
+    begin
+      pid = fork do
+        system "#{bin}/sendurls.py", "127.0.0.1", "https://github.com"
+      end
+      assert_match "https://github.com", test_socket
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+
+    begin
+      touch "test.cia"
+      pid = fork do
+        system "#{bin}/servefiles.py", "127.0.0.1", "test.cia", "127.0.0.1", "8080"
+      end
+      assert_match "127.0.0.1:8080/test.cia", test_socket
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Servefiles is a python2 script that sends CIAs (3DS application installers) to FBI (a 3DS program to install CIAs). It doesn't have its own git repository, but uses the FBI repository. I used the FBI main support thread on GBAtemp (https://gbatemp.net/threads/release-fbi-open-source-cia-installer.386433/) as homepage, as FBI nor servefiles appears to have it's own homepage. The servefiles script is mentioned in the GBAtemp thread.