### PR TITLE
flutter 0.3.1 (new formula)

### DIFF
--- a/Formula/flutter.rb
+++ b/Formula/flutter.rb
@@ -1,0 +1,50 @@
+class Flutter < Formula
+  desc "Build beautiful mobile apps easily and quickly"
+  homepage "https://flutter.io"
+  url "https://storage.googleapis.com/flutter_infra/releases/beta/macos/flutter_macos_v0.3.1-beta.zip"
+  sha256 "a88356eb37c37e89f92698ed06eaf02d6364c50f6accea6fe793b9d04c9e0c98"
+
+  def install
+    # Flutter needs to be in a full git clone of its repository in order to run.
+    # Thankfully, that's included in the tarball/zip, so just copy the contents:
+    cp_r ".", prefix
+  end
+
+  def post_install
+    # Something about Homebrew's post-install process removes write permissions
+    # and Flutter writes to bin/cache, particularly .lockfile, so reenable
+    # write permissions on the cache folder
+    chmod_R "u+w", prefix/"bin/cache"
+    # See https://github.com/Homebrew/homebrew-core/issues/17098#issuecomment-386031418
+  end
+
+  def caveats; <<~EOS
+    Flutter expects to manage its own versions and dependencies like the Dart language and Flutter platform channels,
+    so it's hard to predict what will happen if you try to use it to switch channels or self-update.
+
+    Otherwise, like typical Flutter installations, run `flutter doctor` and follow the instructions to finish setting
+    up your Flutter installation (no need to change your PATH, since Homebrew handles that):
+
+      $ flutter doctor
+
+    EOS
+  end
+
+  test do
+    # system "flutter", "--version"
+
+    # This doesn't work because Flutter uses shlock on macos, which doesn't
+    # work with the `brew test` environment. My guess is that `brew test` runs
+    # flutter with limited permissions. Flutter is set to run shlock and sleep
+    # until it succeeds, so `brew test --verbose flutter` results in:
+    #
+    # shlock: open(/usr/local/Cellar/flutter/0.3.1-beta/bin/cache/shlock53833): Operation not permitted
+    # shlock: open(/usr/local/Cellar/flutter/0.3.1-beta/bin/cache/shlock53835): Operation not permitted
+    # shlock: open(/usr/local/Cellar/flutter/0.3.1-beta/bin/cache/shlock53837): Operation not permitted
+    # ...etc. forever
+    #
+    # So just assert that it exists:
+
+    assert_predicate bin/"flutter", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Regarding the tests:

```
$ brew audit --strict
Missing libraries:
  /System/Library/Frameworks/MobileCoreServices.framework/MobileCoreServices
  /System/Library/Frameworks/OpenGLES.framework/OpenGLES
  /System/Library/Frameworks/UIKit.framework/UIKit
flutter:
  * Stable version URLs should not contain beta
  * fully scope test system calls e.g. system "#{bin}/flutter"
  * Non-executables were installed to "/usr/local/opt/flutter/bin"
    The offending files are:
      /usr/local/opt/flutter/bin/cache
            /usr/local/opt/flutter/bin/internal
            /usr/local/opt/flutter/bin/flutter.bat
  * flutter has broken dynamic library links:
      
Error: 4 problems in 1 formula
```

So clearly everything's fine 👍 🙄 :shipit: 

However `flutter --version` works fine, as does `flutter create foo`. I haven't yet bothered to step through `flutter doctor` and address all the issues, but I thought I'd stop for a bit and submit a PR to get feedback both here from Homebrew and potentially from the folks at https://github.com/flutter/flutter/issues/14050

Feedback welcome!