### PR TITLE
nginx: add comment about using mainline releases only

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -1,6 +1,8 @@
 class Nginx < Formula
   desc "HTTP(S) server and reverse proxy, and IMAP/POP3 proxy server"
   homepage "https://nginx.org/"
+  # Use "mainline" releases only (odd minor version number), not "stable"
+  # See https://www.nginx.com/blog/nginx-1-12-1-13-released/ for why
   url "https://nginx.org/download/nginx-1.13.12.tar.gz"
   sha256 "fb92f5602cdb8d3ab1ad47dbeca151b185d62eedb67d347bbe9d79c1438c85de"
   head "https://hg.nginx.org/nginx/", :using => :hg


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Quoting from https://www.nginx.com/blog/nginx-1-12-1-13-released/

>   We generally recommend using the mainline branch. This is where we
>   commit all new features, performance improvements, and enhancements.
>   We actively test and QA the mainline branch, so it’s arguably more
>   stable than the “stable” branch. The mainline branch is also the
>   source of NGINX Plus builds for our commercial customers.