### PR TITLE
mpd: remove resource limits when run as a service

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -131,6 +131,8 @@ class Mpd < Formula
         <true/>
         <key>KeepAlive</key>
         <true/>
+        <key>ProcessType</key>
+        <string>Interactive</string>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This changes the `ProcessType` from `Standard` to `Interactive`, lifting IO and CPU limits.

It was observed in https://github.com/MusicPlayerDaemon/MPD/issues/72 that playback over Bluetooth lead to constantly skipping playback when MPD is run via this Homebrew service definition. Lifting resource limits fixes the problem.