### PR TITLE
bazel 0.6.1, 0.7.0, 0.7.0_1, 0.8.0, 0.8.1 (new formula)

### DIFF
--- a/Formula/bazel@0.6.1.rb
+++ b/Formula/bazel@0.6.1.rb
@@ -1,0 +1,55 @@
+class BazelAT061 < Formula
+  desc "Google's own build tool"
+  homepage "https://bazel.build/"
+  url "https://github.com/bazelbuild/bazel/releases/download/0.6.1/bazel-0.6.1-dist.zip"
+  sha256 "dada1f60a512789747011184b2767d2b44136ef3b036d86947f1896d200d2ba7"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "c4e0b6d2a060d8119c9cb28562db3298719df466c79e05dce57847eaeb93ac8f" => :high_sierra
+    sha256 "680be93f83faf8dad4c54992b50e2092873db200249ebdc5daf75c44167bdebb" => :sierra
+    sha256 "e9acaaaa8f9d1ab3918519ec467fc1df45cb5bd45708404503143bf610597202" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+  depends_on :java => "1.8+"
+  depends_on :macos => :yosemite
+
+  def install
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+    # Force Bazel ./compile.sh to put its temporary files in the buildpath
+    ENV["BAZEL_WRKDIR"] = buildpath/"work"
+
+    system "./compile.sh"
+    system "./output/bazel", "--output_user_root", buildpath/"output_user_root",
+           "build", "scripts:bash_completion"
+
+    bin.install "scripts/packages/bazel.sh" => "bazel"
+    bin.install "output/bazel" => "bazel-real"
+    bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
+    zsh_completion.install "scripts/zsh_completion/_bazel"
+  end
+
+  test do
+    touch testpath/"WORKSPACE"
+
+    (testpath/"ProjectRunner.java").write <<-EOS.undent
+      public class ProjectRunner {
+        public static void main(String args[]) {
+          System.out.println("Hi!");
+        }
+      }
+    EOS
+
+    (testpath/"BUILD").write <<-EOS.undent
+      java_binary(
+        name = "bazel-test",
+        srcs = glob(["*.java"]),
+        main_class = "ProjectRunner",
+      )
+    EOS
+
+    system bin/"bazel", "build", "//:bazel-test"
+    system "bazel-bin/bazel-test"
+  end
+end

--- a/Formula/bazel@0.7.0.rb
+++ b/Formula/bazel@0.7.0.rb
@@ -1,0 +1,55 @@
+class BazelAT070 < Formula
+  desc "Google's own build tool"
+  homepage "https://bazel.build/"
+  url "https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-dist.zip"
+  sha256 "a084a9c5d843e2343bf3f319154a48abe3d35d52feb0ad45dec427a1c4ffc416"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "39b129d4381684efb8bd1402d461327f775ec62c093baa86fc6904fbfa56bda8" => :high_sierra
+    sha256 "40d7cf9cacfb4265be7bfd5aecd827f541ca5fca37ca6ac789df2ca47e72fa17" => :sierra
+    sha256 "ae2d8748781086c113936ebc180000399f5aed0d9295bd8683894b430872cdd6" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+  depends_on :java => "1.8+"
+  depends_on :macos => :yosemite
+
+  def install
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+    # Force Bazel ./compile.sh to put its temporary files in the buildpath
+    ENV["BAZEL_WRKDIR"] = buildpath/"work"
+
+    system "./compile.sh"
+    system "./output/bazel", "--output_user_root", buildpath/"output_user_root",
+           "build", "scripts:bash_completion"
+
+    bin.install "scripts/packages/bazel.sh" => "bazel"
+    bin.install "output/bazel" => "bazel-real"
+    bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
+    zsh_completion.install "scripts/zsh_completion/_bazel"
+  end
+
+  test do
+    touch testpath/"WORKSPACE"
+
+    (testpath/"ProjectRunner.java").write <<-EOS.undent
+      public class ProjectRunner {
+        public static void main(String args[]) {
+          System.out.println("Hi!");
+        }
+      }
+    EOS
+
+    (testpath/"BUILD").write <<-EOS.undent
+      java_binary(
+        name = "bazel-test",
+        srcs = glob(["*.java"]),
+        main_class = "ProjectRunner",
+      )
+    EOS
+
+    system bin/"bazel", "build", "//:bazel-test"
+    system "bazel-bin/bazel-test"
+  end
+end

--- a/Formula/bazel@0.7.0_1.rb
+++ b/Formula/bazel@0.7.0_1.rb
@@ -1,0 +1,58 @@
+class BazelAT0701 < Formula
+  desc "Google's own build tool"
+  homepage "https://bazel.build/"
+  url "https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-dist.zip"
+  sha256 "a084a9c5d843e2343bf3f319154a48abe3d35d52feb0ad45dec427a1c4ffc416"
+  revision 1
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "a64a3d9c81d3c55f4b8bc216c31a73323579a87a5ba9e8b692cfbea8b31917cd" => :high_sierra
+    sha256 "31718c991ed0d1b4fe92296e0ccb472b908dccabc1d78b29ccf6e8a2b5b2cf1d" => :sierra
+    sha256 "6a6eadd2c6ba3c56b9d592366337775e3933aae70bda18387e464c77f3049aac" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+  depends_on :java => "1.8"
+  depends_on :macos => :yosemite
+
+  def install
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+    # Force Bazel ./compile.sh to put its temporary files in the buildpath
+    ENV["BAZEL_WRKDIR"] = buildpath/"work"
+
+    system "./compile.sh"
+    system "./output/bazel", "--output_user_root", buildpath/"output_user_root",
+           "build", "scripts:bash_completion"
+
+    bin.install "scripts/packages/bazel.sh" => "bazel"
+    bin.install "output/bazel" => "bazel-real"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+
+    bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
+    zsh_completion.install "scripts/zsh_completion/_bazel"
+  end
+
+  test do
+    touch testpath/"WORKSPACE"
+
+    (testpath/"ProjectRunner.java").write <<~EOS
+      public class ProjectRunner {
+        public static void main(String args[]) {
+          System.out.println("Hi!");
+        }
+      }
+    EOS
+
+    (testpath/"BUILD").write <<~EOS
+      java_binary(
+        name = "bazel-test",
+        srcs = glob(["*.java"]),
+        main_class = "ProjectRunner",
+      )
+    EOS
+
+    system bin/"bazel", "build", "//:bazel-test"
+    system "bazel-bin/bazel-test"
+  end
+end

