### PR TITLE
PETSc: import from homebrew-science

### DIFF
--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -35,8 +35,7 @@ class Petsc < Formula
   test do
     test_case = "#{pkgshare}/examples/src/ksp/ksp/examples/tutorials/ex1.c"
     system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
-    example_output = `./a.out`
-    assert($? == 0, "The PETSc example returned an error code: " + $?.to_s)
+    example_output = shell_output("./a.out")
     # This PETSc example prints out several lines of output. The 4th token of
     # the last line of text is an error norm, expected to be small. Check it:
     example_error_norm = example_output.lines.last.split(" ")[3].to_f

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -38,16 +38,11 @@ class Petsc < Formula
     # Build PETSc for real (vs. complex) numbers
     ENV["PETSC_DIR"] = Dir.getwd
     ENV["PETSC_ARCH"] = "real"
-    args_real = %W[--prefix=#{prefix}/real
+    args_real = %W[--prefix=#{prefix}
                    --with-scalar-type=real]
     system "./configure", *(args + args_real)
     system "make", "all", "--makefile=gmakefile"
     system "make", "install"
-
-    # Link #{prefix}/petsc/real/{include,lib} into #{prefix}
-    include.install_symlink Dir["#{prefix}/real/include/*"]
-    lib.install_symlink Dir["#{prefix}/real/lib/lib*.*"]
-    pkgshare.install_symlink Dir["#{prefix}/real/share/*"]
   end
 
   test do

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,0 +1,197 @@
+class Petsc < Formula
+  desc "Scalable solution of models that use partial differential equations"
+  homepage "https://www.mcs.anl.gov/petsc/index.html"
+  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.7.6.tar.gz"
+  sha256 "b07f7b4e57d75f982787bd8169f7b8debd5aee2477293da230ab6c80a52c6ef8"
+  revision 4
+  head "https://bitbucket.org/petsc/petsc", :using => :git
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  option "without-test", "Skip build-time tests (not recommended)"
+  option "with-complex", "Link complex version of PETSc by default."
+  option "with-debug", "Build debug version"
+  option "with-ml", "Download and build ML (will not symlink if Trilinos is installed)"
+
+  depends_on "cmake" => :build
+  depends_on "gcc"
+  depends_on "open-mpi"
+  depends_on :x11 => :optional
+
+  depends_on "superlu"      => :recommended
+  depends_on "metis"        => :recommended
+  depends_on "scalapack"    => :recommended
+  depends_on "hypre"        => :recommended
+  depends_on "hdf5"         => ["with-mpi", :recommended]
+  depends_on "hwloc"        => :recommended
+  depends_on "suite-sparse" => :recommended
+  depends_on "netcdf"       => :recommended
+  depends_on "fftw"         => ["with-mpi", :recommended]
+
+  def oprefix(f)
+    Formula[f].opt_prefix
+  end
+
+  def install
+    ENV.deparallelize
+
+    arch_real="real"
+    arch_complex="complex"
+
+    # Environment variables CC, CXX, etc. will be ignored by PETSc
+    ENV.delete "CC"
+    ENV.delete "CXX"
+    ENV.delete "F77"
+    ENV.delete "FC"
+    # PETSc is not threadsafe, disable pthread/openmp (see http://www.mcs.anl.gov/petsc/miscellaneous/petscthreads.html)
+    args = %w[CC=mpicc
+              CXX=mpicxx
+              F77=mpif77
+              FC=mpif90
+              --with-shared-libraries=1
+              --with-pthread=0
+              --with-openmp=0]
+    args << ("--with-debugging=" + ((build.with? "debug") ? "1" : "0"))
+
+    # We don't download anything, so no need to build against openssl
+    args << "--with-ssl=0"
+
+    if build.with? "superlu43"
+      slu = Formula["superlu43"]
+      args << "--with-superlu-include=#{slu.include}/superlu"
+      args << "--with-superlu-lib=-L#{slu.lib} -lsuperlu"
+    end
+
+    args << "--with-fftw-dir=#{oprefix("fftw")}" if build.with? "fftw"
+    args << "--with-netcdf-dir=#{oprefix("netcdf")}" if build.with? "netcdf"
+    args << "--with-suitesparse-dir=#{oprefix("suite-sparse")}" if build.with? "suite-sparse"
+    args << "--with-hdf5-dir=#{oprefix("hdf5")}" if build.with? "hdf5"
+    args << "--with-metis-dir=#{oprefix("metis")}" if build.with? "metis"
+    args << "--with-scalapack-dir=#{oprefix("scalapack")}" if build.with? "scalapack"
+    args << "--with-x=0" if build.without? "x11"
+
+    # configure fails if those vars are set differently.
+    ENV["PETSC_DIR"] = Dir.getwd
+
+    # real-valued case:
+    ENV["PETSC_ARCH"] = arch_real
+    args_real = ["--prefix=#{prefix}/#{arch_real}", "--with-scalar-type=real"]
+    # TODO: compile separately (https://bitbucket.org/petsc/pkg-ml/commits/tag/v6.2-p3)
+    # --with-ml-include=/path/to/ml/include --with-ml-lib=/path/to/ml/liblibml.a
+    args_real << "--download-ml=1" if build.with? "ml"
+    args_real << "--with-hypre-dir=#{oprefix("hypre")}" if build.with? "hypre"
+    args_real << "--with-hwloc-dir=#{oprefix("hwloc")}" if build.with? "hwloc"
+    system "./configure", *(args + args_real)
+    system "make", "all"
+    system "make", "test" if build.with? "test"
+    system "make", "install"
+
+    # complex-valued case:
+    ENV["PETSC_ARCH"] = arch_complex
+    args_cmplx = ["--prefix=#{prefix}/#{arch_complex}", "--with-scalar-type=complex"]
+    system "./configure", *(args + args_cmplx)
+    system "make", "all"
+    system "make", "test" if build.with? "test"
+    system "make", "install"
+
+    # Link only what we want
+    petsc_arch = ((build.with? "complex") ? arch_complex : arch_real)
+
+    include.install_symlink Dir["#{prefix}/#{petsc_arch}/include/*h"],
+                                "#{prefix}/#{petsc_arch}/include/finclude",
+                                "#{prefix}/#{petsc_arch}/include/petsc-private"
+    # Symlink only files (don't symlink pkgconfig as it won't symlink to opt/lib)
+    lib.install_symlink Dir["#{prefix}/#{petsc_arch}/lib/*.*"]
+    pkgshare.install_symlink Dir["#{prefix}/#{petsc_arch}/share/*"]
+  end
+
+  def caveats; <<-EOS
+    No support for some optional PETSc dependencies:
+      mumps, parmetis, sundials, and superlu_dist
+    Set PETSC_DIR to #{prefix}/real or #{prefix}/complex.
+    Fortran module files are in
+      #{prefix}/real/include and #{prefix}/complex/include
+    EOS
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS
+    static char help[] = "Solve a tridiagonal linear system with KSP.\\n";
+    #include <petscksp.h>
+    #undef __FUNCT__
+    #define __FUNCT__ "main"
+    int main(int argc,char **args) {
+      Vec            x, b, u;
+      Mat            A;
+      KSP            ksp;
+      PC             pc;
+      PetscReal      norm, tol=1.e-14;
+      PetscErrorCode ierr;
+      PetscInt i, n=10, col[3], its;
+      PetscMPIInt size;
+      PetscScalar neg_one=-1.0, one=1.0, value[3];
+      PetscInitialize(&argc, &args, (char*)0, help);
+      ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size); CHKERRQ(ierr);
+      if (size != 1) SETERRQ(PETSC_COMM_WORLD, 1, "This is a uniprocessor example only!\\n");
+
+      /* Create vectors */
+      ierr = VecCreate(PETSC_COMM_WORLD, &x); CHKERRQ(ierr);
+      ierr = PetscObjectSetName((PetscObject) x, "Solution"); CHKERRQ(ierr);
+      ierr = VecSetSizes(x, PETSC_DECIDE, n); CHKERRQ(ierr);
+      ierr = VecSetFromOptions(x); CHKERRQ(ierr);
+      ierr = VecDuplicate(x, &b); CHKERRQ(ierr);
+      ierr = VecDuplicate(x, &u); CHKERRQ(ierr);
+
+      /* Create matrix */
+      ierr = MatCreate(PETSC_COMM_WORLD, &A); CHKERRQ(ierr);
+      ierr = MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n); CHKERRQ(ierr);
+      ierr = MatSetFromOptions(A); CHKERRQ(ierr);
+      ierr = MatSetUp(A); CHKERRQ(ierr);
+
+      /* Setup linear system */
+      value[0] = -1.0; value[1] = 2.0; value[2] = -1.0;
+      for (i = 1; i < n-1; i++) {
+        col[0] = i-1; col[1] = i; col[2] = i+1;
+        ierr = MatSetValues(A, 1, &i, 3, col, value, INSERT_VALUES); CHKERRQ(ierr);
+      }
+      i = n-1; col[0] = n-2; col[1] = n-1;
+      ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
+      i = 0; col[0] = 0; col[1] = 1; value[0] = 2.0; value[1] = -1.0;
+      ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
+      ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+      ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+
+      ierr = VecSet(u, one); CHKERRQ(ierr);
+      ierr = MatMult(A, u, b); CHKERRQ(ierr);
+
+      /* Create linear solver */
+      ierr = KSPCreate(PETSC_COMM_WORLD, &ksp); CHKERRQ(ierr);
+      ierr = KSPSetOperators(ksp, A, A); CHKERRQ(ierr);
+      ierr = KSPGetPC(ksp, &pc); CHKERRQ(ierr);
+      ierr = PCSetType(pc, PCJACOBI); CHKERRQ(ierr);
+      ierr = KSPSetTolerances(ksp, 1.e-8, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);CHKERRQ(ierr);
+
+      /* Solve */
+      ierr = KSPSolve(ksp, b, x); CHKERRQ(ierr);
+      ierr = KSPView(ksp, PETSC_VIEWER_STDOUT_WORLD); CHKERRQ(ierr);
+
+      /* Check solution */
+      ierr = VecAXPY(x, neg_one, u); CHKERRQ(ierr);
+      ierr = VecNorm(x, NORM_2, &norm); CHKERRQ(ierr);
+      ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
+      ierr = PetscPrintf(PETSC_COMM_WORLD, "Norm of error %g\\nIterations %D\\n",
+                         (double)norm, its); CHKERRQ(ierr);
+
+      /* Free work space */
+      ierr = VecDestroy(&x); CHKERRQ(ierr); ierr = VecDestroy(&u); CHKERRQ(ierr);
+      ierr = VecDestroy(&b); CHKERRQ(ierr); ierr = MatDestroy(&A); CHKERRQ(ierr);
+      ierr = KSPDestroy(&ksp); CHKERRQ(ierr);
+
+      ierr = PetscFinalize();
+      return 0;
+    }
+    EOS
+    system "mpicc", "test.c", "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
+    assert (`./test | grep 'Norm of error' | awk '{print $NF}'`.to_f < 1.0e-8)
+  end
+end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -40,7 +40,7 @@ class Petsc < Formula
     # the last line of text is an error norm, expected to be small. Check it:
     example_error_norm = example_output.lines.last.split(" ")[3].to_f
     assert(example_error_norm < 1.0e-13,
-           "The PETSc example ran, but produced incorrect output.\n" +
+           "The PETSc example ran, but produced incorrect output.\n" \
            "Expected error norm ~ 1e-15, instead got error norm " +
            example_error_norm.to_s)
   end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -3,7 +3,6 @@ class Petsc < Formula
   homepage "https://www.mcs.anl.gov/petsc/index.html"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.0.tar.gz"
   sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
