### PR TITLE
bash-git-prompt: add a test

### DIFF
--- a/Formula/bash-git-prompt.rb
+++ b/Formula/bash-git-prompt.rb
@@ -17,11 +17,16 @@ class BashGitPrompt < Formula
   end
 
   def caveats; <<~EOS
-    You should add the following to your .bashrc (or equivalent):
-      if [ -f "#{HOMEBREW_PREFIX}/opt/bash-git-prompt/share/gitprompt.sh" ]; then
-        __GIT_PROMPT_DIR="#{HOMEBREW_PREFIX}/opt/bash-git-prompt/share"
-        source "#{HOMEBREW_PREFIX}/opt/bash-git-prompt/share/gitprompt.sh"
+    You should add the following to your .bashrc (or .bash_profile):
+      if [ -f "#{opt_share}/gitprompt.sh" ]; then
+        __GIT_PROMPT_DIR="#{opt_share}"
+        source "#{opt_share}/gitprompt.sh"
       fi
     EOS
+  end
+
+  test do
+    output = shell_output("/bin/sh #{share}/gitstatus.sh 2>&1")
+    assert_match "Not a git repository", output
   end
 end


### PR DESCRIPTION
Add test because the audit requires a test.

Also the version of the bash-git-prompt has bumped up to 2.7.1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
