### PR TITLE
xml-tooling-c: fix openssl dependency

### DIFF
--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -18,7 +18,7 @@ class XmlToolingC < Formula
   depends_on "xml-security-c"
   depends_on "boost"
   depends_on "openssl"
-  depends_on "curl" => "with-openssl"
+  depends_on "curl"
 
   needs :cxx11
 


### PR DESCRIPTION
Note: this will most likely fail a build as it still needs a test.

A scrict audit on this passed (aside from the lack of a test), allowing this formula to be checked off of #13133's list!