### PR TITLE
mysql-client 5.7.22 (new formula)

### DIFF
--- a/Formula/hydra.rb
+++ b/Formula/hydra.rb
@@ -3,7 +3,7 @@ class Hydra < Formula
   homepage "https://github.com/vanhauser-thc/thc-hydra"
   url "https://github.com/vanhauser-thc/thc-hydra/archive/8.6.tar.gz"
   sha256 "05a87eb018507b24afca970081f067e64441460319fb75ca1e64c4a1f322b80b"
-  revision 1
+  revision 2
   head "https://github.com/vanhauser-thc/thc-hydra.git"
 
   bottle do
@@ -14,7 +14,7 @@ class Hydra < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "openssl"
   depends_on "subversion" => :optional
   depends_on "libidn" => :optional

--- a/Formula/innotop.rb
+++ b/Formula/innotop.rb
@@ -3,7 +3,7 @@ class Innotop < Formula
   homepage "https://github.com/innotop/innotop/"
   url "https://github.com/innotop/innotop/archive/v1.11.4.tar.gz"
   sha256 "fb0d7d2558e2198d9224b44dc4220d4c62e1b5b0069312012306275be39b4ab9"
-  revision 2
+  revision 3
 
   head "https://github.com/innotop/innotop.git"
 
@@ -14,7 +14,7 @@ class Innotop < Formula
     sha256 "d9aca9b48babc73f9b6c17effd1b71c0ad630a0830779ac844959a353315805f" => :el_capitan
   end
 
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "openssl"
 
   resource "DBD::mysql" do

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -3,6 +3,7 @@ class KitchenSync < Formula
   homepage "https://github.com/willbryant/kitchen_sync"
   url "https://github.com/willbryant/kitchen_sync/archive/1.0.tar.gz"
   sha256 "a25bfbf56b4a49f69521ed57d290ad8cb7e190a9e354115bd86e41e9a80cd031"
+  revision 1
   head "https://github.com/willbryant/kitchen_sync.git"
 
   bottle do
@@ -12,11 +13,13 @@ class KitchenSync < Formula
     sha256 "927f44f22aeb09e28a04b7511440e75379748516e99b50333ad8059817c462d5" => :el_capitan
   end
 
+  deprecated_option "without-mysql" => "without-mysql-client"
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "yaml-cpp"
-  depends_on "mysql" => :recommended
+  depends_on "mysql-client" => :recommended
   depends_on "postgresql" => :optional
 
   needs :cxx11

--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -3,7 +3,7 @@ class Libzdb < Formula
   homepage "https://tildeslash.com/libzdb/"
   url "https://tildeslash.com/libzdb/dist/libzdb-3.1.tar.gz"
   sha256 "0f01abb1b01d1a1f4ab9b55ad3ba445d203fc3b4757abdf53e1d85e2b7b42695"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any
@@ -12,9 +12,11 @@ class Libzdb < Formula
     sha256 "9a1722fcff2c7946689a01b65c3151f6f2a9a26a43d50cfbb75ffe816a0a6c12" => :el_capitan
   end
 
+  deprecated_option "without-mysql" => "without-mysql-client"
+
   depends_on "openssl"
   depends_on "postgresql" => :recommended
-  depends_on "mysql" => :recommended
+  depends_on "mysql-client" => :recommended
   depends_on "sqlite" => :recommended
 
   def install
@@ -24,7 +26,7 @@ class Libzdb < Formula
     ]
 
     args << "--without-postgresql" if build.without? "postgresql"
-    args << "--without-mysql" if build.without? "mysql"
+    args << "--without-mysql" if build.without? "mysql-client"
     args << "--without-sqlite" if build.without? "sqlite"
 
     system "./configure", *args

--- a/Formula/mydumper.rb
+++ b/Formula/mydumper.rb
@@ -3,6 +3,7 @@ class Mydumper < Formula
   homepage "https://launchpad.net/mydumper"
   url "https://launchpad.net/mydumper/0.9/0.9.1/+download/mydumper-0.9.1.tar.gz"
   sha256 "aefab5dc4192acb043d685b6bb952c87557fbea5e083b8547c68ccfec878171f"
+  revision 1
 
   bottle do
     cellar :any
@@ -19,7 +20,7 @@ class Mydumper < Formula
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "glib"
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "pcre"
   depends_on "openssl"
 

