### PR TITLE
php: explain slow startup time on missing hostname

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -190,6 +190,13 @@ class Php < Formula
 
       The php.ini and php-fpm.ini file can be found in:
           #{etc}/php/#{php_version}/
+
+      You will experience a +5 secs startup time if your /etc/hosts is missing a
+      reference to your hostname. You can solve this problem using the following
+      command:
+          HOSTNAME=$(hostname); \\
+          echo -e "127.0.0.1\\t${HOSTNAME}" | sudo tee -a /etc/hosts; \\
+          echo -e "::1\\t\\t${HOSTNAME}"     | sudo tee -a /etc/hosts
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
