### PR TITLE
gdal: phase out :fortran

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -87,7 +87,10 @@ class Gdal < Formula
 
   depends_on "python" => :optional if MacOS.version <= :snow_leopard
   depends_on "python3" => :optional
-  depends_on :fortran => :build if build.with?("python") || build.with?("python3")
+
+  if build.with?("python") || build.with?("python3")
+    depends_on "gcc" => :build # for gfortran
+  end
 
   # Extra linking libraries in configure test of armadillo may throw warning
   # see: https://trac.osgeo.org/gdal/ticket/5455


### PR DESCRIPTION
`gdal` uses `:fortran` optionally, so it can be replaced without rebottling