### PR TITLE
added gdal2 optional dependency in mapnik formula

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -24,6 +24,7 @@ class Mapnik < Formula
   depends_on "jpeg"
   depends_on "webp"
   depends_on "gdal" => :optional
+  depends_on "gdal2" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional
 
@@ -89,7 +90,13 @@ class Mapnik < Formula
     else
       args << "CAIRO=False"
     end
+
+    if build.with?("gdal") && build.with("gdal2")
+      odie "Options --with-gdal and --with-gdal2 are mutually exclusive."
+    end
     args << "GDAL_CONFIG=#{Formula["gdal"].opt_bin}/gdal-config" if build.with? "gdal"
+    args << "GDAL_CONFIG=#{Formula["gdal2"].opt_bin}/gdal-config" if build.with? "gdal2"
+
     args << "PG_CONFIG=#{Formula["postgresql"].opt_bin}/pg_config" if build.with? "postgresql"
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Last check didn't pass before this PR also due to particular situation with boost on Maverics.
```
if MacOS.version < :mavericks
    depends_on "boost" => "c++11"
```
The `=> c++11` bit doesn't pass.