### PR TITLE
tnftp 20070806 (new formula), tnftpd 20100324 (new formula), telnetd 54.50.1 (new formula), telnet and inetutils: conflicting files

### DIFF
--- a/Aliases/lukemftp
+++ b/Aliases/lukemftp
@@ -1,0 +1,1 @@
+../Formula/tnftp.rb

--- a/Aliases/lukemftpd
+++ b/Aliases/lukemftpd
@@ -1,0 +1,1 @@
+../Formula/tnftpd.rb

--- a/Formula/telnet.rb
+++ b/Formula/telnet.rb
@@ -4,6 +4,8 @@ class Telnet < Formula
   url "https://opensource.apple.com/tarballs/remote_cmds/remote_cmds-54.50.1.tar.gz"
   sha256 "156ddec946c81af1cbbad5cc6e601135245f7300d134a239cda45ff5efd75930"
 
+  conflicts_with "inetutils", :because => "both install 'telnet' binaries"
+
   bottle do
     cellar :any_skip_relocation
     sha256 "7197673f6d77b6ca1e6c493cdef5f8625cc63f8fd831c0b2a633fcde4ee5a2c6" => :high_sierra
@@ -23,6 +25,8 @@ class Telnet < Formula
 
   def install
     resource("libtelnet").stage do
+      ENV["SDKROOT"] = MacOS.sdk_path
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
       xcodebuild "SYMROOT=build"
 
       libtelnet_dst = buildpath/"telnet.tproj/build/Products"

--- a/Formula/telnetd.rb
+++ b/Formula/telnetd.rb
@@ -1,0 +1,47 @@
+class Telnetd < Formula
+  desc "TELNET server (built from macOS Sierra sources)"
+  homepage "https://opensource.apple.com/"
+  url "https://opensource.apple.com/tarballs/remote_cmds/remote_cmds-54.50.1.tar.gz"
+  sha256 "156ddec946c81af1cbbad5cc6e601135245f7300d134a239cda45ff5efd75930"
+
+  keg_only :provided_pre_high_sierra
+
+  depends_on :xcode => :build
+
+  resource "libtelnet" do
+    url "https://opensource.apple.com/tarballs/libtelnet/libtelnet-13.tar.gz"
+    sha256 "e7d203083c2d9fa363da4cc4b7377d4a18f8a6f569b9bcf58f97255941a2ebd1"
+  end
+
+  def install
+    resource("libtelnet").stage do
+      xcodebuild "SYMROOT=build"
+
+      libtelnet_dst = buildpath/"telnetd.tproj/build/Products"
+      libtelnet_dst.install "build/Release/libtelnet.a"
+      libtelnet_dst.install "build/Release/usr/local/include/libtelnet/"
+    end
+
+    system "make",
+           "-C", "telnetd.tproj",
+           "OBJROOT=build/Intermediates",
+           "SYMROOT=build/Products",
+           "DSTROOT=build/Archive",
+           "CFLAGS=$(CC_Flags) -isystembuild/Products/",
+           "LDFLAGS=$(LD_Flags) -Lbuild/Products/"
+
+    sbin.install "telnetd.tproj/build/Products/telnetd"
+    man8.install "telnetd.tproj/telnetd.8"
+  end
+
+  def caveats
+    <<~EOS
+      You may need super-user privileges to run this program properly. See the man
+      page for more details.
+    EOS
+  end
+
+  test do
+    assert_match "usage: telnetd", shell_output("#{sbin}/telnetd usage 2>&1", 1)
+  end
+end

--- a/Formula/tnftp.rb
+++ b/Formula/tnftp.rb
@@ -1,0 +1,44 @@
+class Tnftp < Formula
+  desc "NetBSD's FTP client (built from macOS Sierra sources)"
+  homepage "https://opensource.apple.com/"
+  url "https://opensource.apple.com/tarballs/lukemftp/lukemftp-16.tar.gz"
+  version "20070806"
+  sha256 "ba35a8e3c2e524e5772e729f592ac0978f9027da2433753736e1eb1f1351ae9d"
+
+  keg_only :provided_pre_high_sierra
+
+  depends_on :xcode => :build
+
+  conflicts_with "inetutils", :because => "both install `ftp' binaries"
+
+  def install
+    # Trying to use Apple's pre-supplied Makefile resulted
+    # in headaches... they have made the build process
+    # specifically for installing to /usr/bin and so it
+    # just doesn't play well with homebrew.
+
+    # so just build straight from ftp's own sources
+    # from the extracted 20070806 tarball which have
+    # already been patched
+    cd "tnftp" do
+      system "./configure"
+      system "make", "all"
+      system "strip", "-x", "src/ftp" # this is done in Apple's `post-install` target
+
+      bin.install "src/ftp"
+      man1.install "src/ftp.1"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    require "pty"
+    require "expect"
+
+    PTY.spawn "#{bin}/ftp ftp://anonymous:none@speedtest.tele2.net" do |input, output, _pid|
+      str = input.expect(/Connected to speedtest.tele2.net./)
+      output.puts "exit"
+      assert_match "Connected to speedtest.tele2.net.", str[0]
+    end
+  end
+end

