### PR TITLE
osquery: depend on python@2 at build time

### DIFF
--- a/Formula/osquery.rb
+++ b/Formula/osquery.rb
@@ -18,6 +18,7 @@ class Osquery < Formula
   depends_on :macos => :sierra
   depends_on "bison" => :build
   depends_on "cmake" => :build
+  depends_on "python@2" => :build
   depends_on "augeas"
   depends_on "boost"
   depends_on "gflags"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
