### PR TITLE
coreos-ct: fix incorrect version output

### DIFF
--- a/Formula/coreos-ct.rb
+++ b/Formula/coreos-ct.rb
@@ -14,7 +14,7 @@ class CoreosCt < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "all"
+    system "make", "all", "VERSION=v#{version}"
     bin.install "./bin/ct"
   end
 


### PR DESCRIPTION
Without this change, ct reports the incorrect version, as reported here:
https://github.com/coreos/bugs/issues/2333

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

(Note: I had a friend with a macbook do the `test` / `audit` steps since I don't have one handy)