### PR TITLE
thefuck: fix fixed post install manual

### DIFF
--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -53,7 +53,7 @@ class Thefuck < Formula
   def caveats; <<~EOS
     Add the following to your .bash_profile, .bashrc or .zshrc:
 
-      eval "$(thefuck --alias)"
+      eval $(thefuck --alias)
 
     For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to official documentation (https://github.com/nvbn/thefuck). With quotes I got some weird behavior:
```
>fuck
usage: thefuck [-v] [-a [ALIAS]] [-l SHELL_LOGGER]
               [--enable-experimental-instant-mode] [-h] [-y | -r] [-d]
               [command [command ...]]
```

Fixing also this https://github.com/nvbn/thefuck/issues/714