### PR TITLE
Secure URLs

### DIFF
--- a/Formula/jnethack.rb
+++ b/Formula/jnethack.rb
@@ -24,7 +24,8 @@ class Jnethack < Formula
   skip_clean "libexec/save"
 
   patch do
-    url "https://ja.osdn.net/frs/redir.php?f=jnethack%2F58545%2Fjnethack-3.4.3-0.11.diff.gz"
+    # Canonical: https://osdn.net/dl/jnethack/jnethack-3.4.3-0.11.diff.gz
+    url "https://dotsrc.dl.osdn.net/osdn/jnethack/58545/jnethack-3.4.3-0.11.diff.gz"
     sha256 "fbc071f6b33c53d89e8f13319ced952e605499a21d2086077296c631caff7389"
   end
 

--- a/Formula/lha.rb
+++ b/Formula/lha.rb
@@ -1,8 +1,8 @@
 class Lha < Formula
   desc "Utility for creating and opening lzh archives"
   homepage "https://lha.osdn.jp/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Flha%2F22231%2Flha-1.14i-ac20050924p1.tar.gz"
-  mirror "http://dl.osdn.jp/lha/22231/lha-1.14i-ac20050924p1.tar.gz"
+  # Canonical: https://osdn.net/dl/lha/lha-1.14i-ac20050924p1.tar.gz
+  url "https://dotsrc.dl.osdn.net/osdn/lha/22231/lha-1.14i-ac20050924p1.tar.gz"
   version "1.14i-ac20050924p1"
   sha256 "b5261e9f98538816aa9e64791f23cb83f1632ecda61f02e54b6749e9ca5e9ee4"
 

--- a/Formula/librcsc.rb
+++ b/Formula/librcsc.rb
@@ -1,8 +1,8 @@
 class Librcsc < Formula
   desc "RoboCup Soccer Simulator library"
   homepage "https://osdn.net/projects/rctools/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Frctools%2F51941%2Flibrcsc-4.1.0.tar.gz"
-  mirror "http://dl.osdn.jp/rctools/51941/librcsc-4.1.0.tar.gz"
+  # Canonical: https://osdn.net/dl/rctools/librcsc-4.1.0.tar.gz
+  url "https://dotsrc.dl.osdn.net/osdn/rctools/51941/librcsc-4.1.0.tar.gz"
   sha256 "1e8f66927b03fb921c5a2a8c763fb7297a4349c81d1411c450b180178b46f481"
 
   bottle do

--- a/Formula/mecab-unidic-extended.rb
+++ b/Formula/mecab-unidic-extended.rb
@@ -1,8 +1,8 @@
 class MecabUnidicExtended < Formula
   desc "Extended morphological analyzer for MeCab"
   homepage "https://osdn.net/projects/unidic/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Funidic%2F58338%2Funidic-mecab_kana-accent-2.1.2_src.zip"
-  mirror "http://dl.osdn.jp/unidic/58338/unidic-mecab_kana-accent-2.1.2_src.zip"
+  # Canonical: https://osdn.net/dl/unidic/unidic-mecab_kana-accent-2.1.2_src.zip
+  url "https://dotsrc.dl.osdn.net/osdn/unidic/58338/unidic-mecab_kana-accent-2.1.2_src.zip"
   sha256 "70793cacda81b403eda71736cc180f3144303623755a612b13e1dffeb6554591"
 
   bottle do

--- a/Formula/mecab-unidic.rb
+++ b/Formula/mecab-unidic.rb
@@ -1,8 +1,8 @@
 class MecabUnidic < Formula
   desc "Morphological analyzer for MeCab"
   homepage "https://osdn.net/projects/unidic/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Funidic%2F58338%2Funidic-mecab-2.1.2_src.zip"
-  mirror "http://dl.osdn.jp/unidic/58338/unidic-mecab-2.1.2_src.zip"
+  # Canonical: https://osdn.net/dl/unidic/unidic-mecab-2.1.2_src.zip
+  url "https://dotsrc.dl.osdn.net/osdn/unidic/58338/unidic-mecab-2.1.2_src.zip"
   sha256 "6cce98269214ce7de6159f61a25ffc5b436375c098cc86d6aa98c0605cbf90d4"
 
   bottle do

