### PR TITLE
Add backwards-compatibility to Hyperscan

### DIFF
--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -12,6 +12,7 @@ class Hyperscan < Formula
   end
 
   option "with-debug", "Build with debug symbols"
+  option "with-ssse3", "Build with SSSE3 for compatibility with older Macs"
 
   depends_on "python@2" => :build if MacOS.version <= :snow_leopard
   depends_on "boost" => :build
@@ -32,6 +33,13 @@ class Hyperscan < Formula
         args += %w[
           -DCMAKE_BUILD_TYPE=Debug
           -DDEBUG_OUTPUT=on
+        ]
+      end
+
+      if build.with? "ssse3"
+        args += %w[
+          -DCMAKE_C_FLAGS=-march=core2
+          -DCMAKE_CXX_FLAGS=-march=core2
         ]
       end
 


### PR DESCRIPTION
- ✅ Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- ✅ Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- ✅ Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- ✅ Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As in [here](https://intel.github.io/hyperscan/dev-reference/getting_started.html#target-architecture)