### PR TITLE
faac: upstream fix for backwards compatibility

### DIFF
--- a/Formula/faac.rb
+++ b/Formula/faac.rb
@@ -3,12 +3,21 @@ class Faac < Formula
   homepage "http://www.audiocoding.com/faac.html"
   url "https://downloads.sourceforge.net/project/faac/faac-src/faac-1.29/faac-1.29.9.tar.gz"
   sha256 "238cb4453b6fe4eebaffb326e40a63786a155e349955c4259925006fa1e2839e"
+  revision 1
 
   bottle do
     cellar :any
     sha256 "7cee7bed3b2cd0971f8c4e7310e5b5419cdfd1c647325616a8320e8727f9c634" => :high_sierra
     sha256 "95f62317820b7349c89dd7a4252797e206ebadc48d4d94ea77961c4510018e39" => :sierra
     sha256 "bf47a2f8598623b87948657e8e740d243e89ce6410b992368b9bf5dfee51784d" => :el_capitan
+  end
+
+  # Remove for > 1.29.9
+  # 14 Nov 2017 "added joint stereo backward compatibility alias"
+  # See https://github.com/knik0/faac/issues/9
+  patch do
+    url "https://github.com/knik0/faac/commit/eadb150.patch?full_index=1"
+    sha256 "770619570b4a85bdceae25855ba72fb1e5644d8ad58096f954cea1dd28297591"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/knik0/faac/issues/9
https://github.com/Homebrew/homebrew-core/issues/20317
https://github.com/Homebrew/homebrew-core/pull/20546

CC @zmwangx