### PR TITLE
lnav: fix libssh2 dependency

### DIFF
--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -22,8 +22,9 @@ class Lnav < Formula
 
   depends_on "readline"
   depends_on "pcre"
+  depends_on "libssh2" => :optional
   depends_on "sqlite" if MacOS.version < :sierra
-  depends_on "curl" => ["with-libssh2", :optional]
+  depends_on "curl" if build.with? "libssh2"
 
   def install
     # Fix errors such as "use of undeclared identifier 'sqlite3_value_subtype'"


### PR DESCRIPTION
Note: this will most likely fail a build as it still needs a test.

A scrict audit on this passed (aside from the lack of a test), allowing this formula to be checked off of #13133's list!