### PR TITLE
Remove c++11 compile flags so that xerces-c can be used on projects t…

### DIFF
--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -13,13 +13,9 @@ class XercesC < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
-
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-Dxmlch-type=uint16_t", *std_cmake_args
       system "make"
       system "ctest", "-V"
       system "make", "install"


### PR DESCRIPTION
…hat use c++98

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
