### PR TITLE
gnupg 2.2.2

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,9 +1,9 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.2.1.tar.bz2"
-  sha256 "34d70cd65b9c95f3f2f90a9f5c1e0b6a0fe039a8d685e2d66d69c33d1cbf62fb"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.2.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnupg/gnupg-2.2.2.tar.bz2"
+  sha256 "bfb62c7412ceb3b9422c6c7134a34ff01a560f98eb981c2d96829c1517c08197"
 
   bottle do
     sha256 "20e4f082250dc48713d3b606f9d5917a12df70b7c31e172d7041a0680ecea8ff" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes in version 2.2.2
===================================

  * gpg: Avoid duplicate key imports by concurrently running gpg
    processes. [#3446]

  * gpg: Fix creating on-disk subkey with on-card primary key. [#3280]

  * gpg: Fix validity retrieval for multiple keyrings. [Debian#878812]

  * gpg: Fix --dry-run and import option show-only for secret keys.

  * gpg: Print "sec" or "sbb" for secret keys with import option
    import-show. [#3431]

  * gpg: Make import less verbose. [#3397]

  * gpg: Add alias "Key-Grip" for parameter "Keygrip" and new
    parameter "Subkey-Grip" to unattended key generation.  [#3478]

  * gpg: Improve "factory-reset" command for OpenPGP cards.  [#3286]

  * gpg: Ease switching Gnuk tokens into ECC mode by using the magic
    keysize value 25519.

  * gpgsm: Fix --with-colon listing in crt records for fields > 12.

  * gpgsm: Do not expect X.509 keyids to be unique.  [#1644]

  * agent: Fix stucked Pinentry when using --max-passphrase-days. [#3190]

  * agent: New option --s2k-count.  [#3276 (workaround)]

  * dirmngr: Do not follow https-to-http redirects. [#3436]

  * dirmngr: Reduce default LDAP timeout from 100 to 15 seconds. [#3487]

  * gpgconf: Ignore non-installed components for commands
    --apply-profile and --apply-defaults. [#3313]

  * Add configure option --enable-werror.  [#2423]
```