### PR TITLE
skinny 2.6.0

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.5.2/skinny-2.5.2.tar.gz"
-  sha256 "0d21d017ef2a32a3e0ef497262c846ad3d04f32d4339b26d6cffc70f952527f6"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/2.6.0/skinny-2.6.0.tar.gz"
+  sha256 "507d6fdf40efe40fe2b06b5eecea6bb3f0f977f27e25723c8a0c2f3a8231f4f2"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Thank you as always :bow:

https://github.com/skinny-framework/skinny-framework/releases/tag/2.6.0

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
$ brew audit --strict Formula/skinny.rb
==> Installing or updating 'rubocop' gem
Fetching: parallel-1.12.1.gem (100%)
Successfully installed parallel-1.12.1
Fetching: ast-2.4.0.gem (100%)
Successfully installed ast-2.4.0
Fetching: parser-2.5.0.5.gem (100%)
Successfully installed parser-2.5.0.5
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: rainbow-3.0.0.gem (100%)
Successfully installed rainbow-3.0.0
Fetching: ruby-progressbar-1.9.0.gem (100%)
Successfully installed ruby-progressbar-1.9.0
Fetching: unicode-display_width-1.3.0.gem (100%)
Successfully installed unicode-display_width-1.3.0
Fetching: rubocop-0.53.0.gem (100%)
Successfully installed rubocop-0.53.0
8 gems installed
$

$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/2.6.0/skinny-2.6.0.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/9b488930-35bb-11e8-87d1-995c202e8600?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180401%2Fus-east-1%2Fs3%2F
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/2.6.0: 474 files, 62.3MB, built in 35 seconds
$
```