### PR TITLE
cockatrice qt5.7

### DIFF
--- a/Formula/cockatrice.rb
+++ b/Formula/cockatrice.rb
@@ -17,7 +17,7 @@ class Cockatrice < Formula
   depends_on :macos => :el_capitan
   depends_on "cmake" => :build
   depends_on "protobuf"
-  depends_on "qt"
+  depends_on "qt@5.7"
 
   fails_with :clang do
     build 503


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Cockatrice Project uses QT5.7 for MacOS builds due to style problems found in QT5.8 and newer. We will be working on fixes for this in the future, but for the time being restricting the download to 5.7 would be optimal.
