### PR TITLE
arcade-learning-environment 0.5.2 (new formula)

### DIFF
--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -1,0 +1,27 @@
+class ArcadeLearningEnvironment < Formula
+  desc "Platform for AI research"
+  homepage "https://github.com/mgbellemare/Arcade-Learning-Environment"
+  url "https://github.com/mgbellemare/Arcade-Learning-Environment/archive/v0.5.2.tar.gz"
+  sha256 "bc158b4fb8edc5034f8f8b4ca1a90d48590f516b33f9edec325fce8762418069"
+  head "https://github.com/mgbellemare/Arcade-Learning-Environment.git"
+
+  depends_on "cmake" => :build
+  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "sdl"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+    system "python", *Language::Python.setup_install_args(prefix)
+  end
+
+  test do
+    output = shell_output("#{bin}/ale 2>&1", 1).lines.last.chomp
+    assert_equal "No ROM File specified.", output
+    (testpath/"test.py").write <<~EOS
+      from ale_python_interface import ALEInterface;
+      ale = ALEInterface();
+    EOS
+    assert_match "ale.cfg", shell_output("python test.py 2>&1")
+  end
+end


### PR DESCRIPTION
Adds the Arcade Learning Environment (ALE). ALE is a framework that
allows researchers and hobbyists to develop AI agents for Atari 2600
games.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
