### PR TITLE
php: do not require root access for starting php as a service

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -259,7 +259,7 @@ class Php < Formula
     version.to_s.split(".")[0..1].join(".")
   end
 
-  plist_options :startup => true, :manual => "php-fpm"
+  plist_options :manual => "php-fpm"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
As pointed out in https://github.com/Homebrew/homebrew-core/commit/4dbb4adf8ebdccc947c2f20f08e8e3ca06c023a3#r27998037 you do not need root access to launch the php service unless you run it on a privileged port which is not the default.