### PR TITLE
opensaml 2.6.1 & shibboleth-sp 2.6.1

### DIFF
--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -1,9 +1,8 @@
 class Opensaml < Formula
   desc "Library for Security Assertion Markup Language"
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/Home"
-  url "https://shibboleth.net/downloads/c++-opensaml/2.6.0/opensaml-2.6.0.tar.gz"
-  sha256 "8c8e7d1d7b045cda330dd49ea1972a3306ebefbf42cc65b8f612d66828352179"
-  revision 1
+  url "https://shibboleth.net/downloads/c++-opensaml/2.6.1/opensaml-2.6.1.tar.bz2"
+  sha256 "69516b165858d381fcf1d8ce809c101246824d383aa635a3676648c88b242a83"
 
   bottle do
     cellar :any

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -1,8 +1,8 @@
 class ShibbolethSp < Formula
   desc "Shibboleth 2 Service Provider daemon"
   homepage "https://wiki.shibboleth.net/confluence/display/SHIB2"
-  url "https://shibboleth.net/downloads/service-provider/2.6.0/shibboleth-sp-2.6.0.tar.gz"
-  sha256 "7f23b8a28e66ae1b0fe525ca1f8b84c4566a071367f5d9a1bd71bd6b29e4d985"
+  url "https://shibboleth.net/downloads/service-provider/2.6.1/shibboleth-sp-2.6.1.tar.bz2"
+  sha256 "1121e3b726b844d829ad86f2047be62da4284ce965ac184de2f81903f16b98e4"
 
   bottle do
     rebuild 2
@@ -55,7 +55,7 @@ class ShibbolethSp < Formula
     mod = build.with?("apache-22") ? "mod_shib_22.so" : "mod_shib_24.so"
     <<~EOS
       You must manually edit httpd.conf to include
-      LoadModule mod_shib #{lib}/shibboleth/#{mod}
+      LoadModule mod_shib #{opt_lib}/shibboleth/#{mod}
       You must also manually configure
         #{etc}/shibboleth/shibboleth2.xml
       as per your own requirements. For more information please see
@@ -78,7 +78,7 @@ class ShibbolethSp < Formula
         <string>-F</string>
         <string>-f</string>
         <string>-p</string>
-        <string>#{prefix}/var/run/shibboleth/shibd.pid</string>
+        <string>#{var}/run/shibboleth/shibd.pid</string>
       </array>
       <key>RunAtLoad</key>
       <true/>
@@ -95,6 +95,6 @@ class ShibbolethSp < Formula
   end
 
   test do
-    system "#{opt_sbin}/shibd", "-t"
+    system sbin/"shibd", "-t"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

So, umm, I tried to build this one from source locally, and... I literally can't. Homebrew has an interesting failure point going on here.

```
==> Installing opensaml dependency: curl
/usr/bin/sandbox-exec -f /tmp/homebrew20171116-30544-1rh8v9b.sb nice /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/curl.rb --verbose --with-libssh2 --with-c-ares --with-gssapi --with-libmetalink --with-nghttp2 --with-openssl
==> Downloading https://curl.haxx.se/download/curl-7.56.1.tar.bz2
/usr/bin/curl --show-error --user-agent Homebrew/1.3.7-4-g2953493 (Macintosh; Intel Mac OS X 10.13.2) curl/7.54.0 --fail --location --remote-time --continue-at - --output /usr/local/var/homebrewcache/curl-7.56.1.tar.bz2.incomplete https://curl.haxx.se/download/curl-7.56.1.tar.bz2 --connect-timeout 5
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2758k  100 2758k    0     0  1382k      0  0:00:01  0:00:01 --:--:-- 1382k

==> Summary
🍺  /usr/local/Cellar/curl/7.56.1: 414 files, 3.2MB, built in 2 minutes 7 seconds
==> Installing opensaml dependency: xml-tooling-c
==> Installing dependencies for xml-tooling-c: curl

~> brew install opensaml -s -v
==> Installing dependencies for opensaml: curl, xml-tooling-c
==> Installing opensaml dependency: curl
/usr/bin/sandbox-exec -f /tmp/homebrew20171116-43275-1sybd8f.sb nice /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/curl.rb --verbose --with-libssh2 --with-c-ares --with-gssapi --with-libmetalink --with-nghttp2 --with-openssl
```

Rinse and repeat.