### PR TITLE
Updated the SQLite documentation ZIP SHA-256 hash.

### DIFF
--- a/Formula/sqlite.rb
+++ b/Formula/sqlite.rb
@@ -39,7 +39,7 @@ class Sqlite < Formula
   resource "docs" do
     url "https://www.sqlite.org/2017/sqlite-doc-3200100.zip"
     version "3.20.1"
-    sha256 "0caf410e604411fd925c699d5fcb1d846f9297cdf2e18251eceb3e5708301e85"
+    sha256 "1c8924df0c562c85c37d33453b71837f911ed87cba8c2b7864fb721c56659283"
   end
 
   def install


### PR DESCRIPTION
It looks there were some updates made to the documentation which made the new generated ZIP file produce a new hash. This is causing Homebrew to fail at upgrading several formulae which depend on SQLite since the hash mismatch causes the upgrade to halt when SQLite is installed with `--with-docs` (which mine is).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
