### PR TITLE
Gpredict 2.0 (new formula)

### DIFF
--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -1,0 +1,30 @@
+class Gpredict < Formula
+  desc "Real-time satellite tracking/prediction application"
+  homepage "http://gpredict.oz9aec.net/"
+  url "https://downloads.sourceforge.net/project/gpredict/Gpredict/2.0/gpredict-2.0.tar.gz"
+  sha256 "508f882383eac326aecb0b058378fc71f13b431c581e0efc28ee3c4216c76e16"
+
+  depends_on :x11
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "goocanvas"
+  depends_on "gtk+"
+  depends_on "hamlib"
+  depends_on "adwaita-icon-theme"
+
+  def install
+    gettext = Formula["gettext"]
+    ENV.append "CFLAGS", "-I#{gettext.include}"
+    ENV.append "LDFLAGS", "-L#{gettext.lib}"
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"gpredict", "-h"
+  end
+end


### PR DESCRIPTION
Gpredict 2.0 doesn't depend on obsolete versions of goocanvas anymore. Works fine with XQuartz on Mac OS 10.12 High Sierra

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
