### PR TITLE
wireguard-tools 0.0.20180202

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -1,10 +1,10 @@
 class WireguardTools < Formula
   desc "Tools for the WireGuard secure network tunnel"
-  homepage "https://www.wireguard.io/"
+  homepage "https://www.wireguard.com/"
   # Please only update version when the tools have been modified/updated,
   # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20171221.tar.xz"
-  sha256 "2b97697e9b271ba8836a04120a287b824648124f21d5309170ec51c1f86ac5ed"
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180202.tar.xz"
+  sha256 "ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722"
   head "https://git.zx2c4.com/WireGuard", :using => :git
 
   bottle do

--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -9,8 +9,11 @@ class WireguardTools < Formula
     url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180202.tar.xz"
     sha256 "ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722"
 
+    # Fix "fatal error: 'endian.h' file not found"
+    # Equivalent to upstream commit from 5 Feb 2018 "tools: endian.h is not portable"
+    # See https://git.zx2c4.com/WireGuard/patch/?id=d99954e0376d50c31f052cd6455e8665d9d9dd66
     patch do
-      url "https://git.zx2c4.com/WireGuard/patch/?id=d99954e0376d50c31f052cd6455e8665d9d9dd66"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/4e4ca86/wireguard-tools/endian.patch"
       sha256 "68d77d13a7fc748f02e4a78eb405599b04d1b99dcbee8af06cf8eb8f0ba9c908"
     end
   end

--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -1,11 +1,19 @@
 class WireguardTools < Formula
   desc "Tools for the WireGuard secure network tunnel"
   homepage "https://www.wireguard.com/"
-  # Please only update version when the tools have been modified/updated,
-  # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180202.tar.xz"
-  sha256 "ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722"
   head "https://git.zx2c4.com/WireGuard", :using => :git
+
+  stable do
+    # Please only update version when the tools have been modified/updated,
+    # since the Linux module aspect isn't of utility for us.
+    url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180202.tar.xz"
+    sha256 "ee3415b482265ad9e8721aa746aaffdf311058a2d1a4d80e7b6d11bbbf71c722"
+
+    patch do
+      url "https://git.zx2c4.com/WireGuard/patch/?id=d99954e0376d50c31f052cd6455e8665d9d9dd66"
+      sha256 "68d77d13a7fc748f02e4a78eb405599b04d1b99dcbee8af06cf8eb8f0ba9c908"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Simple version bump.

```
  * curve25519-fiat32: uninline certain functions
  
  This results in much smaller code size and significanat speed gains on smaller
  hardware.
  
  * poly1305: add poly-specific self-tests
  
  Poly is easy to get wrong, so we've added quite a few tests that examine
  certain edge cases and places where other implementations of historically
  failed.
  
  * tools: dedup secret normalization
  * tools: share curve25519 implementations with kernel
  * contrib: keygen-html: share curve25519 implementation with kernel
  
  There is now only one place where we ship 25519 code.
  
  * qemu: disable PIE for compilation
  * qemu: disable AVX-512 in userland
  * qemu: update base versions
  
  Test suite enhancements.
  
  * device: let udev know what kind of device we are
  
  This enables folks to query the device type via udev, which is what systemd's
  networkctl uses.
  
  * tools: fread doesn't change errno
  
  This fixes clearing pre-shared keys on old glibc.
  
  * chacha20poly1305: use existing rol32 function
  * chacha20poly1305: better buffer alignment
  
  Small enhancements.
  
  * curve25519: verify that specialized basepoint implementations are correct
  
  Since some implementations have a specialized function for computing
  basepoints, it's important to do some basic sanity checking with them.
  
  * curve25519: replace hacl64 with fiat64
  
  For about 24 hours, fiat64 was faster.
  
  * curve25519: replace fiat64 with faster hacl64
  
  Then hacl64 caught up, so we moved back to it.
  
  * curve25519: break more things with more test cases
  
  These extra test cases help break the current "rfc7748_precomputed"
  implementation, which we're not using here at the moment, but it is still
  useful to ensure that we don't fall victim to the same bugs.
```