### PR TITLE
libfaketime: depend on coreutils

### DIFF
--- a/Formula/libfaketime.rb
+++ b/Formula/libfaketime.rb
@@ -3,6 +3,7 @@ class Libfaketime < Formula
   homepage "https://github.com/wolfcw/libfaketime"
   url "https://github.com/wolfcw/libfaketime/archive/v0.9.7.tar.gz"
   sha256 "4d65f368b2d53ee2f93a25d5e9541ce27357f2b95e5e5afff210e0805042811e"
+  revision 1
   head "https://github.com/wolfcw/libfaketime.git"
 
   bottle do
@@ -10,6 +11,11 @@ class Libfaketime < Formula
     sha256 "3fc5f61a8d50f7586cc18d269263fa95481bd741ac1756f2f55b5932e5a01ce5" => :sierra
     sha256 "0b792c716c6e8ba9db928b0c4dc4ab2dc474eb12da529186ba4475f5fba73169" => :el_capitan
   end
+
+  # The `faketime` command needs GNU `gdate` not BSD `date`.
+  # See https://github.com/wolfcw/libfaketime/issues/158 and
+  # https://github.com/Homebrew/homebrew-core/issues/26568
+  depends_on "coreutils"
 
   depends_on :macos => :lion
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `faketime` wrapper needs GNU `gdate` to support relative date syntax
such as "3 weeks ago," which is not supported by macOS's `date` command.

Fixes https://github.com/Homebrew/homebrew-core/issues/26568.