### PR TITLE
gst-plugins-{good,bad}: move gtk+3 from -bad to -good

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -30,7 +30,6 @@ class GstPluginsBad < Formula
   depends_on "faad2" => :optional
   depends_on "fdk-aac" => :optional
   depends_on "gnutls" => :optional
-  depends_on "gtk+3" => :optional
   depends_on "libdvdread" => :optional
   depends_on "libexif" => :optional
   depends_on "libmms" => :optional
@@ -51,8 +50,6 @@ class GstPluginsBad < Formula
       --disable-debug
       --disable-dependency-tracking
     ]
-
-    args << "--with-gtk=3.0" if build.with? "gtk+3"
 
     if build.head?
       # autogen is invoked in "stable" build because we patch configure.ac

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -48,6 +48,7 @@ class GstPluginsGood < Formula
   depends_on "aalib" => :optional
   depends_on "cairo" => :optional
   depends_on "flac" => [:optional, "with-libogg"]
+  depends_on "gtk+3" => :optional
   depends_on "libcaca" => :optional
   depends_on "libdv" => :optional
   depends_on "libpng" => :optional
@@ -71,6 +72,8 @@ class GstPluginsGood < Formula
       --disable-dependency-tracking
       --disable-silent-rules
     ]
+
+    args << "--with-gtk=3.0" if build.with? "gtk+3"
 
     if build.with? "x11"
       args << "--with-x"


### PR DESCRIPTION
`gtk+3` support was moved from `gst-plugins-bad` to `gst-plugins-good` with `GStreamer`
1.14.0 (https://gstreamer.freedesktop.org/releases/1.14/).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

There is a remaining problem in `gst-plugins-good.rb` that was already present before these modifications:
```
 * C: 51: col 37: Dependency flac should not use option with-libogg
``` 
It doesn't prevent the formula from being installed properly though.