### PR TITLE
mpv: when using --with-bundle, set MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -54,7 +54,7 @@ class Mpv < Formula
     # for the --with-bundle option:
     #  - allow the build to work on older versions of OS X
     # see https://github.com/mpv-player/mpv/commit/c176f1169f356059ee6e3c447e4546fcdb335ec2
-    ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.3"
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
 
     # Prevents a conflict between python2 and python3 when
     # gobject-introspection is using brewed python.

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -51,6 +51,11 @@ class Mpv < Formula
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
 
+    # for the --with-bundle option:
+    #  - allow the build to work on older versions of OS X
+    # see https://github.com/mpv-player/mpv/commit/c176f1169f356059ee6e3c447e4546fcdb335ec2
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.3"
+
     # Prevents a conflict between python2 and python3 when
     # gobject-introspection is using brewed python.
     ENV.delete("PYTHONPATH") if MacOS.version <= :mavericks
@@ -85,9 +90,6 @@ class Mpv < Formula
     system "python3", "waf", "install"
 
     if build.with? "bundle"
-      # allow the build to work on older versions of OS X
-      # see https://github.com/mpv-player/mpv/commit/c176f1169f356059ee6e3c447e4546fcdb335ec2
-      ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.3"
       system "python3", "TOOLS/osxbundle.py", "build/mpv"
       prefix.install "build/mpv.app"
     end

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -85,6 +85,9 @@ class Mpv < Formula
     system "python3", "waf", "install"
 
     if build.with? "bundle"
+      # allow the build to work on older versions of OS X
+      # see https://github.com/mpv-player/mpv/commit/c176f1169f356059ee6e3c447e4546fcdb335ec2
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.3"
       system "python3", "TOOLS/osxbundle.py", "build/mpv"
       prefix.install "build/mpv.app"
     end


### PR DESCRIPTION
- enables using the app on older versions of OS X

I'm running 10.11 and when installing mpv with `brew install mpv --HEAD --with-bundle` the resulting app gives an error when running the resulting `mpv.app`.

```
You can’t use this version of the application “mpv” with this version of OS X.

You have OS X 10.11.6. The application requires OS X 10.12 or later.
```

This change fixes that issue.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
