### PR TITLE
augustus: Recompile auxprogs for macOS

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -3,6 +3,7 @@ class Augustus < Formula
   homepage "http://bioinf.uni-greifswald.de/augustus/"
   url "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz"
   sha256 "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,13 +12,23 @@ class Augustus < Formula
     sha256 "57d0cdab04164c968240245b95159b21e464d7988dd4063d758dbfbb93e1b25a" => :el_capitan
   end
 
+  depends_on "bamtools"
   depends_on "boost"
 
   def install
+    # Fix error: api/BamReader.h: No such file or directory
+    inreplace "auxprogs/bam2hints/Makefile",
+      "INCLUDES = /usr/include/bamtools",
+      "INCLUDES = #{Formula["bamtools"].include/"bamtools"}"
+    inreplace "auxprogs/filterBam/src/Makefile",
+      "BAMTOOLS = /usr/include/bamtools",
+      "BAMTOOLS= #{Formula["bamtools"].include/"bamtools"}"
+
     # Prevent symlinking into /usr/local/bin/
     inreplace "Makefile", %r{ln -sf.*/usr/local/bin/}, "#ln -sf"
 
     # Compile executables for macOS. Tarball ships with executables for Linux.
+    system "make", "clean"
     system "make"
 
     system "make", "install", "INSTALLDIR=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This bottle included four ELF files bundled in the source code:
bam2hints, filterBam, homGeneMapping, joingenes.
Compile those tools for macOS. Depends on bamtools.