### PR TITLE
Add caveat to ntopng when built with MariaDB

### DIFF
--- a/Formula/ntopng.rb
+++ b/Formula/ntopng.rb
@@ -27,8 +27,6 @@ class Ntopng < Formula
     end
   end
 
-  option "with-mariadb", "Build with mariadb support"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
@@ -41,8 +39,7 @@ class Ntopng < Formula
   depends_on "rrdtool"
   depends_on "geoip"
   depends_on "redis"
-  depends_on "mysql" if build.without? "mariadb"
-  depends_on "mariadb" => :optional
+  depends_on "mysql"
 
   def install
     resource("nDPI").stage do
@@ -56,11 +53,6 @@ class Ntopng < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
-    If built as "ntopng --with-mariadb" you will need to manually force all upgrades with "brew upgrade --force ntopng" due to the mariadb and mysql naming collision.
-    EOS
-  end
-  
   test do
     system "#{bin}/ntopng", "-V"
   end

--- a/Formula/ntopng.rb
+++ b/Formula/ntopng.rb
@@ -56,6 +56,11 @@ class Ntopng < Formula
     system "make", "install"
   end
 
+  def caveats; <<-EOS.undent
+    If built as "ntopng --with-mariadb" you will need to manually force all upgrades with "brew upgrade --force ntopng" due to the mariadb and mysql naming collision.
+    EOS
+  end
+  
   test do
     system "#{bin}/ntopng", "-V"
   end


### PR DESCRIPTION
As has come up before the MariaDB/mysql name collision continues to rear it's ugly head.

Simply adding a caveat on how to successfully upgrade when this fails to do so through the normal `brew upgrade` path.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
----
- [X] Does your build pass `brew style --fix <formula>`