### PR TITLE
Unify Beats formulae handling of kibana directory, modules, and updated configs

### DIFF
--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -44,20 +44,21 @@ class Auditbeat < Formula
       # prevent downloading binary wheels during python setup
       system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
-      (libexec/"bin").install "auditbeat"
-      libexec.install "_meta/kibana"
 
-      (etc/"auditbeat").install Dir["auditbeat*.yml", "fields.yml"]
-      prefix.install_metafiles
+      (etc/"auditbeat").install Dir["auditbeat.*", "fields.yml"]
+      (libexec/"bin").install "auditbeat"
+      prefix.install "_meta/kibana"
     end
+
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"auditbeat").write <<~EOS
       #!/bin/sh
-        exec #{libexec}/bin/auditbeat \
-        -path.config #{etc}/auditbeat \
-        -path.data #{var}/lib/auditbeat \
-        -path.home #{libexec} \
-        -path.logs #{var}/log/auditbeat \
+      exec #{libexec}/bin/auditbeat \
+        --path.config #{etc}/auditbeat \
+        --path.data #{var}/lib/auditbeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/auditbeat \
         "$@"
     EOS
   end

--- a/Formula/filebeat.rb
+++ b/Formula/filebeat.rb
@@ -38,16 +38,23 @@ class Filebeat < Formula
       system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
       system "make", "modules"
-      libexec.install "filebeat"
-      (prefix/"module").install Dir["_meta/module.generated/*"]
-      (etc/"filebeat").install Dir["filebeat.*", "fields.yml"]
+
+      (etc/"filebeat").install Dir["filebeat.*", "fields.yml", "modules.d"]
+      (etc/"filebeat"/"module").install Dir["_meta/module.generated/*"]
+      (libexec/"bin").install "filebeat"
+      prefix.install "_meta/kibana"
     end
 
     prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"filebeat").write <<~EOS
       #!/bin/sh
-      exec #{libexec}/filebeat -path.config #{etc}/filebeat -path.home #{prefix} -path.logs #{var}/log/filebeat -path.data #{var}/filebeat $@
+      exec #{libexec}/bin/filebeat \
+        --path.config #{etc}/filebeat \
+        --path.data #{var}/lib/filebeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/filebeat \
+        "$@"
     EOS
   end
 

--- a/Formula/heartbeat.rb
+++ b/Formula/heartbeat.rb
@@ -37,20 +37,21 @@ class Heartbeat < Formula
       # prevent downloading binary wheels during python setup
       system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
-      (libexec/"bin").install "heartbeat"
-      libexec.install "_meta/kibana"
 
-      (etc/"heartbeat").install Dir["heartbeat*.{json,yml}", "fields.yml"]
-      prefix.install_metafiles
+      (etc/"heartbeat").install Dir["heartbeat.*", "fields.yml"]
+      (libexec/"bin").install "heartbeat"
+      prefix.install "_meta/kibana"
     end
+
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"heartbeat").write <<~EOS
       #!/bin/sh
-        exec #{libexec}/bin/heartbeat \
-        -path.config #{etc}/heartbeat \
-        -path.home #{libexec} \
-        -path.logs #{var}/log/heartbeat \
-        -path.data #{var}/lib/heartbeat \
+      exec #{libexec}/bin/heartbeat \
+        --path.config #{etc}/heartbeat \
+        --path.data #{var}/lib/heartbeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/heartbeat \
         "$@"
     EOS
   end

--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -45,21 +45,21 @@ class Metricbeat < Formula
       # prevent downloading binary wheels during python setup
       system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
-      system "make", "kibana"
-      (libexec/"bin").install "metricbeat"
-      libexec.install "_meta/kibana"
 
-      (etc/"metricbeat").install Dir["metricbeat*.yml", "fields.yml"]
-      prefix.install_metafiles
+      (etc/"metricbeat").install Dir["metricbeat.*", "fields.yml", "modules.d"]
+      (libexec/"bin").install "metricbeat"
+      prefix.install "_meta/kibana"
     end
+
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"metricbeat").write <<~EOS
       #!/bin/sh
-      exec "#{libexec}/bin/metricbeat" \
-        --path.config "#{etc}/metricbeat" \
-        --path.home="#{prefix}" \
-        --path.logs="#{var}/log/metricbeat" \
-        --path.data="#{var}/lib/metricbeat" \
+      exec #{libexec}/bin/metricbeat \
+        --path.config #{etc}/metricbeat \
+        --path.data #{var}/lib/metricbeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/metricbeat \
         "$@"
     EOS
   end

--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -37,23 +37,23 @@ class Packetbeat < Formula
       # prevent downloading binary wheels during python setup
       system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
       system "make", "DEV_OS=darwin", "update"
-      system "make", "update"
-      (libexec/"bin").install "packetbeat"
-      libexec.install "_meta/kibana"
 
       inreplace "packetbeat.yml", "packetbeat.interfaces.device: any", "packetbeat.interfaces.device: en0"
 
-      (etc/"packetbeat").install Dir["packetbeat*.yml", "fields.yml"]
-      prefix.install_metafiles
+      (etc/"packetbeat").install Dir["packetbeat.*", "fields.yml"]
+      (libexec/"bin").install "packetbeat"
+      prefix.install "_meta/kibana"
     end
+
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
 
     (bin/"packetbeat").write <<~EOS
       #!/bin/sh
       exec #{libexec}/bin/packetbeat \
-        -path.config #{etc}/packetbeat \
-        -path.home #{prefix} \
-        -path.logs #{var}/log/packetbeat \
-        -path.data #{var}/lib/packetbeat \
+        --path.config #{etc}/packetbeat \
+        --path.data #{var}/lib/packetbeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/packetbeat \
         "$@"
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There's a couple of outstanding issues with several of the Beats formulae:
- Metricbeat ships with several modules but the formula doesn't generate or install them
- Both Filebeat and Metricbeat expect modules to be installed to `path.config` and not `path.home`, otherwise they aren't available to use.
- Only Filebeat installs metafiles correctly (with a relevant README, LICENSE, etc.)
- Most fixed executable scripts are inconsistent and use older flag formats, point to differing paths, etc.
- Updated config files may be placed in `.default` files, which users should be aware of if they would like to update their existing configs with new changes.
- [edit] several formulae do not install `kibana` or do so in the wrong directory, which breaks the executables' ability to create Kibana dashboards.

This PR fixes those various issues. With regards to the added `caveats` for each Beat, I made the changed [based upon feedback from Mike on Discourse](https://discourse.brew.sh/t/best-practice-for-updating-etc-files-in-place-while-respecting-changes/1816/2) wherein he indicated that caveats for that particular issue were the best way forward - if there's a better approach, I'm all ears, but in the absence of a formal mechanism to handle changes to configuration files in `etc` then user instructions seem like a minimal step to include.