### PR TITLE
little-cms2: downgrade to 2.8 and bump version_scheme

### DIFF
--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -1,8 +1,11 @@
 class LittleCms2 < Formula
   desc "Color management engine supporting ICC profiles"
   homepage "http://www.littlecms.com/"
-  url "https://downloads.sourceforge.net/project/lcms/lcms/2.9/lcms2-2.9.tar.gz"
-  sha256 "00756bed09ce059a68289f10de56b00267667647393ddc30400cb87c0d9037d5"
+  # Ensure release is announced on http://www.littlecms.com/download.html
+  url "https://downloads.sourceforge.net/project/lcms/lcms/2.8/lcms2-2.8.tar.gz"
+  sha256 "66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22"
+  revision 2
+  version_scheme 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

2.9 was never a real release on http://www.littlecms.com/download.html
contrary to what SourceForge had been indicating.

See https://github.com/mm2/Little-CMS/issues/140.
Fixes https://github.com/Homebrew/homebrew-core/issues/20628.