### PR TITLE
qemu.rb: add optional libusb dependency to pass host usb devs

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -35,6 +35,7 @@ class Qemu < Formula
   depends_on "sdl2" => :optional
   depends_on "gtk+" => :optional
   depends_on "libssh2" => :optional
+  depends_on "libusb" => :optional
 
   deprecated_option "with-sdl" => "with-sdl2"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
