### PR TITLE
ammonite-repl: Add shebang to amm executable

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -10,6 +10,15 @@ class AmmoniteRepl < Formula
 
   def install
     libexec.install Dir["*"].shift => "amm"
+    # See https://github.com/lihaoyi/Ammonite/issues/813#issuecomment-390334869, need to add shebang
+    # manually if it doesn't already exist
+    inreplace libexec/"amm" do |s|
+      if !s.start_with?("#!")
+        s.prepend("#!/usr/bin/env sh\n")
+      else
+        s
+      end
+    end
     chmod 0555, libexec/"amm"
     bin.install_symlink libexec/"amm"
   end


### PR DESCRIPTION
New versions of the ammonite-repl don't include the shebag inside the executable which means it fails to execute if you aren't in a Bourne compliant shell (such as fish)

This fixes https://github.com/lihaoyi/Ammonite/issues/813

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
