### PR TITLE
opencbm 0.4.99.99

### DIFF
--- a/Formula/opencbm.rb
+++ b/Formula/opencbm.rb
@@ -1,8 +1,8 @@
 class Opencbm < Formula
   desc "Provides access to various floppy drive formats"
   homepage "http://www.trikaliotis.net/opencbm-alpha"
-  url "http://www.trikaliotis.net/Download/opencbm-0.4.99.97/opencbm-0.4.99.97.tar.bz2"
-  sha256 "f67c47470181bec2faea45ad2ac82ae237f30ad54c406b0e7dd1a4ad97b16d87"
+  url "http://www.trikaliotis.net/Download/opencbm-0.4.99.99/opencbm-0.4.99.99.tar.bz2"
+  sha256 "b1e4cd73c8459acd48c5e8536d47439bafea51f136f43fde5a4d6a5f7dbaf6c6"
   head "https://git.code.sf.net/p/opencbm/code.git"
 
   bottle do
@@ -18,6 +18,13 @@ class Opencbm < Formula
   depends_on "cc65" => :build
   depends_on "libusb-compat"
 
+  # Fix "usb_echo_test.c:32:10: fatal error: 'endian.h' file not found"
+  # Reported 24 Nov 2017 to www-201506 AT spiro DOT trikaliotis DOT net
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/48bd0fd/opencbm/endian.diff"
+    sha256 "2221fab81cdc0ca0cfbd55eff01ae3cd10b4e8bfca86082c7cbffb0b73b651cf"
+  end
+
   def install
     # This one definitely breaks with parallel build.
     ENV.deparallelize
@@ -29,11 +36,8 @@ class Opencbm < Formula
       MANDIR=#{man1}
     ]
 
-    # The build is buried one directory down.
-    cd "opencbm" do
-      system "make", *args
-      system "make", "install-all", *args
-    end
+    system "make", *args
+    system "make", "install-all", *args
   end
 
   test do


### PR DESCRIPTION
use macOS's OSSwapLittleToHostInt16 as a replacement for le16toh