### PR TITLE
rust-vcprompt 0.1.0 (new formula)

### DIFF
--- a/Formula/rust-vcprompt.rb
+++ b/Formula/rust-vcprompt.rb
@@ -1,0 +1,22 @@
+class RustVcprompt < Formula
+  desc "Informative version control prompt for your shell"
+  homepage "https://github.com/sscherfke/rust-vcprompt"
+  url "https://github.com/sscherfke/rust-vcprompt/archive/0.1.0.tar.gz"
+  sha256 "3c51261c7b75f04de566d97a95530521f71fb8b99529deab5ce8af97702c7acf"
+  head "https://github.com/sscherfke/rust-vcprompt.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--release"
+    mv "target/release/vcprompt", "target/release/rust-vcprompt"
+    bin.install "target/release/rust-vcprompt"
+  end
+
+  test do
+    mkdir "repo"
+    cd "repo"
+    system "git", "init"
+    assert_equal "[00m git:[34mmaster[00m|[32m[01m✔[00m \n", shell_output("#{bin}/rust-vcprompt")
+  end
+end

--- a/Formula/rust-vcprompt.rb
+++ b/Formula/rust-vcprompt.rb
@@ -9,14 +9,13 @@ class RustVcprompt < Formula
 
   def install
     system "cargo", "build", "--release"
-    mv "target/release/vcprompt", "target/release/rust-vcprompt"
-    bin.install "target/release/rust-vcprompt"
+    bin.install "target/release/vcprompt" => "rust-vcprompt"
   end
 
   test do
-    mkdir "repo"
-    cd "repo"
-    system "git", "init"
-    assert_equal "[00m git:[34mmaster[00m|[32m[01m✔[00m \n", shell_output("#{bin}/rust-vcprompt")
+    mkdir "repo" do
+      system "git", "init"
+      assert_equal "[00m git:[34mmaster[00m|[32m[01m✔[00m \n", shell_output("#{bin}/rust-vcprompt")
+    end
   end
 end

--- a/Formula/rust-vcprompt.rb
+++ b/Formula/rust-vcprompt.rb
@@ -15,7 +15,8 @@ class RustVcprompt < Formula
   test do
     mkdir "repo" do
       system "git", "init"
-      assert_equal "[00m git:[34mmaster[00m|[32m[01m✔[00m \n", shell_output("#{bin}/rust-vcprompt")
+      ENV.keys.grep(/^VCP_[A-Z]+/).each { |k| ENV.delete(k) }
+      assert_equal " ±\e[34mmaster\e[00m|\e[32m\e[01m✔\e[00m\n", shell_output("#{bin}/rust-vcprompt")
     end
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds rust-vcprompt 0.1.0 from https://github.com/sscherfke/rust-vcprompt by @sscherfke.

Renames the binary to `rust-vcprompt` to avoid coexistence with other similar tools.