### PR TITLE
Removing :fortran, round 5

### DIFF
--- a/Formula/cp2k.rb
+++ b/Formula/cp2k.rb
@@ -3,6 +3,7 @@ class Cp2k < Formula
   homepage "https://www.cp2k.org/"
   url "https://downloads.sourceforge.net/project/cp2k/cp2k-5.1.tar.bz2"
   sha256 "e23613b593354fa82e0b8410e17d94c607a0b8c6d9b5d843528403ab09904412"
+  revision 1
 
   bottle do
     sha256 "8031b0558f47e19243361ff95f3a151a0d4d778e6f1877b9daeedbab4a0b9be4" => :high_sierra
@@ -10,14 +11,13 @@ class Cp2k < Formula
     sha256 "accb2f2ddc22665e149f9b8e65f2e0eeedeaba55eeddf95f3ca9fc851baacef5" => :el_capitan
   end
 
-  depends_on :fortran
-  depends_on :mpi => [:cc, :cxx, :f77, :f90]
   depends_on "fftw"
-  depends_on "gcc"
+  depends_on "gcc" # for gfortran
   depends_on "libxc"
+  depends_on "open-mpi"
   depends_on "scalapack"
 
-  needs :openmp
+  fails_with :clang # needs OpenMP support
 
   resource "libint" do
     url "https://downloads.sourceforge.net/project/libint/v1-releases/libint-1.1.5.tar.gz"
@@ -28,7 +28,7 @@ class Cp2k < Formula
     resource("libint").stage do
       system "./configure", "--prefix=#{libexec}"
       system "make"
-      system "make", "install"
+      ENV.deparallelize { system "make", "install" }
     end
 
     fcflags = %W[

--- a/Formula/libgetdata.rb
+++ b/Formula/libgetdata.rb
@@ -24,8 +24,6 @@ class Libgetdata < Formula
   depends_on "xz" => :optional
 
   def install
-    ENV.fortran if build.with?("fortran")
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules

--- a/Formula/libxc.rb
+++ b/Formula/libxc.rb
@@ -3,6 +3,7 @@ class Libxc < Formula
   homepage "http://octopus-code.org/wiki/Libxc"
   url "http://www.tddft.org/programs/octopus/down.php?file=libxc/3.0.1/libxc-3.0.1.tar.gz"
   sha256 "836692f2ab60ec3aca0cca105ed5d0baa7d182be07cc9d0daa7b80ee1362caf7"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,14 +12,13 @@ class Libxc < Formula
     sha256 "6618cfcb1cd1a7d69991e97fbc1cda0d67b0dc1f99232057cc0cac9895e031e6" => :el_capitan
   end
 
-  depends_on :fortran
+  depends_on "gcc" # for gfortran
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--enable-shared",
-                          "FCCPP=#{ENV.fc} -E -x c",
-                          "CC=#{ENV.cc}",
-                          "CFLAGS=-pipe"
+                          "FCCPP=gfortran -E -x c",
+                          "CC=#{ENV.cc}"
     system "make", "install"
   end
 
@@ -42,8 +42,8 @@ class Libxc < Formula
         use xc_f90_lib_m
       end program lxctest
     EOS
-    ENV.fortran
-    system ENV.fc, "test.f90", "-L#{lib}", "-lxc", "-I#{include}", "-o", "ftest"
+    system "gfortran", "test.f90", "-L#{lib}", "-lxc", "-I#{include}",
+                       "-o", "ftest"
     system "./ftest"
   end
 end


### PR DESCRIPTION
After that one, we're done with `:fortran`, `:mpi` and `:openmp` in core!