### PR TITLE
sshmux 0.1 (new formula)

### DIFF
--- a/sshmux.rb
+++ b/sshmux.rb
@@ -1,0 +1,18 @@
+class Sshmux < Formula
+  desc "Persistent ssh sessions with tmux and screen"
+  homepage "https://github.com/Russell91/sshmux"
+  url "https://github.com/Russell91/sshmux/archive/0.1.tar.gz"
+  sha256 "7ac0ec6e94a34facc5472bbbdb17ef70c0d2989e2f277ed71325ff36c0bde9a4"
+
+  head do
+    url "https://github.com/Russell91/sshmux.git"
+  end
+
+  def install
+    bin.install "sshmux", "sshscreen/sshscreen"
+  end
+
+  test do
+    assert_equal "ssh: Could not resolve hostname *illegal_host*: nodename nor servname provided, or not known", shell_output("#{bin}/sshmux *illegal_host*", 1).strip
+  end
+end


### PR DESCRIPTION
Adding new formula for sshmux and sshscreen ssh wrapper scripts, which open a tmux/screen session on the remote machine and add 'client side reconnect logic' for persistent ssh sessions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
