### PR TITLE
Update LaTeXML recipe with necessary Perl modules

### DIFF
--- a/Formula/latexml.rb
+++ b/Formula/latexml.rb
@@ -32,7 +32,8 @@ class Latexml < Formula
       Test::More URI XML::LibXML XML::LibXSLT UUID::Tiny"
     # Remove all CPANM files
     remove_dir "#{libexec}/localcpan", :force => true
-    remove ["#{libexec}/bin/config_data", "#{libexec}/bin/cpanm", "#{libexec}/bin/crc32", "#{libexec}/bin/imgsize", "#{libexec}/bin/json_xs", "#{libexec}/bin/lwp-*"], :force => true
+    remove ["#{libexec}/bin/config_data", "#{libexec}/bin/cpanm", "#{libexec}/bin/crc32", "#{libexec}/bin/imgsize", "#{libexec}/bin/json_xs",
+            "#{libexec}/bin/lwp-download", "#{libexec}/bin/lwp-dump", "#{libexec}/bin/lwp-mirror", "#{libexec}/bin/lwp-request"], :force => true
 
     system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
     system "make", "install"


### PR DESCRIPTION
Follow-up of https://github.com/Homebrew/homebrew-core/pull/23562. I've followed @ilovezfs's suggestion and now the necessary Perl modules are installed locally via cpanm.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Tested on my current High Sierra install and on a clean Sierra box.