### PR TITLE
argyll-cms: update dependencies

### DIFF
--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -4,6 +4,7 @@ class ArgyllCms < Formula
   url "https://www.argyllcms.com/Argyll_V2.0.0_src.zip"
   version "2.0.0"
   sha256 "5492896c040b406892864c467466ad6b50eb62954b5874ef0eb9174d1764ff41"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -16,7 +16,6 @@ class ArgyllCms < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "zlib"
 
   conflicts_with "num-utils", :because => "both install `average` binaries"
 

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -14,7 +14,9 @@ class ArgyllCms < Formula
 
   depends_on "jam" => :build
   depends_on "jpeg"
+  depends_on "libpng"
   depends_on "libtiff"
+  depends_on "zlib"
 
   conflicts_with "num-utils", :because => "both install `average` binaries"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`argyll-cms` loads it's own version of `libpng` if it cannot find a pre-installed version.  However, this seems to be the case with all of its dependencies (jpeg, libtiff, and even zlib).  Unfortunately, there's no way to specify `--without-libpng`, which is the final piece of evidence that points towards it being required.

This helps fix opportunistic linkage issues as described in #16531.

-----
