### PR TITLE
openresty 1.13.6.1 (new formula).

### DIFF
--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -1,0 +1,106 @@
+class OpenrestyDebug < Formula
+  desc "Scalable Web Platform by Extending NGINX with Lua"
+  homepage "https://openresty.org"
+  VERSION = "1.13.6.1".freeze
+  url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
+  sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"
+
+  option "with-postgresql", "Compile with ngx_http_postgres_module"
+  option "with-iconv", "Compile with ngx_http_iconv_module"
+  option "with-slice", "Compile with ngx_http_slice_module"
+
+  depends_on "pcre"
+  depends_on "postgresql" => :optional
+  depends_on "openresty-openssl"
+  depends_on "geoip"
+
+  skip_clean "site"
+  skip_clean "pod"
+  skip_clean "nginx"
+  skip_clean "luajit"
+
+  def install
+    # Configure
+    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["openresty-openssl"].opt_include}"
+    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["openresty-openssl"].opt_lib}"
+
+    args = %W[
+      --prefix=#{prefix}
+      --pid-path=#{var}/run/openresty.pid
+      --lock-path=#{var}/run/openresty.lock
+      --conf-path=#{etc}/openresty/nginx.conf
+      --http-log-path=#{var}/log/nginx/access.log
+      --error-log-path=#{var}/log/nginx/error.log
+      --with-debug
+      --with-cc-opt=#{cc_opt}
+      --with-ld-opt=#{ld_opt}
+      --with-pcre-jit
+      --without-http_rds_json_module
+      --without-http_rds_csv_module
+      --without-lua_rds_parser
+      --with-ipv6
+      --with-stream
+      --with-stream_ssl_module
+      --with-http_v2_module
+      --without-mail_pop3_module
+      --without-mail_imap_module
+      --without-mail_smtp_module
+      --with-http_stub_status_module
+      --with-http_realip_module
+      --with-http_addition_module
+      --with-http_auth_request_module
+      --with-http_secure_link_module
+      --with-http_random_index_module
+      --with-http_geoip_module
+      --with-http_gzip_static_module
+      --with-http_sub_module
+      --with-http_dav_module
+      --with-http_flv_module
+      --with-http_mp4_module
+      --with-http_gunzip_module
+      --with-threads
+      --with-luajit-xcflags=-DLUAJIT_NUMMODE=2\ -DLUAJIT_ENABLE_LUA52COMPAT
+      --with-dtrace-probes
+    ]
+
+    args << "--with-http_postgres_module" if build.with? "postgresql"
+    args << "--with-http_iconv_module" if build.with? "iconv"
+    args << "--with-http_slice_module" if build.with? "slice"
+
+    system "./configure", *args
+
+    # Install
+    system "make"
+    system "make", "install"
+  end
+
+  plist_options :manual => "openresty"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{opt_prefix}/bin/openresty</string>
+            <string>-g</string>
+            <string>daemon off;</string>
+        </array>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/openresty", "-V"
+  end
+end

