### PR TITLE
nopoll 0.4.5 (new formula)

### DIFF
--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -1,5 +1,5 @@
 class Nopoll < Formula
-  desc "OpenSource C WebSocket toolkit"
+  desc "Open-source C WebSocket toolkit"
   homepage "https://www.aspl.es/nopoll/"
   url "https://www.aspl.es/nopoll/downloads/nopoll-0.4.5.b375.tar.gz"
   sha256 "4ecbd277714c9acd154277a46388689f9d651836ca5c69990e35d1eee8c7ceae"

--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -2,6 +2,7 @@ class Nopoll < Formula
   desc "Open-source C WebSocket toolkit"
   homepage "https://www.aspl.es/nopoll/"
   url "https://www.aspl.es/nopoll/downloads/nopoll-0.4.5.b375.tar.gz"
+  version "0.4.5.b375"
   sha256 "4ecbd277714c9acd154277a46388689f9d651836ca5c69990e35d1eee8c7ceae"
 
   depends_on "openssl"

--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -3,13 +3,11 @@ class Nopoll < Formula
   homepage "https://www.aspl.es/nopoll/"
   url "https://www.aspl.es/nopoll/downloads/nopoll-0.4.5.b375.tar.gz"
   sha256 "4ecbd277714c9acd154277a46388689f9d651836ca5c69990e35d1eee8c7ceae"
-  head "https://github.com/asples/nopoll.git"
 
   depends_on "openssl"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
@@ -24,7 +22,8 @@ class Nopoll < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{include}/nopoll", "-L#{lib}", "-lnopoll", "-o", "test"
+    system ENV.cc, "test.c", "-I#{include}/nopoll", "-L#{lib}", "-lnopoll",
+           "-o", "test"
     system "./test"
   end
 end

--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -1,0 +1,30 @@
+class Nopoll < Formula
+  desc "OpenSource C WebSocket toolkit"
+  homepage "https://www.aspl.es/nopoll/"
+  url "https://www.aspl.es/nopoll/downloads/nopoll-0.4.5.b375.tar.gz"
+  sha256 "4ecbd277714c9acd154277a46388689f9d651836ca5c69990e35d1eee8c7ceae"
+  head "https://github.com/asples/nopoll.git"
+
+  depends_on "openssl"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <nopoll.h>
+      int main(void) {
+        noPollCtx *ctx = nopoll_ctx_new();
+        nopoll_ctx_unref(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}/nopoll", "-L#{lib}", "-lnopoll", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This commit adds the nopoll formula to the tap.

I tried to get the HEAD version working, but that was harder than
expected.