### PR TITLE
hugo: Add BuildDate based on the commit date of hugo.rb

### DIFF
--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -17,10 +17,16 @@ class Hugo < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+
+    cmd = [HOMEBREW_BREW_FILE, "log", "-1", "--format=%cd", "--date=format:%Y-%m-%dT%H:%M:%S%z", "hugo"]
+    build_date = IO.popen(cmd, :err=>"/dev/null").read.chomp
+    puts "Setting BuildDate to Formula/hugo.rb commit date: #{build_date}"
+    ldflags = "-X github.com/gohugoio/hugo/hugolib.BuildDate=#{build_date}"
+
     (buildpath/"src/github.com/gohugoio/hugo").install buildpath.children
     cd "src/github.com/gohugoio/hugo" do
       system "dep", "ensure"
-      system "go", "build", "-o", bin/"hugo", "main.go"
+      system "go", "build", "-ldflags", ldflags, "-o", bin/"hugo", "main.go"
 
       # Build bash completion
       system bin/"hugo", "gen", "autocomplete", "--completionfile=hugo.sh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is to add a (somewhat) reproducible BuildDate for hugo.

Before:

    $ hugo version
    Hugo Static Site Generator v0.40.1 darwin/amd64 BuildDate:

After:

    $ hugo version
    Hugo Static Site Generator v0.40.1 darwin/amd64 BuildDate: 2018-04-25T16:33:15-0600

Many thanks!