### PR TITLE
gcc: secure head url (attempt #2)

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -2,7 +2,7 @@ class Gcc < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
 
-  head "svn://gcc.gnu.org/svn/gcc/trunk"
+  head "https://gcc.gnu.org/svn/gcc/trunk", :using => :svn
 
   stable do
     url "https://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This was applied earlier this year, then reverted due to this: https://github.com/Homebrew/homebrew-core/issues/11581

The issue (at least what I experienced in local tests) was that the `svn co` command eventually failed in the middle of the process, suggesting issues on the server configuration side.

Anyhow, it'd be nice to avoid checking out C compiler source code via cleartext, so I'd give this another go in the hope the issue got fixed since. This time the checkout completes on High Sierra, using `/usr/bin/svn`.

Alternatively, this officially listed Git mirror (as suggested in the original report) could be used instead: https://gcc.gnu.org/git/gcc.git ~~(or https://github.com/gcc-mirror/gcc even)~~ [it's mirrored from a cleartext git:// URL]

/cc @fxcoudert