### PR TITLE
neofetch: fix --HEAD in prep for 4.0

### DIFF
--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -16,7 +16,12 @@ class Neofetch < Formula
   depends_on "imagemagick" => :recommended
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "SYSCONFDIR=#{etc}"
+    if build.head?
+      bin.install "neofetch"
+      man.install "neofetch.1"
+    else
+      system "make", "install", "PREFIX=#{prefix}", "SYSCONFDIR=#{etc}"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Don't merge this until dylanaraps/neofetch/pull/965 is merged. The `build.head?` block will be removed when 4.0 is released (and the `bin.install` methods will be used instead of `make install`)