### PR TITLE
mutt: Fix HEAD url

### DIFF
--- a/Formula/mutt.rb
+++ b/Formula/mutt.rb
@@ -21,7 +21,7 @@ class Mutt < Formula
   end
 
   head do
-    url "https://dev.mutt.org/hg/mutt#default", :using => :hg
+    url "https://gitlab.com/muttmua/mutt.git", :using => :git
 
     resource "html" do
       url "https://dev.mutt.org/doc/manual.html", :using => :nounzip

--- a/Formula/mutt.rb
+++ b/Formula/mutt.rb
@@ -21,7 +21,7 @@ class Mutt < Formula
   end
 
   head do
-    url "https://gitlab.com/muttmua/mutt.git", :using => :git
+    url "https://gitlab.com/muttmua/mutt.git"
 
     resource "html" do
       url "https://dev.mutt.org/doc/manual.html", :using => :nounzip


### PR DESCRIPTION
Upstream just migrated to gitlab; the dev.mutt.org repo is out of
date and won't be updated any more.