### PR TITLE
Zig 0.2.0

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,9 +1,8 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://github.com/zig-lang/zig/archive/0.1.1.tar.gz"
-  sha256 "fabbfcb0bdb08539d9d8e8e1801d20f25cb0025af75ac996f626bb5e528e71f1"
-  revision 1
+  url "https://github.com/zig-lang/zig/archive/0.2.0.tar.gz"
+  sha256 "09843a3748bf8a5f1742fe93dbf45699f92051ecf479b23272b067dfc3837cc7"
 
   bottle do
     sha256 "3c2e3f738f28287a1fc68ac80d6bf4b0b047a51cc54d0239cd0e4c8a65b47714" => :high_sierra
@@ -12,7 +11,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm@5"
+  depends_on "llvm"
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -21,9 +20,10 @@ class Zig < Formula
 
   test do
     (testpath/"hello.zig").write <<~EOS
-      const io = @import("std").io;
-      pub fn main() -> %void {
-          %%io.stdout.printf("Hello, world!");
+      const std = @import("std");
+      pub fn main() !void {
+          var stdout_file = try std.io.getStdOut();
+          try stdout_file.write("Hello, world!");
       }
     EOS
     system "#{bin}/zig", "build-exe", "hello.zig"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We released Zig 0.2.0 today and since llvm@6 is already merged, this can go out whenever!

I know it's house style to depend on `llvm` here instead of the versioned `llvm@6`, but I'd like to make a case for the latter since this version is pinned to 6 and will not build with <= 5 and will likely not build with 7 when it is released. This is also fine though.

I've simply removed the bottle hashes with the expectation they'll be regenerated in bot land. Lmk if that breaks something for some reason.

Thanks y'all!