### PR TITLE
handbrake 1.0.7: Update the download URL

### DIFF
--- a/Formula/handbrake.rb
+++ b/Formula/handbrake.rb
@@ -1,7 +1,7 @@
 class Handbrake < Formula
   desc "Open-source video transcoder available for Linux, Mac, and Windows"
   homepage "https://handbrake.fr/"
-  url "https://handbrake.fr/mirror/HandBrake-1.0.7.tar.bz2"
+  url "https://download.handbrake.fr/releases/1.0.7/HandBrake-1.0.7.tar.bz2"
   sha256 "ffdee112f0288f0146b965107956cd718408406b75db71c44d2188f5296e677f"
   head "https://github.com/HandBrake/HandBrake.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I was getting this error when installing handbrake:

```
==> Installing handbrake
==> Downloading https://handbrake.fr/mirror/HandBrake-1.0.7.tar.bz2

curl: (22) The requested URL returned error: 404 
Error: Failed to download resource "handbrake"
Download failed: https://handbrake.fr/mirror/HandBrake-1.0.7.tar.bz2
```

It turns out that URL (https://handbrake.fr/mirror/HandBrake-1.0.7.tar.bz2) is bogus. I got the new URL from here:

https://handbrake.fr/rotation.php?file=HandBrake-1.0.7.tar.bz2

With the actual URL to the file being:

https://download.handbrake.fr/releases/1.0.7/HandBrake-1.0.7.tar.bz2