### PR TITLE
socat: Fix TERMIOS setting of custom serial port speed

### DIFF
--- a/Formula/socat.rb
+++ b/Formula/socat.rb
@@ -13,6 +13,11 @@ class Socat < Formula
     sha256 "a5c5b28d9fbf0f52ab0d69dc7cbe44f23a58876e32791b69275d96a15703d3e9" => :yosemite
   end
 
+  patch :p0 do
+    url "https://bz-attachments.freebsd.org/attachment.cgi?id=154044"
+    sha256 "fec773989fd298e53f3d91189253f79d7f23b78ce342b98cd3fd74d8e848b278"
+  end
+
   depends_on "openssl@1.1"
   depends_on "readline"
 


### PR DESCRIPTION
As identified by `hpeyerl` on www.beer.org/blog/index.php/2016/06/26/socat-on-os-x-tcdrain-returns-invalid-argument/, OS X uses FreeBSD termios interface and suffers same issue as have been patched on FreeBSD ports: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198441

This commit uses the patch from FreeBSD bugzilla, not sure if there are other preferences?

----

With SOCAT on systems where b0 to b4000000 options are not available,
like FreeBSD, setting the speed of a TERMIOS terminal is done using the
ispeed and ospeed options.

But when using simultaneously ispeed and ospeed parameters with SOCAT,
the speed values are set within two distinct ioctl requests, so changing
the speed of terminals or devices that need matching input and output
returns an Invalid argument error (the TIOCSETA/TIOCSETAW/TIOCSETAF
ioctl returns -1 and sets errno to EINVAL).

With those drivers, the input and output speeds must match and be set
inside a single ioctl request (TIOCSETA, TIOCSETAW or TIOCSETAF). The
only exception to this rule is when the input baud rate is zero because,
according to POSIX, in that case, the input baud rate is set equal to
the output baud rate.
