### PR TITLE
checkbashisms: replace hardcoded hashbang with env

### DIFF
--- a/Formula/checkbashisms.rb
+++ b/Formula/checkbashisms.rb
@@ -11,6 +11,7 @@ class Checkbashisms < Formula
 
   def install
     inreplace "scripts/checkbashisms.pl", "###VERSION###", version
+    inreplace "scripts/checkbashisms.pl", %r{\A#!/usr/bin/perl}, "#!/usr/bin/env perl"
     bin.install "scripts/checkbashisms.pl" => "checkbashisms"
     man1.install "scripts/checkbashisms.1"
   end


### PR DESCRIPTION
## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] ~~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~~  
[Not necessary](https://github.com/Homebrew/homebrew-core/blob/1f9ba958e21dce9673b932cfc1f55dd155f0df69/Formula/checkbashisms.rb#L10); confirmed by reinstalling and checking executable's source.
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

## Description

This PR fixes the interpreter directive of the `checkbashisms` script to use `env`, rather than a hardcoded path to `/usr/bin/perl`. This enables the Homebrew-installed version of Perl to be used instead of the system's version.

Running the system's version of Perl will cause breakage at startup if the user's installed Perl with compiled XS code:

~~~
dyld: lazy symbol binding failed: Symbol not found: _Perl_xs_handshake
  Referenced from: /Users/johngardner/perl5/lib/perl5/darwin-thread-multi-2level/auto/Cwd/Cwd.bundle
  Expected in: flat namespace

dyld: Symbol not found: _Perl_xs_handshake
  Referenced from: /Users/johngardner/perl5/lib/perl5/darwin-thread-multi-2level/auto/Cwd/Cwd.bundle
  Expected in: flat namespace

Abort trap: 6
~~~

This can be solved by unsetting the `PERL5LIB` variable, which is set by code recommended by Homebrew's [caveat notes](https://github.com/Homebrew/homebrew-core/blob/1f9ba958e21dce9673b932cfc1f55dd155f0df69/Formula/perl.rb#L67-L75) for `perl`:

> By default non-brewed cpan modules are installed to the Cellar. If you wish
for your modules to persist across updates we recommend using `local::lib`.
>
> You can set that up like this:
>
> ~~~shell
> PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
> echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"' >> ~/.bash_profile
> ~~~

I doubt upstream would be interested in accepting this fix, because the script is part of a tool-suite for Debian package maintainers. Ubuntu packages are installed to `/usr/bin` by default (not `/usr/local/bin` like macOS), which makes the fix redundant at best. At worst, it could introduce complications if maintainers are tinkering with the `env` utility, or doing something funky with `perl` binaries.

## Sidenote

Since the issue with installing modules with X codes technically affects every formula with hardcoded Perl hashbangs, it might be worth reviewing how many other formulae are affected by this.