### PR TITLE
dashing 0.3.0 (new formula)

### DIFF
--- a/Formula/dashing.rb
+++ b/Formula/dashing.rb
@@ -1,0 +1,44 @@
+require "language/go"
+
+class Dashing < Formula
+  desc "Generate Dash documentation from HTML files"
+  homepage "https://github.com/technosophos/dashing"
+  url "https://github.com/technosophos/dashing/archive/0.3.0.tar.gz"
+  sha256 "f6569f3df80c964c0482e7adc1450ea44532d8da887091d099ce42a908fc8136"
+  head "https://github.com/technosophos/dashing.git"
+
+  depends_on "go" => :build
+
+  go_resource "github.com/andybalholm/cascadia" do
+    url "https://github.com/andybalholm/cascadia.git"
+  end
+
+  go_resource "github.com/codegangsta/cli" do
+    url "https://github.com/codegangsta/cli.git",
+        :tag => "v1.20.0"
+  end
+
+  go_resource "github.com/mattn/go-sqlite3" do
+    url "https://github.com/mattn/go-sqlite3.git",
+        :tag => "v1.6.0"
+  end
+
+  go_resource "golang.org/x/net" do
+    url "https://go.googlesource.com/net.git",
+        :tag => "release-branch.go1.10",
+        :revision => "0ed95abb35c445290478a5348a7b38bb154135fd"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    system "make", "build"
+    bin.install "dashing"
+  end
+
+  test do
+    system "#{bin}/dashing", "create"
+    File.exist? "dashing.json"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a tool which generates [Dash](https://kapeli.com/dash) docsets from HTML files.

Unfortunately `brew audit` is not passing because `go_resource` is deprecated:

```
dashing:
  * C: 12: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
  * C: 16: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
  * C: 21: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
  * C: 26: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
Error: 4 problems in 1 formula
```

What is one expected to use instead?