### PR TITLE
util-linux 2.32 (new formula)

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -1,0 +1,24 @@
+class UtilLinux < Formula
+  desc "Collection of Linux utilities"
+  homepage "https://github.com/karelzak/util-linux"
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.tar.xz"
+  sha256 "6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--disable-ipcs",     # does not build on macOS
+                          "--disable-ipcrm",    # does not build on macOS
+                          "--disable-wall",     # already comes with macOS
+                          "--disable-libuuid"   # conflicts with ossp-uuid
+
+    system "make", "install"
+  end
+
+  test do
+    out = shell_output("#{bin}/namei -lx /usr").split("\n")
+    assert_equal ["f: /usr", "Drwxr-xr-x root wheel /", "drwxr-xr-x root wheel usr"], out
+  end
+end

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -17,21 +17,8 @@ class UtilLinux < Formula
 
     system "make", "install"
 
-    ["cal", # these already come with macOS
-     "col",
-     "colcrt",
-     "colrm",
-     "getopt",
-     "hexdump",
-     "logger",
-     "nologin",
-     "look",
-     "mesg",
-     "more",
-     "renice",
-     "rev",
-     "ul",
-     "whereis"].each do |prog|
+    # Remove binaries already shipped by macOS
+    %w[cal col colcrt colrm getopt hexdump logger nologin look mesg more renice rev ul whereis].each do |prog|
       rm_f bin/prog
       rm_f sbin/prog
       rm_f man1/"#{prog}.1"

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -1,7 +1,7 @@
 class UtilLinux < Formula
   desc "Collection of Linux utilities"
   homepage "https://github.com/karelzak/util-linux"
-  url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.tar.xz"
+  url "https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.tar.xz"
   sha256 "6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734"
 
   def install
@@ -9,12 +9,36 @@ class UtilLinux < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--disable-ipcs",     # does not build on macOS
-                          "--disable-ipcrm",    # does not build on macOS
-                          "--disable-wall",     # already comes with macOS
-                          "--disable-libuuid"   # conflicts with ossp-uuid
+                          "--disable-ipcs",        # does not build on macOS
+                          "--disable-ipcrm",       # does not build on macOS
+                          "--disable-wall",        # already comes with macOS
+                          "--disable-libuuid",     # conflicts with ossp-uuid
+                          "--disable-libsmartcols" # macOS already ships 'column'
 
     system "make", "install"
+
+    ["cal",   # these already come with macOS
+     "col",
+     "colcrt",
+     "colrm",
+     "getopt",
+     "hexdump",
+     "logger",
+     "nologin",
+     "look",
+     "mesg",
+     "more",
+     "renice",
+     "rev",
+     "ul",
+     "whereis"
+    ].each do |prog|
+      rm_f bin/prog
+      rm_f sbin/prog
+      rm_f man1/"#{prog}.1"
+      rm_f man8/"#{prog}.8"
+      rm_f share/"bash-completion"/"completions"/prog
+    end
   end
 
   test do

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -17,7 +17,7 @@ class UtilLinux < Formula
 
     system "make", "install"
 
-    ["cal",   # these already come with macOS
+    ["cal", # these already come with macOS
      "col",
      "colcrt",
      "colrm",
@@ -31,8 +31,7 @@ class UtilLinux < Formula
      "renice",
      "rev",
      "ul",
-     "whereis"
-    ].each do |prog|
+     "whereis"].each do |prog|
       rm_f bin/prog
       rm_f sbin/prog
       rm_f man1/"#{prog}.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula currently installs these binaries:
```
$ brew ls -v util-linux | egrep -w 'bin|sbin' | sort
/usr/local/Cellar/util-linux/2.32/bin/cal
/usr/local/Cellar/util-linux/2.32/bin/col
/usr/local/Cellar/util-linux/2.32/bin/colcrt
/usr/local/Cellar/util-linux/2.32/bin/colrm
/usr/local/Cellar/util-linux/2.32/bin/column
/usr/local/Cellar/util-linux/2.32/bin/getopt
/usr/local/Cellar/util-linux/2.32/bin/hexdump
/usr/local/Cellar/util-linux/2.32/bin/ipcmk
/usr/local/Cellar/util-linux/2.32/bin/isosize
/usr/local/Cellar/util-linux/2.32/bin/logger
/usr/local/Cellar/util-linux/2.32/bin/look
/usr/local/Cellar/util-linux/2.32/bin/mcookie
/usr/local/Cellar/util-linux/2.32/bin/mesg
/usr/local/Cellar/util-linux/2.32/bin/more
/usr/local/Cellar/util-linux/2.32/bin/namei
/usr/local/Cellar/util-linux/2.32/bin/rename
/usr/local/Cellar/util-linux/2.32/bin/renice
/usr/local/Cellar/util-linux/2.32/bin/rev
/usr/local/Cellar/util-linux/2.32/bin/scriptreplay
/usr/local/Cellar/util-linux/2.32/bin/setsid
/usr/local/Cellar/util-linux/2.32/bin/ul
/usr/local/Cellar/util-linux/2.32/bin/whereis
/usr/local/Cellar/util-linux/2.32/sbin/blkid
/usr/local/Cellar/util-linux/2.32/sbin/findfs
/usr/local/Cellar/util-linux/2.32/sbin/fsck.cramfs
/usr/local/Cellar/util-linux/2.32/sbin/fsck.minix
/usr/local/Cellar/util-linux/2.32/sbin/mkfs
/usr/local/Cellar/util-linux/2.32/sbin/mkfs.bfs
/usr/local/Cellar/util-linux/2.32/sbin/mkfs.cramfs
/usr/local/Cellar/util-linux/2.32/sbin/mkfs.minix
/usr/local/Cellar/util-linux/2.32/sbin/mkswap
/usr/local/Cellar/util-linux/2.32/sbin/nologin
/usr/local/Cellar/util-linux/2.32/sbin/swaplabel
/usr/local/Cellar/util-linux/2.32/sbin/wipefs
```

while my mac already has:
```
$ for f in $(brew ls -v util-linux | egrep -w 'bin|sbin' | xargs -n1 basename) ; do ls {/usr,}/{s,}bin/$f ; done  2>/dev/null
/usr/bin/cal
/usr/bin/col
/usr/bin/colcrt
/usr/bin/colrm
/usr/bin/column
/usr/bin/getopt
/usr/bin/hexdump
/usr/bin/logger
/usr/bin/look
/usr/bin/mesg
/usr/bin/more
/usr/bin/renice
/usr/bin/rev
/usr/bin/ul
/usr/bin/whereis
/sbin/nologin
```

What should we do with these? Remove them from the formula? Attempt to prefix them?

It also ships these libraries:
```
/usr/local/Cellar/util-linux/2.32/lib/libblkid.1.dylib
/usr/local/Cellar/util-linux/2.32/lib/libblkid.a
/usr/local/Cellar/util-linux/2.32/lib/libblkid.dylib
/usr/local/Cellar/util-linux/2.32/lib/libsmartcols.1.dylib
/usr/local/Cellar/util-linux/2.32/lib/libsmartcols.a
/usr/local/Cellar/util-linux/2.32/lib/libsmartcols.dylib
/usr/local/Cellar/util-linux/2.32/lib/pkgconfig/blkid.pc
/usr/local/Cellar/util-linux/2.32/lib/pkgconfig/smartcols.pc
```