### PR TITLE
couchdb: update to 1.7.1 release

### DIFF
--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -1,7 +1,7 @@
 class Couchdb < Formula
   desc "Document database server"
   homepage "https://couchdb.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.7.0/apache-couchdb-1.7.1.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.7.1/apache-couchdb-1.7.1.tar.gz"
   sha256 "91200aa6fbc6fa5e2f3d78ef40e39d8c1ec7c83ea1c2cd730d270658735b2cad"
 
   bottle do

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -1,8 +1,8 @@
 class Couchdb < Formula
   desc "Document database server"
   homepage "https://couchdb.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.7.0/apache-couchdb-1.7.0.tar.gz"
-  sha256 "9b492e7e5389477107100ef83c41cc32185e2fe9cc88c19c550ed4b2192890dd"
+  url "https://www.apache.org/dyn/closer.cgi?path=/couchdb/source/1.7.0/apache-couchdb-1.7.1.tar.gz"
+  sha256 "91200aa6fbc6fa5e2f3d78ef40e39d8c1ec7c83ea1c2cd730d270658735b2cad"
 
   bottle do
     sha256 "2be19b2a69900ede604660d276fb94b2218db732bb68766a4fe533cd2dc90910" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

📶 this one's a keeper --  includes fix for Access to db/_all_docs results in 500 in 1.7.0 if user is only a DB member from https://github.com/apache/couchdb/issues/974