### PR TITLE
tomee-webprofile: use Java 8 specifically

### DIFF
--- a/Formula/tomee-webprofile.rb
+++ b/Formula/tomee-webprofile.rb
@@ -3,8 +3,11 @@ class TomeeWebprofile < Formula
   homepage "https://tomee.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=tomee/tomee-1.7.4/apache-tomee-1.7.4-webprofile.tar.gz"
   sha256 "4a1c13e60fcf1289980b0c14f8e67daf31b1c91f4e208fbc7aeec0a252655897"
+  revision 1
 
   bottle :unneeded
+
+  depends_on :java => "1.8"
 
   def install
     # Remove Windows scripts
@@ -15,7 +18,11 @@ class TomeeWebprofile < Formula
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
     libexec.install Dir["*"]
-    bin.install_symlink "#{libexec}/bin/startup.sh" => "tomee-webprofile-startup"
+    libexec.install_symlink "#{libexec}/bin/startup.sh" => "tomee-webprofile-startup"
+    env = Language::Java.java_home_env("1.8")
+    env[:JRE_HOME] = "$(#{Language::Java.java_home_cmd("1.8")})"
+    (bin/"tomee-webprofile-startup").write_env_script libexec/"tomee-webprofile-startup", env
+    (bin/"tomee-webprofile-configtest").write_env_script libexec/"bin/configtest.sh", env
   end
 
   def caveats; <<~EOS
@@ -27,6 +34,6 @@ class TomeeWebprofile < Formula
   end
 
   test do
-    system "#{opt_libexec}/bin/configtest.sh"
+    system "#{bin}/tomee-webprofile-configtest"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

`tomee-webprofile` uses `-Djava.endorsed.dirs`, which is totally not supported under Java 9, so it won't be a quick migration for them. Taking a hard dependency on Java 8 seems legit here.

Had to do a little hacking to get the test to work: the test program needs to be env-wrapped, too, to pick up the right JVM without resorting to env setup in the `test` block itself.