### PR TITLE
expat: update keg_only reason

### DIFF
--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -12,7 +12,7 @@ class Expat < Formula
     sha256 "618683020e64ef1ca99d0c2f388262cf32117d93d7f047bf8251461d8af3f04e" => :el_capitan
   end
 
-  keg_only :provided_by_osx, "macOS includes Expat 1.5"
+  keg_only :provided_by_macos
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Since Snow Leopard, Apple ships expat 2.0, and El Capitan ships 2.2, which is not very old. Update reason to fix wrong impression.
