### PR TITLE
pyqt: revision bump for Qt 5.10

### DIFF
--- a/Formula/pyqt.rb
+++ b/Formula/pyqt.rb
@@ -3,6 +3,7 @@ class Pyqt < Formula
   homepage "https://www.riverbankcomputing.com/software/pyqt/download5"
   url "https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.9.2/PyQt5_gpl-5.9.2.tar.gz"
   sha256 "c190dac598c97b0113ca5e7a37c71c623f02d1d713088addfacac4acfa4b8394"
+  revision 1
 
   bottle do
     sha256 "4e111ba8e35f8fe50e45e1ed1ff25ba1882578c2c33c1da5bb95794019621cfe" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've been having some quirky runtime issues with `pyqt` ever since the `qt` update was shipped. Rebuilding from source resolved them.

If you don't want to take my word for it _(fair enough)_, with an existing `pyqt` build installed from the old bottle try something like `brew install domt4/crypto/electrum` and you should see the `pyrcc5` step fall apart. I should have kept the error before drowning my terminal in reinstalling `pyqt`, apologies 😓.