### PR TITLE
par2: enable multi-threading

### DIFF
--- a/Formula/par2.rb
+++ b/Formula/par2.rb
@@ -11,6 +11,13 @@ class Par2 < Formula
     sha256 "d6e135782c3e4279e2233cba53d5fc62dc6ea3b5c8f0d2c07c653cc66cac2bcd" => :el_capitan
   end
 
+  option "with-openmp", "Build with OpenMP multithreading support"
+
+  if build.with? "openmp"
+    depends_on "gcc"
+    fails_with :clang
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Enable multi-threading for par2 through openmp.

Although doesn't pass `brew audit --strict par2`
>par2:
>  * C: 15: col 3: 'needs :openmp' should be replaced with 'depends_on "gcc"'
> Error: 1 problem in 1 formula

But llvm works fine and gcc seems unnecessary. 
Tried building it with gcc anyway, but pulled in some new dependencies (gmp, mpfr, libmpc, isl, gcc) and gave the following warning: 
> Warning: par2 dependency gcc was built with a different C++ standard
library (libstdc++ from clang). This may cause problems at runtime.

So aborted and stayed with my initial patch that's shown here.