### PR TITLE
gcc: make head use suffix -HEAD

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -37,7 +37,7 @@ class Gcc < Formula
 
   def version_suffix
     if build.head?
-      (stable.version.to_s.slice(/\d/).to_i + 1).to_s
+      "HEAD"
     else
       version.to_s.slice(/\d/)
     end

--- a/Formula/gcc@4.7.rb
+++ b/Formula/gcc@4.7.rb
@@ -27,8 +27,6 @@ class GccAT47 < Formula
   sha256 "92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282"
   revision 2
 
-  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_7-branch"
-
   bottle do
     sha256 "ae12d27145ab23128be647f41dedebb65fadd504e51ee2a40ed8555044b53577" => :sierra
     sha256 "d00547a951f6b099fbd5fd70c8d6a587e5afe5d0073616c5287a0cc1b8ba920a" => :el_capitan

--- a/Formula/gcc@4.8.rb
+++ b/Formula/gcc@4.8.rb
@@ -26,8 +26,6 @@ class GccAT48 < Formula
   mirror "https://ftpmirror.gnu.org/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
   sha256 "22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23"
 
-  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_8-branch"
-
   bottle do
     rebuild 2
     sha256 "d1092bf457e37a92cc1e9d89ec9f044b29942607dca7e7893f4f94038f8e057e" => :sierra

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -24,7 +24,6 @@ class GccAT49 < Formula
   url "https://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
   mirror "https://ftpmirror.gnu.org/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
   sha256 "6c11d292cd01b294f9f84c9a59c230d80e9e4a47e5c6355f046bb36d4f358092"
-  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
 
   bottle do
     sha256 "2f1986799871c617b028645427210d57ad82d9428402c9b090c462e85fe4fb28" => :high_sierra


### PR DESCRIPTION
Instead of gcc HEAD being `gcc-8` (8 = 7 + 1, where 7 is stable's major version), install it as `gcc-HEAD`. This was decided as the best course in #7642