### PR TITLE
moreutils: fix git url 

### DIFF
--- a/Formula/moreutils.rb
+++ b/Formula/moreutils.rb
@@ -1,10 +1,10 @@
 class Moreutils < Formula
   desc "Collection of tools that nobody wrote when UNIX was young"
   homepage "https://joeyh.name/code/moreutils/"
-  url "git://git.joeyh.name/moreutils",
+  url "https://git.joeyh.name/git/moreutils.git",
       :tag => "0.62",
       :revision => "06b5970631ffbf151893bd3e1e7f03fb76aad4c0"
-  head "git://git.joeyh.name/moreutils"
+  head "https://git.joeyh.name/git/moreutils.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Moreutils seems to no longer be available on the old git repository:
```
$ brew install moreutils
Cloning into '$HOME/Library/Caches/Homebrew/moreutils--git'...
fatal: repository 'https://git.joeyh.name/moreutils/' not found
$ git clone git://git.joeyh.name/moreutils
Cloning into 'moreutils'...
fatal: repository 'https://git.joeyh.name/moreutils/' not found
$ git clone https://git.joeyh.name/git/moreutils.git
Cloning into 'moreutils'...
$ # works
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

