### PR TITLE
MMseqs2 1-c7a89 (new formula)

### DIFF
--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -1,0 +1,47 @@
+class Mmseqs2 < Formula
+  desc "Software suite for very fast protein sequence search and clustering"
+  homepage "https://mmseqs.org/"
+  url "https://github.com/soedinglab/MMseqs2/archive/1-c7a89.tar.gz"
+  version "1-c7a89"
+  sha256 "e756a0e5cb3aa8e1e5a5b834a58ae955d9594be1806f0f32800427c55f3a45d5"
+
+  depends_on "cmake" => :build
+  depends_on "gcc"
+
+  cxxstdlib_check :skip
+
+  fails_with :clang # needs OpenMP support
+
+  resource "documentation" do
+    url "https://github.com/soedinglab/MMseqs2.wiki.git",
+        :revision => "6dbd3666edb64fc71173ee714014e88c1ebe2dfc"
+  end
+
+  def install
+    # version information is read from git by default
+    # next MMseqs2 version will include a cmake flag so we do not need this hack
+    inreplace "src/version/Version.cpp", /.+/m, "const char *version = \"#{version}\";"
+
+    args = *std_cmake_args << "-DHAVE_TESTS=0" << "-DHAVE_MPI=0"
+
+    args << "-DHAVE_SSE4_1=1" if build.bottle?
+
+    system "cmake", ".", *args
+    system "make", "install"
+
+    resource("documentation").stage { doc.install Dir["*"] }
+    pkgshare.install "examples"
+    bash_completion.install "util/bash-completion.sh" => "mmseqs.sh"
+  end
+
+  def caveats
+    unless Hardware::CPU.sse4?
+      "MMseqs2 requires at least SSE4.1 CPU instruction support. The binary will not work correctly."
+    end
+  end
+
+  test do
+    system "#{bin}/mmseqs", "createdb", "#{pkgshare}/examples/QUERY.fasta", "q"
+    system "#{bin}/mmseqs", "cluster", "q", "res", "tmp", "-s", "1", "--cascaded"
+  end
+end


### PR DESCRIPTION
Mseqs2 is a bioinformatics software suite for
ultra fast and sensitive protein sequence
searches and clustering.

I also tested this recipe with linuxbrew
on Ubuntu 16.04.

Originally, I was planning on submitting this to
homebrew/science, but it seems to be in the process
of being phased out.

There are a some potential issues with this recipe:
* Zlib/bzip2 dependency, instead of system ones
  The system zlib errors out with something like
  __OSX_AVAILABLE_STARTING 10_13 on my OSX Sierra.
  bzip2 works, but for consistencies sake, i added
  a dependecy for both.
  brew audit is complaining about this issue
* CPU instructions set is per default autodetected.
  At least SSE4.1 is required for MMseqs2 to work.
  The --with-sse41/avx2 flags force a certain compilation.
  Bottles are always built with sse41 as the lowest
  common denominator. A 'depends_on :cpuid => :sse41',
  would be useful to handle this cleanly.
  I added a caveat about this to the recipe.
* The MMseqs2 build process either needs xxd from vim
  or perl (to run the bundled xxdi.pl script).
  I didn't include either as an dependecy, since
  pretty much every OS (also linuxbrew)  include perl.
  Should I explicitly add perl or vim as a build
  dependency? I would like to keep dependencies to
  a minimum.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Not quite, I have explicitly added zlib and bzip2 as dependencies, since I cannot successfully use the system zlib on MacOS Sierra with the newest Xcode (see above).

-----
