### PR TITLE
add version number to chamber compilation

### DIFF
--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -26,7 +26,8 @@ class Chamber < Formula
 
     cd buildpath/"src/github.com/segmentio/chamber" do
       system "govendor", "sync"
-      system "go", "build", "-o", bin/"chamber"
+      system "go", "build", "-o", bin/"chamber",
+                   "-ldflags", "-X main.Version=#{version}"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
works with both version controlled & `--HEAD` (which shows the git short hash as a version), currently just shows as `dev` in both cases

didn't really feel the need to revision bump it