### PR TITLE
plplot: avoid opportunistic linkage against qhull

### DIFF
--- a/Formula/plplot.rb
+++ b/Formula/plplot.rb
@@ -3,7 +3,7 @@ class Plplot < Formula
   homepage "https://plplot.sourceforge.io"
   url "https://downloads.sourceforge.net/project/plplot/plplot/5.13.0%20Source/plplot-5.13.0.tar.gz"
   sha256 "ec36bbee8b03d9d1c98f8fd88f7dc3415560e559b53eb1aa991c2dcf61b25d2b"
-  revision 4
+  revision 5
 
   bottle do
     sha256 "f77d4f390f617beddf9f21c3edd3ee380ee761c612017f725568497655ee6d6b" => :high_sierra
@@ -22,6 +22,7 @@ class Plplot < Formula
 
   def install
     args = std_cmake_args + %w[
+      -DPL_HAVE_QHULL=OFF
       -DENABLE_ada=OFF
       -DENABLE_d=OFF
       -DENABLE_qt=OFF


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [latest bottle](https://github.com/Homebrew/homebrew-core/commit/4d7c516d97993fc386338f30e30c160f6e834ec2) of `plplot` for High Sierra has an unintended linkage against `qhull`, specifically `libcsironn.0.0.2.dylib`. cc @fxcoudert 