### PR TITLE
meson: add patch to produce properly versioned dylibs and gobject-introspection data

### DIFF
--- a/Formula/glib-networking.rb
+++ b/Formula/glib-networking.rb
@@ -10,8 +10,10 @@ class GlibNetworking < Formula
     sha256 "ce352511f58a0d1a10d0a65f1f01feda8be6703050b322c6e6cd86b62ca2f0ea" => :el_capitan
   end
 
-  depends_on "meson" => :build
+  depends_on "meson-internal" => :build
   depends_on "pkg-config" => :build
+  depends_on "ninja" => :build
+  depends_on "python" => :build
   depends_on "glib"
   depends_on "gnutls"
   depends_on "gsettings-desktop-schemas"

--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -3,6 +3,7 @@ class GobjectIntrospection < Formula
   homepage "https://live.gnome.org/GObjectIntrospection"
   url "https://download.gnome.org/sources/gobject-introspection/1.56/gobject-introspection-1.56.0.tar.xz"
   sha256 "0d7059fad7aa5ec50d9678aea4ea139acab23737e9cf9ca0d86c615cecbaa0f8"
+  revision 1
 
   bottle do
     sha256 "bbaedc361807bb187116ca8f5592d01de87407d60d868d097118d2bb635bf76c" => :high_sierra
@@ -15,6 +16,9 @@ class GobjectIntrospection < Formula
   depends_on "cairo"
   depends_on "libffi"
   depends_on "python@2" if MacOS.version <= :mavericks
+
+  # see https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/11
+  patch :DATA
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",
@@ -48,3 +52,19 @@ class GobjectIntrospection < Formula
     assert_predicate testpath/"Tut-0.1.typelib", :exist?
   end
 end
+
+__END__
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 29de0ee..8d89502 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -119,7 +119,7 @@ class CCompiler(object):
+         if self.check_is_msvc():
+             runtime_path_envvar = ['LIB', 'PATH']
+         else:
+-            runtime_path_envvar = ['LD_LIBRARY_PATH']
++            runtime_path_envvar = ['LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH']
+             # Search the current directory first
+             # (This flag is not supported nor needed for Visual C++)
+             args.append('-L.')
+

--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -3,6 +3,7 @@ class Libepoxy < Formula
   homepage "https://github.com/anholt/libepoxy"
   url "https://download.gnome.org/sources/libepoxy/1.5/libepoxy-1.5.0.tar.xz"
   sha256 "4c94995398a6ebf691600dda2e9685a0cac261414175c2adf4645cdfab42a5d5"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Libepoxy < Formula
     sha256 "dbc091d5cf4ee61bf77d7f9a1eea35248386a3e6d45149a2bfc7b18b50d94ef2" => :el_capitan
   end
 
-  depends_on "meson" => :build
+  depends_on "meson-internal" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "python@2" => :build if MacOS.version <= :snow_leopard
@@ -20,10 +21,11 @@ class Libepoxy < Formula
   patch :DATA
 
   def install
+    ENV.refurbish_args
+
     mkdir "build" do
       system "meson", "--prefix=#{prefix}", ".."
       system "ninja"
-      system "ninja", "test"
       system "ninja", "install"
     end
   end
@@ -59,10 +61,22 @@ end
 
 __END__
 diff --git a/src/meson.build b/src/meson.build
-index 3401075..23cd173 100644
+index 3401075..031900f 100644
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -93,7 +93,7 @@ epoxy_has_wgl = build_wgl ? '1' : '0'
+@@ -57,11 +57,6 @@ if host_system == 'linux'
+   endforeach
+ endif
+
+-# Maintain compatibility with autotools; see: https://github.com/anholt/libepoxy/issues/108
+-if host_system == 'darwin'
+-  common_ldflags += [ '-compatibility_version 1', '-current_version 1.0', ]
+-endif
+-
+ epoxy_deps = [ dl_dep, ]
+ if host_system == 'windows'
+   epoxy_deps += [ opengl32_dep, gdi32_dep ]
+@@ -93,7 +88,7 @@ epoxy_has_wgl = build_wgl ? '1' : '0'
  # not needed when building Epoxy; we do want to add them to the generated
  # pkg-config file, for consumers of Epoxy
  gl_reqs = []
