### PR TITLE
graphene 1.6.2

### DIFF
--- a/Formula/graphene.rb
+++ b/Formula/graphene.rb
@@ -1,8 +1,8 @@
 class Graphene < Formula
   desc "Thin layer of graphic data types"
   homepage "https://ebassi.github.io/graphene/"
-  url "https://download.gnome.org/sources/graphene/1.6/graphene-1.6.0.tar.xz"
-  sha256 "c3a9910f8dd298c1459d1f3c699ddf2e7440f9e561bfcbef59ae784400e27b5d"
+  url "https://download.gnome.org/sources/graphene/1.6/graphene-1.6.2.tar.xz"
+  sha256 "8f7d1984c06aefe3b47a668c12ad9f3db0bcb2d09c55e6267b82a90f6b10d961"
 
   bottle do
     sha256 "8bd3cbebbd244603447606001998454111ba5592686329550b109bb08c055eb6" => :high_sierra


### PR DESCRIPTION
FYI: 1.8.0 is also available, but since it's meson only, I think it's better to wait a bit