### PR TITLE
htop-vim 2.0.2 (new formula)

### DIFF
--- a/Formula/htop-vim.rb
+++ b/Formula/htop-vim.rb
@@ -1,0 +1,38 @@
+class HtopVim < Formula
+  desc "Improved top (interactive process viewer) with vim-style keybindings"
+  homepage "https://github.com/KoffeinFlummi/htop-vim"
+  revision 1
+
+  head do
+    url "https://github.com/KoffeinFlummi/htop-vim.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  option "with-ncurses", "Build using homebrew ncurses (enables mouse scroll)"
+
+  # Running htop can lead to system freezes on macOS 10.13
+  # https://github.com/hishamhm/htop/issues/682
+  depends_on MaximumMacOSRequirement => :sierra
+
+  depends_on "ncurses" => :optional
+
+  def install
+    system "./autogen.sh" if build.head?
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  def caveats; <<~EOS
+    htop requires root privileges to correctly display all running processes,
+    so you will need to run `sudo htop`.
+    You should be certain that you trust any software you grant root privileges.
+    EOS
+  end
+
+  test do
+    pipe_output("#{bin}/htop", "q", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This version is a head-only, maintained fork of original one that adds vim-style navigation key bindings which is [requested feature](https://github.com/hishamhm/htop/issues/98) since 2014 but seems like its developer refuses to add.

`audit` can't pass because it's head-only. I am not really sure whether or not you guys accept head-only forks. I tried to search for it but couldn't find anything. Opening an issue and waiting for answer would have been cumbersome. So, made this PR, if it violates anything, let me now. I am sorry if I did so.

CC: @KoffeinFlummi