### PR TITLE
qt: QTBUG-67545 and QTBUG-67810, work around QTBUG-67606: Homebrew issue #27095

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -60,6 +60,11 @@ class Qt < Formula
     sha256 "8ee0bf71df1043f08ebae3aa35036be29c4d9ebff8a27e3b0411a6bd635e9382"
   end
 
+  # TODO: -no-assimp is a Qt3D configure option that disables use of the assimp
+  # library entirely; this is done because that library fails to build for
+  # Qt 5.10 on macOS 10.13; this might not be required with Qt 5.11 anymore
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67606
   def install
     args = %W[
       -verbose
@@ -75,6 +80,7 @@ class Qt < Formula
       -no-rpath
       -pkg-config
       -dbus-runtime
+      -no-assimp
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -43,6 +43,8 @@ class Qt < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
     url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
     sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/3b023398/qt/QTBUG-67810.patch"
+    sha256 "79738a143850fb98e77c7b6d8bcfe02ef7717e740eba2582911ac3f3b2c2a96b"
   end
 
   def install

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -51,13 +51,13 @@ class Qt < Formula
     sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
   end
 
-  # Fix compile error on macOS 10.13 caused by Boost 1.62.0
-  # using C++ features deprecated in C++ 11 and removed in C++ 17:
+  # Fix compile error on macOS 10.13 caused by qtlocation dependency
+  # mapbox-gl-native using Boost 1.62.0 does not build with C++ 17:
   # https://github.com/Homebrew/homebrew-core/issues/27095
   # https://bugreports.qt.io/browse/QTBUG-67810
   patch do
-    url "https://raw.githubusercontent.com/z00m1n/formula-patches/685eecc0/qt/QTBUG-67810.patch"
-    sha256 "79738a143850fb98e77c7b6d8bcfe02ef7717e740eba2582911ac3f3b2c2a96b"
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/a1a1f0dd/qt/QTBUG-67810.patch"
+    sha256 "8ee0bf71df1043f08ebae3aa35036be29c4d9ebff8a27e3b0411a6bd635e9382"
   end
 
   def install

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -41,9 +41,22 @@ class Qt < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
+  end
+
+  # Fix compile error on macOS 10.13 around QFixed:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67545
+  patch do
     url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
     sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
-    url "https://raw.githubusercontent.com/z00m1n/formula-patches/3b023398/qt/QTBUG-67810.patch"
+  end
+
+  # Fix compile error on macOS 10.13 caused by Boost 1.62.0
+  # using C++ features deprecated in C++ 11 and removed in C++ 17:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67810
+  patch do
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/685eecc0/qt/QTBUG-67810.patch"
     sha256 "79738a143850fb98e77c7b6d8bcfe02ef7717e740eba2582911ac3f3b2c2a96b"
   end
 

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -41,6 +41,8 @@ class Qt < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
+    sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

+ this patch works well, but once applied, a subsequent compile error occurs; hence `WIP:` for work in progress
+ will tick off point 3 and 4 in list above before submitting final pull request
+ see also https://github.com/Homebrew/homebrew-core/issues/27095