### PR TITLE
open-scene-graph 3.5.9

### DIFF
--- a/Formula/open-scene-graph.rb
+++ b/Formula/open-scene-graph.rb
@@ -1,8 +1,8 @@
 class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "https://github.com/openscenegraph/OpenSceneGraph"
-  url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.5.8.tar.gz"
-  sha256 "bda0770ec6167baa864617c49fb379eb56adced1f21e80f6cd8c75578f6702df"
+  url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.5.9.tar.gz"
+  sha256 "e18bd54d7046ea73525941244ef4f77b38b2a90bdf21d81468ac3874c41e9448"
   head "https://github.com/openscenegraph/OpenSceneGraph.git"
 
   bottle do
@@ -43,6 +43,12 @@ class OpenSceneGraph < Formula
   end
 
   def install
+    # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
+    # "error: expected function body after function declarator" on 10.12
+    if MacOS.version == :sierra || MacOS.version == :el_capitan
+      ENV["SDKROOT"] = MacOS.sdk_path
+    end
+
     ENV.cxx11 if build.cxx11?
 
     # Turning off FFMPEG takes this change or a dozen "-DFFMPEG_" variables


### PR DESCRIPTION
10.11:
```
In file included from /tmp/open-scene-graph-20171129-85672-3mba1j/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:6:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:43:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFBase.h:18:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFAvailability.h:21:10: fatal error: 'os/availability.h' file not found
#include <os/availability.h>
         ^
```

