### PR TITLE
tig: add ncurses as dependency

### DIFF
--- a/Formula/tig.rb
+++ b/Formula/tig.rb
@@ -24,6 +24,7 @@ class Tig < Formula
   end
 
   depends_on "readline" => :recommended
+  depends_on "ncurses" => :recommended
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
tig supports highlighting the Git diffs (see jonas/tig#313), but the
current formula uses the system ncurses library and the feature doesn't
work.

Add the Homebrew version of ncurses as a dependency to compile tig
against it and get proper highlighted diffs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
