### PR TITLE
fb-client: fix pycurl on 10.13

### DIFF
--- a/Formula/fb-client.rb
+++ b/Formula/fb-client.rb
@@ -3,7 +3,7 @@ class FbClient < Formula
   homepage "https://paste.xinu.at"
   url "https://paste.xinu.at/data/client/fb-2.0.3.tar.gz"
   sha256 "dd318de67c1581e6dfa6b6c84e8c8e995b27d115fed86d81d5579aa9a2358114"
-
+  revision 1
   head "https://git.server-speed.net/users/flo/fb", :using => :git
 
   bottle do
@@ -36,10 +36,19 @@ class FbClient < Formula
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
 
-    resources.each do |r|
-      r.stage do
-        system "python3", *Language::Python.setup_install_args(libexec/"vendor")
+    # avoid error about libcurl link-time and compile-time ssl backend mismatch
+    resource("pycurl").stage do
+      args = Language::Python.setup_install_args(libexec/"vendor")
+
+      if MacOS.version >= :high_sierra
+        args << "--libcurl-dll=/usr/lib/libcurl.dylib"
       end
+
+      system "python3", *args
+    end
+
+    resource("pyxdg").stage do
+      system "python3", *Language::Python.setup_install_args(libexec/"vendor")
     end
 
     inreplace "fb", "#!/usr/bin/env python", "#!/usr/bin/env python3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

avoid error about libcurl link-time and compile-time ssl backend mismatch