### PR TITLE
w3m: update Debian patches

### DIFF
--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,7 +1,7 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "https://w3m.sourceforge.io/"
-  revision 3
+  revision 4
   head "https://github.com/tats/w3m.git"
 
   stable do
@@ -11,9 +11,9 @@ class W3m < Formula
     # Upstream is effectively Debian https://github.com/tats/w3m at this point.
     # The patches fix a pile of CVEs
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-34.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-34.debian.tar.xz"
-      sha256 "bed288bdc1ba4b8560724fd5dc77d7c95bcabd545ec330c42491cae3e3b09b7e"
+      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz"
+      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz"
+      sha256 "e7f41ac222c55830ce121e1c50e67ab04b292837b9bb1ece2eae2689c82147ec"
       apply "patches/010_upstream.patch",
             "patches/020_debian.patch"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

to 0.5.3-36

w3m (0.5.3-36) unstable; urgency=medium

  * Update 020_debian.patch to v0.5.3+git20180125.
     - Fix stack overflow with malformed text [CVE-2018-6196]
     - Fix null deref with malformed text [CVE-2018-6197]
     - Fix /tmp file races only when ~/.w3m is unwritable [CVE-2018-6198]
       (closes: #888097)
     - Suppress error messages when ~/.w3m is unwritable (closes: #871425)
     - Extend ssl_forbid_method to disable TLSv1.1 (closes: #874218)
     - Typo fix in --help message (closes: #878106)
  * Drop 030_fix_spelling_error.patch (merged in 020_debian.patch)
  * Don't use deprecated autotools-dev tools
  * Migrate from anonscm.debian.org to salsa.debian.org
  * Update debian/copyright
  * Update Standards-Version to 4.1.3

 -- Tatsuya Kinoshita <tats@debian.org>  Thu, 25 Jan 2018 18:53:30 +0900

w3m (0.5.3-35) unstable; urgency=medium

  [ HIGUCHI Daisuke (VDR dai) ]
  * Ack NMU.
  * debian/control
  - run wrap-and-sort
  - eliminate lintian warning: vcs-field-uses-insecure-uri
  - eliminate lintian warning: useless-autoreconf-build-depends
  * fix spelling-error-in-binary
  - d/p/030_fix_spelling_error.patch: new file.
  * fix possible-documentation-but-no-doc-base-registration
  - d/w3m.doc-base: new file.
  * Update debhelper compat version to 10
  * Update Standards-Version to 4.1.2

 -- HIGUCHI Daisuke (VDR dai) <dai@debian.org>  Sun, 24 Dec 2017 11:50:47 +0900