### PR TITLE
libksi-3.16.2482 (New formula)

### DIFF
--- a/Formula/libksi.rb
+++ b/Formula/libksi.rb
@@ -1,0 +1,36 @@
+class Libksi < Formula
+  desc "C SDK for Keyless Signature Infrastructure (c) Guardtime"
+  homepage "https://github.com/guardtime/libksi"
+  url "https://github.com/guardtime/libksi/archive/v3.16.2482.tar.gz"
+  sha256 "a21c6ccdc432ec421df8977948c67bc4d62b50741b59f016c35a1aaf6767ee57"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "openssl"
+
+  def install
+    system "autoreconf", "-if"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <ksi/ksi.h>
+      #include <assert.h>
+      int main()
+      {
+        KSI_CTX *ksi = NULL;
+        assert(KSI_CTX_new(&ksi) == KSI_OK);
+        KSI_CTX_free(ksi);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}",
+                   "-lksi", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libksi.rb
+++ b/Formula/libksi.rb
@@ -18,7 +18,7 @@ class Libksi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<-EOS.undent
+    (testpath/"test.c").write <<~EOS
       #include <ksi/ksi.h>
       #include <assert.h>
       int main()


### PR DESCRIPTION
This is C SDK for Keyless Signature Infrastructure (Guardtime). It is not yet packaged for OSX and users must build it.

- [ok] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ok] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ok] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ok] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
