### PR TITLE
clozure-cl 1.11.5 (restoration of a deleted formula)

### DIFF
--- a/Formula/cclive.rb
+++ b/Formula/cclive.rb
@@ -18,6 +18,8 @@ class Cclive < Formula
   depends_on "boost"
   depends_on "pcre"
 
+  conflicts_with "clozure-cl", :because => "both install a ccl binary"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/clozure-cl.rb
+++ b/Formula/clozure-cl.rb
@@ -1,0 +1,44 @@
+class ClozureCl < Formula
+  desc "Common Lisp implementation with a long history"
+  homepage "https://ccl.clozure.com"
+  url "https://github.com/Clozure/ccl/archive/v1.11.5.tar.gz"
+  sha256 "07c7e05c1d50ccbf1f7602a1d436b6d6da5dcda7656b89b74daa4cf833fc7929"
+  head "https://github.com/Clozure/ccl.git"
+
+  depends_on :xcode => :build
+
+  conflicts_with "cclive", :because => "both install a ccl binary"
+
+  resource "bootstrap" do
+    url "https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-darwinx86.tar.gz"
+    sha256 "5adbea3d8b4a2e29af30d141f781c6613844f468c0ccfa11bae908c3e9641939"
+  end
+
+  def install
+    tmpdir = Pathname.new(Dir.mktmpdir)
+    tmpdir.install resource("bootstrap")
+    buildpath.install tmpdir/"dx86cl64.image"
+    buildpath.install tmpdir/"darwin-x86-headers64"
+    cd "lisp-kernel/darwinx8664" do
+      system "make"
+    end
+
+    ENV["CCL_DEFAULT_DIRECTORY"] = buildpath
+
+    system "./dx86cl64", "-n", "-l", "lib/x8664env.lisp",
+                         "-e", "(ccl:xload-level-0)",
+                         "-e", "(ccl:compile-ccl)",
+                         "-e", "(quit)"
+    system "echo \"(ccl:save-application \\\"dx86cl64.image\\\")\\n(quit)\" | ./dx86cl64 -n --image-name x86-boot64.image"
+
+    prefix.install "doc/README"
+    doc.install Dir["doc/*"]
+    libexec.install Dir["*"]
+    bin.install Dir["#{libexec}/scripts/ccl64"]
+    bin.env_script_all_files(libexec/"bin", :CCL_DEFAULT_DIRECTORY => libexec)
+  end
+
+  test do
+    assert_equal "21", shell_output("#{bin}/ccl64 -n -e '(write-line (write-to-string (* 3 7)))' -e '(quit)'").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula was deleted in https://github.com/Homebrew/homebrew-core/pull/23970. Its problem was apparently that it did not build from sources, according to @ilovezfs. I have tried to address this issue while keeping most of the same code from the original formula. As far as I can tell from running some `find` incantations, there are no binary files in the source directory. So running the same commands as in the original formula seem to do the trick just fine and (I think) are building from source.

Ping @paulvaneecke and @vinay who also expressed interest in this formula's revival.