### PR TITLE
dbus: Warn about Qt issues in a custom prefix

### DIFF
--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -64,6 +64,17 @@ class Dbus < Formula
     system "#{bin}/dbus-uuidgen", "--ensure=#{var}/lib/dbus/machine-id"
   end
 
+  def caveats
+    if HOMEBREW_PREFIX.to_s != "/usr/local"
+      <<~EOS
+        Because your prefix isn't /usr/local, if you want to use DBus features with Qt, you
+        may need to run the following command:
+
+            ln -sf #{opt_prefix}/lib/libdbus-1.dylib /usr/local/lib/
+      EOS
+    end
+  end
+
   test do
     system "#{bin}/dbus-daemon", "--version"
   end


### PR DESCRIPTION
Standard installations of Qt will not be able to find the dbus server if libdbus-1.dylib is not in /usr/local/lib, and it causes a rather confusing error message or crash.

If libdbus-1.dylib is not found, a QDBus application will crash on `QDBusAbstractInterface::callWithArgumentList`, and running the `qdbus` command will throw `org.freedesktop.DBus.Error.Disconnected`.


Simply symlinking libdbus-1.dylib to /usr/local/lib appears to solve the problem.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----