### PR TITLE
lm4tools 0.1.3 (new formula)

### DIFF
--- a/Formula/lm4tools.rb
+++ b/Formula/lm4tools.rb
@@ -1,0 +1,19 @@
+class Lm4tools < Formula
+  desc "Tools for TI Stellaris Launchpad boards"
+  homepage "https://github.com/utzig/lm4tools"
+  url "https://github.com/utzig/lm4tools/archive/v0.1.3.tar.gz"
+  sha256 "e8064ace3c424b429b7e0b50e58b467d8ed92962b6a6dfa7f6a39942416b1627"
+  head "https://github.com/utzig/lm4tools.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    output = shell_output("echo data | #{bin}/lm4flash - 2>&1", 2)
+    assert_equal "Unable to find any ICDI devices\n", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Lm4tools is used for flashing and debugging TI ARM Cortex-M microcontrollers. I needed it and couldn't find a package so here's one.