### PR TITLE
Single make process and better konfigure.perl for finding HDF5

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -5,6 +5,7 @@ class Sratoolkit < Formula
   version "2.8.2-5"
   sha256 "15b41420d95a72de9e24dec53401cc10e435a17ee9c5eec45ef78fd078db544c"
   head "https://github.com/ncbi/sra-tools.git"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
sratoolkit no longer compiled on Linuxbrew. See Linuxbrew/homebrew-core#5323 for more details.

This is linked to the code not finding the hdf5 library, meaning pacbio applications did not compile, and a parallel make process going wrong. I have turned off the parallel make and introduced a new konfigure.perl as a remote resource. This is not an inline patch because another resource must also be patched.

I've asked if the maintainers will be releasing a new version but they have not answered if they will be doing.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
