### PR TITLE
stunnel 5.43

### DIFF
--- a/Formula/stunnel.rb
+++ b/Formula/stunnel.rb
@@ -1,9 +1,9 @@
 class Stunnel < Formula
   desc "SSL tunneling program"
   homepage "https://www.stunnel.org/"
-  url "https://www.stunnel.org/downloads/stunnel-5.42.tar.gz"
-  mirror "https://www.usenix.org.uk/mirrors/stunnel/stunnel-5.42.tar.gz"
-  sha256 "1b6a7aea5ca223990bc8bd621fb0846baa4278e1b3e00ff6eee279cb8e540fab"
+  url "https://www.stunnel.org/downloads/stunnel-5.43.tar.gz"
+  mirror "https://www.usenix.org.uk/mirrors/stunnel/stunnel-5.43.tar.gz"
+  sha256 "05915babf705a0494886a72a7367913d403d07fc908ebb7b380d639e2d8bcee2"
 
   bottle do
     sha256 "a2e746d80d33e11e27347688605c2d955c660b28481b068d0f318b321ad7e8fc" => :high_sierra
@@ -12,8 +12,6 @@ class Stunnel < Formula
     sha256 "2311128cf8eefd1dba064ed592c9e06e1d65502a69ad04b40e6897827b71c3ff" => :yosemite
   end
 
-  # Please revision me whenever OpenSSL is updated
-  # "Update OpenSSL shared libraries or rebuild stunnel"
   depends_on "openssl"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Version 5.43, 2017.11.05, urgency: LOW
* New features
  - OpenSSL DLLs updated to version 1.0.2m.
  - Android build updated to OpenSSL 1.1.0g.
  - Allow for multiple "accept" ports per section.
  - Self-test framework (make check).
  - Added config load before OpenSSL init (thx to Dmitrii Pichulin).
  - OpenSSL 1.1.0 support for Travis CI.
  - OpenSSL 1.1.1-dev compilation fixes.
* Bugfixes
  - Fixed a memory fault on Solaris.
  - Fixed round-robin failover in the FORK threading model.
  - Fixed handling SSL_ERROR_ZERO_RETURN in SSL_shutdown().
  - Minor fixes of the logging subsystem.
```