-  head "https://bitbucket.org/petsc/petsc", :using => :git
 
   depends_on "gcc"
   depends_on "hdf5"
@@ -15,24 +14,22 @@ class Petsc < Formula
   depends_on "suite-sparse"
 
   def install
-    args = %W[CC=mpicc
-              CXX=mpicxx
-              F77=mpif77
-              FC=mpif90
-              --prefix=#{prefix}
-              --with-debugging=0
-              --with-scalar-type=real
-              --with-shared-libraries=1
-              --with-ssl=0
-              --with-x=0
-              --with-hdf5-dir=#{Formula["hdf5"].opt_prefix}
-              --with-hwloc-dir=#{Formula["hwloc"].opt_prefix}
-              --with-metis-dir=#{Formula["metis"].opt_prefix}
-              --with-netcdf-dir=#{Formula["netcdf"].opt_prefix}
-              --with-scalapack-dir=#{Formula["scalapack"].opt_prefix}
-              --with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}]
-
-    system "./configure", *args
+    system "./configure", "CC=mpicc",
+                          "CXX=mpicxx",
+                          "F77=mpif77",
+                          "FC=mpif90",
+                          "--prefix=#{prefix}",
+                          "--with-debugging=0",
+                          "--with-scalar-type=real",
+                          "--with-shared-libraries=1",
+                          "--with-ssl=0",
+                          "--with-x=0",
+                          "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}",
+                          "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}",
+                          "--with-metis-dir=#{Formula["metis"].opt_prefix}",
+                          "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}",
+                          "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}",
+                          "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}"
     system "make", "all"
     system "make", "install"
   end
