### PR TITLE
open-scene-graph 3.5.7

### DIFF
--- a/Formula/open-scene-graph.rb
+++ b/Formula/open-scene-graph.rb
@@ -1,9 +1,8 @@
 class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "https://github.com/openscenegraph/OpenSceneGraph"
-  url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.5.6.tar.gz"
-  sha256 "58e9436b811d0344723116cb1ada6ef305bdb6d97f42f04a700a29eda17f54b2"
-  revision 1
+  url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.5.7.tar.gz"
+  sha256 "32e435184b3e0340adf50558acb890e04fce3b4c990c6b8789479c1a11f08a05"
   head "https://github.com/openscenegraph/OpenSceneGraph.git"
 
   bottle do
@@ -25,6 +24,7 @@ class OpenSceneGraph < Formula
   depends_on "jpeg"
   depends_on "gtkglext"
   depends_on "freetype"
+  depends_on "sdl"
   depends_on "gdal" => :optional
   depends_on "jasper" => :optional
   depends_on "openexr" => :optional
@@ -42,14 +42,6 @@ class OpenSceneGraph < Formula
   if build.with? "docs"
     depends_on "doxygen" => :build
     depends_on "graphviz" => :build
-  end
-
-  # jpeg 9 compatibility
-  # Upstream issue from 18 Feb 2016 "fails to build without -fpermissive"
-  # See https://github.com/openscenegraph/OpenSceneGraph/issues/58
-  patch :p0 do
-    url "https://raw.githubusercontent.com/macports/macports-ports/a54de1ab602/graphics/OpenSceneGraph/files/patch-src_osgPlugins_jpeg_ReaderWriterJPEG.cpp.diff"
-    sha256 "c62a284d1df478a73082bb0c8eae504ffcc8a9e7b00ee541cc00543d6b163c94"
   end
 
   def install


### PR DESCRIPTION
depend on sdl
remove jpeg 9 compatibility patch as it's no longer needed