### PR TITLE
opam: pass -unsafe-string to ocamlc.opt and ocamlopt.opt

### DIFF
--- a/Formula/opam.rb
+++ b/Formula/opam.rb
@@ -70,6 +70,15 @@ class Opam < Formula
   def install
     ENV.deparallelize
 
+    ["ocamlc.opt", "ocamlopt.opt"].each do |cmd|
+      (buildpath/"brew_shim/#{cmd}").write <<~EOS
+        #!/bin/sh
+        exec #{Formula["ocaml"].opt_bin}/#{cmd} -unsafe-string "$@"
+      EOS
+      chmod 0755, "brew_shim/#{cmd}"
+    end
+    ENV.prepend_path "PATH", buildpath/"brew_shim"
+
     if build.without? "ocaml"
       system "make", "cold", "CONFIGURE_ARGS=--prefix #{prefix} --mandir #{man}"
       ENV.prepend_path "PATH", "#{buildpath}/bootstrap/ocaml/bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

so that the build doesn't fail with OCaml 4.06.0