### PR TITLE
jvm-mon: require Java 8 specifically

### DIFF
--- a/Formula/jvm-mon.rb
+++ b/Formula/jvm-mon.rb
@@ -3,15 +3,18 @@ class JvmMon < Formula
   homepage "https://github.com/ajermakovics/jvm-mon"
   url "https://github.com/ajermakovics/jvm-mon/releases/download/0.3/jvm-mon-0.3.tar.gz"
   sha256 "9b5dd3d280cb52b6e2a9a491451da2ee41c65c770002adadb61b02aa6690c940"
+  revision 1
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"bin/jvm-mon"
+
+    (bin/"jvm-mon").write_env_script "#{libexec}/bin/jvm-mon",
+      Language::Java.java_home_env("1.8")
     system "unzip", "-j", libexec/"lib/j2v8_macosx_x86_64-4.6.0.jar", "libj2v8_macosx_x86_64.dylib", "-d", libexec
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

Changes `jvm-mon` to require exactly Java 1.8. I think this is legit, because their home page specifically says they require Java 8, and the program uses `tools.jar`, which is no longer present in Java 9 so it's not going to be a minor change to make it compatible.