### PR TITLE
Bring back par2tbb using archive.org src tarball

### DIFF
--- a/Formula/par2tbb.rb
+++ b/Formula/par2tbb.rb
@@ -1,0 +1,35 @@
+class Par2tbb < Formula
+  desc "Create and repair data files using Reed Solomon coding"
+  homepage "http://chuchusoft.com/par2_tbb/"
+  url "https://web.archive.org/web/20141212202746/http://chuchusoft.com/par2_tbb/par2cmdline-0.4-tbb-20141125.tar.gz"
+  sha256 "17a5bb5e63c1b9dfcf5feb5447cee60a171847be7385d95f1e2193a7b59a01ad"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "tbb"
+
+  conflicts_with "par2",
+    :because => "par2tbb and par2 install the same binaries."
+
+  fails_with :clang do
+    build 318
+  end
+
+  def install
+    system "autoreconf", "-fvi"
+    # par2tbb expects to link against 10.4 / 10.5 SDKs
+    inreplace "Makefile.in", /^.*-mmacosx-version.*$/, ""
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.out").write "test"
+    system "#{bin}/par2", "create", "test", "test.out"
+    system "#{bin}/par2", "verify", "test.par2"
+  end
+end


### PR DESCRIPTION
Hi :)

Noticed this was missing when I tried to reinstall my packages after doing a time machine restore to a slightly different architecture.

I believe the reason is that chuchusoft.com is down, so the sources are no longer online?

I found them on [archive.org](https://web.archive.org/web/20141212202746/http://chuchusoft.com/par2_tbb/download.html), where they also have a cached version of the HTML from chuchusoft, stating a different sha256sum than the one in the previous formula? Seems odd :/

Anyway, I'm not really accustomed to contributing to Homebrew, so if everything I'm doing is wrong, I apologise. I just use par2-tbb all the time, and feel like it should survive as long as it compiles (and this formula compiles fine here, at least).

Perhaps it would make sense to throw the sources onto github to ensure access to them in the future? I noticed there are quite a few clones out there, and there's also a 2015 version, though it only addresses some 32-bit issue in Windows, so no need to bump it for Homebrew :)

Well, cheers!

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