--- a/Formula/tnftpd.rb
+++ b/Formula/tnftpd.rb
@@ -1,0 +1,47 @@
+class Tnftpd < Formula
+  desc "NetBSD's FTP server (built from macOS Sierra sources)"
+  homepage "https://opensource.apple.com/"
+  url "https://opensource.apple.com/tarballs/lukemftpd/lukemftpd-51.tar.gz"
+  version "20100324"
+  sha256 "969b8a35fabcc82759da2433973b9606b7b62f73527e76ac8f18d0a19f473c2a"
+
+  keg_only :provided_pre_high_sierra
+
+  depends_on :xcode => :build
+
+  def install
+    system "tar", "zxvf", "tnftpd-20100324.tar.gz"
+
+    cd "tnftpd-20100324" do
+      system "./configure"
+      system "make"
+
+      sbin.install "src/tnftpd" => "ftpd"
+      man8.install "src/tnftpd.man" => "ftpd.8"
+      man5.install "src/ftpusers.man" => "ftpusers.5"
+      man5.install "src/ftpd.conf.man" => "ftpd.conf.5"
+      etc.install "examples/ftpd.conf"
+      etc.install "examples/ftpusers"
+      prefix.install_metafiles
+    end
+  end
+
+  def caveats
+    <<~EOS
+      You may need super-user privileges to run this program properly. See the man
+      page for more details.
+    EOS
+  end
+
+  test do
+    # running a whole server, connecting, and so forth is a bit clunky and hard
+    # to write properly so...
+    require "pty"
+    require "expect"
+
+    PTY.spawn "#{sbin}/ftpd -x" do |input, _output, _pid|
+      str = input.expect(/ftpd: illegal option -- x/)
+      assert_match "ftpd: illegal option -- x", str[0]
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I'm submitting these patches as a single pull request, since I committed these all at once to my fork and I don't know how to split them up into multiple pull requests. And I'm really tired. Apologies.

So, Apple removed some command-line tools for some important, albeit insecure, networking protocols in 10.13. In these patches, I've attempted to rectify some of those removals.

These patches do several different things:

1. First off, I've added a `conflicts_with` assertion for `inetutils` in `telnet.rb`. The reason is that both formulas install conflicting `telnet` binaries and `telnet` man pages. I see no easy way around that, so it's probably best to just say that they conflict with each other.
2. I've added formulas for `tnftp` and `tnftpd`. There is already [an open pull request for `tnftp`,](https://github.com/Homebrew/homebrew-core/pull/18928) but my formula uses a more recent version from Apple (`20100324` as opposed to `20091122`) and my formula actually works. The `tnftpd` formula is the same sort of thing, but installs the `ftpd` server program from Apple.

3. I've added a formula for `telnetd`, which is just the `telnet` server on OS X.

Now, there are some minor flaws with my formulas, or at least they are things which could be improved.

The first thing is that my tests for `telnetd` and `tnftpd` either spit out usage information or show that the program is not completely brain-dead by making it recognize illegal options, respectively. The reason my tests are so simplistic is because writing tests which verify that servers are up and running is kind of difficult and, frankly, I don't want to put in the time to do it. Anyone else is more than welcome.

The next thing is that it would be nice for the daemons' formulas to have `plist` methods so that users could use them via `brew services`. However, it seems that these daemons require root access to work properly. That makes sense, since that was how Apple intended for them to be used and they wrote their `plist`s accordingly. As such, though, I can't make use of `brew services` since I would need to install these `plist`s to a folder owned by root, such as `/Library/LaunchAgents`, `/Library/LaunchDaemons`, `/System/Library/LaunchAgents`, or `/System/Library/LaunchDaemons`. As far as I can tell, homebrew offers no facilities to allow me to install any files into these locations.

Finally, this is the first time I've contributed to homebrew so it's possible that there are other issues that I'm missing. Please point any such issues out or fix them yourself if you feel so inclined.