### PR TITLE
root 6.10.06

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -1,9 +1,9 @@
 class Root < Formula
   desc "Object oriented framework for large scale data analysis"
   homepage "https://root.cern.ch"
-  url "https://root.cern.ch/download/root_v6.10.04.source.tar.gz"
-  version "6.10.04"
-  sha256 "461bde21d78608422310f04c599e84ce8dfbdd91caf12c2a54db6c01f8228f5b"
+  url "https://root.cern.ch/download/root_v6.10.06.source.tar.gz"
+  version "6.10.06"
+  sha256 "02ba62b2a732f4f8d7beecb29556545cc30d122bc87da904473de69a8972ed74"
   head "http://root.cern.ch/git/root.git"
 
   bottle do
@@ -25,6 +25,24 @@ class Root < Formula
   needs :cxx11
 
   skip_clean "bin"
+
+  # 3 upstream commits that fix compilation with Xcode 9
+  if DevelopmentTools.clang_build_version >= 900
+    patch do
+      url "https://github.com/root-project/root/commit/26350842.patch?full_index=1"
+      sha256 "27d29c775d8c8100ebd7f206eeb8364a30015f39a1af1a00203ef80ff1a04cd9"
+    end
+
+    patch do
+      url "https://github.com/root-project/root/commit/9339de9e.patch?full_index=1"
+      sha256 "f7386c626fcc64791cfcbe35a0efc10c245c10e4f0547687334592da70c99ab5"
+    end
+
+    patch do
+      url "https://github.com/root-project/root/commit/7d585604.patch?full_index=1"
+      sha256 "3ff15aa6f15621d14d07de06ed4e31f901d07da54695fae1948dba5e2884fc8f"
+    end
+  end
 
   def install
     args = std_cmake_args + %W[


### PR DESCRIPTION
Lifting 3 patches from upstream, but still a build issue:

```
In file included from input_line_11:10:
In file included from /tmp/root-20170930-49103-35tkvb/root-6.10.06/builddir/include/TLDAPAttribute.h:12:
In file included from /tmp/root-20170930-49103-35tkvb/root-6.10.06/builddir/include/TNamed.h:26:
In file included from /tmp/root-20170930-49103-35tkvb/root-6.10.06/builddir/include/TString.h:26:
In file included from /tmp/root-20170930-49103-35tkvb/root-6.10.06/builddir/include/TMathBase.h:32:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/cmath:313:9: error: no member named 'signbit' in the global namespace
using ::signbit;
      ~~^
```