### PR TITLE
valgrind: fix build on 10.12 with Xcode 9

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -10,6 +10,16 @@ class Valgrind < Formula
     # valgrind does not yet support High Sierra
     # https://bugs.kde.org/show_bug.cgi?id=383811
     depends_on MaximumMacOSRequirement => :sierra
+
+    # Fix build on 10.12 with Xcode 9
+    # Upstream commit from 24 Sep 2017 "Support all Apple clang/LLVM 5.1+"
+    # See https://sourceware.org/git/?p=valgrind.git;a=commit;h=27e1503bc7bd767f3a98824176558beaa5a7c1d5
+    if DevelopmentTools.clang_build_version >= 900
+      patch :p0 do
+        url "https://raw.githubusercontent.com/Homebrew/formula-patches/b3915f6/valgrind/sierra-xcode9.diff"
+        sha256 "156ea88edd2116dd006d6e5550578af3f2a2e3923818a238b9166cd02e327432"
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Goes together with https://github.com/Homebrew/formula-patches/pull/202.