### PR TITLE
gist: depend on ruby if <= :sierra

### DIFF
--- a/Formula/gist.rb
+++ b/Formula/gist.rb
@@ -3,6 +3,7 @@ class Gist < Formula
   homepage "https://github.com/defunkt/gist"
   url "https://github.com/defunkt/gist/archive/v4.6.2.tar.gz"
   sha256 "149a57ba7e8a8751d6a55dc652ce3cf0af28580f142f2adb97d1ceeccb8df3ad"
+  revision 1
   head "https://github.com/defunkt/gist.git"
 
   bottle do
@@ -12,11 +13,14 @@ class Gist < Formula
     sha256 "5d8c49b8c75cec0f4556c30b98e9af9f6f9a9cde0b208d38f6e410538c0763b7" => :el_capitan
   end
 
+  depends_on "ruby" if MacOS.version <= :sierra
+
   def install
     system "rake", "install", "prefix=#{prefix}"
   end
 
   test do
-    assert_match %r{https:\/\/gist}, pipe_output("#{bin}/gist", "homebrew")
+    output = pipe_output("#{bin}/gist", "homebrew")
+    assert_match "Requires authentication", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fixes #26400 

>Error: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: tlsv1 alert protocol version