### PR TITLE
python, python@2: make PEP 394 compliant

### DIFF
--- a/Formula/ansible-lint.rb
+++ b/Formula/ansible-lint.rb
@@ -5,7 +5,7 @@ class AnsibleLint < Formula
   homepage "https://github.com/willthames/ansible-lint/"
   url "https://files.pythonhosted.org/packages/cd/d6/7e2abd17c523df9f8ae64694f12805c8f30934363f9eb6a68f9ffcbc2ff8/ansible-lint-3.4.20.tar.gz"
   sha256 "1e7f1d5d5ee91b817dedc0b612c2beb5ff44879d592ea17a2eaa6571aa9a2bff"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -5,7 +5,7 @@ class Ansible < Formula
   homepage "https://www.ansible.com/"
   url "https://releases.ansible.com/ansible/ansible-2.4.3.0.tar.gz"
   sha256 "0e98b3a56928d03979d5f8e7ae5d8e326939111b298729b03f00b3ad8f998a3d"
-  revision 2
+  revision 3
   head "https://github.com/ansible/ansible.git", :branch => "devel"
 
   bottle do

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -6,6 +6,7 @@ class Awscli < Formula
   # awscli should only be updated every 10 releases on multiples of 10
   url "https://github.com/aws/aws-cli/archive/1.14.50.tar.gz"
   sha256 "d5705a1c04ce2b9fb6ca6faea3865f5519696b1449064a061eaf5ac35a590ba7"
+  revision 1
   head "https://github.com/aws/aws-cli.git", :branch => "develop"
 
   bottle do

--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -6,7 +6,7 @@ class BandcampDl < Formula
   url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-10.tar.gz"
   version "0.0.8-10"
   sha256 "f02b5067faba3d8e133f9121194cb59d33dc3cbff79eeef5349003e812293c7e"
-  revision 1
+  revision 2
   head "https://github.com/iheanyi/bandcamp-dl.git"
 
   bottle do

--- a/Formula/buku.rb
+++ b/Formula/buku.rb
@@ -5,7 +5,7 @@ class Buku < Formula
   homepage "https://github.com/jarun/Buku"
   url "https://github.com/jarun/Buku/archive/v3.6.tar.gz"
   sha256 "6126dbf820a18af69b0bd24eb86a04a71d4904ba84dc174b98c1050fae8f9fad"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -5,7 +5,7 @@ class ConjureUp < Formula
   homepage "https://conjure-up.io/"
   url "https://github.com/conjure-up/conjure-up/archive/2.5.5.tar.gz"
   sha256 "7a16b91c46c1f86eb7bc96597cbdb371ea94d062ff554c71615267cba54f3433"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/csvkit.rb
+++ b/Formula/csvkit.rb
@@ -5,7 +5,7 @@ class Csvkit < Formula
   homepage "https://csvkit.readthedocs.io/"
   url "https://files.pythonhosted.org/packages/53/de/a8ee2fb47af463251fd39e0dc2b7356ceb58fd0f5867f7f6d0f7cc6e8a0d/csvkit-1.0.2.tar.gz"
   sha256 "5a897f87c920dec3e7debc31102dfe774a8d704641bfafa98e04729bd4d26e17"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/csvtomd.rb
+++ b/Formula/csvtomd.rb
@@ -5,7 +5,7 @@ class Csvtomd < Formula
   homepage "https://github.com/mplewis/csvtomd"
   url "https://files.pythonhosted.org/packages/2f/41/289bedde7fb32d817d5802eff68b99546842cb34df840665ec39b363f258/csvtomd-0.2.1.tar.gz"
   sha256 "d9fdf166c3c299ad5800b3cb1661f223b98237f38f22e9d253d45d321f70ec72"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -5,7 +5,7 @@ class Fdroidserver < Formula
   homepage "https://f-droid.org"
   url "https://files.pythonhosted.org/packages/df/29/163c75b97f8c83f2eb1f5d55978f630a0a99fda989ad857e78cba6eb64fe/fdroidserver-1.0.2.tar.gz"
   sha256 "abb5a16f8e21b4683255a61707d2c31123ad3ab5b091c490aaa524c6b8dfa9a5"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any

--- a/Formula/httpie.rb
+++ b/Formula/httpie.rb
@@ -5,7 +5,7 @@ class Httpie < Formula
   homepage "https://httpie.org/"
   url "https://files.pythonhosted.org/packages/28/93/4ebf2de4bc74bd517a27a600b2b23a5254a20f28e6e36fc876fd98f7a51b/httpie-0.9.9.tar.gz"
   sha256 "f1202e6fa60367e2265284a53f35bfa5917119592c2ab08277efc7fffd744fcb"
-  revision 2
+  revision 3
   head "https://github.com/jkbrzt/httpie.git"
 
   bottle do

