### PR TITLE
kakoune 2018.04.13 (new formula)

### DIFF
--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -9,7 +9,10 @@ class Kakoune < Formula
 
   if MacOS.version <= :el_capitan
     depends_on "gcc"
-    fails_with :clang
+    fails_with :clang do
+      build 800
+      cause "New C++ features"
+    end
   end
 
   def install

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -10,6 +10,11 @@ class Kakoune < Formula
   depends_on "asciidoc" => :build
   depends_on "docbook-xsl" => :build
 
+  if MacOS.version <= :el_capitan
+    depends_on "gcc"
+    fails_with :clang
+  end
+
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -3,7 +3,6 @@ class Kakoune < Formula
   homepage "https://github.com/mawww/kakoune"
   url "https://github.com/mawww/kakoune/releases/download/v2018.04.13/kakoune-2018.04.13.tar.bz2"
   sha256 "cd8ccf8d833a7de8014b6d64f0c34105bc5996c3671275b00ced77996dd17fce"
-  head "https://github.com/mawww/kakoune.git"
 
   depends_on "asciidoc" => :build
   depends_on "docbook-xsl" => :build

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -5,8 +5,6 @@ class Kakoune < Formula
   sha256 "cd8ccf8d833a7de8014b6d64f0c34105bc5996c3671275b00ced77996dd17fce"
   head "https://github.com/mawww/kakoune.git"
 
-  option "with-debug", "Build with debugging symbols"
-
   depends_on "asciidoc" => :build
   depends_on "docbook-xsl" => :build
 
@@ -19,9 +17,7 @@ class Kakoune < Formula
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     cd "src" do
-      args = %W[PREFIX=#{prefix}]
-      args << "debug=no" if build.without?("debug")
-      system "make", "install", *args
+      system "make", "install", "debug=no", "PREFIX=#{prefix}"
     end
   end
 

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -1,0 +1,26 @@
+class Kakoune < Formula
+  desc "Selection-based modal text editor"
+  homepage "https://github.com/mawww/kakoune"
+  url "https://github.com/mawww/kakoune/releases/download/v2018.04.13/kakoune-2018.04.13.tar.bz2"
+  sha256 "cd8ccf8d833a7de8014b6d64f0c34105bc5996c3671275b00ced77996dd17fce"
+  head "https://github.com/mawww/kakoune.git"
+
+  option "with-debug", "Build with debugging symbols"
+
+  depends_on "asciidoc" => :build
+  depends_on "docbook-xsl" => :build
+
+  def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    cd "src" do
+      args = %W[PREFIX=#{prefix}]
+      args << "debug=no" if build.without?("debug")
+      system "make", "install", *args
+    end
+  end
+
+  test do
+    system bin/"kak", "-ui", "dummy", "-e", "q"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

My favouire text editor finally made its first release!

This is a modified version of the formula that has lived in the kakoune repository forever. I've modified it to:

- add stable kakoune
- remove non-macOS stuff
- make `brew audit` happier
- add a `--with-debug` option — the value of this when reporting bugs
  is very large.

`brew audit --new-formula` still complains that new formulae should not have a HEAD. I think it's warranted in this case — kakoune *just* got a release, so I bet a lot of people still want to build it from HEAD regularly.