### PR TITLE
scala 2.13.0-M2 (devel)

### DIFF
--- a/Formula/scala.rb
+++ b/Formula/scala.rb
@@ -1,28 +1,53 @@
 class Scala < Formula
   desc "JVM-based programming language"
   homepage "https://www.scala-lang.org/"
-  url "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz"
-  mirror "https://downloads.typesafe.com/scala/2.12.4/scala-2.12.4.tgz"
-  mirror "https://www.scala-lang.org/files/archive/scala-2.12.4.tgz"
-  sha256 "9554a0ca31aa8701863e881281b1772370a87e993ce785bb24505f2431292a21"
+
+  stable do
+    url "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz"
+    mirror "https://downloads.typesafe.com/scala/2.12.4/scala-2.12.4.tgz"
+    mirror "https://www.scala-lang.org/files/archive/scala-2.12.4.tgz"
+    sha256 "9554a0ca31aa8701863e881281b1772370a87e993ce785bb24505f2431292a21"
+    
+    depends_on :java => "1.8+"
+    
+    resource "docs" do
+      url "https://downloads.lightbend.com/scala/2.12.4/scala-docs-2.12.4.txz"
+      mirror "https://www.scala-lang.org/files/archive/scala-docs-2.12.4.txz"
+      sha256 "477892c8bb7df996166a767037cc16feb67ec9810273fd47bf43fa1eee0597a8"
+    end
+
+    resource "src" do
+      url "https://github.com/scala/scala/archive/v2.12.4.tar.gz"
+      sha256 "9d1eaf570f95204a8894ab941070354b1672904a903ae3d1b45df201ddd1ed7d"
+    end
+  end
+
+  devel do
+    version "2.13.0-M2"
+    url "https://downloads.lightbend.com/scala/2.13.0-M2/scala-2.13.0-M2.tgz"
+    mirror "https://www.scala-lang.org/files/archive/scala-2.13.0-M2.tgz"
+    mirror "https://downloads.typesafe.com/scala/2.13.0-M2/scala-2.13.0-M2.tgz"
+    sha256 "3b83c4165d6be1854078ace552dd424acca6ddf718a908f103c206847802e808"
+
+    depends_on :java => "1.8+"
+
+    resource "docs" do
+      url "https://downloads.lightbend.com/scala/2.13.0-M2/scala-docs-2.13.0-M2.txz"
+      mirror "https://www.scala-lang.org/files/archive/scala-docs-2.13.0-M2.txz"
+      mirror "https://downloads.typesafe.com/scala/2.13.0-M2/scala-docs-2.13.0-M2.txz"
+      sha256 "add2e7d495aedeab0825b8214eb5782c0ab3fa4b65d2e763203d830364e9bbdc"
+    end
+
+    resource "src" do
+      url "https://github.com/scala/scala/archive/v2.13.0-M2.tar.gz"
+      sha256 "2a5f1b4c1fa5551e36965d0eb001d349cf1a217c1962e780cd3ae7a90e0e996a"
+    end
+  end
 
   bottle :unneeded
 
   option "with-docs", "Also install library documentation"
   option "with-src", "Also install sources for IDE support"
-
-  depends_on :java => "1.8+"
-
-  resource "docs" do
-    url "https://downloads.lightbend.com/scala/2.12.4/scala-docs-2.12.4.txz"
-    mirror "https://www.scala-lang.org/files/archive/scala-docs-2.12.4.txz"
-    sha256 "477892c8bb7df996166a767037cc16feb67ec9810273fd47bf43fa1eee0597a8"
-  end
-
-  resource "src" do
-    url "https://github.com/scala/scala/archive/v2.12.4.tar.gz"
-    sha256 "9d1eaf570f95204a8894ab941070354b1672904a903ae3d1b45df201ddd1ed7d"
-  end
 
   resource "completion" do
     url "https://raw.githubusercontent.com/scala/scala-tool-support/0a217bc/bash-completion/src/main/resources/completion.d/2.9.1/scala"
@@ -61,9 +86,7 @@ class Scala < Formula
       }
     EOS
 
-    out = shell_output("#{bin}/scala #{file}").strip
-    # Shut down the compile server so as not to break Travis
-    system bin/"fsc", "-shutdown"
+    out = shell_output("#{bin}/scala -nc #{file}").strip
 
     assert_equal "4", out
   end

--- a/Formula/scala.rb
+++ b/Formula/scala.rb
@@ -7,9 +7,9 @@ class Scala < Formula
     mirror "https://downloads.typesafe.com/scala/2.12.4/scala-2.12.4.tgz"
     mirror "https://www.scala-lang.org/files/archive/scala-2.12.4.tgz"
     sha256 "9554a0ca31aa8701863e881281b1772370a87e993ce785bb24505f2431292a21"
-    
+
     depends_on :java => "1.8+"
-    
+
     resource "docs" do
       url "https://downloads.lightbend.com/scala/2.12.4/scala-docs-2.12.4.txz"
       mirror "https://www.scala-lang.org/files/archive/scala-docs-2.12.4.txz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR introduces the devel and stable options to switch between the new scala 2.13.0 milestone releases. 

This milestone release can be installed with `brew install --build-from-source scala --devel`.
