### PR TITLE
Bazel no longer depends on Java

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -11,7 +11,6 @@ class Bazel < Formula
     sha256 "1fb02eba8851384be7b4745cec3c00929010954142a8b94bf7ec7293bda2a210" => :el_capitan
   end
 
-  depends_on :java => "1.8"
   depends_on :macos => :yosemite
 
   def install


### PR DESCRIPTION
Since 0.5, Bazel has included a statically-linked JDK, so there is no need for the brew recipe to nag users about installing it.

https://github.com/bazelbuild/bazel/releases?after=0.5.1

/cc @dslomov

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
