### PR TITLE
sleuthkit: add dependency

### DIFF
--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -3,6 +3,7 @@ class Sleuthkit < Formula
   homepage "https://www.sleuthkit.org/"
   url "https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.6.1/sleuthkit-4.6.1.tar.gz"
   sha256 "1f68f3b5983acdb871a30592fb735a32f4db93f041fcf318bcf3ec87128ab433"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,7 @@ class Sleuthkit < Formula
 
   depends_on "afflib" => :optional
   depends_on "libewf" => :optional
+  depends_on "postgresql" => :optional
 
   if build.with? "jni"
     depends_on :java


### PR DESCRIPTION
- added postgresql as the optional dependency, since the
  new version of sleuthkit also works with postgresql.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
