### PR TITLE
sslmate: fix failure from perl selection at runtime

### DIFF
--- a/Formula/sslmate.rb
+++ b/Formula/sslmate.rb
@@ -80,6 +80,12 @@ class Sslmate < Formula
     end
     env[:PYTHONPATH] = ENV["PYTHONPATH"] if build.with? "route53"
     bin.env_script_all_files(libexec + "bin", env)
+
+    # Fix failure when Homebrew perl is selected at runtime
+    unless MacOS.version <= :snow_leopard
+      inreplace libexec/"bin/sslmate",
+        "#!/usr/bin/env perl", "#!/usr/bin/perl"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
fix failure from perl selection at runtime