### PR TITLE
openssl@1.1 1.1.1-pre3 (devel)

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -15,8 +15,8 @@ class OpensslAT11 < Formula
   end
 
   devel do
-    url "https://www.openssl.org/source/openssl-1.1.1-pre2.tar.gz"
-    sha256 "33dbda4a90345d256942fb5316967efd90df4f2373578c7b56c90062fe21fc9c"
+    url "https://www.openssl.org/source/openssl-1.1.1-pre3.tar.gz"
+    sha256 "b541d574d8d099b0bc74ebc8174cec1dc9f426d8901d04be7874046ad72116b0"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Heads up on this one too:
```
The OpenSSL project team would like to announce the forthcoming release
of OpenSSL versions 1.1.0h and 1.0.2o.

These releases will be made available on 27th March 2018 between
approximately 1300-1700 UTC.

These are security-fix releases. The highest severity issue fixed in
these releases is MODERATE.
```