### PR TITLE
qpid-proton 0.18.0 (new formula)

### DIFF
--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -1,0 +1,48 @@
+class QpidProton < Formula
+  desc "High-performance, lightweight AMQP 1.0 messaging library."
+  homepage "https://qpid.apache.org/proton/"
+  url "https://www.apache.org/dyn/closer.lua?path=qpid/proton/0.18.0/qpid-proton-0.18.0.tar.gz"
+  sha256 "7f54c3555a8482d439759c087d656d881369252af23f209f1fd5a7e4a8c59bd7"
+
+  head do
+    url "git://git.apache.org/qpid-proton.git"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "libuv"
+  depends_on "openssl"
+
+  def install
+    # Do not build language bindings and enforce installation into lib/ instead of lib64/
+    args = std_cmake_args + ["-DBUILD_BINDINGS=", "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=#{lib}"]
+
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      inreplace "proton-c/CMakeLists.txt",
+        "CHECK_SYMBOL_EXISTS(clock_gettime \"time.h\" CLOCK_GETTIME_IN_LIBC)",
+        "CHECK_SYMBOL_EXISTS(undefined_gibberish \"time.h\" CLOCK_GETTIME_IN_LIBC)"
+    end
+
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
+
+    system "cmake", ".", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include "proton/message.h"
+      #include "proton/messenger.h"
+      int main()
+      {
+          pn_message_t * message;
+          pn_messenger_t * messenger;
+          pn_data_t * body;
+          message = pn_message();
+          messenger = pn_messenger(NULL);
+          return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lqpid-proton", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -11,7 +11,7 @@ class QpidProton < Formula
 
   def install
     system "cmake", ".", "-DBUILD_BINDINGS=",
-                         "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=#{lib}",
+                         "-DLIB_INSTALL_DIR=#{lib}",
                          *std_cmake_args
     system "make", "install"
   end

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -19,7 +19,7 @@ class QpidProton < Formula
   end
 
   test do
-    (testpath/"test.c").write <<-EOS.undent
+    (testpath/"test.c").write <<~EOS
       #include "proton/message.h"
       #include "proton/messenger.h"
       int main()

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -10,8 +10,6 @@ class QpidProton < Formula
   depends_on "openssl"
 
   def install
-    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
-
     system "cmake", ".", "-DBUILD_BINDINGS=",
                          "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=#{lib}",
                          *std_cmake_args

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -1,30 +1,20 @@
 class QpidProton < Formula
-  desc "High-performance, lightweight AMQP 1.0 messaging library."
+  desc "High-performance, lightweight AMQP 1.0 messaging library"
   homepage "https://qpid.apache.org/proton/"
   url "https://www.apache.org/dyn/closer.lua?path=qpid/proton/0.18.0/qpid-proton-0.18.0.tar.gz"
   sha256 "7f54c3555a8482d439759c087d656d881369252af23f209f1fd5a7e4a8c59bd7"
-
-  head do
-    url "git://git.apache.org/qpid-proton.git"
-  end
+  head "git://git.apache.org/qpid-proton.git"
 
   depends_on "cmake" => :build
   depends_on "libuv"
   depends_on "openssl"
 
   def install
-    # Do not build language bindings and enforce installation into lib/ instead of lib64/
-    args = std_cmake_args + ["-DBUILD_BINDINGS=", "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=#{lib}"]
-
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
-      inreplace "proton-c/CMakeLists.txt",
-        "CHECK_SYMBOL_EXISTS(clock_gettime \"time.h\" CLOCK_GETTIME_IN_LIBC)",
-        "CHECK_SYMBOL_EXISTS(undefined_gibberish \"time.h\" CLOCK_GETTIME_IN_LIBC)"
-    end
-
     ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
 
-    system "cmake", ".", *args
+    system "cmake", ".", "-DBUILD_BINDINGS=",
+                         "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=#{lib}",
+                         *std_cmake_args
     system "make", "install"
   end
 
@@ -42,7 +32,7 @@ class QpidProton < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lqpid-proton", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lqpid-proton", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Replaces #10111 (which was closed)

I've intentionally left out the building of bindings as was controversial in #10111, and tried to keep this as small as possible such that it only builds the library.  I think we can do the language bindings in follow up PRs if necessary...thinking we could leverage optional params like `--with-ruby-binding`, `--with-python-binding`, etc, but want to get the opinions from the core team on how to proceed first.

Also I left out the cyrus_sasl (libsasl2) optional dependency, because I don't see it in homebrew.  I'll probably have to create a separate formula for it eventually, but it looks beastly.

---

cc @gberginc @blomquisg @kbrock 