### PR TITLE
cclive 0.9.3

### DIFF
--- a/Formula/cclive.rb
+++ b/Formula/cclive.rb
@@ -1,9 +1,8 @@
 class Cclive < Formula
   desc "Command-line video extraction utility"
   homepage "https://cclive.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/cclive/0.7/cclive-0.7.16.tar.xz"
-  sha256 "586a120faddcfa16f5bb058b5c901f1659336c6fc85a0d3f1538882a44ee10e1"
-  revision 2
+  url "https://downloads.sourceforge.net/project/cclive/0.9/cclive-0.9.3.tar.xz"
+  sha256 "2edeaf5d76455723577e0b593f0322a97f1e0c8b0cffcc70eca8b5d17374a495"
 
   bottle do
     cellar :any
@@ -14,13 +13,32 @@ class Cclive < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "quvi"
   depends_on "boost"
+  depends_on "glibmm"
+  depends_on "libquvi"
   depends_on "pcre"
 
   conflicts_with "clozure-cl", :because => "both install a ccl binary"
 
+  # Upstream PR from 26 Dec 2014 "Add explicit <iostream> includes, fixes build
+  # with Boost 1.56"
+  patch do
+    url "https://github.com/legatvs/cclive/pull/2.patch?full_index=1"
+    sha256 "a4cc99e6b78701c8106871b690c899b95d36d8f873ff4d212e63d8f3f45a990f"
+  end
+
+  # Fix build errors due to assumption of glibc's strerror_r and due to C++11
+  # requirement that there be a space between literal and identifier.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/1266537/cclive/cxx11-and-strerror_r.diff"
+    sha256 "38ce495646de295e8cb2d6712d82f2d995db0601649197bc17ab01c5027e7845"
+  end
+
+  needs :cxx11
+
   def install
+    ENV.cxx11
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- depend on glibmm
- depend on libquvi instead of quvi
- patches for Boost >=1.56, C++11 and glibc's strerror_r