### PR TITLE
sane-backends: add libpng dependency

### DIFF
--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -5,7 +5,7 @@ class SaneBackends < Formula
   mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
-  revision 3
+  revision 4
   head "https://anonscm.debian.org/cgit/sane/sane-backends.git"
 
   bottle do
@@ -16,6 +16,7 @@ class SaneBackends < Formula
   end
 
   depends_on "jpeg"
+  depends_on "libpng"
   depends_on "libtiff"
   depends_on "libusb"
   depends_on "openssl"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #16531.

There's no `--without-libpng` switch in `sane-backends`. But `libpng` is a light dependency, and there are an awful lot of other formulae already using it.

```
$ brew uses libpng | wc -l
     139
```

I'd expect typical users would find it useful, too. What say we just take the dependency?