### PR TITLE
git-ftp: no brotli opportunistic linkage

### DIFF
--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -3,7 +3,7 @@ class GitFtp < Formula
   homepage "https://git-ftp.github.io/"
   url "https://github.com/git-ftp/git-ftp/archive/1.4.0.tar.gz"
   sha256 "080e9385a9470d70a5a2a569c6e7db814902ffed873a77bec9d0084bcbc3e054"
-  revision 5
+  revision 6
   head "https://github.com/git-ftp/git-ftp.git", :branch => "develop"
 
   bottle do
@@ -28,14 +28,15 @@ class GitFtp < Formula
                             "--disable-dependency-tracking",
                             "--disable-silent-rules",
                             "--prefix=#{libexec}",
+                            "--disable-ares",
                             "--with-darwinssl",
+                            "--with-libssh2",
+                            "--without-brotli",
                             "--without-ca-bundle",
                             "--without-ca-path",
-                            "--with-libssh2",
-                            "--without-libmetalink",
                             "--without-gssapi",
-                            "--without-librtmp",
-                            "--disable-ares"
+                            "--without-libmetalink",
+                            "--without-librtmp"
       system "make", "install"
     end
 


### PR DESCRIPTION
```
11:00:05 ==> brew linkage --test git-ftp
11:00:06 ==> FAILED
11:00:06 Missing libraries:
11:00:06   /usr/local/opt/brotli/lib/libbrotlidec.1.dylib
```

says https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/21196/version=high_sierra/console