### PR TITLE
git-annex: Support for installing assistant autostart service.

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -40,6 +40,30 @@ class GitAnnex < Formula
     bin.install_symlink "git-annex" => "git-annex-shell"
   end
 
+  plist_options :startup => true, :manual => "git annex assistant --autostart"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/git-annex</string>
+          <string>assistant</string>
+          <string>--autostart</string>
+        </array>
+      </dict>
+    </plist>
+    EOS
+  end
+
   test do
     # make sure git can find git-annex
     ENV.prepend_path "PATH", bin

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -40,7 +40,7 @@ class GitAnnex < Formula
     bin.install_symlink "git-annex" => "git-annex-shell"
   end
 
-  plist_options :startup => true, :manual => "git annex assistant --autostart"
+  plist_options :manual => "git annex assistant --autostart"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -61,7 +61,7 @@ class GitAnnex < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do


### PR DESCRIPTION
This adds a plist to ensure `git-annex`'s assistant is started and looks at the `~/.config/git-annex/autostart` file that is created by `git-annex` when you check the setting in the webapp to automatically start the assistant for the repo.