### PR TITLE
daq: high-serria doesn't include libpcap

### DIFF
--- a/Formula/daq.rb
+++ b/Formula/daq.rb
@@ -13,6 +13,8 @@ class Daq < Formula
     sha256 "bced15005e13eaa11ec6d47afbb1137f61231a191fb05a295e2762cc6cc8ef29" => :mountain_lion
   end
 
+  depends_on "libpcap" if MacOS.version >= :high_sierra
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
----
This PR is an action for https://github.com/Homebrew/homebrew-core/issues/18493.

```
$ brew install -s daq
==> Downloading https://www.snort.org/downloads/snort/daq-2.0.6.tar.gz
Already downloaded: /Users/aoyamatakuo/Library/Caches/Homebrew/daq-2.0.6.tar.gz
==> ./configure --disable-silent-rules --prefix=/usr/local/Cellar/daq/2.0.6
Last 15 lines from /Users/s172262/Library/Logs/Homebrew/daq/01.configure:
checking libipq.h presence... no
checking for libipq.h... no
checking for linux/netfilter.h... no
checking for netinet/in.h... (cached) yes
checking libnetfilter_queue/libnetfilter_queue.h usability... no
checking libnetfilter_queue/libnetfilter_queue.h presence... no
checking for libnetfilter_queue/libnetfilter_queue.h... no
checking for linux/netfilter.h... (cached) no
checking for pcap.h... (cached) yes
checking for pcap_lib_version... checking for pcap_lib_version in -lpcap... (cached) yes
checking for libpcap version >= "1.0.0"... no

    ERROR!  Libpcap library version >= 1.0.0  not found.
    Get it from http://www.tcpdump.org
``` 
```
$ otool -L /usr/local/Cellar/daq/2.0.6/lib/daq/*.so 
/usr/local/Cellar/daq/2.0.6/lib/daq/daq_dump.so:
	/usr/local/opt/libpcap/lib/libpcap.A.dylib (compatibility version 1.0.0, current version 1.8.1)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
/usr/local/Cellar/daq/2.0.6/lib/daq/daq_ipfw.so:
	/usr/local/Cellar/daq/2.0.6/lib/libsfbpf.0.dylib (compatibility version 1.0.0, current version 1.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
/usr/local/Cellar/daq/2.0.6/lib/daq/daq_pcap.so:
	/usr/local/opt/libpcap/lib/libpcap.A.dylib (compatibility version 1.0.0, current version 1.8.1)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
```
