### PR TITLE
htop: remove MaximumMacOSRequirement and apply 10.13 fix

### DIFF
--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -1,9 +1,21 @@
 class Htop < Formula
   desc "Improved top (interactive process viewer)"
   homepage "https://hisham.hm/htop/"
-  url "https://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz"
-  sha256 "179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487"
-  revision 1
+  revision 2
+
+  stable do
+    url "https://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz"
+    sha256 "179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487"
+
+    # Running htop can lead to system freezes on macOS 10.13
+    # https://github.com/hishamhm/htop/issues/682
+    if MacOS.version >= :high_sierra
+      patch do
+        url "https://github.com/hishamhm/htop/commit/b2771218.patch?full_index=1"
+        sha256 "3369f8aed21706d809db062f25fd46bf9c0677712a624697bc5415aa45d5d104"
+      end
+    end
+  end
 
   bottle do
     sha256 "012058c2b3b3d4061b51ea4782ab4ecbe7063e0256ff4275d5f2f6514617faf4" => :sierra
@@ -16,13 +28,10 @@ class Htop < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    depends_on "pkg-config" => :build
   end
 
   option "with-ncurses", "Build using homebrew ncurses (enables mouse scroll)"
-
-  # Running htop can lead to system freezes on macOS 10.13
-  # https://github.com/hishamhm/htop/issues/682
-  depends_on MaximumMacOSRequirement => :sierra
 
   depends_on "ncurses" => :optional
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

also depend on pkg-config at build time for head

Apply https://github.com/hishamhm/htop/commit/b27712181aa27ae1e993f1a505c8e3717e709244 as a patch

Reference: https://github.com/hishamhm/htop/issues/682

CC @hishamhm