### PR TITLE
fribidi 0.19.7: fix build

### DIFF
--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -1,7 +1,7 @@
 class Fribidi < Formula
   desc "Implementation of the Unicode BiDi algorithm"
-  homepage "https://fribidi.org/"
-  url "https://fribidi.org/download/fribidi-0.19.7.tar.bz2"
+  homepage "https://github.com/fribidi/fribidi"
+  url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/fribidi-0.19.7.tar.bz2"
   sha256 "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The previous URL broke, and the officially recommended way to build the library is now to download a release tarball from GitHub. This requires using autotools, which was not needed for the previous
distribution method.

It also requires building files in the doc directory that were previously just included in the distribution. This doesn't work, so I've had to remove the doc SUBDIR in the main Makefile.