### PR TITLE
mariadb-connector-odbc 3.0.1-beta (new formula)

### DIFF
--- a/Formula/mariadb-connector-c.rb
+++ b/Formula/mariadb-connector-c.rb
@@ -1,9 +1,8 @@
 class MariadbConnectorC < Formula
   desc "MariaDB database connector for C applications"
   homepage "https://downloads.mariadb.org/connector-c/"
-  url "https://downloads.mariadb.org/f/connector-c-2.2.2/mariadb-connector-c-2.2.2-src.tar.gz"
-  sha256 "93f56ad9f08bbaf0da8ef03bc96f7093c426ae40dede60575d485e1b99e6406b"
-
+  url "https://downloads.mariadb.org/f/connector-c-3.0.2/mariadb-connector-c-3.0.2-src.tar.gz"
+  sha256 "518d14b8d77838370767d73f9bf1674f46232e1a2a34d4195bd38f52a3033758"
   bottle do
     sha256 "d569c9bbc70e38697625aaf1ff939689b1b7189d2fcf890546a72dc0e4d8f4c8" => :high_sierra
     sha256 "2efc882d3518dc6932d711b62d5d65a6b2151f7e44d2e6a15917ca4f1d3ce897" => :sierra

--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,0 +1,24 @@
+class MariadbConnectorOdbc < Formula
+  desc "MariaDB Standardized database driver"
+  homepage "https://downloads.mariadb.org/connector-odbc/"
+  url "http://mariadb.mirror.triple-it.nl/connector-odbc-3.0.1/mariadb-connector-odbc-3.0.1-beta-src.tar.gz"
+  sha256 "03e3fbf5f3957c88bc89c45a8396c1aabf88ec86f21e5e6dd0c6ad09e30389aa"
+
+  depends_on "cmake" => :build
+  depends_on "mariadb-connector-c"
+  depends_on "openssl"
+  depends_on "unixodbc"
+
+  def install
+    system "cmake", ".", "-DWITH_UNIXODBC=1", "-DMARIADB_FOUND=1",
+            "-DWITH_OPENSSL=1",
+            "-DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/",
+            *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    output = shell_output("#{Formula["unixodbc"].bin}/dltest #{lib}/libmaodbc.dylib")
+    assert_equal "SUCCESS: Loaded #{lib}/libmaodbc.dylib", output.chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a retry of my earlier pull of https://github.com/Homebrew/homebrew-core/pull/10146 (the discussion got a bit stuck at requesting the use of a newer version not requiring a patch, and then concluding that a newer version would be an alpha). Anyway, the 3.x versions are out of alpha now so I hope we can merge this - and this time around no patches are needed to the upstream code.

I've updated mariadb-connector-c to 3.0.2 as the current 2.2.2 is incompatible with the 3.x odbc drivers

I've added the mariadb-connector-odbc 3.0.1 version as the 3.0.2 version relies on an unpublished fix to mariadb-connector-c (see https://jira.mariadb.org/browse/ODBC-118 )

Apart from the test working, I've successfully tested mariadb-connector-odbc with unixodbc against a live database.