### PR TITLE
makensis: fix PREFIX_DOC

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -49,7 +49,7 @@ class Makensis < Formula
 
     # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
     args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu",
-            "VERSION=#{version}"]
+            "PREFIX_DOC=#{share}/nsis/Docs", "VERSION=#{version}"]
     args << "NSIS_CONFIG_LOG=yes" if build.with? "advanced-logging"
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     scons "makensis", *args
@@ -80,12 +80,12 @@ index a344456..37c575b 100755
 +import os
 +
  Import('defenv')
- 
+
  ### Configuration options
 @@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
  env = Environment()
  cfg.Update(env)
- 
+
 +defenv['CC'] = os.environ['CC']
 +defenv['CXX'] = os.environ['CXX']
 +

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -80,12 +80,12 @@ index a344456..37c575b 100755
 +import os
 +
  Import('defenv')
-
+ 
  ### Configuration options
 @@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
  env = Environment()
  cfg.Update(env)
-
+ 
 +defenv['CC'] = os.environ['CC']
 +defenv['CXX'] = os.environ['CXX']
 +


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Running `makensis -HDRINFO` will list the compiler flags the binary has been built with. Among these are several file locations, including the path for the documentation:

```
NSISDIR=/usr/local/share/nsis
PREFIX_CONF=/usr/local/etc
PREFIX_DATA=/usr/local/share/nsis
PREFIX_DOC=/usr/local/share/doc/nsis
```

Unfortunately, the path in `PREFIX_DOC` does not exist after installation. This PR fixes that. While it works, I'm not 100% sure I used the preferred variable.