### PR TITLE
fork-cleaner 1.3.0 (new formula)

### DIFF
--- a/Formula/fork-cleaner.rb
+++ b/Formula/fork-cleaner.rb
@@ -1,0 +1,26 @@
+class ForkCleaner < Formula
+  desc "Cleans up old and inactive forks on your GitHub account"
+  homepage "https://github.com/caarlos0/fork-cleaner"
+  url "https://github.com/caarlos0/fork-cleaner/archive/v1.3.0.tar.gz"
+  sha256 "6cb97ed035cce26505f8d48406fb57029f629a6df19bfcfe44c8f3d7f60d1008"
+  revision 1
+
+  depends_on "go" => :build
+  depends_on "dep" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/caarlos0/fork-cleaner").install buildpath.children
+    cd "src/github.com/caarlos0/fork-cleaner" do
+      system "dep", "ensure"
+      system "make"
+      bin.install "fork-cleaner"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_match "missing github token",
+      shell_output("#{bin}/fork-cleaner 2>&1", 1)
+  end
+end

--- a/Formula/fork-cleaner.rb
+++ b/Formula/fork-cleaner.rb
@@ -5,13 +5,14 @@ class ForkCleaner < Formula
   sha256 "6cb97ed035cce26505f8d48406fb57029f629a6df19bfcfe44c8f3d7f60d1008"
   revision 1
 
-  depends_on "go" => :build
   depends_on "dep" => :build
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/caarlos0/fork-cleaner").install buildpath.children
-    cd "src/github.com/caarlos0/fork-cleaner" do
+    dir = buildpath/"src/github.com/caarlos0/fork-cleaner"
+    dir.install buildpath.children
+    cd dir do
       system "dep", "ensure"
       system "make"
       bin.install "fork-cleaner"
@@ -20,7 +21,7 @@ class ForkCleaner < Formula
   end
 
   test do
-    assert_match "missing github token",
-      shell_output("#{bin}/fork-cleaner 2>&1", 1)
+    output = shell_output("#{bin}/fork-cleaner 2>&1", 1)
+    assert_match "missing github token", output
   end
 end


### PR DESCRIPTION
- This is technically not notable enough but it's useful and easily packaged.
- The `revision` is to allow people to upgrade from the upstream tap. It can be removed if that's undesirable.
- The test can't really be more complex as it needs GitHub API tokens to do any more.