### PR TITLE
ccache: rework forumula to build without build options

### DIFF
--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -3,7 +3,7 @@ class Ccache < Formula
   homepage "https://ccache.samba.org/"
   url "https://www.samba.org/ftp/ccache/ccache-3.3.4.tar.xz"
   sha256 "24f15bf389e38c41548c9c259532187774ec0cb9686c3497bbb75504c8dc404f"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "e3626c377f89870cccce127738340a1cc22d59506c2175319120112cdc25323a" => :high_sierra
@@ -18,7 +18,8 @@ class Ccache < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "asciidoc" => ["with-docbook-xsl", :build]
+    depends_on "asciidoc" => :build
+    depends_on "docbook-xsl" => :build
   end
 
   def install

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -3,7 +3,7 @@ class Ccache < Formula
   homepage "https://ccache.samba.org/"
   url "https://www.samba.org/ftp/ccache/ccache-3.3.4.tar.xz"
   sha256 "24f15bf389e38c41548c9c259532187774ec0cb9686c3497bbb75504c8dc404f"
-  revision 2
+  revision 1
 
   bottle do
     sha256 "e3626c377f89870cccce127738340a1cc22d59506c2175319120112cdc25323a" => :high_sierra
@@ -19,7 +19,6 @@ class Ccache < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
     depends_on "asciidoc" => :build
-    depends_on "docbook-xsl" => :build
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR should fix ccache related issues related to: https://github.com/Homebrew/homebrew-core/issues/13133

@ilovezfs This solution works with ccache --HEAD as well.
