### PR TITLE
rubberband: restore canonical url after upstream fix

### DIFF
--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -4,7 +4,7 @@ class Rubberband < Formula
   head "https://bitbucket.org/breakfastquay/rubberband/", :using => :hg
 
   stable do
-    url "https://breakfastquay.com/files/releases/34/rubberband-1.8.1.tar.bz2"
+    url "https://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2"
     mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/r/rubberband/rubberband_1.8.1.orig.tar.bz2"
     sha256 "ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75"
 


### PR DESCRIPTION
Ref: https://bitbucket.org/breakfastquay/rubberband/issues/22

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
