### PR TITLE
nikto: added head

### DIFF
--- a/Formula/nikto.rb
+++ b/Formula/nikto.rb
@@ -3,6 +3,7 @@ class Nikto < Formula
   homepage "https://cirt.net/nikto2"
   url "https://github.com/sullo/nikto/archive/2.1.6.tar.gz"
   sha256 "c1731ae4133d3879718bb7605a8d395b2036668505effbcbbcaa4dae4e9f27f2"
+  head "https://github.com/sullo/nikto.git"
 
   bottle :unneeded
 


### PR DESCRIPTION
After the recent change to version 2.1.6, head will now install correctly (#1718). I've added that line to the formula. The author of nikto has [depreciated](https://cirt.net/Nikto-Installing_and_Updating) the in app update function and is recommending users update via git anyway, which is much easier with a --fetch-head.