### PR TITLE
jpeg-turbo 1.5.90 (devel)

### DIFF
--- a/Formula/jpeg-turbo.rb
+++ b/Formula/jpeg-turbo.rb
@@ -11,41 +11,41 @@ class JpegTurbo < Formula
     sha256 "6912770fdaefa0941c3259cbec3abf670ba8b6067239fde276686ed610599dda" => :el_capitan
   end
 
+  devel do
+    url "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.90.tar.gz"
+    sha256 "cb948ade92561d8626fd7866a4a7ba3b952f9759ea3dd642927bc687470f60b7"
+
+    depends_on "cmake" => :build
+  end
+
   head do
     url "https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
+    depends_on "cmake" => :build
   end
 
   keg_only "libjpeg-turbo is not linked to prevent conflicts with the standard libjpeg"
 
   option "without-test", "Skip build-time checks (Not Recommended)"
 
-  depends_on "libtool" => :build
   depends_on "nasm" => :build
 
   def install
-    cp Dir["#{Formula["libtool"].opt_share}/libtool/*/config.{guess,sub}"], buildpath
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --with-jpeg8
-      --mandir=#{man}
-    ]
+    if build.stable?
+      system "./configure", "--disable-dependency-tracking",
+                            "--prefix=#{prefix}",
+                            "--with-jpeg8"
+    else
+      system "cmake", ".", "-DWITH_JPEG8=1", *std_cmake_args
+    end
 
-    system "autoreconf", "-fvi" if build.head?
-    system "./configure", *args
     system "make"
     system "make", "test" if build.with? "test"
-    ENV.deparallelize # Stops a race condition error: file exists
     system "make", "install"
   end
 
   test do
-    system "#{bin}/jpegtran", "-crop", "1x1",
-                              "-transpose", "-perfect",
-                              "-outfile", "out.jpg",
-                              test_fixtures("test.jpg")
+    system "#{bin}/jpegtran", "-crop", "1x1", "-transpose", "-perfect",
+                              "-outfile", "out.jpg", test_fixtures("test.jpg")
   end
 end


### PR DESCRIPTION
- This is 1.5.90 = 2.0 beta1
- The build system for the beta and head has moved to cmake
- Remove some old hacks that are not necessary anymore: `mandir` is set automatically, `deparallelize` is not necessary, `config.{guess,sub}` are up-to-date in the latest tarball