### PR TITLE
alpine: fix homepage, url and digest

### DIFF
--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -1,8 +1,9 @@
 class Alpine < Formula
   desc "News and email agent"
-  homepage "http://alpine.freeiz.com/alpine/"
-  url "http://alpine.freeiz.com/alpine/release/src/alpine-2.21.tar.xz"
-  sha256 "6030b6881b8168546756ab3a5e43628d8d564539b0476578e287775573a77438"
+  homepage "http://repo.or.cz/alpine.git"
+  url "http://repo.or.cz/alpine.git/snapshot/672d6838a9babf2faeb9f79267525a4ab9d20b14.tar.gz"
+  version "2.21"
+  sha256 "a74234fce5fb1bfc1f1a19e9d5dabf71414490f544c4cc854f9eb3e78351964d"
 
   bottle do
     rebuild 1

--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -1,9 +1,9 @@
 class Alpine < Formula
   desc "News and email agent"
   homepage "http://repo.or.cz/alpine.git"
-  url "http://repo.or.cz/alpine.git/snapshot/672d6838a9babf2faeb9f79267525a4ab9d20b14.tar.gz"
-  version "2.21"
-  sha256 "a74234fce5fb1bfc1f1a19e9d5dabf71414490f544c4cc854f9eb3e78351964d"
+  url "https://ftp.osuosl.org/pub/blfs/conglomeration/alpine/alpine-2.21.tar.xz"
+  mirror "https://fossies.org/linux/misc/alpine-2.21.tar.xz"
+  sha256 "6030b6881b8168546756ab3a5e43628d8d564539b0476578e287775573a77438"
 
   bottle do
     rebuild 1


### PR DESCRIPTION
```
Alpine's homepage was updated, see

http://mailman13.u.washington.edu/pipermail/alpine-info/2017-November/007743.html

Update the formula accordingly.

Signed-off-by: Ray Chen <oldsharp@gmail.com>
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

**NOTE**:
```
$ brew audit --strict alpine
alpine:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 1 problem in 1 formula
```
This is because the original package (`alpine-2.21.tar.xz` ) is no longer available.
