### PR TITLE
httpd: Force mod_cgi to be built along with mod_cgid (default)

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -3,6 +3,7 @@ class Httpd < Formula
   homepage "https://httpd.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=httpd/httpd-2.4.29.tar.bz2"
   sha256 "777753a5a25568a2a27428b2214980564bc1c38c1abf9ccc7630b639991f7f00"
+  revision 1
 
   bottle do
     sha256 "9607b2648d706175f8c8a7ee529bb6e57abdb7a60d47bcb4012e403721707d6d" => :high_sierra
@@ -46,6 +47,7 @@ class Httpd < Formula
                           "--localstatedir=#{var}",
                           "--enable-mpms-shared=all",
                           "--enable-mods-shared=all",
+                          "--enable-cgi",
                           "--enable-pie",
                           "--enable-suexec",
                           "--with-suexec-bin=#{opt_bin}/suexec",


### PR DESCRIPTION
The mod_cgi and mod_cgid provide the same features for different MPMs.
The latter is built by default with the current configure flags. The
former requires an additional flag since we are building for both
threaded and non-threaded MPMs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
