### PR TITLE
emacs: make gnutls dependency required instead of optional

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -4,6 +4,7 @@ class Emacs < Formula
   url "https://ftp.gnu.org/gnu/emacs/emacs-26.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/emacs/emacs-26.1.tar.xz"
   sha256 "1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c"
+  revision 1
 
   bottle do
     sha256 "baeeebc020fc3684a3a3c36437399cdaa4904a33308ef2304a9092b4eea70eb9" => :high_sierra
@@ -30,8 +31,8 @@ class Emacs < Formula
   deprecated_option "imagemagick" => "imagemagick@6"
 
   depends_on "pkg-config" => :build
+  depends_on "gnutls"
   depends_on "dbus" => :optional
-  depends_on "gnutls" => :optional
   depends_on "librsvg" => :optional
   # Emacs does not support ImageMagick 7:
   # Reported on 2017-03-04: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=25967
@@ -45,6 +46,7 @@ class Emacs < Formula
       --enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp
       --infodir=#{info}/emacs
       --prefix=#{prefix}
+      --with-gnutls
       --without-x
     ]
 
@@ -58,12 +60,6 @@ class Emacs < Formula
       args << "--with-dbus"
     else
       args << "--without-dbus"
-    end
-
-    if build.with? "gnutls"
-      args << "--with-gnutls"
-    else
-      args << "--without-gnutls"
     end
 
     # Note that if ./configure is passed --with-imagemagick but can't find the


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

If Emacs is not built with GnuTLS, then it cannot make HTTPS connections, meaning it is impossible to install packages without installing workarounds. This is undesirable default behavior.

Thoughts on changing the default to fix this problem, so that Emacs works out of the box?
