### PR TITLE
MythTV 29 (new formula)

### DIFF
--- a/Formula/mythtv.rb
+++ b/Formula/mythtv.rb
@@ -1,0 +1,110 @@
+class Mythtv < Formula
+  desc "MythTV"
+  homepage "https://www.mythtv.org"
+  url "https://www.mythtv.org/download/mythtv/29"
+  sha256 "8ab2423e78974e96fd5f85efb05633897167791c80ba75f198735b9a54ca0bc8"
+  depends_on "taglib"
+  depends_on "exiv2"
+  depends_on "qt"
+  depends_on "fftw"
+  depends_on "x265"
+  depends_on "x264"
+  depends_on "pkg-config"
+  depends_on "yasm"
+  depends_on "xz"
+  depends_on "freetype"
+  depends_on "libass"
+  depends_on "zlib"
+  depends_on "bzip2"
+  depends_on "lame"
+  depends_on "libiconv"
+  depends_on "libxml2"
+  depends_on "openssl"
+  patch do
+    url "https://gist.githubusercontent.com/mmisiewicz/b7f974e1f315f2e78019314a445cd61c/raw/bfb855e4bf0d5a1a7cb0d03efc8458f71163b82f/myth_qtwebkit_option.diff"
+    sha256 "05b800b1daa1367c40edae41fbcd605edf462124995c67c8da7a23d65bfc8c52"
+  end
+  
+  def install
+    extraincludes = "-I#{Formula["fftw"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["openssl"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["libass"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["lame"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["exiv2"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["taglib"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["x265"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["x264"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["xz"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["zlib"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["bzip2"].opt_prefix}/include "
+    extraincludes += "-I#{Formula["libiconv"].opt_prefix}/include "
+    extraldflags = "-L#{Formula["fftw"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["openssl"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["libass"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["lame"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["exiv2"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["taglib"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["x265"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["x264"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["xz"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["zlib"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["bzip2"].opt_prefix}/lib "
+    extraldflags += "-L#{Formula["libiconv"].opt_prefix}/lib "
+    
+    ENV.append_to_cflags extraincludes
+    ENV.append "LDFLAGS", extraldflags
+    
+    qmakearg = "--qmake=#{Formula["qt"].opt_prefix}/bin/qmake"
+    cd "mythtv"
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--extra-cxxflags=#{extraincludes}",
+                          "--extra-cflags=#{extraincludes}",
+                          qmakearg,
+                          "--python=#{HOMEBREW_PREFIX}/bin/python",
+                          "--disable-mythlogserver",
+                          "--disable-ceton",
+                          "--disable-firewire",
+                          "--disable-audio-jack",
+                          "--disable-indev=jack",
+                          "--disable-audio-pulseoutput",
+                          "--disable-gnutls",
+                          "--disable-libcec",
+                          "--disable-libpulse",
+                          "--disable-libvpx",
+                          "--disable-libxcb",
+                          "--disable-libxvid",
+                          "--disable-lzma",
+                          "--disable-qtdbus",
+                          "--disable-sdl",
+                          "--disable-systemd_notify",
+                          "--disable-videotoolbox",
+                          "--disable-xlib",
+                          "--disable-xrandr",
+                          "--disable-xv",
+                          "--enable-iconv",
+                          "--enable-fft",
+                          "--enable-libmp3lame",
+                          "--enable-libass",
+                          "--enable-libx264",
+                          "--enable-nonfree",
+                          "--enable-libx265",
+                          "--enable-securetransport",
+                          "--enable-zlib",
+                          "--disable-qtwebkit"
+    system "make", "install"
+  end
+  
+  def caveats; <<~EOS
+    During the compile, there may be conflicts with MythTV's own ffmpeg. `brew remove ffmpeg` before installing MythTv. It can be reinstalled after.
+    In order for the python MythTV library to compile, you must install the packages: `python-mysql`, `pycurl` and `urlgrabber` using pip. PyCurl requires a special install: `  PYCURL_SSL_LIBRARY=openssl LDFLAGS=-L/usr/local/opt/openssl/lib CPPFLAGS=-I/usr/local/opt/openssl/include pip install pycurl --compile --no-cache-dir`.
+    `Qt` must be installed with MySQL support. `brew install qt --with-mysql`.
+    EOS
+  end
+  
+  test do
+    system "#{bin}/mythbackend", "--help"
+    system "#{bin}/mythfrontend", "--help"
+    system "true"
+  end
+end

