### PR TITLE
chronograf 1.4.4.2

### DIFF
--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Chronograf < Formula
   desc "Open source monitoring and visualization UI for the TICK stack"
   homepage "https://docs.influxdata.com/chronograf/latest/"
-  url "https://github.com/influxdata/chronograf/archive/1.4.4.1.tar.gz"
-  sha256 "b08bbd7224c9e5c2c74101ec4d0f7952bdade531766aacbfbb21e1dca9b6c3d6"
+  url "https://github.com/influxdata/chronograf/archive/1.4.4.2.tar.gz"
+  sha256 "5bedf8f51eac859d762994d7c45fdfef45da5cd5b1d7f36e442f7eebde37c057"
   head "https://github.com/influxdata/chronograf.git"
 
   bottle do
@@ -26,6 +26,9 @@ class Chronograf < Formula
     Language::Node.setup_npm_environment
     chronograf_path = buildpath/"src/github.com/influxdata/chronograf"
     chronograf_path.install buildpath.children
+
+    # fixes yarn + upath@1.0.4 incompatibility, remove once upath is upgraded to 1.0.5+
+    Pathname.new("#{ENV["HOME"]}/.yarnrc").write("ignore-engines true\n")
 
     cd chronograf_path do
       system "make", "dep"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the build issue from #27350 by setting `ignore-engines` to `true` for `yarn` to avoid incorrect incompatibility claims between `upath@1.0.4` and `node@10`, refs: https://github.com/Homebrew/homebrew-core/pull/27101#issuecomment-384570393

An alterntaive fix would be to patch their [`yarn.lock` lockfile](https://github.com/influxdata/chronograf/blob/aa9c02b06bfd3d7a7f8cead128546929d86c72e7/ui/yarn.lock#L8831-L8833) to use `upath@1.0.5` instead of `upath@1.0.4`. (`upath@1.0.5` is already inside the specified version range, it's just the lockfile which prevents the semver patch fix from being automatically picked up)
