### PR TITLE
Add support for LibreSSL in OpenSSH

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -15,11 +15,10 @@ class Openssh < Formula
   # Please don't resubmit the keychain patch option. It will never be accepted.
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
-  depends_on "openssl" # => :optional
+  depends_on "openssl" # OpenSSH will use libressl if specified otherwise use default to OpenSSL
   depends_on "ldns" => :optional
   depends_on "libressl" => :optional
   depends_on "pkg-config" => :build if build.with? "ldns"
-  # depends_on "pkg-config" => :build if build.with? "openssl"
   depends_on "pkg-config" => :build if build.with? "libressl"
 
   # Both these patches are applied by Apple.
@@ -52,14 +51,13 @@ class Openssh < Formula
       --sysconfdir=#{etc}/ssh
       --with-pam
     ]
-    # --with-ssl-dir=#{Formula["openssl"].opt_prefix}
 
     args << "--with-ldns" if build.with? "ldns"
 
     if build.with? "libressl"
-      args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" # if build.with? "libressl"
+      args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" 
     else
-      args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" # if build.with? "openssl"
+      args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" 
     end
 
     system "./configure", *args

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -15,7 +15,7 @@ class Openssh < Formula
   # Please don't resubmit the keychain patch option. It will never be accepted.
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
-  depends_on "openssl" # OpenSSH will use libressl if specified otherwise use default to OpenSSL
+  depends_on "openssl" # OpenSSH will use libressl if specified otherwise default to OpenSSL
   depends_on "ldns" => :optional
   depends_on "libressl" => :optional
   depends_on "pkg-config" => :build if build.with? "ldns"

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -15,11 +15,11 @@ class Openssh < Formula
   # Please don't resubmit the keychain patch option. It will never be accepted.
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
-  depends_on "openssl" => :optional
+  depends_on "openssl" # => :optional
   depends_on "ldns" => :optional
   depends_on "libressl" => :optional
   depends_on "pkg-config" => :build if build.with? "ldns"
-  depends_on "pkg-config" => :build if build.with? "openssl"
+  # depends_on "pkg-config" => :build if build.with? "openssl"
   depends_on "pkg-config" => :build if build.with? "libressl"
 
   # Both these patches are applied by Apple.
@@ -55,8 +55,12 @@ class Openssh < Formula
     # --with-ssl-dir=#{Formula["openssl"].opt_prefix}
 
     args << "--with-ldns" if build.with? "ldns"
-    args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" if build.with? "libressl"
-    args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" if build.with? "openssl"
+
+    if build.with? "libressl"
+      args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" # if build.with? "libressl"
+    else
+      args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" # if build.with? "openssl"
+    end
 
     system "./configure", *args
     system "make"

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -15,9 +15,12 @@ class Openssh < Formula
   # Please don't resubmit the keychain patch option. It will never be accepted.
   # https://github.com/Homebrew/homebrew-dupes/pull/482#issuecomment-118994372
 
-  depends_on "openssl"
+  depends_on "openssl" => :optional
   depends_on "ldns" => :optional
+  depends_on "libressl" => :optional
   depends_on "pkg-config" => :build if build.with? "ldns"
+  depends_on "pkg-config" => :build if build.with? "openssl"
+  depends_on "pkg-config" => :build if build.with? "libressl"
 
   # Both these patches are applied by Apple.
   patch do
@@ -48,10 +51,12 @@ class Openssh < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}/ssh
       --with-pam
-      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
     ]
+    # --with-ssl-dir=#{Formula["openssl"].opt_prefix}
 
     args << "--with-ldns" if build.with? "ldns"
+    args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" if build.with? "libressl"
+    args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" if build.with? "openssl"
 
     system "./configure", *args
     system "make"

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -55,9 +55,9 @@ class Openssh < Formula
     args << "--with-ldns" if build.with? "ldns"
 
     if build.with? "libressl"
-      args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}" 
+      args << "--with-ssl-dir=#{Formula["libressl"].opt_prefix}"
     else
-      args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}" 
+      args << "--with-ssl-dir=#{Formula["openssl"].opt_prefix}"
     end
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

╰─λ brew audit --strict openssh                                                           
openssh:
  * C: 20: col 3: Formulae should not depend on both OpenSSL and LibreSSL (even optionally).
Error: 1 problem in 1 formula

I asked about this in the IRC channel **machomebrew** on freenode didn't get a response.  ¯\\_(ツ)_/¯

This formula is setup to install OpenSSH with OpenSSL if no flags are passed.  However if `--with-libressl` is passed OpenSSH will be built with _LibreSSL_ instead of _OpenSSL_.

Verified with `ssh -V`
```sh
OpenSSH_7.7p1, LibreSSL 2.7.2
```

