### PR TITLE
moc: use upstream patches for FFmpeg 4.0

### DIFF
--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -7,11 +7,6 @@ class Moc < Formula
     url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
     sha256 "f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08"
 
-    # Remove build deps when > 2.5.2 comes out
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gettext" => :build
-
     # Remove for > 2.5.2; FFmpeg 4.0 compatibility
     # 01 to 05 below are backported from patches provided 26 Apr 2018 by
     # upstream's John Fitzgerald
@@ -58,10 +53,6 @@ class Moc < Formula
       sha256 "601b5cdf59db67f180f1aaa6cc90804c1cb69c44cdecb2e8149338782e4f21a8"
     end
 
-    # Remove build deps when 2.6-alpha4 comes out
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gettext" => :build
     depends_on "popt"
 
     # Remove for > 2.6-alpha3; FFmpeg 4.0 compatibility
@@ -95,12 +86,13 @@ class Moc < Formula
   head do
     url "svn://daper.net/moc/trunk"
 
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gettext" => :build
     depends_on "popt"
   end
 
+  # Remove autoconf, automake and gettext when > 2.5.2 and > 2.6-alpha3 come out
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "ffmpeg"

--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -1,9 +1,45 @@
 class Moc < Formula
   desc "Terminal-based music player"
   homepage "https://moc.daper.net/"
-  url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
-  sha256 "f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08"
-  revision 3
+  revision 4
+
+  stable do
+    url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
+    sha256 "f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08"
+
+    # Remove build deps when > 2.5.2 comes out
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gettext" => :build
+
+    # Remove for > 2.5.2; FFmpeg 4.0 compatibility
+    # 01 to 05 below are backported from patches provided 26 Apr 2018 by
+    # upstream's John Fitzgerald
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/01-codec-2.5.2.patch"
+      sha256 "c6144dbbd85e3b775e3f03e83b0f90457450926583d4511fe32b7d655fdaf4eb"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/02-codecpar-2.5.2.patch"
+      sha256 "5ee71f762500e68a6ccce84fb9b9a4876e89e7d234a851552290b42c4a35e930"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/03-defines-2.5.2.patch"
+      sha256 "2ecfb9afbbfef9bd6f235bf1693d3e94943cf1402c4350f3681195e1fbb3d661"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/04-lockmgr-2.5.2.patch"
+      sha256 "9ccfad2f98abb6f974fe6dc4c95d0dc9a754a490c3a87d3bd81082fc5e5f42dc"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/05-audio4-2.5.2.patch"
+      sha256 "9a75ac8479ed895d07725ac9b7d86ceb6c8a1a15ee942c35eb5365f4c3cc7075"
+    end
+  end
 
   bottle do
     sha256 "6885bcf2c1b9d983da98b574679238233e8f72b11835838a60ccb193769661e4" => :high_sierra
@@ -27,6 +63,33 @@ class Moc < Formula
     depends_on "automake" => :build
     depends_on "gettext" => :build
     depends_on "popt"
+
+    # Remove for > 2.6-alpha3; FFmpeg 4.0 compatibility
+    # 01 to 05 below provided 26 Apr 2018 by upstream's John Fitzgerald
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/01-codec.patch"
+      sha256 "c424fcfff8f318896c868ae2e019120b78857f6ef1ccf1000df92fbe571d1f69"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/02-codecpar.patch"
+      sha256 "4bcc745a484c3ffd4c5cf169fd299b6ab18d387740f77d9cc9eec3f57f5fcf7c"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/03-defines.patch"
+      sha256 "088596c51f47d5b4a47fb00def2a832536cba2cdb6bb4dc767af5f2edb33164e"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/04-lockmgr.patch"
+      sha256 "a83d86ac4f0d88afddd0d76516b95071e4b876d51f85ee2c876be9c6f7ce6cc9"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/ilovezfs/formula-patches/b81928d68221e837c028e9c89638272610ca06fe/moc/05-audio4.patch"
+      sha256 "05d467cc7b1f9529187d0fcf5375ccb2088a606fd5ecd75a8330b8f68676eefc"
+    end
   end
 
   head do
@@ -45,16 +108,9 @@ class Moc < Formula
   depends_on "libtool"
   depends_on "ncurses"
 
-  # FFmpeg 4.0 compatibility
-  # Reported 26 Apr 2018 to mocmaint AT daper DOT net
-  patch :p0 do
-    url "https://git.archlinux.org/svntogit/packages.git/plain/trunk/moc-ffmpeg4.patch?h=packages/moc"
-    sha256 "f1a12d7d2e8269974487a2ffb011e87d9a6c5c06e2a47d1312d5965c98f050ea"
-  end
-
   def install
-    # Remove build.devel? when 2.6-alpha4 comes out
-    system "autoreconf", "-fvi" if build.head? || build.devel?
+    # Not needed for devel when 2.6-alpha4 comes out
+    system "autoreconf", "-fvi"
     system "./configure", "--disable-debug", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Goes together with https://github.com/Homebrew/formula-patches/pull/238

depend on autoconf, automake and gettext at build time for stable