### PR TITLE
x264 r2854

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -3,8 +3,8 @@ class X264 < Formula
   homepage "https://www.videolan.org/developers/x264.html"
   # the latest commit on the stable branch
   url "https://git.videolan.org/git/x264.git",
-      :revision => "aaa9aa83a111ed6f1db253d5afa91c5fc844583f"
-  version "r2795"
+      :revision => "e9a5903edf8ca59ef20e6f4894c196f135af735e"
+  version "r2854"
   head "https://git.videolan.org/git/x264.git"
 
   bottle do
@@ -18,7 +18,7 @@ class X264 < Formula
   option "with-10-bit", "Build a 10-bit x264 (default: 8-bit)"
   option "with-l-smash", "Build CLI with l-smash mp4 output"
 
-  depends_on "yasm" => :build
+  depends_on "nasm" => :build
   depends_on "l-smash" => :optional
 
   deprecated_option "10-bit" => "with-10-bit"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Update to [latest stable commit](https://git.videolan.org/?p=x264.git;a=commit;h=e9a5903edf8ca59ef20e6f4894c196f135af735e), also change assembler to nasm per [d2b5f48](https://git.videolan.org/?p=x264.git;a=commit;h=d2b5f4873e2147452a723b61b14f030b2ee760a5).