### PR TITLE
Update rocksdb formula to 5.13.1

### DIFF
--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -1,14 +1,13 @@
 class Rocksdb < Formula
   desc "Embeddable, persistent key-value store for fast storage"
   homepage "https://rocksdb.org/"
-  url "https://github.com/facebook/rocksdb/archive/v5.12.4.tar.gz"
-  sha256 "6e8d0844adc37da331844ac4b21ae33ba1f5265d8914c745760d9209a57e9cc9"
+  url "https://github.com/facebook/rocksdb/archive/v5.13.1.tar.gz"
+  sha256 "a99bf51e1da76d8b6487c1dd694311f4e26031071be7802e76fb926154ff33d2"
 
   bottle do
     cellar :any
-    sha256 "51bfc992203681ea1c797d54ddfed850a8f636144ffed2baf51095b0f0cd5d81" => :high_sierra
-    sha256 "f8acbf443e79406a7d39923360a9960179b748a27b034f771fcd5b783c017cf7" => :sierra
-    sha256 "df75d4898fc368444a3fcb4b0cc169f22a5201c60d35912f5c0740bf792bf082" => :el_capitan
+    rebuild 1
+    sha256 "fda06e8c5f085d74a8cdfb57c8405507120f817b4302dfcbe3529a5145b947ba" => :high_sierra
   end
 
   needs :cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
---
Update rocksdb to the latest stable release, 5.13.1.  built, bottled, audited.