### PR TITLE
cgal: Fix sha256 hash for sierra bottle

### DIFF
--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -7,7 +7,7 @@ class Cgal < Formula
   bottle do
     cellar :any
     sha256 "f68288c1c42f06bd7fa28a5f802966d4b786261677e0504e568edbaf9b522ca2" => :high_sierra
-    sha256 "32e877c60b4027c9daf9dd9c8c8359097e333327d06fe18d3768bb80e89183db" => :sierra
+    sha256 "dfb607d915656ff43d64d0df1586543903b15d4b30191b65339ba43ad9fe92e2" => :sierra
     sha256 "0c07e6ef489eca9ff62da6535bf1a95151a73eebed2ca674511f121819dbc0a9" => :el_capitan
   end
 


### PR DESCRIPTION
The current hash is incorrect, resulting in an error when trying to install cgal on sierra:

```
==> Downloading https://homebrew.bintray.com/bottles/cgal-4.11.1.sierra.bottle.tar.gz
Error: SHA256 mismatch
Expected: 32e877c60b4027c9daf9dd9c8c8359097e333327d06fe18d3768bb80e89183db
Actual: dfb607d915656ff43d64d0df1586543903b15d4b30191b65339ba43ad9fe92e2
Archive: /Users/travis/Library/Caches/Homebrew/cgal-4.11.1.sierra.bottle.tar.gz
To retry an incomplete download, remove the file above.
Warning: Bottle installation failed: building from source.
```

Replace it with the correct hash.

-----

Note that I haven't been able to actually test the above because I lack access to macOS outside of the Travis environment.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?