### PR TITLE
wine: match bundled mono with the version expected by stable

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -1,11 +1,13 @@
-# NOTE: When updating Wine, please check Wine-Gecko and Wine-Mono for updates
-# too:
+# NOTE: When updating Wine, please make sure to match Wine-Gecko and Wine-Mono
+# versions:
 #  - https://wiki.winehq.org/Gecko
 #  - https://wiki.winehq.org/Mono
+# with `GECKO_VERSION` and `MONO_VERSION`, as in:
+#    https://source.winehq.org/git/wine.git/blob/refs/tags/wine-2.0.3:/dlls/appwiz.cpl/addons.c
 class Wine < Formula
   desc "Run Windows applications without a copy of Microsoft Windows"
   homepage "https://www.winehq.org/"
-  head "https://source.winehq.org/git/wine.git"
+  revision 1
 
   stable do
     url "https://dl.winehq.org/wine/source/2.0/wine-2.0.3.tar.xz"
@@ -25,6 +27,11 @@ class Wine < Formula
       url "https://bugs.winehq.org/attachment.cgi?id=55968"
       sha256 "1b5086798ce6dc959b3cbb8f343ee236ae06c7910e4bbae7d9fde3f162f03a79"
     end
+
+    resource "mono" do
+      url "https://dl.winehq.org/wine/wine-mono/4.6.4/wine-mono-4.6.4.msi", :using => :nounzip
+      sha256 "91b7d58177b9a9355edf007dab94535471aebdddae12734ceb4a219d2ecc4152"
+    end
   end
 
   bottle do
@@ -43,6 +50,20 @@ class Wine < Formula
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/74c2566/wine/2.14.patch"
       sha256 "6907471d18996ada60cc0cbc8462a1698e90720c0882846dfbfb163e5d3899b8"
+    end
+
+    resource "mono" do
+      url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi", :using => :nounzip
+      sha256 "2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa"
+    end
+  end
+
+  head do
+    url "https://source.winehq.org/git/wine.git"
+
+    resource "mono" do
+      url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi", :using => :nounzip
+      sha256 "2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa"
     end
   end
 
@@ -68,15 +89,10 @@ class Wine < Formula
     sha256 "c565ea25e50ea953937d4ab01299e4306da4a556946327d253ea9b28357e4a7d"
   end
 
-  resource "mono" do
-    url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi", :using => :nounzip
-    sha256 "2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa"
-  end
-
   resource "openssl" do
-    url "https://www.openssl.org/source/openssl-1.0.2l.tar.gz"
-    mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2l.tar.gz"
-    sha256 "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c"
+    url "https://www.openssl.org/source/openssl-1.0.2m.tar.gz"
+    mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2m.tar.gz"
+    sha256 "8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f"
   end
 
   resource "libtool" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Expected versions of Mono and Gecko are hardwired into the Wine source code:
  https://source.winehq.org/git/wine.git/blob/HEAD:/dlls/appwiz.cpl/addons.c

If these exact versions are not found by the initialization process (e.g. wineboot), the process will fail. This failure takes several minutes on headless systems (e.g. Travis CI):
  https://travis-ci.org/vszakats/harbour-core/builds/296594856#L2117-L2122

Matching addon versions for current wine 2.0.3 can be looked up here:
  https://source.winehq.org/git/wine.git/blob/refs/tags/wine-2.0.3:/dlls/appwiz.cpl/addons.c

Regression from: 15952a9c93f596a13745b244e3984b5801e1f3f3

* Also extend comment to make sure that the hardwired addon versions are
  matched with the bundled (Mono and Gecko) resources.
* Also bump OpenSSL to its latest revision
