### PR TITLE
hexer 1.4.0 (new formula)

### DIFF
--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -1,0 +1,15 @@
+class Hexer < Formula
+  desc "Hexbin density and boundary generation"
+  homepage "https://github.com/hobu/hexer"
+  url "https://github.com/hobu/hexer/archive/1.4.0.tar.gz"
+  sha256 "886134fcdd75da2c50aa48624de19f5ae09231d5290812ec05f09f50319242cb"
+  depends_on "cmake" => :build
+  depends_on "gdal"
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+  test do
+    system bin/"curse", "-c", "hex", "-i", "fake_file"
+  end
+end


### PR DESCRIPTION
Hexer is a LGPL C++ library that provides some classes for generating hexbin density surfaces and multipolygon boundaries for large point sets.

Simple cmake project with 1 dependency (gdal)

I'm starting to add all the dependencies needed to build [OpenDroneMap](opendronemap.org) natively. This library is needed to build a plugin for the `pdal` package (pull request forthcoming).


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
