### PR TITLE
New formula: ParallelSTL 20171127

### DIFF
--- a/Formula/parallelstl.rb
+++ b/Formula/parallelstl.rb
@@ -1,0 +1,34 @@
+class Parallelstl < Formula
+  desc "C++ standard library algorithms with support for execution policies"
+  homepage "https://github.com/intel/parallelstl"
+  url "https://github.com/intel/parallelstl/archive/20171127.tar.gz"
+  sha256 "4d92881984fc476d382454c60f3d10f79605b54206d8fb332fd3287906163dc8"
+
+  bottle :unneeded
+
+  depends_on "tbb"
+
+  def install
+    include.install Dir["include/*"]
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <pstl/execution>
+      #include <pstl/algorithm>
+      #include <array>
+      #include <assert.h>
+
+      int main() {
+        std::array<int, 10> arr {{5,2,3,1,4,9,7,0,8,6}};
+        std::sort(std::execution::par_unseq, arr.begin(), arr.end());
+        for(int i=0; i<10; i++)
+          assert(i==arr.at(i));
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "-L#{Formula["tbb"].opt_lib}", "-ltbb",
+                    "-I#{include}", "test.cpp", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This adds Intel's ParallelSTL, version 20171127, as requested in intel/parallelstl#2. This is a header-only library, so feel free to close if this is not a good idea for homebrew.