### PR TITLE
bandcamp-dl 0.0.8-09

### DIFF
--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -3,10 +3,9 @@ class BandcampDl < Formula
 
   desc "Simple python script to download Bandcamp albums"
   homepage "https://github.com/iheanyi/bandcamp-dl"
-  url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-08.tar.gz"
-  version "0.0.8-08"
-  sha256 "37b0a6e3714de74c6542e1ef1de7c6801b87bfa8022504600706702f87e2118d"
-  revision 1
+  url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-09.tar.gz"
+  version "0.0.8-09"
+  sha256 "725cfe7d50a887bfc228956002e121ec3fb3b04396abaa6c539ee922845d0f7f"
   head "https://github.com/iheanyi/bandcamp-dl.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
brew bump-formula-pr --strict bandcamp-dl --url=https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-09.tar.gz --sha256=725cfe7d50a887bfc228956002e121ec3fb3b04396abaa6c539ee922845d0f7f
Already up-to-date.
==> replace /^  revision \d+\n(\n(  head "))?/m with "\\2"
==> replace /https:\/\/github\.com\/iheanyi\/bandcamp\-dl\/archive\/v0\.0\.8\-08\.tar\.gz/ with "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-09.tar.gz"
==> replace "37b0a6e3714de74c6542e1ef1de7c6801b87bfa8022504600706702f87e2118d" with "725cfe7d50a887bfc228956002e121ec3fb3b04396abaa6c539ee922845d0f7f"
Error: You probably need to bump this formula manually since the new version
and old version are both 0.0.8-08.
```

Not sure how to update bottles shas.