### PR TITLE
netcat: Add 'man nc' alias for GNU netcat, otherwise it shows the ori…

### DIFF
--- a/Formula/netcat.rb
+++ b/Formula/netcat.rb
@@ -21,6 +21,7 @@ class Netcat < Formula
                           "--mandir=#{man}",
                           "--infodir=#{info}"
     system "make", "install"
+    man1.install_symlink "netcat.1" => "nc.1"
   end
 
   test do


### PR DESCRIPTION
…ginal MacOS/BSD man page.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`man nc` will now show the same man page as `man netcat`.
