### PR TITLE
dc3dd: patch gnulib

### DIFF
--- a/Formula/dc3dd.rb
+++ b/Formula/dc3dd.rb
@@ -36,6 +36,12 @@ class Dc3dd < Formula
       system "make", "install"
     end
 
+    # Fixes error: 'Illegal instruction: 4'; '%n used in a non-immutable format string' on 10.13
+    # Patch comes from gnulib upstream (see https://sourceforge.net/p/dc3dd/bugs/17/)
+    inreplace "lib/vasnprintf.c",
+              "# if !(__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))",
+              "# if !(defined __APPLE__ && defined __MACH__)"
+
     chmod 0555, ["build-aux/install-sh", "configure"]
 
     args = %W[--disable-debug


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/issues/18493

Upstream report: https://sourceforge.net/p/dc3dd/bugs/17/
Patch is done via `inreplace` instead of `patch` because source is not extracted through usual means.