### PR TITLE
Jenkins: specify required java version for plist & launcher

### DIFF
--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -6,13 +6,13 @@ class JenkinsLts < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
 
   def install
     system "jar", "xvf", "jenkins.war"
     libexec.install "jenkins.war", "WEB-INF/jenkins-cli.jar"
-    bin.write_jar_script libexec/"jenkins.war", "jenkins-lts"
-    bin.write_jar_script libexec/"jenkins-cli.jar", "jenkins-lts-cli"
+    bin.write_jar_script libexec/"jenkins.war", "jenkins-lts", :java_version => "1.8"
+    bin.write_jar_script libexec/"jenkins-cli.jar", "jenkins-lts-cli", :java_version => "1.8"
   end
 
   def caveats; <<~EOS
@@ -31,7 +31,11 @@ class JenkinsLts < Formula
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
         <array>
-          <string>/usr/bin/java</string>
+          <string>/usr/libexec/java_home</string>
+          <string>-v</string>
+          <string>1.8</string>
+          <string>--exec</string>
+          <string>java</string>
           <string>-Dmail.smtp.starttls.enable=true</string>
           <string>-jar</string>
           <string>#{opt_libexec}/jenkins.war</string>

--- a/Formula/jenkins.rb
+++ b/Formula/jenkins.rb
@@ -20,8 +20,8 @@ class Jenkins < Formula
       system "jar", "xvf", "jenkins.war"
     end
     libexec.install Dir["**/jenkins.war", "**/jenkins-cli.jar"]
-    bin.write_jar_script libexec/"jenkins.war", "jenkins"
-    bin.write_jar_script libexec/"jenkins-cli.jar", "jenkins-cli"
+    bin.write_jar_script libexec/"jenkins.war", "jenkins", :java_version => "1.8"
+    bin.write_jar_script libexec/"jenkins-cli.jar", "jenkins-cli", :java_version => "1.8"
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Java 8 is required since Jenkins 2.54 and Jenkins LTS 2.60.1, however Java 9 is not supported yet, see:
- https://jenkins.io/blog/2017/04/10/jenkins-has-upgraded-to-java-8/
- https://jenkins.io/doc/upgrade-guide/2.60/
- https://issues.jenkins-ci.org/browse/JENKINS-40689

In case one have both java 8 and java 9 installed, it's necessary to specify which java version to use for Jenkins.

Please note this requires an improved version of `bin.write_jar_script`, see:  https://github.com/Homebrew/brew/pull/3656.
