### PR TITLE
rmw 0.4.03 (new formula)

### DIFF
--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -1,8 +1,8 @@
 class Rmw < Formula
   desc "OS portable cli trash can utility written in C"
   homepage "https://github.com/andy5995/rmw/wiki"
-  url "https://github.com/andy5995/rmw/archive/v0.4.01.tar.gz"
-  sha256 "3e53d7c52e2a144f97bbda5ebba51548d3a33cc3f2d37193d9b7e055c4e9d03c"
+  url "https://github.com/andy5995/rmw/archive/v0.4.03.tar.gz"
+  sha256 "5b08fce4392901d7900bfbd65bd8794a1bf9b6700073bc48ed8e88d6185c4177"
 
   depends_on "ncurses"
 

--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -3,6 +3,7 @@ class Rmw < Formula
   homepage "https://github.com/andy5995/rmw/wiki"
   url "https://github.com/andy5995/rmw/archive/v0.4.03.tar.gz"
   sha256 "5b08fce4392901d7900bfbd65bd8794a1bf9b6700073bc48ed8e88d6185c4177"
+  head "https://github.com/andy5995/rmw.git"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -1,0 +1,20 @@
+class Rmw < Formula
+  desc "OS portable cli trash can utility written in C"
+  homepage "https://github.com/andy5995/rmw/wiki"
+  url "https://github.com/andy5995/rmw/archive/v0.4.01.tar.gz"
+  sha256 "3e53d7c52e2a144f97bbda5ebba51548d3a33cc3f2d37193d9b7e055c4e9d03c"
+
+  depends_on "ncurses"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/rmw", "-V"
+  end
+end

--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -4,8 +4,6 @@ class Rmw < Formula
   url "https://github.com/andy5995/rmw/archive/v0.4.03.tar.gz"
   sha256 "5b08fce4392901d7900bfbd65bd8794a1bf9b6700073bc48ed8e88d6185c4177"
 
-  depends_on "ncurses"
-
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
Adds new formula for the application rmw (ReMove to Waste), which is a cross platform utility allowing you to safely remove files via a trash folder.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
