### PR TITLE
vim: Adds support for --with-gui option

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -17,6 +17,7 @@ class Vim < Formula
   option "with-override-system-vi", "Override system vi"
   option "with-gettext", "Build vim with National Language Support (translated messages, keymaps)"
   option "with-client-server", "Enable client/server mode"
+  option "with-gui", "Build vim with GUI support"
 
   LANGUAGES_OPTIONAL = %w[lua python@2 tcl].freeze
   LANGUAGES_DEFAULT  = %w[python].freeze
@@ -36,13 +37,13 @@ class Vim < Formula
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
   depends_on "python@2" => :optional
-  depends_on :x11 if build.with? "client-server"
+  depends_on "python@2" if build.with? ("enable-gui" || "client-server")
 
   conflicts_with "ex-vi",
     :because => "vim and ex-vi both install bin/ex and bin/view"
 
   def install
-    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"
 
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")
@@ -67,12 +68,12 @@ class Vim < Formula
     end
 
     opts << "--disable-nls" if build.without? "gettext"
-    opts << "--enable-gui=no"
 
-    if build.with? "client-server"
-      opts << "--with-x"
+    if build.with? ("gui" || "client-server")
+      opts << "--enable-gui=mac"
     else
       opts << "--without-x"
+      opts << "--enable-gui=no"
     end
 
     if build.with?("lua") || build.with?("luajit")


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Adds support for `--with-gui` for Vim.
- Dropped x11 since I've read you're planning to get it rid soon anyway.
- Enforced Python 2 since some Python scripts from Vim aren't compatible with Python 3 and default `python` formula is using Python 3 (refs: vim/vim/issues/2754)