### PR TITLE
libidn2: add gettext prefix for libintl

### DIFF
--- a/Formula/libidn2.rb
+++ b/Formula/libidn2.rb
@@ -35,6 +35,7 @@ class Libidn2 < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
+                          "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}",
                           "--with-packager=Homebrew"
     system "make", "install"
   end


### PR DESCRIPTION
Specify the path to libintl so that Homebrew's gettext is used.
This avoids finding incompatible versions in other locations.