### PR TITLE
entt 2.5.0 (new formula)

### DIFF
--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -5,7 +5,7 @@ class Entt < Formula
   sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
 
   option "with-docs", "Install the HTML documentation"
-  
+
   depends_on "cmake" => :build if build.with? "docs"
   depends_on "doxygen" => :build if build.with? "docs"
 

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -9,6 +9,37 @@ class Entt < Formula
   end
 
   test do
-    system "true"
+    (testpath/"test.cpp").write <<~EOS
+      #include <entt/entt.hpp>
+
+      struct Position {
+        int x;
+        int y;
+      };
+
+      void moveSystem(entt::DefaultRegistry &reg, Position shift) {
+        auto view = reg.view<Position>();
+        for (const uint32_t entity : view) {
+          Position &pos = view.get(entity);
+          pos.x += shift.x;
+          pos.y += shift.y;
+        }
+      }
+
+      int main() {
+        entt::DefaultRegistry reg;
+        uint32_t entity = reg.create();
+        reg.assign<Position>(entity, 2, 6);
+        moveSystem(reg, {4, 4});
+
+        Position expected = {6, 10};
+        Position actual = reg.get<Position>(entity);
+        reg.destroy(entity);
+
+        return actual.x != expected.x || actual.y != expected.y;
+      }
+    EOS
+    system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test"
+    system "./test"
   end
 end

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -1,0 +1,37 @@
+class Entt < Formula
+  desc "Fast and reliable entity-component system and much more"
+  homepage "https://skypjack.github.io/entt/"
+  url "https://github.com/skypjack/entt/archive/v2.5.0.tar.gz"
+  sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
+
+  depends_on "cmake" => :test
+
+  def install
+    include.install "src/entt"
+
+    # bin.install "." doesn't work
+    
+    bin.install ".travis.yml"
+    bin.install "appveyor.yml"
+    bin.install "AUTHORS"
+    bin.install "build"
+    bin.install "cmake"
+    bin.install "CMakeLists.txt"
+    bin.install "deps"
+    bin.install "docs"
+    bin.install "LICENSE"
+    bin.install "README.md"
+    bin.install "src"
+    bin.install "test"
+    bin.install "TODO"
+  end
+
+  test do
+    system "cp", "-rpX", "#{bin}", testpath
+    cd "bin"
+    cd "build"
+    system "cmake", ".."
+    system "make"
+    system "make", "test"
+  end
+end

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -3,9 +3,17 @@ class Entt < Formula
   homepage "https://skypjack.github.io/entt/"
   url "https://github.com/skypjack/entt/archive/v2.5.0.tar.gz"
   sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
+  head "https://github.com/skypjack/entt.git"
+
+  depends_on "cmake" => :build
+  depends_on "doxygen" => :build
 
   def install
     include.install "src/entt"
+    cd "build"
+    system "cmake", ".."
+    system "make", "docs"
+    (prefix/"docs").install "docs/html"
   end
 
   test do

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -4,34 +4,11 @@ class Entt < Formula
   url "https://github.com/skypjack/entt/archive/v2.5.0.tar.gz"
   sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
 
-  depends_on "cmake" => :test
-
   def install
     include.install "src/entt"
-
-    # bin.install "." doesn't work
-    
-    bin.install ".travis.yml"
-    bin.install "appveyor.yml"
-    bin.install "AUTHORS"
-    bin.install "build"
-    bin.install "cmake"
-    bin.install "CMakeLists.txt"
-    bin.install "deps"
-    bin.install "docs"
-    bin.install "LICENSE"
-    bin.install "README.md"
-    bin.install "src"
-    bin.install "test"
-    bin.install "TODO"
   end
 
   test do
-    system "cp", "-rpX", "#{bin}", testpath
-    cd "bin"
-    cd "build"
-    system "cmake", ".."
-    system "make"
-    system "make", "test"
+    system "true"
   end
 end

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -4,15 +4,19 @@ class Entt < Formula
   url "https://github.com/skypjack/entt/archive/v2.5.0.tar.gz"
   sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
 
-  depends_on "cmake" => :build
-  depends_on "doxygen" => :build
+  option "with-docs", "Install the HTML documentation"
+  
+  depends_on "cmake" => :build if build.with? "docs"
+  depends_on "doxygen" => :build if build.with? "docs"
 
   def install
     include.install "src/entt"
-    cd "build"
-    system "cmake", ".."
-    system "make", "docs"
-    (prefix/"docs").install "docs/html"
+    if build.with? "docs"
+      cd "build"
+      system "cmake", ".."
+      system "make", "docs"
+      (prefix/"docs").install "docs/html"
+    end
   end
 
   test do

--- a/Formula/entt.rb
+++ b/Formula/entt.rb
@@ -3,7 +3,6 @@ class Entt < Formula
   homepage "https://skypjack.github.io/entt/"
   url "https://github.com/skypjack/entt/archive/v2.5.0.tar.gz"
   sha256 "6246501c6589eba9832538c47a23a239eaa1066c77471cae7d79e741141ade82"
-  head "https://github.com/skypjack/entt.git"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`EnTT` is a header-only, tiny and easy to use framework written in modern C++.
It was originally designed entirely around an architectural pattern called ECS that is used mostly in game development.

`brew audit entt` produces no output and `brew audit --strict entt` produces the following message:

```
Error: uninitialized constant FormulaAuditor::MissingFormula
Did you mean?  MissingApplyError
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:311:in `audit_formula_name'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:809:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:802:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:802:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:124:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:120:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:120:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:101:in `<main>'
```

That doesn't look good! Anyone know why this is happening?

-----

It looks like someone just updated Homebrew because now all the tests are passing. Thank you to whoever did that!