### PR TITLE
php: Add autoconf dependency

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -16,6 +16,7 @@ class Php < Formula
   depends_on "apr-util"
   depends_on "argon2"
   depends_on "aspell"
+  depends_on "autoconf"
   depends_on "curl" if MacOS.version < :lion
   depends_on "freetds"
   depends_on "freetype"

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -17,6 +17,7 @@ class PhpAT56 < Formula
   depends_on "apr"
   depends_on "apr-util"
   depends_on "aspell"
+  depends_on "autoconf"
   depends_on "curl" if MacOS.version < :lion
   depends_on "freetds"
   depends_on "freetype"

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -17,6 +17,7 @@ class PhpAT70 < Formula
   depends_on "apr"
   depends_on "apr-util"
   depends_on "aspell"
+  depends_on "autoconf"
   depends_on "curl" if MacOS.version < :lion
   depends_on "freetds"
   depends_on "freetype"

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -17,6 +17,7 @@ class PhpAT71 < Formula
   depends_on "apr"
   depends_on "apr-util"
   depends_on "aspell"
+  depends_on "autoconf"
   depends_on "curl" if MacOS.version < :lion
   depends_on "freetds"
   depends_on "freetype"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
It was discovered that the autoconf dependency was missing as pointed out in #26170 which also made me realise we depend heavily on pecl but its not tested. I'm aware that only the php formula has the test at the moment but I'll add the others once we can confirm that this is the way forward.