--- a/Formula/juju-wait.rb
+++ b/Formula/juju-wait.rb
@@ -5,7 +5,7 @@ class JujuWait < Formula
   homepage "https://launchpad.net/juju-wait"
   url "https://files.pythonhosted.org/packages/3d/c2/8cce9ec8386be418a76566fcd2e7dcbaa7138a92b0b9b463306d9191cfd7/juju-wait-2.6.2.tar.gz"
   sha256 "86622804896e80f26a3ed15dff979584952ba484ccb5258d8bab6589e26dd46d"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/khal.rb
+++ b/Formula/khal.rb
@@ -6,7 +6,7 @@ class Khal < Formula
   url "https://github.com/pimutils/khal.git",
       :tag => "v0.9.8",
       :revision => "b03df58c129f99a35ba74cda0fbc253eb47cfeac"
-  revision 2
+  revision 3
   head "https://github.com/pimutils/khal.git"
 
   bottle do

--- a/Formula/khard.rb
+++ b/Formula/khard.rb
@@ -5,7 +5,7 @@ class Khard < Formula
   homepage "https://github.com/scheibler/khard/"
   url "https://files.pythonhosted.org/packages/19/91/6309d5b0477582b9b663cd65f1346cec6ed5f44e734bac722e1ca2ddc1e3/khard-0.12.2.tar.gz"
   sha256 "9193d2d07cdb69cc6e35a0732111efb92bbfba854a1dd42b4f9c91a52a16c507"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/magic-wormhole.rb
+++ b/Formula/magic-wormhole.rb
@@ -5,7 +5,7 @@ class MagicWormhole < Formula
   homepage "https://github.com/warner/magic-wormhole"
   url "https://files.pythonhosted.org/packages/b5/d3/5409c111835af19af00643a8fbd0c0a6f30f025400ca5bb72f59fd1e42fb/magic-wormhole-0.10.5.tar.gz"
   sha256 "9558ea1f3551e535deec3462cd5c8391cb32ebb12ecd8b40b36861dbee4917ee"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -5,7 +5,7 @@ class Mitmproxy < Formula
   homepage "https://mitmproxy.org"
   url "https://github.com/mitmproxy/mitmproxy/archive/v3.0.3.tar.gz"
   sha256 "e1e33275f4b581d7bc54ea0a014dd105d824f2b1da6068889f652fda8610bb5c"
-  revision 1
+  revision 2
   head "https://github.com/mitmproxy/mitmproxy.git"
 
   bottle do

--- a/Formula/molecule.rb
+++ b/Formula/molecule.rb
@@ -5,7 +5,7 @@ class Molecule < Formula
   homepage "https://molecule.readthedocs.io"
   url "https://files.pythonhosted.org/packages/aa/0f/dc6393eed9588e477a23488fbd23efd40246fcc64815179db6c8c892f554/molecule-1.25.1.tar.gz"
   sha256 "aeafd3a6c5a0de707308006dcf727883c9daf4446d18d9e68eb97659c51ebbb0"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/mps-youtube.rb
+++ b/Formula/mps-youtube.rb
@@ -5,7 +5,7 @@ class MpsYoutube < Formula
   homepage "https://github.com/mps-youtube/mps-youtube"
   url "https://github.com/mps-youtube/mps-youtube/archive/v0.2.8.tar.gz"
   sha256 "d5f2c4bc1f57f0566242c4a0a721a5ceaa6d6d407f9d6dd29009a714a0abec74"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/ponysay.rb
+++ b/Formula/ponysay.rb
@@ -3,7 +3,7 @@ class Ponysay < Formula
   homepage "http://erkin.co/ponysay/"
   url "https://github.com/erkin/ponysay/archive/3.0.3.tar.gz"
   sha256 "c382d7f299fa63667d1a4469e1ffbf10b6813dcd29e861de6be55e56dc52b28a"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/shyaml.rb
+++ b/Formula/shyaml.rb
@@ -5,7 +5,7 @@ class Shyaml < Formula
   homepage "https://github.com/0k/shyaml"
   url "https://files.pythonhosted.org/packages/f7/ec/4143e8ba92d1d3654535f17bc4354f72d3a3e7d6984926d9a7ce1dec46ed/shyaml-0.5.0.tar.gz"
   sha256 "b3711011d37aae4e07b68b31e989aa3715548d5b0759898eda2ba437b9ae3c36"
-  revision 2
+  revision 3
   head "https://github.com/0k/shyaml.git"
 
   bottle do

--- a/Formula/sip.rb
+++ b/Formula/sip.rb
@@ -4,6 +4,7 @@ class Sip < Formula
   url "https://dl.bintray.com/homebrew/mirror/sip-4.19.8.tar.gz"
   mirror "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.19.8/sip-4.19.8.tar.gz"
   sha256 "7eaf7a2ea7d4d38a56dd6d2506574464bddf7cf284c960801679942377c297bc"