--- a/Formula/mythtv.rb
+++ b/Formula/mythtv.rb
@@ -92,6 +92,7 @@ class Mythtv < Formula
                           "--enable-securetransport",
                           "--enable-zlib",
                           "--disable-qtwebkit"
+    system "make" 
     system "make", "install"
   end
   

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -42,6 +42,35 @@ class Qt < Formula
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
+  
+  # # Fix QTBUG-62266
+  # patch do
+  #   url "https://raw.githubusercontent.com/Homebrew/formula-patches/0af7ca663c/qt%405.7/QTBUG-62266.patch"
+  #   sha256 "60471b893eb394db18dacae8bd38727a955742626da641dd980dbb87a8808e9e"
+  # end
+
+  # # Fix QTBUG-62658
+  # patch do
+  #   url "https://raw.githubusercontent.com/Homebrew/formula-patches/48b7e84036/qt%405.7/QTBUG-62658.patch"
+  #   sha256 "1fe7fcbff566bcec3ef9c253f82a8474a0c08f4965565d5d1135df973cd75398"
+  # end
+  
+  # Fix compile error on macOS 10.13 around QFixed:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67545
+  patch do
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
+    sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"
+  end
+
+  # Fix compile error on macOS 10.13 caused by qtlocation dependency
+  # mapbox-gl-native using Boost 1.62.0 does not build with C++ 17:
+  # https://github.com/Homebrew/homebrew-core/issues/27095
+  # https://bugreports.qt.io/browse/QTBUG-67810
+  patch do
+    url "https://raw.githubusercontent.com/z00m1n/formula-patches/a1a1f0dd/qt/QTBUG-67810.patch"
+    sha256 "8ee0bf71df1043f08ebae3aa35036be29c4d9ebff8a27e3b0411a6bd635e9382"
+  end
 
   def install
     args = %W[
@@ -58,6 +87,7 @@ class Qt < Formula
       -no-rpath
       -pkg-config
       -dbus-runtime
+      -no-assimp
     ]
 
     args << "-nomake" << "examples" if build.without? "examples"

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -43,21 +43,6 @@ class Qt < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
   
-  # # Fix QTBUG-62266
-  # patch do
-  #   url "https://raw.githubusercontent.com/Homebrew/formula-patches/0af7ca663c/qt%405.7/QTBUG-62266.patch"
-  #   sha256 "60471b893eb394db18dacae8bd38727a955742626da641dd980dbb87a8808e9e"
-  # end
-
-  # # Fix QTBUG-62658
-  # patch do
-  #   url "https://raw.githubusercontent.com/Homebrew/formula-patches/48b7e84036/qt%405.7/QTBUG-62658.patch"
-  #   sha256 "1fe7fcbff566bcec3ef9c253f82a8474a0c08f4965565d5d1135df973cd75398"
-  # end
-  
-  # Fix compile error on macOS 10.13 around QFixed:
-  # https://github.com/Homebrew/homebrew-core/issues/27095
-  # https://bugreports.qt.io/browse/QTBUG-67545
   patch do
     url "https://raw.githubusercontent.com/z00m1n/formula-patches/0de0e229/qt/QTBUG-67545.patch"
     sha256 "4a115097c7582c7dce4207f5500d13feb8c990eb8a05a43f41953985976ebe6c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula allows compiling of MythTV on Homebrew. It depends on PR #27139 from https://github.com/Homebrew/homebrew-core/pull/27139 . 

To get this working, a change is needed in the MythTV configuration script. This has been submitted as a PR in MythTV as well: https://github.com/MythTV/mythtv/pull/165

I have been invoking MythFrontend on my 5k iMac like this and it's working great! 

```
/usr/local/bin/mythfrontend --geometry 2560x1440
```

