### PR TITLE
Gradle 4.4 alias since 4.5 is broken

### DIFF
--- a/gradle@4.4.rb
+++ b/gradle@4.4.rb
@@ -1,0 +1,23 @@
+class GradleAT44 < Formula
+  desc "Build system based on the Groovy language"
+  homepage "https://www.gradle.org/"
+  url "https://services.gradle.org/distributions/gradle-4.4-all.zip"
+  sha256 "7a2c66d1a78f811d5f37d14630ad21cec5e77a2a4dc61e787e2257a6341016ce"
+
+  bottle :unneeded
+
+  option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
+
+  depends_on :java => "1.7+"
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    libexec.install %w[bin lib]
+    libexec.install %w[docs media samples src] if build.with? "all"
+    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gradle --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an alias to Gradle 4.4, since there are issues with the following update forcing `resolve` instead of `resolveLater`.

https://github.com/gradle/gradle/commit/d7c6df20509781fedacfc9aea24b1f71e88ec768#diff-8f84e5c4c4081205f8a1ee816bafc145R66