### PR TITLE
wget: depend on libidn2

### DIFF
--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -26,11 +26,11 @@ class Wget < Formula
 
   depends_on "pkg-config" => :build
   depends_on "pod2man" => :build if MacOS.version <= :snow_leopard
+  depends_on "libidn2"
   depends_on "openssl@1.1"
   depends_on "pcre" => :optional
   depends_on "libmetalink" => :optional
   depends_on "gpgme" => :optional
-  depends_on "libidn2"
 
   def install
     args = %W[

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -30,6 +30,7 @@ class Wget < Formula
   depends_on "pcre" => :optional
   depends_on "libmetalink" => :optional
   depends_on "gpgme" => :optional
+  depends_on "libidn2"
 
   def install
     args = %W[

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -4,6 +4,7 @@ class Wget < Formula
   url "https://ftp.gnu.org/gnu/wget/wget-1.19.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/wget/wget-1.19.2.tar.gz"
   sha256 "4f4a673b6d466efa50fbfba796bd84a46ae24e370fa562ede5b21ab53c11a920"
+  revision 1
 
   bottle do
     sha256 "4f6896bbed75ea89f04d849357390b32e7462b86c8a3063dca85c9f5f7db1aaa" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This should bring back the ability to use the `wget` option `--local-encoding=UTF-8`; wget was failing with _This version does not have support for IRIs_.

This basically fulfills the wish from the last sentence in https://github.com/Homebrew/homebrew-core/pull/9873#issuecomment-279179737, 
as `libidn2` is available now.