### PR TITLE
expect: update checksum

### DIFF
--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -2,7 +2,8 @@ class Expect < Formula
   desc "Program that can automate interactive applications"
   homepage "https://expect.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/expect/Expect/5.45.4/expect5.45.4.tar.gz"
-  sha256 "d082bf340fdb7a85b1e4e5df4d967d0140835db34a8a035c3102abb5eb62d450"
+  sha256 "49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34"
+  revision 1
 
   bottle do
     sha256 "810489b71778533a2043d36b6bcefe0fdac9ea61ed89819c8b8f95c8a3ea7043" => :high_sierra

--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -3,7 +3,6 @@ class Expect < Formula
   homepage "https://expect.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/expect/Expect/5.45.4/expect5.45.4.tar.gz"
   sha256 "49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34"
-  revision 1
 
   bottle do
     sha256 "810489b71778533a2043d36b6bcefe0fdac9ea61ed89819c8b8f95c8a3ea7043" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It changed when upstream quickly re-tagged the current release (v5.45.4 as of
this writing.)

Refs:  #23665

-----

N. b.:  From https://github.com/Homebrew/homebrew-core/pull/23665#issuecomment-364285875:  

> One last note:  I got this from `brew audit --strict`…:  
>
> ```
> expect:
>   * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
> Error: 1 problem in 1 formula
> ```
>
> …but I think I can ignore this since it's already been confirmed that the `sha256` change in question is kosher upstream.  