### PR TITLE
gpsbabel: move to latest Qt

### DIFF
--- a/Formula/gpsbabel.rb
+++ b/Formula/gpsbabel.rb
@@ -3,7 +3,7 @@ class Gpsbabel < Formula
   homepage "https://www.gpsbabel.org/"
   url "https://github.com/gpsbabel/gpsbabel/archive/gpsbabel_1_5_4.tar.gz"
   sha256 "8cd740db0b92610abff71e942e8a987df58cd6ca5f25cca86e15f2b00e190704"
-  head "https://github.com/gpsbabel/gpsbabel.git"
+  revision 1
 
   bottle do
     sha256 "661fe5794fa01cf8ee57511fc7dcd0a188cea17ef4ff307fadcc86f45fc074fe" => :high_sierra
@@ -12,13 +12,19 @@ class Gpsbabel < Formula
     sha256 "b9dc431b4db6bd91e1a839e4650eafdb9dcf71f238b6d7fda606aa1c36303f10" => :yosemite
   end
 
+  depends_on "qt"
   depends_on "libusb" => :optional
-  depends_on "qt@5.7"
 
   # Fix build with Xcode 9, remove for next version
   patch do
     url "https://github.com/gpsbabel/gpsbabel/commit/b7365b93.patch?full_index=1"
     sha256 "e949182def36fef99889e43ba4bc4d61e36d6b95badc74188a8cd3da5156d341"
+  end
+
+  # Upstream fix to build with Qt 5.10, remove for next version
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/ca4c4730/gpsbabel/qt5.10.patch"
+    sha256 "09efe405f43ae26570d6b5fcb7c5bcc7e0c8bc9a9ad6700d3901bcdcc43c33cf"
   end
 
   def install


### PR DESCRIPTION
Trying to use patch from upstream to move to latest Qt. gpsbabel is our only formula using versioned Qt at the moment!