### PR TITLE
sbt: replace shortened URL with full URL

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -1,7 +1,7 @@
 class Sbt < Formula
   desc "Build tool for Scala projects"
   homepage "https://www.scala-sbt.org/"
-  url "https://piccolo.link/sbt-1.1.5.tgz"
+  url "https://sbt-downloads.cdnedge.bluemix.net/releases/v1.1.5/sbt-1.1.5.tgz"
   sha256 "8303d7496bc70eb441e8136bd29ffc295c629dadecefa4e7a475176ab4d282d5"
 
   bottle :unneeded


### PR DESCRIPTION
The URL shortener piccolo.link is blocked on my corporate network, and further I don't think URL shorteners should be used in Homebrew Formulae.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
