### PR TITLE
GraphicsMagick: add forced --disable-installed and optional --with-broken-coders args

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -1,8 +1,8 @@
 class Graphicsmagick < Formula
   desc "Image processing tools collection"
   homepage "http://www.graphicsmagick.org/"
-  url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.26/GraphicsMagick-1.3.26.tar.xz"
-  sha256 "fba015f3d5e5d5f17e57db663f1aa9d338e7b62f1d415b85d13ee366927e5f88"
+  url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.27/GraphicsMagick-1.3.27.tar.xz"
+  sha256 "d03278d2790efc1dc72309f85a539810d2a81deb47932f7e6720d09ac72d0367"
   revision 1
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg
 
@@ -17,6 +17,7 @@ class Graphicsmagick < Formula
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-svg", "Compile without svg support"
   option "with-perl", "Build PerlMagick; provides the Graphics::Magick module"
+  option "with-broken-coders", "Build GraphicsMagick with experimental file format coders"
 
   depends_on "pkg-config" => :build
   depends_on "libtool" => :run
@@ -47,6 +48,7 @@ class Graphicsmagick < Formula
       --without-lzma
       --disable-openmp
       --with-quantum-depth=16
+      --disable-installed
     ]
 
     args << "--without-gslib" if build.without? "ghostscript"
@@ -58,6 +60,7 @@ class Graphicsmagick < Formula
     args << "--without-ttf" if build.without? "freetype"
     args << "--without-xml" if build.without? "svg"
     args << "--without-lcms2" if build.without? "little-cms2"
+    args << "--enable-broken-coders" if build.with? "broken-coders"
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"

--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -1,8 +1,8 @@
 class Physfs < Formula
   desc "Library to provide abstract access to various archives"
   homepage "https://icculus.org/physfs/"
-  url "https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
-  sha256 "ca862097c0fb451f2cacd286194d071289342c107b6fe69079c079883ff66b69"
+  url "https://icculus.org/physfs/downloads/physfs-3.0.0.tar.bz2"
+  sha256 "f2617d6855ea97ea42e4a8ebcad404354be99dfd8a274eacea92091b27fd7324"
   head "https://hg.icculus.org/icculus/physfs/", :using => :hg
 
   bottle do


### PR DESCRIPTION
Without the `--disable-installed` argument passed to the make file, GraphicsMagic utilizes hard-coded paths that get compiled into the library, which I found out to be a serious pain when attempting to copy it into an app bundle.  As stated in the Unix install guide for GraphicsMagic, "specifying --disable-installed configures GraphicsMagick so that it doesn't use hard-coded paths and locates support files by computing an offset path from the executable (or from the location specified by the MAGICK_HOME environment variable. The uninstalled configuration is ideal for binary distributions which are expected to extract and run in any location."

As for `--with-broken-coders` (or rather, `--enable-broken-coders` as passed into the makefile), this argument allows a user to enable experimental file generators.  Since they may produce corrupt files or present security exploits, it is not enabled by default.  I included this option for those that wish to live on the edge and test out some new functionality.