### PR TITLE
mldonkey: fix opportunistic linkage

### DIFF
--- a/Formula/mldonkey.rb
+++ b/Formula/mldonkey.rb
@@ -29,7 +29,7 @@ class Mldonkey < Formula
     # Fix compiler selection
     ENV["OCAMLC"] = "#{HOMEBREW_PREFIX}/bin/ocamlc.opt -cc #{ENV.cc}"
 
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--disable-magic"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #16531.

Fixes the opportunistic linkage of libmagic by passing --disable-magic.

Also pulls in transitive dependencies from `gd` so they don't get reported as undeclared dependencies by `brew linkage`.

Before:

```
$ brew linkage mldonkey
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libcharset.1.dylib
  /usr/lib/libiconv.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/fontconfig/lib/libfontconfig.1.dylib (fontconfig)
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/gd/lib/libgd.3.dylib (gd)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libmagic/lib/libmagic.1.dylib (libmagic)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
  /usr/local/opt/webp/lib/libwebp.7.dylib (webp)
Undeclared dependencies with linkage:
  fontconfig
  freetype
  jpeg
  libmagic
  libtiff
  webp
```

After:

```
$ brew linkage mldonkey
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libcharset.1.dylib
  /usr/lib/libiconv.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/fontconfig/lib/libfontconfig.1.dylib (fontconfig)
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/gd/lib/libgd.3.dylib (gd)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
  /usr/local/opt/webp/lib/libwebp.7.dylib (webp)
```
