### PR TITLE
wireguard-{tools,go}: 0.0.20180514

### DIFF
--- a/Formula/wireguard-go.rb
+++ b/Formula/wireguard-go.rb
@@ -1,0 +1,24 @@
+class WireguardGo < Formula
+  desc "Userspace Go implementation of WireGuard"
+  homepage "https://www.wireguard.com/"
+  url "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-0.0.20180514.tar.xz"
+  sha256 "5a2a0ac5a3c64a9d0c1811d349c6f3f5deb55c15f00f4c13054b897a8c4ac4ae"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/wireguard-go").install buildpath.children
+    cd "src/wireguard-go" do
+      system "dep", "ensure", "-vendor-only"
+      (buildpath/"gopath/src").install (buildpath/"src/wireguard-go/vendor").children
+      ENV["GOPATH"] = buildpath/"gopath"
+      system "make", "PREFIX=#{prefix}", "install"
+    end
+  end
+
+  test do
+    assert_match "be utun", pipe_output("WG_PROCESS_FOREGROUND=1 #{bin}/wireguard-go notrealutun")
+  end
+end

--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -3,8 +3,8 @@ class WireguardTools < Formula
   homepage "https://www.wireguard.com/"
   # Please only update version when the tools have been modified/updated,
   # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180513.tar.xz"
-  sha256 "28a15c59f6710851587ebca76a335f1aaaa077aad052732e0959f2bae9ba8d5c"
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180514.tar.xz"
+  sha256 "e895b65e06e85429403be3d1987577a6967476b069f0ff53caead6f682f466da"
   head "https://git.zx2c4.com/WireGuard", :using => :git
 
   bottle do
@@ -14,8 +14,13 @@ class WireguardTools < Formula
     sha256 "bc4cebbd91c650870f7ddb34f1f7957597e6c91d997aee772c4e958238be0546" => :el_capitan
   end
 
+  depends_on "bash"
+  depends_on "wireguard-go"
+
   def install
-    system "make", "BASHCOMPDIR=#{bash_completion}", "WITH_BASHCOMPLETION=yes", "WITH_WGQUICK=no", "WITH_SYSTEMDUNITS=no", "PREFIX=#{prefix}", "-C", "src/tools", "install"
+    system "make", "BASHCOMPDIR=#{bash_completion}", "WITH_BASHCOMPLETION=yes", "WITH_WGQUICK=yes",
+                   "WITH_SYSTEMDUNITS=no", "PREFIX=#{prefix}", "SYSCONFDIR=#{prefix}/etc",
+                   "-C", "src/tools", "install"
   end
 
   test do


### PR DESCRIPTION
This pull request at long last completes the reason why wireguard-tools was added to homebrew in the first place: so that people could run WireGuard. This is the first snapshot of wireguard-go, made specifically for use with homebrew, and with it enhanced wireguard-tools tooling to use it. This now means that WireGuard is functional inside of homebrew.

cc @ilovezfs 

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
