### PR TITLE
libtiff 4.0.9-4 (patch)

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -4,7 +4,7 @@ class Libtiff < Formula
   url "https://download.osgeo.org/libtiff/tiff-4.0.9.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.9.tar.gz"
   sha256 "6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -21,11 +21,12 @@ class Libtiff < Formula
   # All of these have been reported upstream & should
   # be fixed in the next release, but please check.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-3.debian.tar.xz"
-    sha256 "c413f5b2423b95d8b068adca695f0ddaea5219088a1d38de4800b379bc20ca73"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-4.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-4.debian.tar.xz"
+    sha256 "f078da1da538109c1e5403dc1f44d23c91f5a5d6ddc5ffc41ff60de006cb2b2e"
     apply "patches/CVE-2017-9935.patch",
-          "patches/CVE-2017-18013.patch"
+          "patches/CVE-2017-18013.patch",
+          "patches/CVE-2018-5784.patch"
   end
 
   def install


### PR DESCRIPTION
Installing libtiff fails because 4.0.9-3 is no longer mirrored.
4.0.9-4 adds a patch for CVE-2018-5784