### PR TITLE
maven 3.5.2

### DIFF
--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -3,9 +3,9 @@ class Maven < Formula
   homepage "https://maven.apache.org/"
 
   stable do
-    url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz"
-    mirror "https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz"
-    sha256 "beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034"
+    url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz"
+    sha256 "707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff"
   end
 
   bottle :unneeded

--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -45,6 +45,7 @@ class Maven < Formula
         <properties>
           <maven.compiler.source>1.8</maven.compiler.source>
           <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         </properties>
       </project>
     EOS

--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -42,6 +42,10 @@ class Maven < Formula
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
       </project>
     EOS
     (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?  <==== **Is it applicable ?**
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Here's an update for maven 3.5.2. 

-----------------------------------------------------
Manual pull request because `hub` has issues.

<details><summary>`brew bump-formula-pr`</summary>

```sh
brew bump-formula-pr --strict maven --url="https://www.apache.org/dyn/closer.cgi\?path\=maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz" --sha256="beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034"                                        •100%
Already up-to-date.
==> replace / +mirror \"https:\/\/archive.apache.org\/dist\/maven\/maven-3\/3.5.0\/binaries\/apache-maven-3.5.0-bin.tar.gz\"\n/m with ""
==> replace "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz" with "https://www.apache.org/dyn/closer.cgi\\?path\\=maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz"
==> replace "beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034" with "beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034"
M	Formula/maven.rb
Switched to a new branch 'maven-3.5.2'
[maven-3.5.2 b9413df2cd] maven 3.5.2
 1 file changed, 1 insertion(+), 2 deletions(-)


Error: cannot get remote from 'hub'!
```

</details>

-----------------------------------------------------

 Indicates the source and target version to 1.8.

By default the compiler plugin of maven assumes a source and target
level aimed at Java 1.5 (5) by default :

https://maven.apache.org/plugins/maven-compiler-plugin/index.html

The used java version on jenkins.brew.sh is not logged, but since the
`maven` formula depend on the `java` formula which targets java 9 it
explains why the build is failing, as Java 9 dropped support for
Java 1.5 (5) : http://openjdk.java.net/jeps/182

To fix this the test pom indicates a more recent source level.