### PR TITLE
git-multipush: remove broken HEAD and spurious asciidoc dep

### DIFF
--- a/Formula/git-multipush.rb
+++ b/Formula/git-multipush.rb
@@ -3,7 +3,6 @@ class GitMultipush < Formula
   homepage "https://github.com/gavinbeatty/git-multipush"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/git-multipush/git-multipush-2.3.tar.bz2"
   sha256 "1f3b51e84310673045c3240048b44dd415a8a70568f365b6b48e7970afdafb67"
-  head "https://github.com/gavinbeatty/git-multipush.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -19,10 +18,7 @@ class GitMultipush < Formula
     sha256 "999d9304f322c1b97d150c96be64ecde30980f97eaaa9d66f365b8b11894c46d"
   end
 
-  depends_on "asciidoc" => :build
-
   def install
-    system "make" if build.head?
     # Devel tarballs don't have versions marked, maybe due to GitHub release process
     # https://github.com/gavinbeatty/git-multipush/issues/1
     (buildpath/"release").write "VERSION = #{version}" if build.devel?


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `--HEAD` build for `git-multipush` is broken. No commits there since 2013, so I don't think it'll be missed. Just remove it.

And it turns out that the `asciidoc` dependency was only really needed for `--HEAD`. So remove it, too.
