### PR TITLE
raylib: fix URL

### DIFF
--- a/Formula/raylib.rb
+++ b/Formula/raylib.rb
@@ -4,7 +4,7 @@ class Raylib < Formula
   url "https://github.com/raysan5/raylib/archive/1.9.1-dev.tar.gz"
   version "1.9.1-dev"
   sha256 "892357fb44d340eb7449c23c425d660d98b34b91434400e7610514ef02698600"
-  head "https://github.com/raysan5/raylib.git", :branch => "develop"
+  head "https://github.com/raysan5/raylib.git", :branch => "master"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Development was moved from develop branch to master in raysan5/raylib#443
and develop branch has been deleted, therefore fixing --HEAD URL here.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
