### PR TITLE
x265: use NASM for HEAD builds

### DIFF
--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -1,9 +1,14 @@
 class X265 < Formula
   desc "H.265/HEVC encoder"
   homepage "http://x265.org"
-  url "https://bitbucket.org/multicoreware/x265/downloads/x265_2.6.tar.gz"
-  sha256 "1bf0036415996af841884802161065b9e6be74f5f6808ac04831363e2549cdbf"
-  head "https://bitbucket.org/multicoreware/x265", :using => :hg
+
+  stable do
+    url "https://bitbucket.org/multicoreware/x265/downloads/x265_2.6.tar.gz"
+    sha256 "1bf0036415996af841884802161065b9e6be74f5f6808ac04831363e2549cdbf"
+
+    # build with nasm when >=2.7 is released
+    depends_on "yasm" => :build
+  end
 
   bottle do
     cellar :any
@@ -12,8 +17,13 @@ class X265 < Formula
     sha256 "868310a95be1b8ad9e784a111fd41ec4a2ac4547f437e7cf5920f391dabdc454" => :el_capitan
   end
 
+  head do
+    url "https://bitbucket.org/multicoreware/x265", :using => :hg
+
+    depends_on "nasm" => :build
+  end
+
   depends_on "cmake" => :build
-  depends_on "yasm" => :build
   depends_on :macos => :lion
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
x265 switched to NASM in [9eabffb](https://bitbucket.org/multicoreware/x265/commits/9eabffb26dd62e4f48c5679594ae13690eb9d221). The `if`/`else` should be removed once a new release is made.
