### PR TITLE
gdk-pixbuf:  Fix Rebuilding the Loader Cache in Post-Install

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -84,7 +84,17 @@ class GdkPixbuf < Formula
 
   def post_install
     ENV["GDK_PIXBUF_MODULEDIR"] = "#{module_dir}/loaders"
-    system "#{bin}/gdk-pixbuf-query-loaders", "--update-cache"
+
+    ohai "#{bin}/gdk-pixbuf-query-loaders --update-cache" # Previously handled by `system`.
+    File.open File.new("#{module_dir}/loaders.cache", "w+").path, "w" do |loader_cache|
+      Utils.popen_read "#{bin}/gdk-pixbuf-query-loaders", "--update-cache" do |pipe|
+        loader_cache.write pipe.read
+      end
+    end
+
+    Utils.popen_read "wc", "-c", "#{module_dir}/loaders.cache" do |stdout_contents|
+      stdout_contents.read.lstrip.split[0].to_i <= 0
+    end
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] ~~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~~  (N/A:  The only changes in this PR apply to the `postinstall` phase of the formula it modifies, which I could run independently of a full reinstallation of said formula's associated software package.)  
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Supersedes the rest of #22955.  