### PR TITLE
fox: update dependencies

### DIFF
--- a/Formula/fox.rb
+++ b/Formula/fox.rb
@@ -12,6 +12,7 @@ class Fox < Formula
   end
 
   depends_on :x11
+  depends_on "fontconfig"
   depends_on "freetype"
   depends_on "libpng"
   depends_on "jpeg"

--- a/Formula/fox.rb
+++ b/Formula/fox.rb
@@ -3,6 +3,7 @@ class Fox < Formula
   homepage "http://www.fox-toolkit.org/"
   url "http://fox-toolkit.org/ftp/fox-1.6.56.tar.gz"
   sha256 "c517e5fcac0e6b78ca003cc167db4f79d89e230e5085334253e1d3f544586cb2"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`fox` doesn't have a way to specify `--without-fontconfig`, but when it can't find `fontconfig`, it loads an old one bundled with X11.  As @ilovezfs says, it's better to just require `fontconfig`.

This helps fix opportunistic linkage issues as described in #16531.

-----
