### PR TITLE
libpeas: add support for running python plugins

### DIFF
--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -18,8 +18,8 @@ class Libpeas < Formula
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
-  depends_on :python => "with-python"
-  depends_on :python3 => "with-python"
+  depends_on "python" => :optional
+  depends_on "python3" if build.with? "python"
   depends_on "pygobject3" if build.with? "python"
 
   def install
@@ -36,14 +36,13 @@ class Libpeas < Formula
 
     if build.with? "python"
       # extra hoop to jump if both, Python 2 and 3 are installed in parallel
-      py2_prefix = `python2-config --prefix`.chomp
+      py2_prefix = Utils.popen_read("python2-config --prefix").chomp
       py2_lib = "#{py2_prefix}/lib"
-      py3_prefix = `python3-config --prefix`.chomp
+      py3_prefix = Utils.popen_read("python3-config --prefix").chomp
       py3_lib = "#{py3_prefix}/lib"
-      ENV["LDFLAGS"] = "#{ENV["LDFLAGS"]} -L#{py2_lib} -L#{py3_lib}"
+      ENV.append "LDFLAGS", "-L#{py2_lib} -L#{py3_lib}"
       # configure argument
-      args << "--enable-python2"
-      args << "--enable-python3"
+      args << "--enable-python2" << "--enable-python3"
     end
 
     system "./configure", *args

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -10,7 +10,7 @@ class Libpeas < Formula
     sha256 "0f521913ca0eaf13b55aacb75e4b87a730be1f527215741ae2ba207caac523b2" => :el_capitan
   end
 
-  option "with-python", "install support for running Python plugins"
+  option "with-python3", "install support for running Python 3 plugins"
 
   depends_on "gettext" => :build
   depends_on "intltool" => :build
@@ -18,9 +18,9 @@ class Libpeas < Formula
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
-  depends_on "python" => :optional
+  depends_on "python" if MacOS.version <= :snow_leopard
+  depends_on "pygobject3"
   depends_on "python3" => :optional
-  depends_on "pygobject3" if build.with?("python")
   depends_on "pygobject3" => ["--with-python3"] if build.with?("python3")
 
   def install
@@ -29,14 +29,12 @@ class Libpeas < Formula
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-gtk
+      --enable-python2
     ]
 
-    if build.with? "python"
-      py2_prefix = Utils.popen_read("python2-config --prefix").chomp
-      py2_lib = "#{py2_prefix}/lib"
-      ENV.append "LDFLAGS", "-L#{py2_lib}"
-      args << "--enable-python2"
-    end
+    py2_prefix = Utils.popen_read("python2-config --prefix").chomp
+    py2_lib = "#{py2_prefix}/lib"
+    ENV.append "LDFLAGS", "-L#{py2_lib}"
 
     if build.with? "python3"
       py3_ver = Formula["python3"].version.to_s.slice(/(3\.\d)/)

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -30,10 +30,6 @@ class Libpeas < Formula
       --enable-gtk
     ]
 
-    # Unset PYTHONPATH as it creates more confusion that it tries to
-    # remove when both v2 and v3 are installed
-    ENV.delete("PYTHONPATH")
-
     if build.with? "python"
       # extra hoop to jump if both, Python 2 and 3 are installed in parallel
       py2_prefix = Utils.popen_read("python2-config --prefix").chomp

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -10,7 +10,7 @@ class Libpeas < Formula
     sha256 "0f521913ca0eaf13b55aacb75e4b87a730be1f527215741ae2ba207caac523b2" => :el_capitan
   end
 
-  option "with-python3", "install support for running Python 3 plugins"
+  option "with-python@2", "install support for running Python 2 plugins"
 
   depends_on "gettext" => :build
   depends_on "intltool" => :build
@@ -18,29 +18,29 @@ class Libpeas < Formula
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
-  depends_on "python" if MacOS.version <= :snow_leopard
+  depends_on "python@2" => :optional if MacOS.version < :snow_leopard
   depends_on "pygobject3"
-  depends_on "python3" => :optional
-  depends_on "pygobject3" => ["--with-python3"] if build.with?("python3")
-
+  depends_on "python"               # this is python@3 as of 1 March 2018
+  depends_on "pygobject3" => ["--with-python@2"] if build.with?("python@2")
+  
   def install
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-gtk
-      --enable-python2
+      --enable-python3
     ]
 
