### PR TITLE
cppad 20170000.8

### DIFF
--- a/Formula/cppad.rb
+++ b/Formula/cppad.rb
@@ -1,9 +1,10 @@
 class Cppad < Formula
   desc "Differentiation of C++ Algorithms"
   homepage "https://www.coin-or.org/CppAD"
-  url "https://www.coin-or.org/download/source/CppAD/cppad-20171128.epl.tgz"
-  version "20171128"
-  sha256 "36f9a4b6c16d720c20547c0a896c0b89fd5f05641dba34274257a1700f85d13b"
+  # Stable versions have numbers of the form 201x0000.y
+  url "https://github.com/coin-or/CppAD/archive/20170000.8.tar.gz"
+  sha256 "195ed02970b06e8b9546ffe198e662dabdaf56f262d11fbdf6fdc9cf77a3e011"
+  version_scheme 1
   head "https://github.com/coin-or/CppAD.git"
 
   bottle do
@@ -37,7 +38,7 @@ class Cppad < Formula
       }
     EOS
 
-    system ENV.cxx, "#{pkgshare}/example/general/acos.cpp", "-I#{include}",
+    system ENV.cxx, "#{pkgshare}/example/acos.cpp", "-I#{include}",
                     "test.cpp", "-o", "test"
     system "./test"
   end


### PR DESCRIPTION
In the past, we've been shipping versions of cppad such as 20171107, 20171111, and 20171128. Turns out, looking at the [CppAD download page](https://www.coin-or.org/CppAD/Doc/download.htm), these are not considered “releases”. Also, these daily source packages disappear every month or so.

> **Release** 
Special versions corresponding to the beginning of each year have mm and dd equal to zero. These version numbers are combined with release numbers denoted by rel . Higher release numbers correspond to more bug fixes. For example version.rel = 20160000.0 corresponds to the first release of the version for 2016, 20160000.1 corresponds to the first bug fix for 2016. 

So we should only ship versions that match `201x0000.z`. These are also the only releases that upstream uploads to [GitHub](https://github.com/coin-or/CppAD/releases), so I'm switching over as it should make our life easier from here on.

Fixes #21873