### PR TITLE
AsciidoctorJ 1.5.6 (new formula)

### DIFF
--- a/Formula/asciidoctorj.rb
+++ b/Formula/asciidoctorj.rb
@@ -1,0 +1,46 @@
+class Asciidoctorj < Formula
+  desc "Java wrapper and bindings for Asciidoctor"
+  homepage "https://github.com/asciidoctor/asciidoctorj"
+  url "https://dl.bintray.com/asciidoctor/maven/org/asciidoctor/asciidoctorj/1.5.6/asciidoctorj-1.5.6-bin.zip"
+  sha256 "be2f7afe0b713bf5b3e625a99a588a87e91afb2eb684c9b1fd0653db88154e1d"
+
+  bottle :unneeded
+
+  depends_on :java => "1.6+"
+
+  def install
+    rm_rf Dir["bin/*.bat"] # Remove Windows files.
+    libexec.install Dir["*"]
+
+    executable = libexec/"bin/asciidoctorj"
+    executable.chmod 0555
+    bin.write_exec_script executable
+  end
+
+  test do
+    (testpath/"test.adoc").write <<-EOS.undent
+      = This Is A Title
+      Random J. Author <rjauthor@example.com>
+      :icons: font
+
+      Hello, World!
+
+      == Syntax Highlighting
+
+      Python source.
+
+      [source, python]
+      ----
+      import something
+      ----
+
+      List
+
+      - one
+      - two
+      - three
+    EOS
+    system bin/"asciidoctorj", "-b", "pdf", "test.adoc"
+    assert_predicate testpath/"test.pdf", :exist?
+  end
+end


### PR DESCRIPTION
AsciidoctorJ is a Java wrapper and library for Asciidoctor. It lets you
convert AsciiDoc markup to (X)HTML, PDF, DocBook, man pages, EPUB3, and
other formats.

https://github.com/asciidoctor/asciidoctorj
http://asciidoctor.org

Copied and modified from fop.rb

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
