### PR TITLE
ruby: replace with perl 6

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -1,206 +1,52 @@
 class Ruby < Formula
-  desc "Powerful, clean, object-oriented scripting language"
-  homepage "https://www.ruby-lang.org/"
-  url "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.xz"
-  sha256 "886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d"
+  desc "Next-generation Perl"
+  homepage "http://rakudo.org/"
+  url "https://rakudo.perl6.org/downloads/star/rakudo-star-2018.01.tar.gz"
+  sha256 "8f0290f409307c45a107360e7883f2fad3c19aa995133ab53e6f36ae9452d351"
 
   bottle do
-    sha256 "8e0435a0c5b066866799464e6603ceb2afe20f5dc92ed98e1057dd5a319f5cc2" => :high_sierra
-    sha256 "3bfecdbe9caf5cf8e13bfccdfb2cf1ad1f8d1ce6efb62152d73717ac63479eaf" => :sierra
-    sha256 "91f06a229b8f8a89cdb3870517d1f5d22a4ba915e43bc7c2b20d3224778492cd" => :el_capitan
+    sha256 "e90c8e08dc6236adbef651d7767fe9230c13cceacee39655707fadc7c92965f4" => :high_sierra
+    sha256 "7fafda1950b60283b2b85b607f2251e42917c727775d7c47cdeeed5feef2fe87" => :sierra
+    sha256 "c5bf17dcfa36cd061fc70b7a5a5ae7e46273ecc87d84bdf65412f98105da135b" => :el_capitan
   end
 
-  devel do
-    url "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.xz"
-    version "2.6.0-preview1"
-    sha256 "1d99139116e4e245ce543edb137b2a8873c26e9f0bde88d8cee6789617cc8d0e"
-  end
+  option "with-jvm", "Build also for jvm as an alternate backend."
 
-  head do
-    url "https://svn.ruby-lang.org/repos/ruby/trunk/"
-    depends_on "autoconf" => :build
-  end
+  depends_on "gmp" => :optional
+  depends_on "icu4c" => :optional
+  depends_on "pcre" => :optional
+  depends_on "libffi"
 
-  depends_on "pkg-config" => :build
-  depends_on "libyaml"
-  depends_on "openssl"
-  depends_on "readline"
-
-  # Should be updated only when Ruby is updated (if an update is available).
-  # The exception is Rubygem security fixes, which mandate updating this
-  # formula & the versioned equivalents and bumping the revisions.
-  resource "rubygems" do
-    url "https://rubygems.org/rubygems/rubygems-2.7.6.tgz"
-    sha256 "67f714a582a9ce471bbbcb417374ea9cf9c061271c865dbb0d093f3bc3371eeb"
-  end
-
-  def api_version
-    Utils.popen_read("#{bin}/ruby -e 'print Gem.ruby_api_version'")
-  end
-
-  def rubygems_bindir
-    HOMEBREW_PREFIX/"bin"
-  end
+  conflicts_with "parrot"
 
   def install
-    # otherwise `gem` command breaks
-    ENV.delete("SDKROOT")
+    libffi = Formula["libffi"]
+    ENV.remove "CPPFLAGS", "-I#{libffi.include}"
+    ENV.prepend "CPPFLAGS", "-I#{libffi.lib}/libffi-#{libffi.version}/include"
 
-    system "autoconf" if build.head?
+    ENV.deparallelize # An intermittent race condition causes random build failures.
 
-    paths = %w[libyaml openssl readline].map { |f| Formula[f].opt_prefix }
-    args = %W[
-      --prefix=#{prefix}
-      --enable-shared
-      --disable-silent-rules
-      --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
-      --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
-      --with-opt-dir=#{paths.join(":")}
-    ]
-    args << "--disable-dtrace" unless MacOS::CLT.installed?
+    backends = ["moar"]
+    generate = ["--gen-moar"]
 
-    system "./configure", *args
+    backends << "jvm" if build.with? "jvm"
 
-    # Ruby has been configured to look in the HOMEBREW_PREFIX for the
-    # sitedir and vendordir directories; however we don't actually want to create
-    # them during the install.
-    #
-    # These directories are empty on install; sitedir is used for non-rubygems
-    # third party libraries, and vendordir is used for packager-provided libraries.
-    inreplace "tool/rbinstall.rb" do |s|
-      s.gsub! 'prepare "extension scripts", sitelibdir', ""
-      s.gsub! 'prepare "extension scripts", vendorlibdir', ""
-      s.gsub! 'prepare "extension objects", sitearchlibdir', ""
-      s.gsub! 'prepare "extension objects", vendorarchlibdir', ""
-    end
-
+    system "perl", "Configure.pl", "--prefix=#{prefix}", "--backends=" + backends.join(","), *generate
     system "make"
     system "make", "install"
 
