### PR TITLE
ffmpeg@2.8 & ffmbc: drop faac

### DIFF
--- a/Formula/ffmbc.rb
+++ b/Formula/ffmbc.rb
@@ -4,7 +4,7 @@ class Ffmbc < Formula
   url "https://drive.google.com/uc?export=download&id=0B0jxxycBojSwTEgtbjRZMXBJREU"
   version "0.7.2"
   sha256 "caaae2570c747077142db34ce33262af0b6d0a505ffbed5c4bdebce685d72e42"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "ef47a0b90417c9464ca3ffc59aaecac8eb84f34c33d665d7a41c6f16bd93b617" => :high_sierra
@@ -22,7 +22,6 @@ class Ffmbc < Formula
   depends_on "yasm" => :build
 
   depends_on "x264" => :recommended
-  depends_on "faac" => :recommended
   depends_on "lame" => :recommended
   depends_on "xvid" => :recommended
 
@@ -43,7 +42,6 @@ class Ffmbc < Formula
             "--cc=#{ENV.cc}"]
 
     args << "--enable-libx264" if build.with? "x264"
-    args << "--enable-libfaac" if build.with? "faac"
     args << "--enable-libmp3lame" if build.with? "lame"
     args << "--enable-libxvid" if build.with? "xvid"
 

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -47,7 +47,6 @@ class FfmpegAT28 < Formula
   depends_on "libvo-aacenc" => :recommended
   depends_on "xvid" => :recommended
 
-  depends_on "faac" => :optional
   depends_on "fontconfig" => :optional
   depends_on "freetype" => :optional
   depends_on "theora" => :optional
@@ -110,7 +109,6 @@ class FfmpegAT28 < Formula
     args << "--enable-libvpx" if build.with? "libvpx"
     args << "--enable-librtmp" if build.with? "rtmpdump"
     args << "--enable-libopencore-amrnb" << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
-    args << "--enable-libfaac" if build.with? "faac"
     args << "--enable-libass" if build.with? "libass"
     args << "--enable-ffplay" if build.with? "ffplay"
     args << "--enable-libssh" if build.with? "libssh"
@@ -139,9 +137,7 @@ class FfmpegAT28 < Formula
 
     # These librares are GPL-incompatible, and require ffmpeg be built with
     # the "--enable-nonfree" flag, which produces unredistributable libraries
-    if %w[faac fdk-aac openssl].any? { |f| build.with? f }
-      args << "--enable-nonfree"
-    end
+    args << "--enable-nonfree" if build.with?("fdk-aac") || build.with?("openssl")
 
     # A bug in a dispatch header on 10.10, included via CoreFoundation,
     # prevents GCC from building VDA support. GCC has no problems on
@@ -173,23 +169,6 @@ class FfmpegAT28 < Formula
     if build.with? "tools"
       system "make", "alltools"
       bin.install Dir["tools/*"].select { |f| File.executable? f }
-    end
-  end
-
-  def caveats
-    if build.without? "faac" then <<~EOS
-      FFmpeg has been built without libfaac for licensing reasons;
-      libvo-aacenc is used by default.
-      To install with libfaac, you can:
-        brew reinstall ffmpeg28 --with-faac
-
-      You can also use the experimental FFmpeg encoder, libfdk-aac, or
-      libvo_aacenc to encode AAC audio:
-        ffmpeg -i input.wav -c:a aac -strict experimental output.m4a
-      Or:
-        brew reinstall ffmpeg28 --with-fdk-aac
-        ffmpeg -i input.wav -c:a libfdk_aac output.m4a
-      EOS
     end
   end
 


### PR DESCRIPTION
I just took a look at #20317 myself. As expected, both won't build with faac 1.29.9, with the same error:

    libavcodec/libfaac.c:87:15: error: no member named 'allowMidside' in 'struct faacEncConfiguration'
        faac_cfg->allowMidside = 1;
        ~~~~~~~~  ^
    1 error generated.

FFmpeg has dropped faac support in 3.2 (a year ago), so I doubt this will be fixed in the 2.8 line — there won't be anything to backport.

FFmbc is so outdated I consider it stale or dead. After dropping faac, there's still the native AAC encoder:

```console
$ ffmbc -codecs | grep aac
FFmbc version 0.7.2
Copyright (c) 2008-2014 Baptiste Coudurier and the FFmpeg developers
 DEA    aac             Advanced Audio Coding
 D A    aac_latm        AAC LATM (Advanced Audio Codec LATM syntax)
```

which I believe was still experimental when FFmbc was last synced with FFmpeg upstream, so it probably doesn't perform as well as libfaac. I checked FFmbc's `configure` and unfortunately it doesn't seem to support libvo-aacenc or libfdk_aac. If you (one the two remaining FFmbc users) absolutely need faac, you need to urge FFmbc upstream to patch and release, or wisely use `brew switch` / `brew pin`.
