### PR TITLE
gforth: fix emacs support & add testing

### DIFF
--- a/Formula/gforth.rb
+++ b/Formula/gforth.rb
@@ -3,6 +3,7 @@ class Gforth < Formula
   homepage "https://www.gnu.org/software/gforth/"
   url "https://www.complang.tuwien.ac.at/forth/gforth/gforth-0.7.3.tar.gz"
   sha256 "2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0"
+  revision 1
 
   bottle do
     sha256 "a8696af411ccf1d3d94263442bb33f8692725acc96648d4b88410ef61f7c09b1" => :high_sierra

--- a/Formula/gforth.rb
+++ b/Formula/gforth.rb
@@ -12,6 +12,7 @@ class Gforth < Formula
     sha256 "d72074880ae4ab11e656645d0d9ab52630640fbb0df713c03fee1a6b8cd84ffa" => :mavericks
   end
 
+  depends_on "emacs" => :build
   depends_on "libtool" => :run
   depends_on "libffi"
   depends_on "pcre"
@@ -20,7 +21,14 @@ class Gforth < Formula
     cp Dir["#{Formula["libtool"].opt_share}/libtool/*/config.{guess,sub}"], buildpath
     ENV.deparallelize
     system "./configure", "--prefix=#{prefix}"
-    system "make" # Separate build steps.
-    system "make", "install"
+    system "make", "EMACS=#{Formula["emacs"].opt_bin}/emacs"
+    elisp.mkpath
+    system "make", "install", "emacssitelispdir=#{elisp}"
+
+    elisp.install "gforth.elc"
+  end
+
+  test do
+    assert_equal "2 ", shell_output("#{bin}/gforth -e '1 1 + . bye'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These changes make it so that Gforth has its Emacs support installed. It also makes it so that it compiles the Elisp file with a more recent version of Emacs than the system Emacs, if possible. Furthermore, I added a test to this formula which it did not have until now. The test just sees whether the interpreter can evaluate `1 + 1` (which is `1 1 +` in Forth) and then exits.