### PR TITLE
Add vitess formula

### DIFF
--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -1,21 +1,15 @@
-require "language/go"
-
 class Vitess < Formula
   desc "Database clustering system for horizontal scaling of MySQL"
   homepage "http://vitess.io"
 
-  url "https://github.com/youtube/vitess.git",
-      :revision => "08d7b71256567b1880ba4a63381ab58908967572"
-  version "2.1.1.08d7b71"
-  head "https://github.com/youtube/vitess.git"
+  url "https://github.com/arthurnn/vitess.git",
+      :revision => "75b5eb418f2b5d5ac1e8f5f8fd6bad723d0dcd48",
+      :branch => "arthurnn/easier_build"
+  version "2.1.1.75b5eb41"
+  head "https://github.com/arthurnn/vitess.git"
 
   depends_on "go" => :build
   depends_on "pkg-config" => :build
-
-  go_resource "github.com/kardianos/govendor" do
-    url "https://github.com/kardianos/govendor.git",
-        :tag => "v1.0.9"
-  end
 
   def install
     ENV["GOPATH"] = buildpath
@@ -23,15 +17,7 @@ class Vitess < Formula
     contents = Dir["{*,.git,.gitignore}"]
     (buildpath/"src/github.com/youtube/vitess").install contents
 
-    ENV.prepend_create_path "PATH", buildpath/"bin"
-    Language::Go.stage_deps resources, buildpath/"src"
-    cd "src/github.com/kardianos/govendor" do
-      system "go", "install"
-    end
-
     cd "src/github.com/youtube/vitess" do
-      system "govendor", "sync"
-
       system "make", "build"
       prefix.install "web"
     end

--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -1,0 +1,71 @@
+require "language/go"
+
+class Vitess < Formula
+  desc "Database clustering system for horizontal scaling of MySQL"
+  homepage "http://vitess.io"
+
+  url "https://github.com/youtube/vitess.git",
+      :revision => "08d7b71256567b1880ba4a63381ab58908967572"
+  version "2.1.1.08d7b71"
+  head "https://github.com/youtube/vitess.git"
+
+  depends_on "go" => :build
+  depends_on "pkg-config" => :build
+
+  go_resource "github.com/kardianos/govendor" do
+    url "https://github.com/kardianos/govendor.git",
+        :tag => "v1.0.9"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    contents = Dir["{*,.git,.gitignore}"]
+    (buildpath/"src/github.com/youtube/vitess").install contents
+
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    Language::Go.stage_deps resources, buildpath/"src"
+    cd "src/github.com/kardianos/govendor" do
+      system "go", "install"
+    end
+
+    cd "src/github.com/youtube/vitess" do
+      system "govendor", "sync"
+
+      system "make", "build"
+      prefix.install "web"
+    end
+
+    %w[vtclient
+       vtcombo
+       vtctl
+       vtctlclient
+       vtctld
+       vtexplain
+       vtgate
+       vtqueryserver
+       vttablet
+       vtworker
+       vtworkerclient].each do |binary|
+      bin.install "bin/#{binary}"
+    end
+  end
+
+  test do
+    begin
+      pid = fork do
+        exec bin/"vtcombo",
+             "-port=15900",
+             "-mycnf_server_id", "1",
+             "-web_dir", "#{prefix}/web/vtctld",
+             "-web_dir2", "#{prefix}/web/vtctld2/app"
+      end
+      sleep 1
+      output = shell_output("curl -I 127.0.0.1:15900/app2/")
+      assert_match "200 OK", output
+    ensure
+      Process.kill(9, pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
### What is Vitess?
Vitess is a proxy on top of MySQL built by YouTube to add a sharding framework as well as other features on top of MySQL.
See http://vitess.io for more.

### What is in here?
This adds a formula to install vitess binaries.
Note 1: for now, I am pointing to a branch I have, until we figure out how we can vendor the libs into the project. see https://github.com/youtube/vitess/pull/3678
Note 2: Most of Vitess' users build it from Master, that's why I picked the latest SHA there. The latest version is 2.1.1 which is old. Soon we will release version 3. Once that gets released we can bump it here. Is it OK for now to run out of master?

### Which dependencies Vitess need?
It is a go project, so it needs Go to compile it.

cc @sougou
review @MikeMcQuaid  

