### PR TITLE
node@4 4.9.0, node@6 6.14.0, node@8 8.11.0

### DIFF
--- a/Formula/node@4.rb
+++ b/Formula/node@4.rb
@@ -1,9 +1,8 @@
 class NodeAT4 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v4.8.7/node-v4.8.7.tar.xz"
-  sha256 "03479a8ce6affedde75d80a6c8c351a7afb5a85b8d7e5119ab6f349100e641f8"
-  revision 1
+  url "https://nodejs.org/dist/v4.9.0/node-v4.9.0.tar.xz"
+  sha256 "a1b271c585f45e2f17c6a211bc87028c448d54f4418a494d5ae62d114ecbb69f"
   head "https://github.com/nodejs/node.git", :branch => "v4.x-staging"
 
   bottle do
@@ -51,11 +50,7 @@ class NodeAT4 < Formula
 
   def post_install
     return if build.without? "npm"
-
-    (lib/"node_modules/npm/npmrc").atomic_write <<~EOS
-      prefix = #{HOMEBREW_PREFIX}
-      python = /usr/bin/python
-    EOS
+    (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
   def caveats

--- a/Formula/node@6.rb
+++ b/Formula/node@6.rb
@@ -1,8 +1,8 @@
 class NodeAT6 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v6.13.1/node-v6.13.1.tar.xz"
-  sha256 "c437350b476503a0f5605a5cc08bc41fe3bdb8ec100939ec7ea6600e44d56a46"
+  url "https://nodejs.org/dist/v6.14.0/node-v6.14.0.tar.xz"
+  sha256 "21ab08323dfd082e60fefa5e1af99b086c6154a6675ad265a42462621c35d599"
   head "https://github.com/nodejs/node.git", :branch => "v6.x-staging"
 
   bottle do
@@ -54,11 +54,7 @@ class NodeAT6 < Formula
 
   def post_install
     return if build.without? "npm"
-
-    (lib/"node_modules/npm/npmrc").atomic_write <<~EOS
-      prefix = #{HOMEBREW_PREFIX}
-      python = /usr/bin/python
-    EOS
+    (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
   def caveats

--- a/Formula/node@8.rb
+++ b/Formula/node@8.rb
@@ -1,8 +1,8 @@
 class NodeAT8 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v8.10.0/node-v8.10.0.tar.xz"
-  sha256 "b72d4e71618d6bcbd039b487b51fa7543631a4ac3331d7caf69bdf55b5b2901a"
+  url "https://nodejs.org/dist/v8.11.0/node-v8.11.0.tar.xz"
+  sha256 "1ad354cf4ac96a904007b907fc1fe7fa2fd3692036da0c2fb1790f7a0204ab3f"
   head "https://github.com/nodejs/node.git", :branch => "v8.x-staging"
 
   bottle do
@@ -46,11 +46,7 @@ class NodeAT8 < Formula
 
   def post_install
     return if build.without? "npm"
-
-    (lib/"node_modules/npm/npmrc").atomic_write <<~EOS
-      prefix = #{HOMEBREW_PREFIX}
-      python = /usr/bin/python
-    EOS
+    (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[March 2018 Security Releases](https://nodejs.org/en/blog/vulnerability/march-2018-security-releases/) update for the versioned node formulaes (update for the current node formula in #25880).

I've also reverted the no longer needed node-gyp python path changes (because it got fixed with the PEP 394 compliant python from #25060). But I've kept the prefix fix, so that user force linking a versioned node formula will have a npm with a proper global prefix in their path (and not with a prefix set to cellar). 

 