### PR TITLE
pdfjam 2.08 (new formula)

### DIFF
--- a/Formula/pdfjam.rb
+++ b/Formula/pdfjam.rb
@@ -1,0 +1,26 @@
+class Pdfjam < Formula
+  desc "Simple shell interface to the pdfpages package for pdfLaTeX"
+  homepage "https://go.warwick.ac.uk/pdfjam"
+  url "https://go.warwick.ac.uk/pdfjam/pdfjam_208.tgz"
+  version "2.08"
+  sha256 "c731c598cfad076c985526ff89cbf34423a216101aa5e2d753a71de119ecc0f3"
+
+  bottle :unneeded
+
+  def install
+    bin.install Dir["bin/pdf*"]
+    man1.install Dir["man1/pdf*.1"]
+    etc.install "pdfjam.conf"
+  end
+
+  def caveats; <<~EOS
+    pdfjam requires the installation of pdfLaTeX. You may need to install the
+    Tex Live in your macOS. Both MacTex (brew cask install mactex) and
+    BasicTex (brew cask install basictex) works well.
+    EOS
+  end
+
+  test do
+    system "#{bin}/pdfjam", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In history, this Formula was added to homebrew-core, and then was moved to [homebrew-tex](https://github.com/Homebrew/homebrew-tex), and then was deleted together with the whole homebrew-tex. 

- [362d450@Formula/pdfjam.rb](https://github.com/Homebrew/homebrew-core/commits/362d45028fe49939e91ea8e33a2a6414105faf07/Formula/pdfjam.rb)
- https://github.com/Homebrew/homebrew-tex/pull/40

But it is still a useful shell script suite. This is a proposal to bring it back, as a simple distribution without any knowledge about latex installation.