### PR TITLE
aria2 1.34.0

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -1,8 +1,8 @@
 class Aria2 < Formula
   desc "Download with resuming and segmented downloading"
   homepage "https://aria2.github.io/"
-  url "https://github.com/aria2/aria2/releases/download/release-1.33.1/aria2-1.33.1.tar.xz"
-  sha256 "2539e4844f55a1f1f5c46ad42744335266053a69162e964d9a2d80a362c75e1b"
+  url "https://github.com/aria2/aria2/releases/download/release-1.34.0/aria2-1.34.0.tar.xz"
+  sha256 "3a44a802631606e138a9e172a3e9f5bcbaac43ce2895c1d8e2b46f30487e77a3"
 
   bottle do
     cellar :any_skip_relocation
@@ -14,10 +14,13 @@ class Aria2 < Formula
   depends_on "pkg-config" => :build
   depends_on "libssh2" => :optional
 
-  needs :cxx11
+  needs :cxx14
 
   def install
-    ENV.cxx11
+    # Fix "error: use of undeclared identifier 'make_unique'"
+    # Reported upstream 15 May 2018 https://github.com/aria2/aria2/issues/1198
+    inreplace "src/bignum.h", "make_unique", "std::make_unique"
+    inreplace "configure", "-std=c++11", "-std=c++14"
 
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
needs C++14
add patch to make sure the build uses -std=c++14