--- a/Formula/openresty-openssl.rb
+++ b/Formula/openresty-openssl.rb
@@ -1,0 +1,66 @@
+class OpenrestyOpenssl < Formula
+  desc "This OpenSSL library build is specifically for OpenResty uses"
+  homepage "https://www.openssl.org/"
+  VERSION = "1.0.2k".freeze
+  revision 1
+
+  stable do
+    url "https://www.openssl.org/source/openssl-#{VERSION}.tar.gz"
+    mirror "https://dl.bintray.com/homebrew/mirror/openssl-1#{VERSION}.tar.gz"
+    sha256 "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0"
+
+    patch do
+      url "https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch"
+      sha256 "6d6e02c21769784b106b62a146bfbfeac54884e23520c8dd29b74f3e1348d4a1"
+    end
+  end
+
+  keg_only "only for use with OpenResty"
+
+  def install
+    # OpenSSL will prefer the PERL environment variable if set over $PATH
+    # which can cause some odd edge cases & isn't intended. Unset for safety.
+    ENV.delete("PERL")
+
+    # Load zlib from an explicit path instead of relying on dyld's fallback
+    # path, which is empty in a SIP context. This patch will be unnecessary
+    # when we begin building openssl with no-comp to disable TLS compression.
+    # https://langui.sh/2015/11/27/sip-and-dlopen
+    inreplace "crypto/comp/c_zlib.c",
+              'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
+              'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);'
+
+    args = [
+      "no-threads",
+      "shared",
+      "zlib",
+      "-g",
+      "--openssldir=#{prefix}",
+      "--libdir=lib",
+    ]
+
+    if MacOS.prefer_64_bit?
+      args << "darwin64-x86_64-cc"
+      args << "enable-ec_nistp_64_gcc_128"
+    else
+      args << "darwin-i386-cc"
+    end
+
+    system "./Configure", *args
+
+    # Install
+    system "make"
+    system "make", "install", "MANDIR=#{man}"
+  end
+
+  test do
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system "#{bin}/openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -1,0 +1,107 @@
+class Openresty < Formula
+  desc "Scalable Web Platform by Extending NGINX with Lua"
+  homepage "https://openresty.org"
+  VERSION = "1.13.6.1".freeze
+  url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
+  sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"
+
+  option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
+  option "with-postgresql", "Compile with ngx_http_postgres_module"
+  option "with-iconv", "Compile with ngx_http_iconv_module"
+  option "with-slice", "Compile with ngx_http_slice_module"
+
+  depends_on "pcre"
+  depends_on "postgresql" => :optional
+  depends_on "openresty-openssl"
+  depends_on "geoip"
+
+  skip_clean "site"
+  skip_clean "pod"
+  skip_clean "nginx"
+  skip_clean "luajit"
+
+  def install
+    # Configure
+    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["openresty-openssl"].opt_include}"
+    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["openresty-openssl"].opt_lib}"
+
+    args = %W[
+      --prefix=#{prefix}
+      --pid-path=#{var}/run/openresty.pid
+      --lock-path=#{var}/run/openresty.lock
+      --conf-path=#{etc}/openresty/nginx.conf
+      --http-log-path=#{var}/log/nginx/access.log
+      --error-log-path=#{var}/log/nginx/error.log
+      --with-cc-opt=#{cc_opt}
+      --with-ld-opt=#{ld_opt}
+      --with-pcre-jit
+      --without-http_rds_json_module
+      --without-http_rds_csv_module
+      --without-lua_rds_parser
+      --with-ipv6
+      --with-stream
+      --with-stream_ssl_module
+      --with-http_v2_module
+      --without-mail_pop3_module
+      --without-mail_imap_module
+      --without-mail_smtp_module
+      --with-http_stub_status_module
+      --with-http_realip_module
+      --with-http_addition_module
+      --with-http_auth_request_module
+      --with-http_secure_link_module
+      --with-http_random_index_module
+      --with-http_geoip_module
+      --with-http_gzip_static_module
+      --with-http_sub_module
+      --with-http_dav_module
+      --with-http_flv_module
+      --with-http_mp4_module
+      --with-http_gunzip_module
+      --with-threads
+      --with-luajit-xcflags=-DLUAJIT_NUMMODE=2\ -DLUAJIT_ENABLE_LUA52COMPAT
+      --with-dtrace-probes
+    ]
+
+    args << "--with-http_postgres_module" if build.with? "postgresql"
+    args << "--with-http_iconv_module" if build.with? "iconv"
+    args << "--with-http_slice_module" if build.with? "slice"
+    args << "--with-debug" if build.with? "debug"
+
+    system "./configure", *args
+
+    # Install
+    system "make"
+    system "make", "install"
+  end
+
+  plist_options :manual => "openresty"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{opt_prefix}/bin/openresty</string>
+            <string>-g</string>
+            <string>daemon off;</string>
+        </array>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/openresty", "-V"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

there has a error when audit `openresty-openssl.rb`, I think we can ignore this error. because this formula is build specifically for OpenResty uses, and it needs a patch to openssl.
```
$ brew audit --new-formula Formula/openresty-openssl.rb
openresty-openssl:
  * New formulae should not require patches to build. Patches should be submitted and accepted upstream first.
Error: 1 problem in 1 formula
```
