### PR TITLE
ice 3.7.1

### DIFF
--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -1,21 +1,14 @@
 class Ice < Formula
   desc "Comprehensive RPC framework"
   homepage "https://zeroc.com"
-  url "https://github.com/zeroc-ice/ice/archive/v3.7.0.tar.gz"
-  sha256 "809fff14a88a7de1364c846cec771d0d12c72572914e6cc4fb0b2c1861c4a1ee"
-  revision 2
+  url "https://github.com/zeroc-ice/ice/archive/v3.7.1.tar.gz"
+  sha256 "b1526ab9ba80a3d5f314dacf22674dff005efb9866774903d0efca5a0fab326d"
 
   bottle do
     cellar :any
     sha256 "f0f7026dee2641341b7ad0afdb2171b3fc9346780cfd41d43d68e000a413ef9e" => :high_sierra
     sha256 "8f88952025f7617e3e9b3812524b9ee05d58c7439f0c2b309a45a6ac9f6cb1fe" => :sierra
     sha256 "5cfc10f845ecf06b9177e1ec7223513e977bb70680a756b906b3b6beaf045bc6" => :el_capitan
-  end
-
-  # Xcode 9 support
-  patch do
-    url "https://github.com/zeroc-ice/ice/commit/3a55ebb51b8914b60d308a0535d9abf97567138d.patch?full_index=1"
-    sha256 "d95e76acebdae69edf3622f5141ea32bbbd5844be7c29d88e6e985d14a5d5dd4"
   end
 
   #


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Ice 3.7.1

Xcode 9 patch is no longer required as it was fixed upstream.