### PR TITLE
spades: depend on gcc

### DIFF
--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -3,6 +3,7 @@ class Spades < Formula
   homepage "http://bioinf.spbau.ru/spades/"
   url "http://cab.spbu.ru/files/release3.11.1/SPAdes-3.11.1.tar.gz"
   sha256 "3ab85d86bf7d595bd8adf11c971f5d258bbbd2574b7c1703b16d6639a725b474"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,6 +13,7 @@ class Spades < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "gcc"
   depends_on :python if MacOS.version <= :snow_leopard
 
   needs :openmp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`needs :openmp` causes the bottles to be linked to gcc