### PR TITLE
skinny 2.5.2

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.5.1/skinny-2.5.1.tar.gz"
-  sha256 "d099f4dc35bb58544c28b6f0a47e650157980326412b29f7e7405738a9c7d200"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.5.2/skinny-2.5.2.tar.gz"
+  sha256 "0d21d017ef2a32a3e0ef497262c846ad3d04f32d4339b26d6cffc70f952527f6"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Skinny 2.5.2 has been released. https://github.com/skinny-framework/skinny-framework/releases/tag/2.5.2

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew audit --strict Formula/skinny.rb
$ $ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.5.2/skinny-2.5.2.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/7b2a41ca-cfd1-11e7-9258-04e62559b281?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20171122%2Fus-eas
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.5.2: 467 files, 61.7MB, built in 42 seconds
```

