### PR TITLE
libsndfile 1.0.28 allow disabling external libs

### DIFF
--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -12,6 +12,8 @@ class Libsndfile < Formula
     sha256 "9df59790751d64c7f61682233a733030de9e6406682f3a15e30e708103930038" => :yosemite
   end
 
+  option "without-external-libs", "Disable external libraries (Flac and Vorbis)"
+
   depends_on "pkg-config" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -21,8 +23,15 @@ class Libsndfile < Formula
   depends_on "libvorbis"
 
   def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+    ]
+
+    args << "--disable-external-libs" if build.without? "external-libs"
+
     system "autoreconf", "-fvi"
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request allow to disable the external libraries for `libsndfile` (Flac, Vorbis).