### PR TITLE
gmp: use assembly in static library

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -4,7 +4,7 @@ class Gmp < Formula
   url "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
   mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
   sha256 "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -14,16 +14,13 @@ class Gmp < Formula
   end
 
   def install
-    args = %W[--prefix=#{prefix} --enable-cxx]
+    # Enable --with-pic to avoid linking issues with the static library
+    args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
     args << "--build=core2-apple-darwin#{`uname -r`.to_i}" if build.bottle?
-    system "./configure", "--disable-static", *args
+    system "./configure", *args
     system "make"
     system "make", "check"
     system "make", "install"
-    system "make", "clean"
-    system "./configure", "--disable-shared", "--disable-assembly", *args
-    system "make"
-    lib.install Dir[".libs/*.a"]
   end
 
   test do
@@ -41,7 +38,12 @@ class Gmp < Formula
         return 0;
       }
     EOS
+
     system ENV.cc, "test.c", "-L#{lib}", "-lgmp", "-o", "test"
+    system "./test"
+
+    # Test the static library to catch potential linking issues
+    system ENV.cc, "test.c", "#{lib}/libgmp.a", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
`--disable-assembly` was introduced in the formula to avoid an “illegal text-relocation” linking error against the static library. This is better avoided by building the static library with PIC code, and allows us to keep the optimised assembly code in the static version. It also simplifies the logic of the formula, and build only once.

I've added a test linking explicitly the static library, which catches the previous compilation issue (tested by removing `--with-pic`).