### PR TITLE
testssl: Fix HEAD branch

### DIFF
--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -4,7 +4,7 @@ class Testssl < Formula
   url "https://github.com/drwetter/testssl.sh/archive/v2.9.5-5.tar.gz"
   version "2.9.5-5"
   sha256 "836a7b45455c95f17c4d7eec9468028a7fc6b613fd4b3c8e8e125b7b8206b89d"
-  head "https://github.com/drwetter/testssl.sh.git"
+  head "https://github.com/drwetter/testssl.sh.git", :branch => "2.9dev"
 
   bottle :unneeded
 


### PR DESCRIPTION
* The testssl.sh developer moved away from having a `master` branch some
time ago, and current development takes places in the branch `2.9dev`
(currently, for the 3.0beta version).
* This change simply adds `, branch => "2.9dev"` to the head git repo
line.
* This may change in the future, but the prior configuration without a
branch specified will always fail.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
