### PR TITLE
latexdiff 1.2.1 (new formula)

### DIFF
--- a/Formula/latexdiff.rb
+++ b/Formula/latexdiff.rb
@@ -5,12 +5,12 @@ class Latexdiff < Formula
   sha256 "12634c8ec5c68b173d3906679bb09330e724491c6a64e675989217cf4790604e"
 
   def install
+    bin.install %w[latexdiff-fast latexdiff-so latexdiff-vc
+                   latexrevise]
     # Replace standard latexdiff with latexdiff-so which uses an inlined
     # version of the Perl algorithm Algorithm::Diff.
     # This is the preferred method according to the README
-    cp "latexdiff-so", "latexdiff"
-    bin.install %w[latexdiff latexdiff-fast latexdiff-so latexdiff-vc
-                   latexrevise]
+    bin.install_symlink "latexdiff-so" => "latexdiff"
     man1.install %w[latexdiff-vc.1 latexdiff.1 latexrevise.1]
     doc.install Dir["doc/*"]
     pkgshare.install %w[contrib example]

--- a/Formula/latexdiff.rb
+++ b/Formula/latexdiff.rb
@@ -1,0 +1,43 @@
+class Latexdiff < Formula
+  desc "Determine and markup differences between two LaTeX files"
+  homepage "https://www.ctan.org/pkg/latexdiff"
+  url "https://github.com/ftilmann/latexdiff/releases/download/1.2.1/latexdiff-1.2.1.tar.gz"
+  sha256 "12634c8ec5c68b173d3906679bb09330e724491c6a64e675989217cf4790604e"
+
+  def install
+    # Replace standard latexdiff with latexdiff-so which uses an inlined
+    # version of the Perl algorithm Algorithm::Diff.
+    # This is the preferred method according to the README
+    cp "latexdiff-so", "latexdiff"
+    bin.install %w[latexdiff latexdiff-fast latexdiff-so latexdiff-vc
+                   latexrevise]
+    man1.install %w[latexdiff-vc.1 latexdiff.1 latexrevise.1]
+    doc.install Dir["doc/*"]
+    pkgshare.install %w[contrib example]
+  end
+
+  test do
+    (testpath/"test1.tex").write <<~EOS
+      \\documentclass{article}
+      \\begin{document}
+      Hello, world.
+      \\end{document}
+    EOS
+
+    (testpath/"test2.tex").write <<~EOS
+      \\documentclass{article}
+      \\begin{document}
+      Goodnight, moon.
+      \\end{document}
+    EOS
+
+    expect = /^\\DIFdelbegin \s+
+             \\DIFdel      \{ Hello,[ ]world \}
+             \\DIFdelend   \s+
+             \\DIFaddbegin \s+
+             \\DIFadd      \{ Goodnight,[ ]moon \}
+             \\DIFaddend   \s+
+             \.$/x
+    assert_match expect, shell_output("#{bin}/latexdiff test[12].tex")
+  end
+end


### PR DESCRIPTION
This adds a formula for latexdiff which previously existed but was removed when homebrew-tex was deprecated.
The previous Formula is here: https://github.com/Homebrew/homebrew-tex/blob/39482c9ee17d77740a756c5885e61311f04c8377/Formula/latexdiff.rb

Note that I chose to install the standalone `latexdiff-so` in place of `latexdiff`, as the former uses an inlined version of the Perl algorithm Algorithm::Diff. This makes it less brittle against changes to that algorithm.
From the latexdiff README:
> Because latexdiff uses internal functions of Algorithm:Diff whose calling format or availability can change without notice, the preferred method is now to use the standalone version

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

