### PR TITLE
Eclipse vert.x 3.5.1

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "http://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.0-full.tar.gz"
-  sha256 "aa4607b5191f6df369d9b765fbc58ecc8ec9a1075fc45d1326ae7812fd85970b"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.1-full.tar.gz"
+  sha256 "a0809a04e62060d737f1784bdbbfd08e9baf38eb7931cfc69e8136f8da5fb3fd"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse vert.x formula to 3.5.1.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
