### PR TITLE
pyenv: fix shell completions

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -24,10 +24,6 @@ class Pyenv < Formula
     system "src/configure"
     system "make", "-C", "src"
 
-    bash_completion.install "completions/pyenv.bash"
-    fish_completion.install "completions/pyenv.fish"
-    zsh_completion.install "completions/pyenv.zsh"
-
     prefix.install Dir["*"]
     %w[pyenv-install pyenv-uninstall python-build].each do |cmd|
       bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"


### PR DESCRIPTION
This fixes pyenv/pyenv#1056.

https://github.com/Homebrew/homebrew-core/pull/21565 broke
https://github.com/pyenv/pyenv/blob/3fd23431af910e0a014f99eeaa39a8ef9af3a72d/libexec/pyenv-init#L98-L101.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
