### PR TITLE
pygobject3: partially revert b3a1ab364f

### DIFF
--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -3,6 +3,7 @@ class Pygobject3 < Formula
   homepage "https://live.gnome.org/PyGObject"
   url "https://download.gnome.org/sources/pygobject/3.26/pygobject-3.26.0.tar.xz"
   sha256 "7411acd600c8cb6f00d2125afa23303f2104e59b83e0a4963288dbecc3b029fa"
+  revision 1
 
   bottle do
     cellar :any
@@ -23,7 +24,9 @@ class Pygobject3 < Formula
 
   def install
     Language::Python.each_python(build) do |python, _version|
-      system python, *Language::Python.setup_install_args(prefix)
+      system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}", "PYTHON=#{python}"
+      system "make", "install"
+      system "make", "clean"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Moving to the:
```ruby
system python, *Language::Python.setup_install_args(prefix)
```
method removed both the installation of the header & the pkg-config files, which has caused various issues. Unless anyone has a solution here we should just revert the change for now.