### PR TITLE
allow kops to work with kubernetes-cli

### DIFF
--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -12,13 +12,17 @@ class Kops < Formula
     sha256 "19edd7d18f20a27927b3a889c263a3b1f2a898e91349ced6e95420cee6081445" => :el_capitan
   end
 
+  stable do
+    depends_on "kubernetes-cli@1.8"
+  end
+
   devel do
     url "https://github.com/kubernetes/kops/archive/1.9.0-beta.2.tar.gz"
     sha256 "b2b8eedfec837cb0f06f0106d2dd76c033cf593d750154b242328790369a0a42"
+    depends_on "kubernetes-cli@1.9"
   end
 
   depends_on "go" => :build
-  depends_on "kubernetes-cli"
 
   def install
     ENV["VERSION"] = version unless build.head?

--- a/Formula/kubernetes-cli@1.8.rb
+++ b/Formula/kubernetes-cli@1.8.rb
@@ -1,0 +1,59 @@
+class KubernetesCliAT18 < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  url "https://github.com/kubernetes/kubernetes.git",
+      :tag => "v1.8.10",
+      :revision => "044cd262c40234014f01b40ed7b9d09adbafe9b1"
+  head "https://github.com/kubernetes/kubernetes.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "77ba4dac3052419899647198e596a81b6b4d8008fb871d610d4cb80b420f1258" => :high_sierra
+    sha256 "fcd65658dabaa02798dab0868f716fa6fdc5300a468e903b327e88c73310c261" => :sierra
+    sha256 "a94c872d0c93c17fc0904cea83eb3e690d2ab7078bd71e517b3c93954ec4f77b" => :el_capitan
+  end
+
+  # kubernetes-cli will not support go1.10 until version 1.11.x
+  depends_on "go@1.9" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    dir = buildpath/"src/k8s.io/kubernetes"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # Race condition still exists in OSX Yosemite
+      # Filed issue: https://github.com/kubernetes/kubernetes/issues/34635
+      ENV.deparallelize { system "make", "generated_files" }
+
+      # Make binary
+      system "make", "kubectl"
+      bin.install "_output/local/bin/darwin/#{arch}/kubectl"
+
+      # Install bash completion
+      output = Utils.popen_read("#{bin}/kubectl completion bash")
+      (bash_completion/"kubectl").write output
+
+      # Install zsh completion
+      output = Utils.popen_read("#{bin}/kubectl completion zsh")
+      (zsh_completion/"_kubectl").write output
+
+      prefix.install_metafiles
+
+      # Install man pages
+      # Leave this step for the end as this dirties the git tree
+      system "hack/generate-docs.sh"
+      man1.install Dir["docs/man/man1/*.1"]
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end

--- a/Formula/kubernetes-cli@1.9.rb
+++ b/Formula/kubernetes-cli@1.9.rb
@@ -1,0 +1,59 @@
+class KubernetesCliAT19 < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  url "https://github.com/kubernetes/kubernetes.git",
+      :tag => "v1.9.6",
+      :revision => "9f8ebd171479bec0ada837d7ee641dec2f8c6dd1"
+  head "https://github.com/kubernetes/kubernetes.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "77ba4dac3052419899647198e596a81b6b4d8008fb871d610d4cb80b420f1258" => :high_sierra
+    sha256 "fcd65658dabaa02798dab0868f716fa6fdc5300a468e903b327e88c73310c261" => :sierra
+    sha256 "a94c872d0c93c17fc0904cea83eb3e690d2ab7078bd71e517b3c93954ec4f77b" => :el_capitan
+  end
+
+  # kubernetes-cli will not support go1.10 until version 1.11.x
+  depends_on "go@1.9" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    dir = buildpath/"src/k8s.io/kubernetes"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # Race condition still exists in OSX Yosemite
+      # Filed issue: https://github.com/kubernetes/kubernetes/issues/34635
+      ENV.deparallelize { system "make", "generated_files" }
+
+      # Make binary
+      system "make", "kubectl"
+      bin.install "_output/local/bin/darwin/#{arch}/kubectl"
+
+      # Install bash completion
+      output = Utils.popen_read("#{bin}/kubectl completion bash")
+      (bash_completion/"kubectl").write output
+
+      # Install zsh completion
+      output = Utils.popen_read("#{bin}/kubectl completion zsh")
+      (zsh_completion/"_kubectl").write output
+
+      prefix.install_metafiles
+
+      # Install man pages
+      # Leave this step for the end as this dirties the git tree
+      system "hack/generate-docs.sh"
+      man1.install Dir["docs/man/man1/*.1"]
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
kops does not align with the latest kubernetes releases, these lag behind a couple of releases.

this installs the correct kubernetes-cli version with kops, and also allows kubernetnes-cli to be installed due to go version error.