### PR TITLE
version 3.0.2

### DIFF
--- a/Formula/dependency-check.rb
+++ b/Formula/dependency-check.rb
@@ -1,8 +1,8 @@
 class DependencyCheck < Formula
   desc "OWASP Dependency Check"
   homepage "https://www.owasp.org/index.php/OWASP_Dependency_Check"
-  url "https://dl.bintray.com/jeremy-long/owasp/dependency-check-3.0.1-release.zip"
-  sha256 "27a6417660cc0783a13fcdb47e6f7b01934b0eff9dfd8fa4fc281dc1b04ab9e2"
+  url "https://dl.bintray.com/jeremy-long/owasp/dependency-check-3.0.2-release.zip"
+  sha256 "90211e05be1d3b1285a04d0949655a7a248a472f35fe5bde02ab227c56c1c818"
 
   bottle :unneeded
 


### PR DESCRIPTION
Version 3.0.2 of OWASP dependency-check was released; updating homebrew.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
