### PR TITLE
rtags: add emacs support, enabled by default

### DIFF
--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -4,6 +4,8 @@ class Rtags < Formula
   url "https://github.com/Andersbakken/rtags.git",
       :tag => "v2.16",
       :revision => "8ef7554852541eced514c56d5e39d6073f7a2ef9"
+  revision 1
+
   head "https://github.com/Andersbakken/rtags.git"
 
   bottle do
@@ -15,6 +17,8 @@ class Rtags < Formula
   depends_on "cmake" => :build
   depends_on "llvm"
   depends_on "openssl"
+
+  depends_on :emacs => ["24.3", :recommended]
 
   def install
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
rtags: add emacs support, enabled by default

minimum version set to upstream recommendation