### PR TITLE
sonarqube : Listen on 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -12,6 +12,9 @@ class Sonarqube < Formula
     # Delete native bin directories for other systems
     rm_rf Dir["bin/{linux,windows}-*"]
 
+    # Listen on 127.0.0.1 instead of 0.0.0.0
+    inreplace("conf/sonar.properties", "#sonar.web.host=0.0.0.0", "sonar.web.host=127.0.0.1")
+
     libexec.install Dir["*"]
 
     bin.install_symlink "#{libexec}/bin/macosx-universal-64/sonar.sh" => "sonar"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
By default the SonarQube server listen on 0.0.0.0. This is a sensible default when installing on a server but this is problematic on a developer machine because by default it opens without any restrictions access to all files in analyzed projects, it also gives access to anyone to the web interface of SonarQube which is a potential security risk. Homebrew formulas should not, by default, open access to files or services on a personal machine. This is why I propose to bound the SonarQube server to 127.0.0.1
