### PR TITLE
ruby@*: remove rubygems resource.

### DIFF
--- a/Formula/ruby@1.8.rb
+++ b/Formula/ruby@1.8.rb
@@ -23,29 +23,12 @@ class RubyAT18 < Formula
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
 
-  # This should be kept in sync with the main Ruby formula
-  # but a revision bump should not be forced every update
-  # unless there are security fixes in that Rubygems release.
-  #
-  # RubyGems 2.7.3 requires Psych of at least 2.0, unless
-  # such a newer version of Psych is vendored within this
-  # formula, RubyGems should not be upgraded until there
-  # is a known vulnerability.
-  resource "rubygems" do
-    url "https://rubygems.org/rubygems/rubygems-2.6.14.tgz"
-    sha256 "406a45d258707f52241843e9c7902bbdcf00e7edc3e88cdb79c46659b47851ec"
-  end
-
   def program_suffix
     build.with?("suffix") ? "187" : ""
   end
 
   def ruby
     "#{bin}/ruby#{program_suffix}"
-  end
-
-  def api_version
-    "1.8"
   end
 
   def install
@@ -66,8 +49,6 @@ class RubyAT18 < Formula
     args = %W[
       --prefix=#{prefix}
       --enable-shared
-      --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
-      --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
     ]
 
     args << "--program-suffix=#{program_suffix}" if build.with? "suffix"
@@ -76,143 +57,14 @@ class RubyAT18 < Formula
     rm_r "ext/tk" if build.without? "tcltk"
 
     system "./configure", *args
-
-    # Ruby has been configured to look in the HOMEBREW_PREFIX for the
-    # sitedir and vendordir directories; however we don't actually want to create
-    # them during the install.
-    #
-    # These directories are empty on install; sitedir is used for non-rubygems
-    # third party libraries, and vendordir is used for packager-provided libraries.
-    inreplace "instruby.rb" do |s|
-      s.gsub! "\n    makedirs [archlibdir, sitearchlibdir, vendorarchlibdir]\n",
-              "\n    makedirs [archlibdir]\n"
-      s.gsub! "\n    makedirs [rubylibdir, sitelibdir, vendorlibdir]\n",
-              "\n    makedirs [rubylibdir]\n"
-    end
-
     system "make"
     system "make", "install"
     system "make", "install-doc" if build.with? "doc"
-
-    # This is easier than trying to keep both current & versioned Ruby
-    # formulae repeatedly updated with Rubygem patches.
-    resource("rubygems").stage do
-      ENV.prepend_path "PATH", bin
-
-      system ruby, "setup.rb", "--prefix=#{buildpath}/vendor_gem"
-      rg_in = lib/"ruby/#{api_version}"
-
-      # Remove bundled Rubygem version.
-      rm_rf rg_in/"rubygems"
-      rm_f rg_in/"rubygems.rb"
-      rm_f rg_in/"ubygems.rb"
-      rm_f bin/"gem#{program_suffix}"
-
-      # Drop in the new version.
-      (rg_in/"rubygems").install Dir[buildpath/"vendor_gem/lib/rubygems/*"]
-      rg_in.install buildpath/"vendor_gem/lib/rubygems.rb"
-      rg_in.install buildpath/"vendor_gem/lib/ubygems.rb"
-      bin.install buildpath/"vendor_gem/bin/gem" => "gem#{program_suffix}"
-    end
-  end
-
-  def post_install
-    # Customize rubygems to look/install in the global gem directory
-    # instead of in the Cellar, making gems last across reinstalls
-    config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
-    config_file.unlink if config_file.exist?
-    config_file.write rubygems_config
-
-    # Create the sitedir and vendordir that were skipped during install
-    %w[sitearchdir vendorarchdir].each do |dir|
-      mkdir_p `#{ruby} -rrbconfig -e 'print RbConfig::CONFIG["#{dir}"]'`
-    end
-
-    # Create the version-specific bindir used by rubygems
-    mkdir_p rubygems_bindir
-  end
-
-  def rubygems_bindir
-    "#{HOMEBREW_PREFIX}/lib/ruby/gems/#{api_version}/bin"
-  end
-
-  def rubygems_config; <<~EOS
-    module Gem
-      class << self
-        alias :old_default_dir :default_dir
-        alias :old_default_path :default_path
-        alias :old_default_bindir :default_bindir
-        alias :old_ruby :ruby
-      end
-
-      def self.default_dir
-        path = [
-          "#{HOMEBREW_PREFIX}",
-          "lib",
-          "ruby",
-          "gems",
-          "#{api_version}"
-        ]
-
-        @default_dir ||= File.join(*path)
-      end
-
-      def self.private_dir
-        path = if defined? RUBY_FRAMEWORK_VERSION then
-                 [
-                   File.dirname(RbConfig::CONFIG['sitedir']),
-                   'Gems',
-                   RbConfig::CONFIG['ruby_version']
-                 ]
-               elsif RbConfig::CONFIG['rubylibprefix'] then
-                 [
-                  RbConfig::CONFIG['rubylibprefix'],
-                  'gems',
-                  RbConfig::CONFIG['ruby_version']
-                 ]
-               else
-                 [
-                   RbConfig::CONFIG['libdir'],
-                   ruby_engine,
-                   'gems',
-                   RbConfig::CONFIG['ruby_version']
-                 ]
-               end
-
-        @private_dir ||= File.join(*path)
-      end
-
-      def self.default_path
-        if Gem.user_home && File.exist?(Gem.user_home)
-          [user_dir, default_dir, private_dir]
-        else
-          [default_dir, private_dir]
-        end
-      end
-
-      def self.default_bindir
-        "#{rubygems_bindir}"
-      end
-
-      def self.ruby
-        "#{opt_bin}/ruby#{program_suffix}"
-      end
-    end
-    EOS
-  end
-
-  def caveats; <<~EOS
-    By default, binaries installed by gem will be placed into:
-      #{rubygems_bindir}
-
-    You may want to add this to your PATH.
-    EOS
   end
 
   test do
     hello_text = shell_output("#{bin}/ruby#{program_suffix} -e 'puts :hello'")
     assert_equal "hello\n", hello_text
     system "#{bin}/ruby#{program_suffix}", "-e", "require 'zlib'"
