### PR TITLE
vips: fix libjpeg-turbo builds

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -25,7 +25,6 @@ class Vips < Formula
   depends_on "little-cms2"
   depends_on "orc"
   depends_on "pango"
-  depends_on "pygobject3"
   depends_on "fftw" => :recommended
   depends_on "poppler" => :recommended
   depends_on "graphicsmagick" => :optional
@@ -44,6 +43,11 @@ class Vips < Formula
 
     if build.with? "graphicsmagick"
       args << "--with-magick" << "--with-magickpackage=GraphicsMagick"
+    end
+
+    if build.with? "jpeg-turbo"
+      ENV["JPEG_CFLAGS"] = "-I#{Formula["jpeg-turbo"].opt_include}"
+      ENV["JPEG_LIBS"] = "-L#{Formula["jpeg-turbo"].opt_lib} -ljpeg"
     end
 
     args << "--without-libwebp" if build.without? "webp"

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -51,6 +51,11 @@ class Vips < Formula
         Formula["jpeg-turbo"].opt_lib/"pkgconfig"
     end
 
+    if build.with? "mozjpeg"
+      ENV.prepend_path "PKG_CONFIG_PATH",
+        Formula["mozjpeg"].opt_lib/"pkgconfig"
+    end
+
     args << "--without-libwebp" if build.without? "webp"
 
     system "./configure", *args

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -46,8 +46,8 @@ class Vips < Formula
     end
 
     if build.with? "jpeg-turbo"
-      ENV["JPEG_CFLAGS"] = "-I#{Formula["jpeg-turbo"].opt_include}"
-      ENV["JPEG_LIBS"] = "-L#{Formula["jpeg-turbo"].opt_lib} -ljpeg"
+      ENV.prepend_path "PKG_CONFIG_PATH",
+        Formula["jpeg-turbo"].opt_lib/"pkgconfig"
     end
 
     args << "--without-libwebp" if build.without? "webp"

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -25,6 +25,7 @@ class Vips < Formula
   depends_on "little-cms2"
   depends_on "orc"
   depends_on "pango"
+  depends_on "pygobject3"
   depends_on "fftw" => :recommended
   depends_on "poppler" => :recommended
   depends_on "graphicsmagick" => :optional


### PR DESCRIPTION
vips 8.6.3 uses pkg-config to find libjpeg. If you build vips with the
--with-jpeg-turbo option, you must somehow arrange for pkg-config to
find libjpeg-turbo (which is keg-only) rather than the standard libjpeg.

This patch sets the build environment variables `JPEG_CFLAGS` and
`JPEG_LIBS` to make pkg-config use libjpeg turbo instead.

See https://github.com/jcupitt/libvips/issues/902

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
