### PR TITLE
highlight: update boost library as build dependency

### DIFF
--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -3,6 +3,7 @@ class Highlight < Formula
   homepage "http://www.andre-simon.de/doku/highlight/en/highlight.html"
   url "http://www.andre-simon.de/zip/highlight-3.40.tar.bz2"
   sha256 "3e55fadd3f2a85f25ea995fd0e57e94e2a59fe2e3ccefe6bd896b50acadc38e3"
+  revision 1
   head "https://github.com/andre-simon/highlight.git"
 
   bottle do

--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -12,7 +12,7 @@ class Highlight < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "boost"
+  depends_on "boost" => :build
   depends_on "lua"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
As stated on this [page](http://www.andre-simon.de/doku/highlight/en/install.php), under section "Dependencies", `boost` library header files are required during build time.