### PR TITLE
Fix autoconf/automake with brewed perl installed

### DIFF
--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -19,7 +19,7 @@ class Autoconf < Formula
   keg_only :provided_until_xcode43
 
   def install
-    ENV["PERL"] = "/usr/bin/perl"
+    ENV["PERL"] = "/usr/bin/env perl"
 
     # force autoreconf to look for and use our glibtoolize
     inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"

--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -17,7 +17,7 @@ class Automake < Formula
   depends_on "autoconf" => :run
 
   def install
-    ENV["PERL"] = "/usr/bin/perl"
+    ENV["PERL"] = "/usr/bin/env perl"
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`autoconf` and `automake` fail to work if homebrew's verison of `perl` is installed, due to the hardcoded use of `/usr/bin/perl` interacting badly with `PERL_MM_OPT` setting recommended in the `perl` formula.

The PR switches `autoconf` and `automake` to use whatever `perl` is first in the path, which should be the homebrew version.

Fixes #24909.