### PR TITLE
mpv: switch to lua@5.1

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,7 +3,8 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.27.0.tar.gz"
   sha256 "341d8bf18b75c1f78d5b681480b5b7f5c8b87d97a0d4f53a5648ede9c219a49c"
-  revision 2
+  revision 3
+
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
@@ -19,10 +20,10 @@ class Mpv < Formula
 
   depends_on "libass"
   depends_on "ffmpeg"
+  depends_on "lua@5.1"
 
   depends_on "jpeg" => :recommended
   depends_on "little-cms2" => :recommended
-  depends_on "lua" => :recommended
   depends_on "youtube-dl" => :recommended
 
   depends_on "jack" => :optional


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Silently fails to build against Lua 5.3.

Fixes https://github.com/Homebrew/homebrew-core/issues/21388.