### PR TITLE
libwebsockets: add compile options

### DIFF
--- a/Formula/libwebsockets.rb
+++ b/Formula/libwebsockets.rb
@@ -3,6 +3,7 @@ class Libwebsockets < Formula
   homepage "https://libwebsockets.org"
   url "https://github.com/warmcat/libwebsockets/archive/v2.4.1.tar.gz"
   sha256 "29414be4f79f6abc0e6aadccd09a4da0f0c431e3b5691f496acd081ae6a8240c"
+  revision 1
   head "https://github.com/warmcat/libwebsockets.git"
 
   bottle do
@@ -13,9 +14,23 @@ class Libwebsockets < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
+  depends_on "libev"
+  depends_on "libuv"
+  depends_on "libevent"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    cmake_args = std_cmake_args.concat %w[
+      -DLWS_WITH_LIBEV=ON
+      -DLWS_WITH_LIBUV=ON
+      -DLWS_WITH_LIBEVENT=ON
+      -DLWS_WITH_HTTP2=ON
+      -DLWS_IPV6=ON
+      -DLWS_UNIX_SOCK=ON
+      -DLWS_WITH_PLUGINS=ON
+      -DLWS_WITHOUT_TESTAPPS=ON
+    ]
+
+    system "cmake", ".", *cmake_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add some common compile options for the libwebsockets package.