### PR TITLE
libmagic: rename to file, alias, make file optional

### DIFF
--- a/Aliases/libmagic
+++ b/Aliases/libmagic
@@ -1,0 +1,1 @@
+../Formula/file.rb

--- a/Formula/file.rb
+++ b/Formula/file.rb
@@ -1,5 +1,5 @@
-class Libmagic < Formula
-  desc "Implementation of the file(1) command"
+class File < Formula
+  desc "Implementation of the file command and libmagic"
   homepage "https://www.darwinsys.com/file/"
   url "ftp://ftp.astron.com/pub/file/file-5.33.tar.gz"
   mirror "https://fossies.org/linux/misc/file-5.33.tar.gz"
@@ -12,6 +12,9 @@ class Libmagic < Formula
   end
 
   deprecated_option "with-python" => "with-python@2"
+
+  # Maybe a better name?
+  option "without-file", "Only install libmagic, don't install the file command"
 
   depends_on "python@2" => :optional
 
@@ -30,9 +33,11 @@ class Libmagic < Formula
       end
     end
 
-    # Don't dupe this system utility
-    rm bin/"file"
-    rm man1/"file.1"
+    if build.without? "file"
+      # Don't dupe this system utility
+      rm bin/"file"
+      rm man1/"file.1"
+    end
   end
 
   test do

--- a/Formula/file.rb
+++ b/Formula/file.rb
@@ -4,6 +4,7 @@ class File < Formula
   url "ftp://ftp.astron.com/pub/file/file-5.33.tar.gz"
   mirror "https://fossies.org/linux/misc/file-5.33.tar.gz"
   sha256 "1c52c8c3d271cd898d5511c36a68059cda94036111ab293f01f83c3525b737c6"
+  head "https://github.com/file/file.git"
 
   bottle do
     sha256 "bd5083a984a62056a9aa0e47997b8c02110e4c8c3cc5114a56fce6c02434c2db" => :high_sierra
@@ -18,7 +19,14 @@ class File < Formula
 
   depends_on "python@2" => :optional
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    if build.head?
+      system "autoreconf", "-f", "-i"
+    end
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -98,6 +98,7 @@
   "ledger26": "ledger@2.6",
   "letsencrypt": "certbot",
   "libcppa": "caf",
+  "libmagic": "file",
   "libmongoclient": "mongo-cxx-driver",
   "libmpc08": "libmpc@0.8",
   "libpng12": "libpng@1.2",


### PR DESCRIPTION
The file utility should be updated (optionally), /usr/bin/file will always use /usr/share/file/magic instead of the one Homebrew installs. In El Capitan's case, Homebrew's magic.mgc is almost three times larger than the system version, and provides a lot more information, such as…
```shell
$ file file
file: Mach-O 64-bit executable x86_64
$ new-file file
file: Mach-O 64-bit x86_64 executable, flags: <NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>

$ file backup.ab
backup.ab: data
$ new-file backup.ab
backup.ab: Android Backup, Compressed, Not-Encrypted

$ file ruby.gba
ruby.gba: data
$ new-file ruby.gba
ruby.gba: Game Boy Advance ROM image: "POKEMON RUBY" (AXVE01, Rev.00)

$ unzip app.apk
$ file AndroidManifest.xml
AndroidManifest.xml: DBase 3 data file (11224 records)
$ new-file AndroidManifest.xml
AndroidManifest.xml: Android binary XML
```

Even though I made the file utility optional, there is no real reason to *not* install it, file and file.1 take up a total of 42 kB. It is practically harmless, and again, it is really useful.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----