### PR TITLE
remove gtest dependency from ninja

### DIFF
--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -16,17 +16,11 @@ class Ninja < Formula
 
   deprecated_option "without-tests" => "without-test"
 
-  resource "gtest" do
-    url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/googletest/gtest-1.7.0.zip"
-    sha256 "247ca18dd83f53deb1328be17e4b1be31514cedfc1e3424f672bf11fd7e0d60d"
-  end
-
   def install
     system "python", "configure.py", "--bootstrap"
 
     if build.with? "test"
-      (buildpath/"gtest").install resource("gtest")
-      system "./configure.py", "--with-gtest=gtest"
+      system "./configure.py"
       system "./ninja", "ninja_test"
       system "./ninja_test", "--gtest_filter=-SubprocessTest.SetWithLots"
     end


### PR DESCRIPTION
Ninja has not depended on GTest since v1.5.3.  It was removed in commit
ninja-build/ninja@b2fe56caaf0bed497ee480003f10486c18d8de9a.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I just ran into this on a annoyingly slow mobile connection, so I thought I'd fix it.