### PR TITLE
PostgreSQL 10.0 and 9.6 Versioned Formula

### DIFF
--- a/Aliases/postgresql@10.0
+++ b/Aliases/postgresql@10.0
@@ -1,0 +1,1 @@
+../Formula/postgresql.rb

--- a/Aliases/postgresql@9.6
+++ b/Aliases/postgresql@9.6
@@ -1,1 +1,0 @@
-../Formula/postgresql.rb

--- a/Formula/citus.rb
+++ b/Formula/citus.rb
@@ -3,6 +3,7 @@ class Citus < Formula
   homepage "https://www.citusdata.com"
   url "https://github.com/citusdata/citus/archive/v7.0.3.tar.gz"
   sha256 "38698986cb807309875b11f548e96b06a35390c9a3e60c233b59356faacd1663"
+  revision 1
   head "https://github.com/citusdata/citus.git"
 
   bottle do

--- a/Formula/pgroonga.rb
+++ b/Formula/pgroonga.rb
@@ -3,6 +3,7 @@ class Pgroonga < Formula
   homepage "https://pgroonga.github.io/"
   url "https://packages.groonga.org/source/pgroonga/pgroonga-2.0.1.tar.gz"
   sha256 "1d6d6fb30dcf2348efaf95979c5549fbda1ffb8da5645cacd530958783540ee2"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/pgrouting.rb
+++ b/Formula/pgrouting.rb
@@ -3,6 +3,7 @@ class Pgrouting < Formula
   homepage "http://www.pgrouting.org"
   url "https://github.com/pgRouting/pgrouting/archive/v2.5.0.tar.gz"
   sha256 "2c97df865484bf4e4e6f059b535b63bbe64534076b9d0c4bdd494f916fa24e9d"
+  revision 1
   head "https://github.com/pgRouting/pgrouting.git"
 
   bottle do

--- a/Formula/pldebugger.rb
+++ b/Formula/pldebugger.rb
@@ -4,7 +4,7 @@ class Pldebugger < Formula
   url "https://git.postgresql.org/git/pldebugger.git",
       :tag => "v1.0",
       :revision => "ca1041dc3db6f516899be669dc6fbfd6339f8168"
-  revision 4
+  revision 5
   head "https://git.postgresql.org/git/pldebugger.git"
 
   bottle do

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -3,6 +3,7 @@ class Postgis < Formula
   homepage "https://postgis.net/"
   url "http://download.osgeo.org/postgis/source/postgis-2.4.0.tar.gz"
   sha256 "02baa90f04da41e04b6c18eedfda53110c45ae943d4e65050f6d202f7de07d29"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -1,8 +1,8 @@
 class Postgresql < Formula
   desc "Object-relational database system"
   homepage "https://www.postgresql.org/"
-  url "https://ftp.postgresql.org/pub/source/v9.6.5/postgresql-9.6.5.tar.bz2"
-  sha256 "06da12a7e3dddeb803962af8309fa06da9d6989f49e22865335f0a14bad0744c"
+  url "https://ftp.postgresql.org/pub/source/v10.0/postgresql-10.0.tar.bz2"
+  sha256 "712f5592e27b81c5b454df96b258c14d94b6b03836831e015c65d6deeae57fd1"
   head "https://github.com/postgres/postgres.git"
 
   bottle do
@@ -100,17 +100,12 @@ class Postgresql < Formula
   end
 
   def caveats; <<-EOS.undent
-    If builds of PostgreSQL 9 are failing and you have version 8.x installed,
-    you may need to remove the previous version first. See:
-      https://github.com/Homebrew/legacy-homebrew/issues/2510
+    To migrate existing data from a previous major version of PostgreSQL, see:
+      https://www.postgresql.org/docs/10/static/upgrading.html
 
-    To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
-      https://www.postgresql.org/docs/9.6/static/upgrading.html
+      You will need your previous PostgreSQL installation from brew to perform
+      `pg_upgrade` or `pg_dumpall` depending on your upgrade method.
 