@@ -40,6 +37,7 @@ class Petsc < Formula
   test do
     test_case = "#{pkgshare}/examples/src/ksp/ksp/examples/tutorials/ex1.c"
     system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
-    assert (`./a.out | grep 'Norm of error' | awk '{print $4}'`.to_f < 1.0e-13)
+    output = shell_output("./a.out | grep 'Norm of error' | awk '{print $4}'")
+    assert(output.to_f < 1.0e-13)
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -55,80 +55,80 @@ class Petsc < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
-    static char help[] = "Solve a tridiagonal linear system with KSP.\\n";
-    #include <petscksp.h>
-    #undef __FUNCT__
-    #define __FUNCT__ "main"
-    int main(int argc,char **args) {
-      Vec            x, b, u;
-      Mat            A;
-      KSP            ksp;
-      PC             pc;
-      PetscReal      norm, tol=1.e-14;
-      PetscErrorCode ierr;
-      PetscInt i, n=10, col[3], its;
-      PetscMPIInt size;
-      PetscScalar neg_one=-1.0, one=1.0, value[3];
-      PetscInitialize(&argc, &args, (char*)0, help);
-      ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size); CHKERRQ(ierr);
-      if (size != 1) SETERRQ(PETSC_COMM_WORLD, 1, "This is a uniprocessor example only!\\n");
+      static char help[] = "Solve a tridiagonal linear system with KSP.\\n";
+      #include <petscksp.h>
+      #undef __FUNCT__
+      #define __FUNCT__ "main"
+      int main(int argc,char **args) {
+        Vec            x, b, u;
+        Mat            A;
+        KSP            ksp;
+        PC             pc;
+        PetscReal      norm, tol=1.e-14;
+        PetscErrorCode ierr;
+        PetscInt i, n=10, col[3], its;
+        PetscMPIInt size;
+        PetscScalar neg_one=-1.0, one=1.0, value[3];
+        PetscInitialize(&argc, &args, (char*)0, help);
+        ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size); CHKERRQ(ierr);
+        if (size != 1) SETERRQ(PETSC_COMM_WORLD, 1, "This is a uniprocessor example only!\\n");
 
-      /* Create vectors */
-      ierr = VecCreate(PETSC_COMM_WORLD, &x); CHKERRQ(ierr);
-      ierr = PetscObjectSetName((PetscObject) x, "Solution"); CHKERRQ(ierr);
-      ierr = VecSetSizes(x, PETSC_DECIDE, n); CHKERRQ(ierr);
-      ierr = VecSetFromOptions(x); CHKERRQ(ierr);
-      ierr = VecDuplicate(x, &b); CHKERRQ(ierr);
-      ierr = VecDuplicate(x, &u); CHKERRQ(ierr);
+        /* Create vectors */
+        ierr = VecCreate(PETSC_COMM_WORLD, &x); CHKERRQ(ierr);
+        ierr = PetscObjectSetName((PetscObject) x, "Solution"); CHKERRQ(ierr);
+        ierr = VecSetSizes(x, PETSC_DECIDE, n); CHKERRQ(ierr);
+        ierr = VecSetFromOptions(x); CHKERRQ(ierr);
+        ierr = VecDuplicate(x, &b); CHKERRQ(ierr);
+        ierr = VecDuplicate(x, &u); CHKERRQ(ierr);
 
