### PR TITLE
openssh:  Revert "openssh: drop ldns dependency temporarily"

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -16,6 +16,8 @@ class Openssh < Formula
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
   depends_on "openssl"
+  depends_on "ldns" => :optional
+  depends_on "pkg-config" => :build if build.with? "ldns"
 
   # Both these patches are applied by Apple.
   patch do
@@ -40,12 +42,18 @@ class Openssh < Formula
     # We introduce this issue with patching, it's not an upstream bug.
     inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
 
-    system "./configure", "--with-libedit",
-                          "--with-kerberos5",
-                          "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}/ssh",
-                          "--with-pam",
-                          "--with-ssl-dir=#{Formula["openssl"].opt_prefix}"
+    args = %W[
+      --with-libedit
+      --with-kerberos5
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}/ssh
+      --with-pam
+      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
+    ]
+
+    args << "--with-ldns" if build.with? "ldns"
+
+    system "./configure", *args
     system "make"
     ENV.deparallelize
     system "make", "install"


### PR DESCRIPTION
This reverts commit `ef4e9ee` from #13488.  (Feasible due to the merger of
https://github.com/Homebrew/homebrew-core/issues/13132#issuecomment-360605107.)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refs:  #13132, #13488, #23284 

CC @DomT4, @ilovezfs, and/or @MikeMcQuaid