### PR TITLE
poppler: don't use @rpath in load commands

### DIFF
--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -70,6 +70,13 @@ class Poppler < Formula
     resource("font-data").stage do
       system "make", "install", "prefix=#{prefix}"
     end
+
+    libpoppler = (lib/"libpoppler.dylib").readlink
+    ["libpoppler-cpp.dylib", "libpoppler-glib.dylib"].each do |dylib|
+      macho = MachO.open("#{lib}/#{dylib}")
+      macho.change_dylib("@rpath/#{libpoppler}", "#{lib}/#{libpoppler}")
+      macho.write!
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

to avoid problems finding libpoppler when poppler is unlinked or the
HOMEBREW_PREFIX is not /usr/local.

CC @woodruffw @Yann-R

Fixes #19766.