### PR TITLE
conjure-up: add awscli dep

### DIFF
--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -6,6 +6,8 @@ class ConjureUp < Formula
   url "https://github.com/conjure-up/conjure-up/archive/2.3.1.tar.gz"
   sha256 "da429aad45ef0c6a70565a3748da2cb668def684b65f04ee3c081ebce065fac7"
 
+  revision 1
+
   bottle do
     cellar :any
     sha256 "d557b765effbc4f473f3fadaeba0a81f0603e20e76630546d2fdadc4f88fcc5a" => :high_sierra
@@ -19,16 +21,12 @@ class ConjureUp < Formula
   depends_on "jq"
   depends_on "wget"
   depends_on "redis"
+  depends_on "awscli"
 
   # list generated from the 'requirements.txt' file in the repository root
   resource "aiofiles" do
     url "https://files.pythonhosted.org/packages/28/51/913ed4312b63b0a1b6cad5a761b2c163eb20e353c7a3f19f08e04e8675e5/aiofiles-0.3.1.tar.gz"
     sha256 "6c4936cea65175277183553dbc27d08b286a24ae5bd86f44fbe485dfcf77a14a"
-  end
-
-  resource "awscli" do
-    url "https://files.pythonhosted.org/packages/91/31/9b420c49cbbc4316bdec5596b659adba934b9209a647bf0a780dc4b11a3b/awscli-1.11.123.tar.gz"
-    sha256 "74808159d67c31ce00f6ef1ea7a7f15794cc9cc16d23e25689bf18c30de24c48"
   end
 
   resource "botocore" do


### PR DESCRIPTION
This adds the awscli tools for our native cloud integration

Fixes https://github.com/conjure-up/conjure-up/issues/1184

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
