### PR TITLE
node_exporter 0.16.0 (new formula)

### DIFF
--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -15,6 +15,8 @@ class NodeExporter < Formula
     bin.install "node_exporter"
   end
 
+  plist_options :startup => "sudo brew services start node_exporter"
+
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -12,7 +12,7 @@ class NodeExporter < Formula
     ln_sf buildpath, buildpath/"src/github.com/prometheus/node_exporter"
 
     system "make", "build"
-    bin.install %w[node_exporter]
+    bin.install "node_exporter"
   end
 
   plist_options :startup => true

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -1,8 +1,8 @@
 class NodeExporter < Formula
   desc "Prometheus exporter for machine metrics"
   homepage "https://prometheus.io/"
-  url "https://github.com/prometheus/node_exporter/archive/v0.15.2.tar.gz"
-  sha256 "940b850376f94580e88b5e99926d92899975d5792d05709cbd9c48dab0a848ad"
+  url "https://github.com/prometheus/node_exporter/archive/v0.16.0.tar.gz"
+  sha256 "2ed1c1c199e047b1524b49a6662d5969936e81520d6613b8b68cc3effda450cf"
 
   depends_on "go" => :build
 

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -55,7 +55,7 @@ class NodeExporter < Formula
     begin
       pid = fork { exec bin/"node_exporter" }
       sleep 2
-      assert_match "# HELP", shell_output("curl localhost:9100/metrics")
+      assert_match "# HELP", shell_output("curl -s localhost:9100/metrics")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -10,7 +10,8 @@ class NodeExporter < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/prometheus").mkpath
     ln_s buildpath, "src/github.com/prometheus/node_exporter"
-    system "go", "build", "-o", bin/"node_exporter",
+    system "go", "build", "-o", bin/"node_exporter", "-ldflags",
+           "-X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.Version=#{version}",
            "github.com/prometheus/node_exporter"
   end
 
@@ -43,6 +44,7 @@ class NodeExporter < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/node_exporter --version")
     begin
       pid = fork { exec bin/"node_exporter" }
       sleep 2

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -43,9 +43,9 @@ class NodeExporter < Formula
         <key>KeepAlive</key>
         <false/>
         <key>StandardErrorPath</key>
-        <string>#{logs}/err.log</string>
+        <string>#{var}/log/node_exporter.err.log</string>
         <key>StandardOutPath</key>
-        <string>#{logs}/out.log</string>
+        <string>#{var}/log/node_exporter.log</string>
       </dict>
     </plist>
     EOS

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -8,10 +8,10 @@ class NodeExporter < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    mkpath buildpath/"src/github.com/prometheus"
+    (buildpath/"src/github.com/prometheus").mkpath
     ln_sf buildpath, buildpath/"src/github.com/prometheus/node_exporter"
 
-    system "make", "build"
+    system "go", "build", "github.com/prometheus/node_exporter"
     bin.install "node_exporter"
   end
 

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -15,6 +15,8 @@ class NodeExporter < Formula
     bin.install "node_exporter"
   end
 
+  plist_options :manual => "node_exporter"
+
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -30,7 +30,7 @@ class NodeExporter < Formula
           <string>nobody</string>
           <string>sh</string>
           <string>-c</string>
-          <string>/usr/local/bin/node_exporter $(&lt; /usr/local/etc/node_exporter.args)</string>
+          <string>#{opt_bin}/node_exporter $(&lt; #{etc}/node_exporter.args)</string>
         </array>
         <key>UserName</key>
         <string>nobody</string>
@@ -41,9 +41,9 @@ class NodeExporter < Formula
         <key>KeepAlive</key>
         <false/>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/node_exporter/output.log</string>
+        <string>#{logs}/err.log</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/node_exporter/output.log</string>
+        <string>#{logs}/out.log</string>
       </dict>
     </plist>
     EOS

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -24,8 +24,20 @@ class NodeExporter < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-        <key>Program</key>
-        <string>#{opt_bin}/node_exporter</string>
+        <!-- See https://github.com/Homebrew/homebrew-services/issues/70 -->
+        <key>ProgramArguments</key>
+        <array>
+          <string>sudo</string>
+          <string>-u</string>
+          <string>nobody</string>
+          <string>sh</string>
+          <string>-c</string>
+          <string>/usr/local/bin/node_exporter $(&lt; /usr/local/etc/node_exporter.args)</string>
+        </array>
+        <key>UserName</key>
+        <string>nobody</string>
+        <key>GroupName</key>
+        <string>nobody</string>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -13,7 +13,6 @@ class NodeExporter < Formula
 
     system "make", "build"
     bin.install %w[node_exporter]
-    # libexec.install %w[consoles console_libraries]
   end
 
   plist_options :startup => true

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -44,7 +44,7 @@ class NodeExporter < Formula
         <string>#{var}/log/node_exporter.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -15,8 +15,6 @@ class NodeExporter < Formula
     bin.install "node_exporter"
   end
 
