### PR TITLE
dep: use build script to maintain all ldflags

### DIFF
--- a/Formula/dep.rb
+++ b/Formula/dep.rb
@@ -1,8 +1,10 @@
 class Dep < Formula
   desc "Go dependency management tool"
   homepage "https://github.com/golang/dep"
-  url "https://github.com/golang/dep/archive/v0.4.1.tar.gz"
-  sha256 "df9b050bf4dbb2a8cf04372097a68b04a6ae1986ed7c5086914ac86d74ea9d49"
+  url "https://github.com/golang/dep.git",
+      :tag => "v0.4.1",
+      :revision => "37d9ea0ac16f0e0a05afc3b60e1ac8c364b6c329"
+  revision 1
   head "https://github.com/golang/dep.git"
 
   bottle do
@@ -16,10 +18,13 @@ class Dep < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    arch = MacOS.prefer_64_bit? ? "amd64" : "386"
     (buildpath/"src/github.com/golang/dep").install buildpath.children
     cd "src/github.com/golang/dep" do
-      system "go", "build", "-o", bin/"dep", "-ldflags",
-             "-X main.version=#{version}", ".../cmd/dep"
+      ENV["DEP_BUILD_PLATFORMS"] = "darwin"
+      ENV["DEP_BUILD_ARCHS"] = arch
+      system "hack/build-all.bash"
+      bin.install "release/dep-darwin-#{arch}" => "dep"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This modifies the build process for dep to use the build script they use to publish real releases. This ensures that the version information is fully populated. It was also necessary to swap over to tag/revision from url/sha to accomplish this.

This ensures that if the project uses additional ldflags in the future, that they will be retained.

Before:
```
dep:
 version     : 0.4.1
 build date  : 
 git hash    : 
 go version  : go1.9.3
 go compiler : gc
 platform    : darwin/amd64
```

After:
```
dep:
 version     : v0.4.1
 build date  : 2018-01-27
 git hash    : 37d9ea0
 go version  : go1.9.3
 go compiler : gc
 platform    : darwin/amd64
```