### PR TITLE
pdftoedn: depend on pkg-config at build time

### DIFF
--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -15,6 +15,7 @@ class Pdftoedn < Formula
   needs :cxx11
   depends_on "automake" => :build
   depends_on "autoconf" => :build
+  depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "libpng"
   depends_on "poppler"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes "configure: error: freetype2 was not found"