### PR TITLE
collector-sidecar: add alternate download for HEAD

### DIFF
--- a/Formula/collector-sidecar.rb
+++ b/Formula/collector-sidecar.rb
@@ -3,6 +3,7 @@ class CollectorSidecar < Formula
   homepage "https://github.com/Graylog2/collector-sidecar"
   url "https://github.com/Graylog2/collector-sidecar/archive/0.1.4.tar.gz"
   sha256 "3d73f8054a52411ff6d71634bc93b23a55372477069fcfad699876f82ae22ce8"
+  head "https://github.com/Graylog2/collector-sidecar.git"
 
   bottle do
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Add head URL to support `brew install --HEAD`. Installing HEAD fixes support for filebeat 6.