### PR TITLE
qtads: use upstream fix for Xcode 9

### DIFF
--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -26,8 +26,8 @@ class Qtads < Formula
     # Reported 11 Dec 2017 https://github.com/realnc/qtads/issues/7
     if DevelopmentTools.clang_build_version >= "900"
       patch do
-        url "https://raw.githubusercontent.com/Homebrew/formula-patches/1cbb81b/qtads/xcode9.diff"
-        sha256 "1523a181cf45294ec2bb5b261279427c8673d547aae885ee50770d06d2231a6c"
+        url "https://raw.githubusercontent.com/Homebrew/formula-patches/e189341/qtads/xcode9.diff"
+        sha256 "2016fef6e867b7b8dfe1bd5db64d588161aad1357faa1962ee48edbe35042ddc"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----