### PR TITLE
kaitai-struct-compiler 0.7 (new formula)

### DIFF
--- a/Formula/kaitai-struct-compiler.rb
+++ b/Formula/kaitai-struct-compiler.rb
@@ -1,0 +1,33 @@
+class KaitaiStructCompiler < Formula
+  desc "Compiler for generating binary data parsers"
+  homepage "http://kaitai.io/"
+  url "https://bintray.com/artifact/download/kaitai-io/universal/0.7/kaitai-struct-compiler-0.7.zip"
+  sha256 "2fdd2646ea019bbf55be5bc27f24b037a7152514dbafbb7cfcdaf27a1d190045"
+
+  bottle :unneeded
+
+  depends_on :java => "1.8+"
+
+  def install
+    libexec.install Dir["lib/*"]
+
+    (bin/"kaitai-struct-compiler").write <<~EOS
+      #!/bin/bash
+      java -cp "#{libexec}/*" io.kaitai.struct.JavaMain "$@"
+    EOS
+  end
+
+  test do
+    (testpath/"Test.ksy").write <<~EOS
+      meta:
+        id: test
+        endian: le
+        file-extension: test
+      seq:
+        - id: header
+          type: u4
+    EOS
+    system bin/"kaitai-struct-compiler", "Test.ksy", "-t", "java", "-d", testpath
+    assert_predicate testpath/"src/Test.java", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed there wasn't a homebrew formula for it yet, never made one before, and I've been using kaitai a lot lately for some reverse-engineering. So figured why not since I love using homebrew on the daily. It's been expediting the process up a lot for me, and the community around the project is starting to grow. My first time contributing to a very large open source project, any comments/recommendations greatly appreciated! I've also never tinkered much with ruby so it was fun to learn and step away from my Java cave.

There is a slight nuance in that I scrapped the bash script it's packaged with since it's intended for linux/macos/cygwin all in one and has a ton of boilerplate that's highly unnecessary for brew. Due to it being a java application, it really just needs a simple java exec.

I couldn't get the write_jar_script function to work properly with setting the classpath. Any variation I tried of "java -cp {dependencies} -jar kaitai-struct-compiler-0.7.jar" presented dependency issues. Took me a bit of time to figure out how to write a bash script within the install step, but I got it! As far as dependency issue, it might be because there's a manifest already in there thus the -cp is ignored with the -jar command. I checked the universal bash script packaged with it and it just has it calling it by the class too instead of referencing a jar argument.