### PR TITLE
plowshare: depend on feh instead of imagemagick with x11

### DIFF
--- a/Formula/plowshare.rb
+++ b/Formula/plowshare.rb
@@ -3,6 +3,7 @@ class Plowshare < Formula
   homepage "https://github.com/mcrapet/plowshare"
   url "https://github.com/mcrapet/plowshare/archive/v2.1.7.tar.gz"
   sha256 "c17d0cc1b3323f72b2c1a5b183a9fcef04e8bfc53c9679a4e1523642310d22ad"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,8 +15,8 @@ class Plowshare < Formula
 
   depends_on "bash"
   depends_on "coreutils"
+  depends_on "feh"
   depends_on "gnu-sed"
-  depends_on "imagemagick" => "with-x11"
   depends_on "libcaca"
   depends_on "recode"
   depends_on "spidermonkey"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/mcrapet/plowshare/blob/master/INSTALL
```
* X11 viewers
  - display (imagemagick, X11) or
  - sxiv (imlib2, X11, very fast) or
  - feh (imlib2, X11) or
  - qiv (imlib2, X11)
```