### PR TITLE
stress-ng 0.09.04 (new formula)

### DIFF
--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -10,6 +10,6 @@ class StressNg < Formula
   end
 
   test do
-    system "#{bin}/stress-ng", "--cpu 1", "--timeout 1s"
+    system "#{bin}/stress-ng", "-c 1", "-t 1"
   end
 end

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -4,6 +4,8 @@ class StressNg < Formula
   url "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.06.tar.xz"
   sha256 "59c09c7cccb34222dc124ce8622a0ac73fe9391ba16a4a561267ca55c02f2520"
 
+  depends_on :macos => :sierra
+
   def install
     inreplace "Makefile", "/usr", prefix
     system "make"

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -1,8 +1,8 @@
 class StressNg < Formula
   desc "Stress test a computer system in various selectable ways"
   homepage "http://kernel.ubuntu.com/~cking/stress-ng/"
-  url "https://github.com/ColinIanKing/stress-ng/archive/V0.09.04.tar.gz"
-  sha256 "83bb1f11e66df753f16dd924c36fea9df20281ca85d49d07c15d970fe902baa4"
+  url "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.06.tar.xz"
+  sha256 "59c09c7cccb34222dc124ce8622a0ac73fe9391ba16a4a561267ca55c02f2520"
 
   def install
     system "make"

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -5,8 +5,9 @@ class StressNg < Formula
   sha256 "59c09c7cccb34222dc124ce8622a0ac73fe9391ba16a4a561267ca55c02f2520"
 
   def install
+    inreplace "Makefile", "/usr", prefix
     system "make"
-    bin.install "stress-ng"
+    system "make", "install"
   end
 
   test do

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -1,0 +1,15 @@
+class StressNg < Formula
+  desc "Stress test a computer system in various selectable ways"
+  homepage "http://kernel.ubuntu.com/~cking/stress-ng/"
+  url "https://github.com/ColinIanKing/stress-ng/archive/V0.09.04.tar.gz"
+  sha256 "83bb1f11e66df753f16dd924c36fea9df20281ca85d49d07c15d970fe902baa4"
+
+  def install
+    system "make"
+    bin.install "stress-ng"
+  end
+
+  test do
+    system "#{bin}/stress-ng", "--cpu 1", "--timeout 1s"
+  end
+end

--- a/Formula/stress-ng.rb
+++ b/Formula/stress-ng.rb
@@ -13,6 +13,7 @@ class StressNg < Formula
   end
 
   test do
-    system "#{bin}/stress-ng", "-c 1", "-t 1"
+    output = shell_output("#{bin}/stress-ng -c 1 -t 1")
+    assert_includes "successful run completed", output
   end
 end


### PR DESCRIPTION
Adds a new formula for [`stress-ng`](https://github.com/ColinIanKing/stress-ng) which is useful for generating
system load and testing of various components like CPU, memory,
syscalls.

--- 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?