### PR TITLE
hugo 0.35

### DIFF
--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -1,8 +1,8 @@
 class Hugo < Formula
   desc "Configurable static site generator"
   homepage "https://gohugo.io/"
-  url "https://github.com/gohugoio/hugo/archive/v0.34.tar.gz"
-  sha256 "4ba991d4de650a97ad51893ce707788b87190bf487f6b13ad88111540469787d"
+  url "https://github.com/gohugoio/hugo/archive/v0.35.tar.gz"
+  sha256 "dfef416fe3a0355caef0210d0e7530383f6ec320ce0891431ab7c039b31a86c4"
   head "https://github.com/gohugoio/hugo.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`$ brew audit --strict hugo` failed to run:

```
Error: Error running `rubocop --format json --force-exclusion --parallel --except NewFormulaAudit --config /usr/local/Homebrew/Library/.rubocop_audit.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/hugo.rb`
```

And calling rubocop directly also failed for an unknown reason:

```
$ rubocop --format json --force-exclusion --parallel --except NewFormulaAudit --config /usr/local/Homebrew/Library/.rubocop_audit.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/hugo.rb
{"metadata":{"rubocop_version":"0.52.1","ruby_engine":"ruby","ruby_version":"2.5.0","ruby_patchlevel":"0","ruby_platform":"x86_64-darwin15"},"files":[{"path":"Formula/hugo.rb","offenses":[]}],"summary":{"offense_count":0,"target_file_count":1,"inspected_file_count":1}}
$ echo $?
0
```