### PR TITLE
bmap-tools 3.4 (new formula)

### DIFF
--- a/Formula/bmap-tools.rb
+++ b/Formula/bmap-tools.rb
@@ -1,0 +1,16 @@
+class BmapTools < Formula
+  desc "Tool to flash image files to block devices using the block map"
+  homepage "https://github.com/intel/bmap-tools"
+  url "https://github.com/intel/bmap-tools/archive/v3.4.tar.gz"
+  sha256 "483c5dd9589920b5bdec85d4cdbe150adb3ca404d205504f85c0fb03edc69c2a"
+
+  depends_on "python"
+
+  def install
+    system "python3", *Language::Python.setup_install_args(prefix)
+  end
+
+  test do
+    system "#{bin}/bmaptool", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While this formula does not have enough GitHub points:
```
bmap-tools:
  * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
```

I still think it's worth adding. It's available on Ubuntu (https://packages.ubuntu.com/xenial/utils/bmap-tools) and has been around for some time.
