### PR TITLE
ipfs: Use the correct manual command to run ipfs daemon

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -25,7 +25,7 @@ class Ipfs < Formula
     bin.install "bin/ipfs"
   end
 
-  plist_options :manual => "ipfs"
+  plist_options :manual => "ipfs daemon"
 
   def plist; <<-EOS.undent
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Running `ipfs` by itself simply prints a help menu and exits. From the [ipfs docs](https://ipfs.io/docs/getting-started/#going-online), this is the correct command to run the ipfs daemon in the foreground.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
