### PR TITLE
patchelf (new formula)

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -1,0 +1,28 @@
+class Patchelf < Formula
+  desc "Modify dynamic ELF executables"
+  homepage "https://nixos.org/patchelf.html"
+  url "https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz"
+  sha256 "f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a"
+
+  resource "hellworld" do
+    url "http://timelessname.com/elfbin/helloworld.tar.gz"
+    sha256 "d8c1e93f13e0b7d8fc13ce75d5b089f4d4cec15dad91d08d94a166822d749459"
+  end
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    resource("hellworld").stage do
+      assert_equal "/lib/ld-linux.so.2\n", shell_output("#{bin}/patchelf --print-interpreter chello")
+      assert_equal "libc.so.6\n", shell_output("#{bin}/patchelf --print-needed chello")
+      assert_equal "\n", shell_output("#{bin}/patchelf --print-rpath chello")
+      assert_equal "", shell_output("#{bin}/patchelf --set-rpath /usr/local/lib chello")
+      assert_equal "/usr/local/lib\n", shell_output("#{bin}/patchelf --print-rpath chello")
+    end
+  end
+end


### PR DESCRIPTION
Modify dynamic ELF executables.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This formula is useful on macOS to modify dynamic ELF executables intended for a Linux system, for example mounted on an NFS file system, or cross-compiled.
This formula is needed on Linux to relocate bottles.