### PR TITLE
bulk_extractor: remove Java GUI

### DIFF
--- a/Formula/bulk_extractor.rb
+++ b/Formula/bulk_extractor.rb
@@ -3,7 +3,7 @@ class BulkExtractor < Formula
   homepage "https://github.com/simsong/bulk_extractor/wiki"
   url "https://digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz"
   sha256 "297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -14,11 +14,11 @@ class BulkExtractor < Formula
     sha256 "b4928062ab8c39d082a9dbba713f4e0e3e460d2c111af0c39981eeba3d1d7638" => :mavericks
   end
 
-  depends_on "afflib" => :optional
   depends_on "boost"
+  depends_on "openssl"
+  depends_on "afflib" => :optional
   depends_on "exiv2" => :optional
   depends_on "libewf" => :optional
-  depends_on "openssl"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -30,12 +30,6 @@ class BulkExtractor < Formula
     (pkgshare/"doc").install Dir["doc/*.{html,txt,pdf}"]
 
     (lib/"python2.7/site-packages").install Dir["python/*.py"]
-
-    # Install the GUI the Homebrew way
-    # .jar gets installed into bin by default
-    libexec.install bin/"BEViewer.jar"
-    (bin/"BEViewer").unlink
-    bin.write_jar_script libexec/"BEViewer.jar", "BEViewer", "-Xmx1g"
   end
 
   test do


### PR DESCRIPTION
This formula does not build anymore, on any macOS version from 10.11 to 10.13, neither on my machine nor on CI machines. The error is:

```
Error: No such file or directory - /usr/local/Cellar/bulk_extractor/1.5.5_1/bin/BEViewer.jar
```

I do not know why it did build and bottle at some point, maybe with a specific Java version? In any case, let's just skip the installation of the Java GUI for now. If it has users, we can figure out how to include it in a proper manner.