### PR TITLE
GraphicsMagick: fix installer arguments

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -14,6 +14,7 @@ class Graphicsmagick < Formula
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-svg", "Compile without svg support"
   option "with-perl", "Build PerlMagick; provides the Graphics::Magick module"
+  option "with-broken-coders", "Build GraphicsMagick with experimental file format coders"
 
   depends_on "pkg-config" => :build
   depends_on "libtool" => :run
@@ -40,6 +41,7 @@ class Graphicsmagick < Formula
       --without-lzma
       --disable-openmp
       --with-quantum-depth=16
+      --disable-installed
     ]
 
     args << "--without-gslib" if build.without? "ghostscript"
@@ -51,6 +53,7 @@ class Graphicsmagick < Formula
     args << "--without-ttf" if build.without? "freetype"
     args << "--without-xml" if build.without? "svg"
     args << "--without-lcms2" if build.without? "little-cms2"
+    args << "--enable-broken-coders" if build.with? "broken-coders"
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"

--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -14,7 +14,6 @@ class Graphicsmagick < Formula
   option "without-magick-plus-plus", "disable build/install of Magick++"
   option "without-svg", "Compile without svg support"
   option "with-perl", "Build PerlMagick; provides the Graphics::Magick module"
-  option "with-broken-coders", "Build GraphicsMagick with experimental file format coders"
 
   depends_on "pkg-config" => :build
   depends_on "libtool" => :run
@@ -53,7 +52,6 @@ class Graphicsmagick < Formula
     args << "--without-ttf" if build.without? "freetype"
     args << "--without-xml" if build.without? "svg"
     args << "--without-lcms2" if build.without? "little-cms2"
-    args << "--enable-broken-coders" if build.with? "broken-coders"
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"


### PR DESCRIPTION
Without the `--disable-installed` argument passed to the make file, GraphicsMagic utilizes hard-coded paths that get compiled into the library, which I found out to be a serious pain when attempting to copy it into an app bundle.  As stated in the Unix install guide for GraphicsMagic, "specifying --disable-installed configures GraphicsMagick so that it doesn't use hard-coded paths and locates support files by computing an offset path from the executable (or from the location specified by the MAGICK_HOME environment variable. The uninstalled configuration is ideal for binary distributions which are expected to extract and run in any location."

As for `--with-broken-coders` (or rather, `--enable-broken-coders` as passed into the makefile), this argument allows a user to enable experimental file generators.  Since they may produce corrupt files or present security exploits, it is not enabled by default.  I included this option for those that wish to live on the edge and test out some new functionality.