### PR TITLE
Remove C++11 options on dependencies

### DIFF
--- a/Formula/gource.rb
+++ b/Formula/gource.rb
@@ -23,21 +23,13 @@ class Gource < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glm" => :build
+  depends_on "boost"
   depends_on "freetype"
   depends_on "glew"
   depends_on "libpng"
   depends_on "pcre"
   depends_on "sdl2"
   depends_on "sdl2_image"
-
-  # boost failing on lion
-  depends_on :macos => :mountain_lion
-
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
 
   needs :cxx11
 

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -15,8 +15,7 @@ class KitchenSync < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "yaml-cpp" => ((MacOS.version <= :mountain_lion) ? "c++11" : [])
-
+  depends_on "yaml-cpp"
   depends_on :mysql => :recommended
   depends_on :postgresql => :optional
 

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -20,14 +20,11 @@ class Ledger < Formula
   option "without-python", "Build without python support"
 
   depends_on "cmake" => :build
+  depends_on "boost"
   depends_on "gmp"
   depends_on "mpfr"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
-
-  boost_opts = []
-  boost_opts << "c++11" if MacOS.version < "10.9"
-  depends_on "boost" => boost_opts
-  depends_on "boost-python" => boost_opts if build.with? "python"
+  depends_on "boost-python" if build.with? "python"
 
   needs :cxx11
 

--- a/Formula/libmatroska.rb
+++ b/Formula/libmatroska.rb
@@ -18,19 +18,10 @@ class Libmatroska < Formula
     depends_on "libtool" => :build
   end
 
-  option :cxx11
-
-  if build.cxx11?
-    depends_on "libebml" => "c++11"
-  else
-    depends_on "libebml"
-  end
-
   depends_on "pkg-config" => :build
+  depends_on "libebml"
 
   def install
-    ENV.cxx11 if build.cxx11?
-
     system "autoreconf", "-fi" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/mal4s.rb
+++ b/Formula/mal4s.rb
@@ -19,6 +19,7 @@ class Mal4s < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "glm" => :build
+  depends_on "boost"
   depends_on "glew"
   depends_on "pcre"
   depends_on "sdl2"
@@ -26,12 +27,6 @@ class Mal4s < Formula
   depends_on "sdl2_mixer"
   depends_on "freetype"
   depends_on :x11 => :optional
-
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
 
   needs :cxx11
 

--- a/Formula/mapcrafter.rb
+++ b/Formula/mapcrafter.rb
@@ -16,14 +16,9 @@ class Mapcrafter < Formula
   needs :cxx11
 
   depends_on "cmake" => :build
+  depends_on "boost"
   depends_on "jpeg-turbo"
   depends_on "libpng"
-
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
 
   def install
     ENV.cxx11

--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -14,6 +14,7 @@ class Mapnik < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "boost"
   depends_on "freetype"
   depends_on "harfbuzz"
   depends_on "libpng"
@@ -25,12 +26,6 @@ class Mapnik < Formula
   depends_on "gdal" => :optional
   depends_on "postgresql" => :optional
   depends_on "cairo" => :optional
-
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
 
   needs :cxx11
 

--- a/Formula/openvdb.rb
+++ b/Formula/openvdb.rb
@@ -19,16 +19,11 @@ class Openvdb < Formula
   deprecated_option "with-tests" => "with-test"
   deprecated_option "with-viewer" => "with-glfw"
 
-  depends_on "openexr"
+  depends_on "boost"
   depends_on "ilmbase"
+  depends_on "openexr"
   depends_on "tbb"
   depends_on "jemalloc" => :recommended
-
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
 
   depends_on "glfw" => :optional
   depends_on "cppunit" if build.with? "test"

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -12,18 +12,11 @@ class Pdal < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "boost"
   depends_on "gdal"
   depends_on "laszip" => :optional
 
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
-
   def install
-    ENV.cxx11 if MacOS.version < :mavericks
-
     args = std_cmake_args
     if build.with? "laszip"
       args << "-DWITH_LASZIP=TRUE"

--- a/Formula/vowpal-wabbit.rb
+++ b/Formula/vowpal-wabbit.rb
@@ -11,15 +11,11 @@ class VowpalWabbit < Formula
     sha256 "46c458b48728a214b102e724dcee15d8c2f6a25c1ec29ac87c5182529564abca" => :el_capitan
   end
 
-  if MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "boost"
+
   needs :cxx11
 
   def install

--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -13,19 +13,12 @@ class YamlCpp < Formula
     sha256 "c779f86632b38472e022ad91f0f5ddb0f399fd547d36cbc5494a76c0f6becd48" => :mavericks
   end
 
-  option :cxx11
   option "with-static-lib", "Build a static library"
 
   depends_on "cmake" => :build
-
-  if build.cxx11? && MacOS.version < :mavericks
-    depends_on "boost" => "c++11"
-  else
-    depends_on "boost"
-  end
+  depends_on "boost"
 
   def install
-    ENV.cxx11 if build.cxx11?
     args = std_cmake_args
     if build.with? "static-lib"
       args << "-DBUILD_SHARED_LIBS=OFF"


### PR DESCRIPTION
Silencing audits by not having dependencies (mostly boost) with C++11 options