### PR TITLE
arcade-learning-environment: depend on numpy

### DIFF
--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -13,20 +13,11 @@ class ArcadeLearningEnvironment < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "numpy"
   depends_on "python@2"
   depends_on "sdl"
 
-  resource "numpy" do
-    url "https://files.pythonhosted.org/packages/0b/66/86185402ee2d55865c675c06a5cfef742e39f4635a4ce1b1aefd20711c13/numpy-1.14.2.zip"
-    sha256 "facc6f925c3099ac01a1f03758100772560a0b020fb9d70f210404be08006bcb"
-  end
-
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    resource("numpy").stage do
-      system "python", *Language::Python.setup_install_args(libexec/"vendor")
-    end
-
     system "cmake", ".", *std_cmake_args
     system "make", "install"
     system "python", *Language::Python.setup_install_args(prefix)

--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -16,7 +16,17 @@ class ArcadeLearningEnvironment < Formula
   depends_on "python@2"
   depends_on "sdl"
 
+  resource "numpy" do
+    url "https://files.pythonhosted.org/packages/0b/66/86185402ee2d55865c675c06a5cfef742e39f4635a4ce1b1aefd20711c13/numpy-1.14.2.zip"
+    sha256 "facc6f925c3099ac01a1f03758100772560a0b020fb9d70f210404be08006bcb"
+  end
+
   def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    resource("numpy").stage do
+      system "python", *Language::Python.setup_install_args(libexec/"vendor")
+    end
+
     system "cmake", ".", *std_cmake_args
     system "make", "install"
     system "python", *Language::Python.setup_install_args(prefix)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
% python test.py
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    from ale_python_interface import ALEInterface;
  File "/usr/local/lib/python2.7/site-packages/ale_python_interface/__init__.py", line 1, in <module>
    from .ale_python_interface import *
  File "/usr/local/lib/python2.7/site-packages/ale_python_interface/ale_python_interface.py", line 8, in <module>
    import numpy as np
ImportError: No module named numpy
```