### PR TITLE
imagemagick@6: add upstream head repository

### DIFF
--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -7,6 +7,7 @@ class ImagemagickAT6 < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick%406-6.9.9-35.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.9-35.tar.xz"
   sha256 "11c07cbf8691787af9746ffd42456755bfa1f45be0ba9a4ef12284b351128825"
+  head "https://github.com/imagemagick/imagemagick.git", :branch => "ImageMagick-6"
 
   bottle do
     sha256 "88d1e9dc0f6e0d1a70fc0c5f6806c86f586296bb81be425c150929cc7cd2bad8" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds support for: `brew install imagemagick@6 --HEAD` which I need. Thank you!