### PR TITLE
travis.yml: generate `brew info` JSON.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: c
+os: linux
+compiler: gcc
+sudo: false
+
+deploy:
+  local-dir: json_test
+  repo: Homebrew/json_test
+  target-branch: master
+  verbose: true
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    all_branches: true
+
+before_install:
+  - HOMEBREW_REPOSITORY="$HOME/Homebrew"
+  - export PATH="$HOMEBREW_REPOSITORY/bin:$PATH"
+  # umask 022 fixes Linux `brew tests` failures
+  - umask 022
+  - chmod 644 Formula/*.rb
+  - rm -rf $HOMEBREW_REPOSITORY
+  - travis_retry git clone --depth=1 https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
+  - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
+  - mkdir -p "$HOMEBREW_TAP_DIR"
+  - rm -rf "$HOMEBREW_TAP_DIR"
+  - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+  # trigger vendored ruby installation
+  - brew help
+
+before_script:
+  - travis_retry git clone https://$GITHUB_TOKEN@github.com/homebrew/json_test
+
+script:
+  - cd json_test && brew ruby generate.rb


### PR DESCRIPTION
Generate a `brew info` JSON output for use by GitHub Pages.

Replaces #26695 with a non-fork branch (so secret tokens can be tested).