### PR TITLE
pngquant: install lib and include files

### DIFF
--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -4,6 +4,7 @@ class Pngquant < Formula
   url "https://pngquant.org/pngquant-2.11.7-src.tar.gz"
   sha256 "d70b46c3335c7abf21944aced2d9d2b54819ab84ed1a140b354d5e8cc9f0fb0a"
   head "https://github.com/kornelski/pngquant.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,14 +14,15 @@ class Pngquant < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "rust" => :build
   depends_on "libpng"
   depends_on "little-cms2"
 
   def install
-    system "cargo", "build", "--release"
-    bin.install "target/release/pngquant"
+    system "make"
+    bin.install "pngquant"
     man1.install "pngquant.1"
+    lib.install "lib/libimagequant.a"
+    include.install "lib/libimagequant.h"
   end
 
   test do

--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -19,7 +19,6 @@ class Pngquant < Formula
 
   def install
     system "./configure", "--prefix=#{prefix}"
-    system "make"
     system "make", "install"
     lib.install "lib/libimagequant.a"
     include.install "lib/libimagequant.h"

--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -18,9 +18,9 @@ class Pngquant < Formula
   depends_on "little-cms2"
 
   def install
+    system "./configure", "--prefix=#{prefix}"
     system "make"
-    bin.install "pngquant"
-    man1.install "pngquant.1"
+    system "make", "install"
     lib.install "lib/libimagequant.a"
     include.install "lib/libimagequant.h"
   end

--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -3,8 +3,8 @@ class Pngquant < Formula
   homepage "https://pngquant.org/"
   url "https://pngquant.org/pngquant-2.11.7-src.tar.gz"
   sha256 "d70b46c3335c7abf21944aced2d9d2b54819ab84ed1a140b354d5e8cc9f0fb0a"
-  head "https://github.com/kornelski/pngquant.git"
   revision 1
+  head "https://github.com/kornelski/pngquant.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Revision to pngquant to also install libimagequant.a and libimagequant.h to support compilation of projects that require imagequant (libimagequant), e.g. Pillow for Python (PIL replacement): https://pillow.readthedocs.io/en/latest/installation.html#macos-installation

Removes unnecessary Rust cargo build.

https://pngquant.org/install.html
https://pngquant.org/lib/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
