### PR TITLE
resty 2.3

### DIFF
--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -1,29 +1,57 @@
 class Resty < Formula
   desc "Command-line REST client that can be used in pipelines"
   homepage "https://github.com/micha/resty"
-  url "https://github.com/micha/resty/archive/2.2.tar.gz"
-  sha256 "a6961e16f1489ffa25bf9f2d8b38b9599c008d49267e32adf93f4f87184d4857"
+  url "https://github.com/micha/resty/archive/2.3.tar.gz"
+  sha256 "65c7bfe1268669d9da5456686c55f1976380b867db5bf12d3603972d7b2d65fd"
   head "https://github.com/micha/resty.git"
 
-  bottle :unneeded
-
-  # Don't take +x off these files
+  # Don't take +x off these files. note: to be killed once a shebang is added to pp
   skip_clean "bin"
 
+  resource "JSON" do
+    url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-2.94.tar.gz"
+    mirror "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-2.94.tar.gz"
+    sha256 "12271b5cee49943bbdde430eef58f1fe64ba6561980b22c69585e08fc977dc6d"
+  end
+
   def install
-    bin.install %w[pp resty pypp]
+    pkgshare.install "resty"
+
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
+    resource("JSON").stage do
+      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+      system "make"
+      system "make", "install"
+    end
+
+    bin.install "pp"
+    bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
+    chmod 0755, "#{bin}/pp" # note: to clean after a shebang is added to pp
+
+    bin.install "pypp"
   end
 
   def caveats; <<~EOS
-    The Python printy-printer (pypp) uses the json module, available in
-    Python 2.6 and newer.
-
-    The Perl printy-printer (pp) depends on JSON from CPAN:
-      cpan JSON
+    To activate the resty, add the following at the end of your #{shell_profile}:
+    source #{opt_pkgshare}/resty
     EOS
   end
 
   test do
-    pipe_output("#{bin}/resty https://api.github.com", "GET /orgs/homebrew/repos")
+    cmd = "zsh -c '. #{pkgshare}/resty && resty https://api.github.com' 2>&1"
+    assert_equal "https://api.github.com*", shell_output(cmd).chomp
+    json_pretty_pypp=<<~EOS
+      {
+          "a": 1
+      }
+    EOS
+    json_pretty_pp=<<~EOS
+      {
+         "a" : 1
+      }
+    EOS
+    assert_equal json_pretty_pypp, pipe_output("#{bin}/pypp", '{"a":1}', 0)
+    assert_equal json_pretty_pp, pipe_output("#{bin}/pp", '{"a":1}', 0).chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Recipe built with `brew bump-formula-pr --strict resty ...`, but command stalled after the commit.

I ran brew audit, outputing the following warning:
```
resty:
  * Non-executables were installed to "/usr/local/opt/resty/bin"
    The offending files are:
      /usr/local/opt/resty/bin/resty
Error: 1 problem in 1 formula
```
I don't know what to do, since resty had to be source, and that was already the case in the precedent recipe. 😕 