### PR TITLE
gnupg 2.2.5

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,8 +1,8 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.4.tar.bz2"
-  sha256 "401a3e64780fdfa6d7670de0880aa5c9d589b3db7a7098979d7606cec546f2ec"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.5.tar.bz2"
+  sha256 "3fa189a32d4fb62147874eb1389047c267d9ba088f57ab521cb0df46f08aef57"
 
   bottle do
     sha256 "b1b9072b7016d6c19dfcc3df4a3b918a26cba41235fe6da811708960ce32515d" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes in version 2.2.5
===================================

  * gpg: Allow the use of the "cv25519" and "ed25519" short names in
    addition to the canonical curve names in --batch --gen-key.

  * gpg: Make sure to print all secret keys with option --list-only
    and --decrypt.  [#3718]

  * gpg: Fix the use of future-default with --quick-add-key for
    signing keys.  [#3747]

  * gpg: Select a secret key by checking availability under gpg-agent.
    [#1967]

  * gpg: Fix reversed prompt texts for --only-sign-text-ids.  [#3787]

  * gpg,gpgsm: Fix detection of bogus keybox blobs on 32 bit systems.
    [#3770]

  * gpgsm: Fix regression since 2.1 in --export-secret-key-raw which
    got $d mod (q-1)$ wrong.  Note that most tools automatically fixup
    that parameter anyway.

  * ssh: Fix a regression in getting the client'd PID on *BSD and
    macOS.

  * scd: Support the KDF Data Object of the OpenPGP card 3.3.  [#3152]

  * scd: Fix a regression in the internal CCID driver for certain card
    readers.  [#3508]

  * scd: Fix a problem on NetBSD killing scdaemon on gpg-agent
    shutdown.  [#3778]

  * dirmngr: Improve returned error description on failure of DNS
    resolving.  [#3756]

  * wks: Implement command --install-key for gpg-wks-server.

  * Add option STATIC=1 to the Speedo build system to allow a build
    with statically linked versions of the core GnuPG libraries.  Also
    use --enable-wks-tools by default by Speedo builds for Unix.
```
