### PR TITLE
optipng: add two CVE fixes

### DIFF
--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -1,6 +1,8 @@
 class Optipng < Formula
   desc "PNG file optimizer"
   homepage "https://optipng.sourceforge.io/"
+  revision 1
+
   head "http://hg.code.sf.net/p/optipng/mercurial", :using => :hg
 
   stable do
@@ -20,6 +22,17 @@ class Optipng < Formula
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/a42e7b3/optipng/optipng-10.13-st_atim.patch"
       sha256 "89849450fa922af0c96e64e316b5f626ec46486cb5d59f85cd4716d2c5fa0173"
+    end
+
+    # https://sourceforge.net/p/optipng/bugs/69/ - CVE-2017-16938
+    # https://sourceforge.net/p/optipng/bugs/65/ - CVE-2017-1000229
+    # Upstream fixes for both should land in 0.7.7, which is due before 2018.
+    patch do
+      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/optipng/optipng_0.7.6-1.1.debian.tar.bz2"
+      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/optipng/optipng_0.7.6-1.1.debian.tar.bz2"
+      sha256 "eef445316b92630920839a0f7249f1a041bafaa95e18c3188eabb84f41d52851"
+      apply "patches/CVE-2017-16938",
+            "patches/CVE-2017-1000229"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As far as I'm aware CVE-2017-1000229 pretty much shouldn't be a problem for any recent version of macOS as it seems to be an issue on 32-bit platforms only, but since it doesn't hurt to patch and the other one does _seem_ to be applicable, 🤷‍♂️.