### PR TITLE
Bump Agda standard library version

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -13,7 +13,7 @@ class Agda < Formula
 
     resource "stdlib" do
       url "https://github.com/agda/agda-stdlib.git",
-          :revision => "477ba28360133b1f5c45ce1b4e6b4efd467af331"
+          :revision => "c06437e4ebb5365d502fb0a79775e5c591ab8ae5" # v0.15
     end
   end
 

--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -5,7 +5,7 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
-  revision 2
+  revision 3
 
   stable do
     url "https://hackage.haskell.org/package/Agda-2.5.3/Agda-2.5.3.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The formula pointed to an intermediate commit between v0.13 and v0.14 of
Agda standard library. This bumps it to v0.15 as suggested by the standard library maintainer in https://github.com/agda/agda-stdlib/issues/226.

