### PR TITLE
chapel: build against python@2

### DIFF
--- a/Formula/chapel.rb
+++ b/Formula/chapel.rb
@@ -3,6 +3,8 @@ class Chapel < Formula
   homepage "https://chapel-lang.org/"
   url "https://github.com/chapel-lang/chapel/releases/download/1.17.0/chapel-1.17.0.tar.gz"
   sha256 "7620b780cf2a2bd3b26022957c3712983519a422a793614426aed6d9d8bf9fab"
+  revision 1
+
   head "https://github.com/chapel-lang/chapel.git"
 
   bottle do
@@ -10,6 +12,8 @@ class Chapel < Formula
     sha256 "c1009b64b0ef3b1fc3a1fa290baab42a84bcbf7009deade060c3931025da6745" => :sierra
     sha256 "0be54353a6e3b7553053173dfa0e4f1a606047ab1add1cd0e265dab07a9abc85" => :el_capitan
   end
+
+  depends_on "python@2"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/pull/26218#issuecomment-379084182 as well as handles pypi's in-progress deprecation of <TLSv1.2 for older versions of macOS where the system Python is linked against the old 0.9.8 branch of OpenSSL.