### PR TITLE
synergy-core 1.9.0 (new formula)

### DIFF
--- a/Formula/synergy-core.rb
+++ b/Formula/synergy-core.rb
@@ -1,0 +1,33 @@
+class SynergyCore < Formula
+  desc "Open source core of Synergy, the keyboard and mouse sharing tool"
+  homepage "https://symless.com/synergy"
+  url "https://github.com/symless/synergy-core.git",
+      :revision => "62ab8ffc4fdbc84b51552d600a8e11f7a7b78d84"
+  version "1.9.0-rc4"
+  head "https://github.com/symless/synergy-core.git"
+
+  depends_on "cmake" => :build
+  depends_on "qt"
+  depends_on "openssh"
+
+  def install
+    mkdir "build" do
+      system "cmake",
+        "-DOSX_TARGET_MAJOR=10",
+        "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}",
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9",
+        "-DCMAKE_OSX_ARCHITECTURES=x86_64",
+        ".."
+
+      system "make"
+
+      bin.install "bin/synergyc"
+      bin.install "bin/synergys"
+    end
+  end
+
+  test do
+    assert_match version.to_s[0, 5], shell_output(bin/"synergys --version | head -1")
+    assert_match version.to_s[0, 5], shell_output(bin/"synergyc --version | head -1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a formula for `synergy-core`, which is an open source command line version of the Synergy client and server. I know Synergy was previously removed because it was unstable and there were [concerns about the ethics of providing a package for paid-for open-source software](https://github.com/Homebrew/legacy-homebrew/issues/34265), however this repository openly provides [build instructions for MacOS](https://github.com/symless/synergy-core/wiki/Compiling#Mac_OS_X_1010_and_above) so I don't believe that is really an issue anymore.

Note that this formula targets an rc version, rather than the latest stable release, as the stable version doesn't work on newer versions of MacOS due to OpenSSL issues.