### PR TITLE
mailutils: avoid build failure when gnutls is built with guile

### DIFF
--- a/Formula/mailutils.rb
+++ b/Formula/mailutils.rb
@@ -19,6 +19,7 @@ class Mailutils < Formula
   def install
     system "./configure", "--disable-mh",
                           "--prefix=#{prefix}",
+                          "--without-guile",
                           "--without-tokyocabinet"
     system "make", "PYTHON_LIBS=-undefined dynamic_lookup", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

mailutils is incompatible with guile 2.2.x, so block it from attempting
to enable guile when its gnutls dependency happens to have been built
with guile support.

Fixes #20282.

CC @RandomDSdevel