### PR TITLE
newsboat: fixed HEAD build

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -3,9 +3,19 @@ class Newsboat < Formula
   homepage "https://newsboat.org/"
   url "https://github.com/newsboat/newsboat/archive/r2.10.1.tar.gz"
   sha256 "82d5e3e2a6dab845aac0bf72580f46c2756375d49214905a627284e5bc32e327"
-  head "https://github.com/newsboat/newsboat.git"
 
-  depends_on "asciidoc" => :build
+  bottle do
+    sha256 "9dcbf0d0a026bc0c0667ce52698365f2f172e1222334657a4327c1101304b8ff" => :high_sierra
+    sha256 "2094f90b7a64c045e408973420cec64805f4ec517a9397f5850d35d9c013151e" => :sierra
+    sha256 "9af1f9da45dcb359481827c3e61e2aef3e21c253b29d436962369b8816be25cc" => :el_capitan
+  end
+
+  head do
+    url "https://github.com/newsboat/newsboat.git"
+
+    depends_on "asciidoc" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "json-c"

--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -24,7 +24,7 @@ class Newsboat < Formula
   needs :cxx11
 
   def install
-    ENV["XML_CATALOG_FILES"] = "/usr/local/etc/xml/catalog"
+    ENV["XML_CATALOG_FILES"] = "/usr/local/etc/xml/catalog" if build.head?
     system "make", "install", "prefix=#{prefix}"
   end
 

--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -5,12 +5,7 @@ class Newsboat < Formula
   sha256 "82d5e3e2a6dab845aac0bf72580f46c2756375d49214905a627284e5bc32e327"
   head "https://github.com/newsboat/newsboat.git"
 
-  bottle do
-    sha256 "9dcbf0d0a026bc0c0667ce52698365f2f172e1222334657a4327c1101304b8ff" => :high_sierra
-    sha256 "2094f90b7a64c045e408973420cec64805f4ec517a9397f5850d35d9c013151e" => :sierra
-    sha256 "9af1f9da45dcb359481827c3e61e2aef3e21c253b29d436962369b8816be25cc" => :el_capitan
-  end
-
+  depends_on "asciidoc" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "json-c"
@@ -19,6 +14,7 @@ class Newsboat < Formula
   needs :cxx11
 
   def install
+    ENV["XML_CATALOG_FILES"] = "/usr/local/etc/xml/catalog"
     system "make", "install", "prefix=#{prefix}"
   end
 


### PR DESCRIPTION
Noticed I couldn't `brew reinstall --HEAD newsboat` so I fixed the formula.