### PR TITLE
pure-ftpd: fix launchd plist

### DIFF
--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -40,16 +40,6 @@ class PureFtpd < Formula
     system "make", "install"
   end
 
-  def caveats
-    <<~EOS
-      pure-ftpd requires to be run as root; to start now and restart during system startup:
-        sudo brew services start pure-ftpd
-      pure-ftpd logins must be created and the pure-ftpd user index rebuilt:
-        pure-pw useradd [ftp-username] -u [macos-account-name] -d [ftp-home-directory]
-        pure-pw mkdb
-      EOS
-  end
-
   plist_options :manual => "pure-ftpd"
 
   def plist; <<~EOS

--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -40,6 +40,16 @@ class PureFtpd < Formula
     system "make", "install"
   end
 
+  def caveats
+    <<~EOS
+      pure-ftpd requires to be run as root; to start now and restart during system startup:
+        sudo brew services start pure-ftpd
+      pure-ftpd logins must be created and the pure-ftpd user index rebuilt:
+        pure-pw useradd [ftp-username] -u [macos-account-name] -d [ftp-home-directory]
+        pure-pw mkdb
+      EOS
+  end
+
   plist_options :manual => "pure-ftpd"
 
   def plist; <<~EOS
@@ -54,7 +64,10 @@ class PureFtpd < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_sbin}/pure-ftpd</string>
-          <string>-A -j -z</string>
+          <string>--chrooteveryone</string>
+          <string>--createhomedir</string>
+          <string>--allowdotfiles</string>
+          <string>--login=puredb:#{etc}/pureftpd.pdb</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
Correct or document several install issues with pure-ftpd

 - plist requires each argument be added as an individual element [1]
 - add default users database location to plist configration [2]
 - document that service must be started as root [3]
 - replace short `-` arguments in plist with equivalent long `--` arguments for better readability [4]

[1] https://apple.stackexchange.com/questions/284209/having-trouble-configuring-homebrew-to-run-pure-ftpd-as-a-service
[2] https://github.com/jedisct1/pure-ftpd/issues/39
[3] https://github.com/jedisct1/pure-ftpd/issues/38
[4] https://download.pureftpd.org/pub/pure-ftpd/doc/README

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?