### PR TITLE
ooniprobe 2.3.0

### DIFF
--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -3,8 +3,8 @@ class Ooniprobe < Formula
 
   desc "Network interference detection tool"
   homepage "https://ooni.torproject.org/"
-  url "https://pypi.python.org/packages/46/eb/e44d255dbd6b2bc8cc6de680ff8ce3c279c9b0694a6eec9059bdf4806dfc/ooniprobe-2.2.0.tar.gz"
-  sha256 "971f7630587b7ba771383f93c10973871e2c5e866a7fde98754a788679361ac3"
+  url "https://pypi.python.org/packages/d8/c0/b4a2ae442dd95160a75251110313d1f9b22834a76ef9bd8f70603b4a867a/ooniprobe-2.3.0.tar.gz"
+  sha256 "b4c4a5665d37123b1a30f26ffb37b8c06bc722f7b829cf83f6c3300774b7acb6"
   revision 1
 
   bottle do

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -5,7 +5,6 @@ class Ooniprobe < Formula
   homepage "https://ooni.torproject.org/"
   url "https://pypi.python.org/packages/d8/c0/b4a2ae442dd95160a75251110313d1f9b22834a76ef9bd8f70603b4a867a/ooniprobe-2.3.0.tar.gz"
   sha256 "b4c4a5665d37123b1a30f26ffb37b8c06bc722f7b829cf83f6c3300774b7acb6"
-  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
This updates the ooniprobe formula to the latest OONI Probe release: 2.3.0.

See: https://github.com/TheTorProject/ooni-probe/releases/tag/v2.3.0