### PR TITLE
Use depends_on :macos.

### DIFF
--- a/Formula/nordugrid-arc.rb
+++ b/Formula/nordugrid-arc.rb
@@ -23,7 +23,7 @@ class NordugridArc < Formula
   # build fails on Mavericks due to a clang compiler bug
   # and bottling also fails if gcc is being used due to conflicts between
   # libc++ and libstdc++
-  depends_on MinimumMacOSRequirement => :yosemite
+  depends_on :macos => :yosemite
 
   # bug filed upstream at http://bugzilla.nordugrid.org/show_bug.cgi?id=3514
   patch do

--- a/Formula/phantomjs.rb
+++ b/Formula/phantomjs.rb
@@ -31,7 +31,7 @@ class Phantomjs < Formula
     sha256 "d837e04d137ae8ddc8eb807b7ca5a08a0fccdfd513f4fdd4f1d610ce8abc0874" => :mavericks
   end
 
-  depends_on MinimumMacOSRequirement => :lion
+  depends_on :macos => :lion
   depends_on :xcode => :build
   depends_on "openssl"
 


### PR DESCRIPTION
`MinimumMacOSRequirement` was the old name for `MacOSRequirement`.