-  plist_options :startup => "sudo brew services start node_exporter"
-
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -24,16 +22,13 @@ class NodeExporter < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-        <!-- See https://github.com/Homebrew/homebrew-services/issues/70 -->
         <key>ProgramArguments</key>
         <array>
-          <string>sudo</string>
-          <string>-u</string>
-          <string>nobody</string>
           <string>sh</string>
           <string>-c</string>
           <string>#{opt_bin}/node_exporter $(&lt; #{etc}/node_exporter.args)</string>
         </array>
+        <!-- UserName is not working; see https://github.com/Homebrew/homebrew-services/issues/70 -->
         <key>UserName</key>
         <string>nobody</string>
         <key>GroupName</key>

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -9,10 +9,9 @@ class NodeExporter < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/prometheus").mkpath
-    ln_sf buildpath, buildpath/"src/github.com/prometheus/node_exporter"
-
-    system "go", "build", "github.com/prometheus/node_exporter"
-    bin.install "node_exporter"
+    ln_s buildpath, "src/github.com/prometheus/node_exporter"
+    system "go", "build", "-o", bin/"node_exporter",
+           "github.com/prometheus/node_exporter"
   end
 
   plist_options :manual => "node_exporter"

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -15,8 +15,6 @@ class NodeExporter < Formula
     bin.install "node_exporter"
   end
 
-  plist_options :startup => true
-
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -8,7 +8,7 @@ class NodeExporter < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    mkdir_p buildpath/"src/github.com/prometheus"
+    mkpath buildpath/"src/github.com/prometheus"
     ln_sf buildpath, buildpath/"src/github.com/prometheus/node_exporter"
 
     system "make", "build"
@@ -30,22 +30,10 @@ class NodeExporter < Formula
         <true/>
         <key>KeepAlive</key>
         <false/>
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardErrorPath</key>
         <string>#{var}/log/node_exporter/output.log</string>
         <key>StandardOutPath</key>
         <string>#{var}/log/node_exporter/output.log</string>
-        <key>HardResourceLimits</key>
-        <dict>
-          <key>NumberOfFiles</key>
-          <integer>4096</integer>
-        </dict>
-        <key>SoftResourceLimits</key>
-        <dict>
-          <key>NumberOfFiles</key>
-          <integer>4096</integer>
-        </dict>
       </dict>
     </plist>
     EOS
@@ -55,7 +43,7 @@ class NodeExporter < Formula
     begin
       pid = fork { exec bin/"node_exporter" }
       sleep 2
-      assert_match /# HELP/, shell_output("curl localhost:9100/metrics")
+      assert_match "# HELP", shell_output("curl localhost:9100/metrics")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -1,0 +1,65 @@
+class NodeExporter < Formula
+  desc "Prometheus exporter for machine metrics"
+  homepage "https://prometheus.io/"
+  url "https://github.com/prometheus/node_exporter/archive/v0.15.2.tar.gz"
+  sha256 "940b850376f94580e88b5e99926d92899975d5792d05709cbd9c48dab0a848ad"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    mkdir_p buildpath/"src/github.com/prometheus"
+    ln_sf buildpath, buildpath/"src/github.com/prometheus/node_exporter"
+
+    system "make", "build"
+    bin.install %w[node_exporter]
+    # libexec.install %w[consoles console_libraries]
+  end
+
+  plist_options :startup => true
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>Program</key>
+        <string>#{opt_bin}/node_exporter</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/node_exporter/output.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/node_exporter/output.log</string>
+        <key>HardResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>4096</integer>
+        </dict>
+        <key>SoftResourceLimits</key>
+        <dict>
+          <key>NumberOfFiles</key>
+          <integer>4096</integer>
+        </dict>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    begin
+      pid = fork { exec bin/"node_exporter" }
+      sleep 2
+      assert_match /# HELP/, shell_output("curl localhost:9100/metrics")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -44,7 +44,8 @@ class NodeExporter < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/node_exporter --version")
+    output = shell_output("#{bin}/node_exporter --version 2>&1")
+    assert_match version.to_s, output
     begin
       pid = fork { exec bin/"node_exporter" }
       sleep 2

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -29,11 +29,6 @@ class NodeExporter < Formula
           <string>-c</string>
           <string>#{opt_bin}/node_exporter $(&lt; #{etc}/node_exporter.args)</string>
         </array>
-        <!-- UserName is not working; see https://github.com/Homebrew/homebrew-services/issues/70 -->
-        <key>UserName</key>
-        <string>nobody</string>
-        <key>GroupName</key>
-        <string>nobody</string>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>


### PR DESCRIPTION
New formula for Prometheus' machine-level metrics exporter,
node_exporter.

Includes a plist for running with `brew services`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
