### PR TITLE
javarepl: require Java 8 specifically

### DIFF
--- a/Formula/javarepl.rb
+++ b/Formula/javarepl.rb
@@ -3,12 +3,17 @@ class Javarepl < Formula
   homepage "https://github.com/albertlatacz/java-repl"
   url "https://github.com/albertlatacz/java-repl/releases/download/428/javarepl-428.jar"
   sha256 "d42de9405aa69ea6c4eb0e28a6b3cb09e3bd008649d9ac6c55a4aa798e284734"
+  revision 1
 
   bottle :unneeded
 
+  depends_on :java => "1.8"
+
   def install
     libexec.install "javarepl-#{version}.jar"
-    bin.write_jar_script libexec/"javarepl-#{version}.jar", "javarepl"
+    (libexec/"bin").write_jar_script libexec/"javarepl-#{version}.jar", "javarepl"
+    (libexec/"bin/javarepl").chmod 0755
+    (bin/"javarepl").write_env_script libexec/"bin/javarepl", Language::Java.java_home_env("1.8")
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates `javarepl` to require exactly Java 1.8, fixing Java 9 breakage.

Addresses #19696.