### PR TITLE
micropython: Build and install mpy-cross

### DIFF
--- a/Formula/micropython.rb
+++ b/Formula/micropython.rb
@@ -20,6 +20,10 @@ class Micropython < Formula
       system "make", "axtls"
       system "make", "install", "PREFIX=#{prefix}", "V=1"
     end
+    cd "mpy-cross" do
+      system "make", "V=1"
+      bin.install "mpy-cross"
+    end
   end
 
   test do
@@ -32,6 +36,7 @@ class Micropython < Formula
       printf("Hello!\\n")
     EOS
 
+    system bin/"mpy-cross", "ffi-hello.py"
     system bin/"micropython", "ffi-hello.py"
   end
 end

--- a/Formula/micropython.rb
+++ b/Formula/micropython.rb
@@ -4,6 +4,7 @@ class Micropython < Formula
   url "https://github.com/micropython/micropython.git",
       :tag => "v1.9.3",
       :revision => "fe45d78b1edd6d2202c3544797885cb0b12d4f03"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,10 +19,11 @@ class Micropython < Formula
   def install
     cd "ports/unix" do
       system "make", "axtls"
-      system "make", "install", "PREFIX=#{prefix}", "V=1"
+      system "make", "install", "PREFIX=#{prefix}"
     end
+
     cd "mpy-cross" do
-      system "make", "V=1"
+      system "make"
       bin.install "mpy-cross"
     end
   end


### PR DESCRIPTION
https://github.com/micropython/micropython/blob/master/mpy-cross/README.md

People who install the Unix port of MicroPython are most likely using it
to test developed code for microcontrollers, and the mpy-cross tool is useful
for pre-compiling modules to bytecode for that microcontroller.  It
would be useful to have mpy-cross available for use.

The compiled .mpy is not usable on the Unix port directly, but running
mpy-cross on ffi-hello.py to generate ffi-hello.mpy is a good test
nonetheless.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
