### PR TITLE
swiftgen 5.3.0

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag => "5.3.0-2",
-      :revision => "50c853836c6c33827232647061094c38b4eba54b"
+      :tag => "5.3.0-3",
+      :revision => "c96194cb64c35a9f8ad949ceee00ac9755a4b62f"
   head "https://github.com/SwiftGen/SwiftGen.git"
 
   bottle do
@@ -22,7 +22,7 @@ class Swiftgen < Formula
     ENV["GEM_HOME"] = buildpath/"gem_home"
     system "gem", "install", "bundler"
     ENV.prepend_path "PATH", buildpath/"gem_home/bin"
-    system "bundle", "install", "--without", "development"
+    system "bundle", "install", "--without", "development", "release"
     system "bundle", "exec", "rake", "cli:install[#{bin},#{lib},#{pkgshare}/templates]"
 
     fixtures = {

--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag => "5.3.0",
-      :revision => "c2b03152f31e779f1deba3811b158ac1670f5b3b"
+      :tag => "5.3.0-2",
+      :revision => "50c853836c6c33827232647061094c38b4eba54b"
   head "https://github.com/SwiftGen/SwiftGen.git"
 
   bottle do
@@ -12,7 +12,7 @@ class Swiftgen < Formula
     sha256 "129d086e2cca6ce4d204ad3a699524e48c5e8eee0c67f0d698a94ac8fa3d7d77" => :sierra
   end
 
-  depends_on :xcode => ["9.0", :build]
+  depends_on :xcode => ["9.2", :build]
 
   def install
     # Disable swiftlint Build Phase to avoid build errors if versions mismatch
@@ -22,7 +22,7 @@ class Swiftgen < Formula
     ENV["GEM_HOME"] = buildpath/"gem_home"
     system "gem", "install", "bundler"
     ENV.prepend_path "PATH", buildpath/"gem_home/bin"
-    system "bundle", "install"
+    system "bundle", "install", "--without", "development"
     system "bundle", "exec", "rake", "cli:install[#{bin},#{lib},#{pkgshare}/templates]"
 
     fixtures = {

--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag => "5.2.1",
-      :revision => "21107b1de6180cf5644e512e67e4d60a0d115ac4"
+      :tag => "5.3.0",
+      :revision => "c2b03152f31e779f1deba3811b158ac1670f5b3b"
   head "https://github.com/SwiftGen/SwiftGen.git"
 
   bottle do
@@ -26,17 +26,17 @@ class Swiftgen < Formula
     system "bundle", "exec", "rake", "cli:install[#{bin},#{lib},#{pkgshare}/templates]"
 
     fixtures = {
-      "Resources/Fixtures/XCAssets/Images.xcassets" => "Images.xcassets",
-      "Resources/Fixtures/XCAssets/Colors.xcassets" => "Colors.xcassets",
-      "Resources/Fixtures/Colors/colors.xml" => "colors.xml",
-      "Resources/Fixtures/Strings/Localizable.strings" => "Localizable.strings",
-      "Resources/Fixtures/Storyboards-iOS" => "Storyboards-iOS",
-      "Resources/Fixtures/Fonts" => "Fonts",
-      "Resources/Tests/Expected/XCAssets/swift3-context-all.swift" => "xcassets.swift",
-      "Resources/Tests/Expected/Colors/swift3-context-defaults.swift" => "colors.swift",
-      "Resources/Tests/Expected/Strings/structured-swift3-context-localizable.swift" => "strings.swift",
-      "Resources/Tests/Expected/Storyboards-iOS/swift3-context-all.swift" => "storyboards.swift",
-      "Resources/Tests/Expected/Fonts/swift3-context-defaults.swift" => "fonts.swift",
+      "Tests/Fixtures/Resources/XCAssets/Images.xcassets" => "Images.xcassets",
+      "Tests/Fixtures/Resources/XCAssets/Colors.xcassets" => "Colors.xcassets",
+      "Tests/Fixtures/Resources/Colors/colors.xml" => "colors.xml",
+      "Tests/Fixtures/Resources/Strings/Localizable.strings" => "Localizable.strings",
+      "Tests/Fixtures/Resources/Storyboards-iOS" => "Storyboards-iOS",
+      "Tests/Fixtures/Resources/Fonts" => "Fonts",
+      "Tests/Fixtures/Generated/XCAssets/swift3-context-all.swift" => "xcassets.swift",
+      "Tests/Fixtures/Generated/Colors/swift3-context-defaults.swift" => "colors.swift",
+      "Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift" => "strings.swift",
+      "Tests/Fixtures/Generated/Storyboards-iOS/swift3-context-all.swift" => "storyboards.swift",
+      "Tests/Fixtures/Generated/Fonts/swift3-context-defaults.swift" => "fonts.swift",
     }
     (pkgshare/"fixtures").install fixtures
   end

--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag => "5.3.0-3",
-      :revision => "c96194cb64c35a9f8ad949ceee00ac9755a4b62f"
+      :tag => "5.3.0-4",
+      :revision => "3a698421fe14947cf26e452f5f127d6c3f3ee8de"
   head "https://github.com/SwiftGen/SwiftGen.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? [Kind of, see below]
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Also passes `brew test swiftgen`

-----


Note: I tried to run `brew bump-formula-pr --strict swiftgen --tag="5.3.0" --revision="c2b03152f31e779f1deba3811b158ac1670f5b3b"`to create that PR as suggested in the updated `CONTRIBUTING.md` , but it failed when trying to run `rubocop`:
```
Already up-to-date.
==> replace "5.2.1" with "5.3.0"
==> replace "21107b1de6180cf5644e512e67e4d60a0d115ac4" with "c2b03152f31e779f1deba3811b158ac1670f5b3b"
Error: Error running `rubocop --format json --force-exclusion --parallel --except NewFormulaAudit --config /usr/local/Homebrew/Library/.rubocop_audit.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/swiftgen.rb`
```
So I made the PR manually, the old way. The command `brew bump-formula-pr` wouldn't have been enough anyway (since the fixtures paths had to be updated), but might as well give you that feedback about the rubocop failure :wink: