### PR TITLE
io: switch from python to python3, which it currently supports

### DIFF
--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -33,7 +33,7 @@ class Io < Formula
     depends_on "pcre"
     depends_on "yajl"
     depends_on "xz"
-    depends_on "python" => :optional
+    depends_on "python3" => :optional
   end
 
   def install
@@ -48,7 +48,7 @@ class Io < Formula
                                   "#add_subdirectory(addons)"
     else
       inreplace "addons/CMakeLists.txt" do |s|
-        if build.without? "python"
+        if build.without? "python3"
           s.gsub! "add_subdirectory(Python)", "#add_subdirectory(Python)"
         end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Looks like `io`'s Python plugin needs Python 3, not Python 2.

From `addons/Python/CMakeLists.txt`:
```
find_package(PythonLibs 3.3 REQUIRED)
```

This PR changes the formula to use Python 3.

Fixes #23982.