### PR TITLE
enchant: update homepage and pyenchant urls

### DIFF
--- a/Formula/enchant.rb
+++ b/Formula/enchant.rb
@@ -1,6 +1,6 @@
 class Enchant < Formula
   desc "Spellchecker wrapping library"
-  homepage "https://www.abisource.com/projects/enchant/"
+  homepage "https://abiword.github.io/enchant/"
   url "https://www.abisource.com/downloads/enchant/1.6.0/enchant-1.6.0.tar.gz"
   sha256 "2fac9e7be7e9424b2c5570d8affe568db39f7572c10ed48d4e13cddf03f7097f"
 
@@ -20,7 +20,7 @@ class Enchant < Formula
 
   # https://pythonhosted.org/pyenchant/
   resource "pyenchant" do
-    url "https://pypi.python.org/packages/source/p/pyenchant/pyenchant-1.6.5.tar.gz"
+    url "https://files.pythonhosted.org/packages/source/p/pyenchant/pyenchant-1.6.5.tar.gz"
     sha256 "623f332a9fbb70ae6c9c2d0d4e7f7bae5922d36ba0fe34be8e32df32ebbb4f84"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Updated url of enchant homepage.
- Updated url of pyenchant .tar.gz file, since it was causing `brew audit --strict enchant` to fail