### PR TITLE
WIP: eccodes 2.5.0

### DIFF
--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -15,7 +15,7 @@ class Eccodes < Formula
   depends_on "cmake" => :build 
   depends_on "netcdf" #=> :optional 
   depends_on "hdf5" 
-  depends_on "jpg" #=> optional 
+  #depends_on "jpg" #=> optional 
   depends_on "python" #=> optional
   depends_on "gcc" #?
  

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -1,0 +1,46 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook.html 
+#                http://www.rubydoc.info/github/Homebrew/brew/master/Formula 
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST! 
+ 
+class Eccodes < Formula 
+  desc "Tools to manipulate grib files" 
+  homepage "https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home" 
+  url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.5.0-Source.tar.gz?api=v2" 
+  sha256 "18ab44bc444168fd324d07f7dea94f89e056f5c5cd973e818c8783f952702e4e" 
+ 
+  #bottle :disable, "needs to be bottled" 
+ 
+  #option "with-netcdf", "Compile with netcdf support" 
+   
+  depends_on "cmake" => :build 
+  #depends_on "netcdf" #=> :optional 
+  #depends_on "hdf5" 
+  #depends_on "jpg" => optional 
+  #depends_on "python" 
+ 
+  def install 
+    # ENV.deparallelize  # if your formula fails when building in parallel 
+ 
+    std_cmake_args = ["-DCMAKE_INSTALL_PREFIX=/usr/local/bin"] 
+ 
+    # untar the package 
+    system "tar xf eccodes-2.5.0-Source.tar" 
+ 
+    # Remove unrecognized options if warned by configure 
+    system "cmake", *std_cmake_args, "eccodes-2.5.0-Source" 
+    system "make", "install" # if this fails, try separate make/make install steps 
+  end 
+ 
+  test do 
+    # `test do` will create, run in and delete a temporary directory. 
+    # 
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core 
+    # this will need to be a test that verifies the functionality of the 
+    # software. Run the test with `brew test eccodes`. Options passed 
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`. 
+    # 
+    # The installed folder is not in the path, so use the entire path to any 
+    # executables being tested: `system "#{bin}/program", "do", "something"`. 
+    system "false" 
+  end 
+end

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -13,10 +13,11 @@ class Eccodes < Formula
   #option "with-netcdf", "Compile with netcdf support" 
    
   depends_on "cmake" => :build 
-  #depends_on "netcdf" #=> :optional 
-  #depends_on "hdf5" 
-  #depends_on "jpg" => optional 
-  #depends_on "python" 
+  depends_on "netcdf" #=> :optional 
+  depends_on "hdf5" 
+  depends_on "jpg" #=> optional 
+  depends_on "python" #=> optional
+  depends_on "gcc" #?
  
   def install 
     # ENV.deparallelize  # if your formula fails when building in parallel 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is my first attempt at a PR for homebrew.

eccodes.rb is a bit of a hack at the moment and i'm trying to do the simplest install.

The install is failing with:
`Scanning dependencies of target grib_to_netcdf make[2]: *** No rule to make target/usr/local/lib/libz.dylib', needed by bin/grib_to_netcdf'. Stop.`

After running brew doctor I remember deleting `/usr/local/lib/libz.1.2.8.dylib` and `/usr/local/lib/libz.a`. Not sure if this is part of the issue?

I also noticed it is naming it eccodes 2 instead of eccodes 2.5.0. I will try to change this in the future.

The logs can be found at:
https://miami.box.com/s/ynfczami03nb71emdvtdpk80f13zh3a3

Any help would be appreciated