### PR TITLE
pandoc: constrain pandoc-types to < 1.17.4

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -22,7 +22,11 @@ class Pandoc < Formula
     cabal_sandbox do
       args = []
       args << "--constraint=cryptonite -support_aesni" if MacOS.version <= :lion
-      install_cabal_package *args
+
+      # Remove pandoc-types constraint for pandoc > 2.1.2
+      # Upstream issue from 13 Mar 2018 "Pandoc 2.1.2 failed building with GHC 8.2.2"
+      # See https://github.com/jgm/pandoc/issues/4448
+      install_cabal_package "--constraint", "pandoc-types < 1.17.4", *args
     end
     (bash_completion/"pandoc").write `#{bin}/pandoc --bash-completion`
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----