### PR TITLE
Fixes gdb on macOS 10.9 and older

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -22,13 +22,12 @@ class Gdb < Formula
   depends_on "pkg-config" => :build
   depends_on "python" => :optional
   depends_on "guile@2.0" => :optional
+
   fails_with :clang do
     build 600
     cause <<~EOS
-      Using clang on version 600 or older result in a segmentation fault:
-      `clang: error: unable to execute command: Segmentation fault: 11`
-      Test done on:
-      Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
+      clang: error: unable to execute command: Segmentation fault: 11
+      Test done on: Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
     EOS
   end
 

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -22,6 +22,15 @@ class Gdb < Formula
   depends_on "pkg-config" => :build
   depends_on "python" => :optional
   depends_on "guile@2.0" => :optional
+  fails_with :clang do
+    build 600
+    cause <<~EOS
+      Using clang on version 600 or older result in a segmentation fault:
+      `clang: error: unable to execute command: Segmentation fault: 11`
+      Test done on:
+      Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
+    EOS
+  end
 
   def install
     args = [


### PR DESCRIPTION
This is done by telling Homebrew that clang version 600 or older fails to compile the formula.
Thanks to @ilovezfs for helping to the fix.
Let me know if I'm wrong in the fail cause explanation.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
