### PR TITLE
poppler 0.63

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha256 "cb90f2e0fd4bc3fe235111f982bc20455a1d6bc13f4219babcba6bd60c1fe466"
-  revision 26
+  revision 27
 
   bottle do
     cellar :any

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -3,7 +3,7 @@ class Pdftoedn < Formula
   homepage "https://github.com/edporras/pdftoedn"
   url "https://github.com/edporras/pdftoedn/archive/v0.34.3.tar.gz"
   sha256 "7ff6d097d1a53246b3c71d9fdaeb58e43aac14291f647d76855c62769c585f25"
-  revision 8
+  revision 9
 
   bottle do
     cellar :any

--- a/Formula/pdftoipe.rb
+++ b/Formula/pdftoipe.rb
@@ -3,7 +3,7 @@ class Pdftoipe < Formula
   homepage "https://github.com/otfried/ipe-tools"
   url "https://github.com/otfried/ipe-tools/archive/v7.2.7.tar.gz"
   sha256 "889cb31bd8769ba111f541ba795cf53fad474aeeafbc87b7cd37c8a24b2dc6f6"
-  revision 8
+  revision 9
 
   bottle do
     cellar :any

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -70,6 +70,12 @@ class Poppler < Formula
 
     system "cmake", ".", *args
     system "make", "install"
+    system "make", "clean"
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=OFF", *args
+    system "make"
+    lib.install "libpoppler.a"
+    lib.install "cpp/libpoppler-cpp.a"
+    lib.install "glib/libpoppler-glib.a"
     resource("font-data").stage do
       system "make", "install", "prefix=#{prefix}"
     end

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -1,8 +1,8 @@
 class Poppler < Formula
   desc "PDF rendering library (based on the xpdf-3.0 code base)"
   homepage "https://poppler.freedesktop.org/"
-  url "https://poppler.freedesktop.org/poppler-0.62.0.tar.xz"
-  sha256 "5b9a73dfd4d6f61d165ada1e4f0abd2d420494bf9d0b1c15d0db3f7b83a729c6"
+  url "https://poppler.freedesktop.org/poppler-0.63.0.tar.xz"
+  sha256 "27cc8addafc791e1a26ce6acc2b490926ea73a4f89196dd8a7742cff7cf8a111"
   head "https://anongit.freedesktop.org/git/poppler/poppler.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates poppler to 0.63. The upstream maintainers have finally fixed static libs in this release, so we also add this (they were broken after we switched from autoconf to cmake a few months back).

We use the same pattern as e.g. the [netcdf](https://github.com/r-hub/homebrew-cran/blob/master/Formula/netcdf.rb#L64-L69) formula to install only the static libs from the second build and nothing else, because `make install` seems to trigger a `make uninstall` first.