### PR TITLE
libtorrent-rasterbar 1.1.7

### DIFF
--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -1,8 +1,8 @@
 class LibtorrentRasterbar < Formula
   desc "C++ bittorrent library by Rasterbar Software"
   homepage "https://www.libtorrent.org/"
-  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1_6/libtorrent-rasterbar-1.1.6.tar.gz"
-  sha256 "b7c74d004bd121bd6e9f8975ee1fec3c95c74044c6a6250f6b07f259f55121ef"
+  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1_7/libtorrent-rasterbar-1.1.7.tar.gz"
+  sha256 "8133bf683308decc24da22aff17437e36c522d8959bcf934e94cf7a3a567f3a9"
 
   bottle do
     cellar :any
@@ -25,6 +25,20 @@ class LibtorrentRasterbar < Formula
   depends_on "python@2" => :optional
   depends_on "boost"
   depends_on "boost-python" if build.with? "python@2"
+
+  # Remove for > 1.1.7
+  # Upstream commit from 11 Apr 2018 "fix boost-1.67 build"
+  patch do
+    url "https://github.com/arvidn/libtorrent/commit/64d6b49004.patch?full_index=1"
+    sha256 "97987e7ec1100c3ae9a0a0b82c1c2237672f15d2abc3b1707c6c8b328c37ce32"
+  end
+
+  # Remove for > 1.1.7
+  # Upstream commit from 12 Apr 2018 "another boost-1.67 build fix"
+  patch do
+    url "https://github.com/arvidn/libtorrent/commit/9cd0ae67e7.patch?full_index=1"
+    sha256 "185d59167d89884849408e7ff831badd3fbf4048b48b634e847134b4a8033299"
+  end
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

apply upstream patches for Boost 1.67 compatibility

See #26769
Upstream issue https://github.com/arvidn/libtorrent/issues/2947