### PR TITLE
szip: switch back to the official source tarball url

### DIFF
--- a/Formula/szip.rb
+++ b/Formula/szip.rb
@@ -1,10 +1,9 @@
 class Szip < Formula
   desc "Implementation of extended-Rice lossless compression algorithm"
   homepage "https://support.hdfgroup.org/HDF5/release/obtain5.html#extlibs"
-  # https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz is 403
-  url "ftp://ftp.hdfgroup.org/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/szip-2.1.1.tar.gz"
-  sha256 "897dda94e1d4bf88c91adeaad88c07b468b18eaf2d6125c47acac57e540904a9"
+  url "https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz"
+  sha256 "21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The official HTTPS download URL works again, but the tarball has a different hash than the existing Homebrew mirror (and possibly the old, but broken official FTP download URL).
The difference comes from certain temporary/generated files being present in the existing tarball and missing from the new download:
```
Only in szip-2.1.1-mirror: autom4te.cache
Only in szip-2.1.1-mirror/src: SZconfig.h.in~
```
The rest of the content is identical.
