### PR TITLE
Opportunistically remove awscli python dep

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -18,7 +18,7 @@ class Awscli < Formula
 
   # Some AWS APIs require TLS1.2, which system Python doesn't have before High
   # Sierra
-  depends_on :python3
+  depends_on :python3 if MacOS.version < :high_sierra
 
   def install
     venv = virtualenv_create(libexec, "python3")


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
Tried to, haven't gotten all the way through yet.

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
can't yet
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
can't yet
-----

I see that recently awscli got updated to require python3 b/c system python on < High Sierra do not provide the required TLS 1.2. That's cool, but it'd be super awesome if it would be possible to limit the python3 dep to systems < High sierra. Obviously that will require more changes than what are here so far, since this just blows up, but I'm not sure what's needed and hope someone can provide some detail, or a link to some docs on the python integration in homebrew.

```
brew reinstall Developer/Ruby/homebrew-core/Formula/awscli.rb --build-from-source 
==> Reinstalling awscli 
==> Downloading https://github.com/aws/aws-cli/archive/1.11.180.tar.gz
Already downloaded: /Users/camdennarzt/Library/Caches/Homebrew/awscli-1.11.180.tar.gz
==> Downloading https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz
Already downloaded: /Users/camdennarzt/Library/Caches/Homebrew/awscli--homebrew-virtualenv-15.1.0.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/tmp/awscli--homebrew-virtualenv-20171103-40857-k0tnvi/target --single-version-externally-managed --record=installed.txt
Last 15 lines from /Users/camdennarzt/Library/Logs/Homebrew/awscli/01.python3:
2017-11-03 11:09:58 -0600

python3
-c
import setuptools, tokenize
__file__ = 'setup.py'
exec(compile(getattr(tokenize, 'open', open)(__file__).read()
  .replace('\r\n', '\n'), __file__, 'exec'))
--no-user-cfg
install
--prefix=/tmp/awscli--homebrew-virtualenv-20171103-40857-k0tnvi/target
--single-version-externally-managed
--record=installed.txt


Do not report this issue to Homebrew/brew or Homebrew/core!
```

I really don't know what the policy is for deps like this, as they've been added and removed many times over for various formulae. Hopefully it's currently a drop em day!