### PR TITLE
fio: use Homebrew's CFLAGS

### DIFF
--- a/Formula/fio.rb
+++ b/Formula/fio.rb
@@ -12,13 +12,13 @@ class Fio < Formula
   end
 
   def install
-    system "./configure"
-    # fio's CFLAGS passes vital stuff around, and crushing it will break the build
+    system "./configure", "--cc=#{ENV.cc}",
+                          "--disable-optimizations",
+                          "--extra-cflags=#{ENV.cflags}"
     system "make", "prefix=#{prefix}",
                    "mandir=#{man}",
                    "sharedir=#{share}",
-                   "CC=#{ENV.cc}",
-                   "V=true", # get normal verbose output from fio's makefile
+                   "V=1", # get normal verbose output from fio's makefile
                    "install"
   end
 


### PR DESCRIPTION
Sadly I'm not in a position to test this change on a real system but I'll post it here for at least review to try and help head off potential future problems.

----

Fio is switching to add march=native by default in 3.6 (see
https://github.com/axboe/fio/commit/a817dc3b3b5a0efc95aaca366875eac67607cd5b
) which can result in binaries that only run on machines similar or
better than the build system. Fix this by disabling fio's default
internal optimization CFLAGS and let Homebrew pass its own in. This
means the build will probably no longer default to -O3 but perhaps it
would be better to set that from the formula so it's more readily under
user control.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----