### PR TITLE
snap7: update sha256, bump revision

### DIFF
--- a/Formula/snap7.rb
+++ b/Formula/snap7.rb
@@ -2,7 +2,8 @@ class Snap7 < Formula
   desc "Ethernet communication suite that works natively with Siemens S7 PLCs"
   homepage "https://snap7.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/snap7/1.4.2/snap7-full-1.4.2.7z"
-  sha256 "65af129e11de4b0d942751bcd9c563f7012cae174931860c03dbb2cdf2e80ae7"
+  sha256 "1f4270cde8684957770a10a1d311c226e670d9589c69841a9012e818f7b9f80e"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
Confirmed by upstream: https://sourceforge.net/p/snap7/tickets/12/