### PR TITLE
imagemagick: add optional HEIF support

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -17,6 +17,7 @@ class Imagemagick < Formula
 
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
+  option "with-libde265", "Compile with HEIF support"
   option "with-opencl", "Compile with OpenCL support"
   option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
@@ -42,6 +43,7 @@ class Imagemagick < Formula
   depends_on "fontconfig" => :optional
   depends_on "little-cms" => :optional
   depends_on "little-cms2" => :optional
+  depends_on "libde265" => :optional
   depends_on "libwmf" => :optional
   depends_on "librsvg" => :optional
   depends_on "liblqr" => :optional

--- a/Formula/libde265.rb
+++ b/Formula/libde265.rb
@@ -1,0 +1,24 @@
+class Libde265 < Formula
+  desc "Open h.265 video codec implementation"
+  homepage "https://github.com/strukturag/libde265"
+  url "https://github.com/strukturag/libde265/releases/download/v1.0.3/libde265-1.0.3.tar.gz"
+  sha256 "e4206185a7c67d3b797d6537df8dcaa6e5fd5a5f93bd14e65a755c33cd645f7a"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-sherlock265",
+                          "--disable-dec265",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+
+    # Install the test-related executables in libexec.
+    (libexec/"bin").install bin/"acceleration_speed",
+                            bin/"block-rate-estim",
+                            bin/"tests"
+  end
+
+  test do
+    system libexec/"bin/tests"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #26444.

Note the upstream PR here which may change things in future in terms of how this option needs handling: ImageMagick/ImageMagick#1099