### PR TITLE
open-mpi: set MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -32,6 +32,9 @@ class OpenMpi < Formula
   conflicts_with "lcdf-typetools", :because => "both install same set of binaries."
 
   def install
+    # otherwise libmpi_usempi_ignore_tkr gets built as a static library
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+
     ENV.cxx11 if build.cxx11?
 
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

otherwise libmpi_usempi_ignore_tkr gets built as a static library