### PR TITLE
icu4c: apply patch for CVE-2017-14952

### DIFF
--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -1,12 +1,24 @@
 class Icu4c < Formula
   desc "C/C++ and Java libraries for Unicode and globalization"
   homepage "http://site.icu-project.org/"
-  url "https://ssl.icu-project.org/files/icu4c/59.1/icu4c-59_1-src.tgz"
-  mirror "https://fossies.org/linux/misc/icu4c-59_1-src.tgz"
-  mirror "https://downloads.sourceforge.net/project/icu/ICU4C/59.1/icu4c-59_1-src.tgz"
-  version "59.1"
-  sha256 "7132fdaf9379429d004005217f10e00b7d2319d0fea22bdfddef8991c45b75fe"
+  revision 1
   head "https://ssl.icu-project.org/repos/icu/trunk/icu4c/", :using => :svn
+
+  stable do
+    url "https://ssl.icu-project.org/files/icu4c/59.1/icu4c-59_1-src.tgz"
+    mirror "https://fossies.org/linux/misc/icu4c-59_1-src.tgz"
+    mirror "https://downloads.sourceforge.net/project/icu/ICU4C/59.1/icu4c-59_1-src.tgz"
+    version "59.1"
+    sha256 "7132fdaf9379429d004005217f10e00b7d2319d0fea22bdfddef8991c45b75fe"
+
+    # Fix CVE-2017-14952
+    # Upstream commit from 9 Aug 2017 "Removed redundant UVector entry clean up
+    # function call."
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/fb441ea/icu4c/CVE-2017-14952.diff"
+      sha256 "1da1eec19cfe4907eb4766192ddbca689506ce44cfeb35c349af9609ae7f7203"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream commit from 9 Aug 2017 "Removed redundant UVector entry clean up function call"
http://bugs.icu-project.org/trac/ticket/13302
http://bugs.icu-project.org/trac/changeset/40324/trunk/icu4c/source/i18n/zonemeta.cpp