### PR TITLE
haxe 3.4.4

### DIFF
--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -2,8 +2,8 @@ class Haxe < Formula
   desc "Multi-platform programming language"
   homepage "https://haxe.org/"
   url "https://github.com/HaxeFoundation/haxe.git",
-      :tag => "3.4.3",
-      :revision => "e24c990d58f2ccff5e5add8369602bb729bcdfab"
+      :tag => "3.4.4",
+      :revision => "4f09586f6691e8a9645844b62036c8c974a00d15"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Haxe 3.4.4 is backward compatible to its previous version. The main new thing is to fix an issue where the compiler produce invalid flash file when compiled with OCaml 4.05.

More info about 3.4.4: https://haxe.org/download/version/3.4.4/