+  revision 1
   head "https://www.riverbankcomputing.com/hg/sip", :using => :hg
 
   bottle do

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -5,7 +5,7 @@ class Snapcraft < Formula
   homepage "https://snapcraft.io/"
   url "https://files.pythonhosted.org/packages/f0/47/453ef9822fd35e4037e4364182e0c5ff57760fde64da0179d8275f83fb0e/snapcraft-2.39.tar.gz"
   sha256 "a1befdd554e27f0b57105fd7e45f8ea1c8a21fe4728d2b60058bee394df93ab9"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -5,7 +5,7 @@ class Thefuck < Formula
   homepage "https://github.com/nvbn/thefuck"
   url "https://files.pythonhosted.org/packages/ec/20/3f136313c27ea36ba38d31818b9f0a1a4656668fc6747b3bfa04f3debc98/thefuck-3.25.tar.gz"
   sha256 "70cbe6295d2d2d371a395619216d38eb1666e4b3c3b1a24f67d11b88e65fea78"
-  revision 2
+  revision 3
   head "https://github.com/nvbn/thefuck.git"
 
   bottle do

--- a/Formula/todoman.rb
+++ b/Formula/todoman.rb
@@ -5,7 +5,7 @@ class Todoman < Formula
   homepage "https://todoman.readthedocs.io/"
   url "https://files.pythonhosted.org/packages/b4/19/9d6fda7af4b17bd75c97efecfbc478f9e39af8c5228d644fc495c646c433/todoman-3.3.0.tar.gz"
   sha256 "dbbe12195d292b48cde8dd9324a14e695cdcb79f3800ddf5f29c8c71bc133952"
-  revision 1
+  revision 2
   head "https://github.com/pimutils/todoman.git"
 
   bottle do

--- a/Formula/vdirsyncer.rb
+++ b/Formula/vdirsyncer.rb
@@ -6,7 +6,7 @@ class Vdirsyncer < Formula
   url "https://github.com/pimutils/vdirsyncer.git",
       :tag => "0.16.4",
       :revision => "c63e55d0201fbfed23287216e7f8e19ff34d5ac3"
-  revision 1
+  revision 2
   head "https://github.com/pimutils/vdirsyncer.git"
 
   bottle do

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -4,7 +4,7 @@ class Vim < Formula
   # vim should only be updated every 50 releases on multiples of 50
   url "https://github.com/vim/vim/archive/v8.0.1553.tar.gz"
   sha256 "c7d6e4b44be07601deedda747dd26cced2d6b8d36e109ce0cf7a134addaf3cf8"
-  revision 1
+  revision 2
   head "https://github.com/vim/vim.git"
 
   bottle do

--- a/Formula/vim@7.4.rb
+++ b/Formula/vim@7.4.rb
@@ -3,7 +3,7 @@ class VimAT74 < Formula
   homepage "https://www.vim.org/"
   url "https://github.com/vim/vim/archive/v7.4.2367.tar.gz"
   sha256 "a9ae4031ccd73cc60e771e8bf9b3c8b7f10f63a67efce7f61cd694cd8d7cda5c"
-  revision 8
+  revision 9
 
   bottle do
     sha256 "a877a9c794cedf1e2cc39c32792616f0a8b619f54600638faa14063874bab970" => :high_sierra

--- a/Formula/xonsh.rb
+++ b/Formula/xonsh.rb
@@ -5,7 +5,7 @@ class Xonsh < Formula
   homepage "http://xon.sh"
   url "https://github.com/xonsh/xonsh/archive/0.6.0.tar.gz"
   sha256 "7d63d040a6df8749480becab4b3bcb1c6589458bad272d5de06c6a063c06c5f1"
-  revision 2
+  revision 3
   head "https://github.com/scopatz/xonsh.git"
 
   bottle do

--- a/Formula/you-get.rb
+++ b/Formula/you-get.rb
@@ -5,6 +5,7 @@ class YouGet < Formula
   homepage "https://you-get.org/"
   url "https://github.com/soimort/you-get/releases/download/v0.4.1040/you-get-0.4.1040.tar.gz"
   sha256 "fdc9021e8b1cf936aad4bd6c74b80ea8fa3573b807c41242ba781e247f8c8ca8"
+  revision 1
   head "https://github.com/soimort/you-get.git", :branch => "develop"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://www.python.org/dev/peps/pep-0394/

This means python (Python 3) installs as `python3` and that python@2
(Python 2) installs as `python` and `python2`.

Also,

python:
- make gdbm, readline, sqlite and xz required instead of recommended
- depend on sphinx-doc at build-time non-optionally to build the docs
- remove quicktest option

python@2:
- make non-keg_only
- make gdbm, readline and sqlite required instead of recommended
- depend on sphinx-doc at build-time non-optionally to build the docs
- remove berkeley-db@4 optional dependency
- remove quicktest option
- remove poll option and leave poll enabled instead of forcing it off
