### PR TITLE
lbzip2: %n crash fix for 10.13

### DIFF
--- a/Formula/lbzip2.rb
+++ b/Formula/lbzip2.rb
@@ -13,6 +13,15 @@ class Lbzip2 < Formula
     sha256 "7e521c70fadae71ad2e7807cc844183c05751e4a2433d9f1210069fb2a34333e" => :mavericks
   end
 
+  # Fix crash from usage of %n in dynamic format strings on High Sierra
+  # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+  if MacOS.version >= :high_sierra
+    patch :p0 do
+      url "https://raw.githubusercontent.com/macports/macports-ports/b832494a90b/sysutils/coreutils/files/secure_snprintf.patch"
+      sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
+    end
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Lbzip2 was also affected with the vasnprintf %n crash on macOS 10.13 when
called with -v or --verbose. This patch fixes the crash.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the same fix as those in #15129. Lbzip2 is only affected when the `-v` parameter is applied. To see a crash log, see https://github.com/kjn/lbzip2/issues/20.