### PR TITLE
neal 0.2.4 (new formula)

### DIFF
--- a/Formula/neal.rb
+++ b/Formula/neal.rb
@@ -28,15 +28,15 @@ class Neal < Formula
   end
 
   test do
-    (testpath/"FailingTest.swift").write <<~EOS.undent
+    (testpath/"FailingTest.swift").write <<~EOS
       (nil as Int?)!
     EOS
 
-    (testpath/"PassingTest.swift").write <<~EOS.undent
+    (testpath/"PassingTest.swift").write <<~EOS
       (nil as Int?)
     EOS
 
-    (testpath/"Swift.rules").write <<~EOS.undent
+    (testpath/"Swift.rules").write <<~EOS
       rule NoForcedValues {
         Swift::ForcedValueExpression {
           fail("No forced unwrapping allowed")
@@ -44,7 +44,9 @@ class Neal < Formula
       }
     EOS
 
-    assert_match "No forced unwrapping allowed", shell_output("#{bin}/neal --reporter arc -r Swift.rules FailingTest.swift", 1)
-    assert_equal "", shell_output("#{bin}/neal --reporter arc -r Swift.rules PassingTest.swift", 0)
+    cmd = "#{bin}/neal --reporter arc -r Swift.rules FailingTest.swift"
+    assert_match "No forced unwrapping allowed", shell_output(cmd, 1)
+    cmd = "#{bin}/neal --reporter arc -r Swift.rules PassingTest.swift"
+    assert_equal "", shell_output(cmd)
   end
 end

--- a/Formula/neal.rb
+++ b/Formula/neal.rb
@@ -1,0 +1,50 @@
+class Neal < Formula
+  desc "Analyzes source code based on user-specified rules written in a custom DSL"
+  homepage "https://uber.github.io/NEAL/"
+  url "https://github.com/uber/NEAL/archive/v0.2.4.tar.gz"
+  sha256 "2dc1f2fd2c1cbdbe4914737fcccb6d13d0eabbc67f764d88a3f8c4a1a2bc6416"
+  head "https://github.com/uber/NEAL.git"
+
+  depends_on "camlp4" => :build
+  depends_on "ocaml" => :build
+  depends_on "ocaml-num" => :build
+  depends_on "ocamlbuild" => :build
+  depends_on "opam" => :build
+
+  def install
+    opamroot = buildpath/"opamroot"
+    opamroot.mkpath
+    ENV["OPAMROOT"] = opamroot
+
+    ENV["OPAMYES"] = "1"
+    ENV["NATIVE"] = "1"
+    ENV["LIB_PATH"] = lib
+    ENV["BIN_PATH"] = bin
+
+    system "opam", "init", "--no-setup"
+    system "opam", "install", "ocamlfind"
+    system "opam", "install", "--fake", "num"
+    system "opam", "config", "exec", "--", "make", "brew"
+  end
+
+  test do
+    (testpath/"FailingTest.swift").write <<~EOS.undent
+      (nil as Int?)!
+    EOS
+
+    (testpath/"PassingTest.swift").write <<~EOS.undent
+      (nil as Int?)
+    EOS
+
+    (testpath/"Swift.rules").write <<~EOS.undent
+      rule NoForcedValues {
+        Swift::ForcedValueExpression {
+          fail("No forced unwrapping allowed")
+        }
+      }
+    EOS
+
+    assert_match "No forced unwrapping allowed", shell_output("#{bin}/neal --reporter arc -r Swift.rules FailingTest.swift", 1)
+    assert_equal "", shell_output("#{bin}/neal --reporter arc -r Swift.rules PassingTest.swift", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'd like to add NEAL, a new code analyser developed by Uber, to Homebrew. I've followed all the guidelines, the only issue I've found is the requirement that the repository is not "notable enough". However, that is expected, as it's a new project that hasn't been publicly announced yet, and my goal is to announce it with easy installation instructions via homebrew. I also went through the "Self-submitted stuff" in the "Acceptable Formulae" guide, and the project does meet most requirements: it's stable, it's maintained, it's used extensively at Uber and it does have a homepage with a lot of docs.