### PR TITLE
nghttp2 up to mavericks need configure w/o threads

### DIFF
--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -60,6 +60,7 @@ class Nghttp2 < Formula
 
     args << "--enable-examples" if build.with? "examples"
     args << "--with-xml-prefix=/usr" if MacOS.version > :lion
+    args << "--disable-threads" if DevelopmentTools.clang_build_version < 800
     args << "--without-jemalloc" if build.without? "jemalloc"
 
     system "autoreconf", "-ivf" if build.head?


### PR DESCRIPTION
As of 1.31.0 threads need to be disabled for mavericks and earlier platforms. nghttp2 is a dependency of php@5.5 and later.
Closes https://github.com/nghttp2/nghttp2/issues/954

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
