### PR TITLE
[ffmpeg@2.8] Add --without-avx2 compilation option

### DIFF
--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -19,6 +19,7 @@ class FfmpegAT28 < Formula
   option "without-xvid", "Disable Xvid MPEG-4 video encoder"
   option "without-qtkit", "Disable deprecated QuickTime framework"
   option "without-securetransport", "Disable use of SecureTransport"
+  option "without-avx2", "Disable AVX2 optimization"
 
   option "with-rtmpdump", "Enable RTMP protocol"
   option "with-libass", "Enable ASS/SSA subtitle format"
@@ -133,6 +134,7 @@ class FfmpegAT28 < Formula
     args << "--enable-libdcadec" if build.with? "dcadec"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
     args << "--disable-securetransport" if build.without? "securetransport"
+    args << "--disable-avx2" if build.without? "avx2"
 
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
