### PR TITLE
xdotool: fix build error on 10.11 with Xcode 8

### DIFF
--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -16,6 +16,13 @@ class Xdotool < Formula
   depends_on :x11
 
   def install
+    # Work around an issue with Xcode 8 on El Capitan, which
+    # errors out with `typedef redefinition with different types`
+    if MacOS.version == :el_capitan && MacOS::Xcode.installed? &&
+       MacOS::Xcode.version >= "8.0"
+      ENV.delete("SDKROOT")
+    end
+
     system "make", "PREFIX=#{prefix}", "INSTALLMAN=#{man}", "install"
   end
 


### PR DESCRIPTION
The `MacOSX10.12.sdk` framework, which comes with Xcode 8 or newer, is not compatible [with upstream’s (fair) assumption](https://github.com/jordansissel/xdotool/blob/6b027967bb0f419de5c7dba4b6f77fe78c11c3a1/cflags.sh#L7) that `CLOCK_MONOTONIC` and `clock_gettime` are not available on El Capitan.

This leads to the following build error when running El Capitan with Xcode 8 or newer:

```
In file included from cmd_behave_screen_edge.c:10:
./patch_clock_gettime.h:5:13: error: typedef redefinition with different types ('int' vs 'enum clockid_t')
typedef int clockid_t;
            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/time.h:171:3: note: previous definition is here
} clockid_t;
  ^
1 error generated.
```

This commit fixes the issue [just like `anttweakbar` and other formulas do](https://github.com/Homebrew/homebrew-core/blob/9344c04ad216a5c44da450a81fb8bdc2c8b47b88/Formula/anttweakbar.rb).