### PR TITLE
Add streamlink head option

### DIFF
--- a/Formula/streamlink.rb
+++ b/Formula/streamlink.rb
@@ -3,6 +3,7 @@ class Streamlink < Formula
   homepage "https://streamlink.github.io/"
   url "https://github.com/streamlink/streamlink/releases/download/0.10.0/streamlink-0.10.0.tar.gz"
   sha256 "8bc06e53ab15fab57f782ea438a5f00c4807148b21f8fbed9238ed4865e08e24"
+  head "https://github.com/streamlink/streamlink.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Allow the latest cutting edge version of streamlink to be installed

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 > Also ran with the `--HEAD` option
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
