### PR TITLE
mariadb: fix Disable numa support

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -68,6 +68,7 @@ class Mariadb < Formula
       -DDEFAULT_COLLATION=utf8_general_ci
       -DINSTALL_SYSCONFDIR=#{etc}
       -DCOMPILATION_COMMENT=Homebrew
+      -DWITH_NUMA=OFF
     ]
 
     # disable TokuDB, which is currently not supported on macOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This commit disable numa support. Cmake (on Linux) try to include the library when libnuma is installed on the system but it fail because Homebrew doesn't allow to include the library as it is not defined in it's dependency list.
More details available here: https://github.com/Linuxbrew/homebrew-core/issues/5962
