### PR TITLE
ocamlsdl: pass -unsafe-string in OMLFLAGS and MLFLAGS

### DIFF
--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -23,7 +23,8 @@ class Ocamlsdl < Formula
   def install
     system "./configure", "--prefix=#{prefix}",
                           "OCAMLLIB=#{lib}/ocaml"
-    system "make"
+    system "make", "OMLFLAGS = -unsafe -unsafe-string",
+                   "MLFLAGS=-g -unsafe-string"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

so that the build doesn't fail with OCaml 4.06.0