### PR TITLE
Add new Etcher CLI tool v1.3.1

### DIFF
--- a/Formula/etcher-cli.rb
+++ b/Formula/etcher-cli.rb
@@ -1,0 +1,16 @@
+class EtcherCli < Formula
+  desc "Flash OS images to SD cards & USB drives, safely and easily"
+  homepage "https://etcher.io/cli"
+  url "https://github.com/resin-io/etcher/releases/download/v1.3.1/Etcher-cli-1.3.1-darwin-x64.tar.gz"
+  version "1.3.1"
+  sha256 "6e862e2d2e64c264fb90ec409d82b43c1719453f5ed1cff18aa31b2d890ac6c7"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink Dir["#{libexec}/etcher"]
+  end
+
+  test do
+    system "#{bin}/etcher", "-v"
+  end
+end


### PR DESCRIPTION
Adding the etcher-cli tool, a specialized tool for writing images to flash
drives for embedded systems.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
