### PR TITLE
taisei: fix installing as an app bundle

### DIFF
--- a/Formula/taisei.rb
+++ b/Formula/taisei.rb
@@ -4,6 +4,7 @@ class Taisei < Formula
   url "https://github.com/taisei-project/taisei.git",
       :tag => "v1.2",
       :revision => "46fb0f894ad269528ac7fda533c7994eddd9b758"
+  revision 1
 
   bottle do
     sha256 "d693cb55f630f29a41d1182179cf019f2fd81593246cd5cd3c5769bcc4d49324" => :high_sierra
@@ -11,20 +12,29 @@ class Taisei < Formula
     sha256 "d9494fdf13cdfdfff4a7107cb93821e39d9079e86f660ce63b15f5ed37df8ce6" => :el_capitan
   end
 
+  # Yes, these are all build deps; the game copies them into the app bundle,
+  # and doesn't require the Homebrew versions at runtime.
+  depends_on "freetype" => :build
+  depends_on "libpng" => :build
+  depends_on "libzip" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "freetype"
-  depends_on "libpng"
-  depends_on "libzip"
-  depends_on "python3"
-  depends_on "sdl2"
-  depends_on "sdl2_mixer"
-  depends_on "sdl2_ttf"
+  depends_on "python3" => :build
+  depends_on "sdl2" => :build
+  depends_on "sdl2_mixer" => :build
+  depends_on "sdl2_ttf" => :build
+
+  # Fixes a bug in the .app bundle build script.
+  # # Will be in the next release.
+  patch do
+    url "https://github.com/taisei-project/taisei/commit/68b0d4f5c6f2015704e1ed1b4098be1c4336db74.patch?full_index=1"
+    sha256 "cb1f79826e632a61daa271cb59d0a80ab77dea876d384c381ab66d5eb9b9bd27"
+  end
 
   def install
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", "-Ddocs=false", "-Dmacos_bundle=false", ".."
+      system "meson", "--prefix=#{prefix}", "-Ddocs=false", ".."
       system "ninja"
       system "ninja", "install"
     end
@@ -35,7 +45,7 @@ class Taisei < Formula
   end
 
   test do
-    output = shell_output("#{bin}/taisei -h", 1)
+    output = shell_output("#{prefix}/Taisei.app/Contents/MacOS/Taisei -h", 1)
     assert_match "Touhou clone", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This incorporates an upstream patch to restore the ability to build as a `.app` bundle, as previous versions did. It also marks the dependencies as build deps, since copies of them are embedded in the app bundle itself.

cc @ilovezfs 