### PR TITLE
jing-trang: require Java 8 specifically

### DIFF
--- a/Formula/jing-trang.rb
+++ b/Formula/jing-trang.rb
@@ -7,7 +7,7 @@ class JingTrang < Formula
   bottle :unneeded
 
   depends_on "ant" => :build
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8"
 
   def install
     system "./ant", "jar"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

Changes `jing-trang` to require specifically Java 8, instead of 1.6+.

This fixes breakage on systems with Java 9 installed.

It loses support for Java 1.6 and 1.7, but I think that's acceptable, since they're EOL.

Upstream bug report: https://github.com/relaxng/jing-trang/issues/223