### PR TITLE
hadoop 3.0.0

### DIFF
--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -1,13 +1,13 @@
 class Hadoop < Formula
   desc "Framework for distributed processing of large data sets"
   homepage "https://hadoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.8.2/hadoop-2.8.2.tar.gz"
-  mirror "https://archive.apache.org/dist/hadoop/common/hadoop-2.8.2/hadoop-2.8.2.tar.gz"
-  sha256 "aea99c7ce8441749d81202bdea431f1024f17ee6e0efb3144226883207cc6292"
+  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-3.0.0/hadoop-3.0.0.tar.gz"
+  mirror "https://archive.apache.org/dist/hadoop/common/hadoop-3.0.0/hadoop-3.0.0.tar.gz"
+  sha256 "726e28fa7aea71e4587ce91ed3d96c56b15777fc859c09a7438a6d0092e08c74"
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   conflicts_with "yarn", :because => "both install `yarn` binaries"
 
@@ -16,28 +16,6 @@ class Hadoop < Formula
     libexec.install %w[bin sbin libexec share etc]
     bin.write_exec_script Dir["#{libexec}/bin/*"]
     sbin.write_exec_script Dir["#{libexec}/sbin/*"]
-    # But don't make rcc visible, it conflicts with Qt
-    (bin/"rcc").unlink
-
-    inreplace "#{libexec}/etc/hadoop/hadoop-env.sh",
-      "export JAVA_HOME=${JAVA_HOME}",
-      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
-    inreplace "#{libexec}/etc/hadoop/yarn-env.sh",
-      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
-      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
-    inreplace "#{libexec}/etc/hadoop/mapred-env.sh",
-      "# export JAVA_HOME=/home/y/libexec/jdk1.6.0/",
-      "export JAVA_HOME=\"$(/usr/libexec/java_home)\""
-  end
-
-  def caveats; <<~EOS
-    In Hadoop's config file:
-      #{libexec}/etc/hadoop/hadoop-env.sh,
-      #{libexec}/etc/hadoop/mapred-env.sh and
-      #{libexec}/etc/hadoop/yarn-env.sh
-    $JAVA_HOME has been set to be the output of:
-      /usr/libexec/java_home
-    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

They've seemingly moved to a system for working out `JAVA_HOME` that's friendlier for us to package. `hadoop-functions.sh` defines `JAVA_HOME` like this now:

```bash
  HADOOP_IS_CYGWIN=false
  case ${HADOOP_OS_TYPE} in
    Darwin)
      if [[ -z "${JAVA_HOME}" ]]; then
        if [[ -x /usr/libexec/java_home ]]; then
          JAVA_HOME="$(/usr/libexec/java_home)"
          export JAVA_HOME
        else
          JAVA_HOME=/Library/Java/Home
          export JAVA_HOME
        fi
      fi
    ;;
```

Which results out-of-the-box in the desired behaviour:

```
=> hadoop envvars
JAVA_HOME='/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home'
HADOOP_COMMON_HOME='/usr/local/Cellar/hadoop/3.0.0/libexec'
HADOOP_COMMON_DIR='share/hadoop/common'
HADOOP_COMMON_LIB_JARS_DIR='share/hadoop/common/lib'
HADOOP_COMMON_LIB_NATIVE_DIR='lib/native'
HADOOP_CONF_DIR='/usr/local/Cellar/hadoop/3.0.0/libexec/etc/hadoop'
HADOOP_TOOLS_HOME='/usr/local/Cellar/hadoop/3.0.0/libexec'
HADOOP_TOOLS_DIR='share/hadoop/tools'
HADOOP_TOOLS_LIB_JARS_DIR='share/hadoop/tools/lib'
```