### PR TITLE
lastpass-cli-completion 1.2.2

### DIFF
--- a/Formula/lastpass-cli-completion.rb
+++ b/Formula/lastpass-cli-completion.rb
@@ -1,0 +1,18 @@
+class LastpassCliCompletion < Formula
+  desc "Bash and Fish LastPass command-line completion"
+  homepage "https://github.com/lastpass/lastpass-cli"
+  url "https://github.com/lastpass/lastpass-cli/archive/v1.2.2.tar.gz"
+  sha256 "26c93ae610932139dacaff2e0f916c5628def48bb4129b4099101cf4e6c7c499"
+  head "https://github.com/lastpass/lastpass-cli.git"
+
+  bottle :unneeded
+
+  def install
+    bash_completion.install "contrib/lpass_bash_completion"
+    fish_completion.install "contrib/completions-lpass.fish"
+  end
+  test do
+    assert_match "-F _lpass",
+      shell_output("bash -c 'source #{bash_completion}/lpass_bash_completion && complete -p lpass'")
+  end
+end


### PR DESCRIPTION
This formula just installs the bash and fish completion scripts that are already
in the official LastPass Repo.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
