### PR TITLE
Fix sha256 for libwebsockets 2.4.2 (release was re-tagged)

### DIFF
--- a/Formula/libwebsockets.rb
+++ b/Formula/libwebsockets.rb
@@ -2,7 +2,8 @@ class Libwebsockets < Formula
   desc "C websockets server library"
   homepage "https://libwebsockets.org"
   url "https://github.com/warmcat/libwebsockets/archive/v2.4.2.tar.gz"
-  sha256 "5cfa77d712e9b9fabb85666a2a42ae712b744a613772f23d85385f30fbc3e0cf"
+  sha256 "73012d7fcf428dedccc816e83a63a01462e27819d5537b8e0d0c7264bfacfad6"
+  revision 1
   head "https://github.com/warmcat/libwebsockets.git"
 
   bottle do


### PR DESCRIPTION
Fix sha256 for libwebsockets 2.4.2 (release was re-tagged)

Closes #25017

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
