### PR TITLE
med-file: import from homebrew/science

### DIFF
--- a/Formula/med-file.rb
+++ b/Formula/med-file.rb
@@ -1,0 +1,44 @@
+class MedFile < Formula
+  desc "Modeling and Data Exchange standardized format library"
+  homepage "http://www.salome-platform.org/"
+  url "http://files.salome-platform.org/Salome/other/med-3.2.0.tar.gz"
+  sha256 "d52e9a1bdd10f31aa154c34a5799b48d4266dc6b4a5ee05a9ceda525f2c6c138"
+
+  depends_on "cmake" => :build
+  depends_on "gcc" => :build   # for gfortan
+  depends_on "swig" => :build
+  depends_on "hdf5"
+  depends_on "python"
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/720fedf/med-file/libc%2B%2B_and_python_bindings_fixes.diff"
+    sha256 "4125238ca3623e682b766cf2d34fed17938007ad326ae3b158a9cd427c638054"
+  end
+
+  def install
+    python_prefix=`#{Formula["python"].opt_bin}/python2-config --prefix`.chomp
+    python_include=Dir["#{python_prefix}/include/*"].first
+
+    system "cmake", ".", "-DMEDFILE_BUILD_PYTHON=ON",
+                         "-DMEDFILE_BUILD_TESTS=OFF",
+                         "-DMEDFILE_INSTALL_DOC=ON",
+                         "-DPYTHON_INCLUDE_DIR=#{python_include}",
+                         *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    output = shell_output("#{bin}/medimport 2>&1", 255).chomp
+    assert_match output, "Nombre de parametre incorrect : medimport filein [fileout]"
+    (testpath/"test.c").write <<~EOS
+      #include <med.h>
+      int main() {
+        med_int major, minor, release;
+        return MEDlibraryNumVersion(&major, &minor, &release);
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["hdf5"].opt_include}",
+                   "-L#{lib}", "-lmedC", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
med-file: import from homebrew/science
  - Made "optionless"
  - Alphabetized dependencies
  - Alphabetized cmake args
  - Reformatted to comply with column-80 guideline
  - Ensured tests execute while unlinked

Unlink test results:
```
[blacey@bbl /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula (med-file-import)]$ brew unlink med-file szip hdf5
Unlinking /usr/local/Cellar/med-file/3.2.0... 79 symlinks removed
Unlinking /usr/local/Cellar/szip/2.1.1... 6 symlinks removed
Unlinking /usr/local/Cellar/hdf5/1.10.1_2... 159 symlinks removed

[blacey@bbl /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula (med-file-import)]$ brew test -f med-file
Testing med-file
==> /usr/local/Cellar/med-file/3.2.0/bin/medimport 2>&1
==> /usr/bin/clang test.c -I/usr/local/Cellar/med-file/3.2.0/include -I/usr/local/opt/hdf5/include -L/usr/local/Cellar/med-file/3.2.0/lib -lmedC -o test
==> ./test
```

@ilovezfs - I look forward to today's lesson so let 'em fly ;)