### PR TITLE
fix install qca qt plugins in right path (/foo/bar/lib/qt5/plugins)

### DIFF
--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -1,7 +1,7 @@
 class Qca < Formula
   desc "Qt Cryptographic Architecture (QCA)"
   homepage "http://delta.affinix.com/qca/"
-  revision 1
+  revision 2
   head "https://anongit.kde.org/qca.git"
 
   stable do

--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -62,6 +62,7 @@ class Qca < Formula
     args = std_cmake_args
     args << "-DQT4_BUILD=OFF"
     args << "-DBUILD_TESTS=OFF"
+    args << "-DQCA_PLUGINS_INSTALL_DIR=#{lib}/qt5/plugins"
 
     # Plugins (qca-ossl, qca-cyrus-sasl, qca-logger, qca-softstore always built)
     args << "-DWITH_botan_PLUGIN=#{build.with?("botan") ? "YES" : "NO"}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Qca qt plugins should be install into Qt plugins directory, this is /usr/local/libs/qt5/plugins

if not, if set QT_PLUGIN_PATH=/usr/local/libs/qt5/plugins (needs in brew installation due sandbox in all Qt based programs) can't see this plugins and fails if need. (http://doc.qt.io/qt-5/deployment-plugins.html)

brew install -v qca.rb --build-from-source
https://gist.github.com/sl1pkn07/dd0c5593a30cdfb0371ffc683bac79c2

brew audit --strict qca
>none output<
