### PR TITLE
fabio 1.5.6-2

### DIFF
--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -2,7 +2,7 @@ class Fabio < Formula
   desc "Zero-conf load balancing HTTP(S) router"
   homepage "https://github.com/fabiolb/fabio"
   url "https://github.com/fabiolb/fabio/archive/v1.5.6.tar.gz"
-  sha256 "07a0d77bb3f718bf9e4f3952726493f3c8610f0427127f0c43172896a4934730"
+  sha256 "178764c8cba2298370166984a13f630a938c51ed8e627e24426538d7af2f3f3e"
   head "https://github.com/fabiolb/fabio.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The source url did not reflect the actual url on github since I did a force push somewhere during the release process. This patch fixes that.