### PR TITLE
Update schismtracker head

### DIFF
--- a/Formula/schismtracker.rb
+++ b/Formula/schismtracker.rb
@@ -3,7 +3,7 @@ class Schismtracker < Formula
   homepage "http://schismtracker.org/"
   url "https://github.com/schismtracker/schismtracker/archive/20170910.tar.gz"
   sha256 "9f32fa71878237267c83279816d6bcccc311c64496cac2933f68dff5ac64ee05"
-  head "https://bitbucket.org/Storlek/schismtracker", :using => :hg
+  head "https://github.com/schismtracker/schismtracker.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The Bitbucket hg repo has been superceded by the GitHub repo.

I don't have a macOS environment to test this with (sorry!), but I hope this change is simple enough that it's not an issue.