### PR TITLE
asciidoc: fix python2 not found

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -4,6 +4,7 @@ class Asciidoc < Formula
   # This release is listed as final on GitHub, but not listed on asciidoc.org.
   url "https://github.com/asciidoc/asciidoc/archive/8.6.10.tar.gz"
   sha256 "9e52f8578d891beaef25730a92a6e723596ddbd07bfe0d2a56486fcf63a0b983"
+  revision 1
   head "https://github.com/asciidoc/asciidoc.git"
 
   bottle do
@@ -23,7 +24,11 @@ class Asciidoc < Formula
     system "autoconf"
     system "./configure", "--prefix=#{prefix}"
 
-    inreplace "asciidoc.py", "#!/usr/bin/env python2", "#!/usr/bin/python"
+    inreplace %w[a2x.py asciidoc.py filters/code/code-filter.py
+                 filters/graphviz/graphviz2png.py filters/latex/latex2img.py
+                 filters/music/music2png.py filters/unwraplatex.py],
+      "#!/usr/bin/env python2", "#!/usr/bin/python"
+
     # otherwise macOS's xmllint bails out
     inreplace "Makefile", "-f manpage", "-f manpage -L"
     system "make", "install"


### PR DESCRIPTION
A clean install of macOS 10.13.x High Sierra does not have a "python2" executable in $PATH; only "python" and "python2.7". The previous version of this formula only patched asciidoc.py; the other scripts were broken. This commit should patch all the relevant files.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
