### PR TITLE
questdb: require Java 8 specifically

### DIFF
--- a/Formula/questdb.rb
+++ b/Formula/questdb.rb
@@ -3,12 +3,14 @@ class Questdb < Formula
   homepage "https://www.questdb.org"
   url "https://www.questdb.org/download/questdb-1.0.4-bin.tar.gz"
   sha256 "a8d907d88c5bf67aeb465540c7e16ad45eccd13d152b34cdcf4e5056ad908739"
+  revision 1
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
 
   def install
+    inreplace "questdb.sh", "1.7+", "1.8"
     rm_rf "questdb.exe"
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/questdb.sh" => "questdb"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

QuestDB is not compatible with Java 9, per [maintainer comments](https://github.com/bluestreak01/questdb/issues/61#issuecomment-364906313). This PR makes it run under Java 8 only.