### PR TITLE
platformio 3.5.2

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -21,8 +21,8 @@ class Platformio < Formula
   end
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/23/3f/8be01c50ed24a4bd6b8da799839066ce0288f66f5e11f0367323467f0cbc/certifi-2017.11.5.tar.gz"
-    sha256 "5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+    url "https://files.pythonhosted.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz"
+    sha256 "edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
   end
 
   resource "chardet" do

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/a4/34/c8a8ea8a8f8082b0f49f4cdf1978d9c7564fc4d70ab0b58dcb805c294b9a/platformio-3.5.1.tar.gz"
-  sha256 "76f427e59be50f8ea8ab1cee97b721e9fb807ea3fd4a70e3f431dc037f2d8131"
+  url "https://files.pythonhosted.org/packages/7c/95/899efc1264c63d1ba1d32b4160b2fe3d48020de00f7b8c91dc5b712aa05f/platformio-3.5.2.tar.gz"
+  sha256 "bb311ce5b8f12c95bc45c2071626a4887a3632fb2472b4d69a873b2acfc2e4ec"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
* [PlatformIO Home](http://docs.platformio.org/page/home/index.html) - interact with PlatformIO ecosystem using modern and cross-platform GUI:

  - Multiple themes (Dark & Light)
  - Ability to specify a name for new project

* Control [PIO Unified Debugger](http://docs.platformio.org/en/latest/plus/debugging.html) and its firmware loading mode using [debug_load_mode](http://docs.platformio.org/en/latest/projectconf/section_env_debug.html#debug-load-mode) option
* Added aliases (off, light, strict) for [LDF Compatibility Mode](http://docs.platformio.org/page/librarymanager/ldf.html)
* Search for a library using PIO Library Registry ID ``id:X`` (e.g. ``pio lib search id:13``)
* Show device system information (MCU, Frequency, RAM, Flash, Debugging tools) in a build log
* Show all available upload protocols before firmware uploading in a build log
* Handle "os.mbed.com" URL as a Mercurial (hg) repository
* Improved support for old mbed libraries without manifest
* Fixed project generator for Qt Creator IDE ([issue #1303](https://github.com/platformio/platformio-core/issues/1303), [issue #1323](https://github.com/platformio/platformio-core/issues/1323))
* Mark project source and library directories for CLion IDE ([issue #1359](https://github.com/platformio/platformio-core/issues/1359), [issue #1345](https://github.com/platformio/platformio-core/issues/1345), [issue #897](https://github.com/platformio/platformio-core/issues/897))
* Fixed issue with duplicated "include" records when generating data for IDE ([issue #1301](https://github.com/platformio/platformio-core/issues/1301))