### PR TITLE
php@7.2: fixes FilesMatch dot escaping

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -185,7 +185,7 @@ class Php < Formula
       To enable PHP in Apache add the following to httpd.conf and restart Apache:
           LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
 
-          <FilesMatch \.php$>
+          <FilesMatch \\.php$>
               SetHandler application/x-httpd-php
           </FilesMatch>
 

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -315,6 +315,10 @@ class Php < Formula
         <?php
         echo 'Hello world!';
       EOS
+      (testpath/"missingdotphp").write <<~EOS
+        <?php
+        echo 'Hello world!';
+      EOS
       main_config = <<~EOS
         Listen #{port}
         ServerName localhost:#{port}
@@ -332,7 +336,7 @@ class Php < Formula
         #{main_config}
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
         LoadModule php7_module #{lib}/httpd/modules/libphp7.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler application/x-httpd-php
         </FilesMatch>
       EOS
@@ -354,7 +358,7 @@ class Php < Formula
         LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
         LoadModule proxy_module lib/httpd/modules/mod_proxy.so
         LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
         </FilesMatch>
       EOS

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -187,7 +187,7 @@ class PhpAT56 < Formula
       To enable PHP in Apache add the following to httpd.conf and restart Apache:
           LoadModule php5_module #{opt_lib}/httpd/modules/libphp5.so
 
-          <FilesMatch \.php$>
+          <FilesMatch \\.php$>
               SetHandler application/x-httpd-php
           </FilesMatch>
 

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -334,7 +334,7 @@ class PhpAT56 < Formula
         #{main_config}
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
         LoadModule php5_module #{lib}/httpd/modules/libphp5.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler application/x-httpd-php
         </FilesMatch>
       EOS
@@ -356,7 +356,7 @@ class PhpAT56 < Formula
         LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
         LoadModule proxy_module lib/httpd/modules/mod_proxy.so
         LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
         </FilesMatch>
       EOS

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -333,7 +333,7 @@ class PhpAT70 < Formula
         #{main_config}
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
         LoadModule php7_module #{lib}/httpd/modules/libphp7.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler application/x-httpd-php
         </FilesMatch>
       EOS
@@ -355,7 +355,7 @@ class PhpAT70 < Formula
         LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
         LoadModule proxy_module lib/httpd/modules/mod_proxy.so
         LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
         </FilesMatch>
       EOS

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -188,7 +188,7 @@ class PhpAT70 < Formula
     <<~EOS
       To enable PHP in Apache add the following to httpd.conf and restart Apache:
           LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
-          <FilesMatch \.php$>
+          <FilesMatch \\.php$>
               SetHandler application/x-httpd-php
           </FilesMatch>
       Finally, check DirectoryIndex includes index.php

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -336,7 +336,7 @@ class PhpAT71 < Formula
         #{main_config}
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
         LoadModule php7_module #{lib}/httpd/modules/libphp7.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler application/x-httpd-php
         </FilesMatch>
       EOS
@@ -358,7 +358,7 @@ class PhpAT71 < Formula
         LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
         LoadModule proxy_module lib/httpd/modules/mod_proxy.so
         LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
-        <FilesMatch \.(php|phar)$>
+        <FilesMatch \\.(php|phar)$>
           SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
         </FilesMatch>
       EOS

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -189,7 +189,7 @@ class PhpAT71 < Formula
       To enable PHP in Apache add the following to httpd.conf and restart Apache:
           LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
 
-          <FilesMatch \.php$>
+          <FilesMatch \\.php$>
               SetHandler application/x-httpd-php
           </FilesMatch>
 


### PR DESCRIPTION
Currently, the php caveats output says:

```
    <FilesMatch .php$>
        SetHandler application/x-httpd-php
    </FilesMatch>
```

... which maches _any_ character before "php" at the end of the file path.

It should be:

```
    <FilesMatch \.php$>
        SetHandler application/x-httpd-php
    </FilesMatch>
```

... to match a literal dot. 

For reference, here's a recent tutorial that has the dot escaped:
<https://www.getgrav.org/blog/macos-sierra-apache-multiple-php-versions>