### PR TITLE
gphoto2: added optional dependencies on libexif and aalib

### DIFF
--- a/Formula/gphoto2.rb
+++ b/Formula/gphoto2.rb
@@ -17,6 +17,9 @@ class Gphoto2 < Formula
   depends_on "popt"
   depends_on "readline"
 
+  depends_on "libexif" => :optional
+  depends_on "aalib" => :optional
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

**Note**
gphoto2 also has an optional dependency on cdk which I would like to add, but building gphoto2 fails with cdk installed by Homebrew.

gphoto2 expects cdk to provide the <cdk/cdk.h> header, while I found that only <cdk.h> is present. Symlinking cdk.h to cdk/cdk.h allows the build to complete correctly.

I’m not sure what should be done here.

cdk's changelog notes that the default location for the header changed back in 2012, although an option is present to switch back to the old behavior.

```
+ add configure --enable-hdr-subdir to control whether cdk.h should
  be in /usr/include/cdk for example, or in /usr/include.  Make the
  default the latter, standard layout.
```
https://invisible-island.net/cdk/CHANGES.html#t20120323