### PR TITLE
libtorrent-rasterbar: patch for Boost 1.67 compatibility

### DIFF
--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -26,6 +26,14 @@ class LibtorrentRasterbar < Formula
   depends_on "boost"
   depends_on "boost-python" if build.with? "python@2"
 
+  # Fix "error: no member named 'prior' in namespace 'boost'"
+  # Upstream issue from 18 Apr 2018 "Boost 1.67.0 build failure"
+  # See https://github.com/arvidn/libtorrent/issues/2947
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/22e74f4/libtorrent-rasterbar/boost-1.67.diff"
+    sha256 "65e9f05f69bdd439f967e127fd07475c77b2f7885c50457d36b170ed5e6a3bb9"
+  end
+
   def install
     ENV.cxx11
     args = ["--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Goes together with https://github.com/Homebrew/formula-patches/pull/236.

See #26769
Upstream issue https://github.com/arvidn/libtorrent/issues/2947