### PR TITLE
gdcm: remove vtk dependency

### DIFF
--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -3,7 +3,7 @@ class Gdcm < Formula
   homepage "https://sourceforge.net/projects/gdcm/"
   url "https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.8.4/gdcm-2.8.4.tar.gz"
   sha256 "8f480d0a9b0b331f2e83dcc9cdb3d957f10eb32ee4db90fc1c153172dcb45587"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "83362d1601aa95241a7b1294e779d0183291ebd9e7e50b4741f0dce0b6b59407" => :high_sierra
@@ -20,7 +20,6 @@ class Gdcm < Formula
   depends_on "pkg-config" => :build
   depends_on "openjpeg"
   depends_on "openssl"
-  depends_on "vtk"
 
   needs :cxx11
 
@@ -33,7 +32,7 @@ class Gdcm < Formula
       -DGDCM_BUILD_TESTING=OFF
       -DGDCM_BUILD_EXAMPLES=OFF
       -DGDCM_BUILD_DOCBOOK_MANPAGES=OFF
-      -DGDCM_USE_VTK=ON
+      -DGDCM_USE_VTK=OFF
       -DGDCM_USE_SYSTEM_OPENJPEG=ON
       -DGDCM_USE_SYSTEM_OPENSSL=ON
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Not compatible with VTK 8.1.x because it uses
vtkStreamingDemandDrivenPipeline::SetUpdateExtent, which has been
deprecated ever since 7.1.

See https://www.vtk.org/doc/nightly/html/VTK-7-1-Changes.html

Follow-up to https://github.com/Homebrew/homebrew-core/pull/22065.