-    system "#{bin}/gem#{program_suffix}", "list", "--local"
   end
 end

--- a/Formula/ruby@2.0.rb
+++ b/Formula/ruby@2.0.rb
@@ -25,14 +25,6 @@ class RubyAT20 < Formula
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
 
-  # This should be kept in sync with the main Ruby formula
-  # but a revision bump should not be forced every update
-  # unless there are security fixes in that Rubygems release.
-  resource "rubygems" do
-    url "https://rubygems.org/rubygems/rubygems-2.7.4.tgz"
-    sha256 "bbe35ce6646e4168fcb1071d5f83b2d1154924f5150df0f5fca0f37d2583a182"
-  end
-
   def program_suffix
     build.with?("suffix") ? "20" : ""
   end
@@ -90,42 +82,9 @@ class RubyAT20 < Formula
 
     system "make"
     system "make", "install"
-
-    # This is easier than trying to keep both current & versioned Ruby
-    # formulae repeatedly updated with Rubygem patches.
-    resource("rubygems").stage do
-      ENV.prepend_path "PATH", bin
-
-      system ruby, "setup.rb", "--prefix=#{buildpath}/vendor_gem"
-      rg_in = lib/"ruby/#{api_version}"
-
-      # Remove bundled Rubygem version.
-      rm_rf rg_in/"rubygems"
-      rm_f rg_in/"rubygems.rb"
-      rm_f rg_in/"ubygems.rb"
-      rm_f bin/"gem#{program_suffix}"
-
-      # Drop in the new version.
-      rg_in.install Dir[buildpath/"vendor_gem/lib/*"]
-      bin.install buildpath/"vendor_gem/bin/gem" => "gem#{program_suffix}"
-      (libexec/"gembin").install buildpath/"vendor_gem/bin/bundle" => "bundle#{program_suffix}"
-      (libexec/"gembin").install_symlink "bundle#{program_suffix}" => "bundler#{program_suffix}"
-    end
   end
 
   def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm_f %W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundle#{program_suffix}
-      #{rubygems_bindir}/bundler
-      #{rubygems_bindir}/bundler#{program_suffix}
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
-    rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
-
     # Customize rubygems to look/install in the global gem directory
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
@@ -216,12 +175,5 @@ class RubyAT20 < Formula
     assert_equal "hello\n", hello_text
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem#{program_suffix}", "install", "json"
-
-    (testpath/"Gemfile").write <<~EOS
-      source 'https://rubygems.org'
-      gem 'gemoji'
-    EOS
-    system rubygems_bindir/"bundle#{program_suffix}", "install", "--binstubs=#{testpath}/bin"
-    assert_predicate testpath/"bin/gemoji", :exist?, "gemoji is not installed in #{testpath}/bin"
   end
 end

--- a/Formula/ruby@2.2.rb
+++ b/Formula/ruby@2.2.rb
@@ -26,14 +26,6 @@ class RubyAT22 < Formula
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
 
-  # This should be kept in sync with the main Ruby formula
-  # but a revision bump should not be forced every update
-  # unless there are security fixes in that Rubygems release.
-  resource "rubygems" do
-    url "https://rubygems.org/rubygems/rubygems-2.7.4.tgz"
-    sha256 "bbe35ce6646e4168fcb1071d5f83b2d1154924f5150df0f5fca0f37d2583a182"
-  end
-
   def program_suffix
     build.with?("suffix") ? "22" : ""
   end
