### PR TITLE
libcdio-paranoia 10.2+0.94+2 (new formula)

### DIFF
--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -15,6 +15,6 @@ class LibcdioParanoia < Formula
   end
 
   test do
-    assert_match /cdparanoia III release 10.2/, shell_output("#{bin}/cd-paranoia -V", 0)
+    assert_match /cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1", 0).partition(" ").first
   end
 end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,4 +1,3 @@
-require "English"
 
 class LibcdioParanoia < Formula
   desc "Audio CD ripper based on libcdio"
@@ -20,7 +19,6 @@ class LibcdioParanoia < Formula
 
   test do
     assert_match /cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1", 0).partition(" ").first
-    system("#{bin}/cd-paranoia", "-V")
-    assert_equal $CHILD_STATUS, 0, "Execution of cd-paranoia failed."
+    shell_output("#{bin}/cd-paranoia -V 2>&1", 0)
   end
 end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,13 +1,12 @@
 class LibcdioParanoia < Formula
-  desc "This is a port of xiph.org's cdda paranoia to use libcdio for CDROM access. By doing this, cdparanoia runs on platforms othe
-r than GNU/Linux."
+  desc "The cd-paranoia audio-cd ripper based on libcdio."
   homepage "https://www.gnu.org/software/libcdio/"
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   sha256 "d60f82ece97eeb92407a9ee03f3499c8983206672c28ae5e4e22179063c81941"
 
-  depends_on "pkg-config" => :build
   depends_on "libcdio" => :build
+  depends_on "pkg-config" => :build
 
   def install
     system "./configure", "--without-versioned-libs",
@@ -16,6 +15,6 @@ r than GNU/Linux."
   end
 
   test do
-     assert_match /cdparanoia III release 10.2/, shell_output("#{bin}/cd-paranoia -V", 0)
+    assert_match /cdparanoia III release 10.2/, shell_output("#{bin}/cd-paranoia -V", 0)
   end
 end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,0 +1,21 @@
+class LibcdioParanoia < Formula
+  desc "This is a port of xiph.org's cdda paranoia to use libcdio for CDROM access. By doing this, cdparanoia runs on platforms othe
+r than GNU/Linux."
+  homepage "https://www.gnu.org/software/libcdio/"
+  url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
+  mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
+  sha256 "d60f82ece97eeb92407a9ee03f3499c8983206672c28ae5e4e22179063c81941"
+
+  depends_on "pkg-config" => :build
+  depends_on "libcdio" => :build
+
+  def install
+    system "./configure", "--without-versioned-libs",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+     assert_match /cdparanoia III release 10.2/, shell_output("#{bin}/cd-paranoia -V", 0)
+  end
+end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -18,5 +18,7 @@ class LibcdioParanoia < Formula
 
   test do
     assert_match /cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1", 0).partition(" ").first
+    system("#{bin}/cd-paranoia", "-V")
+    assert_equal $?.success?, true, "Execution of cd-paranoia failed."
   end
 end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,15 +1,17 @@
 class LibcdioParanoia < Formula
-  desc "The cd-paranoia audio-cd ripper based on libcdio"
+  desc "Audio CD ripper based on libcdio"
   homepage "https://www.gnu.org/software/libcdio/"
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   sha256 "d60f82ece97eeb92407a9ee03f3499c8983206672c28ae5e4e22179063c81941"
 
-  depends_on "libcdio" => :build
   depends_on "pkg-config" => :build
+  depends_on "libcdio"
 
   def install
     system "./configure", "--without-versioned-libs",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,5 +1,5 @@
 class LibcdioParanoia < Formula
-  desc "The cd-paranoia audio-cd ripper based on libcdio."
+  desc "The cd-paranoia audio-cd ripper based on libcdio"
   homepage "https://www.gnu.org/software/libcdio/"
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,10 +1,10 @@
 
 class LibcdioParanoia < Formula
   desc "Audio CD ripper based on libcdio"
-  version "10.2+0.94+2"
   homepage "https://www.gnu.org/software/libcdio/"
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
+  version "10.2+0.94+2"
   sha256 "d60f82ece97eeb92407a9ee03f3499c8983206672c28ae5e4e22179063c81941"
 
   depends_on "pkg-config" => :build

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,3 +1,5 @@
+require "English"
+
 class LibcdioParanoia < Formula
   desc "Audio CD ripper based on libcdio"
   homepage "https://www.gnu.org/software/libcdio/"
@@ -19,6 +21,6 @@ class LibcdioParanoia < Formula
   test do
     assert_match /cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1", 0).partition(" ").first
     system("#{bin}/cd-paranoia", "-V")
-    assert_equal $?.success?, true, "Execution of cd-paranoia failed."
+    assert_equal $CHILD_STATUS, true, "Execution of cd-paranoia failed."
   end
 end

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,6 +1,7 @@
 
 class LibcdioParanoia < Formula
   desc "Audio CD ripper based on libcdio"
+  version "10.2+0.94+2"
   homepage "https://www.gnu.org/software/libcdio/"
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-paranoia-10.2+0.94+2.tar.gz"

--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -21,6 +21,6 @@ class LibcdioParanoia < Formula
   test do
     assert_match /cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1", 0).partition(" ").first
     system("#{bin}/cd-paranoia", "-V")
-    assert_equal $CHILD_STATUS, true, "Execution of cd-paranoia failed."
+    assert_equal $CHILD_STATUS, 0, "Execution of cd-paranoia failed."
   end
 end


### PR DESCRIPTION
libcdio-paranoia.rb

This commit add the formula to support libcdio-paranoia on homebrew. The source
page is https://www.gnu.org/software/libcdio/ for further information and
documentation on this package.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
