### PR TITLE
gcc: Remove jit patch when building HEAD

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -46,9 +46,12 @@ class Gcc < Formula
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
   # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225625332
   # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225626490
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e9e0ee09389a54cc4c8fe1c24ebca3cd765ed0ba/gcc/6.1.0-jit.patch"
-    sha256 "863957f90a934ee8f89707980473769cff47ca0663c3906992da6afb242fb220"
+  # Now fixed on GCC trunk for GCC 8, may backported to other branches
+  unless build.head?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/e9e0ee09389a54cc4c8fe1c24ebca3cd765ed0ba/gcc/6.1.0-jit.patch"
+      sha256 "863957f90a934ee8f89707980473769cff47ca0663c3906992da6afb242fb220"
+    end
   end
 
   # Fix parallel build on APFS filesystem


### PR DESCRIPTION
 - See discussion at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089#c17
 - Patching HEAD currently causes formula to fail (fixed by this commit)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Still building HEAD from source. I can report on success and output of `brew test --HEAD gcc` once the build finishes