### PR TITLE
creduce: depend on llvm instead of llvm@4

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -1,10 +1,21 @@
 class Creduce < Formula
   desc "Reduce a C/C++ program while keeping a property of interest"
   homepage "https://embed.cs.utah.edu/creduce/"
-  url "https://embed.cs.utah.edu/creduce/creduce-2.7.0.tar.gz"
-  sha256 "36dca859c97a988e71b1a08e0cbd5849e4da051d248c5e483494194c4a231a41"
-  revision 1
+  revision 2
   head "https://github.com/csmith-project/creduce.git"
+
+  stable do
+    url "https://embed.cs.utah.edu/creduce/creduce-2.7.0.tar.gz"
+    sha256 "36dca859c97a988e71b1a08e0cbd5849e4da051d248c5e483494194c4a231a41"
+
+    # LLVM 5 compat
+    # Fix "error: use of undeclared identifier 'IK_C'" and similar errors
+    # Upstream commit from 27 Apr 2017 "Fix build failure with LLVM trunk"
+    patch do
+      url "https://github.com/csmith-project/creduce/commit/97e2b299.patch?full_index=1"
+      sha256 "89197f11c1c32bc234a4ba2102c65b96cc2141286e74cb838189c074c9a750d2"
+    end
+  end
 
   bottle do
     cellar :any
@@ -16,7 +27,7 @@ class Creduce < Formula
 
   depends_on "astyle"
   depends_on "delta"
-  depends_on "llvm@4"
+  depends_on "llvm"
 
   depends_on :macos => :mavericks
 
@@ -60,7 +71,7 @@ class Creduce < Formula
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
     # Avoid ending up with llvm's Cellar path hard coded.
-    ENV["CLANG_FORMAT"] = Formula["llvm@4"].opt_bin/"clang-format"
+    ENV["CLANG_FORMAT"] = Formula["llvm"].opt_bin/"clang-format"
 
     resources.each do |r|
       r.stage do
@@ -72,7 +83,7 @@ class Creduce < Formula
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
-                          "--with-llvm=#{Formula["llvm@4"].opt_prefix}",
+                          "--with-llvm=#{Formula["llvm"].opt_prefix}",
                           "--bindir=#{libexec}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Regarding an LLVM 5 compat release, see https://github.com/csmith-project/creduce/issues/147