### PR TITLE
rbspy 0.1.8 (new formula)

### DIFF
--- a/Formula/rbspy.rb
+++ b/Formula/rbspy.rb
@@ -1,0 +1,18 @@
+class Rbspy < Formula
+  desc "Sampling profiler for Ruby"
+  homepage "https://github.com/rbspy/rbspy"
+  url "https://github.com/rbspy/rbspy/archive/v0.1.8.tar.gz"
+  sha256 "87f759acd9d660178737b9f24cc07f0113a81a9fffc1604bae2c756d7f4d815b"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build"
+    bin.install "target/debug/rbspy"
+  end
+
+  test do
+    output = shell_output("#{bin}/rbspy -V")
+    assert_includes output, "rbspy"
+  end
+end

--- a/Formula/rbspy.rb
+++ b/Formula/rbspy.rb
@@ -7,8 +7,8 @@ class Rbspy < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build"
-    bin.install "target/debug/rbspy"
+    system "cargo", "build", "--release"
+    bin.install "target/release/rbspy"
   end
 
   test do


### PR DESCRIPTION
Creates a new formula for `rbspy` which is a Ruby profiler.

cc @jvns 

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
