### PR TITLE
swiftgen 5.2.1

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag => "5.2.0",
-      :revision => "fbf8836f2b63cfcd98999e51b255a25688d04897"
+      :tag => "5.2.1",
+      :revision => "21107b1de6180cf5644e512e67e4d60a0d115ac4"
   head "https://github.com/SwiftGen/SwiftGen.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  > Couldn't test, because this seems to now require rubocop-0.51.0, which itself requires Ruby >= 2.1.0, but I'm still on macOS 10.12 here with system ruby 2.0, and don't want to upgrade my ruby just for that :wink:
  > (But it passed before and only changes are version and sha1, so no change in style in the rest of the Formula)
- [X] Does pass `brew test swiftgen` through 
-----

Hotfix for a blocking bug of the command line invocation