-      /* Create matrix */
-      ierr = MatCreate(PETSC_COMM_WORLD, &A); CHKERRQ(ierr);
-      ierr = MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n); CHKERRQ(ierr);
-      ierr = MatSetFromOptions(A); CHKERRQ(ierr);
-      ierr = MatSetUp(A); CHKERRQ(ierr);
+        /* Create matrix */
+        ierr = MatCreate(PETSC_COMM_WORLD, &A); CHKERRQ(ierr);
+        ierr = MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n); CHKERRQ(ierr);
+        ierr = MatSetFromOptions(A); CHKERRQ(ierr);
+        ierr = MatSetUp(A); CHKERRQ(ierr);
 
-      /* Setup linear system */
-      value[0] = -1.0; value[1] = 2.0; value[2] = -1.0;
-      for (i = 1; i < n-1; i++) {
-        col[0] = i-1; col[1] = i; col[2] = i+1;
-        ierr = MatSetValues(A, 1, &i, 3, col, value, INSERT_VALUES); CHKERRQ(ierr);
+        /* Setup linear system */
+        value[0] = -1.0; value[1] = 2.0; value[2] = -1.0;
+        for (i = 1; i < n-1; i++) {
+          col[0] = i-1; col[1] = i; col[2] = i+1;
+          ierr = MatSetValues(A, 1, &i, 3, col, value, INSERT_VALUES); CHKERRQ(ierr);
+        }
+        i = n-1; col[0] = n-2; col[1] = n-1;
+        ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
+        i = 0; col[0] = 0; col[1] = 1; value[0] = 2.0; value[1] = -1.0;
+        ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
+        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+
+        ierr = VecSet(u, one); CHKERRQ(ierr);
+        ierr = MatMult(A, u, b); CHKERRQ(ierr);
+
+        /* Create linear solver */
+        ierr = KSPCreate(PETSC_COMM_WORLD, &ksp); CHKERRQ(ierr);
+        ierr = KSPSetOperators(ksp, A, A); CHKERRQ(ierr);
+        ierr = KSPGetPC(ksp, &pc); CHKERRQ(ierr);
+        ierr = PCSetType(pc, PCJACOBI); CHKERRQ(ierr);
+        ierr = KSPSetTolerances(ksp, 1.e-8, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);CHKERRQ(ierr);
+
+        /* Solve */
+        ierr = KSPSolve(ksp, b, x); CHKERRQ(ierr);
+        ierr = KSPView(ksp, PETSC_VIEWER_STDOUT_WORLD); CHKERRQ(ierr);
+
+        /* Check solution */
+        ierr = VecAXPY(x, neg_one, u); CHKERRQ(ierr);
+        ierr = VecNorm(x, NORM_2, &norm); CHKERRQ(ierr);
+        ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
+        ierr = PetscPrintf(PETSC_COMM_WORLD, "Norm of error %g\\nIterations %D\\n",
+                           (double)norm, its); CHKERRQ(ierr);
+
+        /* Free work space */
+        ierr = VecDestroy(&x); CHKERRQ(ierr); ierr = VecDestroy(&u); CHKERRQ(ierr);
+        ierr = VecDestroy(&b); CHKERRQ(ierr); ierr = MatDestroy(&A); CHKERRQ(ierr);
+        ierr = KSPDestroy(&ksp); CHKERRQ(ierr);
+
+        ierr = PetscFinalize();
+        return 0;
       }
-      i = n-1; col[0] = n-2; col[1] = n-1;
-      ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
-      i = 0; col[0] = 0; col[1] = 1; value[0] = 2.0; value[1] = -1.0;
-      ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
-      ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-      ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-
-      ierr = VecSet(u, one); CHKERRQ(ierr);
-      ierr = MatMult(A, u, b); CHKERRQ(ierr);
-
-      /* Create linear solver */
-      ierr = KSPCreate(PETSC_COMM_WORLD, &ksp); CHKERRQ(ierr);
-      ierr = KSPSetOperators(ksp, A, A); CHKERRQ(ierr);
-      ierr = KSPGetPC(ksp, &pc); CHKERRQ(ierr);
-      ierr = PCSetType(pc, PCJACOBI); CHKERRQ(ierr);
-      ierr = KSPSetTolerances(ksp, 1.e-8, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);CHKERRQ(ierr);
-
-      /* Solve */
-      ierr = KSPSolve(ksp, b, x); CHKERRQ(ierr);
-      ierr = KSPView(ksp, PETSC_VIEWER_STDOUT_WORLD); CHKERRQ(ierr);
-
-      /* Check solution */
-      ierr = VecAXPY(x, neg_one, u); CHKERRQ(ierr);
-      ierr = VecNorm(x, NORM_2, &norm); CHKERRQ(ierr);
-      ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
-      ierr = PetscPrintf(PETSC_COMM_WORLD, "Norm of error %g\\nIterations %D\\n",
-                         (double)norm, its); CHKERRQ(ierr);
-
-      /* Free work space */
-      ierr = VecDestroy(&x); CHKERRQ(ierr); ierr = VecDestroy(&u); CHKERRQ(ierr);
-      ierr = VecDestroy(&b); CHKERRQ(ierr); ierr = MatDestroy(&A); CHKERRQ(ierr);
-      ierr = KSPDestroy(&ksp); CHKERRQ(ierr);
-
-      ierr = PetscFinalize();
-      return 0;
-    }
     EOS
     system "mpicc", "test.c", "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
     assert (`./test | grep 'Norm of error' | awk '{print $NF}'`.to_f < 1.0e-8)

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -21,8 +21,6 @@ class Petsc < Formula
                           "--prefix=#{prefix}",
                           "--with-debugging=0",
                           "--with-scalar-type=real",
