### PR TITLE
crc32c 1.0.5 (new formula)

### DIFF
--- a/Formula/crc32c.rb
+++ b/Formula/crc32c.rb
@@ -1,0 +1,37 @@
+class Crc32c < Formula
+  desc "CRC32C implementation with support for CPU-specific acceleration instructions"
+  homepage "https://github.com/google/crc32c"
+  url "https://github.com/google/crc32c/archive/1.0.5.tar.gz"
+  sha256 "c2c0dcc8d155a6a56cc8d56bc1413e076aa32c35784f4d457831e8ccebd9260b"
+  head "https://github.com/google/crc32c.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", "-DCRC32C_BUILD_TESTS=0", "-DCRC32C_BUILD_BENCHMARKS=0", "-DCRC32C_USE_GLOG=0", *std_cmake_args
+    system "make", "install"
+    system "make", "clean"
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON", "-DCRC32C_BUILD_TESTS=0", "-DCRC32C_BUILD_BENCHMARKS=0", "-DCRC32C_USE_GLOG=0", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <cassert>
+      #include <crc32c/crc32c.h>
+      #include <cstdint>
+      #include <string>
+
+      int main()
+      {
+        std::uint32_t expected = 0xc99465aa;
+        std::uint32_t result = crc32c::Crc32c(std::string("hello world"));
+        assert(result == expected);
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lcrc32c", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The google/crc32c repository does not currently meet the noteworthiness criterion. However, it will soon be a (strongly) recommended dependency of leveldb, which is currently packaged in homebrew-core. I'm submitting this formula so it will be there when leveldb needs it.

/cc @ilovezfs 