### PR TITLE
fdroidserver: avoid opportunistic linkage to libyaml and little-cms2

### DIFF
--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -197,10 +197,17 @@ class Fdroidserver < Formula
       # avoid triggering "helpful" distutils code that doesn't recognize Xcode 7 .tbd stubs
       ENV.delete "SDKROOT"
       ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
-      venv.pip_install Pathname.pwd
+
+      # avoid opportunistic linkage of little-cms2
+      system libexec/"bin/python", "setup.py", "build_ext", "--disable-lcms", "install"
     end
 
-    res = resources.map(&:name).to_set - ["Pillow"]
+    # avoid opportunistic linkage of libyaml
+    resource("PyYAML").stage do
+      system libexec/"bin/python", "setup.py", "--without-libyaml", "install"
+    end
+
+    res = resources.map(&:name).to_set - ["Pillow", "PyYAML"]
 
     res.each do |r|
       venv.pip_install resource(r)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #16531.

Fixes PyYAML's opportunistic linkage of `libyaml` and Pillow's opportunistic linkage of `little-cms2`.

(Formulae `blastem`, `volatility`, and `weboob` also use `Pillow`, and will probably need the same fix. Waiting on doing those until this PR gets approved. And many formulae use PyYAML.)