### PR TITLE
patchutils --HEAD: Fix docbook dependency

### DIFF
--- a/Formula/patchutils.rb
+++ b/Formula/patchutils.rb
@@ -19,11 +19,13 @@ class Patchutils < Formula
     url "https://github.com/twaugh/patchutils.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
+    depends_on "docbook" => :build
   end
 
   depends_on "xmlto" => :build
 
   def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
     system "./bootstrap" if build.head?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
"brew install patchutils --HEAD" fails while building its manpages, due to a failing dependency on docbook.

    ==> Checking out branch master
    ==> ./bootstrap
    ==> ./configure --prefix=/usr/local/Cellar/patchutils/HEAD-3c70aa1
    ==> make install
    I/O error : Attempt to load network entity http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd
    warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
    validity error : Could not load the external subset "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"

[Other formulas][1] address this issue by setting XML_CATALOG_FILES, which we adopt here as well. The fix ensures that the files are available locally, so network access is not attempted.

[1]: https://github.com/Homebrew/homebrew-core/blob/8399648cf8110f27ea4b2456c81a64be7c4da393/Formula/ascii.rb#L21

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
