### PR TITLE
srm 1.2.15 (new formula)

### DIFF
--- a/Formula/srm.rb
+++ b/Formula/srm.rb
@@ -1,0 +1,18 @@
+class Srm < Formula
+  desc "Secure replacement for rm(1)"
+  homepage "https://srm.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/srm/1.2.15/srm-1.2.15.tar.gz"
+  sha256 "7583c1120e911e292f22b4a1d949b32c23518038afd966d527dae87c61565283"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello_world.txt").write("Hello, world")
+    system bin/"srm", testpath/"hello_world.txt"
+  end
+end


### PR DESCRIPTION
Add a formula for the "srm" package: a secure replacement for rm(1).

Signed-off-by: Jeff Squyres <jeff@squyres.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source srm
==> Downloading https://downloads.sourceforge.net/project/srm/1.2.15/srm-1.2.15.
Already downloaded: /Users/jsquyres/Library/Caches/Homebrew/srm-1.2.15.tar.gz
==> ./configure --prefix=/usr/local/Cellar/srm/1.2.15
==> make install
🍺  /usr/local/Cellar/srm/1.2.15: 11 files, 56.3KB, built in 15 seconds
$ brew audit --strict srm
$ brew test srm
Testing srm
==> /usr/local/Cellar/srm/1.2.15/bin/srm /tmp/srm-test-20171212-84771-jpwjzf/hel
```