### PR TITLE
cfitsio: fix lack of --enable-reentrant flag

### DIFF
--- a/Formula/cfitsio.rb
+++ b/Formula/cfitsio.rb
@@ -13,7 +13,7 @@ class Cfitsio < Formula
     sha256 "7681f60baee8d9a73639be3f54d7f4a1c71c9fc9f4ac7fd0e3ba20cb2a2c3c7b" => :el_capitan
   end
 
-  option "with-reentrant", "build with support for concurrency"
+  option "with-reentrant", "Build with support for concurrency"
 
   def install
     args = ["--prefix=#{prefix}"]

--- a/Formula/cfitsio.rb
+++ b/Formula/cfitsio.rb
@@ -13,8 +13,16 @@ class Cfitsio < Formula
     sha256 "7681f60baee8d9a73639be3f54d7f4a1c71c9fc9f4ac7fd0e3ba20cb2a2c3c7b" => :el_capitan
   end
 
+  option "with-reentrant", "build with support for concurrency"
+
   def install
-    system "./configure", "--prefix=#{prefix}"
+    args = %W[
+      --prefix=#{prefix}
+    ]
+
+    args << "--enable-reentrant" if build.with? "reentrant"
+
+    system "./configure", *args
     system "make", "shared"
     system "make", "install"
     (pkgshare/"testprog").install Dir["testprog*"]

--- a/Formula/cfitsio.rb
+++ b/Formula/cfitsio.rb
@@ -16,12 +16,8 @@ class Cfitsio < Formula
   option "with-reentrant", "build with support for concurrency"
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-    ]
-
+    args = ["--prefix=#{prefix}"]
     args << "--enable-reentrant" if build.with? "reentrant"
-
     system "./configure", *args
     system "make", "shared"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the `--with-reentrant` build option, which builds `cfitsio` with the `--enable-reentrant` configuration option enabled. This enables support for concurrency in `cfitsio`. See [here](https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node15.html) for details.