### PR TITLE
qhttp 0.1.1 (new formula)

### DIFF
--- a/Formula/qhttp.rb
+++ b/Formula/qhttp.rb
@@ -1,0 +1,18 @@
+class Qhttp < Formula
+  desc "Very simple http server"
+  homepage "https://github.com/skyflyer/qhttp"
+  url "https://github.com/skyflyer/qhttp/archive/v0.1.1.tar.gz"
+  sha256 "9f62598e621da2faf40fe3dc9d1266dd5dfc21bcc054c5e45edd6b2ba3effb9d"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", "qhttp"
+    bin.install "qhttp"
+    ohai "Run 'qhttp' in a directory you wish to serve"
+  end
+
+  test do
+    system "#{bin}/qhttp", "-test"
+  end
+end


### PR DESCRIPTION
Adding formula for qhttp installation. qhttp is a very simple
http server used for local development and/or sharing files on
the local network.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    It does not, since the repository is new and not popular enought. Is this really a deciding factor? Should it be added to a custom tap?

-----
