### PR TITLE
ode 0.15.2: build with libccd by default

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -50,7 +50,8 @@ class Ode < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-I#{include}/ode", "-L#{lib}", "-lode", "-lc++", "-o", "test"
+    system ENV.cc, "test.cpp", "-I#{include}/ode", "-L#{lib}", "-lode", "-lccd",
+                   "-lc++", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -1,9 +1,10 @@
 class Ode < Formula
-  desc "Library for simulating articulated rigid body dynamics"
+  desc "Simulating articulated rigid body dynamics"
   homepage "http://www.ode.org/"
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.15.2.tar.gz"
   sha256 "2eaebb9f8b7642815e46227956ca223806f666acd11e31708bd030028cf72bac"
   head "https://bitbucket.org/odedevs/ode/", :using => :hg
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,24 +15,22 @@ class Ode < Formula
 
   option "with-double-precision", "Compile ODE with double precision"
   option "with-shared", "Compile ODE with shared library support"
-  option "with-libccd", "Enable all libccd colliders (except box-cylinder)"
   option "with-x11", "Build the drawstuff library and demos"
 
   deprecated_option "enable-double-precision" => "with-double-precision"
   deprecated_option "enable-shared" => "with-shared"
-  deprecated_option "enable-libccd" => "with-libccd"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "ccd"
   depends_on :x11 => :optional
 
   def install
-    args = ["--prefix=#{prefix}"]
+    args = ["--prefix=#{prefix}", "--enable-libccd"]
     args << "--enable-double-precision" if build.with? "double-precision"
     args << "--enable-shared" if build.with? "shared"
-    args << "--enable-libccd" if build.with? "libccd"
     args << "--with-demos" if build.with? "x11"
 
     inreplace "bootstrap", "libtoolize", "glibtoolize"

--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -24,7 +24,7 @@ class Ode < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "ccd"
+  depends_on "libccd"
   depends_on :x11 => :optional
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Building with `ccd` enables various collision pairs of primitives shapes (see this [code](https://bitbucket.org/odedevs/ode/src/6a68227619feebf85513331d7320b5a89eadf44f/ode/src/collision_kernel.cpp?at=default&fileviewer=file-view-default#collision_kernel.cpp-207:249)).