### PR TITLE
sops: remove unneeded `virtualenv`

### DIFF
--- a/Formula/sops.rb
+++ b/Formula/sops.rb
@@ -1,6 +1,4 @@
 class Sops < Formula
-  include Language::Python::Virtualenv
-
   desc "Editor of encrypted files"
   homepage "https://github.com/mozilla/sops"
   url "https://github.com/mozilla/sops/archive/3.0.3.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
