### PR TITLE
geeqie: add adwaita-icon-theme dependency

### DIFF
--- a/Formula/geeqie.rb
+++ b/Formula/geeqie.rb
@@ -3,7 +3,7 @@ class Geeqie < Formula
   homepage "http://www.geeqie.org/"
   url "http://www.geeqie.org/geeqie-1.3.tar.xz"
   sha256 "4b6f566dd1a8badac68c4353c7dd0f4de17f8627b85a7a70d5eb1ae3b540ec3f"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "ee45d42101e3fdcee8f122a87e32e2b8e6e5e0ee93f6e826c4a2e89ce2ade87b" => :high_sierra
@@ -28,6 +28,7 @@ class Geeqie < Formula
   depends_on "imagemagick"
   depends_on "exiv2"
   depends_on "little-cms2"
+  depends_on "adwaita-icon-theme"
 
   def install
     ENV["NOCONFIGURE"] = "yes"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The icon theme is required, so that all icons are displayed in the toolbar.

Fixes:
```
[...]
(geeqie:57821): Gtk-WARNING **: Error loading theme icon 'zoom-out' for stock: Icon 'zoom-out' not present in theme Adwaita

(geeqie:57821): Gtk-WARNING **: Error loading theme icon 'zoom-fit-best' for stock: Icon 'zoom-fit-best' not present in theme Adwaita

(geeqie:57821): Gtk-WARNING **: Error loading theme icon 'zoom-original' for stock: Icon 'zoom-original' not present in theme Adwaita

(geeqie:57821): Gtk-WARNING **: Error loading theme icon 'document-save' for stock: Icon 'document-save' not present in theme Adwaita
[...]
```