### PR TITLE
x265: switch to multilib build with all bit-depths

### DIFF
--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -3,7 +3,7 @@ class X265 < Formula
   homepage "http://x265.org"
   url "https://bitbucket.org/multicoreware/x265/downloads/x265_2.5.tar.gz"
   sha256 "2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17"
-
+  revision 1
   head "https://bitbucket.org/multicoreware/x265", :using => :hg
 
   bottle do
@@ -14,20 +14,44 @@ class X265 < Formula
     sha256 "a715de311bbcfbcc65353681a5665d395230b2f70e27621c088456f5490f4328" => :yosemite
   end
 
-  option "with-16-bit", "Build a 16-bit x265 (default: 8-bit)"
-
-  deprecated_option "16-bit" => "with-16-bit"
-
-  depends_on "yasm" => :build
   depends_on "cmake" => :build
+  depends_on "yasm" => :build
   depends_on :macos => :lion
 
   def install
-    args = std_cmake_args
-    args << "-DHIGH_BIT_DEPTH=ON" if build.with? "16-bit"
+    # Build based off the script at ./build/linux/multilib.sh
+    args = std_cmake_args + %w[
+      -DLINKED_10BIT=ON
+      -DLINKED_12BIT=ON
+      -DEXTRA_LINK_FLAGS=-L.
+      -DEXTRA_LIB=x265_main10.a;x265_main12.a
+    ]
+    high_bit_depth_args = std_cmake_args + %w[
+      -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF
+      -DENABLE_SHARED=OFF -DENABLE_CLI=OFF
+    ]
+    (buildpath/"8bit").mkpath
 
-    system "cmake", "source", *args
-    system "make", "install"
+    mkdir "10bit" do
+      system "cmake", buildpath/"source", *high_bit_depth_args
+      system "make"
+      mv "libx265.a", buildpath/"8bit/libx265_main10.a"
+    end
+
+    mkdir "12bit" do
+      system "cmake", buildpath/"source", "-DMAIN12=ON", *high_bit_depth_args
+      system "make"
+      mv "libx265.a", buildpath/"8bit/libx265_main12.a"
+    end
+
+    cd "8bit" do
+      system "cmake", buildpath/"source", *args
+      system "make"
+      mv "libx265.a", "libx265_main.a"
+      system "libtool", "-static", "-o", "libx265.a", "libx265_main.a",
+                        "libx265_main10.a", "libx265_main12.a"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This builds all three bit-depths, 8bit, 10bit, and 12bit
but only exports the 8bit C API. The other bit-depths are
accessible at through runtime selection using bit-depth
introspection and also through the x265 CLI.

-----
All of the bit-depths are bottled to reduce the potential for local build issues, and also to remove the need for options in the formula.

cc @tellowkrinkle as this is has its origins their PR.
(I apologize for fairly summarily hijacking it.)