### PR TITLE
tesseract: use new data repository

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -14,7 +14,7 @@ class Tesseract < Formula
   head do
     url "https://github.com/tesseract-ocr/tesseract.git"
     resource "tessdata-head" do
-      url "https://github.com/tesseract-ocr/tessdata.git"
+      url "https://github.com/tesseract-ocr/tessdata_fast.git"
     end
   end
 


### PR DESCRIPTION
The [tesseract wiki](https://github.com/tesseract-ocr/tesseract/wiki/Data-Files#updated-data-files-for-version-400-september-15-2017) states the following:

> ## Updated Data Files for Version 4.00 (September 15, 2017)
> We have three sets of .traineddata files on GitHub in three separate repositories.
>  - https://github.com/tesseract-ocr/tessdata_best
>  - https://github.com/tesseract-ocr/tessdata_fast
>  - https://github.com/tesseract-ocr/tessdata
>
> Most users will want `tessdata_fast` and that is what will be shipped as part of Linux distributions. `tessdata_best` is for people willing to trade a lot of speed for slightly better accuracy. It is also better for certain retraining scenarios for advanced users.
>
>The third set in `tessdata` is for the legacy recognizer. The 4.00 files from November 2016 have both LSTM and legacy models.

So from this I infer that it is recommended to ship the `tessdata_fast` data now. 