### PR TITLE
percona-xtrabackup: depend on mysql instead of :mysql

### DIFF
--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -15,7 +15,7 @@ class PerconaXtrabackup < Formula
 
   depends_on "cmake" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
-  depends_on :mysql => :recommended
+  depends_on "mysql" => :recommended
   depends_on "libev"
   depends_on "libgcrypt"
   depends_on "openssl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----