### PR TITLE
faac 1.29.9.2

### DIFF
--- a/Formula/faac.rb
+++ b/Formula/faac.rb
@@ -1,8 +1,8 @@
 class Faac < Formula
   desc "ISO AAC audio encoder"
   homepage "http://www.audiocoding.com/faac.html"
-  url "https://downloads.sourceforge.net/project/faac/faac-src/faac-1.29/faac-1.29.9.tar.gz"
-  sha256 "238cb4453b6fe4eebaffb326e40a63786a155e349955c4259925006fa1e2839e"
+  url "https://downloads.sourceforge.net/project/faac/faac-src/faac-1.29/faac-1.29.9.2.tar.gz"
+  sha256 "d45f209d837c49dae6deebcdd87b8cc3b04ea290880358faecf5e7737740c771"
 
   bottle do
     cellar :any
@@ -12,10 +12,6 @@ class Faac < Formula
   end
 
   def install
-    # Fix "error: initializer element is not a compile-time constant"
-    # Reported 2 Nov 2017 https://sourceforge.net/p/faac/bugs/228/
-    inreplace "libfaac/stereo.c", "sqrt(2)", "M_SQRT2"
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

upstream added a backwards compatibility alias for allowMidside

CC @zmwangx @knik0 @s172262 @mwunsch

Ref:
https://github.com/knik0/faac/issues/8
https://github.com/knik0/faac/issues/9
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223416

Supersedes #20546.
Fixes #20317.