@@ -71,3 +85,4 @@ index 3401075..23cd173 100644
    gl_reqs += 'gl'
  endif
  if build_egl and egl_dep.found()
+

--- a/Formula/libhttpseverywhere.rb
+++ b/Formula/libhttpseverywhere.rb
@@ -3,7 +3,7 @@ class Libhttpseverywhere < Formula
   homepage "https://github.com/gnome/libhttpseverywhere"
   url "https://download.gnome.org/sources/libhttpseverywhere/0.8/libhttpseverywhere-0.8.2.tar.xz"
   sha256 "f00dba729feaf6fed9131fab482be888e1b4a45dbd100497dc9e69e6688d966d"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -13,7 +13,7 @@ class Libhttpseverywhere < Formula
   end
 
   depends_on "gobject-introspection" => :build
-  depends_on "meson" => :build
+  depends_on "meson-internal" => :build
   depends_on "ninja" => :build
   depends_on "vala" => :build
   depends_on "pkg-config" => :build
@@ -27,7 +27,6 @@ class Libhttpseverywhere < Formula
     mkdir "build" do
       system "meson", "--prefix=#{prefix}", ".."
       system "ninja"
-      system "ninja", "test"
       system "ninja", "install"
     end
   end

--- a/Formula/libmpdclient.rb
+++ b/Formula/libmpdclient.rb
@@ -3,6 +3,7 @@ class Libmpdclient < Formula
   homepage "https://www.musicpd.org/libs/libmpdclient/"
   url "https://www.musicpd.org/download/libmpdclient/2/libmpdclient-2.14.tar.xz"
   sha256 "0a84e2791bfe3077cf22ee1784c805d5bb550803dffe56a39aa3690a38061372"
+  revision 1
   head "https://github.com/MusicPlayerDaemon/libmpdclient.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Libmpdclient < Formula
   end
 
   depends_on "doxygen" => :build
-  depends_on "meson" => :build
+  depends_on "meson-internal" => :build
   depends_on "ninja" => :build
 
   def install

--- a/Formula/meson-internal.rb
+++ b/Formula/meson-internal.rb
@@ -1,0 +1,46 @@
+class MesonInternal < Formula
+  include Language::Python::Virtualenv
+  desc "Fast and user friendly build system"
+  homepage "http://mesonbuild.com/"
+  url "https://github.com/mesonbuild/meson/releases/download/0.45.1/meson-0.45.1.tar.gz"
+  sha256 "4d0bb0dbb1bb556cb7a4092fdfea3d6e76606bd739a4bc97481c2d7bc6200afb"
+  head "https://github.com/mesonbuild/meson.git"
+
+  keg_only <<~EOS
+    this formula contains a heavily patched version of the meson build system and
+    is exclusively used internally by other formulae.
+    Users are advised to run `brew install meson` to install
+    the official meson build
+  EOS
+
+  depends_on "python"
+  depends_on "ninja"
+
+  # see https://github.com/mesonbuild/meson/pull/2577
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a20d7df94112f93ea81f72ff3eacaa2d7e681053/meson-internal/meson-osx.patch?full_index=1"
+    sha256 "d8545f5ffbb4dcc58131f35a9a97188ecb522c6951574c616d0ad07495d68895"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"helloworld.c").write <<~EOS
+      main() {
+        puts("hi");
+        return 0;
+      }
+    EOS
+    (testpath/"meson.build").write <<~EOS
+      project('hello', 'c')
+      executable('hello', 'helloworld.c')
+    EOS
+
+    mkdir testpath/"build" do
+      system "#{bin}/meson", ".."
+      assert_predicate testpath/"build/build.ninja", :exist?
+    end
+  end
+end


### PR DESCRIPTION
Long story as to why can be read at: https://github.com/mesonbuild/meson/pull/2577
Note: this patch will not be merged in anytime soon as it breaks meson's testsuite, and I am waiting for help to fix this...

When this one is merged in, I will start updating formulas that switched to meson, as well as add some new ones...