### PR TITLE
Rebuild macvim

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -5,7 +5,7 @@ class Macvim < Formula
   url "https://github.com/macvim-dev/macvim/archive/snapshot-145.tar.gz"
   version "8.0-145"
   sha256 "37ea193345421ea17731fe2a06806641ef6607d38829b195b596179f70810ce2"
-  revision 1
+  revision 2
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do


### PR DESCRIPTION
It doesn't work now, but it works when build from source.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
