### PR TITLE
libtiff: apply Debian patches for new CVEs

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -4,6 +4,7 @@ class Libtiff < Formula
   url "http://download.osgeo.org/libtiff/tiff-4.0.9.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.9.tar.gz"
   sha256 "6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,16 @@ class Libtiff < Formula
 
   depends_on "jpeg"
   depends_on "xz" => :optional
+
+  # All of these have been reported upstream & should
+  # be fixed in the next release, but please check.
+  patch do
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-3.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-3.debian.tar.xz"
+    sha256 "c413f5b2423b95d8b068adca695f0ddaea5219088a1d38de4800b379bc20ca73"
+    apply "patches/CVE-2017-9935.patch",
+          "patches/CVE-2017-18013.patch"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
tiff (4.0.9-3) unstable; urgency=high

  * Fix CVE-2017-18013: NULL pointer dereference in TIFFPrintDirectory()
    (closes: #885985).

 -- Laszlo Boszormenyi (GCS) <gcs@debian.org>  Mon, 01 Jan 2018 16:26:47 +0000

tiff (4.0.9-2) unstable; urgency=high

  * Fix CVE-2017-9935: heap-based buffer overflow in the t2p_write_pdf()
    function  (closes: #866109).
  * Update debhelper level to 11 .
  * Update Standards-Version to 4.1.2 .

 -- Laszlo Boszormenyi (GCS) <gcs@debian.org>  Fri, 15 Dec 2017 17:45:42 +0000
```