### PR TITLE
multimarkdown 6.2.2

### DIFF
--- a/Formula/multimarkdown.rb
+++ b/Formula/multimarkdown.rb
@@ -1,11 +1,9 @@
 class Multimarkdown < Formula
   desc "Turn marked-up plain text into well-formatted documents"
-  homepage "http://fletcherpenney.net/multimarkdown/"
+  homepage "https://fletcher.github.io/MultiMarkdown-6/"
   # Use git tag instead of the tarball to get submodules
-  url "https://github.com/fletcher/MultiMarkdown-6.git",
-    :tag => "6.2.2",
-    :revision => "97503e55cac9b67721eed0874b4d5135d7ac5b59"
-
+  url "https://github.com/fletcher/MultiMarkdown-6/archive/6.2.2.tar.gz"
+  sha256 "48a7405c524eda7d47c66ed1f61aece142ce91ee35417f9d960587bb9f726b7c"
   head "https://github.com/fletcher/MultiMarkdown-6.git"
 
   bottle do

--- a/Formula/multimarkdown.rb
+++ b/Formula/multimarkdown.rb
@@ -21,9 +21,7 @@ class Multimarkdown < Formula
   conflicts_with "discount", :because => "both install `markdown` binaries"
 
   def install
-    system "sh", "link_git_modules"
-    system "sh", "update_git_modules"
-    system "make"
+    system "make", "release"
 
     cd "build" do
       system "make"

--- a/Formula/multimarkdown.rb
+++ b/Formula/multimarkdown.rb
@@ -1,7 +1,6 @@
 class Multimarkdown < Formula
   desc "Turn marked-up plain text into well-formatted documents"
   homepage "https://fletcher.github.io/MultiMarkdown-6/"
-  # Use git tag instead of the tarball to get submodules
   url "https://github.com/fletcher/MultiMarkdown-6/archive/6.2.2.tar.gz"
   sha256 "48a7405c524eda7d47c66ed1f61aece142ce91ee35417f9d960587bb9f726b7c"
   head "https://github.com/fletcher/MultiMarkdown-6.git"

--- a/Formula/multimarkdown.rb
+++ b/Formula/multimarkdown.rb
@@ -2,11 +2,11 @@ class Multimarkdown < Formula
   desc "Turn marked-up plain text into well-formatted documents"
   homepage "http://fletcherpenney.net/multimarkdown/"
   # Use git tag instead of the tarball to get submodules
-  url "https://github.com/fletcher/MultiMarkdown-5.git",
-    :tag => "5.4.0",
-    :revision => "193c09a5362eb8a6c6433cd5d5f1d7db3efe986a"
+  url "https://github.com/fletcher/MultiMarkdown-6.git",
+    :tag => "6.2.2",
+    :revision => "97503e55cac9b67721eed0874b4d5135d7ac5b59"
 
-  head "https://github.com/fletcher/MultiMarkdown-5.git"
+  head "https://github.com/fletcher/MultiMarkdown-6.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Switch multimarkdown from multimarkdown-5 to multimarkdown-6, update version to 6.2.2.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
