### PR TITLE
Manually update grakn to next release 0.17.1

### DIFF
--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -11,7 +11,7 @@ class Grakn < Formula
   def install
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/grakn", "#{libexec}/graql"]
-    bin.env_script_all_files(libexec/"services/cassandra", :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
+    bin.env_script_all_files(libexec/"", :SERVICE_HOME => ENV["SERVICE_HOME"])
   end
 
   test do

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -1,8 +1,8 @@
 class Grakn < Formula
   desc "The Database for AI"
   homepage "https://grakn.ai"
-  url "https://github.com/graknlabs/grakn/releases/download/v0.16.0/grakn-dist-0.16.0.tar.gz"
-  sha256 "1c7194f09cbf31949323b79b2fb8a5683381af5ecf37886fd45deb71585261ed"
+  url "https://github.com/graknlabs/grakn/releases/download/v0.17.0/grakn-dist-0.17.0.tar.gz"
+  sha256 "27d41b82ea6144af149ed09ab4631501bb2beaea7b94e28f4b1fc4cca0443434"
 
   bottle :unneeded
 
@@ -10,11 +10,11 @@ class Grakn < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
-    bin.env_script_all_files(libexec/"bin", :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
+    bin.install Dir["#{libexec}/*"]
+    bin.env_script_all_files(libexec/, :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
   end
 
   test do
-    assert_match /stopped/i, shell_output("#{bin}/grakn.sh status")
+    assert_match /stopped/i, shell_output("grakn server status")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -10,11 +10,11 @@ class Grakn < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/*"]
-    bin.env_script_all_files(libexec, :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
+    bin.install Dir["#{libexec}/grakn", "#{libexec}/graql"]
+    bin.env_script_all_files(libexec/"services/cassandra", :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
   end
 
   test do
-    assert_match /NOT RUNNING/i, shell_output("grakn server status")
+    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -1,8 +1,8 @@
 class Grakn < Formula
   desc "The Database for AI"
   homepage "https://grakn.ai"
-  url "https://github.com/graknlabs/grakn/releases/download/v0.17.0/grakn-dist-0.17.0.tar.gz"
-  sha256 "27d41b82ea6144af149ed09ab4631501bb2beaea7b94e28f4b1fc4cca0443434"
+  url "https://github.com/graknlabs/grakn/releases/download/v0.17.1/grakn-dist-0.17.1.tar.gz"
+  sha256 "a4d190d95515b01ce736056e2d738d67c14298465ba7fb92df5295612bb91475"
 
   bottle :unneeded
 
@@ -15,7 +15,7 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /Starting Grakn.*SUCCESS/i, shell_output("#{bin}/grakn server start")
-    assert_match /Stopping Grakn.*SUCCESS/i, shell_output("#{bin}/grakn server stop")
+    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server start")
+    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server stop")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -10,7 +10,8 @@ class Grakn < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.write_exec_script libexec/"grakn", libexec/"graql"
+    bin.install libexec/"grakn", libexec/"graql"
+    bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
   end
 
   test do

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -15,7 +15,6 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server start")
-    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server stop")
+    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -15,7 +15,6 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server start")
-    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server stop")
+    assert_match /RUNNING/i, shell_output("#{bin}/grakn server start")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -15,6 +15,7 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
+    assert_match /Starting Grakn.*SUCCESS/i, shell_output("#{bin}/grakn server start")
+    assert_match /Stopping Grakn.*SUCCESS/i, shell_output("#{bin}/grakn server stop")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -6,7 +6,7 @@ class Grakn < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def install
     libexec.install Dir["*"]
@@ -14,6 +14,7 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
+    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server start")
+    assert_match /SUCCESS/i, shell_output("#{bin}/grakn server stop")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -10,8 +10,7 @@ class Grakn < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/grakn", "#{libexec}/graql"]
-    bin.env_script_all_files(libexec/"", :SERVICE_HOME => ENV["SERVICE_HOME"])
+    bin.write_exec_script libexec/"grakn", libexec/"graql"
   end
 
   test do

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -15,6 +15,6 @@ class Grakn < Formula
   end
 
   test do
-    assert_match /RUNNING/i, shell_output("#{bin}/grakn server start")
+    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
   end
 end

--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -11,10 +11,10 @@ class Grakn < Formula
   def install
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/*"]
-    bin.env_script_all_files(libexec/, :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
+    bin.env_script_all_files(libexec, :CASSANDRA_HOME => ENV["CASSANDRA_HOME"])
   end
 
   test do
-    assert_match /stopped/i, shell_output("grakn server status")
+    assert_match /NOT RUNNING/i, shell_output("grakn server status")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Manually update Grakn to next release 0.17.0. A manual update is required because a startup script change led to the automatic update: https://github.com/Homebrew/homebrew-core/pull/20198 failing