### PR TITLE
 man-db 2.8.2 &  libpipeline 1.5.0 (new formulas)

### DIFF
--- a/Formula/libpipeline.rb
+++ b/Formula/libpipeline.rb
@@ -1,0 +1,67 @@
+class Libpipeline < Formula
+  desc "C library for manipulating pipelines of subprocesses"
+  homepage "http://libpipeline.nongnu.org/"
+  url "https://download.savannah.nongnu.org/releases/libpipeline/libpipeline-1.5.0.tar.gz"
+  sha256 "0d72e12e4f2afff67fd7b9df0a24d7ba42b5a7c9211ac5b3dcccc5cd8b286f2b"
+
+  depends_on "pkg-config" => :run
+
+  # Patch explanation:
+  # Gnulib, part of man-db and libpipeline, externs a symbol called
+  # `program_name`. This symbol is supposed to be defined by glibc, which is to
+  # be expected on Linux. However, since we're on OS X, we don't have glibc and
+  # so this symbol will not be defined. This is a known issue and several work-
+  # arounds have been proposed by different people. One option is to use some
+  # CFLAGS to suppress errors about undefined symbols. Unfortunately, this only
+  # seems to work for man-db and doesn't work for other programs which link with
+  # libpipeline. This patch is a more general solution and was almost included
+  # in the Nix package manager at one point. For more info, visit these links:
+  # https://stackoverflow.com/questions/36824434/libpipeline-fails-to-compile-on-mac-os-x
+  # https://github.com/NixOS/nixpkgs/issues/15849
+  # https://lists.gnu.org/archive/html/bug-gnulib/2015-02/msg00079.html
+  patch :DATA
+
+  def install
+    ENV["CC"] = "#{ENV.cc} -arch x86_64"
+
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdint.h>
+      #include <pipeline.h>
+      int main(void)
+      {
+        pipeline *p = pipeline_new_command_args("true", NULL);
+        int status = pipeline_run(p);
+        return status;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lpipeline", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end
+
+__END__
+diff --git a/gnulib/lib/error.c b/gnulib/lib/error.c
+index 31109df3..6b68cd15 100644
+--- a/gnulib/lib/error.c
++++ b/gnulib/lib/error.c
+@@ -110,9 +110,13 @@ int strerror_r ();
+ #  endif
+ # endif
+
++#if defined __APPLE__ && defined __MACH__
++#define program_name (((char **)*_NSGetArgv())[0])
++#else
+ /* The calling program should define program_name and set it to the
+    name of the executing program.  */
+ extern char *program_name;
++#endif
+
+ # if HAVE_STRERROR_R || defined strerror_r
+ #  define __strerror_r strerror_r

--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -1,0 +1,117 @@
+class ManDb < Formula
+  desc "Implementation of the standard Unix man page system, often used on Linux"
+  homepage "https://nongnu.org/man-db/"
+  url "https://download.savannah.nongnu.org/releases/man-db/man-db-2.8.2.tar.xz"
+  sha256 "45bdff87df888ddd93dc2a68abca91a2012d6e08333a8fc7c0dfefe9cbde0c5c"
+
+  depends_on "libpipeline"
+
+  # First patch explanation:
+  # The first two patches are actually the same patch for two different files.
+  # Since this utility is intended for Linux systems, it expects to chown the
+  # installed files as man:man. But, since we're on OS X, this username/group
+  # doesn't exist. Obviously, we don't want to create ad-hoc usernames or groups
+  # just to install this one program.
+  #
+  # Second patch explanation:
+  # Gnulib, part of man-db and libpipeline, externs a symbol called
+  # `program_name`. This symbol is supposed to be defined by glibc, which is to
+  # be expected on Linux. However, since we're on OS X, we don't have glibc and
+  # so this symbol will not be defined. This is a known issue and several work-
+  # arounds have been proposed by different people. One option is to use some
+  # CFLAGS to suppress errors about undefined symbols. Unfortunately, this only
+  # seems to work for man-db and doesn't work for other programs which link with
+  # libpipeline. This patch is a more general solution. Unfortunately, the
+  # upstream has not accpted this patch for two years and so they probably never
+  # will. For more info, visit these links:
+  # https://stackoverflow.com/questions/36824434/libpipeline-fails-to-compile-on-mac-os-x
+  # https://github.com/NixOS/nixpkgs/issues/15849
+  # https://lists.gnu.org/archive/html/bug-gnulib/2015-02/msg00079.html
+  patch :DATA
+
+  def install
+    ENV["CC"] = "#{ENV.cc} -arch x86_64"
+
+    system "./configure", "--prefix=#{prefix}", "--with-systemdtmpfilesdir=''"
+    system "make", "CFLAGS=\"-Wl,-flat_namespace,-undefined,suppress\""
+    system "make", "install"
+  end
+
+  test do
+    ENV["PAGER"] = "cat"
+    true_man_page = <<~EOS
+      TRUE(1)                                      BSD General Commands Manual                                     TRUE(1)
+
+      NAME
+           true -- Return true value.
+
+      SYNOPSIS
+           true
+
+      DESCRIPTION
+           The true utility always returns with exit code zero.
+
+      SEE ALSO
+           csh(1), sh(1), false(1)
+
+      STANDARDS
+           The true utility conforms to IEEE Std 1003.2-1992 (``POSIX.2'').
+
+      BSD                                                 June 27, 1991                                                BSD
+EOS
+    output = shell_output("#{bin}/man true")
+    assert_match(true_man_page, output)
+  end
+end
+
+__END__
+diff --git a/src/Makefile.am b/src/Makefile.am
+index dd7232e6..cc5c9a0d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -173,11 +173,6 @@ apropos$(EXEEXT): whatis$(EXEEXT)
+ all-am: apropos$(EXEEXT)
+
+ install-exec-hook:
+-	if [ "$(man_owner)" ] && [ "$(man_mode)" = 6755 ]; then \
+-		chown $(man_owner):$(man_owner) \
+-			$(DESTDIR)$(bindir)/$(TRANS_MAN) \
+-			$(DESTDIR)$(bindir)/$(TRANS_MANDB); \
+-	fi
+ 	chmod $(man_mode) \
+ 		$(DESTDIR)$(bindir)/$(TRANS_MAN) \
+ 		$(DESTDIR)$(bindir)/$(TRANS_MANDB)
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 5ab90d47..4261d6c8 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -2214,11 +2214,6 @@ apropos$(EXEEXT): whatis$(EXEEXT)
+ all-am: apropos$(EXEEXT)
+
+ install-exec-hook:
+-	if [ "$(man_owner)" ] && [ "$(man_mode)" = 6755 ]; then \
+-		chown $(man_owner):$(man_owner) \
+-			$(DESTDIR)$(bindir)/$(TRANS_MAN) \
+-			$(DESTDIR)$(bindir)/$(TRANS_MANDB); \
+-	fi
+ 	chmod $(man_mode) \
+ 		$(DESTDIR)$(bindir)/$(TRANS_MAN) \
+ 		$(DESTDIR)$(bindir)/$(TRANS_MANDB)
+diff --git a/gnulib/lib/error.c b/gnulib/lib/error.c
+index 31109df3..6b68cd15 100644
+--- a/gnulib/lib/error.c
++++ b/gnulib/lib/error.c
+@@ -110,9 +110,13 @@ int strerror_r ();
+ #  endif
+ # endif
+
++#if defined __APPLE__ && defined __MACH__
++#define program_name (((char **)*_NSGetArgv())[0])
++#else
+ /* The calling program should define program_name and set it to the
+    name of the executing program.  */
+ extern char *program_name;
++#endif
+
+ # if HAVE_STRERROR_R || defined strerror_r
+ #  define __strerror_r strerror_r


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`man-db` is the man page system for Linux. It is more featureful than OS X's built-in `man` command (which is derived from an old version of BSD). It is quite useful for developers and system administrators and some useful software plugins rely on Linux's `man` behavior, which has not been available on OS X hitherto.

`man-db` depends on a library called `libpipeline` which is also included in this PR. Unfortunately, both of these programs expect to be on a Linux system rather exclusively. So, some patches and extra compilation options are necessary in order to get these programs to work right. I hope that these formulas will make it into the trunk; they are very useful and it will be very nice to have Homebrew take care of these packages instead of manually compiling updates by hand.