### PR TITLE
git-annex: depend on ghc

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -5,9 +5,27 @@ class GitAnnex < Formula
 
   desc "Manage files with git without checking in file contents"
   homepage "https://git-annex.branchable.com/"
-  url "https://hackage.haskell.org/package/git-annex-6.20170925/git-annex-6.20170925.tar.gz"
-  sha256 "c0b14db55a215fdc19f129646ad6a014da99cda5a77af5ce3915e2af6cb3f84f"
+  revision 1
   head "git://git-annex.branchable.com/"
+
+  stable do
+    url "https://hackage.haskell.org/package/git-annex-6.20170925/git-annex-6.20170925.tar.gz"
+    sha256 "c0b14db55a215fdc19f129646ad6a014da99cda5a77af5ce3915e2af6cb3f84f"
+
+    # Upstream commit from 29 Sep 2017 "Fix reversion that made it only run
+    # inside a git repository."
+    resource "patch-git-annex-test" do
+      url "http://source.git-annex.branchable.com/?p=source.git;a=patch;h=f84e34883cfb5b45a86f6c69961886c0ec8843c1"
+      sha256 "8291d269e44fce7437016db8e6cf2d27d710aae9b6bcdec28dc11600655f6359"
+    end
+
+    # Upstream commit from 29 Sep 2017 "fix process and FD leak" when building
+    # with GHC 8.2.1
+    resource "patch-fd-leak" do
+      url "http://source.git-annex.branchable.com/?p=source.git;a=patch;h=5c32196a376cdaf231a9ccde9bb97297f651a132"
+      sha256 "57f26b21efac6d07fa5af96333acfa5a1cdf18cc316c97c0567cacb7d7e0e473"
+    end
+  end
 
   bottle do
     sha256 "2c08f39c961a98fd3a98401bdf892018d70b2aba481e3a81affbe1233050fe75" => :high_sierra
@@ -17,8 +35,8 @@ class GitAnnex < Formula
 
   option "with-git-union-merge", "Build the git-union-merge tool"
 
-  depends_on "ghc@8.0" => :build
   depends_on "cabal-install" => :build
+  depends_on "ghc" => :build
   depends_on "pkg-config" => :build
   depends_on "gsasl"
   depends_on "libmagic"
@@ -26,7 +44,20 @@ class GitAnnex < Formula
   depends_on "xdot" => :recommended
 
   def install
-    install_cabal_package :using => ["alex", "happy", "c2hs"], :flags => ["s3", "webapp"] do
+    if build.stable?
+      buildpath.install resource("patch-git-annex-test")
+      puts Utils.popen_read("patch", "-f", "-p1", "-i",
+           "p=source.git;a=patch;h=f84e34883cfb5b45a86f6c69961886c0ec8843c1")
+
+      buildpath.install resource("patch-fd-leak")
+      puts Utils.popen_read("patch", "-f", "-p1", "-i",
+           "p=source.git;a=patch;h=5c32196a376cdaf231a9ccde9bb97297f651a132")
+    end
+
+    # Upstream issue from 7 Sep 2017 "Please support ghc-8.2.1 (by allowing
+    # time-1.8.*)" https://github.com/aristidb/aws/issues/238
+    install_cabal_package "--allow-newer=aws:time",
+                          :using => ["alex", "happy", "c2hs"], :flags => ["s3", "webapp"] do
       # this can be made the default behavior again once git-union-merge builds properly when bottling
       if build.with? "git-union-merge"
         system "make", "git-union-merge", "PREFIX=#{prefix}"
@@ -42,7 +73,7 @@ class GitAnnex < Formula
     ENV.prepend_path "PATH", bin
     # We don't want this here or it gets "caught" by git-annex.
     rm_r "Library/Python/2.7/lib/python/site-packages/homebrew.pth"
-
+    system "git", "annex", "test"
     system "git", "init"
     system "git", "annex", "init"
     (testpath/"Hello.txt").write "Hello!"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

instead of ghc@8.0

CC @joeyh Thanks for the GHC 8.2.1 fix!