### PR TITLE
git-extras: Add ZSH completions

### DIFF
--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -28,7 +28,7 @@ class GitExtras < Formula
     pkgshare.install "etc/git-extras-completion.zsh"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     To load Zsh completions, add the following to your .zschrc:
       source #{opt_pkgshare}/git-extras-completion.zsh
     EOS

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -12,7 +12,14 @@ class GitExtras < Formula
     patch :DATA
   end
 
-  bottle :unneeded
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "9ef2f0f78212b9cbd8cd0e9d6e509961fd7dfc87c191cca27852b99e448176aa" => :high_sierra
+    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :sierra
+    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :el_capitan
+    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :yosemite
+    rebuild 1
+  end
 
   conflicts_with "git-utils",
     :because => "both install a `git-pull-request` script"

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -18,7 +18,6 @@ class GitExtras < Formula
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :sierra
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :el_capitan
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :yosemite
-    rebuild 1
   end
 
   conflicts_with "git-utils",

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -29,15 +29,15 @@ class GitExtras < Formula
     pkgshare.install "etc/git-extras-completion.zsh"
   end
 
-  test do
-    system "git", "init"
-    assert_match(/#{testpath}/, shell_output("#{bin}/git-root"))
-  end
-
   def caveats; <<-EOS.undent
     To load Zsh completions, add the following to your .zschrc:
       source #{opt_pkgshare}/git-extras-completion.zsh
     EOS
+  end
+
+  test do
+    system "git", "init"
+    assert_match(/#{testpath}/, shell_output("#{bin}/git-root"))
   end
 end
 

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -19,12 +19,18 @@ class GitExtras < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "install"
-    zsh_completion.install "etc/git-extras-completion.zsh"
+    pkgshare.install "etc/git-extras-completion.zsh"
   end
 
   test do
     system "git", "init"
     assert_match(/#{testpath}/, shell_output("#{bin}/git-root"))
+  end
+
+  def caveats; <<-EOS.undent
+    To load Zsh completions, add the following to your .zschrc:
+      source #{opt_pkgshare}/git-extras-completion.zsh
+    EOS
   end
 end
 

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -18,6 +18,7 @@ class GitExtras < Formula
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :sierra
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :el_capitan
     sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :yosemite
+    rebuild 1
   end
 
   conflicts_with "git-utils",
@@ -25,6 +26,7 @@ class GitExtras < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "install"
+    zsh_completion.install "etc/git-extras-completion.zsh"
   end
 
   test do

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -12,14 +12,7 @@ class GitExtras < Formula
     patch :DATA
   end
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "9ef2f0f78212b9cbd8cd0e9d6e509961fd7dfc87c191cca27852b99e448176aa" => :high_sierra
-    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :sierra
-    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :el_capitan
-    sha256 "59e7af5b051fcab03f394ebb8627d5f41f9b9c3be543b59329c9356e1565eee8" => :yosemite
-    rebuild 1
-  end
+  bottle :unneeded
 
   conflicts_with "git-utils",
     :because => "both install a `git-pull-request` script"


### PR DESCRIPTION
ZSH completions are available in the 4.4.0 release.  This simply installs them correctly.