### PR TITLE
cromwell: add womtool

### DIFF
--- a/Formula/cromwell.rb
+++ b/Formula/cromwell.rb
@@ -14,14 +14,24 @@ class Cromwell < Formula
   depends_on :java => "1.8+"
   depends_on "akka"
 
+  resource "womtool" do
+    url "https://github.com/broadinstitute/cromwell/releases/download/30.2/womtool-30.2.jar"
+    sha256 "c2dc455a50585a17318ca5b818015f7b2cf9ef99961555650dd7844a928dffc2"
+  end
+
   def install
     if build.head?
       system "sbt", "assembly"
       libexec.install Dir["target/scala-*/cromwell-*.jar"][0]
+      libexec.install Dir["womtool/target/scala-2.12/womtool-*.jar"][0]
     else
       libexec.install Dir["cromwell-*.jar"][0]
+      resource("womtool").stage do
+        libexec.install Dir["womtool-*.jar"][0]
+      end
     end
     bin.write_jar_script Dir[libexec/"cromwell-*.jar"][0], "cromwell"
+    bin.write_jar_script Dir[libexec/"womtool-*.jar"][0], "womtool"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR includes womtool in the cromwell formula as a resource. It downloads the womtool jar (or build it), adding it to the libexec directory and creating a script for launch. This is related with https://github.com/broadinstitute/cromwell/issues/3254 
