### PR TITLE
Remove some options

### DIFF
--- a/Formula/ffmbc.rb
+++ b/Formula/ffmbc.rb
@@ -4,7 +4,7 @@ class Ffmbc < Formula
   url "https://drive.google.com/uc?export=download&id=0B0jxxycBojSwTEgtbjRZMXBJREU"
   version "0.7.2"
   sha256 "caaae2570c747077142db34ce33262af0b6d0a505ffbed5c4bdebce685d72e42"
-  revision 4
+  revision 5
 
   bottle do
     sha256 "93018afba1f0661d6e6a539b189eea0692932a7af0a30b4c81aebadc79332657" => :high_sierra
@@ -12,24 +12,15 @@ class Ffmbc < Formula
     sha256 "118b7d823df82d0b9eb27544dfe0246f8119aac8f48431e814119448dc47b936" => :el_capitan
   end
 
-  option "without-x264", "Disable H.264 encoder"
-  option "without-lame", "Disable MP3 encoder"
-  option "without-xvid", "Disable Xvid MPEG-4 video encoder"
-
-  # manpages won't be built without texi2html
-  depends_on "texi2html" => :build if MacOS.version >= :mountain_lion
+  depends_on "texi2html" => :build
   depends_on "yasm" => :build
-
-  depends_on "x264" => :recommended
-  depends_on "faac" => :recommended
-  depends_on "lame" => :recommended
-  depends_on "xvid" => :recommended
-
-  depends_on "freetype" => :optional
-  depends_on "theora" => :optional
+  depends_on "faac"
+  depends_on "lame"
+  depends_on "x264"
+  depends_on "xvid"
   depends_on "libvorbis" => :optional
-  depends_on "libogg" => :optional
   depends_on "libvpx" => :optional
+  depends_on "theora" => :optional
 
   patch :DATA # fix man page generation, fixed in upstream ffmpeg
 
@@ -38,18 +29,15 @@ class Ffmbc < Formula
             "--disable-debug",
             "--disable-shared",
             "--enable-gpl",
+            "--enable-libfaac",
+            "--enable-libmp3lame",
+            "--enable-libx264",
+            "--enable-libxvid",
             "--enable-nonfree",
             "--cc=#{ENV.cc}"]
 
-    args << "--enable-libx264" if build.with? "x264"
-    args << "--enable-libfaac" if build.with? "faac"
-    args << "--enable-libmp3lame" if build.with? "lame"
-    args << "--enable-libxvid" if build.with? "xvid"
-
-    args << "--enable-libfreetype" if build.with? "freetype"
     args << "--enable-libtheora" if build.with? "theora"
     args << "--enable-libvorbis" if build.with? "libvorbis"
-    args << "--enable-libogg" if build.with? "libogg"
     args << "--enable-libvpx" if build.with? "libvpx"
 
     system "./configure", *args

--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -14,16 +14,13 @@ class Freetype < Formula
 
   keg_only :provided_pre_mountain_lion
 
-  option "without-subpixel", "Disable sub-pixel rendering (a.k.a. LCD rendering, or ClearType)"
-
   depends_on "libpng"
 
   def install
-    if build.with? "subpixel"
-      inreplace "include/freetype/config/ftoption.h",
-          "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */",
-          "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
-    end
+    # Enable sub-pixel rendering (ClearType)
+    inreplace "include/freetype/config/ftoption.h",
+      "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */",
+      "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
 
     system "./configure", "--prefix=#{prefix}", "--without-harfbuzz"
     system "make"

--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -18,23 +18,18 @@ class Webp < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "jpeg"
   depends_on "libpng"
-  depends_on "jpeg" => :recommended
-  depends_on "libtiff" => :optional
-  depends_on "giflib" => :optional
 
   def install
-    args = [
-      "--disable-dependency-tracking",
-      "--disable-gl",
-      "--enable-libwebpmux",
-      "--enable-libwebpdemux",
-      "--enable-libwebpdecoder",
-      "--prefix=#{prefix}",
-    ]
-    args << "--disable-gif" if build.without? "giflib"
     system "./autogen.sh" if build.head?
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-gif",
+                          "--disable-gl",
+                          "--enable-libwebpdecoder",
+                          "--enable-libwebpdemux",
+                          "--enable-libwebpmux"
     system "make", "install"
   end
 

--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -14,25 +14,14 @@ class X264 < Formula
     sha256 "3ac151bdd5cf62a55fb41c60761c548db721a7b6c1ebc6f4af5b4fc71b499e7f" => :el_capitan
   end
 
-  option "with-10-bit", "Build a 10-bit x264 (default: 8-bit)"
-  option "with-l-smash", "Build CLI with l-smash mp4 output"
-
   depends_on "nasm" => :build
-  depends_on "l-smash" => :optional
-
-  deprecated_option "10-bit" => "with-10-bit"
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --enable-shared
-      --enable-static
-      --enable-strip
-    ]
-    args << "--disable-lsmash" if build.without? "l-smash"
-    args << "--bit-depth=10" if build.with? "10-bit"
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-lsmash",
+                          "--enable-shared",
+                          "--enable-static",
+                          "--enable-strip"
     system "make", "install"
   end
 


### PR DESCRIPTION
Remove some seldom-used or useless options from the top used formulas, based on analytics.

For harfbuzz, cairo is already a recursive dep so it makes no sense not to have it recommended.

poke @ilovezfs @MikeMcQuaid 