### PR TITLE
crystal-lang 0.24.1

### DIFF
--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -1,15 +1,14 @@
 class CrystalLang < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
-  revision 3
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.23.1.tar.gz"
-    sha256 "8cf1b9a4eab29fca2f779ea186ae18f7ce444ce189c621925fa1a0c61dd5ff55"
+    url "https://github.com/crystal-lang/crystal/archive/0.24.1.tar.gz"
+    sha256 "4999a4d2a9ffc7bfbea8351b97057c3a135c2091cbd518e5c22ea7f5392b67d8"
 
     resource "shards" do
-      url "https://github.com/crystal-lang/shards/archive/v0.7.1.tar.gz"
-      sha256 "31de819c66518479682ec781a39ef42c157a1a8e6e865544194534e2567cb110"
+      url "https://github.com/crystal-lang/shards/archive/v0.7.2.tar.gz"
+      sha256 "97a3681e74d2fdcba0575f6906f4ba0aefc709a2eb672c7289c63176ff4f3be2"
     end
   end
 
@@ -34,15 +33,15 @@ class CrystalLang < Formula
   depends_on "libatomic_ops" => :build # for building bdw-gc
   depends_on "libevent"
   depends_on "bdw-gc"
-  depends_on "llvm@4"
+  depends_on "llvm"
   depends_on "pcre"
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libyaml" if build.with? "shards"
 
   resource "boot" do
-    url "https://github.com/crystal-lang/crystal/releases/download/0.23.0/crystal-0.23.0-1-darwin-x86_64.tar.gz"
-    version "0.23.0"
-    sha256 "5ffa252d2264ab55504a6325b7c42d0eb16065152d0adfee6be723fd02333fdf"
+    url "https://github.com/crystal-lang/crystal/releases/download/0.23.1/crystal-0.23.1-3-darwin-x86_64.tar.gz"
+    version "0.23.1"
+    sha256 "d3f964ebfc5cd48fad73ab2484ea2a00268812276293dd0f7e9c7d184c8aad8a"
   end
 
   def install
@@ -57,13 +56,13 @@ class CrystalLang < Formula
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
     ENV.append_path "PATH", "boot/bin"
 
-    if build.with? "release"
-      system "make", "crystal", "release=true"
-    else
-      system "make", "deps"
-      (buildpath/".build").mkpath
-      system "bin/crystal", "build", "-o", "-D", "without_openssl", "-D", "without_zlib", ".build/crystal", "src/compiler/crystal.cr"
-    end
+    system "make", "deps"
+    (buildpath/".build").mkpath
+
+    command = ["bin/crystal", "build", "-D", "without_openssl", "-D", "without_zlib", "-o", ".build/crystal", "src/compiler/crystal.cr"]
+    command.concat ["--release", "--no-debug"] if build.with? "release"
+
+    system *command
 
     if build.with? "shards"
       resource("shards").stage do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

We've just released Crystal 0.24.1, so this PR updates Homebrew accordingly.

0.24.0 was a pre-release, so 0.24.1 has to be built with 0.23.1 - as the Formula says.

Thanks for the project!