### PR TITLE
new formula: op -- 1password official CLI

### DIFF
--- a/Formula/op.rb
+++ b/Formula/op.rb
@@ -10,6 +10,6 @@ class Op < Formula
 
   test do
     # 'op -version' exits with status 1, rather than 0
-    assert_match "#{version}", shell_output("#{bin}/op --version", 1)
+    assert_match version.to_s, shell_output("#{bin}/op --version", 1)
   end
 end

--- a/Formula/op.rb
+++ b/Formula/op.rb
@@ -1,0 +1,15 @@
+class Op < Formula
+  desc "CLI for 1password.com"
+  homepage "https://support.1password.com/command-line-getting-started/"
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v0.2.1/op_darwin_amd64_v0.2.1.zip"
+  sha256 "fd15c2c0e429623e3d0bff17f7f94867cd5d8b55d10f69076c2ec277da755d77"
+
+  def install
+    bin.install "op"
+  end
+
+  test do
+    # 'op -version' exits with status 1, rather than 0
+    assert_match "#{version}", shell_output("#{bin}/op --version", 1)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

this PR installs the official "op" ('one password') command line interface to the 1password.com service.