### PR TITLE
TBB: Adding cmake config file

### DIFF
--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -17,6 +17,7 @@ class Tbb < Formula
   depends_on :macos => :lion
   depends_on "python@2"
   depends_on "swig" => :build
+  depends_on "cmake" => :build
 
   def install
     compiler = (ENV.compiler == :clang) ? "clang" : "gcc"
@@ -30,6 +31,13 @@ class Tbb < Formula
       ENV["TBBROOT"] = prefix
       system "python", *Language::Python.setup_install_args(prefix)
     end
+
+    system "cmake", "-DTBB_ROOT=#{prefix}",
+                    "-DTBB_OS=Darwin",
+                    "-DSAVE_TO=lib/cmake/TBB",
+                    "-P", "cmake/tbb_config_generator.cmake"
+
+    (lib/"cmake"/"TBB").install Dir["lib/cmake/TBB/*.cmake"]
   end
 
   test do


### PR DESCRIPTION
The TBB formula is missing the TBB CMake config file, meaning you can't use `find_package(TBB CONFIG)`; using a user-supplied `FindTBB.cmake` module instead is not recommended or supported by Intel. This PR adds the creation of this missing config file so that `find_package(TBB CONFIG)` is supported for TBB. It simply adds CMake as a build dependency and runs `tbb_config_generator.cmake` after the make process is complete. (See https://github.com/01org/tbb/tree/tbb_2018/cmake)

---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?