### PR TITLE
clamav 0.100.0: Fix missing json.h error

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -3,6 +3,7 @@ class Clamav < Formula
   homepage "https://www.clamav.net/"
   url "https://www.clamav.net/downloads/production/clamav-0.100.0.tar.gz"
   sha256 "c5c5edaf75a3c53ac0f271148fd6447310bce53f448ec7e6205124a25918f65c"
+  revision 1
 
   bottle do
     sha256 "b2a3015190e2f9d51f79315a543943ce14a1fb8fbfd026327c4f58e230df38fd" => :high_sierra
@@ -38,7 +39,7 @@ class Clamav < Formula
       --enable-llvm=no
     ]
 
-    args << "--with-libjson=#{Formula["json-c"].opt_prefix}" if build.with? "json-c"
+    args << (build.with?("json-c") ? "--with-libjson=#{Formula["json-c"].opt_prefix}" : "--without-libjson")
     args << "--with-pcre=#{Formula["pcre"].opt_prefix}" if build.with? "pcre"
     args << "--disable-yara" if build.without? "yara"
     args << "--without-pcre" if build.without? "pcre"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When building `clamav` from source, the build fails with an error (occuring more than once):

```
./others.h:55:10: fatal error: 'json.h' file not found
#include "json.h"
         ^~~~~~~~
```

See full build log (with marked error) here: https://gist.github.com/muellermartin/daa5e3b904a74cc583419d579b4a2026#file-02-make-L174

This somehow seems to be related to `json-c` which is installed through another package (I can't remember that I installed it manually). The problem is that the usage of `json-c` is optional (therefore not chosen by default) but somehow the installed version gets automatically recognized during the configure phase. Due to the build phase being sandboxed, the compiler then cannot find the header file. But this is just a guess…

My patch explicitly disables `json-c` when it is not chosen as build option which fixes the error for me.