### PR TITLE
mariadb-connector-odbc 3.0.2 (new formula)

### DIFF
--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,0 +1,24 @@
+class MariadbConnectorOdbc < Formula
+  desc "Database driver using the industry standard ODBC API"
+  homepage "https://downloads.mariadb.org/connector-odbc/"
+  url "https://downloads.mariadb.org/f/connector-odbc-3.0.2/mariadb-connector-odbc-3.0.2-ga-src.tar.gz"
+  sha256 "eba4fbda21ae9d50c94d2cd152f0ec14dde3989522f41ef7d22aa0948882ff93"
+
+  depends_on "cmake" => :build
+  depends_on "mariadb-connector-c"
+  depends_on "openssl"
+  depends_on "unixodbc"
+
+  def install
+    system "cmake", ".", "-DMARIADB_FOUND=1",
+                         "-DWITH_OPENSSL=1",
+                         "-DOPENSSL_INCLUDE_DIR=#{Formula["openssl"].opt_include}",
+                         *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    output = shell_output("#{Formula["unixodbc"].opt_bin}/dltest #{lib}/libmaodbc.dylib")
+    assert_equal "SUCCESS: Loaded #{lib}/libmaodbc.dylib", output.chomp
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **See below**
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

#19764 covers the same formula, but a different version of it, specifically a beta version, and has conflicts.  This grabs @unilynx's formula and modifies it to load version 3.0.2.

-----
