### PR TITLE
Changed download link to be more org friendly

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -2,7 +2,7 @@ class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
   url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.4/rabbitmq-server-mac-standalone-3.7.4.tar.xz"
-  sha256 "536efce8362503d313b136b29b14245f8c7e30e1036c59d4cc1204a22cad9f1f"
+  sha256 "a00b6067ab8f6ea1644fd88f128e3d045b71600c9e0a65021e12453e6000bdb0"
 
   bottle :unneeded
 

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -1,8 +1,8 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://dl.bintray.com/rabbitmq/all/rabbitmq-server/3.7.4/rabbitmq-server-generic-unix-3.7.4.tar.xz"
-  sha256 "a00b6067ab8f6ea1644fd88f128e3d045b71600c9e0a65021e12453e6000bdb0"
+  url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.4/rabbitmq-server-mac-standalone-3.7.4.tar.xz"
+  sha256 "536efce8362503d313b136b29b14245f8c7e30e1036c59d4cc1204a22cad9f1f"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [yes] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Current download url is not org. friendly and is blocked.  Suggest using Github URL with checksum to resolve this issue.