### PR TITLE
gtk+, gdk-pixbuf:  Remove Relocation-Related Formula Options

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -10,7 +10,6 @@ class GdkPixbuf < Formula
     sha256 "70aa88fda9b08b1cbd7fdd3c21d378ce1a95c1c936d5eba9dbe9efcd75254f04" => :el_capitan
   end
 
-  option "with-relocations", "Build with relocation support for bundles"
   option "without-modules", "Disable dynamic module loading"
   option "with-included-loaders=", "Build the specified loaders into gdk-pixbuf"
 
@@ -49,7 +48,6 @@ class GdkPixbuf < Formula
       --without-gdiplus
     ]
 
-    args << "--enable-relocations" if build.with?("relocations")
     args << "--with-libjasper" if build.with?("jasper")
     args << "--disable-modules" if build.without?("modules")
 
@@ -90,7 +88,7 @@ class GdkPixbuf < Formula
   end
 
   def caveats
-    if build.with?("relocations") || HOMEBREW_PREFIX.to_s != "/usr/local"
+    if HOMEBREW_PREFIX.to_s != "/usr/local"
       <<~EOS
         Programs that require this module need to set the environment variable
           export GDK_PIXBUF_MODULEDIR="#{module_dir}/loaders"

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -87,17 +87,6 @@ class GdkPixbuf < Formula
     system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
   end
 
-  def caveats
-    if HOMEBREW_PREFIX.to_s != "/usr/local"
-      <<~EOS
-        Programs that require this module need to set the environment variable
-          export GDK_PIXBUF_MODULEDIR="#{module_dir}/loaders"
-        If you need to manually update the query loader cache, set these variables then run
-          #{bin}/gdk-pixbuf-query-loaders --update-cache
-      EOS
-    end
-  end
-
   test do
     (testpath/"test.c").write <<~EOS
       #include <gdk-pixbuf/gdk-pixbuf.h>

--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -23,8 +23,6 @@ class Gtkx < Formula
     depends_on "gtk-doc" => :build
   end
 
-  option "with-quartz-relocation", "Build with quartz relocation support"
-
   depends_on "pkg-config" => :build
   depends_on "gdk-pixbuf"
   depends_on "jasper" => :optional
@@ -52,8 +50,6 @@ class Gtkx < Formula
             "--enable-introspection=yes",
             "--with-gdktarget=quartz",
             "--disable-visibility"]
-
-    args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
     if build.head?
       inreplace "autogen.sh", "libtoolize", "glibtoolize"

--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -10,8 +10,6 @@ class Gtkx3 < Formula
     sha256 "5ab8f3d5e6d1b83272cfd5db9bd637cb9e92060068a7ebb5ede87491233e902b" => :el_capitan
   end
 
-  option "with-quartz-relocation", "Build with quartz relocation support"
-
   depends_on "pkg-config" => :build
   depends_on "gdk-pixbuf"
   depends_on "atk"
@@ -33,8 +31,6 @@ class Gtkx3 < Formula
       --enable-quartz-backend
       --disable-x11-backend
     ]
-
-    args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
     system "./configure", *args
     # necessary to avoid gtk-update-icon-cache not being found during make install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?  (Close enough, maybe…?  I haven't caused any _new_ audit failures to pop up, anyway…)  

-----

Closes #22768.  

Removes:  

* GTK+ 2.x's formula's `--with-quartz-relocation` option.  
* GDK Pixbuf's formula's `--with-relocations` option.  

Supersedes most of #22955.  

CC @ilovezfs, @tschoonj, @fxcoudert