### PR TITLE
add mysql support to libgda

### DIFF
--- a/Formula/libgda.rb
+++ b/Formula/libgda.rb
@@ -20,6 +20,8 @@ class Libgda < Formula
     sha256 "db6c7f10a9ed832585aae65eb135b718a69c5151375aa21e475ba3031beb0068"
   end
 
+  option "with-mysql", "Build with MySQL support"
+
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "itstool" => :build
@@ -29,15 +31,20 @@ class Libgda < Formula
   depends_on "libgcrypt"
   depends_on "sqlite"
   depends_on "openssl"
+  depends_on "mysql" => :optional
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--disable-binreloc",
-                          "--disable-gtk-doc",
-                          "--without-java"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --disable-binreloc
+      --disable-gtk-doc
+      --without-java
+    ]
+    args << "--with-mysql=#{Formula["mysql"].opt_prefix}" if build.with? "mysql"
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I didn't check `brew audit` because I'm currently getting an error:

```
[aaron@TC ~]$ brew audit --strict libgda
==> Installing or updating 'rubocop' gem
ERROR:  Could not find a valid gem 'rubocop' (= 0.55.0), here is why:
          Unable to download data from https://rubygems.org/ - Failed to open TCP connection to api.rubygems.org:443 (Host is down - connect(2) for "api.rubygems.org" port 443) (https://api.rubygems.org/specs.4.8.gz)
Error: Failed to install/update the 'rubocop' gem.
```