### PR TITLE
ffmpeg: Add option to build without GPL.

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -57,6 +57,7 @@ class Ffmpeg < Formula
   option "without-securetransport", "Disable use of SecureTransport"
   option "without-x264", "Disable H.264 encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
+  option "without-gpl", "Disable building GPL Licensed parts of FFMPEG"
 
   deprecated_option "with-ffplay" => "with-sdl2"
   deprecated_option "with-sdl" => "with-sdl2"
@@ -111,7 +112,6 @@ class Ffmpeg < Formula
       --prefix=#{prefix}
       --enable-shared
       --enable-pthreads
-      --enable-gpl
       --enable-version3
       --enable-hardcoded-tables
       --enable-avresample
@@ -119,7 +119,8 @@ class Ffmpeg < Formula
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}
     ]
-
+    
+    args << "--enable-gpl" if not build.without? "gpl"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
     args << "--disable-securetransport" if build.without? "securetransport"
     args << "--enable-chromaprint" if build.with? "chromaprint"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -120,7 +120,7 @@ class Ffmpeg < Formula
       --host-ldflags=#{ENV.ldflags}
     ]
     
-    args << "--enable-gpl" if not build.without? "gpl"
+    args << "--enable-gpl" if build.with? "gpl"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
     args << "--disable-securetransport" if build.without? "securetransport"
     args << "--enable-chromaprint" if build.with? "chromaprint"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -57,7 +57,7 @@ class Ffmpeg < Formula
   option "without-securetransport", "Disable use of SecureTransport"
   option "without-x264", "Disable H.264 encoder"
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
-  option "without-gpl", "Disable building GPL Licensed parts of FFMPEG"
+  option "without-gpl", "Disable building GPL licensed parts of FFmpeg"
 
   deprecated_option "with-ffplay" => "with-sdl2"
   deprecated_option "with-sdl" => "with-sdl2"
@@ -119,7 +119,7 @@ class Ffmpeg < Formula
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}
     ]
-    
+
     args << "--enable-gpl" if build.with? "gpl"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
     args << "--disable-securetransport" if build.without? "securetransport"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Small change, it should help when using homebrew to build shared libraries as part of CI toolchains where GPL licensed FFMPEG shared libraries are unsuitable. With this change the existing behaviour of GPL builds should remain the default and continue to work unchanged. Its possible the build flags may need more sophistication regarding `without-gpl` and conflicting flags/options to do with GPL licensed components of FFMPEG, but exhaustively installing and uninstalling and reinstalling the combinations of options and flags to be sure is not something I really want to run by hand. (which is why I haven't done a local install with this option)

Edit: checklist syntax