### PR TITLE
zip 3.0 (new formula)

### DIFF
--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -1,0 +1,48 @@
+class Zip < Formula
+  desc "Compression and file packaging/archive utility"
+  homepage "http://www.info-zip.org/Zip.html"
+  url "https://downloads.sourceforge.net/project/infozip/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz"
+  version "3.0"
+  sha256 "f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369"
+
+  keg_only :provided_by_macos
+
+  # Upstream is unmaintained so we use the Debian patchset:
+  # https://packages.debian.org/sid/zip
+  patch do
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
+    sha256 "c5c0714a88592f9e02146bfe4a8d26cd9bd97e8d33b1efc8b37784997caa40ed"
+    apply %w[
+      patches/01-typo-it-is-transferring-not-transfering
+      patches/02-typo-it-is-privileges-not-priviliges
+      patches/03-manpages-in-section-1-not-in-section-1l
+      patches/04-do-not-set-unwanted-cflags
+      patches/05-typo-it-is-preceding-not-preceeding
+      patches/06-stack-markings-to-avoid-executable-stack
+      patches/07-fclose-in-file-not-fclose-x
+      patches/08-hardening-build-fix-1
+      patches/09-hardening-build-fix-2
+      patches/10-remove-build-date
+    ]
+  end
+
+  def install
+    system "make", "-f", "unix/Makefile",
+      "CC=#{ENV.cc}",
+      "generic",
+      "BINDIR=#{bin}",
+      "MANDIR=#{man1}",
+      "install"
+  end
+
+  test do
+    (testpath/"test1").write "Hello!"
+    (testpath/"test2").write "Bonjour!"
+    (testpath/"test3").write "Moien!"
+
+    system "#{bin}/zip", "test.zip", "test1", "test2", "test3"
+    assert_predicate testpath/"test.zip", :exist?
+    assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The formula is mostly inspired from the `unzip` formula.

This is probably completely unnecessary on OS X, but needed for Linuxbrew, so I would prefer it to be added to homebrew first.