### PR TITLE
gtk-doc: use source-highlight instead of vim

### DIFF
--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -3,6 +3,7 @@ class GtkDoc < Formula
   homepage "https://www.gtk.org/gtk-doc/"
   url "https://download.gnome.org/sources/gtk-doc/1.26/gtk-doc-1.26.tar.xz"
   sha256 "bff3f44467b1d39775e94fad545f050faa7e8d68dc6a31aef5024ba3c2d7f2b7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -18,6 +18,7 @@ class GtkDoc < Formula
   depends_on "docbook"
   depends_on "docbook-xsl"
   depends_on "libxml2"
+  depends_on "source-highlight"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
@@ -35,6 +36,7 @@ class GtkDoc < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--with-highlight=source-highlight",
                           "--with-xml-catalog=#{etc}/xml/catalog"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is the action for #19183.

GTK-Doc has syntax highlighting feature by using external highlight tool ([GNU Source-highlight](https://www.gnu.org/software/src-highlite/), [highlight](http://www.andre-simon.de/doku/highlight/en/highlight.php) or vim script). The highlight engine is selected by the build option of GTK-Doc (`--with-highlight`). The current formula does not specify it. In this case, `configure` automatically searches available engine. As a result, the current bottle is built with vim.

GTK-Doc with vim tries to run vim and execute a vim script (`2html.vim`), but it fails to execute `2html.vim`, so `gtkdoc-fixxref` fails with status code 1. This issue has already been reported to the GTK-Doc's bugzilla. Please see [this issue](https://bugzilla.gnome.org/show_bug.cgi?id=787495) for more detail.

The current situation is summarized as follows:

- `gtkdox-fixxref`'s crash issue is caused by vim (see [vim #2135](https://github.com/vim/vim/issues/2135)), and it will be fixed.
- However, even though the crash issue is fixed, `gtkdoc-fixxref` has another problem that the generated code block has a lot of empty lines (see [the result](https://webkitgtk.org/reference/webkit2gtk/2.17.92/WebKitWebView.html#webkit-web-view-run-javascript-finish)).
- If we change the highlight tool (GNU Source-highlight, highlight or disable), it can process correctly.

This issue was reported about 1 month ago, but no reply from GTK-Doc developers for now. So I propose to switch to GNU Source-highlight.
