### PR TITLE
SquashFS: fix LZMA support (#21957)

### DIFF
--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -34,6 +34,7 @@ class Squashfs < Formula
       LZO_DIR=#{Formula["lzo"].opt_prefix}
       XZ_SUPPORT=1
       XZ_DIR=#{Formula["xz"].opt_prefix}
+      LZMA_XZ_SUPPORT=1
     ]
     args << "LZ4_SUPPORT=1" if build.with? "lz4"
 

--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -3,6 +3,7 @@ class Squashfs < Formula
   homepage "https://squashfs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
   sha256 "0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Adding this was trivial, since `squashfs` already depends on `xz`, which is the only package needed to support LZMA. The only missing part was to actually enable `squashfs` to use `xz`.