### PR TITLE
ffmpeg: remove LibOpenJPEG patch for HEAD

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -30,13 +30,6 @@ class Ffmpeg < Formula
     url "https://github.com/FFmpeg/FFmpeg.git"
 
     depends_on "nasm" => :build
-
-    # Mailing list post from 5 Oct 2017 "lavc: add support for OpenJPEG 2.3.0"
-    # See https://ffmpeg.org/pipermail/ffmpeg-devel/2017-October/217389.html
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/4af1f7d/ffmpeg/openjpeg-2.3-head.patch"
-      sha256 "93e5db7697fea9a57ca0a55c832a9ff00eb3eae89c4b2b0d9a0ce542e6d8b9c1"
-    end
   end
 
   option "with-chromaprint", "Enable the Chromaprint audio fingerprinting library"


### PR DESCRIPTION
this has been added to FFmpeg in FFmpeg/FFmpeg@41d6d627024393c142cf7cd93eff1d5a049105f5

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
