### PR TITLE
rsync: reapply patches

### DIFF
--- a/Formula/rsync.rb
+++ b/Formula/rsync.rb
@@ -5,6 +5,7 @@ class Rsync < Formula
   mirror "https://mirrors.kernel.org/gentoo/distfiles/rsync-3.1.3.tar.gz"
   mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.1.3.tar.gz"
   sha256 "55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0"
+  revision 1
 
   bottle do
     sha256 "1b023b82b13c5afaaf0ef980465b660c7a3972f842b2a73cbb2fe541d0a7d210" => :high_sierra
@@ -13,6 +14,22 @@ class Rsync < Formula
   end
 
   depends_on "autoconf" => :build
+
+  # hfs-compression.diff is marked by upstream as broken as of 3.1.3
+  patch do
+    url "https://download.samba.org/pub/rsync/src/rsync-patches-3.1.3.tar.gz"
+    mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-patches-3.1.3.tar.gz"
+    mirror "https://launchpad.net/rsync/main/3.1.2/+download/rsync-patches-3.1.3.tar.gz"
+    sha256 "0dc2848f20ca75c07a30c3237ccf8d61b61082ae7de94758a27dac350c99fb98"
+    apply "patches/fileflags.diff",
+          "patches/crtimes.diff"
+  end
+
+  # Fix "error: too few arguments to function call, expected 4, have 2"
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/344bf3b/rsync/fix-crtimes-patch-3.1.3.diff"
+    sha256 "1a3c9043e19b55290bd6a6bc480544fe79a155c2c7ed003de185521f7516ecc3"
+  end
 
   def install
     system "./prepare-source"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The macOS specific patches are still relevant for 3.1.3. Unfortunately,
hfs-compression.diff is marked as broken by upstream for 3.1.3 so that
one cannot be reapplied at this time.