### PR TITLE
mspdebug: add head spec

### DIFF
--- a/Formula/mspdebug.rb
+++ b/Formula/mspdebug.rb
@@ -3,6 +3,7 @@ class Mspdebug < Formula
   homepage "https://dlbeer.co.nz/mspdebug/"
   url "https://github.com/dlbeer/mspdebug/archive/v0.25.tar.gz"
   sha256 "347b5ae5d0ab0cddb54363b72abe482f9f5d6aedb8f230048de0ded28b7d1503"
+  head "https://github.com/dlbeer/mspdebug.git"
 
   bottle do
     sha256 "4124d4fbd9e191d941153962bb74aed50cc200c473b5ad5850610a1bc85f87b4" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The latest release of mspdebug is from Jul 24, 2017, but the current master contains some fixes required for certain board drivers under macOS (https://github.com/dlbeer/mspdebug/pull/52).