### PR TITLE
cvs: fix runtime error on 10.13 due to %n format string issue

### DIFF
--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -8,6 +8,7 @@ class Cvs < Formula
   homepage "http://cvs.nongnu.org/"
   url "https://ftp.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
   sha256 "78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e"
+  revision 1
 
   bottle do
     sha256 "b8604bdb205a892e4cab5ea86b825080aa22ea5c5bb6e9df9b2b65a67555a105" => :high_sierra
@@ -32,6 +33,13 @@ class Cvs < Formula
           "patches/remove-info.diff",
           "patches/tag.diff",
           "patches/zlib.diff"
+  end
+
+  # Fixes error: 'Illegal instruction: 4'; '%n used in a non-immutable format string' on 10.13
+  # Patches the upstream-provided gnulib on all platforms as is recommended
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/24118ec737c7/cvs/vasnprintf-high-sierra-fix.diff"
+    sha256 "affa485332f66bb182963680f90552937bf1455b855388f7c06ef6a3a25286e2"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
fixes 'Illegal instruction: 4' error

-----
Resolves #18853 