### PR TITLE
ethereum: rename from geth

### DIFF
--- a/Formula/ethereum.rb
+++ b/Formula/ethereum.rb
@@ -1,4 +1,4 @@
-class Geth < Formula
+class Ethereum < Formula
   desc "Official Go implementation of the Ethereum protocol"
   homepage "https://ethereum.github.io/go-ethereum/"
   url "https://github.com/ethereum/go-ethereum/archive/v1.8.4.tar.gz"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -51,6 +51,7 @@
   "gcc5": "gcc@5",
   "gcc6": "gcc@6",
   "geode": "apache-geode",
+  "geth": "ethereum",
   "gitlab-ci-multi-runner": "gitlab-runner",
   "giflib5": "giflib@5",
   "giflib@5": "giflib",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Goes together with https://github.com/ethereum/homebrew-ethereum/pull/166.

This originally installed only `geth` but now installs all the tools.
The upstream formula up for migration into homebrew/core is named
ethereum, so let's rename here first.