-    py2_prefix = Utils.popen_read("python2-config --prefix").chomp
-    py2_lib = "#{py2_prefix}/lib"
-    ENV.append "LDFLAGS", "-L#{py2_lib}"
-
-    if build.with? "python3"
-      py3_ver = Formula["python3"].version.to_s.slice(/(3\.\d)/)
-      py3_lib = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{py3_ver}/lib"
-      ENV.append "LDFLAGS", "-L#{py3_lib}"
-      args << "--enable-python3"
+    py3_ver = Formula["python3"].version.to_s.slice(/(3\.\d)/)
+    py3_lib = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{py3_ver}/lib"
+    ENV.append "LDFLAGS", "-L#{py3_lib}"
+    
+    if build.with? "python@2"
+      py2_prefix = Utils.popen_read("python2-config --prefix").chomp
+      py2_lib = "#{py2_prefix}/lib"
+      ENV.append "LDFLAGS", "-L#{py2_lib}"
+      args << "--enable-python2"
     end
 
     system "./configure", *args

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -32,20 +32,16 @@ class Libpeas < Formula
     ]
 
     if build.with? "python"
-      # extra hoop to jump if both, Python 2 and 3 are installed in parallel
       py2_prefix = Utils.popen_read("python2-config --prefix").chomp
       py2_lib = "#{py2_prefix}/lib"
       ENV.append "LDFLAGS", "-L#{py2_lib}"
-      # configure argument
       args << "--enable-python2"
     end
 
     if build.with? "python3"
-      # extra hoop to jump if both, Python 2 and 3 are installed in parallel
-      py3_prefix = Utils.popen_read("python3-config --prefix").chomp
-      py3_lib = "#{py3_prefix}/lib"
+      py3_ver = Formula["python3"].version.to_s.slice(/(3\.\d)/)
+      py3_lib = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{py3_ver}/lib"
       ENV.append "LDFLAGS", "-L#{py3_lib}"
-      # configure argument
       args << "--enable-python3"
     end
 

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -19,8 +19,9 @@ class Libpeas < Formula
   depends_on "gobject-introspection"
   depends_on "gtk+3"
   depends_on "python" => :optional
-  depends_on "python3" if build.with? "python"
-  depends_on "pygobject3" if build.with? "python"
+  depends_on "python3" => :optional
+  depends_on "pygobject3" if build.with?("python")
+  depends_on "pygobject3" => ["--with-python3"] if build.with?("python3")
 
   def install
     args = %W[
@@ -34,11 +35,18 @@ class Libpeas < Formula
       # extra hoop to jump if both, Python 2 and 3 are installed in parallel
       py2_prefix = Utils.popen_read("python2-config --prefix").chomp
       py2_lib = "#{py2_prefix}/lib"
+      ENV.append "LDFLAGS", "-L#{py2_lib}"
+      # configure argument
+      args << "--enable-python2"
+    end
+
+    if build.with? "python3"
+      # extra hoop to jump if both, Python 2 and 3 are installed in parallel
       py3_prefix = Utils.popen_read("python3-config --prefix").chomp
       py3_lib = "#{py3_prefix}/lib"
-      ENV.append "LDFLAGS", "-L#{py2_lib} -L#{py3_lib}"
+      ENV.append "LDFLAGS", "-L#{py3_lib}"
       # configure argument
-      args << "--enable-python2" << "--enable-python3"
+      args << "--enable-python3"
     end
 
     system "./configure", *args

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -20,9 +20,9 @@ class Libpeas < Formula
   depends_on "gtk+3"
   depends_on "python@2" => :optional if MacOS.version < :snow_leopard
   depends_on "pygobject3"
-  depends_on "python"               # this is python@3 as of 1 March 2018
+  depends_on "python" # this is python@3 as of 1 March 2018
   depends_on "pygobject3" => ["--with-python@2"] if build.with?("python@2")
-  
+
   def install
     args = %W[
       --disable-dependency-tracking
@@ -35,7 +35,7 @@ class Libpeas < Formula
     py3_ver = Formula["python3"].version.to_s.slice(/(3\.\d)/)
     py3_lib = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{py3_ver}/lib"
     ENV.append "LDFLAGS", "-L#{py3_lib}"
-    
+
     if build.with? "python@2"
       py2_prefix = Utils.popen_read("python2-config --prefix").chomp
       py2_lib = "#{py2_prefix}/lib"


### PR DESCRIPTION
Added a new option "--with-python" which builds libpeas with the
python runtime to run python 2 and 3 plugins.

This PR is e.g. required in order to be able to build [astroidmail/astroid](https://github.com/astroidmail/astroid).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
