### PR TITLE
filebeat@5 5.6.5 (new formula)

### DIFF
--- a/Formula/filebeat@5.rb
+++ b/Formula/filebeat@5.rb
@@ -1,0 +1,82 @@
+class FilebeatAT5 < Formula
+  desc "File harvester to ship log files to Elasticsearch or Logstash"
+  homepage "https://www.elastic.co/products/beats/filebeat"
+  url "https://github.com/elastic/beats/archive/v5.6.5.tar.gz"
+  sha256 "1f54e7b642aed29659b6b34977fbb552cfd9332802c09d5185e997b79c713a14"
+  head "https://github.com/elastic/beats.git"
+
+  depends_on "go" => :build
+
+  def install
+    gopath = buildpath/"gopath"
+    (gopath/"src/github.com/elastic/beats").install Dir["{*,.git,.gitignore}"]
+
+    ENV["GOPATH"] = gopath
+
+    cd gopath/"src/github.com/elastic/beats/filebeat" do
+      system "make"
+      system "make", "modules"
+      libexec.install "filebeat"
+      (prefix/"module").install Dir["_meta/module.generated/*"]
+      (etc/"filebeat").install Dir["filebeat.*"]
+    end
+
+    prefix.install_metafiles gopath/"src/github.com/elastic/beats"
+
+    (bin/"filebeat").write <<~EOS
+      #!/bin/sh
+      exec #{libexec}/filebeat -path.config #{etc}/filebeat -path.home #{prefix} -path.logs #{var}/log/filebeat -path.data #{var}/filebeat $@
+    EOS
+  end
+
+  plist_options :manual => "filebeat"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>Program</key>
+        <string>#{opt_bin}/filebeat</string>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    log_file = testpath/"test.log"
+    touch log_file
+
+    (testpath/"filebeat.yml").write <<~EOS
+      filebeat:
+        prospectors:
+          -
+            paths:
+              - #{log_file}
+            scan_frequency: 0.1s
+      filebeat.idle_timeout: 0.1s
+      output:
+        file:
+          path: #{testpath}
+    EOS
+
+    (testpath/"log").mkpath
+    (testpath/"data").mkpath
+
+    filebeat_pid = fork { exec "#{bin}/filebeat -c #{testpath}/filebeat.yml -path.config #{testpath}/filebeat -path.home=#{testpath} -path.logs #{testpath}/log -path.data #{testpath}" }
+    begin
+      sleep 1
+      log_file.append_lines "foo bar baz"
+      sleep 5
+
+      assert_predicate testpath/"filebeat", :exist?
+    ensure
+      Process.kill("TERM", filebeat_pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Create `filebeat@5` formula. `collector-sidecar` currently supports only v5.x and doesn't work with v6.x.

Built from the 5.6.4 version.