### PR TITLE
gomplate: remove glide from deps

### DIFF
--- a/Formula/gomplate.rb
+++ b/Formula/gomplate.rb
@@ -12,13 +12,11 @@ class Gomplate < Formula
     sha256 "adaceb340c8a6efaf8f32eafe64e32e581ba3bb4d3a361ca93c0bba06b3a7aff" => :el_capitan
   end
 
-  depends_on "glide" => :build
   depends_on "go" => :build
   depends_on "upx" => :build
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
     (buildpath/"src/github.com/hairyhenderson/gomplate").install buildpath.children
     cd "src/github.com/hairyhenderson/gomplate" do
       system "make", "compress", "VERSION=#{version}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Just removing `glide` as a dependency. I moved to `dep` back in hairyhenderson/gomplate#185 and dependencies are vendored.