### PR TITLE
electrum 3.0.2 (new formula)

### DIFF
--- a/Formula/electrum.rb
+++ b/Formula/electrum.rb
@@ -1,0 +1,21 @@
+class Electrum < Formula
+  desc "Lightweight Bitcoin wallet"
+  homepage "https://electrum.org/#home"
+  url "https://download.electrum.org/3.0.2/Electrum-3.0.2.tar.gz"
+  sha256 "4dff75bc5f496f03ad7acbe33f7cec301955ef592b0276f2c518e94e47284f53"
+
+  depends_on "pyqt"
+  depends_on "qt"
+  depends_on "gettext"
+  depends_on :python3
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"electrum"
+  end
+
+  test do
+    ENV["LANG"] = "en_US.UTF-8"
+    assert_match version.to_s, shell_output("#{bin}/electrum version 2>&1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- could only test on linuxbrew
- got `depends_on`s from [the install from python sources osx section here](https://electrum.org/#download)
- the gui wouldn't show any text or icons, but it's the same behavior i get with [`wireshark --with-qt`](https://github.com/Homebrew/homebrew-core/blob/dd0a80cdb039a11f47233adf4b71ad542e296e58/Formula/wireshark.rb#L47). which makes me think that's not a problem with this so much as something with qt/my env/linux/etc?
  - my error message for future reference/discovery (adding `depends_on "fontconfig"` didn't fix 😢) 
  ```
  QFontDatabase: Cannot find font directory /home/linuxbrew/.linuxbrew/Cellar/qt/5.9.3/lib/fonts.
  Note that Qt no longer ships fonts. Deploy some (from http://dejavu-fonts.org for example) or switch to fontconfig.
  ```
