### PR TITLE
dropbear: audit fix

### DIFF
--- a/Formula/dropbear.rb
+++ b/Formula/dropbear.rb
@@ -40,6 +40,6 @@ class Dropbear < Formula
     testfile = testpath/"testec521"
     system "#{bin}/dbclient", "-h"
     system "#{bin}/dropbearkey", "-t", "ecdsa", "-f", testfile, "-s", "521"
-    assert testfile.exist?
+    assert_predicate testpath/testfile, :exist?, "Test Failed"
   end
 end

--- a/Formula/dropbear.rb
+++ b/Formula/dropbear.rb
@@ -40,6 +40,6 @@ class Dropbear < Formula
     testfile = testpath/"testec521"
     system "#{bin}/dbclient", "-h"
     system "#{bin}/dropbearkey", "-t", "ecdsa", "-f", testfile, "-s", "521"
-    assert_predicate testpath/testfile, :exist?
+    assert_predicate testfile, :exist?
   end
 end

--- a/Formula/dropbear.rb
+++ b/Formula/dropbear.rb
@@ -40,6 +40,6 @@ class Dropbear < Formula
     testfile = testpath/"testec521"
     system "#{bin}/dbclient", "-h"
     system "#{bin}/dropbearkey", "-t", "ecdsa", "-f", testfile, "-s", "521"
-    assert_predicate testpath/testfile, :exist?, "Test Failed"
+    assert_predicate testpath/testfile, :exist?
   end
 end


### PR DESCRIPTION
C: 43: col 12: Use `assert_predicate <path_to_file>, :exist?` instead of `assert testfile.exist?`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
