### PR TITLE
libgtop 2.38.0

### DIFF
--- a/Formula/libgtop.rb
+++ b/Formula/libgtop.rb
@@ -1,8 +1,8 @@
 class Libgtop < Formula
   desc "Library for portably obtaining information about processes"
   homepage "https://library.gnome.org/devel/libgtop/stable/"
-  url "https://download.gnome.org/sources/libgtop/2.36/libgtop-2.36.0.tar.xz"
-  sha256 "13bfe34c150b2b00b03df4732e8c7ccfae09ab15897ee4f4ebf0d16b0f3ba12b"
+  url "https://download.gnome.org/sources/libgtop/2.38/libgtop-2.38.0.tar.xz"
+  sha256 "4f6c0e62bb438abfd16b4559cd2eca0251de19e291c888cdc4dc88e5ffebb612"
 
   bottle do
     sha256 "47d5cfb321c62629e60f963b93d1bbcbe28443bb0f373a7b19622fb78c77403b" => :high_sierra
@@ -11,16 +11,31 @@ class Libgtop < Formula
     sha256 "68166fd2c7020a59d0a6f4bdc6820c5f461fa813b30e6de14c9728149e619d0d" => :yosemite
   end
 
+  # Some build deps were added for the patch below,
+  # and can be removed on the next release:
+  # autoconf, automake, gnome-common, gtk-doc, libtool
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gnome-common" => :build
+  depends_on "gtk-doc" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext"
   depends_on "glib"
   depends_on "gobject-introspection"
 
+  # Fixes the build on OS X by providing a stub implementation of a new feature
+  # https://gitlab.gnome.org/GNOME/libgtop/issues/36
+  patch do
+    url "https://github.com/GNOME/libgtop/commit/42b049f338363f92c1e93b4549fc944098eae674.patch?full_index=1"
+    sha256 "f05b31e0490f9f98c905a771c02071a554dac9965378d60137e50f1e50e84bed"
+  end
+
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--without-x"
+    system "./autogen.sh", "--disable-debug", "--disable-dependency-tracking",
+                           "--prefix=#{prefix}",
+                           "--without-x"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This currently fails to build:

```
sysdeps.c:52:1: error: use of undeclared identifier 'GLIBTOP_SUID_PROC_IO'
GLIBTOP_SUID_PROC_IO;
^
1 error generated.
```

I tracked it down to this commit: https://github.com/GNOME/libgtop/commit/dff7c5588e9761224f2811f0ce5792ff93d95e29 (The define was later renamed from `GLIBTOP_SUID_PROC_DISKIO` to `GLIBTOP_SUID_PROC_IO`.)

cc @ilovezfs 