### PR TITLE
osx-iso 3.0.0 (new formula)

### DIFF
--- a/Formula/osx-iso.rb
+++ b/Formula/osx-iso.rb
@@ -1,0 +1,15 @@
+class OsxIso < Formula
+  desc "Create a bootable ISO of OS X / macOS, from the installation app file"
+  homepage "https://github.com/busterc/osx-iso"
+  url "https://github.com/busterc/osx-iso/archive/3.0.0.tar.gz"
+  sha256 "65949e58ef68320cb62fb22341fccde3dabb9767d52a5ab00a2aab7f056b5874"
+  head "https://github.com/busterc/osx-iso.git"
+
+  def install
+    bin.install "osxiso"
+  end
+
+  test do
+    File.exist?("#{bin}/osxiso")
+  end
+end


### PR DESCRIPTION
Add osx-iso formula to homebrew core.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
