### PR TITLE
sdl2_image 2.0.2

### DIFF
--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -1,9 +1,8 @@
 class Sdl2Image < Formula
   desc "Library for loading images as SDL surfaces and textures"
   homepage "https://www.libsdl.org/projects/SDL_image/"
-  url "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1.tar.gz"
-  sha256 "3a3eafbceea5125c04be585373bfd8b3a18f259bd7eae3efc4e6d8e60e0d7f64"
-  revision 3
+  url "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.2.tar.gz"
+  sha256 "72df075aef91fc4585098ea7e0b072d416ec7599aa10473719fbe51e9b8f6ce8"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
"--enable-" options still works opposite.
>$ otool -L /usr/local/Cellar/sdl2_image/2.0.2/lib/libSDL2_image-2.0.0.dylib
/usr/local/Cellar/sdl2_image/2.0.2/lib/libSDL2_image-2.0.0.dylib:
	/usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 51.0.0, current version 51.0.0)
	/usr/local/opt/jpeg/lib/libjpeg.9.dylib (compatibility version 12.0.0, current version 12.0.0)
	/usr/local/opt/libtiff/lib/libtiff.5.dylib (compatibility version 8.0.0, current version 8.6.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/local/opt/webp/lib/libwebp.7.dylib (compatibility version 8.0.0, current version 8.0.0)
	/usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.0.0)

