### PR TITLE
vegeta: use statically compiled github releases

### DIFF
--- a/Formula/vegeta.rb
+++ b/Formula/vegeta.rb
@@ -1,36 +1,19 @@
 class Vegeta < Formula
-  desc "HTTP load testing tool and library"
+  desc "HTTP load testing tool and library. It's over 9000!"
   homepage "https://github.com/tsenart/vegeta"
-  url "https://github.com/tsenart/vegeta/archive/v7.0.0.tar.gz"
-  sha256 "b9e2ae43b832849c46e9aa0e1cddf5938e79b9addad01481b3cbfb7aa09a03cb"
+  url "https://github.com/tsenart/vegeta/releases/download/v7.0.0/vegeta-7.0.0-darwin-amd64.tar.gz"
+  sha256 "e0e9250cf60f350cb4e997791cfd7404a590ad41667144bbdcc0b94f157f8b79"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "259302bc8757ce5260679fd5f88826c4e143a106fc27938a145ceb8a321d81bc" => :high_sierra
-    sha256 "47522f5463ed21683a614b90478a2306b6d0ba2cef98d520a78645fa770ee9f3" => :sierra
-    sha256 "2a49fd07e3b3171408ffd8ebbc82793b78217667e0daf63d43e4feaca3f9b279" => :el_capitan
-  end
-
-  depends_on "dep" => :build
-  depends_on "go" => :build
+  bottle :unneeded
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["CGO_ENABLED"] = "0"
-
-    (buildpath/"src/github.com/tsenart/vegeta").install buildpath.children
-    cd "src/github.com/tsenart/vegeta" do
-      system "dep", "ensure"
-      system "go", "build", "-ldflags", "-X main.Version=#{version}",
-                            "-o", bin/"vegeta"
-      prefix.install_metafiles
-    end
+    bin.install "vegeta"
   end
 
   test do
     input = "GET https://google.com"
     output = pipe_output("#{bin}/vegeta attack -duration=1s -rate=1", input, 0)
     report = pipe_output("#{bin}/vegeta report", output, 0)
-    assert_match /Success +\[ratio\] +100.00%/, report
+    assert_match(/Success +\[ratio\] +100.00%/, report)
   end
 end


### PR DESCRIPTION
This commit changes the vegeta formula use the now statically compiled executables in github releases. Background: https://github.com/Homebrew/homebrew-core/pull/28024#issuecomment-390437241

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Unfortunately, I couldn't find information about your current policy regarding statically compiled formulas, and the `audit` above seems to be complaining about that, but I'm confused because there are other formulas doing the same, for instance: https://github.com/Homebrew/homebrew-core/blob/master/Formula/jsonpp.rb

If that was a mistake and source only builds are still the policy, I'll have to change the current Formula to be built with the [correct flags](https://github.com/tsenart/vegeta/blob/master/.goreleaser.yml) so that `vegeta -version` outputs this:

```
Version: 7.0.0
Commit: add59f4e5f067a0d6ceb53aefd57aaa3eee50e88
Go version: go1.10.2
Date: 2018-05-18T14:21:04Z"
```

Instead of this:

```
Version: %!s(*bool=0xc42009e710)
Commit:
Go version:
Date:
```

Additionally, as per https://github.com/Homebrew/homebrew-core/pull/28024#issuecomment-390437241, I'd like to ask the following two questions:

1. How do you discover new releases of the software you have formulas for? Seemed very fast reaction 😄 

2. In order to automate the Brew package release with GoReleaser, would you recommend migrating Vegeta to its own tap repo?

Thank you for your work!