### PR TITLE
basex: remove devel spec

### DIFF
--- a/Formula/basex.rb
+++ b/Formula/basex.rb
@@ -5,12 +5,6 @@ class Basex < Formula
   version "9.0.1"
   sha256 "6c51766ebe976e214cb1b3f3b8d7777d87c5cbef9134bcbf62da0278a47aa00b"
 
-  devel do
-    url "http://files.basex.org/releases/latest/BaseX902-20180424.172952.zip"
-    version "9.0.2-rc20180424.172952"
-    sha256 "ad5b7be68b9170c177e68c01dbf7772c4cf8771ae086f405f47ffacc059c9c3e"
-  end
-
   bottle :unneeded
 
   depends_on :java => "1.8+"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Devel URL is 404 and no one used `--devel` in the last 30 days, so
remove it rather than updating it.