### PR TITLE
vips: depend on webp and graphicsmagick

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -3,7 +3,7 @@ class Vips < Formula
   homepage "https://github.com/jcupitt/libvips"
   url "https://github.com/jcupitt/libvips/releases/download/v8.6.3/vips-8.6.3.tar.gz"
   sha256 "f85adbb9f5f0f66b34a40fd2d2e60d52f6e992831f54af706db446f582e10992"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "6c2b0a986cea55fac585c32c56d67100fbc5e173cca2bb800289a10d1cc3c249" => :high_sierra
@@ -17,7 +17,7 @@ class Vips < Formula
   depends_on "giflib"
   depends_on "glib"
   depends_on "gobject-introspection"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libexif"
   depends_on "libgsf"
   depends_on "libpng"
@@ -27,15 +27,17 @@ class Vips < Formula
   depends_on "orc"
   depends_on "pango"
   depends_on "pygobject3"
+  depends_on "webp"
   depends_on "fftw" => :recommended
+  depends_on "graphicsmagick" => :recommended
   depends_on "poppler" => :recommended
-  depends_on "graphicsmagick" => :optional
   depends_on "imagemagick" => :optional
-  depends_on "jpeg-turbo" => :optional
-  depends_on "mozjpeg" => :optional
   depends_on "openexr" => :optional
   depends_on "openslide" => :optional
-  depends_on "webp" => :optional
+
+  if build.with?("graphicsmagick") && build.with?("imagemagick")
+    odie "vips: --with-imagemagick requires --without-graphicsmagick"
+  end
 
   def install
     args = %W[
@@ -47,20 +49,9 @@ class Vips < Formula
 
     if build.with? "graphicsmagick"
       args << "--with-magick" << "--with-magickpackage=GraphicsMagick"
+    elsif build.with? "imagemagick"
+      args << "--with-magick"
     end
-
-    # Let the formula find optional jpeg libraries before the main
-    # jpeg formula.
-    if build.with? "jpeg-turbo"
-      ENV.prepend_path "PKG_CONFIG_PATH",
-                       Formula["jpeg-turbo"].opt_lib/"pkgconfig"
-    end
-    if build.with? "mozjpeg"
-      ENV.prepend_path "PKG_CONFIG_PATH",
-                       Formula["mozjpeg"].opt_lib/"pkgconfig"
-    end
-
-    args << "--without-libwebp" if build.without? "webp"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
`vips` currently has a high rate of build from source (40%), due to the `webp` and `graphicsmagick` options:

```
install events in the last 30 days for vips
================================================================================
 1 | vips                                                      |   775 |  60.83%
 2 | vips --with-graphicsmagick --with-webp                    |   220 |  17.27%
 3 | vips --with-webp                                          |    78 |   6.12%
```

The cost of enabling these two by default is low, as `vips`'s dep tree is already extensive (43 recursive deps), adding 2 (plus recursive jasper dep) is not much more.

Moreover, `vips` has a high rate of build-from-source failure (5%), mostly due to `--with-webp`. Bottling it will avoid instable builds, or help us address them :)