### PR TITLE
dnscrypt-proxy: replace old tarball with debian's archived source

### DIFF
--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -1,9 +1,10 @@
 class DnscryptProxy < Formula
   desc "Secure communications between a client and a DNS resolver"
   homepage "https://dnscrypt.org"
-  url "https://github.com/jedisct1/dnscrypt-proxy/archive/1.9.5.tar.gz"
-  sha256 "947000568f79ab4d036b259d9cf3fe6fdf8419860d9ad18004ac767db0dbd5ac"
-  revision 2
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dnscrypt-proxy/dnscrypt-proxy_1.9.5.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/dnscrypt-proxy/dnscrypt-proxy_1.9.5.orig.tar.gz"
+  sha256 "64021fabb7d5bab0baf681796d90ecd2095fb81381e6fb317a532039025a9399"
+  revision 3
 
   head "https://github.com/jedisct1/dnscrypt-proxy.git"
 
@@ -52,7 +53,7 @@ class DnscryptProxy < Formula
     if build.with? "minisign"
       (bin/"dnscrypt-update-resolvers").write <<~EOS
         #!/bin/sh
-        RESOLVERS_UPDATES_BASE_URL=https://download.dnscrypt.org/dnscrypt-proxy
+        RESOLVERS_UPDATES_BASE_URL=https://raw.githubusercontent.com/dyne/dnscrypt-proxy/master
         RESOLVERS_LIST_BASE_DIR=#{pkgshare}
         RESOLVERS_LIST_PUBLIC_KEY="RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
 
@@ -73,13 +74,6 @@ class DnscryptProxy < Formula
   end
 
   def post_install
-    chmod 0666, bin/"dnscrypt-update-resolvers"
-    inreplace bin/"dnscrypt-update-resolvers",
-              "https://download.dnscrypt.org/dnscrypt-proxy",
-              "https://raw.githubusercontent.com/dyne/dnscrypt-proxy/master",
-              false
-    chmod 0555, bin/"dnscrypt-update-resolvers"
-
     return if build.without? "minisign"
 
     ENV["PATH"] = PATH.new(ENV["PATH"]).prepend(Formula["minisign"].opt_bin)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is necessary due to upstream currently being in a state of
flux, which has led to the removal of the old artifacts. Falling back
on the source tarball that Debian uses should be a safe alternate,
and there is nothing to indicate any kind of foul play was involved.
The tarball almost exactly matches
https://github.com/dyne/dnscrypt-proxy/commit/3762f45e2f0 which is
likely right before the release was tagged.