### PR TITLE
orocos-kdl: import from homebrew/science

### DIFF
--- a/Formula/orocos-kdl.rb
+++ b/Formula/orocos-kdl.rb
@@ -1,0 +1,34 @@
+class OrocosKdl < Formula
+  desc "Orocos Kinematics and Dynamics C++ library"
+  homepage "http://www.orocos.org/kdl"
+  url "https://github.com/orocos/orocos_kinematics_dynamics/archive/v1.3.1.tar.gz"
+  sha256 "aff361d2b4e2c6d30ae959308a124022eeef5dc5bea2ce779900f9b36b0537bd"
+
+  depends_on "cmake" => :build
+  depends_on "eigen"
+
+  def install
+    cd "orocos_kdl" do
+      system "cmake", ".", "-DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3",
+                           *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <kdl/frames.hpp>
+      int main()
+      {
+        using namespace KDL;
+        Vector v1(1.,0.,1.);
+        Vector v2(1.,0.,1.);
+        assert(v1==v2);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lorocos-kdl",
+                    "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a formula import from the recently deprecated homebrew/science.  I have attempted to address all issues that @ilovezfs cited during the import of the opencascade formula however in this case, I took extra steps to retain the original commit history.
  