### PR TITLE
python*: tweak caveats.

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -334,21 +334,26 @@ class Python < Formula
       xy = version.to_s.slice(/(3\.\d)/) || "3.6"
     end
     text = <<~EOS
-      Pip, setuptools, and wheel have been installed. To update them
+      Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
+      `python3`, `python3-config`, `pip3` etc., respectively, have been installed into
+        #{HOMEBREW_PREFIX}/bin
+
+      If you need Homebrew's Python 2.7 run
+        brew install python@2
+
+      If you wish to have python@2's python and python2 executables in your PATH then
+      add the following to #{shell_profile}:
+        export PATH="#{HOMEBREW_PREFIX}/opt/python@2/libexec/bin:#{HOMEBREW_PREFIX}/opt/python@2/bin:$PATH"
+
+      Pip, setuptools, and wheel have been installed. To update them run
         pip3 install --upgrade pip setuptools wheel
 
       You can install Python packages with
         pip3 install <package>
-
       They will install into the site-package directory
         #{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}
 
       See: https://docs.brew.sh/Homebrew-and-Python
-
-      Unversioned symlinks python, python-config, pip etc. pointing to python3,
-      python3-config, pip3 etc., respectively, have been installed.
-
-      If you need Homebrew's Python 2, `brew install python@2`.
     EOS
 
     # Tk warning only for 10.6

--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -371,22 +371,25 @@ class PythonAT2 < Formula
     EOS
   end
 
-  def caveats; <<~EOS
-    This formula installs a python2 executable to #{opt_bin}
-    If you wish to have this formula's python executable in your PATH then add
-    the following to #{shell_profile}:
-      export PATH="#{opt_libexec}/bin:$PATH"
+  def caveats
+    <<~EOS
+      If you wish to have this formula's `python2`, `python2-config`, `pip2` etc.
+      executables in your PATH then add the following to #{shell_profile}:
+        export PATH="#{opt_bin}:$PATH"
 
-    Pip and setuptools have been installed. To update them
-      pip2 install --upgrade pip setuptools
+      If you wish to have this formula's `python` executable in your PATH then add
+      the following to #{shell_profile}:
+        export PATH="#{opt_libexec}/bin:$PATH"
 
-    You can install Python packages with
-      pip2 install <package>
+      Pip and setuptools have been installed. To update them run
+        pip2 install --upgrade pip setuptools
 
-    They will install into the site-package directory
-      #{site_packages}
+      You can install Python packages with
+        pip2 install <package>
+      They will install into the site-package directory
+        #{site_packages}
 
-    See: https://docs.brew.sh/Homebrew-and-Python
+      See: https://docs.brew.sh/Homebrew-and-Python
     EOS
   end
 


### PR DESCRIPTION
This should help people who need `python` or `python2` in their `PATH`.