### PR TITLE
add formula for azure-functions-core-tools

### DIFF
--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -1,0 +1,22 @@
+class AzureFunctionsCoreTools < Formula
+  desc "Azure Function Cli 2.0"
+  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/2.0.1-beta.22/osx/azure.functions.cli.osx-x64.2.0.1-beta.22.zip"
+  version "2.0.1-beta.22"
+  sha256 "d99f03b54c399479246d6c395dd1fa93092769796e7a5bbd5c6b5da1c07fd766"
+  head "https://github.com/Azure/azure-functions-core-tools"
+
+  bottle :unneeded
+
+  def install
+    prefix.install Dir["*"]
+    chmod 0555, prefix/"func"
+    bin.install_symlink prefix/"func"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/func")
+    system bin/"func", "new", "-l", "C#", "-t", "HttpTrigger", "-n", "confusedDevTest"
+    assert_predicate testpath/"confusedDevTest/function.json", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[azure-functions-core-tools](https://github.com/Azure/azure-functions-core-tools) already works in MacOS, but it was installed using `npm`, we want to provide a `homebrew` experience

Reading [formula requirements](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md#acceptable-formulae), we are having some issues:
1. "[Binares are not welcome](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md#we-dont-like-binary-formulae)". However, we cannot use source code, it requires `dotnet sdk` to build, and is currently not available through `homebrew`. Same goes for bytecode... we need `dotnet runtime` which does not have a formula in core repo. [Here](https://github.com/dotnet/cli/issues/533) is the issue tracking that
2. "[Version cannot be beta](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md#stable-versions)". This is developer tool, so even when its under `beta`, we still want to distribute it to our users. Is there a workaround or can you guys make an exception? I do notice there is a [`unstable_whitelist`](https://github.com/Homebrew/brew/blob/650d6dbaac625a758881a215a35d8d4a248de5bf/Library/Homebrew/dev-cmd/audit.rb#L542-L564) when running `brew audit`

If possible, we would really want to make it work here instead of moving to cask, which is one extra step for our developers and it seems that this type of formula does not meet [cask requirement](https://github.com/caskroom/homebrew-cask/blob/master/doc/faq/rejected_casks.md):

> The app is both open-source and CLI-only (i.e. it only uses the binary artifact). In that case, and in the spirit of deduplication, submit it first to Homebrew/core. If it is rejected there, you may then try again in Homebrew-Cask (link us to the issue on Homebrew so we can see their reasoning for rejection).