### PR TITLE
RabbitMQ 3.7.2

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -1,8 +1,8 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://dl.bintray.com/rabbitmq/binaries/rabbitmq-server-generic-unix-3.7.1.tar.xz"
-  sha256 "66622252372ea70f5cf1eb60fa9421dd933834272823ea269b2435d3ab33bafb"
+  url "https://dl.bintray.com/rabbitmq/all/rabbitmq-server/3.7.2/rabbitmq-server-generic-unix-3.7.2.tar.xz"
+  sha256 "2c99d885e5d8ad8f45997a30642632d02fd5fe9da718c2ee991ddb978a7c3f99"
 
   bottle :unneeded
 
@@ -34,7 +34,7 @@ class Rabbitmq < Formula
     rabbitmq_env_conf = etc/"rabbitmq/rabbitmq-env.conf"
     rabbitmq_env_conf.write rabbitmq_env unless rabbitmq_env_conf.exist?
 
-    # Enable plugins - management web UI and visualiser; STOMP, MQTT, AMQP 1.0 protocols
+    # Enable plugins - management web UI; STOMP, MQTT, AMQP 1.0 protocols
     enabled_plugins_path = etc/"rabbitmq/enabled_plugins"
     enabled_plugins_path.write "[rabbitmq_management,rabbitmq_stomp,rabbitmq_amqp1_0,rabbitmq_mqtt]." unless enabled_plugins_path.exist?
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source rabbitmq`?
- [x] Does your build pass `brew audit --strict rabbitmq`?

-----

This bumps RabbitMQ to 3.7.2.

Note that this switches the repository to bintray.com/rabbitmq/all.
bintray.com/rabbitmq/binaries still gets updates but is considered to be deprecated.

While at it, remove a mention of rabbitmq-management-visualiser in a comment:
it no longer ships with RabbitMQ as of 3.7.0.