### PR TITLE
pgloader: don't install man page if building HEAD

### DIFF
--- a/Formula/pgloader.rb
+++ b/Formula/pgloader.rb
@@ -329,7 +329,7 @@ class Pgloader < Formula
     system "make", "pgloader-standalone", "BUILDAPP=buildapp"
 
     bin.install "build/bin/pgloader"
-    man1.install "pgloader.1"
+    man1.install "pgloader.1" unless build.head?
   end
 
   def launch_postgres(socket_dir)


### PR DESCRIPTION
The man page was removed in dimitri/pgloader@6ae3bd18.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
