### PR TITLE
Build curl with openssl

### DIFF
--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -3,6 +3,7 @@ class ShibbolethSp < Formula
   homepage "https://wiki.shibboleth.net/confluence/display/SHIB2"
   url "https://shibboleth.net/downloads/service-provider/2.6.1/shibboleth-sp-2.6.1.tar.bz2"
   sha256 "1121e3b726b844d829ad86f2047be62da4284ce965ac184de2f81903f16b98e4"
+  revision 1
 
   bottle do
     sha256 "1a91c531f1be5c05e66aa27f486034dc80f8a43b831ef7af67cbf4df5b8b3f67" => :high_sierra
@@ -11,7 +12,7 @@ class ShibbolethSp < Formula
   end
 
   depends_on :macos => :yosemite
-  depends_on "curl" => "with-openssl"
+  depends_on "curl"
   depends_on "httpd" if MacOS.version >= :high_sierra
   depends_on "opensaml"
   depends_on "xml-tooling-c"

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -3,6 +3,7 @@ class XmlToolingC < Formula
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/XMLTooling-C"
   url "https://shibboleth.net/downloads/c++-opensaml/2.6.1/xmltooling-1.6.3.tar.gz"
   sha256 "dd1216805e9f24eff5cd047f29dd0c27548c6e2e9f426ea1ba930150a88010f9"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,7 +18,7 @@ class XmlToolingC < Formula
   depends_on "xml-security-c"
   depends_on "boost"
   depends_on "openssl"
-  depends_on "curl" => "with-openssl"
+  depends_on "curl"
 
   needs :cxx11
 


### PR DESCRIPTION
- `curl --with-openssl` accounts for 11% of install requests (and 9% of all curl installs)
- Two other formulas have curl deps with this option: https://github.com/Homebrew/homebrew-core/issues/13133
- `openssl` is our most popular formula, depended upon by 386 existing formulas, making it not much of an additional burden for users