### PR TITLE
lastpass-cli - add bash and fish completion scripts

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -23,6 +23,9 @@ class LastpassCli < Formula
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
     system "make", "PREFIX=#{prefix}", "install"
     system "make", "MANDIR=#{man}", "install-doc"
+
+    bash_completion.install "contrib/lpass_bash_completion"
+    fish_completion.install "contrib/completions-lpass.fish"
   end
 
   test do


### PR DESCRIPTION
Added to the formula the code to install the bash and fish completion
scripts.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
