### PR TITLE
pcb2gcode: depend on pkg-config at build time

### DIFF
--- a/Formula/pcb2gcode.rb
+++ b/Formula/pcb2gcode.rb
@@ -20,6 +20,7 @@ class Pcb2gcode < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "gtkmm"
   depends_on "gerbv"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes
```
checking boost/format.hpp presence... yes
checking for boost/format.hpp... yes
checking for pkg-config... no
checking for glibmm... no
configure: error: in `/private/tmp/pcb2gcode-20180418-58533-g3olq5/pcb2gcode-1.3.2':
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.

Alternatively, you may set the environment variables glibmm_CFLAGS
and glibmm_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.

To get pkg-config, see <http://pkg-config.freedesktop.org/>.
See `config.log' for more details
```