### PR TITLE
Adding dependencies for MD5sum programs

### DIFF
--- a/Formula/rex.rb
+++ b/Formula/rex.rb
@@ -14,6 +14,7 @@ class Rex < Formula
   end
 
   depends_on :perl => "5.16"
+  depends_on "md5sha1sum"
 
   resource "Module::Build" do
     # AWS::Signature4 requires Module::Build v0.4205 and above, while standard


### PR DESCRIPTION
Rex uses these in a number of different places including virtually all SSH access.
While it might be possible there are use cases that do not require this, it is effectively
required for standard use of software.

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

brew audit --strict rex fails for reasons unrelated to this PR.  Apparently depends_on :perl => "5.16" is deprecated, and this has not yet been fixed.  I would recommend fixing this by just depending on Perl and ignoring the option but this is a different discussion.
