### PR TITLE
icarus-verilog: Build with brewed bison

### DIFF
--- a/Formula/icarus-verilog.rb
+++ b/Formula/icarus-verilog.rb
@@ -3,6 +3,7 @@ class IcarusVerilog < Formula
   homepage "http://iverilog.icarus.com/"
   url "ftp://icarus.com/pub/eda/verilog/v10/verilog-10.2.tar.gz"
   sha256 "96dedbddb12d375edb45a144a926a3ba1e3e138d6598b18e7d79f2ae6de9e500"
+  revision 1
 
   bottle do
     sha256 "81e937d3d6a5f7b22271e79b73618e96db1e52ee491eaf3506671cfb5891c129" => :high_sierra
@@ -19,12 +20,11 @@ class IcarusVerilog < Formula
   depends_on "bison" => :build
 
   def install
-    bison = Formula["bison"].bin/"bison"
     system "autoconf" if build.head?
     system "./configure", "--prefix=#{prefix}"
     # https://github.com/steveicarus/iverilog/issues/85
     ENV.deparallelize
-    system "make", "install", "BISON=#{bison}"
+    system "make", "install", "BISON=#{Formula["bison"].opt_bin}/bison"
   end
 
   test do
@@ -42,7 +42,7 @@ class IcarusVerilog < Formula
 
     # test syntax errors do not cause segfaults
     (testpath/"error.v").write "error;"
-    assert_equal "-:1: error: variable declarations must be contained within a module.\n",
-      shell_output("#{bin}/iverilog error.v 2>&1", 1)
+    assert_equal "-:1: error: variable declarations must be contained within a module.",
+      shell_output("#{bin}/iverilog error.v 2>&1", 1).chomp
   end
 end


### PR DESCRIPTION
When iverilog is built with the macOS provided bison, it segfaults when
outputting certain syntax errors. (#26790 was closed for inactivity with no response.)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?