### PR TITLE
sdl2_mixer: make libmodplug required instead of optional

### DIFF
--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -3,6 +3,7 @@ class Sdl2Mixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2.tar.gz"
   sha256 "4e615e27efca4f439df9af6aa2c6de84150d17cbfd12174b54868c12f19c83bb"
+  revision 1
   head "https://hg.libsdl.org/SDL_mixer", :using => :hg
 
   bottle do
@@ -13,12 +14,12 @@ class Sdl2Mixer < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libmodplug"
   depends_on "libvorbis"
   depends_on "sdl2"
   depends_on "flac" => :optional
   depends_on "fluid-synth" => :optional
   depends_on "libmikmod" => :optional
-  depends_on "libmodplug" => :optional
   depends_on "smpeg2" => :optional
 
   def install


### PR DESCRIPTION
ref https://github.com/Homebrew/homebrew-core/pull/20746

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
