### PR TITLE
mldonkey: depend on ocaml-num at build time

### DIFF
--- a/Formula/mldonkey.rb
+++ b/Formula/mldonkey.rb
@@ -16,11 +16,14 @@ class Mldonkey < Formula
 
   depends_on "camlp4" => :build
   depends_on "ocaml" => :build
+  depends_on "ocaml-num" => :build
   depends_on "pkg-config" => :build
   depends_on "gd"
   depends_on "libpng"
 
   def install
+    ENV["OCAMLPARAM"] = "safe-string=0,_" # OCaml 4.06.0 compat
+
     ENV.deparallelize
 
     # Fix compiler selection


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

and set safe-string=0 for OCaml 4.06.0 compat