### PR TITLE
Bazel only needs Java at build time, not when installing from a bottle

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -11,6 +11,7 @@ class Bazel < Formula
     sha256 "1fb02eba8851384be7b4745cec3c00929010954142a8b94bf7ec7293bda2a210" => :el_capitan
   end
 
+  depends_on :java => ["1.8", :build]
   depends_on :macos => :yosemite
 
   def install

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -11,7 +11,6 @@ class Bazel < Formula
     sha256 "1fb02eba8851384be7b4745cec3c00929010954142a8b94bf7ec7293bda2a210" => :el_capitan
   end
 
-  depends_on :java => "1.8"
   depends_on :macos => :yosemite
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
