### PR TITLE
bumpversion 0.5.3 (new formula)

### DIFF
--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -3,7 +3,7 @@ class Bumpversion < Formula
 
   desc "Version-bump your software with a single command"
   homepage "https://pypi.python.org/pypi/bumpversion"
-  url "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.3.tar.gz"
+  url "https://files.pythonhosted.org/packages/source/b/bumpversion/bumpversion-0.5.3.tar.gz"
   sha256 "6744c873dd7aafc24453d8b6a1a0d6d109faf63cd0cd19cb78fd46e74932c77e"
 
   depends_on "python@2"

--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -9,11 +9,7 @@ class Bumpversion < Formula
   depends_on "python@2"
 
   def install
-    venv = virtualenv_create(libexec)
-    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
-                              "--ignore-installed", buildpath
-    system libexec/"bin/pip", "uninstall", "-y", name
-    venv.pip_install_and_link buildpath
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -3,8 +3,8 @@ class Bumpversion < Formula
 
   desc "Version-bump your software with a single command"
   homepage "https://pypi.python.org/pypi/bumpversion"
-  url "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.0.tar.gz"
-  sha256 "030832b9b46848e1c1ac6678dba8242a021e35e908b65565800c9650291117dc"
+  url "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.3.tar.gz"
+  sha256 "6744c873dd7aafc24453d8b6a1a0d6d109faf63cd0cd19cb78fd46e74932c77e"
 
   depends_on "python@2"
 

--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -1,0 +1,27 @@
+class Bumpversion < Formula
+  include Language::Python::Virtualenv
+
+  desc "Version-bump your software with a single command"
+  homepage "https://pypi.python.org/pypi/bumpversion"
+  url "https://pypi.io/packages/source/b/bumpversion/bumpversion-0.5.0.tar.gz"
+  sha256 "030832b9b46848e1c1ac6678dba8242a021e35e908b65565800c9650291117dc"
+
+  depends_on "python@2"
+
+  def install
+    venv = virtualenv_create(libexec)
+    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
+                              "--ignore-installed", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", name
+    venv.pip_install_and_link buildpath
+  end
+
+  test do
+    (testpath/"VERSION").write "1.2.0"
+    system "#{bin}/bumpversion", "patch",
+           "--current-version", "1.2.0",
+           "--new-version", "1.2.1",
+           "VERSION"
+    assert_equal "1.2.1", (testpath/"VERSION").read
+  end
+end


### PR DESCRIPTION
Add a formula for the bumpversion tool, which lets you:

>Version-bump your software with a single command

While it's written in Python, its usage is language agnostic and useful in various release workflows.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
