### PR TITLE
mame & rom-tools: use system's expat

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -4,6 +4,7 @@ class Mame < Formula
   url "https://github.com/mamedev/mame/archive/mame0191.tar.gz"
   version "0.191"
   sha256 "e1faed5ee39e977d9a4e60e439c4d36d55a476dbe70a3e8fbe6aadb2a63b1e31"
+  revision 1
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -17,13 +18,13 @@ class Mame < Formula
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
   depends_on "sdl2"
-  depends_on "expat"
   depends_on "jpeg"
   depends_on "flac"
   depends_on "sqlite"
   depends_on "portmidi"
   depends_on "portaudio"
   depends_on "utf8proc"
+  depends_on "expat" if MacOS.version < :el_capitan
 
   # Need C++ compiler and standard library support C++14.
   needs :cxx14

--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -4,6 +4,7 @@ class RomTools < Formula
   url "https://github.com/mamedev/mame/archive/mame0191.tar.gz"
   version "0.191"
   sha256 "e1faed5ee39e977d9a4e60e439c4d36d55a476dbe70a3e8fbe6aadb2a63b1e31"
+  revision 1
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -16,10 +17,10 @@ class RomTools < Formula
   depends_on :python => :build if MacOS.version <= :snow_leopard
   depends_on "pkg-config" => :build
   depends_on "sdl2"
-  depends_on "expat"
   depends_on "flac"
   depends_on "portmidi"
   depends_on "utf8proc"
+  depends_on "expat" if MacOS.version < :el_capitan
 
   def install
     inreplace "scripts/src/osd/sdl.lua", "--static", ""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Recent macOS has expat 2.2, it's latest mahor and minor version. I think mame can use system's expat. I don't test the earlier expat (ships in Yosemite and earlier) can link or not. So Yosemite need Homebrew's expat right now.

~~Also update expat's keg_only reason.~~