### PR TITLE
Fix lastpass-cli install with or without docs

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -15,11 +15,13 @@ class LastpassCli < Formula
 
   depends_on "asciidoc" => :build
   depends_on "cmake" => :build
+  depends_on "docbook-xsl" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "pinentry" => :optional
 
   def install
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
     system "make", "PREFIX=#{prefix}", "install"
     system "make", "MANDIR=#{man}", "install-doc"
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fixes #9740 by making doc installation optional.