### PR TITLE
exim: update Debian patches

### DIFF
--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -3,7 +3,7 @@ class Exim < Formula
   homepage "https://exim.org"
   url "https://ftp.exim.org/pub/exim/exim4/exim-4.89.tar.bz2"
   sha256 "912f2ee03c8dba06a3a4c0ee40522d367e1b65dc59e38dfcc1f5d9eecff51ab0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "e034ee4ff0a3a7c4ba72be9c9dd971dc0e3d26c4559dc30e5c6a67608e54d216" => :high_sierra
@@ -21,9 +21,9 @@ class Exim < Formula
   # Patch applied upstream but doesn't apply cleanly from git.
   # https://github.com/Exim/exim/commit/65e061b76867a9ea7aeeb535341b790b90ae6c21
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/e/exim4/exim4_4.89-7.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/e/exim4/exim4_4.89-7.debian.tar.xz"
-    sha256 "e24464a5a803e4063b32e42543f9a9352ed2fa6bfde7b0f608e59582a23a853f"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/e/exim4/exim4_4.89-11.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/e/exim4/exim4_4.89-11.debian.tar.xz"
+    sha256 "13572f80d8eb93b7d3186bb2cc12c80d9931885dfb6c40ef8a9d477ecdc040e0"
     apply "patches/75_fixes_01-Start-exim-4_89-fixes-to-cherry-pick-some-commits-fr.patch"
     apply "patches/75_fixes_02-Cleanup-prevent-repeated-use-of-p-oMr-to-avoid-mem-l.patch"
     apply "patches/75_fixes_03-Fix-log-line-corruption-for-DKIM-status.patch"
@@ -35,6 +35,13 @@ class Exim < Formula
     apply "patches/75_fixes_10-Fix-cache-cold-random-callout-verify.-Bug-2147.patch"
     apply "patches/75_fixes_11-On-callout-avoid-SIZE-every-time-but-noncacheable-rc.patch"
     apply "patches/75_fixes_12-Fix-build-for-earlier-version-Berkeley-DB.patch"
+    apply "patches/75_fixes_13-Document-CVE-assignment-for-Berkeley-DB-issue.patch"
+    apply "patches/75_fixes_14-DKIM-fix-signing-bug-induced-by-total-size-of-parame.patch"
+    apply "patches/75_fixes_15-SOCKS-fix-unitialized-pointer.patch"
+    apply "patches/75_fixes_16-Fix-crash-in-transport-on-second-smtp-connect-fail-f.patch"
+    apply "patches/75_fixes_17-Fix-queue_run_in_order-to-ignore-the-PID-portion-of-.patch"
+    apply "patches/75_fixes_18-Use-safer-routine-for-possibly-overlapping-copy.patch"
+    apply "patches/78_Disable-chunking-BDAT-by-default.patch"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

to 4.89-11.

Sync with exim-4_89+fixes branch:
- 75_fixes_13-Document-CVE-assignment-for-Berkeley-DB-issue.patch
- 75_fixes_14-DKIM-fix-signing-bug-induced-by-total-size-of-parame.patch
- 75_fixes_15-SOCKS-fix-unitialized-pointer.patch
- 75_fixes_16-Fix-crash-in-transport-on-second-smtp-connect-fail-f.patch
- 75_fixes_17-Fix-queue_run_in_order-to-ignore-the-PID-portion-of-.patch
- 75_fixes_18-Use-safer-routine-for-possibly-overlapping-copy.patch

Patch for unfixed security issue:
- 78_Disable-chunking-BDAT-by-default.patch

"As a workaround for the yet-unfixed security vulnerability resurrect
78_Disable-chunking-BDAT-by-default.patch (dropped in 4.89-4) to disable
both incoming and outgoing BDAT/CHUNKING." Debian 882648

https://lists.exim.org/lurker/message/20171125.034842.d1d75cac.en.html

CC @DomT4 :face_with_head_bandage: