### PR TITLE
add istio.rb to use istio

### DIFF
--- a/Formula/istio.rb
+++ b/Formula/istio.rb
@@ -1,0 +1,14 @@
+class Istio < Formula
+  desc "Istio configuration command line utility"
+  homepage "https://istio.io"
+  url "https://github.com/istio/istio/releases/download/0.5.0/istio-0.5.0-osx.tar.gz"
+  sha256 "34c3f2cab1d25f99dd8b411e97c7eb5a527d44c77775ff0ee4c26ad531564373"
+
+  def install
+    bin.install "bin/istioctl"
+  end
+
+  test do
+    system "#{bin}/istioctl", "--help"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a formula to install Istio. 

Related:  https://github.com/Homebrew/homebrew-core/pull/16586 https://github.com/Homebrew/homebrew-core/pull/22897
 https://github.com/istio/istio/issues/2615