### PR TITLE
.exist => assert_predicate

### DIFF
--- a/Formula/blazegraph.rb
+++ b/Formula/blazegraph.rb
@@ -40,7 +40,7 @@ class Blazegraph < Formula
     end
     sleep 5
     Process.kill("TERM", server)
-    File.exist? "blazegraph.jnl"
-    File.exist? "rules.log"
+    assert_predicate testpath/"blazegraph.jnl", :exist?
+    assert_predicate testpath/"rules.log", :exist?
   end
 end

--- a/Formula/blazegraph.rb
+++ b/Formula/blazegraph.rb
@@ -28,7 +28,7 @@ class Blazegraph < Formula
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
-        <string>#{prefix}</string>
+        <string>#{opt_prefix}</string>
       </dict>
     </plist>
     EOS

--- a/Formula/chromedriver.rb
+++ b/Formula/chromedriver.rb
@@ -45,6 +45,6 @@ class Chromedriver < Formula
     end
     sleep 5
     Process.kill("TERM", driver)
-    File.exist? testpath/"cd.log"
+    assert_predicate testpath/"cd.log", :exist?
   end
 end

--- a/Formula/cuetools.rb
+++ b/Formula/cuetools.rb
@@ -36,7 +36,7 @@ class Cuetools < Formula
           INDEX 01 00:00:00
     EOS
     system "cueconvert", testpath/"test.cue", testpath/"test.toc"
-    File.exist? "test.toc"
+    assert_predicate testpath/"test.toc", :exist?
   end
 end
 

--- a/Formula/freeciv.rb
+++ b/Formula/freeciv.rb
@@ -75,13 +75,13 @@ class Freeciv < Formula
 
   test do
     system bin/"freeciv-manual"
-    File.exist? testpath/"manual6.html"
+    assert_predicate testpath/"manual6.html", :exist?
 
     server = fork do
       system bin/"freeciv-server", "-l", testpath/"test.log"
     end
     sleep 5
     Process.kill("TERM", server)
-    File.exist? testpath/"test.log"
+    assert_predicate testpath/"test.log", :exist?
   end
 end

--- a/Formula/ganglia.rb
+++ b/Formula/ganglia.rb
@@ -67,7 +67,7 @@ class Ganglia < Formula
         exec bin/"gmetad", "--pid-file=#{testpath}/pid"
       end
       sleep 2
-      File.exist? testpath/"pid"
+      assert_predicate testpath/"pid", :exist?
     ensure
       Process.kill "TERM", pid
       Process.wait pid

--- a/Formula/gtk-chtheme.rb
+++ b/Formula/gtk-chtheme.rb
@@ -28,6 +28,6 @@ class GtkChtheme < Formula
   test do
     # package contains just an executable and a man file
     # executable accepts no options and just spawns a GUI
-    assert (bin/"gtk-chtheme").exist?
+    assert_predicate bin/"gtk-chtheme", :exist?
   end
 end

--- a/Formula/hicolor-icon-theme.rb
+++ b/Formula/hicolor-icon-theme.rb
@@ -29,6 +29,6 @@ class HicolorIconTheme < Formula
   end
 
   test do
-    File.exist? share/"icons/hicolor/index.theme"
+    assert_predicate share/"icons/hicolor/index.theme", :exist?
   end
 end

--- a/Formula/hiredis.rb
+++ b/Formula/hiredis.rb
@@ -3,7 +3,6 @@ class Hiredis < Formula
   homepage "https://github.com/redis/hiredis"
   url "https://github.com/redis/hiredis/archive/v0.13.3.tar.gz"
   sha256 "717e6fc8dc2819bef522deaca516de9e51b9dfa68fe393b7db5c3b6079196f78"
-
   head "https://github.com/redis/hiredis.git"
 
   bottle do
@@ -28,6 +27,6 @@ class Hiredis < Formula
     # sure it compiles
     system ENV.cc, "-I#{include}/hiredis", "-L#{lib}", "-lhiredis",
            pkgshare/"examples/example.c", "-o", testpath/"test"
-    File.exist? testpath/"test"
+    assert_predicate testpath/"test", :exist?
   end
 end

--- a/Formula/hyperspec.rb
+++ b/Formula/hyperspec.rb
@@ -28,6 +28,6 @@ class Hyperspec < Formula
   end
 
   test do
-    assert (doc/"HyperSpec-README.text").exist?
+    assert_predicate doc/"HyperSpec-README.text", :exist?
   end
 end

--- a/Formula/jpegrescan.rb
+++ b/Formula/jpegrescan.rb
@@ -15,6 +15,6 @@ class Jpegrescan < Formula
 
   test do
     system bin/"jpegrescan", "-v", test_fixtures("test.jpg"), testpath/"out.jpg"
-    File.exist? testpath/"out.jpg"
+    assert_predicate testpath/"out.jpg", :exist?
   end
 end

--- a/Formula/naga.rb
+++ b/Formula/naga.rb
@@ -18,6 +18,6 @@ class Naga < Formula
   end
 
   test do
-    File.exist? "#{bin}/naga"
+    assert_predicate bin/"naga", :exist?
   end
 end

--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -26,6 +26,6 @@ class Pngquant < Formula
 
   test do
     system "#{bin}/pngquant", test_fixtures("test.png"), "-o", "out.png"
-    File.exist? testpath/"out.png"
+    assert_predicate testpath/"out.png", :exist?
   end
 end

