### PR TITLE
jthread 1.3.3 (new formula)

### DIFF
--- a/Formula/jthread.rb
+++ b/Formula/jthread.rb
@@ -1,0 +1,34 @@
+class Jthread < Formula
+  desc "C++ class to make use of threads easy"
+  homepage "https://research.edm.uhasselt.be/jori/jthread"
+  url "https://research.edm.uhasselt.be/jori/jthread/jthread-1.3.3.tar.bz2"
+  sha256 "17560e8f63fa4df11c3712a304ded85870227b2710a2f39692133d354ea0b64f"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <jthread/jthread.h>
+      using namespace jthread;
+      int main() {
+        JMutex* jm = new JMutex();
+        jm->Init();
+        jm->Lock();
+        jm->Unlock();
+        return 0;
+      }
+    EOS
+
+    libs = `pkg-config --libs jthread`.chomp
+    cflags = `pkg-config --cflags jthread`.chomp
+
+    system "#{ENV.cxx} test.cpp -o test #{libs} #{cflags}"
+    system "./test"
+  end
+end

--- a/Formula/jthread.rb
+++ b/Formula/jthread.rb
@@ -16,6 +16,7 @@ class Jthread < Formula
     (testpath/"test.cpp").write <<~EOS
       #include <jthread/jthread.h>
       using namespace jthread;
+
       int main() {
         JMutex* jm = new JMutex();
         jm->Init();
@@ -25,10 +26,8 @@ class Jthread < Formula
       }
     EOS
 
-    libs = `pkg-config --libs jthread`.chomp
-    cflags = `pkg-config --cflags jthread`.chomp
-
-    system "#{ENV.cxx} test.cpp -o test #{libs} #{cflags}"
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-ljthread",
+                    "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The main reason for adding jthread to Homebrew, is so that I can also raise a PR for [JRTPLIB](https://github.com/j0r1/JRTPLIB) which depends upon the jthread library.

~~Note that `brew audit --strict` does not pass, because of passing a string with spaces into `system`, which is used in the test. The reason I have done this, is because one of the arguments is itself a string with spaces in it - so must be parsed by the shell.~~

~~I looked at doing this instead:~~
```ruby
libs = `pkg-config --libs jthread`.chomp.split
```

~~But it start getting complex/unreliable compared with just passing a single string to `system`.~~

~~Pointers to a better way of doing this would be very welcome.~~