### PR TITLE
pinboard-notes-backup 1.0.3 (new formula)

### DIFF
--- a/Formula/pinboard-notes-backup.rb
+++ b/Formula/pinboard-notes-backup.rb
@@ -3,28 +3,23 @@ require "language/haskell"
 class PinboardNotesBackup < Formula
   include Language::Haskell::Cabal
 
-  desc "Efficiently back up the notes you’ve saved to Pinboard"
+  desc "Efficiently back up the notes you've saved to Pinboard"
   homepage "https://github.com/bdesham/pinboard-notes-backup"
   url "https://github.com/bdesham/pinboard-notes-backup/archive/v1.0.3.tar.gz"
   sha256 "bc3ab1a8a3d92fcbda86dd8b4756b035be89e1e5b50bdd61f998b67c89243ae3"
   head "https://github.com/bdesham/pinboard-notes-backup.git"
 
-  depends_on "ghc@8.0" => :build
   depends_on "cabal-install" => :build
+  depends_on "ghc" => :build
 
   def install
     install_cabal_package
   end
 
-  # A real test would require hard-coding someone's Pinboard API key here,
-  # which would be a bad idea. Instead, as a simple functional test, we call
-  # the executable without the required --token parameter and make sure that
-  # the exit code is 1.
+  # A real test would require hard-coding someone's Pinboard API key here
   test do
-    require "open3"
-    Open3.popen3("#{bin}/pnbackup", "Notes.sqlite") do |stdin, _, _, wait_thr|
-      stdin.close
-      assert_equal wait_thr.value.exitstatus, 1
-    end
+    assert_match "TOKEN", shell_output("#{bin}/pnbackup Notes.sqlite 2>&1", 1)
+    output = shell_output("#{bin}/pnbackup -t token Notes.sqlite 2>&1", 1)
+    assert_match "statusCode = 500", output
   end
 end

--- a/Formula/pinboard-notes-backup.rb
+++ b/Formula/pinboard-notes-backup.rb
@@ -1,0 +1,30 @@
+require "language/haskell"
+
+class PinboardNotesBackup < Formula
+  include Language::Haskell::Cabal
+
+  desc "Efficiently back up the notes you’ve saved to Pinboard"
+  homepage "https://github.com/bdesham/pinboard-notes-backup"
+  url "https://github.com/bdesham/pinboard-notes-backup/archive/v1.0.3.tar.gz"
+  sha256 "bc3ab1a8a3d92fcbda86dd8b4756b035be89e1e5b50bdd61f998b67c89243ae3"
+  head "https://github.com/bdesham/pinboard-notes-backup.git"
+
+  depends_on "ghc@8.0" => :build
+  depends_on "cabal-install" => :build
+
+  def install
+    install_cabal_package
+  end
+
+  # A real test would require hard-coding someone's Pinboard API key here,
+  # which would be a bad idea. Instead, as a simple functional test, we call
+  # the executable without the required --token parameter and make sure that
+  # the exit code is 1.
+  test do
+    require "open3"
+    Open3.popen3("#{bin}/pnbackup", "Notes.sqlite") do |stdin, _, _, wait_thr|
+      stdin.close
+      assert_equal wait_thr.value.exitstatus, 1
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

----

This PR adds a formula for [pinboard-notes-backup](https://github.com/bdesham/pinboard-notes-backup), a command-line utility to back up the notes you’ve saved to [Pinboard](https://pinboard.in).