### PR TITLE
hdf5: fix installation '--with-mpi'

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -51,7 +51,7 @@ class Hdf5 < Formula
     if build.with? "mpi"
       ENV["CC"] = "mpicc"
       ENV["CXX"] = "mpicxx"
-      ENV["FC"] = "mpifc"
+      ENV["FC"] = "mpifort"
 
       args << "--enable-parallel"
     end

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -51,7 +51,7 @@ class Hdf5 < Formula
     if build.with? "mpi"
       ENV["CC"] = "mpicc"
       ENV["CXX"] = "mpicxx"
-      ENV["FC"] = "mpifort"
+      ENV["FC"] = "mpif90"
 
       args << "--enable-parallel"
     end


### PR DESCRIPTION
open-mpi fortran comiler is called 'mpifort', not 'mpifc'

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] Built formula locally with `brew install hdf5 --with-mpi`
