### PR TITLE
Drop privs when running knot-resolver

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -38,13 +38,23 @@ class KnotResolver < Formula
     end
 
     cp "etc/config.personal", "config"
-    inreplace "config", /^\s*user\(/, "-- user("
+    user = 'nobody'
+    group = 'nobody'
+    inreplace "config", /^\s*user\(.*/, "user('#{user}','#{group}')"
     (etc/"kresd").install "config"
 
     (etc/"kresd").install "etc/root.hints"
 
     (buildpath/"root.keys").write(root_keys)
     (var/"kresd").install "root.keys"
+  end
+
+  def caveats; <<~EOS
+    knot-resolver requires root privileges to bind to port 53 but runs as "nobody".
+    You should be certain that you trust any software you grant root privileges.
+    The "nobody" user will need permission to write DNS data to disk:
+    sudo chown -R nobody:nobody /usr/local/var/kresd
+    EOS
   end
 
   # DNSSEC root anchor published by IANA (https://www.iana.org/dnssec/files)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  - the [source download](https://secure.nic.cz/files/knot-resolver/knot-resolver-2.2.0.tar.xz") for knot-resolver is broken right now. 
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, I'd like to not run my DNS resolver as root; so I've patched the `knot-resolver` formula to:
* configure `kdnsd` to drop to the nobody user after binding to 53.
* instruct the user to `sudo chown -R nobody:nobody /usr/local/var/kresd` 

I'm not sure if this is the right approach.