### PR TITLE
Gecode 6.0.0: updated repository and sha256 (see issues)

### DIFF
--- a/Formula/gecode.rb
+++ b/Formula/gecode.rb
@@ -1,8 +1,8 @@
 class Gecode < Formula
   desc "Toolkit for developing constraint-based systems and applications"
   homepage "http://www.gecode.org/"
-  url "http://www.gecode.org/download/gecode-6.0.0.tar.gz"
-  sha256 "79b8ef0253ba5ac2cbc8b8adf45abff2884b1ba6705bc26d6a1758331e79f8db"
+  url "https://github.com/Gecode/gecode/archive/release-6.0.0.tar.gz"
+  sha256 "58621b01fd069a488a3020491ec36b4293a5da42e7750bd8fc758b0c3a92daad"
 
   bottle do
     cellar :any


### PR DESCRIPTION
…d of the original www.gecode.org) and sha256 signature (the archive has been updated).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The `brew audit --strict` was pending because of the change of sha256. According to the message I also opened an issue for this purpose.