### PR TITLE
Use python 3 on gobject-introspection on old macOS

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -15,7 +15,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
-  depends_on "python@2" if MacOS.version <= :mavericks
+  depends_on "python" if MacOS.version <= :mavericks
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",
@@ -32,7 +32,7 @@ class GobjectIntrospection < Formula
     python = if MacOS.version >= :yosemite
       "/usr/bin/python2.7"
     else
-      Formula["python@2"].opt_bin/"python2.7"
+      Formula["python"].opt_bin/"python3"
     end
 
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
On Mavericks and older, we use homebrew's python rather than system's
one to overcome some issues. gobject-introspection now supports python
3, so it's better to rely on it rather than on python 2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
