### PR TITLE
PhysFS 3.0.0 (update)

### DIFF
--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -1,8 +1,8 @@
 class Physfs < Formula
   desc "Library to provide abstract access to various archives"
   homepage "https://icculus.org/physfs/"
-  url "https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
-  sha256 "ca862097c0fb451f2cacd286194d071289342c107b6fe69079c079883ff66b69"
+  url "https://icculus.org/physfs/downloads/physfs-3.0.0.tar.bz2"
+  sha256 "f2617d6855ea97ea42e4a8ebcad404354be99dfd8a274eacea92091b27fd7324"
   head "https://hg.icculus.org/icculus/physfs/", :using => :hg
 
   bottle do


### PR DESCRIPTION
Update to the newest PhysFS, 3.0.0, which was released on September 27th, 2017.  This is a manual PR, as `brew bump-formula-pr` crashed midway, and won't rerun since a branch for `physfs-3.0.0` already exists.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
