### PR TITLE
sphinx-doc: patch `'DirectiveAdapter' object has no attribute 'env'`

### DIFF
--- a/Formula/sphinx-doc.rb
+++ b/Formula/sphinx-doc.rb
@@ -3,6 +3,7 @@ class SphinxDoc < Formula
   homepage "http://sphinx-doc.org"
   url "https://files.pythonhosted.org/packages/ff/bd/a709626705bb1f13b86904f6caaf53e3d088cbf2919b678296ce11fd646c/Sphinx-1.7.3.tar.gz"
   sha256 "9495a1f78c13d0a725ab8104e923e9663519ecc04552aa4a8f684c2da355443d"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -122,6 +123,13 @@ class SphinxDoc < Formula
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz"
     sha256 "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+  end
+
+  # Remove for > 1.7.3
+  # Upstream commit from 23 Apr 2018: "'DirectiveAdapter' object has no attribute 'env'"
+  patch do
+    url "https://github.com/sphinx-doc/sphinx/commit/3735ba39db51ee429344f88b8201cc3ac37496f4.diff?full_index=1"
+    sha256 "84559785c7a0b6df040f5c05904c25036714840e38ff14cc023ca27521393d38"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fixes #27026 