### PR TITLE
libtomcrypt 1.18.0 (new formula)

### DIFF
--- a/Formula/libtomcrypt.rb
+++ b/Formula/libtomcrypt.rb
@@ -1,0 +1,29 @@
+class Libtomcrypt < Formula
+  desc "Comprehensive, modular and portable cryptographic toolkit"
+  homepage "http://www.libtom.net"
+  url "https://github.com/libtom/libtomcrypt/archive/v1.18.0.tar.gz"
+  sha256 "bdba1499dab3bf3365fa75553f069eba7bea392e8f9e0381aa0e950a08bd85ba"
+
+  option "with-gmp", "enable gmp as MPI provider"
+  option "with-libtommath", "enable libtommath as MPI provider"
+
+  depends_on "gmp" => :optional
+  depends_on "libtommath" => :optional
+
+  def install
+    ENV.append "CFLAGS", "-DUSE_GMP -DGMP_DESC" if build.with?("gmp")
+    ENV.append "EXTRALIBS", "-lgmp" if build.with?("gmp")
+    ENV.append "CFLAGS", "-DUSE_LTM -DLTM_DESC" if build.with?("libtommath")
+    ENV.append "EXTRALIBS", "-ltommath" if build.with?("libtommath")
+    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "test"
+    pkgshare.install "./test"
+    (pkgshare/"tests").install "tests/test.key"
+  end
+
+  test do
+    cd pkgshare do
+      system "./test"
+    end
+  end
+end

--- a/Formula/libtomcrypt.rb
+++ b/Formula/libtomcrypt.rb
@@ -11,19 +11,22 @@ class Libtomcrypt < Formula
   depends_on "libtommath" => :optional
 
   def install
-    ENV.append "CFLAGS", "-DUSE_GMP -DGMP_DESC" if build.with?("gmp")
-    ENV.append "EXTRALIBS", "-lgmp" if build.with?("gmp")
-    ENV.append "CFLAGS", "-DUSE_LTM -DLTM_DESC" if build.with?("libtommath")
-    ENV.append "EXTRALIBS", "-ltommath" if build.with?("libtommath")
-    system "make", "install", "PREFIX=#{prefix}"
+    if build.with? "gmp"
+      ENV.append "CFLAGS", "-DUSE_GMP -DGMP_DESC"
+      ENV.append "EXTRALIBS", "-lgmp"
+    end
+    if build.with? "libtommath"
+      ENV.append "CFLAGS", "-DUSE_LTM -DLTM_DESC"
+      ENV.append "EXTRALIBS", "-ltommath"
+    end
     system "make", "test"
-    pkgshare.install "./test"
+    system "make", "install", "PREFIX=#{prefix}"
+    pkgshare.install "test"
     (pkgshare/"tests").install "tests/test.key"
   end
 
   test do
-    cd pkgshare do
-      system "./test"
-    end
+    cp_r Dir[pkgshare/"*"], testpath
+    system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Moved to boneyard in https://github.com/Homebrew/homebrew-core/commit/add830d17087c27bae6f3805e458f578486f87cf, but upstream maintenance has now resumed, with the latest release being in October (compare to previous 1.17 in 2010).