### PR TITLE
ttyrec: macOS has openpty(), use it

### DIFF
--- a/Formula/ttyrec.rb
+++ b/Formula/ttyrec.rb
@@ -3,6 +3,7 @@ class Ttyrec < Formula
   homepage "http://0xcc.net/ttyrec/"
   url "http://0xcc.net/ttyrec/ttyrec-1.0.8.tar.gz"
   sha256 "ef5e9bf276b65bb831f9c2554cd8784bd5b4ee65353808f82b7e2aef851587ec"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -20,7 +21,11 @@ class Ttyrec < Formula
   end
 
   def install
-    system "make"
+    # macOS has openpty() in <util.h>
+    # Reported by email to satoru@0xcc.net on 2017-12-20
+    inreplace "ttyrec.c", "<libutil.h>", "<util.h>"
+
+    system "make", "CFLAGS=#{ENV.cflags} -DHAVE_openpty"
     bin.install %w[ttytime ttyplay ttyrec]
     man1.install Dir["*.1"]
   end


### PR DESCRIPTION
Documentation says to compile with `make -DHAVE_openpty` if `openpty()` is available, which is the case on macOS. However, it tries to find it in the wrong header :(

Reported by email, not expecting much since the last release was in 2006. However, it is still widely used (it has a wikipedia page and 222 installs last month), so I think it's worth fixing.

Fixes #21907 