### PR TITLE
mysql 8.0.4-rc (devel)

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -11,8 +11,8 @@ class Mysql < Formula
   end
 
   devel do
-    url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.3-rc.tar.gz"
-    sha256 "bc6ef8e496447edde87da243db56682d44c8344e5695c3f265b3316b3a8aa56f"
+    url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.4-rc.tar.gz"
+    sha256 "648b1e39f45d7e4b65bae572f5d475db4a0c5e9db6ede75d8a3762972f312833"
 
     fails_with :clang do
       build 800


### PR DESCRIPTION
Note that in-place upgrade from 8.0.3-rc will fail due to:

https://bugs.mysql.com/bug.php?id=89372

So to upgrade use `mysqldump -A` on 8.0.3-rc, remove the data directory, install 8.0.4-rc, restore dump and run `mysql_upgrade`.

Since this is a `--devel` bump and upgrade between non-GA releases are explicitly not supported according to the [MySQL 8.0 Upgrade docs](https://dev.mysql.com/doc/refman/8.0/en/upgrading-strategies.html) I guess that's fine.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----