### PR TITLE
fizmo: update dependencies

### DIFF
--- a/Formula/fizmo.rb
+++ b/Formula/fizmo.rb
@@ -12,6 +12,7 @@ class Fizmo < Formula
 
   depends_on "pkg-config" => :build
   depends_on :x11
+  depends_on "freetype"
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libsndfile"

--- a/Formula/fizmo.rb
+++ b/Formula/fizmo.rb
@@ -3,6 +3,7 @@ class Fizmo < Formula
   homepage "https://fizmo.spellbreaker.org"
   url "https://fizmo.spellbreaker.org/source/fizmo-0.8.5.tar.gz"
   sha256 "1c259a29b21c9f401c12fc24d555aca4f4ff171873be56fb44c0c9402c61beaa"
+  revision 1
 
   bottle do
     sha256 "8f712f9199f9b0dd2ff31e09f8cd48c6796592b7f06f14d78fd3a5c56a661ea8" => :high_sierra


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`fizmo` actually requires `freetype` -- why it wasn't specified, yet allowed for install, I have no idea.

This helps fix opportunistic linkage issues as described in #16531.

-----
