### PR TITLE
Trickle (43f1659) (new formula)

### DIFF
--- a/Formula/trickle.rb
+++ b/Formula/trickle.rb
@@ -1,0 +1,16 @@
+class Trickle < Formula
+  desc "600 baud pipe and terminal."
+  homepage "https://github.com/sjmulder/trickle"
+  url "https://github.com/sjmulder/trickle/archive/43f1659c66de1bd32492c5a6e85ed9b9e9593ca1.tar.gz"
+  sha256 "3648a94208c7059c57e6728a76aea2b9c4d8a511562ed7181323b7861aa97408"
+
+  def install
+    system "make"
+    bin.install "trickle"
+    bin.install "tritty"
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
Tirckle is a 600 baud pipe and terminal. Introduced on Hackernews and not available on brew right now.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [?] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
Kinda, source repo is rather new.
-----
