### PR TITLE
gdb: Automatic code signing

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -12,7 +12,7 @@ class CodesignRequirement < Requirement
   def message
     <<-EOS.undent
     gdb_codesign identity is needed to build with automated signing.
-    See: https://sourceware.org/gdb/wiki/BuildingOnDarwin
+      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
     EOS
   end
 end
@@ -74,6 +74,15 @@ class Gdb < Formula
     system "make", "install"
 
     if build.with? "code-signing"
+      # Building gdb requires a code signing certificate.
+      # The instructions provided by llvm creates this certificate in the
+      # user's login keychain. Unfortunately, the login keychain is not in
+      # the search path in a superenv build. The following three lines add
+      # the login keychain to ~/Library/Preferences/com.apple.security.plist,
+      # which adds it to the superenv keychain search path.
+      mkdir_p "#{ENV["HOME"]}/Library/Preferences"
+      username = ENV["USER"]
+      system "security", "list-keychains", "-d", "user", "-s", "/Users/#{username}/Library/Keychains/login.keychain"
       system "/usr/bin/codesign", "-f", "-s", "gdb_codesign", bin/"gdb"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Recreated the PR after a messed up rebase. The issue discussed previously is that GDB's instructions have the user put his code signing identity in the `System` keychain instead of the `login` keychain, which makes builds interactive. Currently I decided to solve this by linking llvm's instructions.
What do you guys think?