### PR TITLE
Update monero to latest HF v0.12.0.0

### DIFF
--- a/Formula/monero.rb
+++ b/Formula/monero.rb
@@ -1,8 +1,7 @@
 class Monero < Formula
-  desc "Official monero wallet and cpu miner"
-  homepage "https://getmonero.org/"
-  url "https://github.com/monero-project/monero/archive/v0.11.1.0.tar.gz"
-  sha256 "b5b48d3e5317c599e1499278580e9a6ba3afc3536f4064fcf7b20840066a509b"
+  desc "Monero: the secure, private, untraceable cryptocurrency"
+  homepage "https://getmonero.org"
+  url "https://github.com/monero-project/monero.git", :tag => "v0.12.0.0"
 
   bottle do
     sha256 "4605768a865c17daae09b3e1ddfd96babe0779126ff1ed90db26238e020d8283" => :high_sierra


### PR DESCRIPTION
All passes.

The Hard Fork is scheduled for April 4. I changed source path to git, because there is a submodule.