### PR TITLE
Add rs-git-fsmonitor formula

### DIFF
--- a/Formula/rs-git-fsmonitor.rb
+++ b/Formula/rs-git-fsmonitor.rb
@@ -1,0 +1,21 @@
+class RsGitFsmonitor < Formula
+  desc "Git fsmonitor hook written in Rust"
+  homepage "https://github.com/jgavris/rs-git-fsmonitor"
+
+  url "https://github.com/jgavris/rs-git-fsmonitor/releases/download/v0.1.0/rs-git-fsmonitor"
+  sha256 "4faf1723ea75a76e0dd6187d5a3e9074fd5e93dd13f1024843d4ed256ff689e8"
+
+  depends_on "watchman"
+
+  def install
+    bin.install "rs-git-fsmonitor"
+  end
+
+  def post_install
+    ohai "Run `git config --global core.fsmonitor rs-git-fsmonitor` to install!"
+  end
+
+  test do
+    system "git init . && git config core.fsmonitor rs-git-fsmonitor && git status"
+  end
+end


### PR DESCRIPTION
Git 2.16 added support for a `core.fsmonitor` hook to allow an external tool to inform it which files have changed.

https://blog.github.com/2018-04-05-git-217-released/#speeding-up-status-with-watchman

This Rust implementation is approximately twice as fast as the sample one (written in Perl).

https://github.com/git/git/blob/v2.16.0/templates/hooks--fsmonitor-watchman.sample

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
