### PR TITLE
Add post-install instructions for direnv

### DIFF
--- a/Formula/direnv.rb
+++ b/Formula/direnv.rb
@@ -23,6 +23,20 @@ class Direnv < Formula
     end
   end
 
+  def caveats; <<~EOS
+    You must now configure your shell to enable direnv.
+
+    If you use Bash, add the following line to ~/.bashrc:
+      eval "$(direnv hook bash)"
+
+    If you use Zsh, add the following line to ~/.zshrc:
+      eval "$(direnv hook zsh)"
+
+    For other shells, consult the direnv setup instructions:
+      https://github.com/direnv/direnv/blob/master/README.md#setup
+    EOS
+  end
+
   test do
     system bin/"direnv", "status"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed that the `direnv` formula didn't tell me how to activate it, so I cribbed the code from the `bash-preexec` formula and replaced the text.