### PR TITLE
kubecfg 0.8.0 (new formula)

### DIFF
--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -23,12 +23,6 @@ class Kubecfg < Formula
     (zsh_completion/"_kubecfg").write output
   end
 
-  def caveats; <<~EOS
-    Example templates have been installed to:
-      #{opt_pkgshare}
-    EOS
-  end
-
   test do
     system bin/"kubecfg", "show", pkgshare/"kubecfg_test.jsonnet"
   end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -16,6 +16,13 @@ class Kubecfg < Formula
     mv sources, srcdir
     # The real build steps:
     cd srcdir do
+      # v0.7.2 doesn't yet include kubecfg.jsonnet in the binary, so
+      # let's add its location to the search path by default. This can
+      # be removed when v0.7.3 is released.
+      unless build.head?
+        inreplace "cmd/root.go", "JPaths: searchPaths",
+          "JPaths: append(searchPaths, \"#{share}/lib\")"
+      end
       args = []
       args.push("VERSION=v#{version}") unless build.head?
       system "make", *args
@@ -30,9 +37,8 @@ class Kubecfg < Formula
   end
 
   def caveats; <<~EOS
-    The builtin template "kubecfg.libsonnet" is installed for reference at:
-      #{lib}/kubecfg.libsonnet
-    but changing that file won't affect the compiled-in template.
+    The template directory #{lib} is the default library search
+    path. Set KUBECFG_JPATH in the environment to add to the search path.
 
     You can find more useful templates at:
       https://github.com/ksonnet/ksonnet-lib/releases

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -6,7 +6,6 @@ class Kubecfg < Formula
   head "https://github.com/ksonnet/kubecfg.git"
 
   depends_on "go" => :build
-  depends_on "go-bindata" => :build if build.head?
 
   def install
     # Standard gopath shenanigans to keep "go build" happy:
@@ -19,7 +18,6 @@ class Kubecfg < Formula
     cd srcdir do
       args = []
       args.push("VERSION=#{version}") unless build.head?
-      system "make", "generate", *args if build.head?
       system "make", *args
       system "make", "test", *args if build.head?
     end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -1,0 +1,48 @@
+class Kubecfg < Formula
+  desc "Manage complex enterprise Kubernetes environments as code"
+  homepage "https://github.com/ksonnet/kubecfg"
+  url "https://github.com/ksonnet/kubecfg/archive/v0.7.2.tar.gz"
+  sha256 "a01de014904af9177bb0ad15a249346d4b7bd6412268d0f83756541aa19fa38c"
+  head "https://github.com/ksonnet/kubecfg.git"
+
+  depends_on "go" => :build
+  depends_on "go-bindata" => :build if build.head?
+
+  def install
+    # Standard gopath shenanigans to keep "go build" happy:
+    sources = buildpath.children - [buildpath/".brew_home"]
+    ENV["GOPATH"] = buildpath
+    srcdir = buildpath/"src/github.com/ksonnet/kubecfg"
+    srcdir.mkpath
+    mv sources, srcdir
+    # The real build steps:
+    cd srcdir do
+      args = []
+      args.push("VERSION=#{version}") unless build.head?
+      system "make", "generate", *args if build.head?
+      system "make", *args
+      system "make", "test", *args if build.head?
+    end
+    # The install steps:
+    bin.install srcdir/"kubecfg"
+    sharelib = share/"lib"
+    sharelib.mkpath
+    sharelib.install srcdir/"lib/kubecfg.libsonnet"
+    sharelib.install srcdir/"lib/kubecfg_test.jsonnet"
+  end
+
+  def caveats; <<~EOS
+    The builtin template "kubecfg.libsonnet" is installed for reference at:
+      #{lib}/kubecfg.libsonnet
+    but changing that file won't affect the compiled-in template.
+
+    You can find more useful templates at:
+      https://github.com/ksonnet/ksonnet-lib/releases
+      https://github.com/bitnami/kube-manifests
+    EOS
+  end
+
+  test do
+    system "#{bin}/kubecfg", "show", "#{share}/lib/kubecfg_test.jsonnet"
+  end
+end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -43,6 +43,9 @@ class Kubecfg < Formula
   end
 
   test do
-    system "#{bin}/kubecfg", "show", "#{share}/lib/kubecfg_test.jsonnet"
+    output, status = Open3.capture2("#{bin}/kubecfg", "show",
+      "#{share}/lib/kubecfg_test.jsonnet")
+    assert_equal 0, status
+    assert_equal "---\napiVersion: test\nkind: Result\nresult: SUCCESS\n", output
   end
 end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -43,9 +43,6 @@ class Kubecfg < Formula
   end
 
   test do
-    output, status = Open3.capture2("#{bin}/kubecfg", "show",
-      "#{share}/lib/kubecfg_test.jsonnet")
-    assert_equal 0, status
-    assert_equal "---\napiVersion: test\nkind: Result\nresult: SUCCESS\n", output
+    system "#{bin}/kubecfg", "show", "#{share}/lib/kubecfg_test.jsonnet"
   end
 end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -17,7 +17,7 @@ class Kubecfg < Formula
     # The real build steps:
     cd srcdir do
       args = []
