### PR TITLE
task-spooler: add test

### DIFF
--- a/Formula/task-spooler.rb
+++ b/Formula/task-spooler.rb
@@ -17,4 +17,8 @@ class TaskSpooler < Formula
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end
+
+  test do
+    system "#{bin}/ts", "-l"
+  end
 end


### PR DESCRIPTION
I have added a basic test to the task-spooler Formula.  The Formula code details a potential conflict with the installation of [time-stamp](https://linux.die.net/man/1/ts) which also creates a 'ts' executable, so, this test invokes task-spooler with an option (`-l`) that is not available to timesamp, a simple listing of the current tasks `ts -l`

Test output...
```
$ brew test task-spooler 
Testing task-spooler
==> /usr/local/Cellar/task-spooler/1.0/bin/ts -l
```

`brew audit --strict` appears happy.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
