### PR TITLE
pyenv: fix add option to install bash_completions

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -24,6 +24,10 @@ class Pyenv < Formula
     system "src/configure"
     system "make", "-C", "src"
 
+    bash_completion.install "completions/pyenv.bash"
+    fish_completion.install "completions/pyenv.fish"
+    zsh_completion.install "completions/pyenv.zsh"
+
     prefix.install Dir["*"]
     %w[pyenv-install pyenv-uninstall python-build].each do |cmd|
       bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
