### PR TITLE
gegl: fix dependencies

### DIFF
--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -24,23 +24,33 @@ class Gegl < Formula
   depends_on "babl"
   depends_on "gettext"
   depends_on "glib"
+  depends_on "jpeg"
   depends_on "json-glib"
   depends_on "libpng"
-  depends_on "jpeg"
   depends_on "cairo" => :optional
+  depends_on "jasper" => :optional
   depends_on "librsvg" => :optional
   depends_on "lua" => :optional
   depends_on "pango" => :optional
   depends_on "sdl" => :optional
+  depends_on "suite-sparse" => :optional
 
   conflicts_with "coreutils", :because => "both install `gcut` binaries"
 
   def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --disable-docs
+    ]
+
+    args << "--without-cairo" if build.without? "cairo"
+    args << "--without-jasper" if build.without? "jasper"
+    args << "--without-umfpack" if build.without? "suite-sparse"
+
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-docs"
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -28,12 +28,10 @@ class Gegl < Formula
   depends_on "json-glib"
   depends_on "libpng"
   depends_on "cairo" => :optional
-  depends_on "jasper" => :optional
   depends_on "librsvg" => :optional
   depends_on "lua" => :optional
   depends_on "pango" => :optional
   depends_on "sdl" => :optional
-  depends_on "suite-sparse" => :optional
 
   conflicts_with "coreutils", :because => "both install `gcut` binaries"
 
@@ -43,11 +41,11 @@ class Gegl < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --disable-docs
+      --without-jasper
+      --without-umfpack
     ]
 
     args << "--without-cairo" if build.without? "cairo"
-    args << "--without-jasper" if build.without? "jasper"
-    args << "--without-umfpack" if build.without? "suite-sparse"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`gegl` also seems to be linking to `cairo` and `jasper`.  All of them have been added as optional dependencies, and will not link unless requested.

This helps fix opportunistic linkage issues as described in #16531.

-----
