### PR TITLE
snakemake: update homepage

### DIFF
--- a/Formula/snakemake.rb
+++ b/Formula/snakemake.rb
@@ -1,6 +1,6 @@
 class Snakemake < Formula
   desc "Pythonic workflow system"
-  homepage "https://bitbucket.org/snakemake/snakemake/wiki/Home"
+  homepage "https://snakemake.readthedocs.io/"
   url "https://files.pythonhosted.org/packages/2f/2a/88d21e9d9b4c9d9f9328720c5d5841595beb9f8848d7854ff53c3e7dc96c/snakemake-4.6.0.tar.gz"
   sha256 "c5e2e44ec59233a2763f54c9d534f7f580288ec135230bccd6d5ac7f6e25314b"
   head "https://bitbucket.org/snakemake/snakemake.git"


### PR DESCRIPTION
The previous BitBucket wiki homepage currently just directs users to the
Read the Docs page, and appears to have done so since January 2017, so
Homebrew should probably link to the new page accordingly.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
