### PR TITLE
docker-ls 0.3.1 (new formula)

### DIFF
--- a/Formula/docker-ls.rb
+++ b/Formula/docker-ls.rb
@@ -1,0 +1,34 @@
+class DockerLs < Formula
+  desc "Tools for browsing and manipulating docker registries"
+  homepage "https://github.com/mayflower/docker-ls"
+  url "https://github.com/mayflower/docker-ls.git",
+    :tag => "v0.3.1",
+    :revision => "d80310976c9707e261e57ebfa9acf4e0b1781460"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    (buildpath/"src/github.com/mayflower/docker-ls").install buildpath.children
+
+    system "go", "generate", "github.com/mayflower/docker-ls/lib"
+
+    cd "src/github.com/mayflower/docker-ls" do
+      system "go", "build", "-o", bin/"docker-ls", "./cli/docker-ls"
+      system "go", "build", "-o", bin/"docker-rm", "./cli/docker-rm"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_match /\Wlatest\W/m, pipe_output("#{bin}/docker-ls tags \
+      -r https://index.docker.io -u '' -p '' \
+      --progress-indicator=false library/busybox \
+    ")
+
+    assert_match /401/, pipe_output("#{bin}/docker-rm  \
+      -r https://index.docker.io -u foo -p bar library/busybox:latest 2<&1 \
+    ")
+  end
+end


### PR DESCRIPTION
This commit adds docker-ls 0.3.1 .

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
