### PR TITLE
scala@2.10: require Java 8 specifically

### DIFF
--- a/Formula/scala@2.10.rb
+++ b/Formula/scala@2.10.rb
@@ -5,7 +5,7 @@ class ScalaAT210 < Formula
   mirror "https://downloads.typesafe.com/scala/2.10.6/scala-2.10.6.tgz"
   mirror "https://www.scala-lang.org/files/archive/scala-2.10.6.tgz"
   sha256 "54adf583dae6734d66328cafa26d9fa03b8c4cf607e27b9f3915f96e9bcd2d67"
-  revision 1
+  revision 2
 
   bottle :unneeded
 
@@ -14,7 +14,7 @@ class ScalaAT210 < Formula
   option "with-docs", "Also install library documentation"
   option "with-src", "Also install sources for IDE support"
 
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8"
 
   resource "docs" do
     url "https://downloads.lightbend.com/scala/2.10.6/scala-docs-2.10.6.txz"
@@ -37,7 +37,8 @@ class ScalaAT210 < Formula
     doc.install Dir["doc/*"]
     share.install "man"
     libexec.install "bin", "lib"
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
     bash_completion.install resource("completion")
     doc.install resource("docs") if build.with? "docs"
     libexec.install resource("src").files("src") if build.with? "src"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696.

Makes Scala 2.10 use Java 8 specifically.

Looks like there's a lot of work to be done in Scala for Java 9 support:
  https://github.com/scala/scala-dev/issues/139
  https://github.com/scala/docs.scala-lang/issues/1000
So it doesn't seem likely that the 2.10 and 2.11 series will get Java 9 support soon. So it seems legit to pin them to Java 8.

(I also tested the new Scala 2.10.7 release, whose [release notes](https://github.com/scala/scala/releases/tag/v2.10.7) say it has "(partial) support" for Java 9, but it still broke under a Homebrew install.)

If this PR is accepted, I'll do the same for `scala@2.11`.