--- a/Formula/mysql++.rb
+++ b/Formula/mysql++.rb
@@ -3,7 +3,7 @@ class Mysqlxx < Formula
   homepage "https://tangentsoft.com/mysqlpp/home"
   url "https://tangentsoft.com/mysqlpp/releases/mysql++-3.2.3.tar.gz"
   sha256 "c804c38fe229caab62a48a6d0a5cb279460da319562f41a16ad2f0a0f55b6941"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -12,15 +12,15 @@ class Mysqlxx < Formula
     sha256 "1668ebf91ee98d2d898f2b2eb75adba49f7bb3c8e353f2ac95f722da2858110b" => :el_capitan
   end
 
-  depends_on "mysql"
+  depends_on "mysql-client"
 
   def install
-    mysql_include_dir = Utils.popen_read("mysql_config --variable=pkgincludedir")
+    mysql = Formula["mysql-client"]
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-field-limit=40",
-                          "--with-mysql-lib=#{HOMEBREW_PREFIX}/lib",
-                          "--with-mysql-include=#{mysql_include_dir}"
+                          "--with-mysql-lib=#{mysql.opt_lib}",
+                          "--with-mysql-include=#{mysql.opt_include}/mysql"
     system "make", "install"
   end
 
@@ -35,7 +35,7 @@ class Mysqlxx < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", Utils.popen_read("mysql_config --include").chomp,
+    system ENV.cxx, "test.cpp", "-I#{Formula["mysql-client"].opt_include}/mysql",
                     "-L#{lib}", "-lmysqlpp", "-o", "test"
     system "./test", "-u", "foo", "-p", "bar"
   end

--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -1,0 +1,47 @@
+class MysqlClient < Formula
+  desc "Open source relational database management system"
+  homepage "https://dev.mysql.com/doc/refman/5.7/en/"
+  # Pinned at `5.7.*`
+  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-boost-5.7.22.tar.gz"
+  sha256 "5b2a61700af7c99f5630a7dfdb099af9283c3029843cddd9e123bcdbcc4aad03"
+
+  keg_only "conflicts with mysql"
+
+  depends_on "cmake" => :build
+  # https://github.com/Homebrew/homebrew-core/issues/1475
+  # Needs at least Clang 3.3, which shipped alongside Lion.
+  # Note: MySQL themselves don't support anything below El Capitan.
+  depends_on :macos => :lion
+  depends_on "openssl"
+
+  def install
+    # https://bugs.mysql.com/bug.php?id=87348
+    # Fixes: "ADD_SUBDIRECTORY given source
+    # 'storage/ndb' which is not an existing"
+    inreplace "CMakeLists.txt", "ADD_SUBDIRECTORY(storage/ndb)", ""
+
+    # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
+    args = %W[
+      -DCOMPILATION_COMMENT=Homebrew
+      -DDEFAULT_CHARSET=utf8
+      -DDEFAULT_COLLATION=utf8_general_ci
+      -DINSTALL_DOCDIR=share/doc/#{name}
+      -DINSTALL_INCLUDEDIR=include/mysql
+      -DINSTALL_INFODIR=share/info
+      -DINSTALL_MANDIR=share/man
+      -DINSTALL_MYSQLSHAREDIR=share/mysql
+      -DWITH_BOOST=boost
+      -DWITH_EDITLINE=system
+      -DWITH_SSL=yes
+      -DWITH_UNIT_TESTS=OFF
+      -DWITHOUT_SERVER=ON
+    ]
+
+    system "cmake", ".", *std_cmake_args, *args
+    system "make", "install"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mysql --version")
+  end
+end

--- a/Formula/mysql-connector-c++.rb
+++ b/Formula/mysql-connector-c++.rb
@@ -3,7 +3,7 @@ class MysqlConnectorCxx < Formula
   homepage "https://dev.mysql.com/downloads/connector/cpp/"
   url "https://cdn.mysql.com/Downloads/Connector-C++/mysql-connector-c++-1.1.9.tar.gz"
   sha256 "3e31847a69a4e5c113b7c483731317ec4533858e3195d3a85026a0e2f509d2e4"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class MysqlConnectorCxx < Formula
   depends_on "cmake" => :build
   depends_on "boost" => :build
   depends_on "openssl"
