### PR TITLE
rst-lint 1.1.2 (new formula)

### DIFF
--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -5,7 +5,6 @@ class RstLint < Formula
   homepage "https://github.com/twolfson/restructuredtext-lint"
   url "https://github.com/twolfson/restructuredtext-lint/archive/1.1.2.tar.gz"
   sha256 "baa99906eaafc00a975a8dee59f6bbbbecc21add2eb630dce6bef64ac0efd4d0"
-  head "https://github.com/twolfson/restructuredtext-lint.git"
 
   depends_on :python if MacOS.version <= :snow_leopard
 
@@ -24,15 +23,14 @@ class RstLint < Formula
       Hello World
       ===========
     EOS
-    assert_equal "",
-      shell_output("#{bin}/rst-lint pass.rst")
+    assert_equal "", shell_output("#{bin}/rst-lint pass.rst")
 
     # test invocation on a file with a whitespace style issue
     (testpath/"fail.rst").write <<~EOS
       Hello World
       ==========
     EOS
-    assert_match "WARNING fail.rst:2 Title underline too short.",
-      shell_output("#{bin}/rst-lint fail.rst", 2)
+    output = shell_output("#{bin}/rst-lint fail.rst", 2)
+    assert_match "WARNING fail.rst:2 Title underline too short.", output
   end
 end

--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -1,0 +1,38 @@
+class RstLint < Formula
+  include Language::Python::Virtualenv
+
+  desc "ReStructuredText linter"
+  homepage "https://github.com/twolfson/restructuredtext-lint"
+  url "https://github.com/twolfson/restructuredtext-lint/archive/1.1.2.tar.gz"
+  sha256 "baa99906eaafc00a975a8dee59f6bbbbecc21add2eb630dce6bef64ac0efd4d0"
+  head "https://github.com/twolfson/restructuredtext-lint.git"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  resource "docutils" do
+    url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
+    sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # test invocation on a file with no issues
+    (testpath/"pass.rst").write <<~EOS
+      Hello World
+      ===========
+    EOS
+    assert_equal "",
+      shell_output("#{bin}/rst-lint pass.rst")
+
+    # test invocation on a file with a whitespace style issue
+    (testpath/"fail.rst").write <<~EOS
+      Hello World
+      ==========
+    EOS
+    assert_match "WARNING fail.rst:2 Title underline too short.",
+      shell_output("#{bin}/rst-lint fail.rst", 2)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixed the following audit error:

Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<~`.