### PR TITLE
libtorrent-rasterbar: remove unsupported options

### DIFF
--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -21,7 +21,6 @@ class LibtorrentRasterbar < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on :python => :optional
-  depends_on "geoip" => :optional
   depends_on "boost"
   depends_on "boost-python" if build.with? "python"
 
@@ -38,11 +37,6 @@ class LibtorrentRasterbar < Formula
     if build.with? "python"
       args << "--enable-python-binding"
       args << "--with-boost-python=boost_python-mt"
-    end
-
-    if build.with? "geoip"
-      args << "--enable-geoip"
-      args << "--with-libgeoip"
     end
 
     if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
GeoIP support has been removed from the library. [Details](
https://github.com/arvidn/libtorrent/blob/f040d6d86060a0d26ca58e55a9b83b75981aa98c/include/libtorrent/session_handle.hpp#L519-L522)