### PR TITLE
redis: listen on 127.0.0.1 and ::1 since localhost resolves to both

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -31,7 +31,7 @@ class Redis < Formula
     inreplace "redis.conf" do |s|
       s.gsub! "/var/run/redis.pid", var/"run/redis.pid"
       s.gsub! "dir ./", "dir #{var}/db/redis/"
-      s.gsub! "\# bind 127.0.0.1", "bind 127.0.0.1"
+      s.sub!  /^bind .*$/, "bind 127.0.0.1 ::1"
     end
 
     etc.install "redis.conf"


### PR DESCRIPTION
Upstream redis.conf binds to 127.0.0.1 by default now
(https://github.com/antirez/redis/blob/634b096/redis.conf#L69)
so the existing code to uncomment `# bind 127.0.0.1` results in two
bind declarations:

```
bind 127.0.0.1 ::1  # was commented out
…
bind 127.0.0.1      # was already uncommented
```

The second bind clobbers the first, so connecting to `localhost`
on IPv6 doesn't work.

To fix, change the `gsub!` to specifically `sub!` the existing
uncommented `bind …`, replacing it with `bind 127.0.0.1 ::1`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
