### PR TITLE
 R: symlink doc path

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -105,6 +105,10 @@ class R < Formula
     site_library = HOMEBREW_PREFIX/"lib/R/#{short_version}/site-library"
     site_library.mkpath
     ln_s site_library, lib/"R/site-library"
+
+    doc_library = HOMEBREW_PREFIX/"lib/R/#{short_version}/doc"
+    doc_library.mkpath
+    ln_s doc_library, lib/"R/doc"
   end
 
   test do


### PR DESCRIPTION
Symlink the doc path for the R formula to the local library to prevent permission errors while installing HTML manuals.

Fixes #17098 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
