### PR TITLE
Fixes mpv on macOS 10.9 and older

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -51,6 +51,10 @@ class Mpv < Formula
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
 
+    # Force to use Homebrew's python for Mavericks and older by cleaning
+    # PYTHONPATH before setting it instead of appending
+    ENV.delete("PYTHONPATH") if MacOS.version <= :mavericks
+
     ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
     resource("docutils").stage do
       system "python", *Language::Python.setup_install_args(buildpath/"vendor")

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -51,8 +51,8 @@ class Mpv < Formula
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
 
-    # Force to use Homebrew's python for Mavericks and older by cleaning
-    # PYTHONPATH before setting it instead of appending
+    # Prevents a conflict between python2 and python3 when gobject-introspection
+    # is using the :python requirement
     ENV.delete("PYTHONPATH") if MacOS.version <= :mavericks
 
     ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"


### PR DESCRIPTION
This is done by using Homebrew's python only if macOS version is
mavericks or older.
Thanks to @ilovezfs for helping to the fix.
Let me know if I'm wrong for the comment to explain the line fixing the issue.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
