### PR TITLE
wxmac: bump the devel version to 3.1.1

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -14,34 +14,18 @@ class Wxmac < Formula
     sha256 "591bffb395156566ef3e55a9a8f2c193bdcde8b941d42cc6e6b41833ceeeaba2" => :yosemite
   end
 
-  # Fix compilation on High Sierra
-  # https://trac.wxwidgets.org/ticket/17929#ticket
-  patch do
-    url "https://github.com/wxWidgets/wxWidgets/commit/9a610eadcfe.patch?full_index=1"
-    sha256 "b445ddf1331b8ec21790b7e3fe3ac6059a2548002e7cbb9bf22b597baf32e3bf"
+  stable do
+    # Fix compilation on High Sierra
+    # https://trac.wxwidgets.org/ticket/17929#ticket
+    patch do
+      url "https://github.com/wxWidgets/wxWidgets/commit/9a610eadcfe.patch?full_index=1"
+      sha256 "b445ddf1331b8ec21790b7e3fe3ac6059a2548002e7cbb9bf22b597baf32e3bf"
+    end
   end
 
   devel do
-    url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
-    sha256 "e082460fb6bf14b7dd6e8ac142598d1d3d0b08a7b5ba402fdbf8711da7e66da8"
-
-    # Creating wxComboCtrl without wxTE_PROCESS_ENTER style results in an assert
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/cee3188c1abaa5b222c57b87cc94064e56921db8.patch?full_index=1"
-      sha256 "c2389fcb565ec4d488aed2586da15ec72d7fdb8c614f266f8f936d6e4ea10210"
-    end
-
-    # Building under macOS in C++11 mode for i386 architecture (but not amd64) results in an error about narrowing conversion
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/ee486dba32d02c744ae4007940f41a5b24b8c574.patch?full_index=1"
-      sha256 "dd73556b7a91cbfa63e2eafa8bab48ce5308b382d8e26e60b79f61d0520871e3"
-    end
-
-    # Building under macOS in C++11 results in several -Winconsistent-missing-override warnings
-    patch do
-      url "https://github.com/wxWidgets/wxWidgets/commit/173ecd77c4280e48541c33bdfe499985852935ba.patch?full_index=1"
-      sha256 "200c4fc3e103c7c9aa36ff35335af1a05494bf00a7181b6d6a11f0ffb2e4dc5d"
-    end
+    url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.1/wxWidgets-3.1.1.tar.bz2"
+    sha256 "c925dfe17e8f8b09eb7ea9bfdcfcc13696a3e14e92750effd839f5e10726159e"
   end
 
   option "with-stl", "use standard C++ classes for everything"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The audit can not pass because of the patch needed for the stable version.