### PR TITLE
gnupg 2.2.7

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,8 +1,8 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.6.tar.bz2"
-  sha256 "e64d8c5fa2d05938a5080cb784a98ac21be0812f2a26f844b18f0d6a0e711984"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.7.tar.bz2"
+  sha256 "d95b361ee6ef7eff86af40c8c72bf9313736ac9f7010d6604d78bf83818e976e"
 
   bottle do
     sha256 "38302b573c7a247dec8aae9645c2164071b911ad572521d0bc16df1dad1843ec" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes in version 2.2.7
===================================

  * gpg: New option --no-symkey-cache to disable the passphrase cache
    for symmetrical en- and decryption.

  * gpg: The ERRSIG status now prints the fingerprint if that is part
    of the signature.

  * gpg: Relax emitting of FAILURE status lines

  * gpg: Add a status flag to "sig" lines printed with --list-sigs.

  * gpg: Fix "Too many open files" when using --multifile.  [#3951]

  * ssh: Return an error for unknown ssh-agent flags.  [#3880]

  * dirmngr: Fix a regression since 2.1.16 which caused corrupted CRL
    caches under Windows.  [#2448,#3923]

  * dirmngr: Fix a CNAME problem with pools and TLS.  Also use a fixed
    mapping of keys.gnupg.net to sks-keyservers.net.  [#3755]

  * dirmngr: Try resurrecting dead hosts earlier (from 3 to 1.5 hours).

  * dirmngr: Fallback to CRL if no default OCSP responder is configured.

  * dirmngr: Implement CRL fetching via https.  Here a redirection to
    http is explictly allowed.

  * dirmngr: Make LDAP searching and CRL fetching work under Windows.
    This stopped working with 2.1.  [#3937]

  * agent,dirmngr: New sub-command "getenv" for "getinfo" to ease
    debugging.
```