### PR TITLE
Remove Jasper from gtk+3 as no longer supported

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -21,7 +21,6 @@ class Gtkx3 < Formula
   depends_on "glib"
   depends_on "hicolor-icon-theme"
   depends_on "gsettings-desktop-schemas" => :recommended
-  depends_on "jasper" => :optional
 
   def install
     args = %W[


### PR DESCRIPTION
Remove the optional `Jasper :optional` as it is no longer supported, and may be causing compile-time errors, for those that used it previously. See #25284.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?