### PR TITLE
wine: remove screen-flickering patch

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -7,19 +7,12 @@
 class Wine < Formula
   desc "Run Windows applications without a copy of Microsoft Windows"
   homepage "https://www.winehq.org/"
-  revision 1
+  revision 2
 
   stable do
     url "https://dl.winehq.org/wine/source/3.0/wine-3.0.tar.xz"
     mirror "https://downloads.sourceforge.net/project/wine/Source/wine-3.0.tar.xz"
     sha256 "346a050aca5cd0d9978a655af11c30e68c201a58aea0c70d5e4c4f1b63c2fbec"
-
-    # Patch to fix screen-flickering issues. Still relevant on 3.0.
-    # https://bugs.winehq.org/show_bug.cgi?id=34166
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/74c2566/wine/2.14.patch"
-      sha256 "6907471d18996ada60cc0cbc8462a1698e90720c0882846dfbfb163e5d3899b8"
-    end
 
     resource "mono" do
       url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi", :using => :nounzip


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in #26114, this removes the flickering patch from wine stable (3.0). We should hold of merging until we have confirmed that this works sans patch on 10.11 and 10.12.

Please help us test this using some known affected games ❤️ 

- Age of Empires 1
- Age of Empires 2
- Black and White 1
- Midtown Madness 2

```markdown
- OS Verison: **found under  > About this mac, e.g. macOS 10.13.4 (17E199)**
- Computer: **found under  > About this mac, e.g. MacBook Pro (Retina, 13-inch, Early 2015)**
- Built wine without patch: **yes**
- Game tested: **choose from above**
- Observed flickering: **yes/no**
```

You can install this unpatched version using:

```sh
brew install --build-from-source https://raw.githubusercontent.com/LinusU/homebrew-core/df366f138aa6033993a9fea4c1f6b988c91669c3/Formula/wine.rb
```

Here is a link to a (I think legal) abandonware copy of Black and White:

https://www.myabandonware.com/game/black-white-a33