### PR TITLE
neomutt 20171215 (new formula)

### DIFF
--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -29,6 +29,8 @@ class Neomutt < Formula
   end
 
   test do
-    system bin/"neomutt", "-D"
+    expected = "debug_level=0"
+    output = pipe_output("#{bin}/neomutt -F /dev/null -D -S | grep debug_level", "", 0)
+    assert_equal expected, output.chomp
   end
 end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -16,11 +16,11 @@ class Neomutt < Formula
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-    system "./configure", "--enable-gpgme",
+    system "./configure", "--prefix=#{prefix}",
+                          "--enable-gpgme",
                           "--gss",
                           "--lmdb",
                           "--notmuch",
-                          "--prefix=#{prefix}",
                           "--sasl",
                           "--tokyocabinet",
                           "--with-ssl=#{Formula["openssl"].opt_prefix}",
@@ -29,8 +29,7 @@ class Neomutt < Formula
   end
 
   test do
-    expected = "debug_level=0"
-    output = pipe_output("#{bin}/neomutt -F /dev/null -D -S | grep debug_level", "", 0)
-    assert_equal expected, output.chomp
+    output = shell_output("#{bin}/neomutt -F /dev/null -Q debug_level")
+    assert_equal "debug_level=0", output.chomp
   end
 end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -17,7 +17,7 @@ class Neomutt < Formula
   depends_on "krb5" => :build unless OS.mac?
 
   depends_on "openssl"
-  depends_on "tokyo-cabinet" => :recommended unless build.with?("lmdb")
+  depends_on "tokyo-cabinet" => :recommended if build.without?("lmdb")
   depends_on "lmdb" => :optional
   depends_on "gpgme" => :optional
   depends_on "libidn" => :optional

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -1,37 +1,35 @@
 class Neomutt < Formula
-  desc "Email reader with support for Notmuch (fast indexing), News (NNTP) and much more"
+  desc "E-mail reader with support for Notmuch, NNTP and much more"
   homepage "https://www.neomutt.org/"
   url "https://github.com/neomutt/neomutt/archive/neomutt-20171215.tar.gz"
   sha256 "7fb76e99a9f23715ad772ad8f7008c6e2db05eed344817055176c76dbd60c1b5"
   head "https://github.com/neomutt/neomutt.git"
 
-  depends_on "gettext" => :build
   depends_on "docbook-xsl" => :build
-
-  depends_on "openssl"
-  depends_on "tokyo-cabinet"
-  depends_on "lmdb"
+  depends_on "gettext" => :build
   depends_on "gpgme"
   depends_on "libidn"
+  depends_on "lmdb"
   depends_on "notmuch"
+  depends_on "openssl"
+  depends_on "tokyo-cabinet"
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-
-    args = %W[
-      --prefix=#{prefix}
-      --with-ssl=#{Formula["openssl"].opt_prefix}
-      --sasl
-      --gss
-      --disable-idn
-      --with-ui=ncurses
-      --notmuch
-      --lmdb
-      --tokyocabinet
-      --enable-gpgme
-    ]
-
-    system "./configure", *args
+    system "./configure", "--disable-idn",
+                          "--enable-gpgme",
+                          "--gss",
+                          "--lmdb",
+                          "--notmuch",
+                          "--prefix=#{prefix}",
+                          "--sasl",
+                          "--tokyocabinet",
+                          "--with-ssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-ui=ncurses"
     system "make", "install"
+  end
+
+  test do
+    system bin/"mutt", "-D"
   end
 end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -1,72 +1,37 @@
 class Neomutt < Formula
-  desc "Teaching an Old Dog New Tricks"
+  desc "Email reader with support for Notmuch (fast indexing), News (NNTP) and much more"
   homepage "https://www.neomutt.org/"
-  url "https://github.com/neomutt/neomutt.git", :tag => "neomutt-20171215", :revision => "ae61285170533b4be544e738cdd2eedefd1856ff"
-  head "https://github.com/neomutt/neomutt.git", :branch => "master"
-
-  option "with-lmdb", "Build with lmdb support"
-  option "with-lua", "Build with lua scripting support enabled"
-  option "with-s-lang", "Build against slang instead of ncurses"
-
-  # Neomutt-specific patches
-  option "with-notmuch-patch", "Apply notmuch patch"
+  url "https://github.com/neomutt/neomutt/archive/neomutt-20171215.tar.gz"
+  sha256 "7fb76e99a9f23715ad772ad8f7008c6e2db05eed344817055176c76dbd60c1b5"
+  head "https://github.com/neomutt/neomutt.git"
 
   depends_on "gettext" => :build
   depends_on "docbook-xsl" => :build
-  depends_on "libxslt" => :build unless OS.mac?
-  depends_on "krb5" => :build unless OS.mac?
 
   depends_on "openssl"
-  depends_on "tokyo-cabinet" => :recommended if build.without?("lmdb")
-  depends_on "lmdb" => :optional
-  depends_on "gpgme" => :optional
-  depends_on "libidn" => :optional
-  depends_on "lua" => :optional
-  depends_on "s-lang" => :optional
-  depends_on "notmuch" if build.with? "notmuch-patch"
+  depends_on "tokyo-cabinet"
+  depends_on "lmdb"
+  depends_on "gpgme"
+  depends_on "libidn"
+  depends_on "notmuch"
 
   def install
