### PR TITLE
elektra 0.8.21 (new formula)

### DIFF
--- a/Formula/elektra.rb
+++ b/Formula/elektra.rb
@@ -1,0 +1,37 @@
+class Elektra < Formula
+  desc "Framework to access config settings in a global key database"
+  homepage "https://libelektra.org/"
+  url "https://www.libelektra.org/ftp/elektra/releases/elektra-0.8.21.tar.gz"
+  sha256 "51892570f18d1667d0da4d0908a091e41b41c20db9835765677109a3d150cd26"
+  head "https://github.com/ElektraInitiative/libelektra.git"
+
+  option "with-qt", "Build GUI frontend"
+
+  depends_on "cmake" => :build
+  depends_on "doxygen" => :build
+  depends_on "qt" => :optional
+  depends_on "discount" if build.with? "qt"
+
+  def install
+    tools = "kdb;"
+    tools << "qt-gui;" if build.with? "qt"
+
+    mkdir "build" do
+      system "cmake", "..", "-DBINDINGS=cpp", "-DTOOLS=#{tools}",
+                            "-DPLUGINS=NODEP", *std_cmake_args
+      system "make", "install"
+    end
+
+    bash_completion.install "scripts/kdb-bash-completion" => "kdb"
+    fish_completion.install "scripts/kdb.fish"
+    zsh_completion.install "scripts/kdb_zsh_completion" => "_kdb"
+  end
+
+  test do
+    output = shell_output("#{bin}/kdb get system/elektra/version/infos/licence")
+    assert_match "BSD", output
+    Utils.popen_read("#{bin}/kdb", "list").split.each do |plugin|
+      system "#{bin}/kdb", "check", plugin
+    end
+  end
+end


### PR DESCRIPTION
Hi,

this PR contains a formula for the configuration framework [Elektra](http://libelektra.org). I tried to add the package twice already:

- [Elektra 0.8.19](https://github.com/Homebrew/homebrew-core/pull/7850)
- [Elektra 0.8.20](https://github.com/Homebrew/homebrew-core/pull/20461)

. As far as I can tell, the new formula should incorporate all the input of the first two rejections. If I should change anything else in the formula, please just comment below. Thank you.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?