### PR TITLE
Install fields.yml file into etc/ for all beats formulas

### DIFF
--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -39,14 +39,14 @@ class Auditbeat < Formula
     ENV.prepend_path "PATH", buildpath/"vendor/bin"
 
     cd "src/github.com/elastic/beats/auditbeat" do
-      # prevent downloading binary wheels
-      inreplace "../libbeat/scripts/Makefile", "pip install", "pip install --no-binary :all"
       system "make"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
       (libexec/"bin").install "auditbeat"
       libexec.install "_meta/kibana"
 
-      (etc/"auditbeat").install Dir["auditbeat*.yml"]
+      (etc/"auditbeat").install Dir["auditbeat*.yml", "fields.yml"]
       prefix.install_metafiles
     end
 

--- a/Formula/filebeat.rb
+++ b/Formula/filebeat.rb
@@ -14,21 +14,35 @@ class Filebeat < Formula
 
   depends_on "go" => :build
 
+  resource "virtualenv" do
+    url "https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz"
+    sha256 "02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a"
+  end
+
   def install
-    gopath = buildpath/"gopath"
-    (gopath/"src/github.com/elastic/beats").install Dir["{*,.git,.gitignore}"]
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/elastic/beats").install Dir["{*,.git,.gitignore}"]
 
-    ENV["GOPATH"] = gopath
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
 
-    cd gopath/"src/github.com/elastic/beats/filebeat" do
+    resource("virtualenv").stage do
+      system "python", *Language::Python.setup_install_args(buildpath/"vendor")
+    end
+
+    ENV.prepend_path "PATH", buildpath/"vendor/bin"
+
+    cd "src/github.com/elastic/beats/filebeat" do
       system "make"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
+      system "make", "DEV_OS=darwin", "update"
       system "make", "modules"
       libexec.install "filebeat"
       (prefix/"module").install Dir["_meta/module.generated/*"]
-      (etc/"filebeat").install Dir["filebeat.*"]
+      (etc/"filebeat").install Dir["filebeat.*", "fields.yml"]
     end
 
-    prefix.install_metafiles gopath/"src/github.com/elastic/beats"
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"filebeat").write <<~EOS
       #!/bin/sh

--- a/Formula/heartbeat.rb
+++ b/Formula/heartbeat.rb
@@ -14,16 +14,32 @@ class Heartbeat < Formula
 
   depends_on "go" => :build
 
+  resource "virtualenv" do
+    url "https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz"
+    sha256 "02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/elastic/beats").install buildpath.children
 
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+
+    resource("virtualenv").stage do
+      system "python", *Language::Python.setup_install_args(buildpath/"vendor")
+    end
+
+    ENV.prepend_path "PATH", buildpath/"vendor/bin"
+
     cd "src/github.com/elastic/beats/heartbeat" do
       system "make"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
+      system "make", "DEV_OS=darwin", "update"
       (libexec/"bin").install "heartbeat"
       libexec.install "_meta/kibana"
 
-      (etc/"heartbeat").install Dir["heartbeat*.{json,yml}"]
+      (etc/"heartbeat").install Dir["heartbeat*.{json,yml}", "fields.yml"]
       prefix.install_metafiles
     end
 

--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -22,17 +22,33 @@ class Metricbeat < Formula
 
   depends_on "go" => :build
 
+  resource "virtualenv" do
+    url "https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz"
+    sha256 "02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/elastic/beats").install buildpath.children
 
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+
+    resource("virtualenv").stage do
+      system "python", *Language::Python.setup_install_args(buildpath/"vendor")
+    end
+
+    ENV.prepend_path "PATH", buildpath/"vendor/bin"
+
     cd "src/github.com/elastic/beats/metricbeat" do
       system "make"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
+      system "make", "DEV_OS=darwin", "update"
       system "make", "kibana"
       (libexec/"bin").install "metricbeat"
       libexec.install "_meta/kibana"
 
-      (etc/"metricbeat").install Dir["metricbeat*.yml"]
+      (etc/"metricbeat").install Dir["metricbeat*.yml", "fields.yml"]
       prefix.install_metafiles
     end
 

--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -32,17 +32,17 @@ class Packetbeat < Formula
     ENV.prepend_path "PATH", buildpath/"vendor/bin"
 
     cd "src/github.com/elastic/beats/packetbeat" do
-      # prevent downloading binary wheels
-      inreplace "../libbeat/scripts/Makefile", "pip install", "pip install --no-binary :all"
       system "make"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
+      system "make", "DEV_OS=darwin", "update"
       system "make", "update"
       (libexec/"bin").install "packetbeat"
       libexec.install "_meta/kibana"
 
       inreplace "packetbeat.yml", "packetbeat.interfaces.device: any", "packetbeat.interfaces.device: en0"
 
-      (etc/"packetbeat").install Dir["packetbeat*.yml"]
-      (etc/"packetbeat").install "fields.yml"
+      (etc/"packetbeat").install Dir["packetbeat*.yml", "fields.yml"]
       prefix.install_metafiles
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The various Beats formulas install default config files but fail to install `fields.yml` which comes standard with a new installation. There was some requisite python virtualenv changes to the formulas as well to satisfy some dependencies for the make targets, but this at least makes things a bit more standard since now all the beats do so instead of just auditbeat.