### PR TITLE
libplctag 1.5.8 (new formula)

### DIFF
--- a/Formula/libplctag.rb
+++ b/Formula/libplctag.rb
@@ -1,0 +1,37 @@
+class Libplctag < Formula
+  desc "Portable and simple API for accessing AB PLC data over Ethernet"
+  homepage "https://github.com/kyle-github/libplctag"
+  url "https://github.com/kyle-github/libplctag/archive/v1.5.8.tar.gz"
+  sha256 "03847aeb4bdbfad255e62feff029b9b0c81758e66b840237023243b1c1b764ec"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdlib.h>
+      #include <libplctag.h>
+
+      #define TAG_PATH "protocol=ab_eip&gateway=192.168.1.42&path=1,0&cpu=LGX&elem_size=4&elem_count=10&name=myDINTArray"
+
+      int main(int argc, char **argv)
+      {
+        plc_tag tag = PLC_TAG_NULL;
+
+        tag = plc_tag_create(TAG_PATH);
+
+        if(!tag)
+            abort();
+
+        plc_tag_destroy(tag);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-lplctag", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libplctag.rb
+++ b/Formula/libplctag.rb
@@ -16,17 +16,9 @@ class Libplctag < Formula
       #include <stdlib.h>
       #include <libplctag.h>
 
-      #define TAG_PATH "protocol=ab_eip&gateway=192.168.1.42&path=1,0&cpu=LGX&elem_size=4&elem_count=10&name=myDINTArray"
-
-      int main(int argc, char **argv)
-      {
-        plc_tag tag = PLC_TAG_NULL;
-
-        tag = plc_tag_create(TAG_PATH);
-
-        if(!tag)
-            abort();
-
+      int main(int argc, char **argv) {
+        plc_tag tag = plc_tag_create("protocol=ab_eip&gateway=192.168.1.42&path=1,0&cpu=LGX&elem_size=4&elem_count=10&name=myDINTArray");
+        if (!tag) abort();
         plc_tag_destroy(tag);
         return 0;
       }


### PR DESCRIPTION
libplctag is a library that provides a portable and simple API for accessing
Allen-Bradley PLC data over Ethernet.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