--- a/Formula/nicovideo-dl.rb
+++ b/Formula/nicovideo-dl.rb
@@ -1,8 +1,8 @@
 class NicovideoDl < Formula
   desc "Command-line program to download videos from www.nicovideo.jp"
   homepage "https://osdn.net/projects/nicovideo-dl/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Fnicovideo-dl%2F56304%2Fnicovideo-dl-0.0.20120212.tar.gz"
-  mirror "http://dl.osdn.jp/nicovideo-dl/56304/nicovideo-dl-0.0.20120212.tar.gz"
+  # Canonical: https://osdn.net/dl/nicovideo-dl/nicovideo-dl-0.0.20120212.tar.gz
+  url "https://dotsrc.dl.osdn.net/osdn/nicovideo-dl/56304/nicovideo-dl-0.0.20120212.tar.gz"
   sha256 "a50e9d5c9c291e1e10e5fc3ad27d528b49c9671bdd63e36fb2f49d70b54b89d8"
 
   bottle :unneeded

--- a/Formula/nkf.rb
+++ b/Formula/nkf.rb
@@ -1,8 +1,8 @@
 class Nkf < Formula
   desc "Network Kanji code conversion Filter (NKF)"
   homepage "https://osdn.net/projects/nkf/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Fnkf%2F64158%2Fnkf-2.1.4.tar.gz"
-  mirror "http://dl.osdn.jp/nkf/64158/nkf-2.1.4.tar.gz"
+  # Canonical: https://osdn.net/dl/nkf/nkf-2.1.4.tar.gz
+  url "https://dotsrc.dl.osdn.net/osdn/nkf/64158/nkf-2.1.4.tar.gz"
   sha256 "b4175070825deb3e98577186502a8408c05921b0c8ff52e772219f9d2ece89cb"
 
   bottle do

--- a/Formula/vnstat.rb
+++ b/Formula/vnstat.rb
@@ -1,7 +1,7 @@
 class Vnstat < Formula
   desc "Console-based network traffic monitor"
-  homepage "http://humdi.net/vnstat/"
-  url "http://humdi.net/vnstat/vnstat-1.17.tar.gz"
+  homepage "https://humdi.net/vnstat/"
+  url "https://humdi.net/vnstat/vnstat-1.17.tar.gz"
   sha256 "18e4c53576ca9e1ef2f0e063a6d83b0c44e3b1cf008560d658745df5c9aa7971"
   head "https://github.com/vergoh/vnstat.git"
 

--- a/Formula/yash.rb
+++ b/Formula/yash.rb
@@ -1,8 +1,8 @@
 class Yash < Formula
   desc "Yet another shell: a POSIX-compliant command-line shell"
   homepage "https://yash.osdn.jp/"
-  url "https://ja.osdn.net/frs/redir.php?f=%2Fyash%2F68578%2Fyash-2.46.tar.xz"
-  mirror "http://dl.osdn.jp/yash/68578/yash-2.46.tar.xz"
+  # Canonical: https://osdn.net/dl/yash/yash-2.46.tar.xz
+  url "https://dotsrc.dl.osdn.net/osdn/yash/68578/yash-2.46.tar.xz"
   sha256 "93431d897ce2b176c9f97b879c70a426ebc125b073d5894c00cd746f3a8455cb"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
OSDN (osdn.net) canonical URLs don't work with Homebrew's default download method, because they [require](https://github.com/Homebrew/homebrew-core/pull/24575#issuecomment-368809322) a User Agent starting with `curl/` or `Wget/`. They will also redirect to a mixture of HTTP and HTTPS effective URLs (mostly HTTP). So, link directly to the single HTTPS mirror offered and include the canonical URL as a comment.

This PR also contains a non-OSDN patch for `vnstat`.