### PR TITLE
pldebugger 1.0

### DIFF
--- a/Formula/pldebugger.rb
+++ b/Formula/pldebugger.rb
@@ -2,9 +2,9 @@ class Pldebugger < Formula
   desc "PL/pgSQL debugger server-side code"
   homepage "https://git.postgresql.org/gitweb/"
   url "https://git.postgresql.org/git/pldebugger.git",
-      :revision => "4058a938f588397b2923247974eb22106f530ebb"
-  version "1.0" # See default_version field in pldbgapi.control
-  revision 3
+      :tag => "v1.0",
+      :revision => "ca1041dc3db6f516899be669dc6fbfd6339f8168"
+  revision 4
   head "https://git.postgresql.org/git/pldebugger.git"
 
   bottle do


### PR DESCRIPTION
Bump pldebugger to the v1.0 tag, which points to the revision "ca1041dc3db6f516899be669dc6fbfd6339f8168" and is required for
compatibility with postgres 10.0.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
