### PR TITLE
gmp: fix static library via --disable-assembly, fixes #19407

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -4,6 +4,7 @@ class Gmp < Formula
   url "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
   mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
   sha256 "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -20,10 +20,14 @@ class Gmp < Formula
     ENV.cxx11 if build.cxx11?
     args = %W[--prefix=#{prefix} --enable-cxx]
     args << "--build=core2-apple-darwin#{`uname -r`.to_i}" if build.bottle?
-    system "./configure", *args
+    system "./configure", "--disable-static", *args
     system "make"
     system "make", "check"
     system "make", "install"
+    system "make", "clean"
+    system "./configure", "--disable-shared", "--disable-assembly", *args
+    system "make"
+    lib.install Dir[".libs/*.a"]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR applies the patch suggested by @ilovezfs in https://github.com/Homebrew/homebrew-core/issues/19407. 