### PR TITLE
geckodriver: patch stable and add HEAD support

### DIFF
--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -1,9 +1,17 @@
 class Geckodriver < Formula
   desc "WebDriver <-> Marionette proxy"
   homepage "https://github.com/mozilla/geckodriver"
-  url "https://github.com/mozilla/geckodriver/archive/v0.19.1.tar.gz"
-  sha256 "f590ddfef42995a23e781b52befdbc2ac342bf829008e98d212f2e1e15d9f713"
   head "https://hg.mozilla.org/mozilla-central/", :using => :hg
+
+  stable do
+    url "https://github.com/mozilla/geckodriver/archive/v0.19.1.tar.gz"
+    sha256 "f590ddfef42995a23e781b52befdbc2ac342bf829008e98d212f2e1e15d9f713"
+
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/8920856c/geckodriver/bug-1435830.patch"
+      sha256 "578cdb22803c2f6ee00e8e0b1ca6fcde622c743572aad7038dda0d63cbce4500"
+    end
+  end
 
   bottle do
     sha256 "469b6c642b0029195c94eacf68cc4b8d90a51fcd39f1c6eee7a38b74face0f35" => :high_sierra

--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -7,8 +7,11 @@ class Geckodriver < Formula
     url "https://github.com/mozilla/geckodriver/archive/v0.19.1.tar.gz"
     sha256 "f590ddfef42995a23e781b52befdbc2ac342bf829008e98d212f2e1e15d9f713"
 
+    # Remove for > 0.19.1
+    # Fixes E0277 when building slog with Rust > 1.23
+    # Fixed upstream in https://hg.mozilla.org/mozilla-central/rev/cbd3741a4bb0 on 2018-02-15.
     patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/8920856c/geckodriver/bug-1435830.patch"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/e89f1ad/geckodriver/bug-1435830.patch"
       sha256 "578cdb22803c2f6ee00e8e0b1ca6fcde622c743572aad7038dda0d63cbce4500"
     end
   end

--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -3,6 +3,7 @@ class Geckodriver < Formula
   homepage "https://github.com/mozilla/geckodriver"
   url "https://github.com/mozilla/geckodriver/archive/v0.19.1.tar.gz"
   sha256 "f590ddfef42995a23e781b52befdbc2ac342bf829008e98d212f2e1e15d9f713"
+  head "https://hg.mozilla.org/mozilla-central/", :using => :hg
 
   bottle do
     sha256 "469b6c642b0029195c94eacf68cc4b8d90a51fcd39f1c6eee7a38b74face0f35" => :high_sierra
@@ -13,7 +14,8 @@ class Geckodriver < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build"
+    dir = build.head? ? "testing/geckodriver" : "."
+    cd(dir) { system "cargo", "build" }
     bin.install "target/debug/geckodriver"
     bin.install_symlink bin/"geckodriver" => "wires"
   end


### PR DESCRIPTION
I needed to build HEAD because stable is broken with current Rust.

https://bugzilla.mozilla.org/show_bug.cgi?id=1441204

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?