### PR TITLE
bitcoin: include rpcuser.py

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -52,6 +52,8 @@ class Bitcoin < Formula
                           "--with-boost-libdir=#{Formula["boost"].opt_lib}",
                           "--prefix=#{prefix}"
     system "make", "install"
+    libexec.install "share/rpcuser"
+    bin.install_symlink libexec/"rpcuser/rpcuser.py" => "bitcoin-rpcuser"
   end
 
   plist_options :manual => "bitcoind"

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -52,8 +52,7 @@ class Bitcoin < Formula
                           "--with-boost-libdir=#{Formula["boost"].opt_lib}",
                           "--prefix=#{prefix}"
     system "make", "install"
-    libexec.install "share/rpcuser"
-    bin.install_symlink libexec/"rpcuser/rpcuser.py" => "bitcoin-rpcuser"
+    pkgshare.install "share/rpcuser"
   end
 
   plist_options :manual => "bitcoind"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The documentation for `bitcoind` suggests that the idiomatic way of setting the `rpcauth` configuration value is to use a script provided with the release. From `bitcoind.1`:

> `-rpcauth=<userpw>` — Username and hashed password for JSON-RPC connections. The field `<userpw>` comes in the format: `<USERNAME>:<SALT>$<HASH>`. A canonical python script is included in `share/rpcuser`. The client then  connects normally using the `rpcuser=<USERNAME>`/`rpcpassword=<PASSWORD>` pair of arguments. This option can be specified multiple times.

This script isn't provided by the Homebrew release. This PR fixes that.

I wasn't sure how exactly the script should be *exposed*; expecting the user to go into `/usr/local/Cellar/bitcoin/.../share` to find it is asking a lot, IMHO. So I put it in `libexec` (since it's an executable utility) and, further, symlinked it into the `bin` directory under the name `bitcoin-rpcuser`. I can remove the symlink if it goes against formula convention.