### PR TITLE
youtube-dl: fix optional extractor dependency

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -11,6 +11,8 @@ class YoutubeDl < Formula
 
   bottle :unneeded
 
+  depends_on "phantomjs" => :optional
+
   def install
     system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Some extractors (currently openload’s)  use PhantomJS to scrape the page for the information required. Marking the dependency as optional as all other extractors can be used without it being installed.

The openload extractor will error out with `ERROR: PhantomJS executable not found in PATH, download it from http://phantomjs.org`.

I am not 100% sure on `:optional` over e.g. `:recommended` so I hope somebody will enlighten me.