### PR TITLE
docker and docker-completion: fix revision hash

### DIFF
--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -3,7 +3,7 @@ class DockerCompletion < Formula
   homepage "https://www.docker.com/"
   url "https://github.com/docker/docker-ce.git",
       :tag => "v17.12.0-ce",
-      :revision => "486a48d2701493bb65385788a291e36febb44ec1"
+      :revision => "c97c6d62c26c1da407e3086f0b5d3d866ed308bc"
 
   bottle :unneeded
 

--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -4,6 +4,7 @@ class DockerCompletion < Formula
   url "https://github.com/docker/docker-ce.git",
       :tag => "v17.12.0-ce",
       :revision => "c97c6d62c26c1da407e3086f0b5d3d866ed308bc"
+  revision 1
 
   bottle :unneeded
 

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -4,6 +4,7 @@ class Docker < Formula
   url "https://github.com/docker/docker-ce.git",
       :tag => "v17.12.0-ce",
       :revision => "c97c6d62c26c1da407e3086f0b5d3d866ed308bc"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -3,7 +3,7 @@ class Docker < Formula
   homepage "https://www.docker.com/"
   url "https://github.com/docker/docker-ce.git",
       :tag => "v17.12.0-ce",
-      :revision => "486a48d2701493bb65385788a291e36febb44ec1"
+      :revision => "c97c6d62c26c1da407e3086f0b5d3d866ed308bc"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Tag was updated in #22174  but the commit hash wasn't, updated according to the [official repo](https://github.com/docker/docker-ce/releases/tag/v17.12.0-ce).