-    # A newer version of ruby-mode.el is shipped with Emacs
-    elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
+    # Panda is now in share/perl6/site/bin, so we need to symlink it too.
+    bin.install_symlink Dir[share/"perl6/site/bin/*"]
 
-    # This is easier than trying to keep both current & versioned Ruby
-    # formulae repeatedly updated with Rubygem patches.
-    resource("rubygems").stage do
-      ENV.prepend_path "PATH", bin
-
-      system "#{bin}/ruby", "setup.rb", "--prefix=#{buildpath}/vendor_gem"
-      rg_in = lib/"ruby/#{api_version}"
-
-      # Remove bundled Rubygem version.
-      rm_rf rg_in/"rubygems"
-      rm_f rg_in/"rubygems.rb"
-      rm_f rg_in/"ubygems.rb"
-      rm_f bin/"gem"
-
-      # Drop in the new version.
-      rg_in.install Dir[buildpath/"vendor_gem/lib/*"]
-      bin.install buildpath/"vendor_gem/bin/gem" => "gem"
-      (libexec/"gembin").install buildpath/"vendor_gem/bin/bundle" => "bundle"
-      (libexec/"gembin").install_symlink "bundle" => "bundler"
-    end
-  end
-
-  def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm_f %W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
-    rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
-
-    # Customize rubygems to look/install in the global gem directory
-    # instead of in the Cellar, making gems last across reinstalls
-    config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
-    config_file.unlink if config_file.exist?
-    config_file.write rubygems_config(api_version)
-
-    # Create the sitedir and vendordir that were skipped during install
-    %w[sitearchdir vendorarchdir].each do |dir|
-      mkdir_p `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["#{dir}"]'`
-    end
-  end
-
-  def rubygems_config(api_version); <<~EOS
-    module Gem
-      class << self
-        alias :old_default_dir :default_dir
-        alias :old_default_path :default_path
-        alias :old_default_bindir :default_bindir
-        alias :old_ruby :ruby
-      end
-
-      def self.default_dir
-        path = [
-          "#{HOMEBREW_PREFIX}",
-          "lib",
-          "ruby",
-          "gems",
-          "#{api_version}"
-        ]
-
-        @default_dir ||= File.join(*path)
-      end
-
-      def self.private_dir
-        path = if defined? RUBY_FRAMEWORK_VERSION then
-                 [
-                   File.dirname(RbConfig::CONFIG['sitedir']),
-                   'Gems',
-                   RbConfig::CONFIG['ruby_version']
-                 ]
-               elsif RbConfig::CONFIG['rubylibprefix'] then
-                 [
-                  RbConfig::CONFIG['rubylibprefix'],
-                  'gems',
-                  RbConfig::CONFIG['ruby_version']
-                 ]
-               else
-                 [
-                   RbConfig::CONFIG['libdir'],
-                   ruby_engine,
-                   'gems',
-                   RbConfig::CONFIG['ruby_version']
-                 ]
-               end
-
-        @private_dir ||= File.join(*path)
-      end
-
-      def self.default_path
-        if Gem.user_home && File.exist?(Gem.user_home)
-          [user_dir, default_dir, private_dir]
-        else
-          [default_dir, private_dir]
-        end
-      end
-
-      def self.default_bindir
-        "#{rubygems_bindir}"
-      end
-
-      def self.ruby
-        "#{opt_bin}/ruby"
-      end
-    end
-    EOS
+    # Move the man pages out of the top level into share.
+    # Not all backends seem to generate man pages at this point (moar does not, parrot does),
+    # so we need to check if the directory exists first.
+    mv "#{prefix}/man", share if File.directory?("#{prefix}/man")
   end
 
   test do
-    hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
-    assert_equal "hello\n", hello_text
-    ENV["GEM_HOME"] = testpath
-    system "#{bin}/gem", "install", "json"
-
-    (testpath/"Gemfile").write <<~EOS
-      source 'https://rubygems.org'
-      gem 'gemoji'
-    EOS
-    system rubygems_bindir/"bundle", "install", "--binstubs=#{testpath}/bin"
-    assert_predicate testpath/"bin/gemoji", :exist?, "gemoji is not installed in #{testpath}/bin"
+    out = `#{bin}/perl6 -e 'loop (my $i = 0; $i < 10; $i++) { print $i }'`
+    assert_equal "0123456789", out
+    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It's often acknowledged that Ruby is heavily inspired by Perl. From the syntax to the naming of early stdlib methods, Ruby is in many ways a modern version of Perl. It's not unfair to say that Ruby has replaced Perl in many developers' toolboxes.

As Perl 6 has matured, however, it's fair to say that it has assumed the mantle of modern Perl. Ruby has done well for us over the years, but it's time to finally say goodbye and acknowledge that Perl 6 has taken its place fair and square.