### PR TITLE
Update filebeat manual path to use wrapper script (same as service)

### DIFF
--- a/Formula/filebeat.rb
+++ b/Formula/filebeat.rb
@@ -58,7 +58,7 @@ class Filebeat < Formula
     EOS
   end
 
-  plist_options :manual => "filebeat"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/filebeat/bin/filebeat -e"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi all. So I'm pretty new to filebeat, and the one thing that I had issues with was that just running `filebeat` (as `brew info filebeat` suggests), isn't the same thing as running the service. I had to figure out `--path.home` and some other arguments before getting it to work as expected. I then checked the plist file and found the wrapper script.

I noticed that a few other formulas do the same thing so I hope this change is ok:
- https://github.com/Homebrew/homebrew-core/blob/0ae87c7bfbfeb09db3ee58faa5cdd8e142cbea91/Formula/artifactory.rb#L48
- https://github.com/Homebrew/homebrew-core/blob/ec2da05a0dc0a47727da888239d219bd604b6b7e/Formula/solr%405.5.rb#L35
- https://github.com/Homebrew/homebrew-core/blob/30abddeed8f2b8d6e3d7b5ee313ddcd2c8ff1671/Formula/apache-archiva.rb#L25

I also added `-e` since otherwise there is no output. Let me know if you want me to remove it.

Thanks!!