### PR TITLE
conjure-up - fix missing symlinks, add pwgen dep

### DIFF
--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -5,6 +5,7 @@ class ConjureUp < Formula
   homepage "https://conjure-up.io/"
   url "https://github.com/conjure-up/conjure-up/archive/2.4.1.tar.gz"
   sha256 "f3f897522691d9ab2016db675b5e1a5cf209f071b1e1784d1e35619ea12a4965"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,6 +21,7 @@ class ConjureUp < Formula
   depends_on "wget"
   depends_on "redis"
   depends_on "awscli"
+  depends_on "pwgen"
 
   # list generated from the 'requirements.txt' file in the repository root
   resource "aiofiles" do
@@ -204,6 +206,8 @@ class ConjureUp < Formula
 
   def install
     virtualenv_install_with_resources
+    bin.install_symlink "#{libexec}/bin/kv-cli"
+    bin.install_symlink "#{libexec}/bin/juju-wait"
   end
 
   test do


### PR DESCRIPTION
Some of our dependencies were in `#{libexec}/bin` and was causing conjure-up to
fail deployments. This addresses that issue by symlinking the requirements into
`/usr/local/bin`

Also, pwgen is required for our k8s tagging and aws bucket creation names.

Fixes https://github.com/conjure-up/conjure-up/issues/1215
Fixes https://github.com/conjure-up/conjure-up/issues/1231

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
