### PR TITLE
hatop: add formula

### DIFF
--- a/Formula/hatop.rb
+++ b/Formula/hatop.rb
@@ -1,0 +1,15 @@
+class Hatop < Formula
+  desc "Interactive ncurses client for HAProxy"
+  homepage "http://feurix.org/projects/hatop/"
+  url "https://github.com/feurix/hatop/archive/v0.7.7.tar.gz"
+  sha256 "497a28e484940bf2f6dd5919041d5d03025325a59e8f95f376f573db616ca35d"
+
+  def install
+    man1.install "man/hatop.1"
+    bin.install "bin/hatop"
+  end
+
+  test do
+    system bin/"hatop", "--version"
+  end
+end


### PR DESCRIPTION
- [✓] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✓] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The only dependency is Python 2.x, which I think comes standard with macOS? Not sure if there's anything else I need here. Tested that it all works fine locally. Thanks.