### PR TITLE
kattis 40d54c (new formula)

### DIFF
--- a/Formula/kattis.rb
+++ b/Formula/kattis.rb
@@ -1,0 +1,15 @@
+class Kattis < Formula
+  desc "Command-line submission tool for the Kattis online judge"
+  homepage "https://open.kattis.com/"
+  url "https://open.kattis.com/download/submit.py?#{version}"
+  version "40d54c"
+  sha256 "e0077380c6e479c03c631caf652f02e0d85d5ae288b4f4a79c285bb22f3bc3f5"
+
+  def install
+    bin.install "submit.py" => "kattis"
+  end
+
+  test do
+    system "#{bin}/kattis", "-h"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is the command-line tool for the Kattis online judge. I understand that the version numbering isn't ideal, but they don't have numbered releases, they publish git hashes. Let me know if I should just institute a new versioning that's specific to this Formula.