### PR TITLE
fabio-1.5.7-1: Rebuild fabio-1.5.7 with go1.9.4

### DIFF
--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -4,6 +4,7 @@ class Fabio < Formula
   url "https://github.com/fabiolb/fabio/archive/v1.5.7.tar.gz"
   sha256 "c33cf4f5e3bf7c9ce2ef634cccebed01d1f0c6e1f31759111db7d94f7a0ceadb"
   head "https://github.com/fabiolb/fabio.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR should rebuild fabio-1.5.7 with go1.9.4. My assumption is that it will build it with the most recent go version in Homebrew which is go1.9.4. How can I specify the go version in the formula as a requirement?
