### PR TITLE
Allow `--with-posix` for mingw-w64

### DIFF
--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -11,6 +11,8 @@ class MingwW64 < Formula
     sha256 "077d13bc5b6576ff1976ff4320382449f248224888d6e13d49871ce49c945a18" => :el_capitan
   end
 
+  option "with-posix", "Compile with posix thread model"
+
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "libmpc"
@@ -18,8 +20,6 @@ class MingwW64 < Formula
 
   # Apple's makeinfo is old and has bugs
   depends_on "texinfo" => :build
-
-  option "with-posix", "Compile with posix thread model"
 
   resource "binutils" do
     url "https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz"

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -20,8 +20,6 @@ class MingwW64 < Formula
   depends_on "texinfo" => :build
 
   option "with-posix", "Compile with posix thread model"
-  option "without-i686", "Compile without support for 32bit"
-  option "without-x86_64", "Compile witout support for 64bit"
 
   resource "binutils" do
     url "https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz"
@@ -36,13 +34,7 @@ class MingwW64 < Formula
   end
 
   def target_archs
-    if build.with? "i686" and build.with? "x86_64"
-      ["i686", "x86_64"].freeze
-    elif build.with? "i686"
-      ["i686"].freeze
-    else
-      ["x86_64"].freeze
-    end
+    ["i686", "x86_64"].freeze
   end
 
   def install


### PR DESCRIPTION
Cross compiling software that uses c++11 features like `<mutex>`, ... require that libgcc has a pthreads library available, as the win32 library is not sufficient enough.

Fixes #21839, #21706

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
