### PR TITLE
nmh 1.7

### DIFF
--- a/Formula/nmh.rb
+++ b/Formula/nmh.rb
@@ -1,16 +1,10 @@
 class Nmh < Formula
   desc "The new version of the MH mail handler"
   homepage "http://www.nongnu.org/nmh/"
-  url "https://download.savannah.gnu.org/releases/nmh/nmh-1.6.tar.gz"
-  sha256 "29338ae2bc8722fe8a5904b7b601a63943b72b07b6fcda53f3a354edb6a64bc3"
+  url "https://download.savannah.gnu.org/releases/nmh/nmh-1.7.tar.gz"
+  sha256 "cd05c7ca2cae524ae99f6ba673463a5cdeff62df93e85913aa9277ae8304ce44"
 
-  bottle do
-    sha256 "7c17be97fcf0b6b79c9142887ce966868ed07c856bdd5e0ecdd9a2767a66fc51" => :high_sierra
-    sha256 "62b6f1754f82dcf84674eeddfe2bf7637262324b384e6d90a52bd2a694061da0" => :sierra
-    sha256 "8c508d92233154eb888357f62d84440526fd2acea65566ef5d3325fd0b57caa8" => :el_capitan
-    sha256 "bdd5c9d0e4bd341df41972b4e651761798660eadbac1332409e184e5e8e2b877" => :yosemite
-  end
-
+  bottle :disable, "Needs to look for helper programs at compile time"
   depends_on "openssl"
 
   def install
@@ -20,6 +14,7 @@ class Nmh < Formula
                           "--prefix=#{prefix}", "--libdir=#{libexec}",
                           "--with-cyrus-sasl",
                           "--with-tls"
+    ENV.append_path "PATH", "#{HOMEBREW_PREFIX}/bin"
     system "make", "install"
   end
 

--- a/Formula/nmh.rb
+++ b/Formula/nmh.rb
@@ -4,7 +4,13 @@ class Nmh < Formula
   url "https://download.savannah.gnu.org/releases/nmh/nmh-1.7.tar.gz"
   sha256 "cd05c7ca2cae524ae99f6ba673463a5cdeff62df93e85913aa9277ae8304ce44"
 
-  bottle :disable, "Needs to look for helper programs at compile time"
+  bottle do
+    sha256 "7c17be97fcf0b6b79c9142887ce966868ed07c856bdd5e0ecdd9a2767a66fc51" => :high_sierra
+    sha256 "62b6f1754f82dcf84674eeddfe2bf7637262324b384e6d90a52bd2a694061da0" => :sierra
+    sha256 "8c508d92233154eb888357f62d84440526fd2acea65566ef5d3325fd0b57caa8" => :el_capitan
+    sha256 "bdd5c9d0e4bd341df41972b4e651761798660eadbac1332409e184e5e8e2b877" => :yosemite
+  end
+
   depends_on "openssl"
 
   def install
@@ -14,7 +20,6 @@ class Nmh < Formula
                           "--prefix=#{prefix}", "--libdir=#{libexec}",
                           "--with-cyrus-sasl",
                           "--with-tls"
-    ENV.append_path "PATH", "#{HOMEBREW_PREFIX}/bin"
     system "make", "install"
   end
 


### PR DESCRIPTION
This update disables the bottle build; nmh looks for some helper programs
at build time and I just couldn't find a good way to make it work from a
binary distribution.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
