### PR TITLE
shadowsocks-libev: enable UDP relay by default

### DIFF
--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -43,7 +43,7 @@ class ShadowsocksLibev < Formula
     system "make", "install"
   end
 
-  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json -u"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
@@ -57,6 +57,7 @@ class ShadowsocksLibev < Formula
           <string>#{opt_bin}/ss-local</string>
           <string>-c</string>
           <string>#{etc}/shadowsocks-libev.json</string>
+          <string>-u</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
shadowsocks-libev: open UDP relay by default