-                          "--with-shared-libraries=1",
-                          "--with-ssl=0",
                           "--with-x=0",
                           "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}",
                           "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}",

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -5,7 +5,6 @@ class Petsc < Formula
   sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
   head "https://bitbucket.org/petsc/petsc", :using => :git
 
-  depends_on "cmake" => :build
   depends_on "gcc"
   depends_on "hdf5"
   depends_on "hwloc"
@@ -16,16 +15,12 @@ class Petsc < Formula
   depends_on "suite-sparse"
 
   def install
-    # PETSc is not threadsafe, disable pthread/openmp
-    # (see http://www.mcs.anl.gov/petsc/miscellaneous/petscthreads.html)
     args = %W[CC=mpicc
               CXX=mpicxx
               F77=mpif77
               FC=mpif90
               --prefix=#{prefix}
               --with-debugging=0
-              --with-openmp=0
-              --with-pthread=0
               --with-scalar-type=real
               --with-shared-libraries=1
               --with-ssl=0
@@ -46,8 +41,6 @@ class Petsc < Formula
     (testpath/"test.c").write <<~EOS
       static char help[] = "Solve a tridiagonal linear system with KSP.\\n";
       #include <petscksp.h>
-      #undef __FUNCT__
-      #define __FUNCT__ "main"
       int main(int argc,char **args) {
         Vec            x, b, u;
         Mat            A;

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -22,9 +22,11 @@ class Petsc < Formula
               CXX=mpicxx
               F77=mpif77
               FC=mpif90
+              --prefix=#{prefix}
               --with-debugging=0
               --with-openmp=0
               --with-pthread=0
+              --with-scalar-type=real
               --with-shared-libraries=1
               --with-ssl=0
               --with-x=0
@@ -35,12 +37,7 @@ class Petsc < Formula
               --with-scalapack-dir=#{Formula["scalapack"].opt_prefix}
               --with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}]
 
-    # Build PETSc for real (vs. complex) numbers
-    ENV["PETSC_DIR"] = Dir.getwd
-    ENV["PETSC_ARCH"] = "real"
-    args_real = %W[--prefix=#{prefix}
-                   --with-scalar-type=real]
-    system "./configure", *(args + args_real)
+    system "./configure", *args
     system "make", "all"
     system "make", "install"
   end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -41,7 +41,7 @@ class Petsc < Formula
     args_real = %W[--prefix=#{prefix}
                    --with-scalar-type=real]
     system "./configure", *(args + args_real)
-    system "make", "all", "--makefile=gmakefile"
+    system "make", "all"
     system "make", "install"
   end
 

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -7,12 +7,11 @@ class Petsc < Formula
 
   depends_on "cmake" => :build
   depends_on "gcc"
-  depends_on "open-mpi"
-
   depends_on "hdf5"
   depends_on "hwloc"
   depends_on "metis"
   depends_on "netcdf"
+  depends_on "open-mpi"
   depends_on "scalapack"
   depends_on "suite-sparse"
 

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -20,8 +20,6 @@ class Petsc < Formula
   depends_on "fftw"         => ["with-mpi", :recommended]
 
   def install
-    ENV.deparallelize
-
     arch_real="real"
     arch_complex="complex"
 
@@ -56,14 +54,14 @@ class Petsc < Formula
     args_real << "--with-hypre-dir=#{Formula["hypre"].opt_prefix}" if build.with? "hypre"
     args_real << "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}" if build.with? "hwloc"
     system "./configure", *(args + args_real)
-    system "make", "all"
+    system "make", "all", "--makefile=gmakefile"
     system "make", "install"
 
     # complex-valued case:
     ENV["PETSC_ARCH"] = arch_complex
     args_cmplx = ["--prefix=#{prefix}/#{arch_complex}", "--with-scalar-type=complex"]
     system "./configure", *(args + args_cmplx)
-    system "make", "all"
+    system "make", "all", "--makefile=gmakefile"
     system "make", "install"
 
     # Link only what we want

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,5 +1,5 @@
 class Petsc < Formula
-  desc "Tools for solving partial differential equations in parallel"
+  desc "Portable, Extensible Toolkit for Scientific Computation"
   homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.0.tar.gz"
   sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
@@ -32,9 +32,8 @@ class Petsc < Formula
     # This PETSc example prints several lines of output. The last line contains
     # an error norm, expected to be small.
     line = output.lines.last
-    match = /(?<=^Norm of error )(.+)(?=,)/.match(line)
-    assert match, "Unexpected output format"
-    error = match[0]
-    assert (error.to_f >= 0.0 && error.to_f < 1.0e-13), "Error norm too large"
+    assert_match /^Norm of error .+, Iterations/, line, "Unexpected output format"
+    error = line.split()[3].to_f
+    assert (error >= 0.0 && error < 1.0e-13), "Error norm too large"
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -17,7 +17,6 @@ class Petsc < Formula
   depends_on "hwloc"
   depends_on "suite-sparse"
   depends_on "netcdf"
