### PR TITLE
install manpages for notmuch

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -20,6 +20,8 @@ class Notmuch < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libgpg-error" => :build
+  depends_on "sphinx-doc" => :build
+  depends_on "doxygen" => :build
   depends_on "glib"
   depends_on "gmime"
   depends_on "talloc"
@@ -36,7 +38,7 @@ class Notmuch < Formula
   patch :DATA
 
   def install
-    args = %W[--prefix=#{prefix}]
+    args = %W[--prefix=#{prefix} --mandir=#{man}]
 
     if build.with? "emacs"
       ENV.deparallelize # Emacs and parallel builds aren't friends

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -38,6 +38,10 @@ class Notmuch < Formula
   patch :DATA
 
   def install
+    # configure runs `python -m sphinx.writers.manpage` to detect if `sphinx-build` will work 
+    ENV.prepend_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"vendor/lib/python2.7/site-packages"
+    ENV.prepend_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"lib/python2.7/site-packages"
+
     args = %W[--prefix=#{prefix} --mandir=#{man}]
 
     if build.with? "emacs"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Fixes #26067 

-----

The `HAVE_SPHINX` check here https://github.com/notmuch/notmuch/blob/c117306f2dfcdf705ef3433962d227d1cb39eb90/doc/Makefile.local#L85 still fails because it requires _sphinx with nroff support_  https://github.com/notmuch/notmuch/blob/040c3236afcf95bead0324a48c2e0b9cd7934993/configure#L635, no idea how to fix this? that's why man pages are not built.

running the install command with `--verbose` shows this

```
...
Checking if emacs is available... Yes.
Checking if doxygen is available... Yes.
Checking if sphinx is available and supports nroff output... No (so will not install man pages).
...
rm -f doc/_build/man/man3/notmuch.3.gz && gzip --stdout doc/_build/man/man3/notmuch.3 > doc/_build/man/man3/notmuch.3.gz
mkdir -p "/usr/local/Cellar/notmuch/0.26_2/share/man/man3"
install -m0644 doc/_build/man/man3/notmuch.3.gz //usr/local/Cellar/notmuch/0.26_2/share/man/man3
No sphinx, will not install man pages.
...
```

---