### PR TITLE
Remove conflict between `open-mpi` and `lcdf-typetools`

### DIFF
--- a/Formula/lcdf-typetools.rb
+++ b/Formula/lcdf-typetools.rb
@@ -10,8 +10,6 @@ class LcdfTypetools < Formula
     sha256 "761612b6522dffab0ea197e1ff27422bc8d34ffaf080518d148249bf7731e3ed" => :el_capitan
   end
 
-  conflicts_with "open-mpi", :because => "both install same set of binaries."
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -29,7 +29,6 @@ class OpenMpi < Formula
   depends_on "libevent"
 
   conflicts_with "mpich", :because => "both install MPI compiler wrappers"
-  conflicts_with "lcdf-typetools", :because => "both install same set of binaries"
 
   needs :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not sure when the conflicting binaries were remove from `open-mpi`, but these two formulas no longer appear to conflict.
