### PR TITLE
neomutt: add s-lang support

### DIFF
--- a/Formula/neomutt.rb
+++ b/Formula/neomutt.rb
@@ -11,6 +11,8 @@ class Neomutt < Formula
     sha256 "089407d9e5b6743ad574e259e3a7efa7179f6ae16cd9594c4bdcafff2cf626f0" => :el_capitan
   end
 
+  option "with-s-lang", "Build against slang instead of ncurses"
+
   depends_on "docbook-xsl" => :build
   depends_on "gettext"
   depends_on "gpgme"
@@ -19,18 +21,29 @@ class Neomutt < Formula
   depends_on "notmuch"
   depends_on "openssl"
   depends_on "tokyo-cabinet"
+  depends_on "s-lang" => :optional
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-    system "./configure", "--prefix=#{prefix}",
-                          "--enable-gpgme",
-                          "--gss",
-                          "--lmdb",
-                          "--notmuch",
-                          "--sasl",
-                          "--tokyocabinet",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}",
-                          "--with-ui=ncurses"
+
+    args = %W[
+      --prefix=#{prefix}
+      --enable-gpgme
+      --gss
+      --lmdb
+      --notmuch
+      --sasl
+      --tokyocabinet
+      --with-ssl=#{Formula["openssl"].opt_prefix}
+    ]
+
+    if build.with? "s-lang"
+      args << "--with-ui=slang"
+    else
+      args << "--with-ui=ncurses"
+    end
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
Allow neomutt to be compiled with s-lang support instead of ncurses.