### PR TITLE
simg2img 1.1.1 (new formula)

### DIFF
--- a/Formula/simg2img.rb
+++ b/Formula/simg2img.rb
@@ -1,0 +1,24 @@
+class Simg2img < Formula
+  desc "Tool to convert Android sparse images to raw images and back"
+  homepage "https://github.com/anestisb/android-simg2img"
+  url "https://github.com/anestisb/android-simg2img/archive/1.1.1.tar.gz"
+  sha256 "d096ca7e02b3ad5b87cbb6467d3766720355f32aa5ae9b9264d7ca7c486b0738"
+  head "https://github.com/anestisb/android-simg2img.git"
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  test do
+    system "dd", "if=/dev/zero", "of=512k-zeros.img", "bs=512", "count=1024"
+    assert_equal 524288, (testpath/"512k-zeros.img").size?,
+                 "Could not create 512k-zeros.img with 512KiB of zeros"
+    system bin/"img2simg", "512k-zeros.img", "512k-zeros.simg"
+    assert_equal 44, (testpath/"512k-zeros.simg").size?,
+                 "Converting 512KiB of zeros did not result in a 44 byte simg"
+    system bin/"simg2img", "512k-zeros.simg", "new-512k-zeros.img"
+    assert_equal 524288, (testpath/"new-512k-zeros.img").size?,
+                 "Converting a 44 byte simg did not result in 512KiB"
+    system "diff", "512k-zeros.img", "new-512k-zeros.img"
+  end
+end


### PR DESCRIPTION
This adds a new formula for the simg2img project which provides tools for converting between raw disk images and Android sparse images.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
