### PR TITLE
fifechan: link with sdl2 not sdl

### DIFF
--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -14,13 +14,15 @@ class Fifechan < Formula
 
   depends_on "cmake" => :build
   depends_on "allegro" => :recommended
-  depends_on "sdl" => :recommended
-  depends_on "sdl_image" => :recommended
+  depends_on "sdl2" => :recommended
+  depends_on "sdl2_image" => :recommended
+  depends_on "sdl2_ttf" => :recommended
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
+      args = std_cmake_args
+      args << "-DENABLE_SDL_CONTRIB=ON" if build.with? "sdl2_ttf"
+      system "cmake", "..", *args
     end
   end
 

--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -3,6 +3,7 @@ class Fifechan < Formula
   homepage "https://fifengine.github.io/fifechan/"
   url "https://github.com/fifengine/fifechan/archive/0.1.4.tar.gz"
   sha256 "a93b015b5852b8fe2a0a2a6891d3de2cacb196732f670e081d7b7966f9ed1b87"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -23,6 +23,7 @@ class Fifechan < Formula
       args = std_cmake_args
       args << "-DENABLE_SDL_CONTRIB=ON" if build.with? "sdl2_ttf"
       system "cmake", "..", *args
+      system "make", "install"
     end
   end
 

--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -21,7 +21,7 @@ class Fifechan < Formula
   def install
     mkdir "build" do
       args = std_cmake_args
-      args << "-DENABLE_SDL_CONTRIB=ON" if build.with? "sdl2_ttf"
+      args << "-DENABLE_SDL_CONTRIB=ON" if (build.with? "sdl2_ttf") && (build.with? "sdl2_image")
       system "cmake", "..", *args
       system "make", "install"
     end

--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -21,9 +21,7 @@ class Fifechan < Formula
 
   def install
     mkdir "build" do
-      args = std_cmake_args
-      args << "-DENABLE_SDL_CONTRIB=ON"
-      system "cmake", "..", *args
+      system "cmake", "..", "-DENABLE_SDL_CONTRIB=ON", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/fifechan.rb
+++ b/Formula/fifechan.rb
@@ -14,15 +14,15 @@ class Fifechan < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "allegro" => :recommended
-  depends_on "sdl2" => :recommended
-  depends_on "sdl2_image" => :recommended
-  depends_on "sdl2_ttf" => :recommended
+  depends_on "allegro"
+  depends_on "sdl2"
+  depends_on "sdl2_image"
+  depends_on "sdl2_ttf"
 
   def install
     mkdir "build" do
       args = std_cmake_args
-      args << "-DENABLE_SDL_CONTRIB=ON" if (build.with? "sdl2_ttf") && (build.with? "sdl2_image")
+      args << "-DENABLE_SDL_CONTRIB=ON"
       system "cmake", "..", *args
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
Current `bottle` doesn't have `libfifechan_sdl.0.1.4.dylib`. 
```
$ brew fetch fifechan
==> Downloading https://homebrew.bintray.com/bottles/fifechan-0.1.4.high_sierra.
######################################################################## 100.0%
Downloaded to: /Users/s172262/Library/Caches/Homebrew/fifechan-0.1.4.high_sierra.bottle.tar.gz
SHA256: 5eba713dbc0b32b14703d9423c61b4272984eb6c6d24f10cb2f7fbca30ec4581

$ tar xf fifechan-0.1.4.high_sierra.bottle.tar.gz
$ cd fifechan/0.1.4/lib/
$ ls
libfifechan.0.1.4.dylib		libfifechan_opengl.0.1.4.dylib
libfifechan.dylib		libfifechan_opengl.dylib

$ otool -L lib*.dylib |sed -e "/:/d" |sort |uniq
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
	@@HOMEBREW_PREFIX@@/opt/fifechan/lib/libfifechan.0.1.4.dylib (compatibility version 0.1.4, current version 0.1.4)
	@@HOMEBREW_PREFIX@@/opt/fifechan/lib/libfifechan_opengl.0.1.4.dylib (compatibility version 0.1.4, current version 0.1.4)
	@loader_path/libfifechan.0.1.4.dylib (compatibility version 0.1.4, current version 0.1.4)
```
This commite builds `libfifechan_sdl.0.1.4.dylib`.
```
$ brew list fifechan
/usr/local/Cellar/fifechan/0.1.4/include/fifechan/ (71 files)
/usr/local/Cellar/fifechan/0.1.4/include/fifechan.hpp
/usr/local/Cellar/fifechan/0.1.4/lib/libfifechan.0.1.4.dylib
/usr/local/Cellar/fifechan/0.1.4/lib/libfifechan_opengl.0.1.4.dylib
/usr/local/Cellar/fifechan/0.1.4/lib/libfifechan_sdl.0.1.4.dylib
/usr/local/Cellar/fifechan/0.1.4/lib/ (3 other files)

 $ otool -L /usr/local/Cellar/fifechan/0.1.4/lib/libfifechan_sdl.0.1.4.dylib
/usr/local/Cellar/fifechan/0.1.4/lib/libfifechan_sdl.0.1.4.dylib:
	/usr/local/opt/fifechan/lib/libfifechan_sdl.0.1.4.dylib (compatibility version 0.1.4, current version 0.1.4)
	/usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib (compatibility version 1.0.0, current version 1.1.0)
	@loader_path/libfifechan.0.1.4.dylib (compatibility version 0.1.4, current version 0.1.4)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)
```
