### PR TITLE
qt@5.9.1: fix QTBUG-62266 on 10.12

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -61,7 +61,7 @@ class Qt < Formula
 
   # Patch fixing bugs QTBUG-62266 and QTBUG-62658 on macOS 10.13 High Sierra
   # https://github.com/Homebrew/homebrew-core/issues/17075
-  if MacOS.version >= :high_sierra
+  if MacOS.version >= :sierra
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/45282b5b48/qt/high-sierra.diff"
       sha256 "d8589d747a9ce0b7b7ddf1b59c4d999bbf8a02261e047a602cff39bea151eb42"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
$ brew install qt --with-qtwebkit
Updating Homebrew...
==> Downloading https://download.qt.io/official_releases/qt/5.9/5.9.1/single/qt-everywhere-opensource-src-5.9.1.tar.xz
Already downloaded: /Users/kaneko/Library/Caches/Homebrew/qt-5.9.1.tar.xz
==> Downloading https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch
Already downloaded: /Users/kaneko/Library/Caches/Homebrew/qt--patch-48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b.patch
==> Downloading https://raw.githubusercontent.com/Homebrew/formula-patches/a627e0a/qt5/QTBUG-56814.patch
Already downloaded: /Users/kaneko/Library/Caches/Homebrew/qt--patch-b18e4715fcef2992f051790d3784a54900508c93350c25b0f2228cb058567142.patch
==> Patching
==> Applying restore-pc-files.patch
patching file qtbase/mkspecs/features/qt_module.prf
Hunk #1 succeeded at 264 (offset 19 lines).
==> Applying QTBUG-56814.patch
patching file qttools/src/macdeployqt/shared/shared.cpp
patch unexpectedly ends in middle of line
Hunk #1 succeeded at 821 with fuzz 2 (offset 18 lines).
==> Downloading https://download.qt.io/official_releases/qt/5.9/5.9.1/submodules/qtwebkit-opensource-src-5.9.1.tar.xz
Already downloaded: /Users/kaneko/Library/Caches/Homebrew/qt--qt-webkit-5.9.1.tar.xz
==> ./configure -verbose -prefix /usr/local/Cellar/qt/5.9.1 -release -opensource -confirm-license -system-zlib -qt-libpng -qt-libjpeg
==> make
Last 15 lines from /Users/kaneko/Library/Logs/Homebrew/qt/02.make:
painting/qcoregraphics.mm:81:39: error: use of undeclared identifier 'InvalidContext'
    require_action(inContext != NULL, InvalidContext, err = paramErr);
                                      ^
painting/qcoregraphics.mm:82:38: error: use of undeclared identifier 'InvalidBounds'
    require_action(inBounds != NULL, InvalidBounds, err = paramErr);
                                     ^
painting/qcoregraphics.mm:83:37: error: use of undeclared identifier 'InvalidImage'
    require_action(inImage != NULL, InvalidImage, err = paramErr);
                                    ^
3 errors generated.
make[3]: *** [.obj/qcoregraphics.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [sub-gui-make_first] Error 2
make[1]: *** [sub-src-make_first] Error 2
make: *** [module-qtbase-make_first] Error 2

READ THIS: https://docs.brew.sh/Troubleshooting.html

These open issues may also help:
OpenCV option to build --with-java was removed https://github.com/Homebrew/homebrew-core/issues/17106
Formulae affected by Homebrew/brew#2482 https://github.com/Homebrew/homebrew-core/issues/13133
```

My environment is macOS: 10.12.6(Sierra)