### PR TITLE
.travis.yml: Use final URL for formulae.brew.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - brew help
 
 before_script:
-  - travis_retry git clone https://$GITHUB_TOKEN@github.com/homebrew/json_test
+  - travis_retry git clone https://$GITHUB_TOKEN@github.com/Homebrew/formulae.brew.sh
 
 script:
-  - cd json_test && brew ruby script/generate.rb
+  - cd formulae.brew.sh && brew ruby script/generate.rb


### PR DESCRIPTION
GitHub’s redirection for renamed repositories saved us from errors, but we should get this right.