### PR TITLE
rust: cargo 0.25.0, and prevent segfaults from builds with mismatched SSL libs

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -8,8 +8,8 @@ class Rust < Formula
 
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
-          :tag => "0.24.0",
-          :revision => "45043115c9094d82f0f407ebc7ef7e583f438d12"
+          :tag => "0.25.0",
+          :revision => "8c93e089536467783957fec23b0f2627bb6ce357"
     end
 
     resource "racer" do

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -57,18 +57,14 @@ class Rust < Formula
   end
 
   def install
-    # Remove for > 1.23.0; fix build failure on APFS
-    # See https://github.com/rust-lang/cargo/pull/4739
-    if build.stable? && MacOS.version >= :high_sierra
-      inreplace "src/stage0.txt" do |s|
-        s.gsub! "date: 2017-11-20", "date: 2017-11-23"
-        s.gsub! "rustc: 1.22.0", "rustc: 1.22.1"
-      end
-    end
-
     # Fix build failure for compiler_builtins "error: invalid deployment target
     # for -stdlib=libc++ (requires OS X 10.7 or later)"
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+
+    # Prevent cargo from linking against a different library (like openssl@1.1)
+    # than libssh2 and causing segfaults
+    ENV["OPENSSL_INCLUDE_DIR"] = Formula["openssl"].opt_include
+    ENV["OPENSSL_LIB_DIR"] = Formula["openssl"].opt_lib
 
     # Fix build failure for cmake v0.1.24 "error: internal compiler error:
     # src/librustc/ty/subst.rs:127: impossible case reached" on 10.11, and for


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

**Description:** update cargo to 0.25.0, prevent cargo from linking against a different SSL library than libssh2 (like openssl@1.1) and causing segfaults, also remove an apparently obsolete inreplace.

**Context:** I built from source and cargo was previously finding openssl@1.1 so my `cargo build` attempts would all immediately segfault. It seems that I wasn't the only one to have that problem: rust-lang/cargo#3766, rust-lang/cargo#4775
