### PR TITLE
slicot: import from homebrew/science

### DIFF
--- a/Formula/slicot.rb
+++ b/Formula/slicot.rb
@@ -1,0 +1,22 @@
+class Slicot < Formula
+  desc "Fortran 77 algorithms for computations in systems and control theory"
+  homepage "http://www.slicot.org"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"
+  version "5.0+20101122"
+  sha256 "fa80f7c75dab6bfaca93c3b374c774fd87876f34fba969af9133eeaea5f39a3d"
+
+  depends_on "gcc"
+
+  def install
+    args = [
+      "FORTRAN=#{ENV.fc}",
+      "LOADER=#{ENV.fc}",
+    ]
+    system "make", "lib", "OPTS=-fPIC", "SLICOTLIB=../libslicot_pic.a", *args
+    system "make", "clean"
+    system "make", "lib", "OPTS=-fPIC -fdefault-integer-8",
+           "SLICOTLIB=../libslicot64_pic.a", *args
+    lib.install "libslicot_pic.a", "libslicot64_pic.a"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, I would like to transfer this formula to homebrew core from homebrew science as a formula I maintain, dynare, depends on it. It is [packaged in Debian](https://packages.debian.org/source/stretch/slicot). This does not compile locally because the `FC` environment variable is not found. It further does not pass the `--strict` audit because there are no tests. The codebase will not change because the authors have changed the license of their code going forward.