### PR TITLE
eccodes 2.7.3 (new formula)

### DIFF
--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -1,8 +1,8 @@
 class Eccodes < Formula
   desc "Decode and encode messages in the GRIB 1/2 and  BUFR 3/4 formats"
   homepage "https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home"
-  url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.7.0-Source.tar.gz"
-  sha256 "118f46cf6f800585580a5bc838128537ab0879073e9fcded49cd374e4c8d8e6a"
+  url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.7.3-Source.tar.gz"
+  sha256 "6fab143dbb34604bb2e04d10143855c0906b00411c1713fd7ff5c35519b871db"
 
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
@@ -14,7 +14,7 @@ class Eccodes < Formula
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 
     mkdir "build" do
-      system "cmake", "..", "-DENABLE_NETCDF=OFF", *std_cmake_args
+      system "cmake", "..", "-DENABLE_NETCDF=OFF", "-DENABLE_PNG=ON", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -23,7 +23,7 @@ class Eccodes < Formula
 
   test do
     grib_samples_path = shell_output("#{bin}/codes_info -s").strip
-    system bin/"grib_ls", "#{grib_samples_path}/GRIB1.tmpl"
-    system bin/"grib_ls", "#{grib_samples_path}/GRIB2.tmpl"
+    assert_match "packingType", shell_output("#{bin}/grib_ls #{grib_samples_path}/GRIB1.tmpl")
+    assert_match "gridType", shell_output("#{bin}/grib_ls #{grib_samples_path}/GRIB2.tmpl")
   end
 end

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -3,26 +3,19 @@ class Eccodes < Formula
   homepage "https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home"
   url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.7.0-Source.tar.gz"
   sha256 "118f46cf6f800585580a5bc838128537ab0879073e9fcded49cd374e4c8d8e6a"
+
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
   depends_on "numpy"
-  depends_on "jasper" => :recommended
-  depends_on "libpng" => :optional
+  depends_on "libpng"
+  depends_on "jasper"
 
   def install
-    # Fix "no member named 'inmem_' in 'jas_image_t'"
-    inreplace "src/grib_jasper_encoding.c", "image.inmem_    = 1;", ""
 
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 
     mkdir "build" do
       args = std_cmake_args
-      args << "-DBUILD_SHARED_LIBS=OFF" if build.with? "static"
-
-      if build.with? "libpng"
-        args << "-DPNG_PNG_INCLUDE_DIR=#{Formula["libpng"].opt_include}"
-        args << "-DENABLE_PNG=ON"
-      end
 
       system "cmake", "..", "-DENABLE_NETCDF=OFF", *args
       system "make", "install"

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -14,8 +14,6 @@ class Eccodes < Formula
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 
     mkdir "build" do
-      args = std_cmake_args
-
       system "cmake", "..", "-DENABLE_NETCDF=OFF", *std_cmake_args
       system "make", "install"
     end

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -9,6 +9,7 @@ class Eccodes < Formula
   depends_on "jasper"
   depends_on "libpng"
   depends_on "numpy"
+  conflicts_with "grib-api", :because => "both install /usr/local/include/grib_api.h"
 
   def install
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -9,6 +9,7 @@ class Eccodes < Formula
   depends_on "jasper"
   depends_on "libpng"
   depends_on "numpy"
+
   conflicts_with "grib-api", :because => "both install /usr/local/include/grib_api.h"
 
   def install

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -6,18 +6,17 @@ class Eccodes < Formula
 
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
-  depends_on "numpy"
-  depends_on "libpng"
   depends_on "jasper"
+  depends_on "libpng"
+  depends_on "numpy"
 
   def install
-
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 
     mkdir "build" do
       args = std_cmake_args
 
-      system "cmake", "..", "-DENABLE_NETCDF=OFF", *args
+      system "cmake", "..", "-DENABLE_NETCDF=OFF", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -1,0 +1,37 @@
+class Eccodes < Formula
+  desc "Decode and encode messages in the GRIB 1/2 and  BUFR 3/4 formats"
+  homepage "https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home"
+  url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.7.0-Source.tar.gz"
+  sha256 "118f46cf6f800585580a5bc838128537ab0879073e9fcded49cd374e4c8d8e6a"
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "numpy"
+  depends_on "jasper" => :recommended
+  depends_on "libpng" => :optional
+
+  def install
+    # Fix "no member named 'inmem_' in 'jas_image_t'"
+    inreplace "src/grib_jasper_encoding.c", "image.inmem_    = 1;", ""
+
+    inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
+
+    mkdir "build" do
+      args = std_cmake_args
+      args << "-DBUILD_SHARED_LIBS=OFF" if build.with? "static"
+
+      if build.with? "libpng"
+        args << "-DPNG_PNG_INCLUDE_DIR=#{Formula["libpng"].opt_include}"
+        args << "-DENABLE_PNG=ON"
+      end
+
+      system "cmake", "..", "-DENABLE_NETCDF=OFF", *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    grib_samples_path = shell_output("#{bin}/codes_info -s").strip
+    system bin/"grib_ls", "#{grib_samples_path}/GRIB1.tmpl"
+    system bin/"grib_ls", "#{grib_samples_path}/GRIB2.tmpl"
+  end
+end


### PR DESCRIPTION
This is the replacement for the ECMWF GRIB API library. The ECMWF developers consider the eccodes library the primary library they continue to work on. It also contains support for the BUFR file format besides GRIB 1 and 2. The build procedure is very similar to what was used in the grib-api formula, so this is a copy of that formula with the relevant details changed for the new library.

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
Yes, there is one but it was not merged for various reasons
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
