### PR TITLE
Fixes gobject-introspection on macOS 10.9 & older

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -14,6 +14,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
+  depends_on :python if MacOS.version <= :mavericks
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",


### PR DESCRIPTION
This is done by using Homebrew's python only for if macOS version is
mavericks or older.
Thanks to @ilovezfs for helping to the fix.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
