### PR TITLE
[bitcoin] Allow bitcoin to be compiled with optional zmq dependency

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -35,6 +35,7 @@ class Bitcoin < Formula
   depends_on "libevent"
   depends_on "miniupnpc"
   depends_on "openssl"
+  depends_on "zmq"
 
   needs :cxx11
 

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -1,6 +1,7 @@
 class Bitcoin < Formula
   desc "Decentralized, peer to peer payment network"
   homepage "https://bitcoin.org/"
+  revision 1
 
   stable do
     url "https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1.tar.gz"

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -36,7 +36,7 @@ class Bitcoin < Formula
   depends_on "libevent"
   depends_on "miniupnpc"
   depends_on "openssl"
-  depends_on "zmq"
+  depends_on "zeromq"
 
   needs :cxx11
 


### PR DESCRIPTION
Since the 0.12 release of `bitcoin`, it has been possible to utilize ZMQ for pub-sub messaging to allow `bitcoind` to communicate with other processes.

The UNIX installation docs list it as an optional dependency: https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependencies

Here are detailed docs in the [`bitcoin`](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md#enabling) GH repo discussing how to make use of ZMQ.

In particular, ZMQ is needed to facilitate message passing from `bitcoind` to-and-from [`lnd`](https://github.com/lightningnetwork/lnd). [Here](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#running-lnd-using-the-bitcoind-backend) are docs from the Lightning team discussing how to wire up `bitcoind` to communicate with `lnd`.