### PR TITLE
update dependency-check to version 3.0.0

### DIFF
--- a/Formula/dependency-check.rb
+++ b/Formula/dependency-check.rb
@@ -1,8 +1,8 @@
 class DependencyCheck < Formula
   desc "OWASP Dependency Check"
   homepage "https://www.owasp.org/index.php/OWASP_Dependency_Check"
-  url "https://dl.bintray.com/jeremy-long/owasp/dependency-check-2.1.1-release.zip"
-  sha256 "fbfd94c6a9eb28cefe093b12d49b49fb1f994abf68c1f6cfc36889066d6b0f36"
+  url "https://dl.bintray.com/jeremy-long/owasp/dependency-check-3.0.0-release.zip"
+  sha256 "b107fffc5504bbb34bf7a91e312ec575a819b6baa77daa66b31035af843b2622"
 
   bottle :unneeded
 


### PR DESCRIPTION
Version 3.0.0 of dependency-check was released; updating homebrew.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
