### PR TITLE
Fix test of maven@3.x formulas

### DIFF
--- a/Formula/maven@3.0.rb
+++ b/Formula/maven@3.0.rb
@@ -38,6 +38,11 @@ class MavenAT30 < Formula
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
       </project>
     EOS
     (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS

--- a/Formula/maven@3.1.rb
+++ b/Formula/maven@3.1.rb
@@ -43,6 +43,11 @@ class MavenAT31 < Formula
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
       </project>
     EOS
     (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS

--- a/Formula/maven@3.2.rb
+++ b/Formula/maven@3.2.rb
@@ -44,6 +44,11 @@ class MavenAT32 < Formula
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
       </project>
     EOS
     (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS

--- a/Formula/maven@3.3.rb
+++ b/Formula/maven@3.3.rb
@@ -37,6 +37,11 @@ class MavenAT33 < Formula
         <groupId>org.homebrew</groupId>
         <artifactId>maven-test</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
       </project>
     EOS
     (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS


### PR DESCRIPTION
Reporting fix of PR #19832, commit `ba20536`, maven is tested
using the `java` formula, which has been updated to JDK 9.
JDK 9 dropped support of source and target 1.5, however they
are the default for maven. This commit changes this.

Also it removes the warning about file encoding.

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

