### PR TITLE
curl: fix http mirror.

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -2,7 +2,7 @@ class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.59.0.tar.bz2"
-  mirror "http://curl.askapache.com/download/curl-7.59.0.tar.bz2"
+  mirror "http://curl.mirror.anstey.ca/curl-7.59.0.tar.bz2"
   sha256 "b5920ffd6a8c95585fb95070e0ced38322790cb335c39d0dab852d12e157b5a0"
 
   bottle do


### PR DESCRIPTION
The `askapache` one was redirecting to HTTPS which means it cannot be
downloaded by a system `curl` on <=10.7.

Thanks to @ilovezfs in https://github.com/Homebrew/brew/pull/3837#issuecomment-375901439 for finding this URL.