### PR TITLE
freeswitch: update dependencies

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -4,7 +4,7 @@ class Freeswitch < Formula
   url "https://freeswitch.org/stash/scm/fs/freeswitch.git",
       :tag => "v1.6.19",
       :revision => "7a77e0bb2ca875cb977b1e698a1783e575d96563"
-  revision 2
+  revision 3
   head "https://freeswitch.org/stash/scm/fs/freeswitch.git"
 
   bottle do
@@ -18,21 +18,23 @@ class Freeswitch < Formula
   option "with-sounds-fr", "Install French (June) sounds"
   option "with-sounds-ru", "Install Russian (Elena) sounds"
 
+  depends_on "apr-util" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "apr-util" => :build
   depends_on "yasm" => :build
   depends_on "jpeg"
-  depends_on "openssl"
-  depends_on "pcre"
-  depends_on "sqlite"
-  depends_on "lua"
-  depends_on "opus"
   depends_on "libsndfile"
+  depends_on "lua"
+  depends_on "openssl"
+  depends_on "opus"
+  depends_on "pcre"
+  depends_on "postgresql"
   depends_on "speex"
   depends_on "speexdsp"
+  depends_on "sqlite"
+  depends_on "unixodbc"
 
   # https://github.com/Homebrew/homebrew/issues/42865
   fails_with :gcc


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`freeswitch` also seems to be linking to `unixodbc`.  Both it and `postgresql` seem to be installing anyways, however.  As such, I've decided to simply add these two ass dependencies.

This helps fix opportunistic linkage issues as described in #16531.

-----
