### PR TITLE
ssh-permit-a38 0.1.0 (new formula)

### DIFF
--- a/Formula/ssh-permit-a38.rb
+++ b/Formula/ssh-permit-a38.rb
@@ -1,0 +1,23 @@
+class SshPermitA38 < Formula
+  desc "Central management and deployment for SSH keys"
+  homepage "https://github.com/ierror/ssh-permit-a38/"
+  url "https://github.com/ierror/ssh-permit-a38/archive/v0.1.0.tar.gz"
+  sha256 "933ba4512def25216d7798a6cf3c455634be8193098e2a55a82cb189ad8554e3"
+
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+  depends_on "openssl"
+
+  def install
+    ENV["OPENSSL_INCLUDE_DIR"] = Formula["openssl"].opt_include
+    ENV["DEP_OPENSSL_INCLUDE"] = Formula["openssl"].opt_include
+    ENV["OPENSSL_LIB_DIR"] = Formula["openssl"].opt_lib
+    system "cargo", "install", "--root", prefix
+  end
+
+  test do
+    system bin/"ssh-permit-a38 host 1.exmaple.com add"
+
+    assert(File.readlines("ssh-permit.json").grep(/1.exmaple.com/).size == 1, "Test host not found in ssh-permit.json")
+  end
+end


### PR DESCRIPTION
New Formular SSH Permit A38 - Central management and deployment for SSH keys

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
