### PR TITLE
Turn off link time optimization for ponyc builds

### DIFF
--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -29,7 +29,7 @@ class Ponyc < Formula
   def install
     ENV.cxx11
     ENV["LLVM_CONFIG"] = "#{Formula["llvm@3.9"].opt_bin}/llvm-config"
-    system "make", "config=release", "destdir=#{prefix}", "install", "verbose=1"
+    system "make", "config=release", "lto=no", "destdir=#{prefix}", "install", "verbose=1"
   end
 
   test do


### PR DESCRIPTION
By building bottles with lto aka link time optimization on, user's must
run the same XCode as the bottle was built with. Example scenario where
this causes issue:

User installs XCode in July 2017. Gets XCode 8.x
User installs Ponyc in October 2017. Gets a version built with XCode 9.x

Because of the mismatch in xcode versions and lto being on, programs
won't compile.

This change results in a drop in overall performance for compiled Pony
programs but improve basic usability. We, the Pony core team, discussed
the issue and decided that this was a better way to build when using
homebrew.

In order to get peak performance, you already need to install ponyc from
source, so, this makes sense as a change.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
