### PR TITLE
libtiff: update Debian patches

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -4,7 +4,7 @@ class Libtiff < Formula
   url "https://download.osgeo.org/libtiff/tiff-4.0.9.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.9.tar.gz"
   sha256 "6e7bdeec2c310734e734d19aae3a71ebe37a4d842e0e23dbb1b8921c0026cfcd"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -21,12 +21,16 @@ class Libtiff < Formula
   # All of these have been reported upstream & should
   # be fixed in the next release, but please check.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-4.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-4.debian.tar.xz"
-    sha256 "f078da1da538109c1e5403dc1f44d23c91f5a5d6ddc5ffc41ff60de006cb2b2e"
+    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-5.debian.tar.xz"
+    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-5.debian.tar.xz"
+    sha256 "5c98180b77457fc5452f3b4fed85862172dbfdb342d7a98e88363e439a669c96"
     apply "patches/CVE-2017-9935.patch",
           "patches/CVE-2017-18013.patch",
-          "patches/CVE-2018-5784.patch"
+          "patches/CVE-2018-5784.patch",
+          "patches/CVE-2017-11613_part1.patch",
+          "patches/CVE-2017-11613_part2.patch",
+          "patches/CVE-2018-7456.patch",
+          "patches/CVE-2017-17095.patch"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

to 4.0.9-5.

- Fix CVE-2017-11613: avoid memory exhaustion in
  ChopUpSingleUncompressedStrip() (closes: 869823).
- Fix CVE-2018-7456: NULL pointer dereference in TIFFPrintDirectory()
  (closes: 891288).
- Fix CVE-2017-17095: heap-based buffer overflow in pal2rgb tool
  (closes: 883320).