### PR TITLE
dssim: with-library

### DIFF
--- a/Formula/dssim.rb
+++ b/Formula/dssim.rb
@@ -13,36 +13,27 @@ class Dssim < Formula
     sha256 "51756e74240d03c87a79ff0e14e494d249701d4069ea336b529b47a179c469d3" => :mavericks
   end
 
-  option "with-library", "Build library (require `python3` and `ninja`)"
-
-  if build.with? "library"
-    resource "meson-0.27.0" do
-      url "https://github.com/mesonbuild/meson/archive/0.27.0.tar.gz"
-      sha256 "0ecc660f87d55c3cfee5e8ffd53c91227e3d0c9f0c3b4187cd7e8679e30f2255"
-    end
+  resource "meson-0.27.0" do
+    url "https://github.com/mesonbuild/meson/archive/0.27.0.tar.gz"
+    sha256 "0ecc660f87d55c3cfee5e8ffd53c91227e3d0c9f0c3b4187cd7e8679e30f2255"
   end
 
   depends_on "pkg-config" => :build
   depends_on "libpng"
-  depends_on :python3 if build.with? "library"
-  depends_on "ninja" if build.with? "library"
+  depends_on :python3
+  depends_on "ninja"
 
   def install
-    if build.with? "library"
+    (buildpath/"mesonbuild").install resource("meson-0.27.0")
+    cd buildpath/"mesonbuild" do
       version = Language::Python.major_minor_version("python3")
-      (buildpath/"mesonbuild").install resource("meson-0.27.0")
-      cd buildpath/"mesonbuild" do
-        ENV["PYTHONPATH"] = buildpath/"meson-0.27.0/lib/python#{version}/site-packages"
-        system "python3", "install_meson.py", "--prefix=#{buildpath}/meson-0.27.0"
-      end
-      ENV.prepend_path "PATH", buildpath/"meson-0.27.0/bin"
-      mkdir buildpath/"macbuild" do
-        system "../meson-0.27.0/bin/meson", "--prefix=#{prefix}", ".."
-        system "ninja", "install"
-      end
-    else
-      system "make"
-      bin.install "bin/dssim"
+      ENV["PYTHONPATH"] = buildpath/"meson-0.27.0/lib/python#{version}/site-packages"
+      system "python3", "install_meson.py", "--prefix=#{buildpath}/meson-0.27.0"
+    end
+    ENV.prepend_path "PATH", buildpath/"meson-0.27.0/bin"
+    mkdir buildpath/"macbuild" do
+      system "../meson-0.27.0/bin/meson", "--prefix=#{prefix}", ".."
+      system "ninja", "install"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
----
```
$ brew info dssim
dssim: stable 1.3.2 (bottled)
RGBA Structural Similarity C implementation (with a Rust API)
https://github.com/pornel/dssim
/usr/local/Cellar/dssim/1.3.2 (9 files, 97.3KB) *
  Built from source on 2017-10-19 at 20:53:00 with: --with-library
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/dssim.rb
==> Dependencies
Build: pkg-config ✔
Required: libpng ✔
==> Options
--with-library
	Build library (require `python3` and `ninja`)

$ brew list dssim --verbose
/usr/local/Cellar/dssim/1.3.2/INSTALL_RECEIPT.json
/usr/local/Cellar/dssim/1.3.2/LICENSE
/usr/local/Cellar/dssim/1.3.2/bin/dssim
/usr/local/Cellar/dssim/1.3.2/.brew/dssim.rb
/usr/local/Cellar/dssim/1.3.2/include/dssim.h
/usr/local/Cellar/dssim/1.3.2/README.md
/usr/local/Cellar/dssim/1.3.2/lib/pkgconfig/dssim.pc
/usr/local/Cellar/dssim/1.3.2/lib/libdssim-lib.dylib
/usr/local/Cellar/dssim/1.3.2/lib/libdssim-lib.dylib.1.1

$ otool -L /usr/local/Cellar/dssim/1.3.2/bin/dssim
/usr/local/Cellar/dssim/1.3.2/bin/dssim:
	/usr/local/Cellar/dssim/1.3.2/lib/libdssim-lib.dylib.1.1 (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 51.0.0, current version 51.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
```