### PR TITLE
Fgsl 1.2.0 (new formula)

### DIFF
--- a/Formula/fgsl.rb
+++ b/Formula/fgsl.rb
@@ -1,0 +1,30 @@
+class Fgsl < Formula
+  desc "Fortran bindings for the GNU Scientific Library"
+  homepage "https://www.lrz.de/services/software/mathematik/gsl/fortran/"
+  url "https://www.lrz.de/services/software/mathematik/gsl/fortran/download/fgsl-1.2.0.tar.gz"
+  sha256 "00fd467af2bb778e8d15ac8c27ddc7b9024bb8fa2f950a868d9d24b6086e5ca7"
+
+  depends_on "pkg-config" => :build
+  depends_on "gcc"
+  depends_on :fortran
+  depends_on "gsl"
+
+  def install
+    ENV.deparallelize
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "CC=gcc-7",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    ENV.fortran
+    system ENV.fc, "#{share}/examples/fgsl/fft.f90",
+                   "-L#{lib}", "-lfgsl", "-I#{include}/fgsl", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/fgsl@1.rb
+++ b/Formula/fgsl@1.rb
@@ -1,0 +1,28 @@
+class FgslAT1 < Formula
+  desc "Fortran bindings for the GNU Scientific Library v1.x"
+  homepage "https://www.lrz.de/services/software/mathematik/gsl/fortran/"
+  url "https://www.lrz.de/services/software/mathematik/gsl/fortran/download/fgsl-1.0.0.tar.gz"
+  sha256 "2841f6deb2ce05e153fc1d89fe5e46aba74c60a2595c857cef9ca771a0cf6290"
+
+  depends_on "pkg-config" => :build
+  depends_on "gcc"
+  depends_on "gsl@1"
+
+  def install
+    ENV.deparallelize
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    ENV.fortran
+    system ENV.fc, "#{share}/examples/fgsl/fft.f90",
+                   "-L#{lib}", "-lfgsl", "-I#{include}/fgsl", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
**This is a port from homebrew-science but I need it to add fgsl@1 (the older version) in a following request.**

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
