### PR TITLE
ipfs-update 1.5.2 (new formula)

### DIFF
--- a/Formula/ipfs-update.rb
+++ b/Formula/ipfs-update.rb
@@ -1,0 +1,15 @@
+class IpfsUpdate < Formula
+  desc "CLI tool to help update and install IPFS easily"
+  homepage "https://dist.ipfs.io/#ipfs-update"
+  url "https://dist.ipfs.io/ipfs-update/v1.5.2/ipfs-update_v1.5.2_darwin-amd64.tar.gz"
+  version "1.5.2"
+  sha256 "9f7017fe7453fd42b35a52d631ba4765fdc0e6d0cd890f0eb1a12a64f086c922"
+
+  def install
+    bin.install "ipfs-update"
+  end
+
+  test do
+    system "#{bin}/ipfs-update", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I am unsure if this formula is appropriate. The `url` is for a prebuilt binary (9MB), and `install` is simply moving the executable to the `bin` folder for symlinking (as opposed to installing Go and using it to build).

Following the advice from the [Homebrew-Cask Rejected Casks FAQ](https://github.com/caskroom/homebrew-cask/blob/master/doc/faq/rejected_casks.md)…
> The app is both open-source and CLI-only (i.e. it only uses the binary artifact). In that case, and in the spirit of deduplication, submit it first to Homebrew/core. If it is rejected there, you may then try again in Homebrew-Cask (link us to the issue on Homebrew so we can see their reasoning for rejection).

I'm submitting here first. If it is rejected as there isn't a proper `--build-from-source` option, I'll invest the time to move this to Homebrew-Cask and do another one for ipfs-update going the `go build` route for Homebrew/core.