### PR TITLE
freenet 1479 (new formula)

### DIFF
--- a/Formula/freenet.rb
+++ b/Formula/freenet.rb
@@ -1,0 +1,26 @@
+class Freenet < Formula
+  desc "P2P platform for censorship-resistant communication & publishing"
+  homepage "https://freenetproject.org"
+  url "https://github.com/freenet/fred/releases/download/build01479/new_installer_offline_1479.jar"
+  sha256 "b630cc310987cd225d5250061abb0e72bc19c5ae3b0870c73a979cafea872760"
+
+  bottle :unneeded
+
+  depends_on :java => "1.7+"
+
+  def install
+    (buildpath/"__FreeNetinstall__").write "INSTALL_PATH=#{libexec}"
+
+    system "java", "-jar", "new_installer_offline_#{version}.jar", "-options", "__FreeNetinstall__"
+
+    bin.install_symlink libexec/"run.sh" => "freenet"
+  end
+
+  def caveats
+    "run wrapper script symlinked to #{bin}/freenet"
+  end
+
+  test do
+    assert_match "Freenet 0.7 is running", shell_output("#{bin}/freenet status", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- could only test on the linuxbrew fork... but it's java, so i'd imagine it's cross platform and should go here?
- patched together from [a legacy commit](https://github.com/Homebrew/legacy-homebrew/blob/1019f672153e6ca3f757576e5415c60c55901157/Library/Formula/freenet.rb) and [the i2p formula](https://github.com/Homebrew/homebrew-core/blob/f0cc548de1decd2d2419da7dac898d9905826d80/Formula/i2p.rb). wasn't sure if there was a reason it wasn't carried over from the legacy repo, didn't see any issues/discussions on that?