### PR TITLE
Change url for gnu-getopt to more reliable server

### DIFF
--- a/Formula/gnu-getopt.rb
+++ b/Formula/gnu-getopt.rb
@@ -2,6 +2,7 @@ class GnuGetopt < Formula
   desc "Command-line option parsing library"
   homepage "http://software.frodo.looijaard.name/getopt/"
   url "http://frodo.looijaard.name/system/files/software/getopt/getopt-1.1.6.tar.gz"
+  mirror "https://fossies.org/linux/misc/getopt-1.1.6.tar.gz"
   sha256 "d0bf1dc642a993e7388a1cddfb9409bed375c21d5278056ccca3a0acd09dc5fe"
 
   bottle do


### PR DESCRIPTION
- Use fossies.org for primary download URL, frodo.looijaard.name as mirror

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Got this warning

```
  * C: 4: col 3: Please don't use fossies.org in the url (using as a mirror is fine)
```

Will push an updated commit

