### PR TITLE
pinentry: build pinentry-tty

### DIFF
--- a/Formula/pinentry.rb
+++ b/Formula/pinentry.rb
@@ -27,6 +27,7 @@ class Pinentry < Formula
       --disable-pinentry-gnome3
       --disable-pinentry-tqt
       --disable-pinentry-fltk
+      --enable-pinentry-tty
     ]
 
     args << "--disable-pinentry-gtk2" if build.without? "gtk+"
@@ -37,5 +38,6 @@ class Pinentry < Formula
 
   test do
     system "#{bin}/pinentry", "--version"
+    system "#{bin}/pinentry-tty", "--version"
   end
 end

--- a/Formula/pinentry.rb
+++ b/Formula/pinentry.rb
@@ -4,6 +4,7 @@ class Pinentry < Formula
   url "https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.0.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/pinentry/pinentry-1.1.0.tar.bz2"
   sha256 "68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This diff enables the tty variant of `pinentry`, `pinentry-tty`. This will allow `gpg-agent`'s `pinentry-program` to point at `pinentry-tty` for tty-only password input.