### PR TITLE
Force DNS update to ddclient service

### DIFF
--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -67,6 +67,7 @@ class Ddclient < Formula
         <string>#{opt_sbin}/ddclient</string>
         <string>-file</string>
         <string>#{etc}/ddclient/ddclient.conf</string>
+        <string>-force</string>
       </array>
       <key>RunAtLoad</key>
       <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`-force` flag ensures that the information (your IP) is updated to the Dynamic DNS server. Without  this flag and if you modify the IP of the DNS record on the server or cached data is wrong, the service simply does not work and it does not update the record.

The default is `-noforce`, to save from doing unnecessary DNS updates, but it looks like it doesn't work as expected.