### PR TITLE
wimlib: ntfs-3g optional dep was imported from homebrew/fuse

### DIFF
--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -13,7 +13,7 @@ class Wimlib < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "homebrew/fuse/ntfs-3g" => :optional
+  depends_on "ntfs-3g" => :optional
   depends_on "openssl"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #23731 
