### PR TITLE
fix issues/22679

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -169,6 +169,9 @@ class Llvm < Formula
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 
+    # https://github.com/Homebrew/homebrew-core/issues/22679
+    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+
     (buildpath/"tools/clang").install resource("clang")
     (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")
     (buildpath/"projects/openmp").install resource("openmp")

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -169,8 +169,9 @@ class Llvm < Formula
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 
-    # https://github.com/Homebrew/homebrew-core/issues/22679
-    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+    if build.with? "python"
+      ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+    end
 
     (buildpath/"tools/clang").install resource("clang")
     (buildpath/"tools/clang/tools/extra").install resource("clang-extra-tools")


### PR DESCRIPTION
fixes https://github.com/Homebrew/homebrew-core/issues/22679 LLVM --with-python --with-lldb fails

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

question: not sure what to do about:
```
brew audit --strict llvm

* python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /Users/timothee/homebrew/opt/llvm_tim/lib/python2.7/site-packages/lldb/_lldb.so
```

