### PR TITLE
Add formula for GNU Regex

### DIFF
--- a/Formula/gnuregex.rb
+++ b/Formula/gnuregex.rb
@@ -1,0 +1,31 @@
+class GnuRegex < Formula
+  desc "GNU regex library"
+  homepage "https://ftp.gnu.org/old-gnu/regex/"
+  url "https://ftp.gnu.org/old-gnu/regex/regex-0.12.tar.gz"
+  sha256 "f36e2d8d56bf15054a850128fcb2f51807706a92d3bb4b37ceadd731535ce230"
+
+  def install
+    system "./configure"
+    system "make", "subdirs=test", "all"
+    system "mkdir", "-p", "#{lib}"
+    system "libtool", "-lSystem", "-dynamic", "-install_name",
+      "#{lib}/libgnuregex.dylib", "-o", "#{lib}/libgnuregex.dylib", "regex.o"
+    system "mkdir", "-p", "#{include}"
+    system "cp", "regex.h", "#{include}/gnuregex.h"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <regex.h>
+      int main(void) {
+        regex_t start_state;
+        if (regcomp(&start_state, "^\w+$", REG_EXTENDED)) {
+          return 1;
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/gnuregex.rb
+++ b/Formula/gnuregex.rb
@@ -1,4 +1,4 @@
-class GnuRegex < Formula
+class Gnuregex < Formula
   desc "GNU regex library"
   homepage "https://ftp.gnu.org/old-gnu/regex/"
   url "https://ftp.gnu.org/old-gnu/regex/regex-0.12.tar.gz"


### PR DESCRIPTION
GNU regex library, deprecated but still needed sometimes

Port of Macports port:
https://github.com/macports/macports-ports/blob/master/sysutils/gnuregex/Portfile

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
