### PR TITLE
osm2pgrouting: use 10.12 bottle on 10.13

### DIFF
--- a/Formula/osm2pgrouting.rb
+++ b/Formula/osm2pgrouting.rb
@@ -8,7 +8,7 @@ class Osm2pgrouting < Formula
 
   bottle do
     cellar :any
-    sha256 "5769b38d9088a52f6ee9f52cad4f8bb7519743c78e79972c33570e525f6a0a7d" => :sierra
+    sha256 "5769b38d9088a52f6ee9f52cad4f8bb7519743c78e79972c33570e525f6a0a7d" => :sierra_or_later
     sha256 "b5d772a54d0f247d357442b244fd9bf581f98c1b2c7b4b2aa760eb8a3f5fe6c1" => :el_capitan
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow-up to https://github.com/Homebrew/homebrew-core/pull/27502.

Needed due to https://github.com/pgRouting/osm2pgrouting/issues/227.