### PR TITLE
sdl_mixer: make libmikmod a required dependency

### DIFF
--- a/Formula/enigma.rb
+++ b/Formula/enigma.rb
@@ -3,7 +3,7 @@ class Enigma < Formula
   homepage "http://www.nongnu.org/enigma/"
   url "https://downloads.sourceforge.net/project/enigma-game/Release%201.21/enigma-1.21.tar.gz"
   sha256 "d872cf067d8eb560d3bb1cb17245814bc56ac3953ae1f12e2229c8eb6f82ce01"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "fe7c8716e916535682f46b41905aa139da60a5505302b9001a02f14e804264d1" => :high_sierra
@@ -22,7 +22,7 @@ class Enigma < Formula
   depends_on "imagemagick" => :build
   depends_on "sdl"
   depends_on "sdl_image"
-  depends_on "sdl_mixer" => "with-libmikmod"
+  depends_on "sdl_mixer"
   depends_on "sdl_ttf"
   depends_on "freetype"
   depends_on "libpng"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -3,7 +3,7 @@ class SdlMixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -14,13 +14,13 @@ class SdlMixer < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libmikmod"
   depends_on "libogg"
   depends_on "libvorbis"
   depends_on "sdl"
   depends_on "flac" => :optional
   depends_on "fluid-synth" => :optional
   depends_on "smpeg" => :optional
-  depends_on "libmikmod" => :optional
 
   def install
     inreplace "SDL_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
@@ -30,9 +30,9 @@ class SdlMixer < Formula
       --disable-dependency-tracking
       --enable-music-ogg
       --disable-music-ogg-shared
+      --disable-music-mod-shared
     ]
 
-    args << "--disable-music-mod-shared" if build.with? "libmikmod"
     args << "--disable-music-fluidsynth-shared" if build.with? "fluid-synth"
     args << "--disable-music-flac-shared" if build.with? "flac"
     args << "--disable-music-mp3-shared" if build.with? "smpeg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [no] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
sdl_mixer: make libmikmod a required dependency

enigma: revison for sdl_mixer;
libmikmod is now a required dep of sdl_mixer