### PR TITLE
stellar-core: 9.2.0 (fix commit hash for tag)

### DIFF
--- a/Formula/stellar-core.rb
+++ b/Formula/stellar-core.rb
@@ -4,6 +4,7 @@ class StellarCore < Formula
   url "https://github.com/stellar/stellar-core.git",
     :tag => "v9.2.0",
     :revision => "7561c1d53366ec79b908de533726269e08474f77"
+  revision 1
   head "https://github.com/stellar/stellar-core.git"
 
   bottle do

--- a/Formula/stellar-core.rb
+++ b/Formula/stellar-core.rb
@@ -3,7 +3,7 @@ class StellarCore < Formula
   homepage "https://www.stellar.org/"
   url "https://github.com/stellar/stellar-core.git",
     :tag => "v9.2.0",
-    :revision => "a8b6a9dcb6550ce652dc9f81bc92a28be7c9baf8"
+    :revision => "7561c1d53366ec79b908de533726269e08474f77"
   head "https://github.com/stellar/stellar-core.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Prior to this fix I get the following error trying to upgrade `stellar-core` to `9.2.0` via build from source:

```
==> Cloning https://github.com/stellar/stellar-core.git
Updating /Users/isaac/Library/Caches/Homebrew/stellar-core--git
==> Checking out tag v9.2.0
Error: v9.2.0 tag should be a8b6a9dcb6550ce652dc9f81bc92a28be7c9baf8
but is actually 7561c1d53366ec79b908de533726269e08474f77
```

With this fix I have verified that build from source completes successfully and `7561c1d53366ec79b908de533726269e08474f77` is the correct `v9.2.0` commit hash.

Thanks.