### PR TITLE
sbt@0.13 0.13.17

### DIFF
--- a/Formula/sbt@0.13.rb
+++ b/Formula/sbt@0.13.rb
@@ -1,9 +1,8 @@
 class SbtAT013 < Formula
   desc "Build tool for Scala projects"
   homepage "https://www.scala-sbt.org/"
-  url "https://dl.bintray.com/homebrew/mirror/sbt-0.13.16"
-  mirror "https://cocl.us/sbt01316tgz"
-  sha256 "22729580a581e966259267eda4d937a2aecad86848f8a82fcc716dcae8dc760c"
+  url "https://github.com/sbt/sbt/releases/download/v0.13.17/sbt-0.13.17.tgz"
+  sha256 "25f782ccb2ad6d54e13ce6cec0afa3d2328874c508d68ee34e2f742e99f2c847"
 
   bottle :unneeded
 
@@ -13,7 +12,7 @@ class SbtAT013 < Formula
 
   def install
     inreplace "bin/sbt" do |s|
-      s.gsub! 'etc_sbt_opts_file="${sbt_home}/conf/sbtopts"', "etc_sbt_opts_file=\"#{etc}/sbtopts\""
+      s.gsub! 'etc_sbt_opts_file="/etc/sbt/sbtopts"', "etc_sbt_opts_file=\"#{etc}/sbtopts\""
       s.gsub! "/etc/sbt/sbtopts", "#{etc}/sbtopts"
     end
 


### PR DESCRIPTION
Bumps up sbt@0.13 to the latest maintenance release 0.13.17.
Also this changes installs it as `bin/sbt0` so we can use it side by side with sbt 1.x.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
