### PR TITLE
Add head to zig formula

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -4,6 +4,8 @@ class Zig < Formula
   url "https://github.com/zig-lang/zig/archive/0.1.1.tar.gz"
   sha256 "fabbfcb0bdb08539d9d8e8e1801d20f25cb0025af75ac996f626bb5e528e71f1"
 
+  head "https://github.com/zig-lang/zig.git"
+
   bottle do
     sha256 "2184016574a84b2c0a8cdedd95727a265bb6459d580348200722e4cf36b82ed7" => :high_sierra
     sha256 "78b8bac1021aa558183c8f9d46a918c89378b6473a688f20713d9b9c85879562" => :sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi, I should have thought of this in the initial PR but it would be nice to have this option for Zig as it's moving fairly quickly. Please lmkwyt!

Currently both `head` and `0.1.1` depend on the same llvm version and build fine as written. What happens if they diverge? Will I need to add a separate dependency for both?

Thanks y'all!