### PR TITLE
ecj: Require Java 8 exactly

### DIFF
--- a/Formula/ecj.rb
+++ b/Formula/ecj.rb
@@ -9,6 +9,8 @@ class Ecj < Formula
 
   bottle :unneeded
 
+  depends_on :java => "1.8"
+
   def install
     (share/"java").install "ecj-#{version}.jar" => "ecj.jar"
   end
@@ -23,7 +25,11 @@ class Ecj < Formula
         }
       }
     EOS
-    system "java", "-cp", share/"java/ecj.jar", "org.eclipse.jdt.internal.compiler.batch.Main", "Hello.java"
+
+    java_home = `#{Language::Java.java_home_cmd("1.8")}`
+    java_home.chomp!
+    system "#{java_home}/bin/java", "-cp", share/"java/ecj.jar",
+      "org.eclipse.jdt.internal.compiler.batch.Main", "Hello.java"
     assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
     assert_equal "Hello Homebrew\n", shell_output("java Hello")
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

This PR updates `ecj` to use specifically Java 8, since it's not compatible with Java 9.

The test code is ugly: you can't just call `java`; you need to call the version-specific `java` that's compatible with this formula.

Might be worth considering a `java_home` or `java` method in `Formula` to support this, to avoid redundant boilerplate code in the `do test`s.

On the other hand, maybe not, since this pattern is only needed for formulae that install Java libraries, as opposed to Java applications/commands.