### PR TITLE
cmusfm 0.3.3 (new formula)

### DIFF
--- a/Formula/cmusfm.rb
+++ b/Formula/cmusfm.rb
@@ -1,0 +1,67 @@
+class Cmusfm < Formula
+  desc "Last.fm standalone scrobbler for the cmus music player"
+  homepage "https://github.com/Arkq/cmusfm"
+  url "https://github.com/Arkq/cmusfm/archive/v0.3.3.tar.gz"
+  sha256 "9d9fa7df01c3dd7eecd72656e61494acc3b0111c07ddb18be0ad233110833b63"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libfaketime" => :test
+
+  def install
+    system "autoreconf", "--install"
+    mkdir "build" do
+      system "../configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "--disable-silent-rules"
+      system "make", "install"
+    end
+  end
+
+  test do
+    cmus_home = testpath/".config/cmus"
+    cmusfm_conf = cmus_home/"cmusfm.conf"
+    cmusfm_sock = cmus_home/"cmusfm.socket"
+    cmusfm_cache = cmus_home/"cmusfm.cache"
+    faketime_conf = testpath/".faketimerc"
+
+    test_artist = "Test Artist"
+    test_title = "Test Title"
+    test_duration = 260
+    status_args = %W[
+      artist #{test_artist}
+      title #{test_title}
+      duration #{test_duration}
+    ]
+
+    mkpath cmus_home
+    touch cmusfm_conf
+
+    begin
+      server = fork do
+        faketime_conf.write "+0"
+        ENV["DYLD_INSERT_LIBRARIES"] = Formula["libfaketime"].lib/"faketime"/"libfaketime.1.dylib"
+        ENV["DYLD_FORCE_FLAT_NAMESPACE"] = "1"
+        ENV["FAKETIME_NO_CACHE"] = "1"
+        exec bin/"cmusfm", "server"
+      end
+      loop do
+        sleep 0.5
+        assert_equal nil, Process.wait(server, Process::WNOHANG)
+        break if cmusfm_sock.exist?
+      end
+
+      system bin/"cmusfm", "status", "playing", *status_args
+      sleep 5
+      faketime_conf.atomic_write "+#{test_duration}"
+      system bin/"cmusfm", "status", "stopped", *status_args
+    ensure
+      Process.kill :TERM, server
+      Process.wait server
+    end
+
+    assert_predicate cmusfm_cache, :exist?
+    strings = shell_output "strings #{cmusfm_cache}"
+    assert_match /^#{test_artist}$/, strings
+    assert_match /^#{test_title}$/, strings
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[cmusfm](https://github.com/Arkq/cmusfm) is one of the more prominently listed scrobblers for [cmus](https://github.com/Homebrew/homebrew-core/blob/master/Formula/cmus.rb). Whilst its last stable release was over a year ago, it seems nonetheless maintained, with the last bugfix committed two months ago.
