### PR TITLE
libssh2: make openssl required

### DIFF
--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -21,7 +21,7 @@ class Libssh2 < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl" => :recommended
+  depends_on "openssl"
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
OpenSSL was made recommended on f4eb2b4efd1 so that users can choose LibreSSL.
Since LibreSSL has gone, we should revert this change.