### PR TITLE
llvm: Handle the inreplace error in llvm

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -269,7 +269,11 @@ class Llvm < Formula
 
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
     (share/"cmake").install "cmake/modules"
-    inreplace "#{share}/clang/tools/scan-build/bin/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
+    begin
+      inreplace "#{share}/clang/tools/scan-build/bin/scan-build", "$RealBin/bin/clang", "#{bin}/clang"
+    rescue InreplaceError
+      inreplace "#{share}/clang/tools/scan-build/bin/scan-build", "$RealBin/clang", "#{bin}/clang"
+    end
     bin.install_symlink share/"clang/tools/scan-build/bin/scan-build", share/"clang/tools/scan-view/bin/scan-view"
     man1.install_symlink share/"clang/tools/scan-build/man/scan-build.1"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This fix handles the issue that scan build may not contain the string "$RealBin/bin/clang" and provides a fallback replacement using the 2nd line "$RealBin/clang". It is meant to prevent the inreplace from throwing an unrecoverable error in what could be a normal build.
