### PR TITLE
node, yarn: fix node-gyp after python3 -> python rename

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -3,6 +3,7 @@ class Node < Formula
   homepage "https://nodejs.org/"
   url "https://nodejs.org/dist/v9.7.1/node-v9.7.1.tar.xz"
   sha256 "06fae194a1eb962cc6f69f74f5be9f7c022265e7b3c3d7b08872157d02929042"
+  revision 1
   head "https://github.com/nodejs/node.git"
 
   bottle do
@@ -100,9 +101,12 @@ class Node < Formula
       cp Dir[libexec/"lib/node_modules/npm/man/#{man}/{npm,package.json,npx}*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 
-    npm_root = node_modules/"npm"
-    npmrc = npm_root/"npmrc"
-    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+    npmrc = <<~EOS
+      prefix = #{HOMEBREW_PREFIX}
+      python = /usr/bin/python\n
+    EOS
+    (node_modules/"npm"/"npmrc").atomic_write npmrc
+    (libexec/"lib/node_modules/npm/npmrc").atomic_write npmrc
   end
 
   def caveats

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,6 +3,7 @@ class Yarn < Formula
   homepage "https://yarnpkg.com/"
   url "https://yarnpkg.com/downloads/1.5.1/yarn-v1.5.1.tar.gz"
   sha256 "cd31657232cf48d57fdbff55f38bfa058d2fb4950450bd34af72dac796af4de1"
+  revision 1
 
   bottle :unneeded
 
@@ -12,13 +13,14 @@ class Yarn < Formula
 
   def install
     libexec.install Dir["*"]
-    (bin/"yarn").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX
-    (bin/"yarnpkg").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX
+    (bin/"yarn").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX, :NPM_CONFIG_PYTHON => "/usr/bin/python"
+    (bin/"yarnpkg").write_env_script "#{libexec}/bin/yarn.js", :PREFIX => HOMEBREW_PREFIX, :NPM_CONFIG_PYTHON => "/usr/bin/python"
     inreplace "#{libexec}/package.json", '"installationMethod": "tar"', '"installationMethod": "homebrew"'
   end
 
   test do
     (testpath/"package.json").write('{"name": "test"}')
     system bin/"yarn", "add", "jquery"
+    system bin/"yarn", "add", "fsevents", "--build-from-source=true"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `python3` to `python` rename from https://github.com/Homebrew/homebrew-core/pull/24604 has broken `node-gyp`, because it expects that `python` (on the `$PATH`) to be version 2.7.x.

Fixes: #24869 (look at this for additional context)

BTW: This issue was covered by our [native addon test](https://github.com/Homebrew/homebrew-core/blob/master/Formula/node.rb#L140) (`brew test node` is failing without this atm), but I can understand that you couldn't run all formulaes test in #24604.