### PR TITLE
php-cs-fixer 2.11.1 (new formula)

### DIFF
--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -1,0 +1,26 @@
+class PhpCsFixer < Formula
+  desc "Tool to automatically fix PHP coding standards issues"
+  homepage "https://wp-cli.org/"
+  url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.11.1/php-cs-fixer.phar"
+  version "2.11.1"
+  sha256 "cb1092637760c7283f63af3ef74ae835a861b123f8592a0aa195bd757cd1e088"
+
+  bottle :unneeded
+
+  def install
+    bin.install "php-cs-fixer.phar" => "php-cs-fixer"
+  end
+
+  test do
+    (testpath/"test.php").write <<~EOS
+      <?php $a = new    class(2){};
+    EOS
+    (testpath/"correct_test.php").write <<~EOS
+      <?php $a = new class(2) {
+      };
+    EOS
+
+    system "#{bin}/php-cs-fixer", "fix", "test.php"
+    assert compare_file("test.php", "correct_test.php")
+  end
+end

--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -15,11 +15,10 @@ class PhpCsFixer < Formula
 
   test do
     (testpath/"test.php").write <<~EOS
-      <?php $a = new    class(2){};
+      <?php $this->foo(   'homebrew rox'   );
     EOS
     (testpath/"correct_test.php").write <<~EOS
-      <?php $a = new class(2) {
-      };
+      <?php $this->foo('homebrew rox');
     EOS
 
     system "#{bin}/php-cs-fixer", "fix", "test.php"

--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -7,6 +7,8 @@ class PhpCsFixer < Formula
 
   bottle :unneeded
 
+  depends_on "php" if MacOS.version <= :el_capitan
+
   def install
     bin.install "php-cs-fixer.phar" => "php-cs-fixer"
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The version line needed adding since otherwise audit said `* Stable: version (cs) is set to a string without a digit` - should this be addressed in the version detection code perphaps ?