### PR TITLE
circleci 0.0.4705-deba4df (new formula)

### DIFF
--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -15,7 +15,7 @@ class Circleci < Formula
     # assert basic script execution
     assert_match version.to_s, shell_output("#{bin}/circleci --version")
     # assert script fails for missing docker (docker not on homebrew CI servers)
-    command_output = shell_output("#{bin}/circleci config validate 2>&1", 1)
-    assert_match /.*Is the docker daemon running.*/, command_output
+    output = shell_output("#{bin}/circleci config validate 2>&1", 1)
+    assert_match "Is the docker daemon running", output
   end
 end

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -5,6 +5,8 @@ class Circleci < Formula
   version "0.0.4705-deba4df"
   sha256 "0c2b76afc04f3883ad46aa095509749faed3d7ae392fe54399aba60e6721f4a3"
 
+  bottle :unneeded
+
   depends_on "docker"
 
   def install

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -1,0 +1,21 @@
+class Circleci < Formula
+  desc "Enables you to reproduce the CircleCI environment locally"
+  homepage "https://circleci.com/docs/2.0/local-cli/"
+  url "https://github.com/circleci/local-cli/releases/download/v0.0.4705-deba4df/circleci_v0.0.4705-deba4df.tar.gz"
+  version "0.0.4705-deba4df"
+  sha256 "0c2b76afc04f3883ad46aa095509749faed3d7ae392fe54399aba60e6721f4a3"
+
+  depends_on "docker"
+
+  def install
+    bin.install "circleci.sh" => "circleci"
+  end
+
+  test do
+    # assert basic script execution
+    assert_match version.to_s, shell_output("#{bin}/circleci --version")
+    # assert script fails for missing docker (docker not on homebrew CI servers)
+    command_output = shell_output("#{bin}/circleci config validate 2>&1", 1)
+    assert_match /.*Is the docker daemon running.*/, command_output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds CircleCI's local CLI.  It was requested in a [previously rejected PR](https://github.com/Homebrew/homebrew-core/pull/21661) because at the time, there was no versioned URL.   I [worked with with CircleCI](https://github.com/circleci/local-cli/issues/7) to expose a versioned URL used by this Formula.


