### PR TITLE
Remove C++11 options from CGAL and sfcgal

### DIFF
--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -11,10 +11,9 @@ class Cgal < Formula
     sha256 "13e8723280f9b2de2a1d348cbe07f814dc3ea44e466b14781755552db9ac13c2" => :el_capitan
   end
 
-  option :cxx11
-  option "with-qt", "Build ImageIO and Qt components of CGAL"
   option "with-eigen", "Build with Eigen3 support"
   option "with-lapack", "Build with LAPACK support"
+  option "with-qt", "Build ImageIO and Qt components of CGAL"
 
   deprecated_option "imaging" => "with-qt"
   deprecated_option "with-imaging" => "with-qt"
@@ -22,22 +21,13 @@ class Cgal < Formula
   deprecated_option "with-qt5" => "with-qt"
 
   depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "gmp"
   depends_on "mpfr"
-
   depends_on "qt" => :optional
   depends_on "eigen" => :optional
 
-  if build.cxx11?
-    depends_on "boost" => "c++11"
-    depends_on "gmp"   => "c++11"
-  else
-    depends_on "boost"
-    depends_on "gmp"
-  end
-
   def install
-    ENV.cxx11 if build.cxx11?
-
     args = std_cmake_args + %W[
       -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
       -DCMAKE_INSTALL_NAME_DIR=#{HOMEBREW_PREFIX}/lib

--- a/Formula/sfcgal.rb
+++ b/Formula/sfcgal.rb
@@ -10,22 +10,13 @@ class Sfcgal < Formula
     sha256 "0348fd098cfb8a0d2ce913fa256178c63c47216415507a962c5999a5c62853ac" => :el_capitan
   end
 
-  option :cxx11
-
   depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "cgal"
+  depends_on "gmp"
   depends_on "mpfr"
-  if build.cxx11?
-    depends_on "boost" => "c++11"
-    depends_on "cgal" => "c++11"
-    depends_on "gmp" => "c++11"
-  else
-    depends_on "boost"
-    depends_on "cgal"
-    depends_on "gmp"
-  end
 
   def install
-    ENV.cxx11 if build.cxx11?
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
Fix audit errors: don't have dependencies with options. Creates a mess of dependency tree if we want stuff with and without C++11.

Analytics show they're seldom used: 1 install / month in sfcgal, 10 installs / month in cgal (0.36%).