### PR TITLE
svcat v0.2.1 (new formula)

### DIFF
--- a/Formula/svcat.rb
+++ b/Formula/svcat.rb
@@ -1,0 +1,24 @@
+class Svcat < Formula
+  desc "Kubernetes Service Catalog CLI"
+  homepage "https://github.com/Azure/service-catalog-cli"
+  url "https://github.com/Azure/service-catalog-cli/archive/v0.2.1.tar.gz"
+  sha256 "47d77c644f420f9889df6ef2851a24d32418f1eb7077ab09e2638e6e46e4079a"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    (buildpath/"src/github.com/Azure/service-catalog-cli").install buildpath.children
+
+    cd "src/github.com/Azure/service-catalog-cli" do
+      system "make", "build", "VERSION=#{version}"
+      bin.install "bin/svcat"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/svcat", "version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the [kubernetes service catalog cli](https://github.com/Azure/service-catalog-cli), `svcat`.
