### PR TITLE
pdal: depend on numpy

### DIFF
--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -3,6 +3,7 @@ class Pdal < Formula
   homepage "https://www.pdal.io/"
   url "https://github.com/PDAL/PDAL/archive/1.7.1.tar.gz"
   sha256 "a560d3962b5ffdf58876155b33f816f24dbaf9a313ae308d9bf63adb8edac951"
+  revision 1
   head "https://github.com/PDAL/PDAL.git"
 
   bottle do
@@ -15,6 +16,7 @@ class Pdal < Formula
   depends_on "gdal"
   depends_on "hdf5"
   depends_on "laszip"
+  depends_on "numpy"
   depends_on "pcl"
   depends_on "postgresql"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes
```
-- Numpy output: 
CMake Error at /usr/local/Cellar/cmake/3.11.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find NumPy (missing: NUMPY_VERSION NUMPY_INCLUDE_DIR) (Required
  is at least version "1.5")
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.11.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindNumPy.cmake:32 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/python.cmake:16 (find_package)
  plugins/python/CMakeLists.txt:5 (include)
```

CC @tschoonj