@@ -96,42 +88,9 @@ class RubyAT22 < Formula
 
     # A newer version of ruby-mode.el is shipped with Emacs
     elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
-
-    # This is easier than trying to keep both current & versioned Ruby
-    # formulae repeatedly updated with Rubygem patches.
-    resource("rubygems").stage do
-      ENV.prepend_path "PATH", bin
-
-      system ruby, "setup.rb", "--prefix=#{buildpath}/vendor_gem"
-      rg_in = lib/"ruby/#{api_version}"
-
-      # Remove bundled Rubygem version.
-      rm_rf rg_in/"rubygems"
-      rm_f rg_in/"rubygems.rb"
-      rm_f rg_in/"ubygems.rb"
-      rm_f bin/"gem#{program_suffix}"
-
-      # Drop in the new version.
-      rg_in.install Dir[buildpath/"vendor_gem/lib/*"]
-      bin.install buildpath/"vendor_gem/bin/gem" => "gem#{program_suffix}"
-      (libexec/"gembin").install buildpath/"vendor_gem/bin/bundle" => "bundle#{program_suffix}"
-      (libexec/"gembin").install_symlink "bundle#{program_suffix}" => "bundler#{program_suffix}"
-    end
   end
 
   def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm_f %W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundle#{program_suffix}
-      #{rubygems_bindir}/bundler
-      #{rubygems_bindir}/bundler#{program_suffix}
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
-    rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
-
     # Customize rubygems to look/install in the global gem directory
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
@@ -222,12 +181,5 @@ class RubyAT22 < Formula
     assert_equal "hello\n", hello_text
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem#{program_suffix}", "install", "json"
-
-    (testpath/"Gemfile").write <<~EOS
-      source 'https://rubygems.org'
-      gem 'gemoji'
-    EOS
-    system rubygems_bindir/"bundle#{program_suffix}", "install", "--binstubs=#{testpath}/bin"
-    assert_predicate testpath/"bin/gemoji", :exist?, "gemoji is not installed in #{testpath}/bin"
   end
 end

--- a/Formula/ruby@2.3.rb
+++ b/Formula/ruby@2.3.rb
@@ -26,14 +26,6 @@ class RubyAT23 < Formula
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
 
-  # This should be kept in sync with the main Ruby formula
-  # but a revision bump should not be forced every update
-  # unless there are security fixes in that Rubygems release.
-  resource "rubygems" do
-    url "https://rubygems.org/rubygems/rubygems-2.7.4.tgz"
-    sha256 "bbe35ce6646e4168fcb1071d5f83b2d1154924f5150df0f5fca0f37d2583a182"
-  end
-
   def program_suffix
     build.with?("suffix") ? "23" : ""
   end
@@ -99,42 +91,9 @@ class RubyAT23 < Formula
 
     # A newer version of ruby-mode.el is shipped with Emacs
     elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
-
-    # This is easier than trying to keep both current & versioned Ruby
-    # formulae repeatedly updated with Rubygem patches.
-    resource("rubygems").stage do
-      ENV.prepend_path "PATH", bin
-
-      system ruby, "setup.rb", "--prefix=#{buildpath}/vendor_gem"
-      rg_in = lib/"ruby/#{api_version}"
-
-      # Remove bundled Rubygem version.
-      rm_rf rg_in/"rubygems"
-      rm_f rg_in/"rubygems.rb"
-      rm_f rg_in/"ubygems.rb"
-      rm_f bin/"gem#{program_suffix}"
-
-      # Drop in the new version.
-      rg_in.install Dir[buildpath/"vendor_gem/lib/*"]
-      bin.install buildpath/"vendor_gem/bin/gem" => "gem#{program_suffix}"
-      (libexec/"gembin").install buildpath/"vendor_gem/bin/bundle" => "bundle#{program_suffix}"
-      (libexec/"gembin").install_symlink "bundle#{program_suffix}" => "bundler#{program_suffix}"
-    end
   end
 
   def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm_f %W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundle#{program_suffix}
-      #{rubygems_bindir}/bundler
-      #{rubygems_bindir}/bundler#{program_suffix}
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
-    rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
-
     # Customize rubygems to look/install in the global gem directory
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
@@ -225,12 +184,5 @@ class RubyAT23 < Formula
     assert_equal "hello\n", hello_text
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem#{program_suffix}", "install", "json"
-
-    (testpath/"Gemfile").write <<~EOS
-      source 'https://rubygems.org'
-      gem 'gemoji'
-    EOS
-    system rubygems_bindir/"bundle#{program_suffix}", "install", "--binstubs=#{testpath}/bin"
-    assert_predicate testpath/"bin/gemoji", :exist?, "gemoji is not installed in #{testpath}/bin"
   end
 end


### PR DESCRIPTION
Use upstream's RubyGems. Users can still update this if desired.

`rbenv` is a better replacement if you need your old Rubies built exactly to your requirements.