### PR TITLE
perl: fix caveat description for a custom local::lib path

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -70,7 +70,7 @@ class Perl < Formula
 
     You can set that up like this:
       PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
-      echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >> #{shell_profile}
+      echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"' >> #{shell_profile}
     EOS
   end
 


### PR DESCRIPTION
This is a fix for the #22745 thanks to the @Habbie 