### PR TITLE
kubernetes-cli 1.9.4

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -2,8 +2,8 @@ class KubernetesCli < Formula
   desc "Kubernetes command-line interface"
   homepage "https://kubernetes.io/"
   url "https://github.com/kubernetes/kubernetes.git",
-      :tag => "v1.9.3",
-      :revision => "d2835416544f298c919e2ead3be3d0864b52323b"
+      :tag => "v1.9.4",
+      :revision => "bee2d1505c4fe820744d26d41ecd3fdd4a3d6546"
   head "https://github.com/kubernetes/kubernetes.git"
 
   bottle do
@@ -13,7 +13,8 @@ class KubernetesCli < Formula
     sha256 "70f600bd7cefd0733ca95aa0e82d408d6b803774ad556974db899902802637dc" => :el_capitan
   end
 
-  depends_on "go" => :build
+  # kubernetes-cli will not support go1.10 until version 1.11.x
+  depends_on "go@1.9" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Change the build dependency for kubernetes-cli to use go@1.9. We don't support go1.10 yet for kubectl.

fixes #25312.