### PR TITLE
itstool: upstream fix for crashes freeing xmlDocs

### DIFF
--- a/Formula/itstool.rb
+++ b/Formula/itstool.rb
@@ -1,8 +1,19 @@
 class Itstool < Formula
   desc "Make XML documents translatable through PO files"
   homepage "http://itstool.org/"
-  url "http://files.itstool.org/itstool/itstool-2.0.4.tar.bz2"
-  sha256 "97c208b51da33e0b553e830b92655f8deb9132f8fbe9a646771f95c33226eb60"
+  revision 1
+
+  stable do
+    url "http://files.itstool.org/itstool/itstool-2.0.4.tar.bz2"
+    sha256 "97c208b51da33e0b553e830b92655f8deb9132f8fbe9a646771f95c33226eb60"
+
+    # Upstream commit from 25 Oct 2017 "Be more careful about libxml2 memory management"
+    # See https://github.com/itstool/itstool/issues/17
+    patch do
+      url "https://github.com/itstool/itstool/commit/9b84c00.patch?full_index=1"
+      sha256 "c33f44affc27604c6a91a8ae2e992273bf588c228e635ea46d958e2c3046e9ca"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Discovered the issue while attempting to build `gtk-doc`.