--- a/Formula/qcli.rb
+++ b/Formula/qcli.rb
@@ -39,6 +39,6 @@ class Qcli < Formula
     # Create a qcli report from the mp4
     qcliout = testpath/"video.mp4.qctools.xml.gz"
     system bin/"qcli", "-i", mp4out, "-o", qcliout
-    assert qcliout.exist?
+    assert_predicate qcliout, :exist?
   end
 end

--- a/Formula/quex.rb
+++ b/Formula/quex.rb
@@ -3,7 +3,6 @@ class Quex < Formula
   homepage "http://quex.org/"
   url "https://downloads.sourceforge.net/project/quex/DOWNLOAD/quex-0.67.5.tar.gz"
   sha256 "f7fff3db5967fc2a5e0673aa5fa6f4f9388a53b89932d76499deb52ef26be1b9"
-
   head "https://svn.code.sf.net/p/quex/code/trunk"
 
   bottle do
@@ -16,8 +15,9 @@ class Quex < Formula
   def install
     libexec.install "quex", "quex-exe.py"
     doc.install "README", "demo"
+
     # Use a shim script to set QUEX_PATH on the user's behalf
-    (bin+"quex").write <<-EOS.undent
+    (bin/"quex").write <<-EOS.undent
       #!/bin/bash
       QUEX_PATH="#{libexec}" "#{libexec}/quex-exe.py" "$@"
     EOS
@@ -31,6 +31,6 @@ class Quex < Formula
 
   test do
     system bin/"quex", "-i", doc/"demo/C/000/simple.qx", "-o", "tiny_lexer"
-    File.exist? "tiny_lexer"
+    assert_predicate testpath/"tiny_lexer", :exist?
   end
 end

--- a/Formula/rzip.rb
+++ b/Formula/rzip.rb
@@ -31,7 +31,7 @@ class Rzip < Formula
 
     # compress: data.txt -> data.txt.rz
     system bin/"rzip", path
-    assert !path.exist?
+    refute_predicate path, :exist?
 
     # decompress: data.txt.rz -> data.txt
     system bin/"rzip", "-d", "#{path}.rz"

--- a/Formula/snag.rb
+++ b/Formula/snag.rb
@@ -40,6 +40,6 @@ class Snag < Formula
       Process.kill "TERM", pid
       Process.wait pid
     end
-    File.exist? testpath/"snagged"
+    assert_predicate testpath/"snagged", :exist?
   end
 end

--- a/Formula/tvnamer.rb
+++ b/Formula/tvnamer.rb
@@ -35,10 +35,10 @@ class Tvnamer < Formula
   end
 
   test do
-    raw_file = "brass.eye.s01e01.avi"
-    expected_file = "Brass Eye - [01x01] - Animals.avi"
-    touch testpath/raw_file
-    system bin/"tvnamer", "-b", testpath/raw_file
-    File.exist? testpath/expected_file
+    raw_file = testpath/"brass.eye.s01e01.avi"
+    expected_file = testpath/"Brass Eye - [01x01] - Animals.avi"
+    touch raw_file
+    system bin/"tvnamer", "-b", raw_file
+    assert_predicate expected_file, :exist?
   end
 end

--- a/Formula/unpaper.rb
+++ b/Formula/unpaper.rb
@@ -45,6 +45,6 @@ class Unpaper < Formula
       0 0 0 0 0 0
     EOS
     system bin/"unpaper", testpath/"test.pbm", testpath/"out.pbm"
-    File.exist? testpath/"out.pbm"
+    assert_predicate testpath/"out.pbm", :exist?
   end
 end

--- a/Formula/wavpack.rb
+++ b/Formula/wavpack.rb
@@ -33,6 +33,6 @@ class Wavpack < Formula
 
   test do
     system bin/"wavpack", test_fixtures("test.wav"), "-o", testpath/"test.wv"
-    File.exist? "test.wv"
+    assert_predicate testpath/"test.wv", :exist?
   end
 end

--- a/Formula/zopfli.rb
+++ b/Formula/zopfli.rb
@@ -22,6 +22,6 @@ class Zopfli < Formula
   test do
     system "#{bin}/zopfli"
     system "#{bin}/zopflipng", test_fixtures("test.png"), "#{testpath}/out.png"
-    File.exist? "#{testpath}/out.png"
+    assert_predicate testpath/"out.png", :exist?
   end
 end

--- a/Formula/zzz.rb
+++ b/Formula/zzz.rb
@@ -3,7 +3,6 @@ class Zzz < Formula
   homepage "https://github.com/Orc/Zzz"
   url "https://github.com/Orc/Zzz/archive/v1.tar.gz"
   sha256 "8c8958b65a74ab1081ce1a950af6d360166828bdb383d71cc8fe37ddb1702576"
-
   head "https://github.com/Orc/Zzz.git"
 
   bottle :unneeded
@@ -15,6 +14,6 @@ class Zzz < Formula
   end
 
   test do
-    File.exist? "#{bin}/Zzz"
+    assert_predicate bin/"Zzz", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Found some more @ilovezfs. Also found a couple of issues not discovered in testing beforehand which I'll need to think about:
* Formulae like `root` use `File.exist?` semi-legitimately, but still gets flagged here. We could change the method slightly or try & work out an exemption to the new audit rule.
* The `(dog/"cat/dragon.txt").exist?` style syntax isn't flagged, but probably should be.