### PR TITLE
Git-FTP Homepage update [1 Line]

### DIFF
--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -1,6 +1,6 @@
 class GitFtp < Formula
   desc "Git-powered FTP client"
-  homepage "https://git-ftp.github.io/git-ftp"
+  homepage "https://git-ftp.github.io/"
   url "https://github.com/git-ftp/git-ftp/archive/1.4.0.tar.gz"
   sha256 "080e9385a9470d70a5a2a569c6e7db814902ffed873a77bec9d0084bcbc3e054"
   revision 3


### PR DESCRIPTION
Git-FTP homepage moved to https://git-ftp.github.io/

---

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?