### PR TITLE
neon: use mirrors

### DIFF
--- a/Formula/neon.rb
+++ b/Formula/neon.rb
@@ -1,7 +1,8 @@
 class Neon < Formula
   desc "HTTP and WebDAV client library with a C interface"
   homepage "http://www.webdav.org/neon/"
-  url "http://www.webdav.org/neon/neon-0.30.2.tar.gz"
+  url "http://www.mirrorservice.org/sites/distfiles.macports.org/neon/neon-0.30.2.tar.gz"
+  mirror "https://fossies.org/linux/www/neon-0.30.2.tar.gz"
   sha256 "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca"
 
   bottle do

--- a/Formula/neon.rb
+++ b/Formula/neon.rb
@@ -1,7 +1,7 @@
 class Neon < Formula
   desc "HTTP and WebDAV client library with a C interface"
   homepage "http://www.webdav.org/neon/"
-  url "http://www.mirrorservice.org/sites/distfiles.macports.org/neon/neon-0.30.2.tar.gz"
+  url "https://www.mirrorservice.org/sites/distfiles.macports.org/neon/neon-0.30.2.tar.gz"
   mirror "https://fossies.org/linux/www/neon-0.30.2.tar.gz"
   sha256 "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca"
 


### PR DESCRIPTION
WebDAV.org is down.  This will tell `neon` to use mirrors of the versions instead.