### PR TITLE
packetbeat: changed log path from /logs/ to /log/

### DIFF
--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -3,7 +3,7 @@ class Packetbeat < Formula
   homepage "https://www.elastic.co/products/beats/packetbeat"
   url "https://github.com/elastic/beats/archive/v6.1.2.tar.gz"
   sha256 "e673b4f03bc73807d23083b8d6a5f45f5a8b3fa3a6709f89881a2debb10a8d2f"
-
+  revision 1
   head "https://github.com/elastic/beats.git"
 
   bottle do
@@ -52,7 +52,7 @@ class Packetbeat < Formula
       exec #{libexec}/bin/packetbeat \
         -path.config #{etc}/packetbeat \
         -path.home #{prefix} \
-        -path.logs #{var}/logs/packetbeat \
+        -path.logs #{var}/log/packetbeat \
         -path.data #{var}/lib/packetbeat \
         "$@"
     EOS


### PR DESCRIPTION
All elastic beats formulas (auditbeat, filebeat, heartbeat and
metricbeat) are using #{var}/log/, as well as few different tools.
only packetbeat writes logs to /logs/ instead of /log/.

- [+] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [+] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [+] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [+] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
