### PR TITLE
hwloc: Enable X11 when `--with-cairo` is specified

### DIFF
--- a/Formula/hwloc.rb
+++ b/Formula/hwloc.rb
@@ -20,18 +20,35 @@ class Hwloc < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cairo" => :optional
+  depends_on :x11 if build.with? "cairo" => ["with-x11"]
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--enable-shared",
-                          "--enable-static",
-                          "--prefix=#{prefix}",
-                          "--without-x"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --enable-shared
+      --enable-static
+      --prefix=#{prefix}
+    ]
+
+    if build.with? "cairo" => ["with-x11"]
+      args << "--with-x"
+    else
+      args << "--without-x"
+    end
+
+    system "./configure", *args
     system "make", "install"
 
     pkgshare.install "tests"
+  end
+
+  def caveats; <<~EOS
+    X11 GUI support for tools like lstopo requires cairo built with X11 support:
+      brew install cairo --with-x11
+      brew install hwloc --with-cairo
+    EOS
   end
 
   test do


### PR DESCRIPTION
 - Without these changes lstopo does not open the gui window
 - Cairo without `--with-x11` allows the output of images ~~but once
   you are building hwloc from source you may as well get gui support
   and build cairo from source too~~.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
