### PR TITLE
rust: cargo 0.22.0

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -8,8 +8,8 @@ class Rust < Formula
 
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
-          :tag => "0.21.1",
-          :revision => "6084a2ba03aaa73794e6b86199e463ea6df290fe"
+          :tag => "0.22.0",
+          :revision => "3423351a5d75ac7377bb15987842aadcfd068ad2"
     end
 
     resource "racer" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

rustup already installs cargo 0.22.0 for stable rust.