### PR TITLE
freewswitch: remove curl dependency

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -4,7 +4,7 @@ class Freeswitch < Formula
   url "https://freeswitch.org/stash/scm/fs/freeswitch.git",
       :tag => "v1.6.19",
       :revision => "7a77e0bb2ca875cb977b1e698a1783e575d96563"
-  revision 1
+  revision 2
   head "https://freeswitch.org/stash/scm/fs/freeswitch.git"
 
   bottle do
@@ -24,8 +24,6 @@ class Freeswitch < Formula
   depends_on "pkg-config" => :build
   depends_on "apr-util" => :build
   depends_on "yasm" => :build
-
-  depends_on "curl"
   depends_on "jpeg"
   depends_on "openssl"
   depends_on "pcre"
@@ -145,6 +143,8 @@ class Freeswitch < Formula
   #------------------------ End sound file resources --------------------------
 
   def install
+    ENV["ac_cv_lib_lzma_lzma_code"] = "no" # prevent opportunistic linkage to xz
+
     # avoid a dependency on ldns to prevent OpenSSL version conflicts
     inreplace "build/modules.conf.in", "applications/mod_enum",
                                        "#applications/mod_enum"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- system curl is sufficient so the curl dependency is unnecessary
- avoid opportunistic linkage to xz