### PR TITLE
Add JAVA_OPTS to cromwell wrapper

### DIFF
--- a/Formula/cromwell.rb
+++ b/Formula/cromwell.rb
@@ -30,7 +30,7 @@ class Cromwell < Formula
         libexec.install Dir["womtool-*.jar"][0]
       end
     end
-    bin.write_jar_script Dir[libexec/"cromwell-*.jar"][0], "cromwell"
+    bin.write_jar_script Dir[libexec/"cromwell-*.jar"][0], "cromwell", "$JAVA_OPTS"
     bin.write_jar_script Dir[libexec/"womtool-*.jar"][0], "womtool"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR includes a way to add java options to the cromwell wrapper script. This is important for configuring cromwell, because the configuration file is passed by the property `-Dconfig.file=${configuration_file}` (see https://github.com/broadinstitute/cromwell/issues/3262 for the original issue). The approach used here is the same as the [ivy formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ivy.rb): adding a `$JAVA_OPT` environmental variable that can be set to run with a custom configuration file.