### PR TITLE
libp11 0.4.7

### DIFF
--- a/Formula/libp11.rb
+++ b/Formula/libp11.rb
@@ -1,8 +1,8 @@
 class Libp11 < Formula
   desc "PKCS#11 wrapper library in C"
   homepage "https://github.com/OpenSC/libp11/wiki"
-  url "https://downloads.sourceforge.net/project/opensc/libp11/libp11-0.2.8.tar.gz"
-  sha256 "a4121015503ade98074b5e2a2517fc8a139f8b28aed10021db2bb77283f40691"
+  url "https://github.com/OpenSC/libp11/releases/download/libp11-0.4.7/libp11-0.4.7.tar.gz"
+  sha256 "32e486d4279e09174b63eb263bc840016ebfa80b0b154390c0539b211aec0452"
   revision 1
 
   bottle do


### PR DESCRIPTION
update libp11 to 0.4.7.tar, this will fix pkcs#11 problems opensc and openconnect

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
