### PR TITLE
creating a new Prime Server formula

### DIFF
--- a/Formula/prime_server.rb
+++ b/Formula/prime_server.rb
@@ -1,0 +1,26 @@
+class PrimeServer < Formula
+  desc "non-blocking (web)server API for distributed computing and SOA based on zeromq"
+  homepage "https://github.com/kevinkreiser/prime_server"
+  head "https://github.com/kevinkreiser/prime_server.git", tag: "0.6.3"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "gcc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "curl"
+  depends_on "czmq"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    pipe_output("prime_serverd").include?("Usage: prime_serverd num_requests|server_listen_endpoint concurrency")
+  end
+end


### PR DESCRIPTION
see https://github.com/kevinkreiser/prime_server

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

On the last item, I get the follow error:

```bash
Error: Error running `rubocop --format json --force-exclusion --parallel --except NewFormulaAudit --config /usr/local/Homebrew/Library/.rubocop_audit.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/prime_server.rb`
```

I would appreciate any help others can give debugging that error.

-----
