### PR TITLE
dns2tcp: Update mirror

### DIFF
--- a/Formula/dns2tcp.rb
+++ b/Formula/dns2tcp.rb
@@ -1,7 +1,7 @@
 class Dns2tcp < Formula
   desc "TCP over DNS tunnel"
   homepage "http://www.hsc.fr/ressources/outils/dns2tcp/index.html.en"
-  url "http://www.hsc.fr/ressources/outils/dns2tcp/download/dns2tcp-0.5.2.tar.gz"
+  url "https://downloads.aredn.org/sources/dns2tcp-0.5.2.tar.gz"
   sha256 "ea9ef59002b86519a43fca320982ae971e2df54cdc54cdb35562c751704278d9"
 
   bottle do

--- a/Formula/dns2tcp.rb
+++ b/Formula/dns2tcp.rb
@@ -1,7 +1,8 @@
 class Dns2tcp < Formula
   desc "TCP over DNS tunnel"
-  homepage "http://www.hsc.fr/ressources/outils/dns2tcp/index.html.en"
-  url "https://downloads.aredn.org/sources/dns2tcp-0.5.2.tar.gz"
+  homepage "https://packages.debian.org/sid/dns2tcp"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
   sha256 "ea9ef59002b86519a43fca320982ae971e2df54cdc54cdb35562c751704278d9"
 
   bottle do


### PR DESCRIPTION
SHA256 matches the original one -- it seems that the homepage now redirects to some company's website, which is why there was an issue with the SHA256 not matching when attempting to download.