### PR TITLE
fribidi 1.0.1

### DIFF
--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -1,9 +1,8 @@
 class Fribidi < Formula
   desc "Implementation of the Unicode BiDi algorithm"
   homepage "https://github.com/fribidi/fribidi"
-  url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/fribidi-0.19.7.tar.bz2"
-  sha256 "08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e"
-  revision 1
+  url "https://github.com/fribidi/fribidi/releases/download/v1.0.1/fribidi-1.0.1.tar.bz2"
+  sha256 "c1b182d70590b6cdb5545bab8149de33b966800f27f2d9365c68917ed5a174e4"
 
   bottle do
     cellar :any


### PR DESCRIPTION
depend on Autotools at build time as there's no 1.0.0 release tarball