### PR TITLE
use sha256 for 1.00.70 bz2

### DIFF
--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -1,9 +1,9 @@
 class Freetds < Formula
   desc "Libraries to talk to Microsoft SQL Server and Sybase databases"
   homepage "http://www.freetds.org/"
-  url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.70.tar.bz2"
-  mirror "https://fossies.org/linux/privat/freetds-1.00.70.tar.bz2"
-  sha256 "f76319f65beadc2a189a99adb79faffef2564f5378aea9b881dc2c9b1003b0f9"
+  url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.70.tar.gz"
+  mirror "https://fossies.org/linux/privat/freetds-1.00.70.tar.gz"
+  sha256 "197fbd902970c95d74e9d69da94db7d346ef0b7836c5eaf520f9917a8ab64658"
 
   bottle do
     sha256 "cb74512024248731f73803d76bd32b73d87c159375e77e2296d4abbdf84e4309" => :high_sierra

--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -1,9 +1,9 @@
 class Freetds < Formula
   desc "Libraries to talk to Microsoft SQL Server and Sybase databases"
   homepage "http://www.freetds.org/"
-  url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.70.tar.gz"
+  url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.70.tar.bz2"
   mirror "https://fossies.org/linux/privat/freetds-1.00.70.tar.bz2"
-  sha256 "197fbd902970c95d74e9d69da94db7d346ef0b7836c5eaf520f9917a8ab64658"
+  sha256 "f76319f65beadc2a189a99adb79faffef2564f5378aea9b881dc2c9b1003b0f9"
 
   bottle do
     sha256 "cb74512024248731f73803d76bd32b73d87c159375e77e2296d4abbdf84e4309" => :high_sierra


### PR DESCRIPTION
see https://fossies.org/linux/privat/freetds-1.00.70.tar.bz2/

this fixes the following failure:

```
==> Downloading ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.70.tar.gz
Already downloaded: /Users/sds/Library/Caches/Homebrew/freetds-1.00.70.tar.gz
Error: SHA256 mismatch
Expected: 197fbd902970c95d74e9d69da94db7d346ef0b7836c5eaf520f9917a8ab64658
Actual: f76319f65beadc2a189a99adb79faffef2564f5378aea9b881dc2c9b1003b0f9
Archive: /Users/sds/Library/Caches/Homebrew/freetds-1.00.70.tar.gz
To retry an incomplete download, remove the file above.
```