### PR TITLE
LMod 7.7.18 (new formula)

### DIFF
--- a/Formula/lmod.rb
+++ b/Formula/lmod.rb
@@ -1,0 +1,55 @@
+class Lmod < Formula
+  desc "Lua-based environment modules system to modify PATH variable"
+  homepage "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod"
+  url "https://github.com/TACC/Lmod/archive/7.7.18.tar.gz"
+  sha256 "fe8905938d741fff02b7596b28fef26c311ffb807d27bdc1d83b185cc4d25fd7"
+
+  depends_on "lua"
+
+  resource "luafilesystem" do
+    url "https://github.com/keplerproject/luafilesystem/archive/v1_7_0_2.tar.gz"
+    sha256 "23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59"
+  end
+
+  resource "luaposix" do
+    url "https://github.com/luaposix/luaposix/archive/v34.0.4.tar.gz"
+    sha256 "eb6e7322da3013bdb3d524f68df4f5510a2efd805c06bf7cc27be6611eab7483"
+  end
+
+  def install
+    luapath = libexec/"vendor"
+    ENV["LUA_PATH"] = "?.lua;" \
+                      "#{luapath}/share/lua/5.3/?.lua;" \
+                      "#{luapath}/share/lua/5.3/?/init.lua"
+    ENV["LUA_CPATH"] = "#{luapath}/lib/lua/5.3/?.so"
+
+    resources.each do |r|
+      r.stage do
+        system "luarocks", "make", "--tree=#{luapath}"
+      end
+    end
+
+    system "./configure", "--prefix=#{libexec}"
+    system "make", "install"
+    prefix.install_symlink "libexec/lmod/lmod" => "lmod"
+  end
+
+  def caveats
+    <<~EOS
+      To use LMod, you should add the init script to the shell you are using.
+
+      For example, the bash setup script is here: #{opt_prefix}/lmod/init/profile
+      and you can source it in your bash setup or link to it.
+
+      If you use fish, use #{opt_prefix}/lmod/init/fish, such as:
+        ln -s #{opt_prefix}/lmod/init/fish ~/.config/fish/conf.d/00_lmod.fish
+    EOS
+  end
+
+  test do
+    system "#{prefix}/lmod/init/sh"
+    output = shell_output("#{prefix}/lmod/libexec/spider #{prefix}/lmod/modulefiles/Core/")
+    assert_match "lmod", output
+    assert_match "settarg", output
+  end
+end


### PR DESCRIPTION
This is a conversion of the lmod formula from the defunct homebrew-science tap. It has been updated to support the latest Lua 5.3 in Homebrew (the one in the science repos is broken due to 5.2 usage). The old formula was incorrectly downloading lua packages then installing the online versions anyway. This formula actually uses the downloaded packages. Help for new users has been added to caveats.

LMod (Lua environment MODules) is a tool for manipulating environments and is common in supercomputing clusters. It is most commonly used for setting up MPI, but it can be used for almost any tool that needs a custom environment, such as setting up other compilers. An example for switching between the default macOS compiler and the brew installed one can be found [here](https://github.com/CLIUtils/envmodule_setup/tree/master/macOS/Core/llvm). This makes it more generally useful than just in science or on Linux clusters.