### PR TITLE
collectd: Add libgcrypt dependency

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -3,6 +3,7 @@ class Collectd < Formula
   homepage "https://collectd.org/"
   url "https://collectd.org/files/collectd-5.8.0.tar.bz2"
   sha256 "b06ff476bbf05533cb97ae6749262cc3c76c9969f032bd8496690084ddeb15c9"
+  revision 1
 
   bottle do
     sha256 "c228054cab6171395cf7fc0aae7baa020743514a41dd374e668d4d9440675e7f" => :high_sierra

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -28,6 +28,7 @@ class Collectd < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libtool"
+  depends_on "libgcrypt" => :recommended
   depends_on "riemann-client" => :optional
   depends_on :java => :optional
   depends_on "python@2" => :optional

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -27,8 +27,8 @@ class Collectd < Formula
   deprecated_option "with-python" => "with-python@2"
 
   depends_on "pkg-config" => :build
+  depends_on "libgcrypt"
   depends_on "libtool"
-  depends_on "libgcrypt" => :recommended
   depends_on "riemann-client" => :optional
   depends_on :java => :optional
   depends_on "python@2" => :optional


### PR DESCRIPTION
Without libgcrypt it is impossible to use secure network communications as described in https://collectd.org/wiki/index.php/Networking_introduction#Cryptographic_setup