### PR TITLE
notmuch-address-cache 0.1 (new formula)

### DIFF
--- a/Formula/notmuch-address-cache.rb
+++ b/Formula/notmuch-address-cache.rb
@@ -1,0 +1,14 @@
+class NotmuchAddressCache < Formula
+  desc "notmuch-address-cache is basically a cache in front of the notmuch-address command."
+  homepage "https://github.com/mbauhardt/notmuch-address-cache"
+  url "https://github.com/mbauhardt/notmuch-address-cache/archive/0.1.tar.gz"
+  sha256 "db43c114184f402c9baba20215f0cf57cc83b4701f034b96f0511b3c81463088"
+
+
+  def install
+    bin.install "bin/notmuch-address-cache"
+    man.mkpath
+    man1.install "share/man/man1/notmuch-address-cache.1"
+  end
+
+end


### PR DESCRIPTION
This program is basically a cache in from of notmuch-address command.
notmuch-address can be slow in case you have alot emails. This program is
there to be fast - when using in mutt or alot -  also with alot of emails.

More details can be read here:
https://raw.githubusercontent.com/mbauhardt/notmuch-address-cache/master/manual

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
