### PR TITLE
audacious: fix build with Qt 5.10

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -57,6 +57,13 @@ class Audacious < Formula
   depends_on "libmms" => :optional
   depends_on "libmodplug" => :optional
 
+  # Fixes "info_bar.cc:258:21: error: no viable overloaded '='"
+  # Upstream PR from 11 Dec 2017 "qtui: fix build with Qt 5.10"
+  resource "qt510_patch" do
+    url "https://github.com/audacious-media-player/audacious-plugins/pull/62.patch?full_index=1"
+    sha256 "055e11096de7a8b695959b0d5f69a7f84630764f7abd7ec7b4dc3f14a719d9de"
+  end
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -74,6 +81,8 @@ class Audacious < Formula
     system "make", "install"
 
     resource("plugins").stage do
+      Pathname.pwd.install resource("qt510_patch")
+      system "patch", "-p1", "-i", "62.patch"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{lib}/pkgconfig"
 
       system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow-up to https://github.com/Homebrew/homebrew-core/pull/21435.