### PR TITLE
brew-php-switcher 2.0 (new formula)

### DIFF
--- a/Formula/brew-php-switcher.rb
+++ b/Formula/brew-php-switcher.rb
@@ -1,0 +1,27 @@
+class BrewPhpSwitcher < Formula
+  desc "Switch Apache / Valet / CLI configs between PHP versions"
+  homepage "https://github.com/philcook/php-switcher"
+  url "https://github.com/philcook/brew-php-switcher/archive/v2.0.tar.gz"
+  sha256 "c2303b1b1a66ee90ed900c3beabacd6aa4e921dbcad5242e399c45d86899bc88"
+
+  bottle :unneeded
+
+  depends_on "php" => :test
+
+  def install
+    bin.install "phpswitch.sh"
+    bin.install_symlink "phpswitch.sh" => "brew-php-switcher"
+  end
+
+  test do
+    expected_output = <<~EOF
+      usage: brew-php-switcher version [-s|-s=*] [-c=*]
+
+          version    one of: 5.6,7.0,7.1,7.2
+          -s         skip change of mod_php on apache
+          -s=*         skip change of mod_php on apache or valet restart i.e (apache|valet,apache|valet)
+          -c=*         switch a specific config (apache|valet,apache|valet
+    EOF
+    assert_match expected_output, shell_output("#{bin}/brew-php-switcher")
+  end
+end

--- a/Formula/brew-php-switcher.rb
+++ b/Formula/brew-php-switcher.rb
@@ -14,7 +14,7 @@ class BrewPhpSwitcher < Formula
   end
 
   test do
-    assert_match "usage: brew-php-switcher version", 
+    assert_match "usage: brew-php-switcher version",
                  shell_output("#{bin}/brew-php-switcher")
   end
 end

--- a/Formula/brew-php-switcher.rb
+++ b/Formula/brew-php-switcher.rb
@@ -14,14 +14,7 @@ class BrewPhpSwitcher < Formula
   end
 
   test do
-    expected_output = <<~EOF
-      usage: brew-php-switcher version [-s|-s=*] [-c=*]
-
-          version    one of: 5.6,7.0,7.1,7.2
-          -s         skip change of mod_php on apache
-          -s=*         skip change of mod_php on apache or valet restart i.e (apache|valet,apache|valet)
-          -c=*         switch a specific config (apache|valet,apache|valet
-    EOF
-    assert_match expected_output, shell_output("#{bin}/brew-php-switcher")
+    assert_match "usage: brew-php-switcher version", 
+                 shell_output("#{bin}/brew-php-switcher")
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Migrated brew-php-switcher after updating to work with the new formula naming.