### PR TITLE
woff2 1.0.2 (new formula)

### DIFF
--- a/Formula/woff2.rb
+++ b/Formula/woff2.rb
@@ -1,13 +1,8 @@
 class Woff2 < Formula
   desc "Utilities to create and convert Web Open Font File (WOFF) files"
   homepage "https://github.com/google/woff2"
-
   url "https://github.com/google/woff2/archive/v1.0.2.tar.gz"
   sha256 "add272bb09e6384a4833ffca4896350fdb16e0ca22df68c0384773c67a175594"
-
-  bottle do
-    sha256 "01a88969d60bbb128a4a73a6b9b6d4c75f4ff08b7c3df45139fc73b7fc76d694" => :high_sierra
-  end
 
   depends_on "cmake" => :build
   depends_on "brotli"
@@ -18,12 +13,24 @@ class Woff2 < Formula
     bin.install "woff2_info", "woff2_decompress", "woff2_compress"
   end
 
-  test do
-    # Fetch a woff2 file from Google Fonts
-    system "curl", "-o", "roboto.woff2", "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
+  resource "roboto_1" do
+    url "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxP.ttf"
+    sha256 "466989fd178ca6ed13641893b7003e5d6ec36e42c2a816dee71f87b775ea097f"
+  end
+  resource "roboto_2" do
+    url "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
+    sha256 "90a0ad0b48861588a6e33a5905b17e1219ea87ab6f07ccc41e7c2cddf38967a8"
+  end
 
-    system "#{bin}/woff2_info", "roboto.woff2"
-    system "#{bin}/woff2_decompress", "roboto.woff2"
-    system "#{bin}/woff2_compress", "roboto.ttf"
+  test do
+    # Convert a TTF to WOFF2
+    resource("roboto_1").stage testpath
+    system "#{bin}/woff2_compress", "KFOmCnqEu92Fr1Mu4mxP.ttf"
+    system "#{bin}/woff2_info", "KFOmCnqEu92Fr1Mu4mxP.woff2"
+
+    # Convert a WOFF2 to TTF
+    resource("roboto_2").stage testpath
+    system "#{bin}/woff2_decompress", "KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
+    assert_match "TrueType font data", shell_output("file --brief KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.ttf")
   end
 end

--- a/Formula/woff2.rb
+++ b/Formula/woff2.rb
@@ -1,0 +1,29 @@
+class Woff2 < Formula
+  desc "Utilities to create and convert Web Open Font File (WOFF) files"
+  homepage "https://github.com/google/woff2"
+
+  url "https://github.com/google/woff2/archive/v1.0.2.tar.gz"
+  sha256 "add272bb09e6384a4833ffca4896350fdb16e0ca22df68c0384773c67a175594"
+
+  bottle do
+    sha256 "01a88969d60bbb128a4a73a6b9b6d4c75f4ff08b7c3df45139fc73b7fc76d694" => :high_sierra
+  end
+
+  depends_on "cmake" => :build
+  depends_on "brotli"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+    bin.install "woff2_info", "woff2_decompress", "woff2_compress"
+  end
+
+  test do
+    # Fetch a woff2 file from Google Fonts
+    system "curl", "-o", "roboto.woff2", "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
+
+    system "#{bin}/woff2_info", "roboto.woff2"
+    system "#{bin}/woff2_decompress", "roboto.woff2"
+    system "#{bin}/woff2_compress", "roboto.ttf"
+  end
+end

--- a/Formula/woff2.rb
+++ b/Formula/woff2.rb
@@ -7,12 +7,6 @@ class Woff2 < Formula
   depends_on "cmake" => :build
   depends_on "brotli"
 
-  def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
-    bin.install "woff2_info", "woff2_decompress", "woff2_compress"
-  end
-
   resource "roboto_1" do
     url "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxP.ttf"
     sha256 "466989fd178ca6ed13641893b7003e5d6ec36e42c2a816dee71f87b775ea097f"
@@ -20,6 +14,12 @@ class Woff2 < Formula
   resource "roboto_2" do
     url "https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
     sha256 "90a0ad0b48861588a6e33a5905b17e1219ea87ab6f07ccc41e7c2cddf38967a8"
+  end
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+    bin.install "woff2_info", "woff2_decompress", "woff2_compress"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New formula for Google's Web Open Font Format 2 toolset, which is used by web developers when working with web fonts. It includes three binaries:

* `woff2_info`: Provides technical information about a .woff2 font file.
* `woff2_compress`: Converts a TTF file to WOFF2.
* `woff2_decompress`: Converts a WOFF2 file to TTF.
