### PR TITLE
kops 1.8.0 (devel)

### DIFF
--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -14,8 +14,8 @@ class Kops < Formula
   end
 
   devel do
-    url "https://github.com/kubernetes/kops/archive/1.8.0-beta.2.tar.gz"
-    sha256 "f82a3fd9672a839b3991b7109a0d2fc5e73491e104c5afcb0168e65d20cffcd9"
+    url "https://github.com/kubernetes/kops/archive/1.8.0.tar.gz"
+    sha256 "dfab4c304247723d02cdabc83840ff0fbfd8ae4238d248839b06cd62f84400d7"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## Update kops --devel to [1.8.0](https://github.com/kubernetes/kops/releases/tag/1.8.0)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
$ brew bump-formula-pr kops \
>        --devel \
>        --url=https://github.com/kubernetes/kops/archive/1.8.0.tar.gz \
>        --sha256=dfab4c304247723d02cdabc83840ff0fbfd8ae4238d248839b06cd62f84400d7

Updated Homebrew from 459fef3b to 0ad42ebb.
No changes to formulae.
==> replace "https://github.com/kubernetes/kops/archive/1.8.0-beta.2.tar.gz" with "https://github.com/kubernetes/kops/archive/1.8.0.tar.gz"
==> replace "f82a3fd9672a839b3991b7109a0d2fc5e73491e104c5afcb0168e65d20cffcd9" with "dfab4c304247723d02cdabc83840ff0fbfd8ae4238d248839b06cd62f84400d7"

$ brew install --devel kops
==> Downloading https://github.com/kubernetes/kops/archive/1.8.0.tar.gz
==> Downloading from https://codeload.github.com/kubernetes/kops/tar.gz/1.8.0
######################################################################## 100.0%
==> make -C /private/tmp/kops-20171204-9394-aat2yh/kops-1.8.0/src/k8s.io/kops
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/kops/1.8.0: 5 files, 121.8MB, built in 2 minutes 28 seconds


$ brew audit --strict kops
==> Installing or updating 'rubocop' gem
Fetching: parallel-1.12.0.gem (100%)
Successfully installed parallel-1.12.0
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.4.0.2.gem (100%)
Successfully installed parser-2.4.0.2
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions.  This could take a while...
Successfully installed rainbow-2.2.2
Fetching: ruby-progressbar-1.9.0.gem (100%)
Successfully installed ruby-progressbar-1.9.0
Fetching: unicode-display_width-1.3.0.gem (100%)
Successfully installed unicode-display_width-1.3.0
Fetching: rubocop-0.51.0.gem (100%)
Successfully installed rubocop-0.51.0
8 gems installed
```