### PR TITLE
fix afsctool for High Sierra

### DIFF
--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -4,13 +4,16 @@ class Afsctool < Formula
   url "https://docs.google.com/uc?export=download&id=0BwQlnXqL939ZQjBQNEhRQUo0aUk"
   version "1.6.4"
   sha256 "bb6a84370526af6ec1cee2c1a7199134806e691d1093f4aef060df080cd3866d"
-  revision 1
+  revision 2
 
   # Fixes Sierra "Unable to compress" issue; reported upstream on 24 July 2017
   patch do
     url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.diff?full_index=1"
     sha256 "a541526679eb5d2471b3f257dab6103300d950f7b2f9d49bbfeb9f27dfc48542"
   end
+
+  # Fixes High Sierra "Expecting f_type of 17 or 23. f_type is 24" issue
+  patch :DATA
 
   bottle do
     cellar :any_skip_relocation
@@ -35,3 +38,20 @@ class Afsctool < Formula
     system "#{bin}/afsctool", "-v", path
   end
 end
+
+__END__
+diff --git a/afsctool_34/afsctool.c b/afsctool_34/afsctool.c
+index 8713407fa673f216e69dfc36152c39bc1dea4fe7..7038859f43e035be44c9b8cfbb1bb76a93e26e0a 100644
+--- a/afsctool_34/afsctool.c
++++ b/afsctool_34/afsctool.c
+@@ -104,8 +104,8 @@ void compressFile(const char *inFile, struct stat *inFileInfo, long long int max
+
+ 	if (statfs(inFile, &fsInfo) < 0)
+ 		return;
+-	if (fsInfo.f_type != 17 && fsInfo.f_type != 23) {
+-		printf("Expecting f_type of 17 or 23. f_type is %i.\n", fsInfo.f_type);
++	if (fsInfo.f_type != 17 && fsInfo.f_type != 23 && fsInfo.f_type != 24) {
++		printf("Expecting f_type of 17, 23 or 24. f_type is %i.\n", fsInfo.f_type);
+ 		return;
+ 	}
+ 	if (!S_ISREG(inFileInfo->st_mode))


### PR DESCRIPTION
patch file type to allow file type 24 as well
ref: https://github.com/diimdeep/afsctool/issues/3
original diff: https://github.com/gingerbeardman/afsctool/commit/1fab0d87546f36e24e89a9f73f187b3ff639b920.diff?full_index=1

modified path in patch to afsctool_34/afsctool.c

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