-  depends_on "fftw"         => ["with-mpi", :recommended]
 
   def install
     arch_real="real"
@@ -37,7 +36,6 @@ class Petsc < Formula
     # We don't download anything, so no need to build against openssl
     args << "--with-ssl=0"
 
-    args << "--with-fftw-dir=#{Formula["fftw"].opt_prefix}" if build.with? "fftw"
     args << "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}"
     args << "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}"
     args << "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -27,11 +27,14 @@ class Petsc < Formula
 
   test do
     test_case = "#{pkgshare}/examples/src/ksp/ksp/examples/tutorials/ex1.c"
-    system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
-    example_output = shell_output("./a.out")
-    # This PETSc example prints out several lines of output. The 4th token of
-    # the last line of text is an error norm, expected to be small.
-    example_error_norm = example_output.lines.last.split(" ")[3].to_f
-    assert(example_error_norm < 1.0e-13, "Error norm too large")
+    system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
+    output = shell_output("./test")
+    # This PETSc example prints several lines of output. The last line contains
+    # an error norm, expected to be small.
+    line = output.lines.last
+    match = /(?<=^Norm of error )(.+)(?=,)/.match(line)
+    assert match, "Unexpected output format")
+    error = match[0]
+    assert (error.to_f >= 0.0 && error.to_f < 1.0e-13, "Error norm too large")
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -9,14 +9,14 @@ class Petsc < Formula
   depends_on "gcc"
   depends_on "open-mpi"
 
-  depends_on "superlu"      => :recommended
-  depends_on "metis"        => :recommended
-  depends_on "scalapack"    => :recommended
-  depends_on "hypre"        => :recommended
+  depends_on "superlu"
+  depends_on "metis"
+  depends_on "scalapack"
+  depends_on "hypre"
   depends_on "hdf5"         => ["with-mpi", :recommended]
-  depends_on "hwloc"        => :recommended
-  depends_on "suite-sparse" => :recommended
-  depends_on "netcdf"       => :recommended
+  depends_on "hwloc"
+  depends_on "suite-sparse"
+  depends_on "netcdf"
   depends_on "fftw"         => ["with-mpi", :recommended]
 
   def install
@@ -38,11 +38,11 @@ class Petsc < Formula
     args << "--with-ssl=0"
 
     args << "--with-fftw-dir=#{Formula["fftw"].opt_prefix}" if build.with? "fftw"
-    args << "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}" if build.with? "netcdf"
-    args << "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}" if build.with? "suite-sparse"
+    args << "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}"
+    args << "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}"
     args << "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}" if build.with? "hdf5"
-    args << "--with-metis-dir=#{Formula["metis"].opt_prefix}" if build.with? "metis"
-    args << "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}" if build.with? "scalapack"
+    args << "--with-metis-dir=#{Formula["metis"].opt_prefix}"
+    args << "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}"
     args << "--with-x=0"
 
     # configure fails if those vars are set differently.
@@ -51,8 +51,8 @@ class Petsc < Formula
     # real-valued case:
     ENV["PETSC_ARCH"] = arch_real
     args_real = ["--prefix=#{prefix}/#{arch_real}", "--with-scalar-type=real"]
-    args_real << "--with-hypre-dir=#{Formula["hypre"].opt_prefix}" if build.with? "hypre"
-    args_real << "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}" if build.with? "hwloc"
+    args_real << "--with-hypre-dir=#{Formula["hypre"].opt_prefix}"
+    args_real << "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}"
     system "./configure", *(args + args_real)
     system "make", "all", "--makefile=gmakefile"
     system "make", "install"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,8 +1,8 @@
 class Petsc < Formula
   desc "Scalable solution of models that use partial differential equations"
   homepage "https://www.mcs.anl.gov/petsc/index.html"
-  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.7.6.tar.gz"
-  sha256 "b07f7b4e57d75f982787bd8169f7b8debd5aee2477293da230ab6c80a52c6ef8"
+  url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.0.tar.gz"
+  sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
   head "https://bitbucket.org/petsc/petsc", :using => :git
 
   depends_on "cmake" => :build
@@ -11,7 +11,6 @@ class Petsc < Formula
 
   depends_on "hdf5"
   depends_on "hwloc"
-  depends_on "hypre"
   depends_on "metis"
   depends_on "netcdf"
   depends_on "scalapack"
@@ -32,7 +31,6 @@ class Petsc < Formula
               --with-x=0
               --with-hdf5-dir=#{Formula["hdf5"].opt_prefix}
               --with-hwloc-dir=#{Formula["hwloc"].opt_prefix}
-              --with-hypre-dir=#{Formula["hypre"].opt_prefix}
               --with-metis-dir=#{Formula["metis"].opt_prefix}
               --with-netcdf-dir=#{Formula["netcdf"].opt_prefix}
               --with-scalapack-dir=#{Formula["scalapack"].opt_prefix}

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,6 +1,6 @@
 class Petsc < Formula
-  desc "Scalable solution of models that use partial differential equations"
-  homepage "https://www.mcs.anl.gov/petsc/index.html"
+  desc "Tools for solving partial differential equations in parallel"
+  homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.0.tar.gz"
   sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
 

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -35,7 +35,14 @@ class Petsc < Formula
   test do
     test_case = "#{pkgshare}/examples/src/ksp/ksp/examples/tutorials/ex1.c"
     system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
