### PR TITLE
poppler: add option to build with NSS

### DIFF
--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -12,6 +12,7 @@ class Poppler < Formula
 
   option "with-qt", "Build Qt5 backend"
   option "with-little-cms2", "Use color management system"
+  option "with-nss", "Use NSS library for PDF signature validation"
 
   deprecated_option "with-qt4" => "with-qt"
   deprecated_option "with-qt5" => "with-qt"
@@ -31,6 +32,7 @@ class Poppler < Formula
   depends_on "openjpeg"
   depends_on "qt" => :optional
   depends_on "little-cms2" => :optional
+  depends_on "nss" => :optional
 
   conflicts_with "pdftohtml", "pdf2image", "xpdf",
     :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"


### PR DESCRIPTION
This option enables the build of signature verification API in libpoppler and a new
commandline utility: pdfsig

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
