### PR TITLE
 php & php@7.1: remove ICU 61.1 fix since its now upstream default

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -67,9 +67,6 @@ class Php < Formula
     # Required due to icu4c dependency
     ENV.cxx11
 
-    # icu4c 61.1 compatability
-    ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"
-
     config_path = etc/"php/#{php_version}"
     # Prevent system pear config from inhibiting pear install
     (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -72,9 +72,6 @@ class PhpAT71 < Formula
     # Required due to icu4c dependency
     ENV.cxx11
 
-    # icu4c 61.1 compatability
-    ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"
-
     config_path = etc/"php/#{php_version}"
     # Prevent system pear config from inhibiting pear install
     (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This fix has only been merged in 7.2 and 7.1 so far so that's why the other formulas are missing and still require the workaround in the Formula. For further info http://www.php.net/ChangeLog-7.php

https://github.com/php/php-src/commit/710284cbc4a54cac0a9ec4ea29a7486e0d99a33b#diff-b1d6ce06730b9b37d70f7824e04f7980