-    output = shell_output("./a.out | grep 'Norm of error' | awk '{print $4}'")
-    assert(output.to_f < 1.0e-13)
+    example_output = `./a.out`
+    assert($? == 0, "The PETSc example returned an error code: " + $?.to_s)
+    # This PETSc example prints out several lines of output. The 4th token of
+    # the last line of text is an error norm, expected to be small. Check it:
+    example_error_norm = example_output.lines.last.split(" ")[3].to_f
+    assert(example_error_norm < 1.0e-13,
+           "The PETSc example ran, but produced incorrect output.\n" +
+           "Expected error norm ~ 1e-15, instead got error norm " +
+           example_error_norm.to_s)
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -47,10 +47,10 @@ class Petsc < Formula
     system "make", "all", "--makefile=gmakefile"
     system "make", "install"
 
-    # PETSc produces some non-executables in bin dir; do not link these
-    ln_s "#{prefix}/real/bin/*.py", bin.to_s
-    ln_s "#{prefix}/real/include", include.to_s
-    ln_s "#{prefix}/real/lib", lib.to_s
+    # Link #{prefix}/petsc/real/{include,lib} into #{prefix}
+    include.install_symlink Dir["#{prefix}/real/include/*"]
+    lib.install_symlink Dir["#{prefix}/real/lib/lib*.*"]
+    pkgshare.install_symlink Dir["#{prefix}/real/share/*"]
   end
 
   test do

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -39,12 +39,6 @@ class Petsc < Formula
     # We don't download anything, so no need to build against openssl
     args << "--with-ssl=0"
 
-    if build.with? "superlu43"
-      slu = Formula["superlu43"]
-      args << "--with-superlu-include=#{slu.include}/superlu"
-      args << "--with-superlu-lib=-L#{slu.lib} -lsuperlu"
-    end
-
     args << "--with-fftw-dir=#{Formula["fftw"].opt_prefix}" if build.with? "fftw"
     args << "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}" if build.with? "netcdf"
     args << "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}" if build.with? "suite-sparse"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -38,81 +38,8 @@ class Petsc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
-      static char help[] = "Solve a tridiagonal linear system with KSP.\\n";
-      #include <petscksp.h>
-      int main(int argc,char **args) {
-        Vec            x, b, u;
-        Mat            A;
-        KSP            ksp;
-        PC             pc;
-        PetscReal      norm, tol=1.e-14;
-        PetscErrorCode ierr;
-        PetscInt i, n=10, col[3], its;
-        PetscMPIInt size;
-        PetscScalar neg_one=-1.0, one=1.0, value[3];
-        PetscInitialize(&argc, &args, (char*)0, help);
-        ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size); CHKERRQ(ierr);
-        if (size != 1) SETERRQ(PETSC_COMM_WORLD, 1, "This is a uniprocessor example only!\\n");
-
-        /* Create vectors */
-        ierr = VecCreate(PETSC_COMM_WORLD, &x); CHKERRQ(ierr);
-        ierr = PetscObjectSetName((PetscObject) x, "Solution"); CHKERRQ(ierr);
-        ierr = VecSetSizes(x, PETSC_DECIDE, n); CHKERRQ(ierr);
-        ierr = VecSetFromOptions(x); CHKERRQ(ierr);
-        ierr = VecDuplicate(x, &b); CHKERRQ(ierr);
-        ierr = VecDuplicate(x, &u); CHKERRQ(ierr);
-
-        /* Create matrix */
-        ierr = MatCreate(PETSC_COMM_WORLD, &A); CHKERRQ(ierr);
-        ierr = MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n); CHKERRQ(ierr);
-        ierr = MatSetFromOptions(A); CHKERRQ(ierr);
-        ierr = MatSetUp(A); CHKERRQ(ierr);
-
-        /* Setup linear system */
-        value[0] = -1.0; value[1] = 2.0; value[2] = -1.0;
-        for (i = 1; i < n-1; i++) {
-          col[0] = i-1; col[1] = i; col[2] = i+1;
-          ierr = MatSetValues(A, 1, &i, 3, col, value, INSERT_VALUES); CHKERRQ(ierr);
-        }
-        i = n-1; col[0] = n-2; col[1] = n-1;
-        ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
-        i = 0; col[0] = 0; col[1] = 1; value[0] = 2.0; value[1] = -1.0;
-        ierr = MatSetValues(A, 1, &i, 2, col, value, INSERT_VALUES); CHKERRQ(ierr);
-        ierr = MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-        ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-
-        ierr = VecSet(u, one); CHKERRQ(ierr);
-        ierr = MatMult(A, u, b); CHKERRQ(ierr);
-
-        /* Create linear solver */
-        ierr = KSPCreate(PETSC_COMM_WORLD, &ksp); CHKERRQ(ierr);
-        ierr = KSPSetOperators(ksp, A, A); CHKERRQ(ierr);
-        ierr = KSPGetPC(ksp, &pc); CHKERRQ(ierr);
-        ierr = PCSetType(pc, PCJACOBI); CHKERRQ(ierr);
-        ierr = KSPSetTolerances(ksp, 1.e-8, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);CHKERRQ(ierr);
-
-        /* Solve */
-        ierr = KSPSolve(ksp, b, x); CHKERRQ(ierr);
-        ierr = KSPView(ksp, PETSC_VIEWER_STDOUT_WORLD); CHKERRQ(ierr);
-
-        /* Check solution */
-        ierr = VecAXPY(x, neg_one, u); CHKERRQ(ierr);
-        ierr = VecNorm(x, NORM_2, &norm); CHKERRQ(ierr);
-        ierr = KSPGetIterationNumber(ksp, &its); CHKERRQ(ierr);
-        ierr = PetscPrintf(PETSC_COMM_WORLD, "Norm of error %g\\nIterations %D\\n",
-                           (double)norm, its); CHKERRQ(ierr);
-
-        /* Free work space */
-        ierr = VecDestroy(&x); CHKERRQ(ierr); ierr = VecDestroy(&u); CHKERRQ(ierr);
-        ierr = VecDestroy(&b); CHKERRQ(ierr); ierr = MatDestroy(&A); CHKERRQ(ierr);
-        ierr = KSPDestroy(&ksp); CHKERRQ(ierr);
-
-        ierr = PetscFinalize();
-        return 0;
-      }
-    EOS
-    system "mpicc", "test.c", "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
-    assert (`./test | grep 'Norm of error' | awk '{print $NF}'`.to_f < 1.0e-8)
+    test_case = "#{pkgshare}/examples/src/ksp/ksp/examples/tutorials/ex1.c"
+    system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
+    assert (`./a.out | grep 'Norm of error' | awk '{print $4}'`.to_f < 1.0e-13)
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -13,7 +13,7 @@ class Petsc < Formula
   depends_on "metis"
   depends_on "scalapack"
   depends_on "hypre"
