### PR TITLE
correct sha256 hash for ammonite-repl 1.0.3

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -2,7 +2,7 @@ class AmmoniteRepl < Formula
   desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
   homepage "https://lihaoyi.github.io/Ammonite/#Ammonite-REPL"
   url "https://github.com/lihaoyi/Ammonite/releases/download/1.0.3/2.12-1.0.3", :using => :nounzip
-  sha256 "95672d12fab73938797df9eed99ad3a07fb4759c5a5dcd6140a74f5dbc03465d"
+  sha256 "69ee90b067cb5546480c54887a3325f87e272464452fbeaaa0628379936bae3c"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```shellsession
$ brew install ammonite-repl
==> Downloading https://github.com/lihaoyi/Ammonite/releases/download/1.0.3/2.12-1.0.3
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/29178282/4940b24c-b862-11e7-8f1a-4b29686fe4e5?X-Amz-Algorithm=AWS4-HMAC-SHA
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 95672d12fab73938797df9eed99ad3a07fb4759c5a5dcd6140a74f5dbc03465d
Actual: 69ee90b067cb5546480c54887a3325f87e272464452fbeaaa0628379936bae3c
Archive: /Users/bholt/Library/Caches/Homebrew/ammonite-repl-1.0.3.3
To retry an incomplete download, remove the file above.
```

I verified the `69ee90b067cb5546480c54887a3325f87e272464452fbeaaa0628379936bae3c` hash by downloading the file directly from the [GitHub release page](https://github.com/lihaoyi/Ammonite/releases/tag/1.0.3):


```shellsession
$ curl --silent -L https://github.com/lihaoyi/Ammonite/releases/download/1.0.3/2.12-1.0.3 | shasum -a 256
69ee90b067cb5546480c54887a3325f87e272464452fbeaaa0628379936bae3c  -
```