### PR TITLE
cmus: allow use of Homebrew ncurses for ncursesw support

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -18,6 +18,8 @@ class Cmus < Formula
     sha256 "b594087f16053f4db49e89d72b1c6dbb12e221373e806e62b3e97c327de1dac9"
   end
 
+  option "with-ncurses", "Use Homebrew's version of ncurses"
+
   depends_on "pkg-config" => :build
   depends_on "libao"
   depends_on "mad"
@@ -30,6 +32,7 @@ class Cmus < Formula
   depends_on "ffmpeg" => :optional
   depends_on "opusfile" => :optional
   depends_on "jack" => :optional
+  depends_on "ncurses" => :optional
 
   def install
     system "./configure", "prefix=#{prefix}", "mandir=#{man}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This adds support for `ncursesw` ("wide"/Unicode character support) by allowing to link against Homebrew's `ncurses` lib.