### PR TITLE
Remove some options

### DIFF
--- a/Formula/alure.rb
+++ b/Formula/alure.rb
@@ -15,12 +15,6 @@ class Alure < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
-  depends_on "flac" => :optional
-  depends_on "fluid-synth" => :optional
-  depends_on "libogg" => :optional
-  depends_on "libsndfile" => :optional
-  depends_on "libvorbis" => :optional
-  depends_on "mpg123" => :optional
 
   # Fix missing unistd include
   # Reported by email to author on 2017-08-25
@@ -32,14 +26,6 @@ class Alure < Formula
   end
 
   def install
-    # fix a broken include flags line, which fixes a build error.
-    # Not reported upstream.
-    # https://github.com/Homebrew/legacy-homebrew/pull/6368
-    if build.with? "libvorbis"
-      inreplace "CMakeLists.txt", "${VORBISFILE_CFLAGS}",
-        Utils.popen_read("pkg-config --cflags vorbisfile").chomp
-    end
-
     cd "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"

--- a/Formula/inspircd.rb
+++ b/Formula/inspircd.rb
@@ -3,7 +3,6 @@ class Inspircd < Formula
   homepage "https://www.inspircd.org/"
   url "https://github.com/inspircd/inspircd/archive/v2.0.25.tar.gz"
   sha256 "c2488fafd04fcabbd8ddc8b9cdc6e0b57e942802b451c9cbccaf5d8483ebd251"
-  head "https://github.com/inspircd/inspircd.git", :branch => "insp20"
 
   bottle do
     sha256 "fa0c21347636bbcf3cdb50606bc993607a705d6fc740d7af61c3d637af21aa42" => :high_sierra
@@ -14,31 +13,10 @@ class Inspircd < Formula
   skip_clean "data"
   skip_clean "logs"
 
-  option "without-ldap", "Build without ldap support"
-
   depends_on "pkg-config" => :build
-  depends_on "geoip" => :optional
-  depends_on "gnutls" => :optional
-  depends_on "mysql" => :optional
-  depends_on "openssl" => :optional
-  depends_on "pcre" => :optional
-  depends_on "postgresql" => :optional
-  depends_on "sqlite" => :optional
-  depends_on "tre" => :optional
 
   def install
-    modules = []
-    modules << "m_geoip.cpp" if build.with? "geoip"
-    modules << "m_ssl_gnutls.cpp" if build.with? "gnutls"
-    modules << "m_mysql.cpp" if build.with? "mysql"
-    modules << "m_ssl_openssl.cpp" if build.with? "openssl"
-    modules << "m_ldapauth.cpp" << "m_ldapoper.cpp" if build.with? "ldap"
-    modules << "m_regex_pcre.cpp" if build.with? "pcre"
-    modules << "m_pgsql.cpp" if build.with? "postgresql"
-    modules << "m_sqlite3.cpp" if build.with? "sqlite"
-    modules << "m_regex_tre.cpp" if build.with? "tre"
-
-    system "./configure", "--enable-extras=#{modules.join(",")}" unless modules.empty?
+    system "./configure", "--enable-extras=m_ldapauth.cpp,m_ldapoper.cpp"
     system "./configure", "--prefix=#{prefix}", "--with-cc=#{ENV.cc}"
     system "make", "install"
   end

--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -1,6 +1,6 @@
 class Moc < Formula
   desc "Terminal-based music player"
-  homepage "https://moc.daper.net"
+  homepage "https://moc.daper.net/"
   url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
   sha256 "f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08"
   revision 2
@@ -38,23 +38,12 @@ class Moc < Formula
     depends_on "popt"
   end
 
-  option "with-ncurses", "Build with wide character support."
-
   depends_on "pkg-config" => :build
-  depends_on "libtool"
   depends_on "berkeley-db"
+  depends_on "ffmpeg"
   depends_on "jack"
-  depends_on "ffmpeg" => :recommended
-  depends_on "mad" => :optional
-  depends_on "flac" => :optional
-  depends_on "speex" => :optional
-  depends_on "musepack" => :optional
-  depends_on "libsndfile" => :optional
-  depends_on "wavpack" => :optional
-  depends_on "faad2" => :optional
-  depends_on "timidity" => :optional
-  depends_on "libmagic" => :optional
-  depends_on "ncurses" => :optional
+  depends_on "libtool"
+  depends_on "ncurses"
 
   def install
     # Remove build.devel? when 2.6-alpha4 comes out

--- a/Formula/sox.rb
+++ b/Formula/sox.rb
@@ -3,6 +3,7 @@ class Sox < Formula
   homepage "https://sox.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz"
   sha256 "b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,15 +15,15 @@ class Sox < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "flac"
+  depends_on "lame"
   depends_on "libpng"
+  depends_on "libvorbis"
   depends_on "mad"
   depends_on "opencore-amr" => :optional
   depends_on "opusfile" => :optional
-  depends_on "libvorbis" => :optional
-  depends_on "flac" => :optional
   depends_on "libsndfile" => :optional
   depends_on "libao" => :optional
-  depends_on "lame" => :optional
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/whatmp3.rb
+++ b/Formula/whatmp3.rb
@@ -13,15 +13,10 @@ class Whatmp3 < Formula
     sha256 "0166d5c0eca7e9e3022baad9dea3679ede00bdfb29c1a5b875d477a38c5c74cf" => :el_capitan
   end
 
-  depends_on "python"
   depends_on "flac"
-  depends_on "mktorrent" => :recommended
-  depends_on "lame" => :recommended
-  depends_on "vorbis-tools" => :optional
-  depends_on "mp3gain" => :optional
-  depends_on "aacgain" => :optional
-  depends_on "vorbisgain" => :optional
-  depends_on "sox" => :optional
+  depends_on "lame"
+  depends_on "mktorrent"
+  depends_on "python"
 
   def install
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/writerperfect.rb
+++ b/Formula/writerperfect.rb
@@ -13,16 +13,10 @@ class Writerperfect < Formula
 
   depends_on "pkg-config" => :build
   depends_on "boost" => :build
-  depends_on "libmwaw" => :optional
   depends_on "libodfgen"
-  depends_on "libwps"
-  depends_on "libwpg"
   depends_on "libwpd"
-  depends_on "libetonyek" => :optional
-  depends_on "libvisio" => :optional
-  depends_on "libmspub" => :optional
-  depends_on "libfreehand" => :optional
-  depends_on "libcdr" => :optional
+  depends_on "libwpg"
+  depends_on "libwps"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",


### PR DESCRIPTION
Fewer builds from source, less CO₂ emitted, more users happy

- Some formulas with low install count and never-used options: writerperfect, inspircd, moc
- Formulas with often used options that carry no extra dependency (mpv) or few deps (sox)