### PR TITLE
httpd: use prefork mpm as the default

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -54,6 +54,7 @@ class Httpd < Formula
                           "--with-sslport=8443",
                           "--with-apr=#{Formula["apr"].opt_prefix}",
                           "--with-apr-util=#{Formula["apr-util"].opt_prefix}",
+                          "--with-mpm=prefork",
                           "--with-nghttp2=#{Formula["nghttp2"].opt_prefix}",
                           "--with-ssl=#{Formula["openssl"].opt_prefix}",
                           "--with-pcre=#{Formula["pcre"].opt_prefix}"
@@ -140,11 +141,11 @@ class Httpd < Formula
         LoadModule authz_core_module #{lib}/httpd/modules/mod_authz_core.so
         LoadModule unixd_module #{lib}/httpd/modules/mod_unixd.so
         LoadModule dir_module #{lib}/httpd/modules/mod_dir.so
-        LoadModule mpm_event_module #{lib}/httpd/modules/mod_mpm_event.so
+        LoadModule mpm_prefork_module #{lib}/httpd/modules/mod_mpm_prefork.so
       EOS
 
       pid = fork do
-        exec bin/"httpd", "-DFOREGROUND", "-f", "#{testpath}/httpd.conf"
+        exec bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
       end
       sleep 3
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
In #16067 we discovered that the mpm default for Apache httpd had changed when the new core Formula was introduced. The new default mpm for php forces php to build as thread safe which is not the recommended way of running php which is documented here http://php.net/manual/en/faq.installation.php#faq.installation.apache2 .

This PR restores the behaviour that the old Formula had and selected the prefork mpm as the default.

NB: Afaik this won't change any of the config files that has already been installed since the new Formula was introduced which uses the threaded event mpm as the default.