### PR TITLE
Remove build dependency with option from ccache

### DIFF
--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -18,7 +18,6 @@ class Ccache < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "asciidoc" => ["with-docbook-xsl", :build]
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove build dependency on asciidoc because of audit change: https://github.com/Homebrew/homebrew-core/issues/13133

Is this the correct way to handle this for ccache?

