### PR TITLE
ocaml-num 1.1 (new formula)

### DIFF
--- a/Formula/ocaml-num.rb
+++ b/Formula/ocaml-num.rb
@@ -1,0 +1,37 @@
+class OcamlNum < Formula
+  desc "OCaml legacy Num library for arbitrary-precision arithmetic"
+  homepage "https://github.com/ocaml/num"
+  url "https://github.com/ocaml/num/archive/v1.1.tar.gz"
+  sha256 "04ac85f6465b9b2bf99e814ddc798a25bcadb3cca2667b74c1af02b6356893f6"
+
+  depends_on "ocaml"
+
+  def install
+    (lib/"ocaml").mkpath
+    cp Formula["ocaml"].opt_lib/"ocaml/Makefile.config", lib/"ocaml"
+
+    # install in #{lib}/ocaml not #{HOMEBREW_PREFIX}/lib/ocaml
+    inreplace lib/"ocaml/Makefile.config", /^PREFIX=#{HOMEBREW_PREFIX}$/,
+                                           "PREFIX=#{prefix}"
+
+    system "make"
+
+    (lib/"ocaml/stublibs").mkpath # `make install` assumes this directory exists
+
+    # Set OCAMLFIND to echo to avoid an unnecessary dependency
+    system "make", "install", "OCAMLFIND=echo", "STDLIBDIR=#{lib}/ocaml"
+
+    pkgshare.install "test"
+
+    rm lib/"ocaml/Makefile.config" # avoid conflict with ocaml
+  end
+
+  test do
+    cp_r pkgshare/"test/.", "."
+    system Formula["ocaml"].opt_bin/"ocamlopt", "-I", lib/"ocaml", "-I",
+           Formula["ocaml"].opt_lib/"ocaml", "-o", "test", "nums.cmxa",
+           "test.ml", "test_nats.ml", "test_big_ints.ml", "test_ratios.ml",
+           "test_nums.ml", "test_io.ml", "end_test.ml"
+    assert_match "1... 2... 3", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The legacy num library was removed from the standard OCaml distribution.

See https://github.com/ocaml/ocaml/pull/1300.

This requires OCaml 4.06.0 (#20239).