### PR TITLE
goocanvasmm 1.90.11 (new formula)

### DIFF
--- a/Formula/goocanvasmm.rb
+++ b/Formula/goocanvasmm.rb
@@ -1,0 +1,29 @@
+class Goocanvasmm < Formula
+  desc "C++ wrappers for goocanvas"
+  homepage "https://www.gtkmm.org"
+  url "https://download.gnome.org/sources/goocanvasmm/1.90/goocanvasmm-1.90.11.tar.xz"
+  sha256 "80ff11873ec0e73d9e38b0eb2ffb1586621f0b804093b990e49fdb546476ed6e"
+
+  depends_on "pkg-config" => :build
+  depends_on "glibmm"
+  depends_on "gtkmm3"
+  depends_on "goocanvas"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cc").write <<-EOS.undent
+      #include <goocanvasmm.h>
+      int main(int argc, char **argv) {
+        Goocanvas::init();
+      }
+    EOS
+    system ENV.cc, "-std=c++14", *shell_output("pkg-config --cflags --libs goocanvasmm-2.0").split, testpath/"test.cc", "-o", testpath/"test"
+    system testpath/"test"
+  end
+end


### PR DESCRIPTION
This adds the goocanvasmm C++ wrapper project for goocanvas to Homebrew.
The package includes a `make check`, but as far as I can see that is not
accessible from the `do test` in the formula, and this works fine as well.
(As in: it will not compile and run if goocanvasmm is not correctly
installed, which is the point of the test.)

The package doesn't seem to have a real home page, but since its GitHub
repo description links to the http version of https://www.gtkmm.org, I
added that page. It's relevant, but not perfect.
Debian (https://packages.debian.org/source/wheezy/goocanvasmm) links to
some page about goocanvas, which is also related but I think less relevant,
especially since the names are alike but the packages are definitely not.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
