### PR TITLE
git: Install utilities in libexec/git_core

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -3,6 +3,7 @@ class Git < Formula
   homepage "https://git-scm.com"
   url "https://www.kernel.org/pub/software/scm/git/git-2.15.1.tar.xz"
   sha256 "999c90fd7d45066992cdb87dda35bdff6dfc1d01496118ea718dfb866da4045c"
+  revision 1
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do
@@ -114,11 +115,12 @@ class Git < Formula
     system "make", "install", *args
 
     # Install the macOS keychain credential helper
+    git_core = libexec/"git-core"
     cd "contrib/credential/osxkeychain" do
       system "make", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",
                      "LDFLAGS=#{ENV.ldflags}"
-      bin.install "git-credential-osxkeychain"
+      git_core.install "git-credential-osxkeychain"
       system "make", "clean"
     end
 
@@ -130,7 +132,7 @@ class Git < Formula
     # Install the netrc credential helper
     cd "contrib/credential/netrc" do
       system "make", "test"
-      bin.install "git-credential-netrc"
+      git_core.install "git-credential-netrc"
     end
 
     # Install git-subtree
@@ -138,13 +140,13 @@ class Git < Formula
       system "make", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",
                      "LDFLAGS=#{ENV.ldflags}"
-      bin.install "git-subtree"
+      git_core.install "git-subtree"
     end
 
     if build.with? "persistent-https"
       cd "contrib/persistent-https" do
         system "make"
-        bin.install "git-remote-persistent-http",
+        git_core.install "git-remote-persistent-http",
                     "git-remote-persistent-https",
                     "git-remote-persistent-https--proxy"
       end

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -114,8 +114,9 @@ class Git < Formula
 
     system "make", "install", *args
 
-    # Install the macOS keychain credential helper
     git_core = libexec/"git-core"
+
+    # Install the macOS keychain credential helper
     cd "contrib/credential/osxkeychain" do
       system "make", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -147,8 +147,8 @@ class Git < Formula
       cd "contrib/persistent-https" do
         system "make"
         git_core.install "git-remote-persistent-http",
-                    "git-remote-persistent-https",
-                    "git-remote-persistent-https--proxy"
+                         "git-remote-persistent-https",
+                         "git-remote-persistent-https--proxy"
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

git searches `libexec/git_core/` and `PATH` for git utilities, but not `bin`.
It fails if `PATH` does not include `/usr/local/bin`.

```
❯❯❯ PATH=/usr/bin:/bin /usr/local/bin/git fetch
git: 'credential-osxkeychain' is not a git command. See 'git --help'.
```

See also https://github.com/Homebrew/brew/pull/3594