### PR TITLE
umlet: uses application name and application icon

### DIFF
--- a/Formula/umlet.rb
+++ b/Formula/umlet.rb
@@ -12,9 +12,8 @@ class Umlet < Formula
     rm Dir["*.{desktop,exe}"]
     libexec.install Dir["*"]
 
-    inreplace "#{libexec}/umlet.sh", " java ", " ${JAVA_HOME}/bin/java "
-    inreplace "#{libexec}/umlet.sh", /^programDir=.*$/,
-      "programDir=#{libexec}"
+    inreplace "#{libexec}/umlet.sh", /^programDir=.*$/, "programDir=#{libexec}"
+    inreplace "#{libexec}/umlet.sh", " java ", " ${JAVA_HOME}/bin/java -Xdock:name='UMLet #{version}' -Xdock:icon=${programDir}/img/umlet_logo.png "
 
     chmod 0755, "#{libexec}/umlet.sh"
 


### PR DESCRIPTION
Use of non-standard Java parameters to configure the application name (instead of 'java') and the application icon  in the macOS dock.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
