### PR TITLE
gradle 4.3.1

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -1,8 +1,8 @@
 class Gradle < Formula
   desc "Build system based on the Groovy language"
   homepage "https://www.gradle.org/"
-  url "https://services.gradle.org/distributions/gradle-4.3-all.zip"
-  sha256 "b3afcc2d5aaf4d23eeab2409d64c54046147322d05acc7fb5a63f84d8a2b8bd7"
+  url "https://services.gradle.org/distributions/gradle-4.3.1-all.zip"
+  sha256 "c5b67330a8a211539d713852c56a6a80fdea365d8902df92d1759d913d18fa2d"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Output:
```
[jvasallo@jvasallo-mbp2016 Formula]$ brew bump-formula-pr --strict gradle --url=https://services.gradle.org/distributions/gradle-4.3.1-all.zip --sha256=c5b67330a8a211539d713852c56a6a80fdea365d8902df92d1759d913d18fa2d
Updated Homebrew from 5d9215b2 to 934480ca.
No changes to formulae.
==> replace "https://services.gradle.org/distributions/gradle-4.3-all.zip" with "https://services.gradle.org/distributions/gradle-4.3.1-all.zip"
==> replace "b3afcc2d5aaf4d23eeab2409d64c54046147322d05acc7fb5a63f84d8a2b8bd7" with "c5b67330a8a211539d713852c56a6a80fdea365d8902df92d1759d913d18fa2d"
==> Installing or updating 'rubocop' gem
Fetching: parallel-1.12.0.gem (100%)
Successfully installed parallel-1.12.0
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.4.0.0.gem (100%)
Successfully installed parser-2.4.0.0
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions.  This could take a while...
Successfully installed rainbow-2.2.2
Fetching: ruby-progressbar-1.9.0.gem (100%)
Successfully installed ruby-progressbar-1.9.0
Fetching: unicode-display_width-1.3.0.gem (100%)
Successfully installed unicode-display_width-1.3.0
Fetching: rubocop-0.51.0.gem (100%)
Successfully installed rubocop-0.51.0
8 gems installed
==> Downloading https://homebrew.bintray.com/bottles/hub-2.2.9.high_sierra.bottle.tar.gz
######################################################################## 100.0%
==> Pouring hub-2.2.9.high_sierra.bottle.tar.gz
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/hub/2.2.9: 10 files, 9.4MB
M	Formula/gradle.rb
Switched to a new branch 'gradle-4.3.1'
[gradle-4.3.1 dd904c2ec1] gradle 4.3.1
 1 file changed, 2 insertions(+), 2 deletions(-)
[jvasallo@jvasallo-mbp2016 Formula]$ brew upgrade
==> Upgrading 1 outdated package, with result:
gradle 4.3.1
==> Upgrading gradle
==> Downloading https://services.gradle.org/distributions/gradle-4.3.1-all.zip
==> Downloading from https://downloads.gradle.org/distributions/gradle-4.3.1-all.zip
######################################################################## 100.0%
🍺  /usr/local/Cellar/gradle/4.3.1: 182 files, 77.6MB, built in 12 seconds
[jvasallo@jvasallo-mbp2016 Formula]$ gradle -v

------------------------------------------------------------
Gradle 4.3.1
------------------------------------------------------------

Build time:   2017-11-08 08:59:45 UTC
Revision:     e4f4804807ef7c2829da51877861ff06e07e006d

Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.8.0_121 (Oracle Corporation 25.121-b13)
OS:           Mac OS X 10.13 x86_64
```