### PR TITLE
gdk-pixbuf: make introspection optional

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -19,7 +19,7 @@ class GdkPixbuf < Formula
   depends_on "jpeg"
   depends_on "libtiff"
   depends_on "libpng"
-  depends_on "gobject-introspection"
+  depends_on "gobject-introspection" => :recommended
 
   # gdk-pixbuf has an internal version number separate from the overall
   # version number that specifies the location of its module and cache
@@ -43,7 +43,6 @@ class GdkPixbuf < Formula
       --disable-maintainer-mode
       --enable-debug=no
       --prefix=#{prefix}
-      --enable-introspection=yes
       --disable-Bsymbolic
       --enable-static
       --without-gdiplus
@@ -51,6 +50,12 @@ class GdkPixbuf < Formula
 
     args << "--enable-relocations" if build.with?("relocations")
     args << "--disable-modules" if build.without?("modules")
+
+    if build.with? "gobject-introspection"
+      args << "--enable-introspection=yes"
+    else
+      args << "--enable-introspection=no"
+    end
 
     included_loaders = ARGV.value("with-included-loaders")
     args << "--with-included-loaders=#{included_loaders}" if included_loaders


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? (no but unrelated existing issue)

-----


Add an option to make gobject-introspection dependency optional, similar to e.g. [gmime](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gmime.rb#L26-L30), [harfbuzz](https://github.com/Homebrew/homebrew-core/blob/master/Formula/harfbuzz.rb#L63-L66), [libsecret](https://github.com/Homebrew/homebrew-core/blob/30abddeed8f2b8d6e3d7b5ee313ddcd2c8ff1671/Formula/libsecret.rb#L35) etc.
