### PR TITLE
phantomjs: fix build on 10.12 with Xcode 9

### DIFF
--- a/Formula/phantomjs.rb
+++ b/Formula/phantomjs.rb
@@ -14,7 +14,7 @@ class Phantomjs < Formula
 
   # Fix a variant of QTBUG-62266 in included Qt source
   # https://github.com/ariya/phantomjs/issues/15116
-  if MacOS.version >= :high_sierra
+  if MacOS::Xcode.version >= "9.0"
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/33dbb45f82/phantomjs/QTBUG-62266.diff"
       sha256 "d47b52c6a932139a448340244f66ea126412d210ab94dc19da7c468afaf5f45a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

apply 10.13 Xcode 9 patch on 10.12 too