### PR TITLE
Various: Have asciidoc use local docbook-xsl everywhere

### DIFF
--- a/Formula/flactag.rb
+++ b/Formula/flactag.rb
@@ -15,6 +15,7 @@ class Flactag < Formula
 
   depends_on "pkg-config" => :build
   depends_on "asciidoc" => :build
+  depends_on "docbook-xsl" => :build
   depends_on "flac"
   depends_on "libmusicbrainz"
   depends_on "neon"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? *except i3; not a regression*

-----

Based on discussion in #20227 and my own previous experience, when using `asciidoc` for its `a2x` program, you need to have it use the local docbook-xsl XML files to avoid potential intermittent errors due to download problems from Sourceforge. To make that happen in Homebrew, you have to both:
 * declare a `depends_on "docbook-xsl" => :build` in addition to your `depends_on "asciidoc" => :build`
 * put `ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"` in the install method.

This PR makes sure that the rest of the formulae that build `asciidoc` do those steps. Same fix as in #23951.

Doesn't fix any outstanding issues, but should avoid occasional mysterious failures in CI or on the part of users trying to build these formulae from source.

-------

This is the audit failure for `i3` in this PR. It's not a regression; `master` gets the same audit failure due to  `depends_on "cairo" => ["with-x11"]`; covered in #13133.

$ brew audit --strict i3
i3:
  * C: 21: col 14: Dependency cairo should not use option with-x11
Error: 1 problem in 1 formula
