### PR TITLE
futhark: depend on ghc at build time

### DIFF
--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -3,6 +3,7 @@ class Futhark < Formula
   homepage "https://futhark-lang.org/"
   url "https://github.com/diku-dk/futhark/archive/v0.3.1.tar.gz"
   sha256 "a3e8ab25dc53160da5e4bef58fe91107909ade6f93523227a935c5330d3ea8f7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -11,13 +12,13 @@ class Futhark < Formula
     sha256 "be8f8db352fdd341b9dc29dd0a11d15c6d12230f076852e854903f2643f2727e" => :el_capitan
   end
 
+  depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
   depends_on "sphinx-doc" => :build
 
   def install
-    # Avoid touching the user's own .stack_root
-    ENV["STACK_ROOT"] = Pathname.pwd/"stack_root"
-    system "stack", "--local-bin-path=#{bin}", "install"
+    system "stack", "-j#{ENV.make_jobs}", "--system-ghc",
+           "--local-bin-path=#{bin}", "install"
 
     system "make", "-C", "docs", "man"
     man1.install Dir["docs/_build/man/*.1"]
@@ -28,6 +29,6 @@ class Futhark < Formula
       let main (n: i32) = reduce (*) 1 (1...n)
     EOS
     system "#{bin}/futhark-c", "test.fut"
-    assert_equal "3628800i32\n", pipe_output("./test", "10")
+    assert_equal "3628800i32", pipe_output("./test", "10", 0).chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

and pass `--system-ghc` instead of letting `stack` download its own GHC.

Also,
- remove unecessary setting of STACK_ROOT as we already override HOME
- pass number of intended make jobs to `stack` with `-j`
- assert 0 exit code in the test

CC @Athas @fxcoudert