### PR TITLE
wpscan: fix test

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -50,6 +50,6 @@ class Wpscan < Formula
 
   test do
     assert_match "URL: https://wordpress.org/",
-                 shell_output("#{bin}/wpscan --url https://wordpress.org/")
+                 pipe_output("#{bin}/wpscan --url https://wordpress.org/")
   end
 end


### PR DESCRIPTION
The exit status may not be zero and it's fine.