### PR TITLE
ocaml-findlib 1.7.3 (new formula)

### DIFF
--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -7,12 +7,11 @@ class OcamlFindlib < Formula
   depends_on "ocaml"
 
   def install
-    ENV.deparallelize
-
+    ENV.deparallelize # See https://gitlab.camlcity.org/gerd/lib-findlib/merge_requests/8
     system "./configure", "-bindir", bin,
                           "-mandir", man,
                           "-sitelib", lib/"ocaml",
-                          "-config", etc/"ocamlfind.conf",
+                          "-config", etc/"findlib.conf",
                           "-no-topfind"
     system "make", "all"
     system "make", "opt"
@@ -21,6 +20,6 @@ class OcamlFindlib < Formula
   end
 
   test do
-    system bin/"ocamlfind", "query", "findlib"
+    assert_equal "#{HOMEBREW_PREFIX}/lib/ocaml/findlib", shell_output("#{bin}/ocamlfind query findlib").strip
   end
 end

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -9,17 +9,18 @@ class OcamlFindlib < Formula
   def install
     ENV.deparallelize
 
-    system "./configure", "-bindir", "#{HOMEBREW_PREFIX}/bin",
-                          "-mandir", "#{HOMEBREW_PREFIX}/share/man",
-                          "-sitelib", "#{HOMEBREW_PREFIX}/lib/ocaml",
-                          "-config", "#{HOMEBREW_PREFIX}/etc/ocamlfind.conf"
+    system "./configure", "-bindir", bin,
+                          "-mandir", man,
+                          "-sitelib", lib/"ocaml",
+                          "-config", etc/"ocamlfind.conf",
+                          "-no-topfind"
     system "make", "all"
     system "make", "opt"
-    system "make", "install", "prefix=#{buildpath}/output/"
-    prefix.install Dir["output/#{HOMEBREW_PREFIX}/*"]
+    inreplace "findlib.conf", prefix, HOMEBREW_PREFIX
+    system "make", "install"
   end
 
   test do
-    system "#{bin}/ocamlfind", "query", "findlib"
+    system bin/"ocamlfind", "query", "findlib"
   end
 end

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -7,7 +7,9 @@ class OcamlFindlib < Formula
   depends_on "ocaml"
 
   def install
-    ENV.deparallelize # See https://gitlab.camlcity.org/gerd/lib-findlib/merge_requests/8
+    # See https://gitlab.camlcity.org/gerd/lib-findlib/merge_requests/8
+    ENV.deparallelize
+
     system "./configure", "-bindir", bin,
                           "-mandir", man,
                           "-sitelib", lib/"ocaml",
@@ -20,6 +22,7 @@ class OcamlFindlib < Formula
   end
 
   test do
-    assert_equal "#{HOMEBREW_PREFIX}/lib/ocaml/findlib", shell_output("#{bin}/ocamlfind query findlib").strip
+    output = shell_output("#{bin}/ocamlfind query findlib")
+    assert_equal "#{HOMEBREW_PREFIX}/lib/ocaml/findlib", output.chomp
   end
 end

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -1,0 +1,25 @@
+class OcamlFindlib < Formula
+  desc "OCaml library manager"
+  homepage "http://projects.camlcity.org/projects/findlib.html"
+  url "http://download.camlcity.org/download/findlib-1.7.3.tar.gz"
+  sha256 "d196608fa23c36c2aace27d5ef124a815132a5fcea668d41fa7d6c1ca246bd8b"
+
+  depends_on "ocaml"
+
+  def install
+    ENV.deparallelize
+
+    system "./configure", "-bindir", "#{HOMEBREW_PREFIX}/bin",
+                          "-mandir", "#{HOMEBREW_PREFIX}/share/man",
+                          "-sitelib", "#{HOMEBREW_PREFIX}/lib/ocaml",
+                          "-config", "#{HOMEBREW_PREFIX}/etc/ocamlfind.conf"
+    system "make", "all"
+    system "make", "opt"
+    system "make", "install", "prefix=#{buildpath}/output/"
+    prefix.install Dir["output/#{HOMEBREW_PREFIX}/*"]
+  end
+
+  test do
+    system "#{bin}/ocamlfind", "query", "findlib"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the `findlib` package that offers the `ocamlfind` tool which is used by many OCaml projects to find and manage OCaml libraries. (The instance that I currently care about is that the Z3 install script uses `ocamlfind` to install the OCaml bindings.)

You will notice that I am diverging from the rule that the formula should be named like the way the author markets their package. The author calls the package just "Findlib", but this seems too generic. All other packagers ([Debian, Ubuntu, Arch Linux, Cygwin, MSYS2](https://gitlab.camlcity.org/btj/lib-findlib/wikis/downstream-packages)) seem to have thought so, too.