### PR TITLE
thrift@0.9 0.9.3

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -1,12 +1,8 @@
-# The 0.9.0 tag in homebrew repository isn't working in OSX Mavericks
-# this version fixes Cpp11 problems about syntax and tr1 headers
-# All patches and this file can be found in this public gist:
-# https://gist.githubusercontent.com/rafaelverger/58b6eeafaae7d28b06cc
-class ThriftAT090 < Formula
+class ThriftAT09 < Formula
   desc "Framework for scalable cross-language services development"
   homepage "https://thrift.apache.org"
-  url "https://archive.apache.org/dist/thrift/0.9.0/thrift-0.9.0.tar.gz"
-  sha256 "71d129c49a2616069d9e7a93268cdba59518f77b3c41e763e09537cb3f3f0aac"
+  url "https://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz"
+  sha256 "b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e"
 
   bottle do
     cellar :any
@@ -17,23 +13,6 @@ class ThriftAT090 < Formula
 
   keg_only :versioned_formula
 
-  # These patches are 0.9.0-specific and can go away once a newer version is release
-  [
-    # patch-tsocket.patch
-    %w[a1dc9e54ffacf04c6ba6d1e37b734684ff09d149a88ca7425a4237267f674829 tsocket.patch],
-    # patch-cxx11-compat.patch
-    %w[74fd5282f159bf4d7ee5ca977b36534e2182709fe4c17cc5907c6bd615cfe0ef cxx11-compat.patch],
-    # patch-use-boost-cpp-client-server.patch
-    %w[2ea5a69c5358a56ef945d4fb127c11a7797afc751743b20f58dfff0955a68117 use-boost-cpp-client-server.patch],
-    # patch-remove-tr1-dependency.patch
-    %w[c4419ce40b7fda9ffd58a5dad7856b64ee84e3c1b820f3a64fed0b01b4bc9c42 remove-tr1-dependency.patch],
-  ].each do |sha, patch|
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/dee880b1baba827255f7b0806ca32d36c4d1c2ca/thrift/0.9.0/#{patch}"
-      sha256 sha
-    end
-  end
-
   option "with-haskell", "Install Haskell binding"
   option "with-erlang", "Install Erlang binding"
   option "with-java", "Install Java binding"
@@ -42,6 +21,7 @@ class ThriftAT090 < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "bison" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
@@ -60,7 +40,7 @@ class ThriftAT090 < Formula
 
     ENV.cxx11 if MacOS.version >= :mavericks && ENV.compiler == :clang
 
-    # Don't install extensions to /usr:
+    # Don't install extensions to /usr
     ENV["PY_PREFIX"] = prefix
     ENV["PHP_PREFIX"] = prefix
 
@@ -73,6 +53,6 @@ class ThriftAT090 < Formula
   end
 
   test do
-    assert_match /Thrift/, shell_output("#{bin}/thrift --version", 1)
+    assert_match /Thrift/, shell_output("#{bin}/thrift --version")
   end
 end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -168,6 +168,7 @@
   "swig304": "swig@3.04",
   "team-explorer-everywhere": "tee-clc",
   "tensorflow": "libtensorflow",
+  "thrift@0.90": "thrift@0.9",
   "thrift090": "thrift@0.90",
   "tomcat6": "tomcat@6",
   "tomcat7": "tomcat@7",


### PR DESCRIPTION
- Updating to 0.9.3.
- Changing the formula name, which was wrongly renamed when imported from homebrew-versions