### PR TITLE
vim: make --with-python@2 hide the python dependency

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -32,7 +32,7 @@ class Vim < Formula
 
   depends_on "perl"
   depends_on "ruby"
-  depends_on "python" => :recommended
+  depends_on "python" => :recommended if build.without? "python@2"
   depends_on "gettext" => :optional
   depends_on "lua" => :optional
   depends_on "luajit" => :optional


### PR DESCRIPTION
This saves users a cumbersome --with-python@2 --without-python, which
has no additional meaning beyond just --with-python@2 since vim doesn't
support building with both Python 2 and Python 3 support simultaneously.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #24789.