### PR TITLE
tinyproxy: use local docbook-xsl files with asciidoc

### DIFF
--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -16,10 +16,13 @@ class Tinyproxy < Formula
   option "with-filter", "Enable url filtering"
 
   depends_on "asciidoc" => :build
+  depends_on "docbook-xsl" => :build
 
   deprecated_option "reverse" => "with-reverse"
 
   def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Makes `tinyproxy` use local `docbook-xsl` files with `asciidoc`. Should fix an intermittent build problem as discussed in https://github.com/Homebrew/homebrew-core/pull/20227 and https://github.com/tinyproxy/tinyproxy/issues/111.

Addresses #18493.