### PR TITLE
python: use --without-computed-gotos to mitigate performance issue

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -5,7 +5,7 @@ class Macvim < Formula
   url "https://github.com/macvim-dev/macvim/archive/snapshot-144.tar.gz"
   version "8.0-144"
   sha256 "23e1eaa00e9268eaa9a9061ea6018ad20f288bd6c03c1d8553a745d72527d33f"
-  revision 3
+  revision 4
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do

--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -3,7 +3,7 @@ class Python < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tar.xz"
   sha256 "71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66"
-  revision 2
+  revision 3
   head "https://github.com/python/cpython.git", :branch => "2.7"
 
   bottle do
@@ -104,6 +104,15 @@ class Python < Formula
       --enable-framework=#{frameworks}
       --without-ensurepip
     ]
+
+    # See upstream bug report from 22 Jan 2018 "Significant performance problems
+    # with Python 2.7 built with clang 3.x or 4.x"
+    # https://bugs.python.org/issue32616
+    # https://github.com/Homebrew/homebrew-core/issues/22743
+    if DevelopmentTools.clang_build_version >= 802 &&
+       DevelopmentTools.clang_build_version < 1000
+      args << "--without-computed-gotos"
+    end
 
     args << "--without-gcc" if ENV.compiler == :clang
 

--- a/Formula/sip.rb
+++ b/Formula/sip.rb
@@ -3,6 +3,7 @@ class Sip < Formula
   homepage "https://www.riverbankcomputing.com/software/sip/intro"
   url "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.19.7/sip-4.19.7.tar.gz"
   sha256 "25b50d29dd4b72965e7980c41e3320e460eff481a177beeddebf8c3be84b8cde"
+  revision 1
   head "https://www.riverbankcomputing.com/hg/sip", :using => :hg
 
   bottle do

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -4,6 +4,7 @@ class Vim < Formula
   # vim should only be updated every 50 releases on multiples of 50
   url "https://github.com/vim/vim/archive/v8.0.1450.tar.gz"
   sha256 "9d5294c592784213e6ac653cf228702ce59905b26e58cf4a01993d6264e1e774"
+  revision 1
   head "https://github.com/vim/vim.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See upstream bug report from 22 Jan 2018 "Significant performance problems with Python 2.7 built with clang 3.x or 4.x"

https://bugs.python.org/issue32616
https://github.com/Homebrew/homebrew-core/issues/22743