### PR TITLE
basex: re-add devel spec

### DIFF
--- a/Formula/basex.rb
+++ b/Formula/basex.rb
@@ -5,6 +5,12 @@ class Basex < Formula
   version "9.0.1"
   sha256 "6c51766ebe976e214cb1b3f3b8d7777d87c5cbef9134bcbf62da0278a47aa00b"
 
+  devel do
+    url "http://files.basex.org/releases/homebrew-snapshot/BaseX902-20180515.190444.zip"
+    version "9.0.2-rc20180515.190444"
+    sha256 "4603bdcd05ba550edb056c75e1e3c70253bbfc5f70d42afce8eeca4003ecf05d"
+  end
+
   bottle :unneeded
 
   depends_on :java => "1.8+"


### PR DESCRIPTION
- fixed upstream to provide persistent snapshot url for homebrew version
