### PR TITLE
Pipenv completion

### DIFF
--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -69,8 +69,10 @@ class Pipenv < Formula
     ENV["LC_ALL"] = "en_US.UTF-8"
     assert_match "Commands", shell_output("#{bin}/pipenv")
     system "#{bin}/pipenv", "install", "requests"
+    system "#{bin}/pipenv", "install", "boto3"
     assert_predicate testpath/"Pipfile", :exist?
     assert_predicate testpath/"Pipfile.lock", :exist?
     assert_match "requests", (testpath/"Pipfile").read
+    assert_match "boto3", (testpath/"Pipfile").read
   end
 end

--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -47,6 +47,9 @@ class Pipenv < Formula
       :PATH => "#{libexec}/tools:$PATH",
     }
     (bin/"pipenv").write_env_script(libexec/"bin/pipenv", env)
+
+    output = Utils.popen_read("#{libexec}/bin/pipenv --completion")
+    (bash_completion/"pipenv").write output
   end
 
   # Avoid relative paths


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds `--with-completion` option to install bash-completion using the output of the command `pipenv --completion`

Also adds an install of `boto3` to the test section, as a previous version (`11.6.1`) had a bug that prevented pipenv from locking dependencies when installing this library. My feeling is that `boto3` is a common-enough library to warrant a test.

I welcome feedback, especially from pipenv's core contributor, @kennethreitz.

You can replicate the issue outlined above in Docker:

```bash
docker run --rm --workdir /tmp/boto3 \
  python sh -c 'pip install pipenv==11.6.1 && pipenv install boto3'
```