### PR TITLE
[WIP] gdk-pixbuf:  Permanently Resolve All Possible GTK+ 2.x Problems Discussed in Issue #22768

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -90,6 +90,13 @@ class GdkPixbuf < Formula
         loader_cache.write pipe.read
       end
     end
+
+    # FIXME:  I _greatly_ suspect that what follows likely implements the wrong kind of
+    #         error-reporting strategy.  Seek advice/feedback on how to do it _properly._
+    Utils.popen_read "wc", "-c", "#{module_dir}/loaders.cache" do |stdout_contents|
+      cache_size = stdout_contents.read
+      cache_size.lstrip.split[0].to_i <= 0
+    end
   end
 
   def caveats

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -87,7 +87,7 @@ class GdkPixbuf < Formula
 
     File.open File.new("#{module_dir}/loaders.cache", "w+").path, "w" do |loader_cache|
       Utils.popen_read "#{bin}/gdk-pixbuf-query-loaders", "--update-cache" do |pipe|
-        loader_cache.puts pipe.read
+        loader_cache.write pipe.read
       end
     end
   end

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -85,7 +85,7 @@ class GdkPixbuf < Formula
   def post_install
     ENV["GDK_PIXBUF_MODULEDIR"] = "#{module_dir}/loaders"
 
-    File.open "#{module_dir}/loaders.cache", "w" do |loader_cache|
+    File.open File.new("#{module_dir}/loaders.cache", "w+").path, "w" do |loader_cache|
       Utils.popen_read "#{bin}/gdk-pixbuf-query-loaders", "--update-cache" do |pipe|
         loader_cache.puts pipe
       end

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -84,7 +84,12 @@ class GdkPixbuf < Formula
 
   def post_install
     ENV["GDK_PIXBUF_MODULEDIR"] = "#{module_dir}/loaders"
-    system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
+
+    File.open "#{module_dir}/loaders.cache", "w" do |loader_cache|
+      Utils.popen_read "#{bin}/gdk-pixbuf-query-loaders", "--update-cache" do |pipe|
+        loader_cache.puts pipe
+      end
+    end
   end
 
   def caveats

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -87,7 +87,7 @@ class GdkPixbuf < Formula
 
     File.open File.new("#{module_dir}/loaders.cache", "w+").path, "w" do |loader_cache|
       Utils.popen_read "#{bin}/gdk-pixbuf-query-loaders", "--update-cache" do |pipe|
-        loader_cache.puts pipe
+        loader_cache.puts pipe.read
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #22768.  

Actually, it doesn't do that _quite_ yet, hence the '[WIP]' in this issue's title.  Refinements still to pursue, in no particular order other than that in which I added them to the list, entail:  

* [ ] Fixing the `post_install` step to:  
   * [ ] Resolve the '`FIXME`' comment I put there, if applicable (though it probably _is_, knowing me…)  
   * [x] Actually make it _work_ (it's currently not completing successfully.)  
* [ ] Enforcing code sanity.  (I'm still a Ruby newbie, so what the heck do _I_ know if I'm doing things right or not?!)  
* [ ] Per https://github.com/Homebrew/homebrew-core/issues/22768#issuecomment-358152561 and https://github.com/Homebrew/homebrew-core/pull/22955#issuecomment-358163472, decide and/or figure out if and how to deal with GDK Pixbuf's Heisenberg dependency on `shared-mime-info`.  
* [ ] Per https://github.com/Homebrew/homebrew-core/pull/22955#issuecomment-358842862, add any necessary `revision` bumps.  
* [ ] Resolve https://github.com/Homebrew/homebrew-core/pull/22955#issuecomment-359541432 by having Homebrew stick copies of GDK Pixbuf's loader cache not only in `/usr/local/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache`, but _also_ in `/usr/local/opt/gdk-pixbuf/bin/../lib/gdk-pixbuf-2.0/2.10.0/loaders.cache`, which is where GTK+ 2.x's build process looks for and expects to find it.  

/cc @ilovezfs