### PR TITLE
botan: fix option to enable debugging symbols

### DIFF
--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -43,7 +43,7 @@ class Botan < Formula
       --with-bzip2
     ]
 
-    args << "--enable-debug" if build.with? "debug"
+    args << "--with-debug" << "--debug-mode" if build.with? "debug"
 
     system "./configure.py", *args
     # A hack to force them use our CFLAGS. MACH_OPT is empty in the Makefile


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Closes #22262 