### PR TITLE
elasticsearch@*: fix java version.

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -4,11 +4,12 @@ class ElasticsearchAT24 < Formula
   url "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz"
   sha256 "5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f"
 
+  revision 1
   bottle :unneeded
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -49,7 +50,9 @@ class ElasticsearchAT24 < Formula
     (etc/"elasticsearch/scripts").mkpath
     (libexec/"config").rmtree
 
-    bin.write_exec_script Dir[libexec/"bin/elasticsearch"]
+    bin.install libexec/"bin/elasticsearch",
+                libexec/"bin/plugin"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
   end
 
   def post_install

--- a/Formula/elasticsearch@5.6.rb
+++ b/Formula/elasticsearch@5.6.rb
@@ -4,11 +4,12 @@ class ElasticsearchAT56 < Formula
   url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz"
   sha256 "64b9486d5bdeb6f85d09fdc30aa2d0e1ce7fb8f253084a8d7cb15652494da96a"
 
+  revision 1
   bottle :unneeded
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -49,8 +50,11 @@ class ElasticsearchAT56 < Formula
     (etc/"elasticsearch/scripts").mkdir unless File.exist?(etc/"elasticsearch/scripts")
     (libexec/"config").rmtree
 
-    bin.write_exec_script Dir[libexec/"bin/elasticsearch"]
-    bin.write_exec_script Dir[libexec/"bin/elasticsearch-plugin"]
+    bin.install libexec/"bin/elasticsearch",
+                libexec/"bin/elasticsearch-keystore",
+                libexec/"bin/elasticsearch-plugin",
+                libexec/"bin/elasticsearch-translog"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
   end
 
   def post_install


### PR DESCRIPTION
Technically Java 1.7 can be used for `elasticsearch@2.4` but we don't have a way of specifying that really.