### PR TITLE
faas-cli: fix set version.Version from tag on build

### DIFF
--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -22,8 +22,11 @@ class FaasCli < Formula
     cd "src/github.com/openfaas/faas-cli" do
       project = "github.com/openfaas/faas-cli"
       commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+      version = ""
+      tag = Utils.popen_read("git", "describe", "--all", "--exact-match", commit).strip
+      tag.match("tags/(.*)") { |m| version=m[1] }
       system "go", "build", "-ldflags",
-             "-s -w -X #{project}/version.GitCommit=#{commit}", "-a",
+             "-s -w -X #{project}/version.GitCommit=#{commit} -X #{project}/version.Version=#{version}", "-a",
              "-installsuffix", "cgo", "-o", bin/"faas-cli"
       bin.install_symlink "faas-cli" => "faas"
       pkgshare.install "template"

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -22,9 +22,6 @@ class FaasCli < Formula
     cd "src/github.com/openfaas/faas-cli" do
       project = "github.com/openfaas/faas-cli"
       commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
-      version = ""
-      tag = Utils.popen_read("git", "describe", "--all", "--exact-match", commit).strip
-      tag.match("tags/(.*)") { |m| version=m[1] }
       system "go", "build", "-ldflags",
              "-s -w -X #{project}/version.GitCommit=#{commit} -X #{project}/version.Version=#{version}", "-a",
              "-installsuffix", "cgo", "-o", bin/"faas-cli"
@@ -92,7 +89,9 @@ class FaasCli < Formula
 
       stable_resource = stable.instance_variable_get(:@resource)
       commit = stable_resource.instance_variable_get(:@specs)[:revision]
-      assert_match commit, shell_output("#{bin}/faas-cli version")
+      faas_cli_version = shell_output("#{bin}/faas-cli version")
+      assert_match /\s#{commit}$/, faas_cli_version
+      assert_match /\s#{version}$/, faas_cli_version
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)


### PR DESCRIPTION
This PR sets the `version.Version` variable from the git tag at build time for inclusion in the version subcommand.

Signed-off-by: John McCabe <john@johnmccabe.net>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
