### PR TITLE
xmrig: put example config in pkgshare, not share

### DIFF
--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -22,7 +22,7 @@ class Xmrig < Formula
       system "make"
       bin.install "xmrig"
     end
-    share.install "src/config.json"
+    pkgshare.install "src/config.json"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`config.json` is a massively generic name to leave lying around in `share`, sadly.