-  depends_on "hdf5"         => ["with-mpi", :recommended]
+  depends_on "hdf5"
   depends_on "hwloc"
   depends_on "suite-sparse"
   depends_on "netcdf"
@@ -40,7 +40,7 @@ class Petsc < Formula
     args << "--with-fftw-dir=#{Formula["fftw"].opt_prefix}" if build.with? "fftw"
     args << "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}"
     args << "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}"
-    args << "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}" if build.with? "hdf5"
+    args << "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}"
     args << "--with-metis-dir=#{Formula["metis"].opt_prefix}"
     args << "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}"
     args << "--with-x=0"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -37,11 +37,8 @@ class Petsc < Formula
     system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc"
     example_output = shell_output("./a.out")
     # This PETSc example prints out several lines of output. The 4th token of
-    # the last line of text is an error norm, expected to be small. Check it:
+    # the last line of text is an error norm, expected to be small.
     example_error_norm = example_output.lines.last.split(" ")[3].to_f
-    assert(example_error_norm < 1.0e-13,
-           "The PETSc example ran, but produced incorrect output.\n" \
-           "Expected error norm ~ 1e-15, instead got error norm " +
-           example_error_norm.to_s)
+    assert(example_error_norm < 1.0e-13, "Error norm too large")
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -33,7 +33,7 @@ class Petsc < Formula
     # an error norm, expected to be small.
     line = output.lines.last
     assert_match /^Norm of error .+, Iterations/, line, "Unexpected output format"
-    error = line.split()[3].to_f
+    error = line.split[3].to_f
     assert (error >= 0.0 && error < 1.0e-13), "Error norm too large"
   end
 end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -4,7 +4,6 @@ class Petsc < Formula
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.0.tar.gz"
   sha256 "a233e0d7f69c98504a1c3548162c6024f7797dde5556b83b0f98ce7326251ca1"
 
-  depends_on "gcc"
   depends_on "hdf5"
   depends_on "hwloc"
   depends_on "metis"
@@ -14,20 +13,14 @@ class Petsc < Formula
   depends_on "suite-sparse"
 
   def install
-    system "./configure", "CC=mpicc",
-                          "CXX=mpicxx",
-                          "F77=mpif77",
-                          "FC=mpif90",
-                          "--prefix=#{prefix}",
+    ENV["CC"] = "mpicc"
+    ENV["CXX"] = "mpicxx"
+    ENV["F77"] = "mpif77"
+    ENV["FC"] = "mpif90"
+    system "./configure", "--prefix=#{prefix}",
                           "--with-debugging=0",
                           "--with-scalar-type=real",
-                          "--with-x=0",
-                          "--with-hdf5-dir=#{Formula["hdf5"].opt_prefix}",
-                          "--with-hwloc-dir=#{Formula["hwloc"].opt_prefix}",
-                          "--with-metis-dir=#{Formula["metis"].opt_prefix}",
-                          "--with-netcdf-dir=#{Formula["netcdf"].opt_prefix}",
-                          "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}",
-                          "--with-suitesparse-dir=#{Formula["suite-sparse"].opt_prefix}"
+                          "--with-x=0"
     system "make", "all"
     system "make", "install"
   end

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -33,8 +33,8 @@ class Petsc < Formula
     # an error norm, expected to be small.
     line = output.lines.last
     match = /(?<=^Norm of error )(.+)(?=,)/.match(line)
-    assert match, "Unexpected output format")
+    assert match, "Unexpected output format"
     error = match[0]
-    assert (error.to_f >= 0.0 && error.to_f < 1.0e-13, "Error norm too large")
+    assert (error.to_f >= 0.0 && error.to_f < 1.0e-13), "Error norm too large"
   end
 end


### PR DESCRIPTION
Ports PETSc, with some changes.

The changes are to remove some optional dependencies that do not build (see #22660), lead to build failures, etc:
* Address several `brew audit` issues
* Remove optional dependency openblas, because `brew audit` said so
* Remove optional dependency parmetis, which needs a patch to compile
* Remove optional dependency superlu_dist, which depends on parmetis
* Remove optional dependency mumps (had problems building its (optional) dependency scotch)
* Remove optional dependency sundials (had problems building PETSc against this)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----