### PR TITLE
Deprecate :ruby - part 4

### DIFF
--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -3,7 +3,7 @@ class Mikutter < Formula
   homepage "https://mikutter.hachune.net/"
   url "https://mikutter.hachune.net/bin/mikutter.3.6.0.tar.gz"
   sha256 "c9bec16f5b82873a59be079538192c0007359c612c0224b9c579dae18631e8c9"
-  revision 1
+  revision 2
   head "git://toshia.dip.jp/mikutter.git", :branch => "develop"
 
   bottle do
@@ -14,8 +14,8 @@ class Mikutter < Formula
 
   depends_on "gtk+"
   depends_on "libidn"
+  depends_on "ruby"
   depends_on "terminal-notifier" => :recommended
-  depends_on :ruby => "2.1"
 
   resource "addressable" do
     url "https://rubygems.org/gems/addressable-2.5.2.gem"

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -3,7 +3,7 @@ class Wpscan < Formula
   homepage "https://wpscan.org"
   url "https://github.com/wpscanteam/wpscan/archive/2.9.3.tar.gz"
   sha256 "1bacc03857cca5a2fdcda060886bf51dbf73b129abbb7251b8eb95bc874e5376"
-  revision 3
+  revision 4
 
   head "https://github.com/wpscanteam/wpscan.git"
 
@@ -13,7 +13,7 @@ class Wpscan < Formula
     sha256 "469a94fdf86b201508e72fbc3900aed3c82b3891393dda1d7fa5d4e042754442" => :el_capitan
   end
 
-  depends_on :ruby => "2.1.9"
+  depends_on "ruby"
 
   def install
     inreplace "lib/common/common_helper.rb" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/Homebrew/homebrew-core/pull/22721#issuecomment-356790311

Both fail with system ruby on high sierra, not sure if fixing those issues is preferred over depending on `"ruby"`?