### PR TITLE
recutils: %n crash fix for 10.13

### DIFF
--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -16,6 +16,13 @@ class Recutils < Formula
     sha256 "aec2464c5e26a561b340e9ae5a080366a068936ff2ba4e86e6a4bcf0ed8a95d0" => :mountain_lion
   end
 
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
@@ -31,7 +38,7 @@ class Recutils < Formula
     (testpath/"test.rec").write <<~EOS
       %rec: Book
       %mandatory: Title
-      
+
       Title: GNU Emacs Manual
     EOS
     system "#{bin}/recsel", "test.rec"

--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -27,5 +27,13 @@ class Recutils < Formula
       1,2,3
     EOS
     system "#{bin}/csv2rec", "test.csv"
+
+    (testpath/"test.rec").write <<~EOS
+      %rec: Book
+      %mandatory: Title
+      
+      Title: GNU Emacs Manual
+    EOS
+    system "#{bin}/recsel", "test.rec"
   end
 end

--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -4,6 +4,7 @@ class Recutils < Formula
   url "https://ftp.gnu.org/gnu/recutils/recutils-1.7.tar.gz"
   mirror "https://ftpmirror.gnu.org/recutils/recutils-1.7.tar.gz"
   sha256 "233dc6dedb1916b887de293454da7e36a74bed9ebea364f7e97e74920051bc31"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/recutils.rb
+++ b/Formula/recutils.rb
@@ -24,7 +24,9 @@ class Recutils < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--datarootdir=#{elisp}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
On the topic of `brew audit --strict`, I am getting an error related to the location of Emacs Lisp files:
```
* Emacs Lisp files were linked directly to /usr/local/share/emacs/site-lisp
    This may cause conflicts with other packages.
    They should instead be installed into:
    /usr/local/opt/recutils/share/emacs/site-lisp/recutils

    The offending files are:
      /usr/local/opt/recutils/share/emacs/site-lisp/rec-mode.el
            /usr/local/opt/recutils/share/emacs/site-lisp/ob-rec.el
```

Not sure how to resolve that one.