### PR TITLE
tintin: depend on gnutls

### DIFF
--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -3,7 +3,7 @@ class Tintin < Formula
   homepage "https://tintin.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tintin/TinTin%2B%2B%20Source%20Code/2.01.4/tintin-2.01.4.tar.gz"
   sha256 "dd22afbff45a93ec399065bae385489131af7e1b6ae8abb28f80d6a03b82ebbc"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -12,8 +12,8 @@ class Tintin < Formula
     sha256 "42985a4b7b44e3036348ce810aa6301adac1564bbb5caac55fb44e14e10a9e25" => :el_capitan
   end
 
-  depends_on "pcre"
   depends_on "gnutls"
+  depends_on "pcre"
 
   def install
     # find Homebrew's libpcre

--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -13,6 +13,7 @@ class Tintin < Formula
   end
 
   depends_on "pcre"
+  depends_on "gnutls"
 
   def install
     # find Homebrew's libpcre


### PR DESCRIPTION
Adding gnutls to the build automatically enables support of the `#SSL` command.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
