### PR TITLE
supermodel: update links

### DIFF
--- a/Formula/supermodel.rb
+++ b/Formula/supermodel.rb
@@ -1,7 +1,7 @@
 class Supermodel < Formula
   desc "Sega Model 3 arcade emulator"
-  homepage "https://www.supermodel3.com/"
-  url "https://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
+  homepage "http://www.supermodel3.com/"
+  url "http://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
   sha256 "ecaf3e7fc466593e02cbf824b722587d295a7189654acb8206ce433dcff5497b"
   head "https://svn.code.sf.net/p/model3emu/code/trunk"
 


### PR DESCRIPTION
The website that supermodel is hosted on has expired SSL certificates, thus we're downgrading protocols (which, of course, isn't optimal).  The checksum still matches what's in the formula, however.  There's two options: one, merge this PR and simply accept HTTP instead of HTTPS, or two, submit an issue upstream (if possible) and see if they can get new SSL certificates.