### PR TITLE
unbound: Bind unbound to username

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -53,8 +53,8 @@ class Unbound < Formula
   def post_install
     conf = etc/"unbound/unbound.conf"
     return unless conf.exist?
-    return unless conf.read.include?('username: "@@HOMEBREW-UNBOUND-USER@@"')
-    inreplace conf, 'username: "@@HOMEBREW-UNBOUND-USER@@"',
+    return unless conf.read.include?('# username: "@@HOMEBREW-UNBOUND-USER@@"')
+    inreplace conf, '# username: "@@HOMEBREW-UNBOUND-USER@@"',
                     "username: \"#{ENV["USER"]}\""
   end
 


### PR DESCRIPTION
When starting unbound via `sudo brew services start unbound` and testing via `dig google.com @127.0.0.1` I got a timeout.

When uncommenting the `username` in the config it works.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
