### PR TITLE
io: disable ODE

### DIFF
--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -62,9 +62,9 @@ class Io < Formula
     end
 
     mkdir "buildroot" do
-      system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",
-        "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
-        *std_cmake_args
+      system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
+                            "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",                      
+                            *std_cmake_args
       system "make"
       output = `./_build/binaries/io ../libs/iovm/tests/correctness/run.io`
       if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -63,7 +63,8 @@ class Io < Formula
 
     mkdir "buildroot" do
       system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",
-                            *std_cmake_args
+        "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
+        *std_cmake_args
       system "make"
       output = `./_build/binaries/io ../libs/iovm/tests/correctness/run.io`
       if $CHILD_STATUS.exitstatus.nonzero?

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -63,7 +63,7 @@ class Io < Formula
 
     mkdir "buildroot" do
       system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
-                            "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",                      
+                            "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",
                             *std_cmake_args
       system "make"
       output = `./_build/binaries/io ../libs/iovm/tests/correctness/run.io`


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This prevents the Io build from breaking when Homebrew's ODE is installed,
since Io requires the ODE variant with DrawStuff included, and Homebrew's
ODE does not include it. (Also would prevent opportunistic linkage in the case
where the build against Homebrew's ODE actually worked.)