### PR TITLE
log4cplus: build with cxx11

### DIFF
--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -1,8 +1,8 @@
 class Log4cplus < Formula
   desc "Logging Framework for C++"
   homepage "https://sourceforge.net/p/log4cplus/wiki/Home/"
-  url "https://github.com/log4cplus/log4cplus/archive/REL_1_2_1.tar.gz"
-  sha256 "510c916194ea86f1cc47070e96981aa80f3ca5944544711c225d8bcf7283b2fc"
+  url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/1.2.1/log4cplus-1.2.1.tar.xz"
+  sha256 "09899274d18af7ec845ef2c36a86b446a03f6b0e3b317d96d89447007ebed0fc"
 
   bottle do
     cellar :any

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -11,10 +11,10 @@ class Log4cplus < Formula
     sha256 "8819df40a1477a3fb87a4a3dcd36ec8e2292b5aed362851549e8e2df74ffad9d" => :el_capitan
   end
 
-  option "with-cxx11", "set -std=c++11 in the envvar CXXFLAG"
+  needs :cxx11
 
   def install
-    ENV["CXXFLAGS"]="-std=c++11" if build.with? "cxx11"
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -1,8 +1,8 @@
 class Log4cplus < Formula
   desc "Logging Framework for C++"
   homepage "https://sourceforge.net/p/log4cplus/wiki/Home/"
-  url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/1.2.1/log4cplus-1.2.1.tar.xz"
-  sha256 "09899274d18af7ec845ef2c36a86b446a03f6b0e3b317d96d89447007ebed0fc"
+  url "https://github.com/log4cplus/log4cplus/archive/REL_1_2_1.tar.gz"
+  sha256 "510c916194ea86f1cc47070e96981aa80f3ca5944544711c225d8bcf7283b2fc"
 
   bottle do
     cellar :any

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -10,8 +10,11 @@ class Log4cplus < Formula
     sha256 "f5f8ec470c5a4e1b0043ff44f85b8deda8ad27189f5766f330e60e162f7054c8" => :sierra
     sha256 "8819df40a1477a3fb87a4a3dcd36ec8e2292b5aed362851549e8e2df74ffad9d" => :el_capitan
   end
-
+  
+  option "with-cxx11", "set -std=c++11 in the envvar CXXFLAG"
+  
   def install
+    ENV['CXXFLAGS']="-std=c++11" if build.with? "cxx11"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -10,11 +10,11 @@ class Log4cplus < Formula
     sha256 "f5f8ec470c5a4e1b0043ff44f85b8deda8ad27189f5766f330e60e162f7054c8" => :sierra
     sha256 "8819df40a1477a3fb87a4a3dcd36ec8e2292b5aed362851549e8e2df74ffad9d" => :el_capitan
   end
-  
+
   option "with-cxx11", "set -std=c++11 in the envvar CXXFLAG"
-  
+
   def install
-    ENV['CXXFLAGS']="-std=c++11" if build.with? "cxx11"
+    ENV["CXXFLAGS"]="-std=c++11" if build.with? "cxx11"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
[log4cplus] add option --with-cxx11

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No, it didn't before.

-----
