### PR TITLE
openmsx: fix build

### DIFF
--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -35,9 +35,16 @@ class Openmsx < Formula
     # Filed with Apple: rdar://30475877
     ENV.O0
 
+    # Hardcode prefix
     inreplace "build/custom.mk", "/opt/openMSX", prefix
-    # Help finding Tcl
-    inreplace "build/libraries.py", /\((distroRoot), \)/, "(\\1, '/usr', '#{MacOS.sdk_path}/usr')"
+
+    # Help finding Tcl (https://github.com/openMSX/openMSX/issues/1082)
+    inreplace "build/libraries.py" do |s|
+      sdkprefix = MacOS::CLT.installed? ? "" : MacOS.sdk_path
+      s.gsub! /\((distroRoot), \)/, "(\\1, '/usr', '#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework')"
+      s.gsub! "lib/tcl", "."
+    end
+
     system "./configure"
     system "make"
     prefix.install Dir["derived/**/openMSX.app"]

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -40,7 +40,6 @@ class Openmsx < Formula
 
     # Help finding Tcl (https://github.com/openMSX/openMSX/issues/1082)
     inreplace "build/libraries.py" do |s|
-      sdkprefix = MacOS::CLT.installed? ? "" : MacOS.sdk_path
       s.gsub! /\((distroRoot), \)/, "(\\1, '/usr', '#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework')"
       s.gsub! "lib/tcl", "."
     end


### PR DESCRIPTION
Tcl headers and libraries moved away from `/usr/` in 10.13 SDK. This makes our job a little harder in `openmsx` because it doesn't have configure options or other nice mechanisms: https://github.com/openMSX/openMSX/issues/1082