-    To migrate existing data from a previous minor version (9.0-9.5) of PostgreSQL, see:
-      https://www.postgresql.org/docs/9.6/static/pgupgrade.html
-
-      You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
       Do not run `brew cleanup postgresql` until you have performed the migration.
     EOS
   end

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -1,0 +1,143 @@
+class PostgresqlAT96 < Formula
+  desc "Object-relational database system"
+  homepage "https://www.postgresql.org/"
+  url "https://ftp.postgresql.org/pub/source/v9.6.5/postgresql-9.6.5.tar.bz2"
+  sha256 "06da12a7e3dddeb803962af8309fa06da9d6989f49e22865335f0a14bad0744c"
+
+  keg_only :versioned_formula
+
+  option "without-perl", "Build without Perl support"
+  option "without-tcl", "Build without Tcl support"
+  option "with-dtrace", "Build with DTrace support"
+  option "with-python", "Enable PL/Python2"
+  option "with-python3", "Enable PL/Python3 (incompatible with --with-python)"
+
+  deprecated_option "no-perl" => "without-perl"
+  deprecated_option "no-tcl" => "without-tcl"
+  deprecated_option "enable-dtrace" => "with-dtrace"
+
+  depends_on "openssl"
+  depends_on "readline"
+
+  depends_on :python => :optional
+  depends_on :python3 => :optional
+
+  fails_with :clang do
+    build 211
+    cause "Miscompilation resulting in segfault on queries"
+  end
+
+  def install
+    # avoid adding the SDK library directory to the linker search path
+    ENV["XML2_CONFIG"] = "xml2-config --exec-prefix=/usr"
+
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --datadir=#{pkgshare}
+      --libdir=#{lib}
+      --sysconfdir=#{prefix}/etc
+      --docdir=#{doc}
+      --enable-thread-safety
+      --with-bonjour
+      --with-gssapi
+      --with-ldap
+      --with-openssl
+      --with-pam
+      --with-libxml
+      --with-libxslt
+    ]
+
+    args << "--with-perl" if build.with? "perl"
+
+    which_python = nil
+    if build.with?("python") && build.with?("python3")
+      odie "Cannot provide both --with-python and --with-python3"
+    elsif build.with?("python") || build.with?("python3")
+      args << "--with-python"
+      which_python = which(build.with?("python") ? "python" : "python3")
+    end
+    ENV["PYTHON"] = which_python
+
+    # The CLT is required to build Tcl support on 10.7 and 10.8 because
+    # tclConfig.sh is not part of the SDK
+    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
+      args << "--with-tcl"
+
+      if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
+        args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
+      end
+    end
+
+    args << "--enable-dtrace" if build.with? "dtrace"
+    args << "--with-uuid=e2fs"
+
+    system "./configure", *args
+    system "make"
+    system "make", "install-world", "datadir=#{pkgshare}",
+                                    "libdir=#{lib}",
+                                    "pkglibdir=#{lib}"
+  end
+
+  def post_install
+    (var/"log").mkpath
+    (var/name).mkpath
+    unless File.exist? "#{var}/#{name}/PG_VERSION"
+      system "#{bin}/initdb", "#{var}/#{name}"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    If builds of PostgreSQL 9 are failing and you have version 8.x installed,
+    you may need to remove the previous version first. See:
+      https://github.com/Homebrew/legacy-homebrew/issues/2510
+
+    To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
+      https://www.postgresql.org/docs/9.6/static/upgrading.html
+
+    To migrate existing data from a previous minor version (9.0-9.5) of PostgreSQL, see:
+      https://www.postgresql.org/docs/9.6/static/pgupgrade.html
+
+      You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
+        Do not run `brew cleanup postgresql@9.6` until you have performed the migration.
+    EOS
+  end
+
+  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.6 start"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/postgres</string>
+        <string>-D</string>
+        <string>#{var}/#{name}</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{HOMEBREW_PREFIX}</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/#{name}.log</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/initdb", testpath/"test"
+    assert_equal pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
+    assert_equal lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
+    assert_equal lib.to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
+  end
+end

--- a/Formula/temporal_tables.rb
+++ b/Formula/temporal_tables.rb
@@ -3,6 +3,7 @@ class TemporalTables < Formula
   homepage "https://pgxn.org/dist/temporal_tables/"
   url "https://github.com/arkhipov/temporal_tables/archive/v1.1.1.tar.gz"
   sha256 "8e1496e8b04a1a8df98450710be71156d6e94d9089d31dba4e56cb156649ca45"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
This PR bumps postgresql to 10.0 and add a versioned formula for `postgresql@9.6`.

I'm not sure wether it is correct to submit the versioned formula in the same commit, I can create a separate PR if you prefer.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
