### PR TITLE
gpredict 2.2.1 (new formula)

### DIFF
--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -1,29 +1,25 @@
 class Gpredict < Formula
   desc "Real-time satellite tracking/prediction application"
   homepage "http://gpredict.oz9aec.net/"
-  url "https://downloads.sourceforge.net/project/gpredict/Gpredict/2.0/gpredict-2.0.tar.gz"
-  sha256 "508f882383eac326aecb0b058378fc71f13b431c581e0efc28ee3c4216c76e16"
+  url "https://github.com/csete/gpredict/releases/download/v2.2.1/gpredict-2.2.1.tar.bz2"
+  sha256 "e759c4bae0b17b202a7c0f8281ff016f819b502780d3e77b46fe8767e7498e43"
 
-  depends_on "pkg-config" => :build
   depends_on "intltool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "adwaita-icon-theme"
   depends_on "gettext"
   depends_on "glib"
   depends_on "goocanvas"
   depends_on "gtk+3"
   depends_on "hamlib"
-  depends_on "adwaita-icon-theme"
 
   def install
-    gettext = Formula["gettext"]
-    ENV.append "CFLAGS", "-I#{gettext.include}"
-    ENV.append "LDFLAGS", "-L#{gettext.lib}"
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
-    system bin/"gpredict", "-h"
+    assert_match "real-time", shell_output("bin/gpredict -h")
   end
 end

--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -20,6 +20,6 @@ class Gpredict < Formula
   end
 
   test do
-    assert_match "real-time", shell_output("bin/gpredict -h")
+    assert_match "real-time", shell_output("#{bin}/gpredict -h")
   end
 end

--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -1,0 +1,29 @@
+class Gpredict < Formula
+  desc "Real-time satellite tracking/prediction application"
+  homepage "http://gpredict.oz9aec.net/"
+  url "https://downloads.sourceforge.net/project/gpredict/Gpredict/2.0/gpredict-2.0.tar.gz"
+  sha256 "508f882383eac326aecb0b058378fc71f13b431c581e0efc28ee3c4216c76e16"
+
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "goocanvas"
+  depends_on "gtk+3"
+  depends_on "hamlib"
+  depends_on "adwaita-icon-theme"
+
+  def install
+    gettext = Formula["gettext"]
+    ENV.append "CFLAGS", "-I#{gettext.include}"
+    ENV.append "LDFLAGS", "-L#{gettext.lib}"
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"gpredict", "-h"
+  end
+end


### PR DESCRIPTION
Gpredict is a real time satellite tracking and orbit prediction program

https://github.com/csete/gpredict

---


Tidying up @mathisschmieder `PR` Homebrew/homebrew-core#21522
Removed dep on `x11` added `gtk+3` dep

---

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

## I did but the `PR` Homebrew/homebrew-core#21522 has dependency issues

- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?