--- a/Formula/bazel@0.8.0.rb
+++ b/Formula/bazel@0.8.0.rb
@@ -1,0 +1,57 @@
+class BazelAT080 < Formula
+  desc "Google's own build tool"
+  homepage "https://bazel.build/"
+  url "https://github.com/bazelbuild/bazel/releases/download/0.8.0/bazel-0.8.0-dist.zip"
+  sha256 "aa840321d056abd3c6be10c4a1e98a64f9f73fff9aa89c468dae8c003974a078"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "d520b2179836981c0caa8bf6f30c0af358a04ed25531f07a723091a323512850" => :high_sierra
+    sha256 "23f5efc1f93950b8a66fed135e6e4ffd492df6664455c2ee35ff92fb927499d3" => :sierra
+    sha256 "348245044d0eae3182d0521b28469cedf0a9de40286a1efbe728ede0c85b1f3c" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+  depends_on :java => "1.8"
+  depends_on :macos => :yosemite
+
+  def install
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+    # Force Bazel ./compile.sh to put its temporary files in the buildpath
+    ENV["BAZEL_WRKDIR"] = buildpath/"work"
+
+    system "./compile.sh"
+    system "./output/bazel", "--output_user_root", buildpath/"output_user_root",
+           "build", "scripts:bash_completion"
+
+    bin.install "scripts/packages/bazel.sh" => "bazel"
+    bin.install "output/bazel" => "bazel-real"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+
+    bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
+    zsh_completion.install "scripts/zsh_completion/_bazel"
+  end
+
+  test do
+    touch testpath/"WORKSPACE"
+
+    (testpath/"ProjectRunner.java").write <<~EOS
+      public class ProjectRunner {
+        public static void main(String args[]) {
+          System.out.println("Hi!");
+        }
+      }
+    EOS
+
+    (testpath/"BUILD").write <<~EOS
+      java_binary(
+        name = "bazel-test",
+        srcs = glob(["*.java"]),
+        main_class = "ProjectRunner",
+      )
+    EOS
+
+    system bin/"bazel", "build", "//:bazel-test"
+    system "bazel-bin/bazel-test"
+  end
+end

--- a/Formula/bazel@0.8.1.rb
+++ b/Formula/bazel@0.8.1.rb
@@ -1,0 +1,57 @@
+class BazelAT081 < Formula
+  desc "Google's own build tool"
+  homepage "https://bazel.build/"
+  url "https://github.com/bazelbuild/bazel/releases/download/0.8.1/bazel-0.8.1-dist.zip"
+  sha256 "dfd0761e0b7e36c1d74c928ad986500c905be5ebcfbc29914d574af1db7218cf"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "35b1c0670208b22810d029c6c68c6311b3c511f8645159f611dca5a65ca27147" => :high_sierra
+    sha256 "9901031265cc4c1851e62b1e54f4993b90bd4a071eddeaffb5c7cf07c4031126" => :sierra
+    sha256 "54b3b426eefef6a205146bbbfe19bec1c03abe18de0d9c3692c407d32e2b2426" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+  depends_on :java => "1.8"
+  depends_on :macos => :yosemite
+
+  def install
+    ENV["EMBED_LABEL"] = "#{version}-homebrew"
+    # Force Bazel ./compile.sh to put its temporary files in the buildpath
+    ENV["BAZEL_WRKDIR"] = buildpath/"work"
+
+    system "./compile.sh"
+    system "./output/bazel", "--output_user_root", buildpath/"output_user_root",
+           "build", "scripts:bash_completion"
+
+    bin.install "scripts/packages/bazel.sh" => "bazel"
+    bin.install "output/bazel" => "bazel-real"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+
+    bash_completion.install "bazel-bin/scripts/bazel-complete.bash"
+    zsh_completion.install "scripts/zsh_completion/_bazel"
+  end
+
+  test do
+    touch testpath/"WORKSPACE"
+
+    (testpath/"ProjectRunner.java").write <<~EOS
+      public class ProjectRunner {
+        public static void main(String args[]) {
+          System.out.println("Hi!");
+        }
+      }
+    EOS
+
+    (testpath/"BUILD").write <<~EOS
+      java_binary(
+        name = "bazel-test",
+        srcs = glob(["*.java"]),
+        main_class = "ProjectRunner",
+      )
+    EOS
+
+    system bin/"bazel", "build", "//:bazel-test"
+    system "bazel-bin/bazel-test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

# Context
This is a copy of a personal [tap](https://github.com/improbable/homebrew-bazel) which was created as different (internal) projects rely on different versions of bazel. I believe that this situation is not unique to my organisation and thus want to see what the community/maintainers think of adding other versions to `homebrew-core`.

## Previous discussions
Previously, it was decided that `homebrew-core` should not support/maintain multiple versions, see conversation [here](https://github.com/Homebrew/homebrew-core/pull/10217). However, since version 0.2 already exists and other projects like `gcc` also maintain multiple versions, I would like to revisit this conversation.