### PR TITLE
mysql: Add 8.0.3-rc as devel version

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -10,6 +10,18 @@ class Mysql < Formula
     sha256 "016deb20192b24bfdb8011918941da4b9752a5237fbeec4b29568e8dd1417189" => :el_capitan
   end
 
+  devel do
+    url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.3-rc.tar.gz"
+    sha256 "bc6ef8e496447edde87da243db56682d44c8344e5695c3f265b3316b3a8aa56f"
+
+    fails_with :clang do
+      build 800
+      cause "Wrong inlining with Clang 8.0, see MySQL Bug #86711"
+    end
+    # GCC is not supported either, so exclude for El Capitan.
+    depends_on :macos => :sierra if DevelopmentTools.clang_build_version == 800
+  end
+
   option "with-test", "Build with unit tests"
   option "with-embedded", "Build the embedded server"
   option "with-archive-storage-engine", "Compile with the ARCHIVE storage engine enabled"
@@ -104,8 +116,10 @@ class Mysql < Formula
     # Perl script was removed in 5.7.9 so install C++ binary instead.
     # Binary is deprecated & will be removed in future upstream
     # update but is still required for mysql-test-run to pass in test.
-    (prefix/"scripts").install "client/mysql_install_db"
-    bin.install_symlink prefix/"scripts/mysql_install_db"
+    if build.stable?
+      (prefix/"scripts").install "client/mysql_install_db"
+      bin.install_symlink prefix/"scripts/mysql_install_db"
+    end
 
     # Fix up the control script and link into bin.
     inreplace "#{prefix}/support-files/mysql.server",


### PR DESCRIPTION
This adds MySQL 8.0.3, the first 8.0 release candidate as `--devel` version.

I manually tested upgrade from the stable 5.7.19.

I also had to scope the installation of `install_mysql_db` to the stable version, because it was already deprecated in 5.7 and it appears it has not been completely removed (it has been replaced by `mysqld --initialize` or `mysqld --initialize-insecure` which `brew test` is already using.

Clang build 800 is excluded because it is rejected by make due to generating bad code, see https://bugs.mysql.com/bug.php?id=86711 for details.

This is a resubmission of PR #19192 which had become stale.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----