### PR TITLE
masscan: fix build with Xcode 9

### DIFF
--- a/Formula/masscan.rb
+++ b/Formula/masscan.rb
@@ -12,6 +12,13 @@ class Masscan < Formula
     sha256 "969e348d0a3738b1fcc5082a6c0feef0f18d1f462b3d9bec0cd1751781b263e3" => :yosemite
   end
 
+  if DevelopmentTools.clang_build_version >= 900
+    patch do
+      url "https://github.com/robertdavidgraham/masscan/pull/282.patch?full_index=1"
+      sha256 "0daa190200f5cf3e11e9e1c29ea65e7e8e8c0b13fbeccf9a2319cb166234d684"
+    end
+  end
+
   def install
     # Fix `dyld: lazy symbol binding failed: Symbol not found: _clock_gettime`
     # Reported 8 July 2017: https://github.com/robertdavidgraham/masscan/issues/284


### PR DESCRIPTION
Upstream open pull request fixes the build: https://github.com/robertdavidgraham/masscan/issues/294