### PR TITLE
rpm: Switch to rpm.org variant and update to 4.14

### DIFF
--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -1,24 +1,9 @@
-class RpmDownloadStrategy < CurlDownloadStrategy
-  def stage
-    tarball_name = "#{name}-#{version}.tar.gz"
-    safe_system "rpm2cpio.pl <#{cached_location} | cpio -vi #{tarball_name}"
-    safe_system "/usr/bin/tar -xzf #{tarball_name} && rm #{tarball_name}"
-    chdir
-  end
-
-  def ext
-    ".src.rpm"
-  end
-end
-
 class Rpm < Formula
   desc "Standard unix software packaging tool"
-  homepage "http://www.rpm5.org/"
-  url "http://rpm5.org/files/rpm/rpm-5.4/rpm-5.4.15-0.20140824.src.rpm",
-      :using => RpmDownloadStrategy
-  version "5.4.15"
-  sha256 "d4ae5e9ed5df8ab9931b660f491418d20ab5c4d72eb17ed9055b80b71ef6c4ee"
-  revision 3
+  homepage "http://www.rpm.org/"
+  url "http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.0.tar.bz2"
+  sha256 "06a0ad54600d3c42e42e02701697a8857dc4b639f6476edefffa714d9f496314"
+  version_scheme 1
 
   bottle do
     sha256 "8b97b8f0d4b260884b7e51fd0e0afcd2bb8312877bb21e488ad4f21d85500c25" => :high_sierra
@@ -27,52 +12,40 @@ class Rpm < Formula
     sha256 "3a276b6a3f7273f8f88effbb057e8d65fc53fa9e812054951bfdd5ce618f54ac" => :yosemite
   end
 
-  depends_on "rpm2cpio" => :build
+  depends_on "pkg-config" => :run
   depends_on "berkeley-db"
-  depends_on "libmagic"
-  depends_on "popt"
-  depends_on "libtasn1"
   depends_on "gettext"
+  depends_on "libarchive"
+  depends_on "libmagic"
+  depends_on "lua"
+  depends_on "openssl@1.1"
+  depends_on "popt"
   depends_on "xz"
-  depends_on "ossp-uuid"
+  depends_on "zstd"
 
   def install
     # only rpm should go into HOMEBREW_CELLAR, not rpms built
-    inreplace "macros/macros.in", "@prefix@", HOMEBREW_PREFIX
-    args = %W[
-      --prefix=#{prefix}
-      --localstatedir=#{var}
-      --with-path-cfg=#{etc}/rpm
-      --with-path-magic=#{HOMEBREW_PREFIX}/share/misc/magic
-      --with-path-sources=#{var}/lib/rpmbuild
-      --with-libiconv-prefix=/usr
-      --disable-openmp
-      --disable-nls
-      --disable-dependency-tracking
-      --with-db=external
-      --with-sqlite=external
-      --with-file=external
-      --with-popt=external
-      --with-beecrypt=internal
-      --with-libtasn1=external
-      --with-neon=internal
-      --with-uuid=external
-      --with-pcre=internal
-      --with-lua=internal
-      --with-syck=internal
-      --without-apidocs
-      varprefix=#{var}
-    ]
-
-    system "./configure", *args
-    inreplace "Makefile", "--tag=CC", "--tag=CXX"
-    inreplace "Makefile", "--mode=link $(CCLD)", "--mode=link $(CXX)"
-    system "make"
-    # enable rpmbuild macros, for building *.rpm packages
-    inreplace "macros/macros", "#%%{load:%{_usrlibrpm}/macros.rpmbuild}", "%{load:%{_usrlibrpm}/macros.rpmbuild}"
-    # using __scriptlet_requires needs bash --rpm-requires
-    inreplace "macros/macros.rpmbuild", "%_use_internal_dependency_generator\t2", "%_use_internal_dependency_generator\t1"
+    inreplace ["macros.in", "platform.in"], "@prefix@", HOMEBREW_PREFIX
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--localstatedir=#{var}",
+                          "--sharedstatedir=#{var}/lib",
+                          "--sysconfdir=#{etc}",
+                          "--with-path-magic=#{HOMEBREW_PREFIX}/share/misc/magic",
+                          "--enable-nls",
+                          "--disable-plugins",
+                          "--with-external-db",
+                          "--with-crypto=openssl",
+                          "--without-apidocs",
+                          "--with-vendor=homebrew"
     system "make", "install"
+  end
+
+  def post_install
+    # substitute gpg binary path with what's available
+    gnupg = Gpg.gpg2 || Gpg.gpg || HOMEBREW_PREFIX/"bin/gpg"
+    inreplace lib/"rpm/macros", "/usr/bin/gpg2", gnupg
   end
 
   def test_spec
@@ -114,8 +87,7 @@ class Rpm < Formula
     EOS
 
     system "#{bin}/rpm", "-vv", "-qa", "--dbpath=#{testpath}/var/lib/rpm"
-    assert_predicate testpath/"var/lib/rpm/sqldb", :exist?, "Failed to create 'sqldb' file!"
-    assert_match "Packages", shell_output("sqlite3 #{testpath}/var/lib/rpm/sqldb <<< .tables")
+    assert_predicate testpath/"var/lib/rpm/Packages", :exist?, "Failed to create 'Packages' file!"
     rpmdir("%_builddir").mkpath
     specfile = rpmdir("%_specdir")+"test.spec"
     specfile.write(test_spec)


### PR DESCRIPTION
Update the rpm formula to the newly released version of rpm from rpm.org (v4.14).

The commonly used version of RPM is from rpm.org, which is actively maintained by developers of Fedora (Red Hat), SUSE, and Mageia. It is also the variant shipped in Gentoo, Debian/Ubuntu, and other non-RPM based Linux distributions.

Generally speaking, this is the RPM people expect for building and testing packages.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
