### PR TITLE
libstfl: Depend on ruby to fix linker error

### DIFF
--- a/Formula/libstfl.rb
+++ b/Formula/libstfl.rb
@@ -3,7 +3,7 @@ class Libstfl < Formula
   homepage "http://www.clifford.at/stfl/"
   url "http://www.clifford.at/stfl/stfl-0.24.tar.gz"
   sha256 "d4a7aa181a475aaf8a8914a8ccb2a7ff28919d4c8c0f8a061e17a0c36869c090"
-  revision 6
+  revision 7
 
   bottle do
     cellar :any
@@ -16,7 +16,7 @@ class Libstfl < Formula
   option "without-python", "Build without Python 2 support"
   option "without-ruby", "Build without Ruby support"
 
-  depends_on "ruby" => :recommended if MacOS.version <= :mountain_lion
+  depends_on "ruby" => :recommended
   depends_on "swig" => :build if build.with?("python") || build.with?("ruby") || build.with?("perl")
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] ~~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~~ There seems to be an issue with a line which my patch does not touch: `` `Use :optional` or `:recommended` instead of `depends_on "swig" => :build if build.with?("python")` ``

-----

When `libstfl` is built from source, currently the build fails with the following linker error:

```
Undefined symbols for architecture x86_64:
  "_rb_cFixnum", referenced from:
      _Init_stfl in stfl_wrap.o
  "_rb_data_object_alloc", referenced from:
      _Init_stfl in stfl_wrap.o
      __wrap_stfl_form_allocate in stfl_wrap.o
      _SWIG_Ruby_NewPointerObj in stfl_wrap.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [stfl.bundle] Error 1
make: *** [ruby/build_ok] Error 2
```

See full log (with marked error) here: https://gist.github.com/muellermartin/b6f4ce3e123055ba772b29e5406192a4#file-01-make-L62

This issue was adressed in a very old PR #250 but seems to have been reintroduced by commit 3375486.

My patch simply also pulls `ruby` as recommended dependency (not just on Mac OS X as old as or older than Mountain Lion) which fixes the error for me.