### PR TITLE
flyway 5.0.2 (updated formula) - Updated flyway verson from 4.2.0

### DIFF
--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -1,8 +1,8 @@
 class Flyway < Formula
   desc "Database version control to control migrations"
   homepage "https://flywaydb.org/"
-  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/4.2.0/flyway-commandline-4.2.0.tar.gz"
-  sha256 "c198497cdbad6eaec052cf7db1999c7899998e4d0c980bcad757998e8139b2bb"
+  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/5.0.2/flyway-commandline-5.0.2-macosx-x64.tar.gz"
+  sha256 "acda5a1d1b04b8e58969feb85bd4eed7d830099c057337b92d481b16a7f17fe2"
 
   bottle :unneeded
 

--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -1,8 +1,8 @@
 class Flyway < Formula
   desc "Database version control to control migrations"
   homepage "https://flywaydb.org/"
-  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/5.0.2/flyway-commandline-5.0.2-macosx-x64.tar.gz"
-  sha256 "acda5a1d1b04b8e58969feb85bd4eed7d830099c057337b92d481b16a7f17fe2"
+  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/5.0.2/flyway-commandline-5.0.2.tar.gz"
+  sha256 "23ee3d33f571ec5f76288680b0bf276e0e6e758da5ab2ae6ed43098688dab7ac"
 
   bottle :unneeded
 


### PR DESCRIPTION
Flyway 4.2.0 has a conflict with Java 9 - [flyway issue 1545](https://github.com/flyway/flyway/issues/1545) and no longer works on the latest version of MacOS. Flyway 5.0.2 works with Java 9 and the latest version of MacOS