### PR TITLE
gdal: fix database dependencies to be requirements

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -47,8 +47,8 @@ class Gdal < Formula
   depends_on "freexl"
   depends_on "libspatialite"
 
-  depends_on "postgresql" => :optional
-  depends_on "mysql" => :optional
+  depends_on :postgresql => :optional
+  depends_on :mysql => :optional
   depends_on "armadillo" => :optional
 
   if build.with? "libkml"


### PR DESCRIPTION
Change the gdal formula to use the mysql and postgresql requirements
rather than the specific formulas.

This change enables gdal to build against keg-only, old versions that
users may have linked, or against externally managed dependencies.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Does not pass `brew audit --strict gdal`, for reasons of a redirect in the numpy download, but I do not want to fix something unrelated in this PR.