### PR TITLE
mupdf, mupdf-tools: enable OpenGL

### DIFF
--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -18,8 +18,7 @@ class MupdfTools < Formula
            "verbose=yes",
            "HAVE_X11=no",
            "CC=#{ENV.cc}",
-           "prefix=#{prefix}",
-           "HAVE_GLFW=no" # Do not build OpenGL viewer: https://bugs.ghostscript.com/show_bug.cgi?id=697842
+           "prefix=#{prefix}"
 
     # Symlink `mutool` as `mudraw` (a popular shortcut for `mutool draw`).
     bin.install_symlink bin/"mutool" => "mudraw"

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -23,8 +23,7 @@ class Mupdf < Formula
            "build=release",
            "verbose=yes",
            "CC=#{ENV.cc}",
-           "prefix=#{prefix}",
-           "HAVE_GLFW=no" # Do not build OpenGL viewer: https://bugs.ghostscript.com/show_bug.cgi?id=697842
+           "prefix=#{prefix}"
     bin.install_symlink "mutool" => "mudraw"
   end
 


### PR DESCRIPTION
Requested in #21343.
The bug which was the reason for it not being enabled has been fixed.