### PR TITLE
zig 0.1.1 (new formula)

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,0 +1,25 @@
+class Zig < Formula
+  desc "Programming language designed for robustness, optimality, and clarity"
+  homepage "http://ziglang.org/"
+  url "https://github.com/zig-lang/zig/archive/0.1.1.tar.gz"
+  sha256 "fabbfcb0bdb08539d9d8e8e1801d20f25cb0025af75ac996f626bb5e528e71f1"
+
+  depends_on "cmake" => :build
+  depends_on "llvm"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.zig").write <<~EOS
+      const io = @import("std").io;
+      pub fn main() -> %void {
+          %%io.stdout.printf("Hello, world!");
+      }
+    EOS
+    system "#{bin}/zig", "build-exe", "hello.zig"
+    assert_equal "Hello, world!", shell_output("./hello")
+  end
+end


### PR DESCRIPTION
HI! Thanks for `brew`.

I'd like to add [zig](http://ziglang.org/)'s 0.1.1 release to brew. I do need feedback on a dependency issue, though.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
~ $ brew audit --strict zig
zig:
  * Dependency 'llvm@5' is an alias; use the canonical name 'llvm'.
Error: 1 problem in 1 formula
```

See: https://github.com/zig-lang/zig/issues/714#issuecomment-359631483

Please lmkwyt! Thank you.

This PR resolves https://github.com/zig-lang/zig/issues/714