### PR TITLE
imagesnap: don't unconditionally call Xcode version

### DIFF
--- a/Formula/imagesnap.rb
+++ b/Formula/imagesnap.rb
@@ -18,7 +18,7 @@ class Imagesnap < Formula
   depends_on :xcode => :build
 
   # Upstream PR from 19 Dec 2015 "Replace QTKit"
-  if MacOS::Xcode.version >= "8.0"
+  if MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
     patch do
       url "https://github.com/rharder/imagesnap/pull/13.patch?full_index=1"
       sha256 "3bef0164843bc229cacdfe04e819515d30b78ee402d76fd2197a8b5d9e5159e9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Xcode dependency doesn't nullify brew's ability to "read" this formula and throw errors about Xcode version returning nil which cannot be compared to `>=`, as least AFAIK.

Possibly another part of https://github.com/Homebrew/homebrew-core/issues/20052.