### PR TITLE
OpenCoarrays: Use MPICH over OpenMPI & add option

### DIFF
--- a/Formula/opencoarrays.rb
+++ b/Formula/opencoarrays.rb
@@ -12,13 +12,17 @@ class Opencoarrays < Formula
     sha256 "84cbce876804c2f46cda80bec9b4b310aa0d06300e65473a89207ae6ea8679a3" => :el_capitan
   end
 
+  option "without-failed-image-support", "Disable F2018 failed image support that uses experimental MPI features"
+
   depends_on "cmake" => :build
   depends_on "gcc"
-  depends_on "open-mpi"
+  depends_on "mpich"
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      args = std_cmake_args
+      args << "-DCAF_ENABLE_FAILED_IMAGES=FALSE" if build.without? "failed-image-support"
+      system "cmake", "..", *args
       system "make"
       system "make", "install"
     end

--- a/Formula/opencoarrays.rb
+++ b/Formula/opencoarrays.rb
@@ -13,6 +13,7 @@ class Opencoarrays < Formula
   end
 
   option "without-failed-image-support", "Disable F2018 failed image support that uses experimental MPI features"
+  option "with-compile-time-tests", "Run the OpenCoarrays test suite at build time."
 
   depends_on "cmake" => :build
   depends_on "gcc"
@@ -24,6 +25,7 @@ class Opencoarrays < Formula
       args << "-DCAF_ENABLE_FAILED_IMAGES=FALSE" if build.without? "failed-image-support"
       system "cmake", "..", *args
       system "make"
+      system "make", "check" if build.with? "compile-time-tests"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- OpenMPI requires a hosts file to run on macOS which causes `brew test OpenCoarrays`
  to fail and is generally a PITA
- An option to disable failed image support which relies on
  experimental MPI features was added; a bug, fixed on MPICH master
  for quite some time but not in any release yet, causes issues in
  OpenCoarrays. This flag will help users work around that upstream
  bug.
- The OpenCoarrays development team recommends and tests against MPICH regularly
- Features like Fortran 2018 failed image support are not available through OpenMPI due to lack of support for required experimental MPI features

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
