### PR TITLE
nzbget: switch HEAD-mode to use develop branch

### DIFF
--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -3,7 +3,7 @@ class Nzbget < Formula
   homepage "https://nzbget.net/"
   url "https://github.com/nzbget/nzbget/releases/download/v19.1/nzbget-19.1-src.tar.gz"
   sha256 "06df42356ac2d63bbc9f7861abe9c3216df56fa06802e09e8a50b05f4ad95ce6"
-  head "https://github.com/nzbget/nzbget.git"
+  head "https://github.com/nzbget/nzbget.git", :branch => "develop"
 
   bottle do
     sha256 "0f508d759d085ea42af708598eba3d2f589614f6025f8ca160b93c6170d5576b" => :high_sierra


### PR DESCRIPTION
Development of nzbget has moved to develop branch.
- the most recent commit to master is July 8th
- develop has been committed to 2 days ago

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
