### PR TITLE
openal-soft: utilities fail to run

### DIFF
--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -1,8 +1,8 @@
 class OpenalSoft < Formula
   desc "Implementation of the OpenAL 3D audio API"
   homepage "http://kcat.strangesoft.net/openal.html"
-  url "http://kcat.strangesoft.net/openal-releases/openal-soft-1.18.2.tar.bz2"
-  sha256 "9f8ac1e27fba15a59758a13f0c7f6540a0605b6c3a691def9d420570506d7e82"
+  url "https://github.com/kcat/openal-soft/archive/openal-soft-1.18.2.tar.gz"
+  sha256 "a598241d1af2e90c25a1b91da4c9ddc0e7cb6a4b5f1477fc680d139c57cd38cc"
   head "http://repo.or.cz/openal-soft.git"
 
   bottle do

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -36,6 +36,7 @@ class OpenalSoft < Formula
     args << "-DALSOFT_BACKEND_PORTAUDIO=OFF" if build.without? "portaudio"
     args << "-DALSOFT_BACKEND_PULSEAUDIO=OFF" if build.without? "pulseaudio"
     args << "-DALSOFT_MIDI_FLUIDSYNTH=OFF" if build.without? "fluid-synth"
+    args << "-DALSOFT_BACKEND_JACK=OFF" if build.without? "jack"
 
     system "cmake", ".", *args
     system "make", "install"

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -1,8 +1,8 @@
 class OpenalSoft < Formula
   desc "Implementation of the OpenAL 3D audio API"
   homepage "http://kcat.strangesoft.net/openal.html"
-  url "https://github.com/kcat/openal-soft/archive/openal-soft-1.18.2.tar.gz"
-  sha256 "a598241d1af2e90c25a1b91da4c9ddc0e7cb6a4b5f1477fc680d139c57cd38cc"
+  url "http://kcat.strangesoft.net/openal-releases/openal-soft-1.18.2.tar.bz2"
+  sha256 "9f8ac1e27fba15a59758a13f0c7f6540a0605b6c3a691def9d420570506d7e82"
   head "http://repo.or.cz/openal-soft.git"
 
   bottle do

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -17,7 +17,6 @@ class OpenalSoft < Formula
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "portaudio" => :optional
-  depends_on "pulseaudio" => :optional
   depends_on "fluid-synth" => :optional
   depends_on "jack" => :optional
 
@@ -31,10 +30,9 @@ class OpenalSoft < Formula
     # Please don't reenable example building. See:
     # https://github.com/Homebrew/homebrew/issues/38274
     args = std_cmake_args
-    args << "-DALSOFT_EXAMPLES=OFF"
+    args << "-DALSOFT_EXAMPLES=OFF" <<"-DALSOFT_BACKEND_PULSEAUDIO=OFF"
 
     args << "-DALSOFT_BACKEND_PORTAUDIO=OFF" if build.without? "portaudio"
-    args << "-DALSOFT_BACKEND_PULSEAUDIO=OFF" if build.without? "pulseaudio"
     args << "-DALSOFT_MIDI_FLUIDSYNTH=OFF" if build.without? "fluid-synth"
     args << "-DALSOFT_BACKEND_JACK=OFF" if build.without? "jack"
 

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -19,15 +19,16 @@ class OpenalSoft < Formula
   depends_on "portaudio" => :optional
   depends_on "pulseaudio" => :optional
   depends_on "fluid-synth" => :optional
+  depends_on "jack" => :optional
 
   # clang 4.2's support for alignas is incomplete
   fails_with(:clang) { build 425 }
 
   def install
-    # Please don't reenable example building. See:
-    # https://github.com/Homebrew/homebrew/issues/38274
+    #  See: https://github.com/kcat/openal-soft/issues/153
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{opt_lib}"
+
     args = std_cmake_args
-    args << "-DALSOFT_EXAMPLES=OFF" << "-DALSOFT_UTILS=OFF"
 
     args << "-DALSOFT_BACKEND_PORTAUDIO=OFF" if build.without? "portaudio"
     args << "-DALSOFT_BACKEND_PULSEAUDIO=OFF" if build.without? "pulseaudio"

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -27,7 +27,7 @@ class OpenalSoft < Formula
     # Please don't reenable example building. See:
     # https://github.com/Homebrew/homebrew/issues/38274
     args = std_cmake_args
-    args << "-DALSOFT_EXAMPLES=OFF"
+    args << "-DALSOFT_EXAMPLES=OFF" << "-DALSOFT_UTILS=OFF"
 
     args << "-DALSOFT_BACKEND_PORTAUDIO=OFF" if build.without? "portaudio"
     args << "-DALSOFT_BACKEND_PULSEAUDIO=OFF" if build.without? "pulseaudio"

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -28,7 +28,10 @@ class OpenalSoft < Formula
     #  See: https://github.com/kcat/openal-soft/issues/153
     ENV.append "LDFLAGS", "-Wl,-rpath,#{opt_lib}"
 
+    # Please don't reenable example building. See:
+    # https://github.com/Homebrew/homebrew/issues/38274
     args = std_cmake_args
+    args << "-DALSOFT_EXAMPLES=OFF"
 
     args << "-DALSOFT_BACKEND_PORTAUDIO=OFF" if build.without? "portaudio"
     args << "-DALSOFT_BACKEND_PULSEAUDIO=OFF" if build.without? "pulseaudio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
----
Because these don't work. See https://github.com/kcat/openal-soft/issues/153
We cannot use _runpath_ for `openal-soft` because `openal-soft` is _keg-only_.