### PR TITLE
clog, vit, vramsteg: update urls

### DIFF
--- a/Formula/clog.rb
+++ b/Formula/clog.rb
@@ -1,9 +1,9 @@
 class Clog < Formula
   desc "Colorized pattern-matching log tail utility"
   homepage "https://taskwarrior.org/docs/clog/"
-  url "https://tasktools.org/download/clog-1.3.0.tar.gz"
+  url "https://gothenburgbitfactory.org/download/clog-1.3.0.tar.gz"
   sha256 "fed44a8d398790ab0cf426c1b006e7246e20f3fcd56c0ec4132d24b05d5d2018"
-  head "https://git.tasktools.org/scm/ut/clog.git", :branch => "1.4.0", :shallow => false
+  head "https://github.com/GothenburgBitFactory/clog.git", :branch => "1.4.0", :shallow => false
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/vit.rb
+++ b/Formula/vit.rb
@@ -4,7 +4,7 @@ class Vit < Formula
   url "https://taskwarrior.org/download/vit-1.2.tar.gz"
   sha256 "a78dee573130c8d6bc92cf60fafac0abc78dd2109acfba587cb0ae202ea5bbd0"
   revision 1
-  head "https://git.tasktools.org/scm/ex/vit.git"
+  head "https://github.com/scottkosty/vit.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/vramsteg.rb
+++ b/Formula/vramsteg.rb
@@ -1,9 +1,9 @@
 class Vramsteg < Formula
   desc "Add progress bars to command-line applications"
-  homepage "https://tasktools.org/projects/vramsteg.html"
-  url "https://tasktools.org/download/vramsteg-1.1.0.tar.gz"
+  homepage "https://gothenburgbitfactory.org/projects/vramsteg.html"
+  url "https://gothenburgbitfactory.org/download/vramsteg-1.1.0.tar.gz"
   sha256 "9cc82eb195e4673d9ee6151373746bd22513033e96411ffc1d250920801f7037"
-  head "https://git.tasktools.org/scm/ut/vramsteg.git", :branch => "1.1.1"
+  head "https://github.com/GothenburgBitFactory/vramsteg.git", :branch => "1.1.1"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

git.tasktools.org moved to github.com/GothenburgBitFactory

except https://git.tasktools.org/scm/ex/vit.git which moved to https://github.com/scottkosty/vit.git