### PR TITLE
libquvi 0.9.4, quvi 0.9.5 and cclive 0.9.3

### DIFF
--- a/Formula/cclive.rb
+++ b/Formula/cclive.rb
@@ -1,9 +1,8 @@
 class Cclive < Formula
   desc "Command-line video extraction utility"
   homepage "https://cclive.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/cclive/0.7/cclive-0.7.16.tar.xz"
-  sha256 "586a120faddcfa16f5bb058b5c901f1659336c6fc85a0d3f1538882a44ee10e1"
-  revision 2
+  url "https://downloads.sourceforge.net/project/cclive/0.9/cclive-0.9.3.tar.xz"
+  sha256 "2edeaf5d76455723577e0b593f0322a97f1e0c8b0cffcc70eca8b5d17374a495"
 
   bottle do
     cellar :any
@@ -14,16 +13,58 @@ class Cclive < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "quvi"
   depends_on "boost"
+  depends_on "glibmm"
   depends_on "pcre"
+  depends_on "libquvi"
 
   conflicts_with "clozure-cl", :because => "both install a ccl binary"
 
+  # Upstream PR from 26 Dec 2014 "Add explicit <iostream> includes, fixes build
+  # with Boost 1.56"
+  patch do
+    url "https://github.com/legatvs/cclive/pull/2.patch?full_index=1"
+    sha256 "a4cc99e6b78701c8106871b690c899b95d36d8f873ff4d212e63d8f3f45a990f"
+  end
+
+  # Fix build errors due to assumption of glibc's strerror_r and due to C++11
+  # requirement that there be a space between literal and identifier.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/1266537/cclive/cxx11-and-strerror_r.diff"
+    sha256 "38ce495646de295e8cb2d6712d82f2d995db0601649197bc17ab01c5027e7845"
+  end
+
+  resource "luasocket" do
+    url "https://luarocks.org/luasocket-3.0rc1-2.src.rock"
+    version "3.0rc1-2"
+    sha256 "3882f2a1e1c6145ceb43ead385b861b97fa2f8d487e8669ec5b747406ab251c7"
+  end
+
+  needs :cxx11
+
   def install
+    ENV.cxx11
+
+    luapath = libexec/"vendor"
+    ENV["LUA_PATH"] = "#{luapath}/share/lua/5.1/?.lua;;#{luapath}/share/lua/5.1/lxp/?.lua"
+    ENV["LUA_CPATH"] = "#{luapath}/lib/lua/5.1/?.so"
+
+    resource("luasocket").stage do
+      system "luarocks-5.1", "install", "--tree=#{luapath}",
+             Dir["*.rockspec"].first
+    end
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+
+    (libexec/"bin").install bin/"cclive"
+    (bin/"cclive").write <<~EOS
+      #!/bin/bash
+      export LUA_PATH="#{ENV["LUA_PATH"]}"
+      export LUA_CPATH="#{ENV["LUA_CPATH"]}"
+      "#{libexec}/bin/cclive" "$@"
+    EOS
   end
 
   test do

--- a/Formula/cclive.rb
+++ b/Formula/cclive.rb
@@ -35,7 +35,7 @@ class Cclive < Formula
   end
 
   resource "luasocket" do
-    url "https://luarocks.org/luasocket-3.0rc1-2.src.rock"
+    url "https://commondatastorage.googleapis.com/moonrocks/54/luasocket-3.0rc1-2.src.rock"
     version "3.0rc1-2"
     sha256 "3882f2a1e1c6145ceb43ead385b861b97fa2f8d487e8669ec5b747406ab251c7"
   end

--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -1,9 +1,8 @@
 class Libquvi < Formula
   desc "C library to parse flash media stream properties"
   homepage "https://quvi.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2"
-  sha256 "f5a2fb0571634483e8a957910f44e739f5a72eb9a1900bd10b453c49b8d5f49d"
-  revision 2
+  url "https://downloads.sourceforge.net/project/quvi/0.9/libquvi/libquvi-0.9.4.tar.xz"
+  sha256 "2d3fe28954a68ed97587e7b920ada5095c450105e993ceade85606dadf9a81b2"
 
   bottle do
     sha256 "bb5a4201afd814e87ee496b8cefbcf126f0245d7b3c600039e71e7b355115bf7" => :high_sierra
@@ -12,11 +11,14 @@ class Libquvi < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libgcrypt"
+  depends_on "libproxy"
   depends_on "lua@5.1"
 
   resource "scripts" do
-    url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz"
-    sha256 "b8d17d53895685031cd271cf23e33b545ad38cad1c3bddcf7784571382674c65"
+    url "https://downloads.sourceforge.net/project/quvi/0.9/libquvi-scripts/libquvi-scripts-0.9.20131130.tar.xz"
+    sha256 "17f21f9fac10cf60af2741f2c86a8ffd8007aa334d1eb78ff6ece130cb3777e3"
   end
 
   def install
@@ -29,7 +31,9 @@ class Libquvi < Formula
     end
     ENV.append_path "PKG_CONFIG_PATH", "#{scripts}/lib/pkgconfig"
 
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
     system "make", "install"
   end
 end

--- a/Formula/quvi.rb
+++ b/Formula/quvi.rb
@@ -1,8 +1,8 @@
 class Quvi < Formula
   desc "Parse video download URLs"
   homepage "https://quvi.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/quvi/0.4/quvi/quvi-0.4.2.tar.bz2"
-  sha256 "1f4e40c14373cb3d358ae1b14a427625774fd09a366b6da0c97d94cb1ff733c3"
+  url "https://downloads.sourceforge.net/project/quvi/0.9/quvi/quvi-0.9.5.tar.xz"
+  sha256 "cb3918aad990b9bc49828a5071159646247199a63de0dd4c706adc5c8cd0a2c0"
 
   bottle do
     cellar :any
@@ -17,7 +17,9 @@ class Quvi < Formula
   depends_on "libquvi"
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
libquvi:
- depend on glib, libgcrypt and libproxy

cclive:
- depend on glibmm
- depend on libquvi instead of quvi
- patches for Boost >=1.56, C++11 and glibc's strerror_r
- vendor luasocket