### PR TITLE
superlu: do not build with -fPIC

### DIFF
--- a/Formula/superlu.rb
+++ b/Formula/superlu.rb
@@ -3,7 +3,7 @@ class Superlu < Formula
   homepage "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/"
   url "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_5.2.1.tar.gz"
   sha256 "28fb66d6107ee66248d5cf508c79de03d0621852a0ddeba7301801d3d859f463"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
@@ -34,7 +34,6 @@ class Superlu < Formula
     args = ["SuperLUroot=#{buildpath}",
             "SUPERLULIB=$(SuperLUroot)/lib/libsuperlu.a",
             "CC=#{ENV.cc}",
-            "CFLAGS=-fPIC #{ENV.cflags}",
             "BLASLIB=#{blas}"]
     args << "LOADOPTS=-fopenmp" if build.with?("openmp")
 


### PR DESCRIPTION
`-fPIC` was introduced for Linuxbrew: https://github.com/Homebrew/homebrew-science/pull/1919