-    # Find our docbook catalog
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     args = %W[
       --prefix=#{prefix}
       --with-ssl=#{Formula["openssl"].opt_prefix}
+      --sasl
       --gss
       --disable-idn
+      --with-ui=ncurses
+      --notmuch
+      --lmdb
+      --tokyocabinet
+      --enable-gpgme
     ]
 
-    args << "--enable-gpgme" if build.with? "gpgme"
-
-    # Neomutt-specific patches
-    args << "--notmuch" if build.with? "notmuch-patch"
-
-    args << "--sasl" unless OS.linux?
-
-    if build.with? "lmdb"
-      args << "--lmdb"
-    else
-      args << "--tokyocabinet"
-    end
-
-    if build.with? "lua"
-      args << "--lua"
-      args << "--with-lua=#{Formula["lua"].prefix}"
-    end
-
-    if build.with? "s-lang"
-      args << "--with-ui=slang"
-    else
-      args << "--with-ui=ncurses"
-    end
-
     system "./configure", *args
-    system "make"
-
     system "make", "install"
-  end
-
-  test do
-    system bin/"neomutt", "-D"
   end
 end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -6,7 +6,7 @@ class Neomutt < Formula
   head "https://github.com/neomutt/neomutt.git"
 
   depends_on "docbook-xsl" => :build
-  depends_on "gettext" => :build
+  depends_on "gettext"
   depends_on "gpgme"
   depends_on "libidn"
   depends_on "lmdb"

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -1,0 +1,72 @@
+class Neomutt < Formula
+  desc "Teaching an Old Dog New Tricks"
+  homepage "https://www.neomutt.org/"
+  url "https://github.com/neomutt/neomutt.git", :tag => "neomutt-20171215", :revision => "ae61285170533b4be544e738cdd2eedefd1856ff"
+  head "https://github.com/neomutt/neomutt.git", :branch => "master"
+
+  option "with-lmdb", "Build with lmdb support"
+  option "with-lua", "Build with lua scripting support enabled"
+  option "with-s-lang", "Build against slang instead of ncurses"
+
+  # Neomutt-specific patches
+  option "with-notmuch-patch", "Apply notmuch patch"
+
+  depends_on "gettext" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "libxslt" => :build unless OS.mac?
+  depends_on "krb5" => :build unless OS.mac?
+
+  depends_on "openssl"
+  depends_on "tokyo-cabinet" => :recommended unless build.with?("lmdb")
+  depends_on "lmdb" => :optional
+  depends_on "gpgme" => :optional
+  depends_on "libidn" => :optional
+  depends_on "lua" => :optional
+  depends_on "s-lang" => :optional
+  depends_on "notmuch" if build.with? "notmuch-patch"
+
+  def install
+    # Find our docbook catalog
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    args = %W[
+      --prefix=#{prefix}
+      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --gss
+      --disable-idn
+    ]
+
+    args << "--enable-gpgme" if build.with? "gpgme"
+
+    # Neomutt-specific patches
+    args << "--notmuch" if build.with? "notmuch-patch"
+
+    args << "--sasl" unless OS.linux?
+
+    if build.with? "lmdb"
+      args << "--lmdb"
+    else
+      args << "--tokyocabinet"
+    end
+
+    if build.with? "lua"
+      args << "--lua"
+      args << "--with-lua=#{Formula["lua"].prefix}"
+    end
+
+    if build.with? "s-lang"
+      args << "--with-ui=slang"
+    else
+      args << "--with-ui=ncurses"
+    end
+
+    system "./configure", *args
+    system "make"
+
+    system "make", "install"
+  end
+
+  test do
+    system bin/"neomutt", "-D"
+  end
+end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -16,8 +16,7 @@ class Neomutt < Formula
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-    system "./configure", "--disable-idn",
-                          "--enable-gpgme",
+    system "./configure", "--enable-gpgme",
                           "--gss",
                           "--lmdb",
                           "--notmuch",
@@ -30,6 +29,6 @@ class Neomutt < Formula
   end
 
   test do
-    system bin/"mutt", "-D"
+    system bin/"neomutt", "-D"
   end
 end

--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -1,8 +1,8 @@
 class Neomutt < Formula
   desc "E-mail reader with support for Notmuch, NNTP and much more"
   homepage "https://www.neomutt.org/"
-  url "https://github.com/neomutt/neomutt/archive/neomutt-20171215.tar.gz"
-  sha256 "7fb76e99a9f23715ad772ad8f7008c6e2db05eed344817055176c76dbd60c1b5"
+  url "https://github.com/neomutt/neomutt/archive/neomutt-20180223.tar.gz"
+  sha256 "10ba010017cf7db6bb5ac3e2116d6defad56d34be0dceea9d70a66d8510927bb"
   head "https://github.com/neomutt/neomutt.git"
 
   depends_on "docbook-xsl" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
We would like to move neomutt from neomutt Tap: https://github.com/neomutt/homebrew-neomutt/issues/39

There are some errors in the output of brew audit:
The message _only supports macOS_ is printed because we recently added conditions to support linux brew. If this is a problem I think we can remove those and move linux brew Formula here https://github.com/Linuxbrew/homebrew-core/

Here is the brew audit output:
```neomutt:
  * C: 16: col 41: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 17: col 38: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 44: col 29: Don't use OS.linux?; Homebrew/core only supports macOS
Error: 3 problems in 1 formula```