### PR TITLE
Update sbt's caveats

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -29,7 +29,7 @@ class Sbt < Formula
 
   def caveats;  <<~EOS
     You can use $SBT_OPTS to pass additional JVM options to SBT:
-       SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
+       SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=256M"
 
     This formula uses the standard Lightbend sbt launcher script.
     Project specific options should be placed in .sbtopts in the root of your project.

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -28,10 +28,7 @@ class Sbt < Formula
   end
 
   def caveats;  <<~EOS
-    You can use $SBT_OPTS to pass additional JVM options to SBT:
-       SBT_OPTS="-XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=256M"
-
-    This formula uses the standard Lightbend sbt launcher script.
+    You can use $SBT_OPTS to pass additional JVM options to SBT.
     Project specific options should be placed in .sbtopts in the root of your project.
     Global settings should be placed in #{etc}/sbtopts
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Replace JVM option from `MaxPermSize` to `MaxMetaspaceSize`. `MaxPermSize` was already deprecated in Java 8. cc @eed3si9n and @dwijnand 