### PR TITLE
git-extras 4.5.0

### DIFF
--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -1,16 +1,9 @@
 class GitExtras < Formula
   desc "Small git utilities"
   homepage "https://github.com/tj/git-extras"
+  url "https://github.com/tj/git-extras/archive/4.5.0.tar.gz"
+  sha256 "cb099d9e155c3bf863f95dd91c72bcc2e05fb28e3ebce527cd70d1b517402615"
   head "https://github.com/tj/git-extras.git"
-
-  stable do
-    url "https://github.com/tj/git-extras/archive/4.4.0.tar.gz"
-    sha256 "16c2184f13272dd032717ebd22a88762759cd10d2b9357e4ac7bd992bdd7686d"
-    # Disable "git extras update", which will produce a broken install under Homebrew
-    # https://github.com/Homebrew/homebrew/issues/44520
-    # https://github.com/tj/git-extras/pull/491
-    patch :DATA
-  end
 
   bottle do
     cellar :any_skip_relocation
@@ -24,7 +17,7 @@ class GitExtras < Formula
     :because => "both install a `git-pull-request` script"
 
   def install
-    system "make", "PREFIX=#{prefix}", "install"
+    system "make", "PREFIX=#{prefix}", "INSTALL_VIA=brew", "install"
     pkgshare.install "etc/git-extras-completion.zsh"
   end
 
@@ -39,29 +32,3 @@ class GitExtras < Formula
     assert_match(/#{testpath}/, shell_output("#{bin}/git-root"))
   end
 end
-
-__END__
-diff --git a/bin/git-extras b/bin/git-extras
-index e49cd24..4ae28b5 100755
---- a/bin/git-extras
-+++ b/bin/git-extras
-@@ -4,13 +4,12 @@ VERSION="4.3.0"
- INSTALL_SCRIPT="https://raw.githubusercontent.com/tj/git-extras/master/install.sh"
-
- update() {
--  local bin="$(which git-extras)"
--  local prefix=${bin%/*/*}
--  local orig=$PWD
--
--  curl -s $INSTALL_SCRIPT | PREFIX="$prefix" bash /dev/stdin \
--    && cd "$orig" \
--    && echo "... updated git-extras $VERSION -> $(git extras --version)"
-+  echo "This git-extras installation is managed by Homebrew."
-+  echo "If you'd like to update git-extras, run the following:"
-+  echo
-+  echo "  brew upgrade git-extras"
-+  echo
-+  return 1
- }
-
- updateForWindows() {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This pr upgrades git-extras from 4.4.0 to 4.5.0.