### PR TITLE
gcc@6: vendor in ecj

### DIFF
--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -43,8 +43,6 @@ class GccAT49 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
-  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
-
   resource "gmp" do
     url "https://ftp.gnu.org/gnu/gmp/gmp-4.3.2.tar.bz2"
     mirror "https://ftpmirror.gnu.org/gmp/gmp-4.3.2.tar.bz2"
@@ -79,6 +77,12 @@ class GccAT49 < Formula
     url "https://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
     mirror "http://archive.ubuntu.com/ubuntu/pool/universe/c/cloog/cloog_0.18.4.orig.tar.gz"
     sha256 "325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e"
+  end
+
+  resource "ecj" do
+    url "https://sourceware.org/pub/java/ecj-4.9.jar"
+    mirror "https://mirrors.kernel.org/sources.redhat.com/java/ecj-4.9.jar"
+    sha256 "9506e75b862f782213df61af67338eb7a23c35ff425d328affc65585477d34cd"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work
@@ -158,7 +162,8 @@ class GccAT49 < Formula
     args << "--disable-nls" if build.without? "nls"
 
     if build.with?("java") || build.with?("all-languages")
-      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+      (libexec/"java").install resource("ecj")
+      args << "--with-ecj-jar=#{libexec}/java/ecj-4.9.jar"
     end
 
     if MacOS.prefer_64_bit?

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -44,7 +44,6 @@ class GccAT5 < Formula
   depends_on "gmp"
   depends_on "libmpc"
   depends_on "mpfr"
-  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   resource "isl" do
     url "https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.14.tar.bz2"
@@ -85,6 +84,12 @@ class GccAT5 < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/413cfac6/gcc%405/10.13_headers.patch"
       sha256 "94aaec20c8c7bfd3c41ef8fb7725bd524b1c0392d11a411742303a3465d18d09"
     end
+  end
+
+  resource "ecj" do
+    url "https://sourceware.org/pub/java/ecj-4.9.jar"
+    mirror "https://mirrors.kernel.org/sources.redhat.com/java/ecj-4.9.jar"
+    sha256 "9506e75b862f782213df61af67338eb7a23c35ff425d328affc65585477d34cd"
   end
 
   def install
@@ -141,7 +146,8 @@ class GccAT5 < Formula
     args << "--disable-nls" if build.without? "nls"
 
     if build.with?("java") || build.with?("all-languages")
-      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+      (libexec/"java").install resource("ecj")
+      args << "--with-ecj-jar=#{libexec}/java/ecj-4.9.jar"
     end
 
     if MacOS.prefer_64_bit?

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -24,7 +24,6 @@ class GccAT6 < Formula
   depends_on "libmpc"
   depends_on "mpfr"
   depends_on "isl"
-  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   fails_with :gcc_4_0
 
@@ -54,6 +53,12 @@ class GccAT6 < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/df0465c02a/gcc/apfs.patch"
       sha256 "f7772a6ba73f44a6b378e4fe3548e0284f48ae2d02c701df1be93780c1607074"
     end
+  end
+
+  resource "ecj" do
+    url "https://sourceware.org/pub/java/ecj-4.9.jar"
+    mirror "https://mirrors.kernel.org/sources.redhat.com/java/ecj-4.9.jar"
+    sha256 "9506e75b862f782213df61af67338eb7a23c35ff425d328affc65585477d34cd"
   end
 
   def install
@@ -115,7 +120,8 @@ class GccAT6 < Formula
     args << "--disable-nls" if build.without? "nls"
 
     if build.with?("java") || build.with?("all-languages")
-      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+      (libexec/"java").install resource("ecj")
+      args << "--with-ecj-jar=#{libexec}/java/ecj-4.9.jar"
     end
 
     if MacOS.prefer_64_bit?


### PR DESCRIPTION
Following up on #24029, by vendoring ecj in old GCC formulas before we kill it