### PR TITLE
coq: depend on ocaml-num

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -15,6 +15,7 @@ class Coq < Formula
   homepage "https://coq.inria.fr/"
   url "https://github.com/coq/coq/archive/V8.7.0.tar.gz"
   sha256 "f376207ed051b3fd27c519f44b25eb25f8dddbce22715f68c3cedfd2e4b39297"
+  revision 1
   head "https://github.com/coq/coq.git"
 
   bottle do
@@ -27,6 +28,7 @@ class Coq < Formula
   depends_on Camlp5TransitionalModeRequirement
   depends_on "camlp5"
   depends_on "ocaml"
+  depends_on "ocaml-num"
 
   def install
     ENV["OPAMYES"] = "1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

needed due to OCaml 4.06.0