### PR TITLE
pucrunch 1.14 (new formula)

### DIFF
--- a/Formula/pucrunch.rb
+++ b/Formula/pucrunch.rb
@@ -1,6 +1,6 @@
 class Pucrunch < Formula
   desc "Hybrid LZ77 and RLE compressor"
-  homepage "http://a1bert.kapsi.fi/Dev/pucrunch/"
+  homepage "https://a1bert.kapsi.fi/Dev/pucrunch/"
   url "http://urchlay.naptime.net/~urchlay/src/pucrunch-20081122.tar.xz"
   version "1.14"
   sha256 "3488bfad58e2fac8f6c429c8727336dff7840d3c1dbf3131afd5380d77996d25"

--- a/Formula/pucrunch.rb
+++ b/Formula/pucrunch.rb
@@ -1,0 +1,21 @@
+class Pucrunch < Formula
+  desc "Hybrid LZ77 and RLE compressor"
+  homepage "http://a1bert.kapsi.fi/Dev/pucrunch/"
+  url "http://urchlay.naptime.net/~urchlay/src/pucrunch-20081122.tar.xz"
+  version "1.14"
+  sha256 "3488bfad58e2fac8f6c429c8727336dff7840d3c1dbf3131afd5380d77996d25"
+
+  def install
+    system "make"
+    bin.install "pucrunch"
+  end
+
+  test do
+    code = [0x00, 0xc0, 0x4c, 0xe2, 0xfc]
+    File.open(testpath/"a.prg", "wb") do |output|
+      output.write [code.join].pack("H*")
+    end
+
+    system "#{bin}/pucrunch", "-c64", "a.prg", "b.prg"
+  end
+end


### PR DESCRIPTION
Pucrunch is an executable packer for Commodore 64 (an VIC20) that runs the
packing phase on a host system with virtually unlimited resources.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
