### PR TITLE
proj: Update to proj-datumgrids version 1.7

### DIFF
--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -3,6 +3,7 @@ class Proj < Formula
   homepage "http://proj4.org/"
   url "https://download.osgeo.org/proj/proj-5.0.0.tar.gz"
   sha256 "b30df08d736e69744cb255828721abb545b494d6032c13a96520f3219a444cd2"
+  revision 1
 
   bottle do
     sha256 "e8593ac943fbf2911a66b300c0c3f55ec7bfb9fe1ac636ff59ac50de85d04daa" => :high_sierra

--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -21,8 +21,8 @@ class Proj < Formula
 
   # The datum grid files are required to support datum shifting
   resource "datumgrid" do
-    url "https://download.osgeo.org/proj/proj-datumgrid-1.5.zip"
-    sha256 "723c4017d95d7a8abdf3bda4e18d3c15d79b00f9326d453da5fdf13f96c287db"
+    url "https://download.osgeo.org/proj/proj-datumgrid-1.7.zip"
+    sha256 "ffcad4453fac3b4a13ca678ef343e688496e18019f35709ef03c5f200e9fb85a"
   end
 
   # Vertical datum files
@@ -59,11 +59,6 @@ class Proj < Formula
   resource "vertconw" do
     url "https://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx"
     sha256 "de648c0f6e8b5ebfc4b2d82f056c7b993ca3c37373a7f6b7844fe9bd4871821b"
-  end
-
-  resource "egm96_15" do
-    url "https://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx"
-    sha256 "c02a6eb70a7a78efebe5adf3ade626eb75390e170bb8b3f36136a2c28f5326a0"
   end
 
   resource "egm08_25" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates the PROJ formula so it uses the most recent version of the proj-datumgrids package. Version 1.7 of this package now includes the `egm96_15.gtx` grid so this has been removed from the `--with-vdatum` install option.

Background info on the updated datumgrid package: http://lists.maptools.org/pipermail/proj/2018-March/008098.html
