### PR TITLE
e2tools 0.0.16 (new formula)

### DIFF
--- a/Formula/e2tools.rb
+++ b/Formula/e2tools.rb
@@ -1,0 +1,22 @@
+class E2tools < Formula
+  desc "Utilities to read, write, and manipulate files in ext2/3/4 filesystems"
+  homepage "http://home.earthlink.net/~k_sheff/sw/e2tools/"
+  url "http://home.earthlink.net/~k_sheff/sw/e2tools/e2tools-0.0.16.tar.gz"
+  sha256 "4e3c8e17786ccc03fc9fb4145724edf332bb50e1b3c91b6f33e0e3a54861949b"
+
+  depends_on "e2fsprogs"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    mkfs = shell_output("brew --prefix e2fsprogs").strip.concat("/sbin/mkfs.ext2")
+    system mkfs, "test.raw", "1024"
+    system bin/"e2ls", "test.raw"
+  end
+end

--- a/Formula/e2tools.rb
+++ b/Formula/e2tools.rb
@@ -16,6 +16,6 @@ class E2tools < Formula
 
   test do
     system Formula["e2fsprogs"].opt_sbin/"mkfs.ext2", "test.raw", "1024"
-    system bin/"e2ls", "test.raw"
+    assert_match "lost+found", shell_output("#{bin}/e2ls test.raw")
   end
 end

--- a/Formula/e2tools.rb
+++ b/Formula/e2tools.rb
@@ -15,8 +15,7 @@ class E2tools < Formula
   end
 
   test do
-    mkfs = shell_output("brew --prefix e2fsprogs").strip.concat("/sbin/mkfs.ext2")
-    system mkfs, "test.raw", "1024"
+    system Formula["e2fsprogs"].opt_sbin/"mkfs.ext2", "test.raw", "1024"
     system bin/"e2ls", "test.raw"
   end
 end


### PR DESCRIPTION
This adds a new formula for the e2tools package to provide tools to manipulate files inside of an ext2, ext3, or ext4 filesystem. The filesystem may be a block device or a raw image file

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
