### PR TITLE
dhall-json: depend on ghc at build time

### DIFF
--- a/Formula/dhall-json.rb
+++ b/Formula/dhall-json.rb
@@ -17,10 +17,22 @@ class DhallJson < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.2" => :build
+  depends_on "ghc" => :build
+
+  # Remove when dhall > 1.11.1 is released
+  # See https://github.com/dhall-lang/dhall-haskell/pull/330
+  resource "dhall" do
+    url "https://github.com/dhall-lang/dhall-haskell.git",
+        :revision => "ed2041ee7709969ca63b4d9d1a82a34ffc145f3d"
+  end
 
   def install
-    install_cabal_package
+    (buildpath/"dhall").install resource("dhall")
+
+    cabal_sandbox do
+      cabal_sandbox_add_source "dhall"
+      install_cabal_package
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

instead of ghc@8.2