### PR TITLE
Create faas alias for faas-cli

### DIFF
--- a/Aliases/faas
+++ b/Aliases/faas
@@ -1,0 +1,1 @@
+../Formula/faas-cli.rb

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -25,6 +25,7 @@ class FaasCli < Formula
       system "go", "build", "-ldflags",
              "-s -w -X #{project}/version.GitCommit=#{commit}", "-a",
              "-installsuffix", "cgo", "-o", bin/"faas-cli"
+      bin.install_symlink "faas-cli" => "faas"
       pkgshare.install "template"
       prefix.install_metafiles
     end


### PR DESCRIPTION
As suggested by @ilovezfs - https://github.com/openfaas/faas-cli/issues/130

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [-] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Does not affect formula, adds alias. Let me know if I've not got the process right.