### PR TITLE
bower 1.8.4

### DIFF
--- a/Formula/bower.rb
+++ b/Formula/bower.rb
@@ -3,8 +3,9 @@ require "language/node"
 class Bower < Formula
   desc "Package manager for the web"
   homepage "https://bower.io/"
-  url "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz"
-  sha256 "6bcf10e9c192fdbd6e89f98e431e095764c8571f66bcd6dd08fbcbd52e8dd722"
+  # Use Github tarball to avoid bowers npm 4+ incompatible bundled dep usage
+  url "https://github.com/bower/bower/archive/v1.8.4.tar.gz"
+  sha256 "ed4719fa1131dae285de3a013332756ec39f28bc38ec778bc777d74e935163c5"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes the build/test failure from #27320:

Bower is using a unsupported (and imho ugly) way to bundle their dependencies in the npm registry package instead of using the officially supported bundledDependency feature of npm. Unfortunately npm 4+ has broken the ability to publish a package in this format, which has broken language node (with recent node releases shipping npm 4+) and upstream 1.8.3 release (see release notes for 1.8.4). Installing the current version of the formula from source (with npm 4+) is already broken.

This PR is fixing the issue by switching to Github source tarballs to avoid this ugly bundled dep format.

Refs: https://github.com/bower/bower/commit/51feb8f925d57d069de6a54bc56e4164ec7245ec#diff-35b4a816e0441e6a375cd925af50752cR88
Refs: https://github.com/bower/bower/releases/tag/v1.8.4 