-      args.push("VERSION=#{version}") unless build.head?
+      args.push("VERSION=v#{version}") unless build.head?
       system "make", *args
       system "make", "test", *args if build.head?
     end

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -8,24 +8,20 @@ class Kubecfg < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    srcdir = buildpath/"src/github.com/ksonnet/kubecfg"
-    srcdir.install buildpath.children - [buildpath/".brew_home"]
-    # The real build steps:
-    cd srcdir do
-      args = []
-      args.push("VERSION=v#{version}")
-      system "make", *args
+    (buildpath/"src/github.com/ksonnet/kubecfg").install buildpath.children
+
+    cd "src/github.com/ksonnet/kubecfg" do
+      system "make", "VERSION=v#{version}"
+      bin.install "kubecfg"
+      sharelib = share/"lib"
+      sharelib.mkpath
+      sharelib.install "lib/kubecfg.libsonnet"
+      sharelib.install "lib/kubecfg_test.jsonnet"
+      output = Utils.popen_read("#{bin}/kubecfg completion --shell bash")
+      (bash_completion/"kubecfg").write output
+      output = Utils.popen_read("#{bin}/kubecfg completion --shell zsh")
+      (zsh_completion/"_kubecfg").write output
     end
-    # The install steps:
-    bin.install srcdir/"kubecfg"
-    sharelib = share/"lib"
-    sharelib.mkpath
-    sharelib.install srcdir/"lib/kubecfg.libsonnet"
-    sharelib.install srcdir/"lib/kubecfg_test.jsonnet"
-    output = Utils.popen_read("#{bin}/kubecfg completion --shell bash")
-    (bash_completion/"kubecfg").write output
-    output = Utils.popen_read("#{bin}/kubecfg completion --shell zsh")
-    (zsh_completion/"_kubecfg").write output
   end
 
   def caveats; <<~EOS

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -3,7 +3,6 @@ class Kubecfg < Formula
   homepage "https://github.com/ksonnet/kubecfg"
   url "https://github.com/ksonnet/kubecfg/archive/v0.8.0.tar.gz"
   sha256 "25d054af96a817bad0f33998895a9988c187e1399822c8220528e64f56ccb3ae"
-  head "https://github.com/ksonnet/kubecfg.git"
 
   depends_on "go" => :build
 
@@ -14,9 +13,8 @@ class Kubecfg < Formula
     # The real build steps:
     cd srcdir do
       args = []
-      args.push("VERSION=v#{version}") unless build.head?
+      args.push("VERSION=v#{version}")
       system "make", *args
-      system "make", "test", *args if build.head?
     end
     # The install steps:
     bin.install srcdir/"kubecfg"

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -13,30 +13,23 @@ class Kubecfg < Formula
     cd "src/github.com/ksonnet/kubecfg" do
       system "make", "VERSION=v#{version}"
       bin.install "kubecfg"
-      sharelib = share/"lib"
-      sharelib.mkpath
-      sharelib.install "lib/kubecfg.libsonnet"
-      sharelib.install "lib/kubecfg_test.jsonnet"
-      output = Utils.popen_read("#{bin}/kubecfg completion --shell bash")
-      (bash_completion/"kubecfg").write output
-      output = Utils.popen_read("#{bin}/kubecfg completion --shell zsh")
-      (zsh_completion/"_kubecfg").write output
+      pkgshare.install Dir["examples/*"], "lib/kubecfg_test.jsonnet"
+      prefix.install_metafiles
     end
+
+    output = Utils.popen_read("#{bin}/kubecfg completion --shell bash")
+    (bash_completion/"kubecfg").write output
+    output = Utils.popen_read("#{bin}/kubecfg completion --shell zsh")
+    (zsh_completion/"_kubecfg").write output
   end
 
   def caveats; <<~EOS
-    The builtin template "kubecfg.libsonnet" is installed for reference at:
-      #{lib}/kubecfg.libsonnet
-    but changing that file won't affect the compiled-in template.
-    Set KUBECFG_JPATH in the environment to add to the search path.
-
-    You can find more useful templates at:
-      https://github.com/ksonnet/ksonnet-lib/releases
-      https://github.com/bitnami/kube-manifests
+    Example templates have been installed to:
+      #{opt_pkgshare}
     EOS
   end
 
   test do
-    system "#{bin}/kubecfg", "show", "#{share}/lib/kubecfg_test.jsonnet"
+    system bin/"kubecfg", "show", pkgshare/"kubecfg_test.jsonnet"
   end
 end


### PR DESCRIPTION
This is a Kubernetes tool developed at Bitnami. It is a prerequisite
for some development tasks with the better-known Kubeless project
(http://kubeless.io/docs/dev-guide/). It should not be confused with
the identically-named, defunct precursor to kubectl.

I am slightly concerned that it doesn't have its own website, except
for its Github repository and a couple of YouTube videos. But a quick
survey shows that 25% of homebrew-core formulae have homepages in
the github.com domain, so I suspect it's OK.

- [✓] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✓] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