10.12
```
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:28:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecCertificate.h:181:5: error: expected function body after function declarator
    __OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
    ^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:61:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:28:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecCertificate.h:205:5: error: expected function body after function declarator
    __OSX_AVAILABLE_BUT_DEPRECATED_MSG(__MAC_10_7, __MAC_10_13, __IPHONE_NA, __IPHONE_NA, "SecCertificateCopySerialNumber is deprecated. Use SecCertificateCopySerialNumberData instead.");
    ^
/usr/include/Availability.h:204:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED_MSG'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep##_MSG(_msg)
                                                    ^
<scratch space>:61:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_7_DEP__MAC_10_13_MSG
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:35:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecImportExport.h:41:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecKeychain.h:610:2: error: expected function body after function declarator
        __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_2, __MAC_10_13, __IPHONE_NA, __IPHONE_NA);
        ^
/usr/include/Availability.h:202:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep
                                                    ^
<scratch space>:23:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_2_DEP__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:35:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecImportExport.h:41:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecKeychain.h:620:2: error: expected function body after function declarator
        __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_2, __MAC_10_13, __IPHONE_NA, __IPHONE_NA);
        ^
/usr/include/Availability.h:202:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep
                                                    ^
<scratch space>:23:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_2_DEP__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:36:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:170:67: error: expected ';' after top level declarator
extern const CFStringRef kSecTrustCertificateTransparencyWhiteList
                                                                  ^
                                                                  ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:615:5: error: expected function body after function declarator
    __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_3, __MAC_10_13, __IPHONE_NA, __IPHONE_NA);
    ^
/usr/include/Availability.h:202:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep
                                                    ^
<scratch space>:23:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_3_DEP__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:99:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/CMSDecoder.h:130:5: error: expected function body after function declarator
    __OSX_AVAILABLE_BUT_DEPRECATED_MSG(__MAC_10_5, __MAC_10_13, __IPHONE_NA, __IPHONE_NA,
    ^
/usr/include/Availability.h:204:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED_MSG'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep##_MSG(_msg)
                                                    ^
<scratch space>:30:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_5_DEP__MAC_10_13_MSG
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:104:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:319:51: error: expected ';' after top level declarator
extern const CFStringRef kSSLSessionConfig_default
                                                  ^
                                                  ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:335:56: error: expected ';' after top level declarator
extern const CFStringRef kSSLSessionConfig_RC4_fallback
                                                       ^
                                                       ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:343:62: error: expected ';' after top level declarator
extern const CFStringRef kSSLSessionConfig_TLSv1_RC4_fallback
                                                             ^
                                                             ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:359:57: error: expected ';' after top level declarator
extern const CFStringRef kSSLSessionConfig_3DES_fallback
                                                        ^
                                                        ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:363:63: error: expected ';' after top level declarator
extern const CFStringRef kSSLSessionConfig_TLSv1_3DES_fallback
                                                              ^
                                                              ;
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:820:5: error: expected function body after function declarator
    __OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
    ^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:18:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:104:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:1191:5: error: expected function body after function declarator
    __OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
    ^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:18:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:104:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:1209:5: error: expected function body after function declarator
    __OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
    ^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:18:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:104:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:1220:1: error: expected function body after function declarator
__OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:18:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:85:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLCredential.h:9:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/Security.h:104:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Security.framework/Headers/SecureTransport.h:1501:5: error: expected function body after function declarator
    __OSX_AVAILABLE_STARTING(__MAC_10_13, __IPHONE_11_0);
    ^
/usr/include/Availability.h:200:50: note: expanded from macro '__OSX_AVAILABLE_STARTING'
    #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_osx
                                                 ^
<scratch space>:18:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_13
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:87:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLError.h:14:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:39:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/LaunchServices.h:22:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/IconsCore.h:663:70: error: expected function body after function declarator
  SInt16 *                 outLabel)               /* can be NULL */ __OSX_AVAILABLE_BUT_DEPRECATED_MSG(__MAC_10_1, __MAC_10_13, __IPHONE_NA, __IPHONE_NA, "Use -[NSWorkspace iconForFile:] instead.");
                                                                     ^
/usr/include/Availability.h:204:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED_MSG'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep##_MSG(_msg)
                                                    ^
<scratch space>:29:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_1_DEP__MAC_10_13_MSG
^
In file included from /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/FileUtils.cpp:892:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:87:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLError.h:14:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:39:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/LaunchServices.h:22:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/IconsCore.h:899:63: error: expected function body after function declarator
  IconRef *      theIconRef)                                  __OSX_AVAILABLE_BUT_DEPRECATED_MSG(__MAC_10_1, __MAC_10_13, __IPHONE_NA, __IPHONE_NA, "You do not need to register .icns files to use them with -[NSImage initWithContentsOfURL:].");
                                                              ^
/usr/include/Availability.h:204:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED_MSG'
                                                    __AVAILABILITY_INTERNAL##_osxIntro##_DEP##_osxDep##_MSG(_msg)
                                                    ^
<scratch space>:29:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_1_DEP__MAC_10_13_MSG
^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
[ 16%] Building CXX object src/osgDB/CMakeFiles/osgDB.dir/ImagePager.cpp.o
cd /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/build/src/osgDB && /usr/local/Homebrew/Library/Homebrew/shims/super/clang++  -DDARWIN_IMAGEIO -DOSGDB_LIBRARY -DOSG_DEFAULT_LIBRARY_PATH=\"/usr/local/Cellar/open-scene-graph/3.5.9/lib/osgPlugins-3.5.9\" -DOSG_PLUGIN_EXTENSION=.so -DUSE_AV_FOUNDATION -DUSE_ZLIB -DosgDB_EXPORTS -I/tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/include -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks -I/tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/build/include  -Wno-error=narrowing -std=c++11 -stdlib=libc++  -Wno-conversion -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.8 -fPIC   -o CMakeFiles/osgDB.dir/ImagePager.cpp.o -c /tmp/open-scene-graph-20171129-53123-ghd1ol/OpenSceneGraph-OpenSceneGraph-3.5.9/src/osgDB/ImagePager.cpp
20 errors generated.
make[2]: *** [src/osgDB/CMakeFiles/osgDB.dir/FileUtils.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/osgDB/CMakeFiles/osgDB.dir/all] Error 2
make: *** [all] Error 2
```