-  depends_on "mysql"
+  depends_on "mysql-client"
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -34,7 +34,8 @@ class MysqlConnectorCxx < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", `mysql_config --include`.chomp, "-L#{lib}", "-lmysqlcppconn", "-o", "test"
+    system ENV.cxx, "test.cpp", "-I#{Formula["mysql-client"].opt_include}",
+                    "-L#{lib}", "-lmysqlcppconn", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -5,7 +5,7 @@ class Mytop < Formula
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any
@@ -14,7 +14,7 @@ class Mytop < Formula
     sha256 "a7a00e844c2adb87eb4379faf0d3dd60443f9383cb295688ae2dac47051f3483" => :el_capitan
   end
 
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "openssl"
 
   conflicts_with "mariadb", :because => "both install `mytop` binaries"

--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -3,6 +3,7 @@ class PerconaToolkit < Formula
   homepage "https://www.percona.com/software/percona-toolkit/"
   url "https://www.percona.com/downloads/percona-toolkit/3.0.10/source/tarball/percona-toolkit-3.0.10.tar.gz"
   sha256 "ee89aa2a3c5a1a98e234a2564859fb95685838bef72cc76548ddfa62843844d6"
+  revision 1
   head "lp:percona-toolkit", :using => :bzr
 
   bottle do
@@ -12,7 +13,7 @@ class PerconaToolkit < Formula
     sha256 "e8d508cd6f63532716d8da71464f587828c9c67a745372c36aa44bb8f2929977" => :el_capitan
   end
 
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "openssl"
 
   resource "DBD::mysql" do

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -3,6 +3,7 @@ class PerconaXtrabackup < Formula
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
   url "https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.11/source/tarball/percona-xtrabackup-2.4.11.tar.gz"
   sha256 "67506507628eec5edc88d2000f423e892b46c8ca56dbe5a02566a11168ee6483"
+  revision 1
 
   bottle do
     sha256 "f2b03221466dc0f23682f981aa711ca7be0d4589216ab63d488c50701cdfd85b" => :high_sierra
@@ -11,11 +12,13 @@ class PerconaXtrabackup < Formula
   end
 
   option "without-docs", "Build without man pages (which requires python-sphinx)"
-  option "without-mysql", "Build without bundled Perl DBD::mysql module, to use the database of your choice."
+  option "without-mysql-client", "Build without bundled Perl DBD::mysql module, to use the database of your choice."
+
+  deprecated_option "without-mysql" => "without-mysql-client"
 
   depends_on "cmake" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
-  depends_on "mysql" => :recommended
+  depends_on "mysql-client" => :recommended
   depends_on "libev"
   depends_on "libgcrypt"
   depends_on "openssl"
@@ -66,7 +69,7 @@ class PerconaXtrabackup < Formula
     rm lib/"libmysqlservices.a"
     rm lib/"plugin/keyring_file.so"
 
-    if build.with? "mysql"
+    if build.with? "mysql-client"
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
       resource("DBD::mysql").stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"

--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -3,6 +3,7 @@ class Sysbench < Formula
   homepage "https://github.com/akopytov/sysbench"
   url "https://github.com/akopytov/sysbench/archive/1.0.14.tar.gz"
   sha256 "81669cee6e0d5fccd5543dbcefec18826db43abba580de06cecf5b54483f6079"
+  revision 1
 
   bottle do
     sha256 "fcb780c85ec232d60edbbb9fbdb384c3f8e3a26314e625a5bf60461905b636a0" => :high_sierra
@@ -10,19 +11,21 @@ class Sysbench < Formula
     sha256 "d00d69c96c281d3185ffe1db96e625a3baf8b392098c681f560d7b72e605ff09" => :el_capitan
   end
 
+  deprecated_option "without-mysql" => "without-mysql-client"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "postgresql" => :optional
-  depends_on "mysql" => :recommended
+  depends_on "mysql-client" => :recommended
 
   def install
     system "./autogen.sh"
 
     args = ["--prefix=#{prefix}"]
-    if build.with? "mysql"
+    if build.with? "mysql-client"
       args << "--with-mysql"
     else
       args << "--without-mysql"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Goes with https://github.com/Homebrew/homebrew-core/pull/27210.

This allows formulae with a `mysql` dep to be built on < sierra.

cc @ilovezfs 