### PR TITLE
notmuch 0.26

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -1,8 +1,8 @@
 class Notmuch < Formula
   desc "Thread-based email index, search, and tagging"
   homepage "https://notmuchmail.org"
-  url "https://notmuchmail.org/releases/notmuch-0.25.3.tar.gz"
-  sha256 "4bd58e035c34a36ba3c7027e19f763905b99812eeabab283146ef12b3310ddbb"
+  url "https://notmuchmail.org/releases/notmuch-0.26.tar.gz"
+  sha256 "d3e894ed2ad9d721a442663f07a6f2a241dc98be7cc4af681f16edf88e0d76df"
   head "git://notmuchmail.org/git/notmuch"
 
   bottle do
@@ -21,9 +21,9 @@ class Notmuch < Formula
   depends_on "talloc"
   depends_on "xapian"
   depends_on "zlib"
-  depends_on :emacs => ["24.1", :optional]
-  depends_on :python3 => :optional
-  depends_on :ruby => ["1.9", :optional]
+  depends_on "emacs" => :optional
+  depends_on "python3" => :optional
+  depends_on "ruby" => :optional
 
   # Fix SIP issue with python bindings
   # A more comprehensive patch has been submitted upstream


### PR DESCRIPTION
depend on emacs instead of :emacs
depend on python3 instead of :python3
depend on ruby instead of :ruby