### PR TITLE
zip: add bzip2 support

### DIFF
--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -1,5 +1,5 @@
 class Zip < Formula
-  desc "Compression and file packaging/archive utility"
+  desc "Compression and file packaging/archive utility, including bzip2 support"
   homepage "http://www.info-zip.org/Zip.html"
   url "https://downloads.sourceforge.net/project/infozip/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz"
   version "3.0"
@@ -13,8 +13,6 @@ class Zip < Formula
   end
 
   keg_only :provided_by_macos
-
-  option "with-bzip2", "Support bzip2 compression method in *.zip files."
 
   # Upstream is unmaintained so we use the Debian patchset:
   # https://packages.debian.org/sid/zip
@@ -36,22 +34,7 @@ class Zip < Formula
     ]
   end
 
-  # compile in bzip2 support using the bzip2 library sources
-  # https://github.com/LuaDist/zip/blob/master/bzip2/install.txt
-  if build.with? "bzip2"
-
-    resource "bzip2" do
-      url "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
-      mirror "https://fossies.org/linux/misc/bzip2-1.0.6.tar.gz"
-      sha256 "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
-    end
-
-  end
-
   def install
-    if build.with? "bzip2"
-      resource("bzip2").stage buildpath/"bzip2"
-    end
     system "make", "-f", "unix/Makefile", "CC=#{ENV.cc}", "generic"
     system "make", "-f", "unix/Makefile", "BINDIR=#{bin}", "MANDIR=#{man1}", "install"
   end
@@ -65,10 +48,9 @@ class Zip < Formula
     assert_predicate testpath/"test.zip", :exist?
     assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip")
 
-    if build.with? "bzip2"
-      system "#{bin}/zip", "-Z", "bzip2", "test2.zip", "test1", "test2", "test3"
-      assert_predicate testpath/"test2.zip", :exist?
-      assert_match "test of test2.zip OK", shell_output("#{bin}/zip -T test2.zip")
-    end
+    # test bzip2 support that should be automatically linked in using the bzip2 library in macOS
+    system "#{bin}/zip", "-Z", "bzip2", "test2.zip", "test1", "test2", "test3"
+    assert_predicate testpath/"test2.zip", :exist?
+    assert_match "test of test2.zip OK", shell_output("#{bin}/zip -T test2.zip")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a new option `--with-bzip2` to the `zip` formula, which compiles in bzip2 support.

Use with `zip -Z bzip2 <zipfile> <files...>`.