### PR TITLE
 ipython,  ipython@5,  jupyter, urh: depend on zeromq

### DIFF
--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -5,7 +5,7 @@ class Ipython < Formula
   homepage "https://ipython.org/"
   url "https://files.pythonhosted.org/packages/fa/50/974211502bd72873728d44c3013fe79875c819c8fb69f778bcfd67bc7d38/ipython-6.2.1.tar.gz"
   sha256 "51c158a6c8b899898d1c91c6b51a34110196815cc905f9be0fa5878e19355608"
-  revision 2
+  revision 3
   head "https://github.com/ipython/ipython.git"
 
   bottle do
@@ -16,6 +16,7 @@ class Ipython < Formula
   end
 
   depends_on "python"
+  depends_on "zeromq"
 
   resource "appnope" do
     url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"

--- a/Formula/ipython@5.rb
+++ b/Formula/ipython@5.rb
@@ -3,7 +3,7 @@ class IpythonAT5 < Formula
   homepage "https://ipython.org/"
   url "https://files.pythonhosted.org/packages/14/7c/bbc1e749e1739208324af3f05ac7256985e21fc5f24d3c8da20aae844ad0/ipython-5.5.0.tar.gz"
   sha256 "66469e894d1f09d14a1f23b971a410af131daa9ad2a19922082e02e0ddfd150f"
-  revision 3
+  revision 4
   head "https://github.com/ipython/ipython.git", :branch => "5.x"
 
   bottle do
@@ -16,6 +16,7 @@ class IpythonAT5 < Formula
   keg_only :versioned_formula
 
   depends_on "python@2"
+  depends_on "zeromq"
 
   resource "appnope" do
     url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"

--- a/Formula/jupyter.rb
+++ b/Formula/jupyter.rb
@@ -3,7 +3,7 @@ class Jupyter < Formula
   homepage "https://jupyter.org/"
   url "https://files.pythonhosted.org/packages/c9/a9/371d0b8fe37dd231cf4b2cff0a9f0f25e98f3a73c3771742444be27f2944/jupyter-1.0.0.tar.gz"
   sha256 "d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -19,6 +19,7 @@ class Jupyter < Formula
 
   depends_on "ipython@5"
   depends_on "python@2"
+  depends_on "zeromq"
   depends_on "pandoc" if build.with?("nbconvert") || build.with?("notebook")
   depends_on "pyqt" if build.with? "qtconsole"
 

--- a/Formula/urh.rb
+++ b/Formula/urh.rb
@@ -3,7 +3,7 @@ class Urh < Formula
   homepage "https://github.com/jopohl/urh"
   url "https://files.pythonhosted.org/packages/76/14/f5a44ea32d473f9432c05087b5cab4c77882a18da48c2d258474d0fe7c63/urh-2.0.0.tar.gz"
   sha256 "b52b6d85a2f5af1fc87603365d6572dd1b68f396b281f7059fe32415f8ea03dd"
-  revision 1
+  revision 2
   head "https://github.com/jopohl/urh.git"
 
   bottle do
@@ -18,6 +18,7 @@ class Urh < Formula
 
   depends_on "python"
   depends_on "pyqt"
+  depends_on "zeromq"
 
   depends_on "hackrf" => :optional
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

IMO, leaving it as-is by explicitly enforcing `pyzmq` using its bundled `zeromq` might be better than introducing `zeromq` as a new dependency. 🤔️ However, @ilovezfs, if you prefer the latter, we can always change it. 🧐