### PR TITLE
gst-plugins-good: fix High Sierra issue in osxvideosink

### DIFF
--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -1,12 +1,19 @@
 class GstPluginsGood < Formula
   desc "GStreamer plugins (well-supported, under the LGPL)"
   homepage "https://gstreamer.freedesktop.org/"
-  revision 1
+  revision 2
 
   stable do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.14.0.tar.xz"
     sha256 "6afa35747d528d3ab4ed8f5eac13f7235d7d28100d6a24dd78f81ec7c0d04688"
 
+    if MacOS.version == :high_sierra
+      # Fix for illegal instruction error in osxvideosink https://bugzilla.gnome.org/show_bug.cgi?id=786047
+      patch do
+        url "https://bug786047.bugzilla-attachments.gnome.org/attachment.cgi?id=357262"
+        sha256 "1268a98ae3463ee61e5be3ea186701e75fb84fc9a0c9d280c2fc07faa2732201"
+      end
+    end
     depends_on "check" => :optional
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apply fix from https://bugzilla.gnome.org/show_bug.cgi?id=786047 if the OS version is High Sierra.  without this, trying to use `osxvideosink` will result in an `Illegal Instruction: 4` error.  Tried latest gstreamer HEAD as well, issue still occurs.