### PR TITLE
nagios: fix opportunistic linkage of libtool

### DIFF
--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -54,7 +54,8 @@ class Nagios < Formula
                           "--with-nagios-group='#{group}'",
                           "--with-command-user=#{user}",
                           "--with-command-group=_www",
-                          "--with-httpd-conf=#{share}"
+                          "--with-httpd-conf=#{share}",
+                          "--disable-libtool"
     system "make", "all"
     system "make", "install"
 


### PR DESCRIPTION

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #16531.

Also pulls in the transitive `jpeg` dependency it acquires through `gd`.

No revision bump on this one: even though it's adding a declared `jpeg` dependency; that was picked up transitively before, so this doesn't change the libs/formulae the bottle is actually linked to, so I don't think a revision bump is needed.