### PR TITLE
jnettop: switch back to the official source tarball url

### DIFF
--- a/Formula/jnettop.rb
+++ b/Formula/jnettop.rb
@@ -1,11 +1,9 @@
 class Jnettop < Formula
   desc "View hosts/ports taking up the most network traffic"
   homepage "https://web.archive.org/web/20161127214942/jnettop.kubs.info/wiki/"
-  # Please switch back to the canonical source on the next update:
-  # https://downloads.sourceforge.net/project/jnettop/jnettop/0.13/jnettop-0.13.0.tar.gz
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jnettop/jnettop_0.13.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jnettop/jnettop_0.13.0.orig.tar.gz"
-  sha256 "e987a1a9325595c8a0543ab61cf3b6d781b4faf72dd0e0e0c70b2cc2ceb5a5a0"
+  url "https://downloads.sourceforge.net/project/jnettop/jnettop/0.13/jnettop-0.13.0.tar.gz"
+  sha256 "a005d6fa775a85ff9ee91386e25505d8bdd93bc65033f1928327c98f5e099a62"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The official one has an extra 4 lines in ChangeLog, other
than that it is identical to the tarball used so far:

```diff
diff -r -u jnettop-0.13.0/ChangeLog jnettop-0.13.0-official/ChangeLog
--- jnettop-0.13.0/ChangeLog	2006-04-11 15:21:05.000000000 +0000
+++ jnettop-0.13.0-official/ChangeLog	2006-05-01 17:22:21.000000000 +0000
@@ -1,3 +1,7 @@
+2006-05-01	Jakub Skopal <j@kubs.cz>
+ * added support for JNET protocol (used by jnettop-gui)
+ * minor refactorings
+
 2006-04-11	Jakub Skopal <j@kubs.cz>
  * added support for UIA output (protocol and sources provided by Justin Killen)
  * added support for conditional compilation of ncurses and uia output
```
