### PR TITLE
Remove retired search.cpan.org mirrors (2/2)

### DIFF
--- a/Formula/namazu.rb
+++ b/Formula/namazu.rb
@@ -19,7 +19,6 @@ class Namazu < Formula
 
   resource "text-kakasi" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DANKOGAI/Text-Kakasi-2.04.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DA/DANKOGAI/Text-Kakasi-2.04.tar.gz"
     sha256 "844c01e78ba4bfb89c0702995a86f488de7c29b40a75e7af0e4f39d55624dba0"
   end
 

--- a/Formula/oysttyer.rb
+++ b/Formula/oysttyer.rb
@@ -11,7 +11,6 @@ class Oysttyer < Formula
 
   resource "Term::ReadLine::TTYtter" do
     url "https://cpan.metacpan.org/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz"
     sha256 "ac373133cee1b2122a8273fe7b4244613d0eecefe88b668bd98fe71d1ec4ac93"
   end
 

--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -17,13 +17,11 @@ class PerconaToolkit < Formula
 
   resource "DBD::mysql" do
     url "https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.046.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.046.tar.gz"
     sha256 "6165652ec959d05b97f5413fa3dff014b78a44cf6de21ae87283b28378daf1f7"
   end
 
   resource "JSON" do
     url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-2.97001.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-2.97001.tar.gz"
     sha256 "e277d9385633574923f48c297e1b8acad3170c69fa590e31fa466040fc6f8f5a"
   end
 

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -22,7 +22,6 @@ class PerconaXtrabackup < Formula
 
   resource "DBD::mysql" do
     url "https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.046.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.046.tar.gz"
     sha256 "6165652ec959d05b97f5413fa3dff014b78a44cf6de21ae87283b28378daf1f7"
   end
 

--- a/Formula/perl-build.rb
+++ b/Formula/perl-build.rb
@@ -16,116 +16,97 @@ class PerlBuild < Formula
   # Perl::Strip dependency
   resource "common::sense" do
     url "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/common-sense-3.74.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN/common-sense-3.74.tar.gz"
     sha256 "771f7d02abd1ded94d9e37d3f66e795c8d2026d04defbeb5b679ca058116bbf3"
   end
 
   resource "Perl::Strip" do
     url "https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN/Perl-Strip-1.1.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/M/ML/MLEHMANN/Perl-Strip-1.1.tar.gz"
     sha256 "38030abf96af7d8080157ea42ede8564565cc0de4e7689dd8f85d824b4f54142"
   end
 
   resource "App::FatPacker" do
     url "https://cpan.metacpan.org/authors/id/M/MS/MSTROUT/App-FatPacker-0.010007.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/M/MS/MSTROUT/App-FatPacker-0.010007.tar.gz"
     sha256 "d1158202cae6052385e8c7b1e5874992f5c2c5d85ef40894dcedbce6927336bd"
   end
 
   resource "CPAN::Perl::Releases" do
     url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/CPAN-Perl-Releases-3.14.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/CPAN-Perl-Releases-3.14.tar.gz"
     sha256 "c27d718004adaa22c7f6f0ccb471237610c4fc1ed928306e9900e2bb0d20ab56"
   end
 
   resource "File::pushd" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/File-pushd-1.014.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/File-pushd-1.014.tar.gz"
     sha256 "b5ab37ffe3acbec53efb7c77b4423a2c79afa30a48298e751b9ebee3fdc6340b"
   end
 
   resource "HTTP::Tiny" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/HTTP-Tiny-0.070.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/HTTP-Tiny-0.070.tar.gz"
     sha256 "74f385d1e96de887a4df5a222d93afdc7d81ea9ad721a56ff3d8449bb12f7733"
   end
 
   # Devel::PatchPerl dependencies
   resource "IO::File" do
     url "https://cpan.metacpan.org/authors/id/G/GB/GBARR/IO-1.25.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/G/GB/GBARR/IO-1.25.tar.gz"
     sha256 "89790db8b9281235dc995c1a85d532042ff68a90e1504abd39d463f05623e7b5"
   end
 
   resource "MIME::Base64" do
     url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/MIME-Base64-3.15.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/MIME-Base64-3.15.tar.gz"
     sha256 "7f863566a6a9cb93eda93beadb77d9aa04b9304d769cea3bb921b9a91b3a1eb9"
   end
 
   resource "XSLoader" do
     url "https://cpan.metacpan.org/authors/id/S/SA/SAPER/XSLoader-0.24.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/S/SA/SAPER/XSLoader-0.24.tar.gz"
     sha256 "e819a35a6b8e55cb61b290159861f0dc00fe9d8c4f54578eb24f612d45c8d85f"
   end
 
   resource "Module::Pluggable" do
     url "https://cpan.metacpan.org/authors/id/S/SI/SIMONW/Module-Pluggable-5.2.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/S/SI/SIMONW/Module-Pluggable-5.2.tar.gz"
     sha256 "b3f2ad45e4fd10b3fb90d912d78d8b795ab295480db56dc64e86b9fa75c5a6df"
   end
 
   resource "Exporter" do
     url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/Exporter-5.72.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/Exporter-5.72.tar.gz"
     sha256 "cd13b7a0e91e8505a0ce4b25f40fab2c92bb28a99ef0d03da1001d95a32f0291"
   end
 
   resource "Carp" do
     url "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Carp-1.38.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Carp-1.38.tar.gz"
     sha256 "a5a9ce3cbb959dfefa8c2dd16552567199b286d39b0e55053ca247c038977101"
   end
 
   resource "ExtUtils::MakeMaker" do
     url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.24.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.24.tar.gz"
     sha256 "416abc97c3bb2cc72bef28852522f2859de53e37bf3d0ae8b292067d78755e69"
   end
 
   resource "Data::Dumper" do
     url "https://cpan.metacpan.org/authors/id/S/SM/SMUELLER/Data-Dumper-2.161.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/S/SM/SMUELLER/Data-Dumper-2.161.tar.gz"
     sha256 "3aa4ac1b042b3880438165fb2b2139d377564a8e9928ffe689ede5304ee90558"
   end
 
   resource "Encode" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DANKOGAI/Encode-2.89.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DA/DANKOGAI/Encode-2.89.tar.gz"
     sha256 "e6299e67bc7379117015fcff38ba09da37441046a7f16a63dbaaf48b5738fcb4"
   end
 
   resource "parent" do
     url "https://cpan.metacpan.org/authors/id/C/CO/CORION/parent-0.236.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CO/CORION/parent-0.236.tar.gz"
     sha256 "2d837ebd04f6aa4b8634c9fa9d0bead83f1bee4a8072defe862ee6eb82be127a"
   end
 
   resource "PathTools" do
     url "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/PathTools-3.62.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/PathTools-3.62.tar.gz"
     sha256 "36350e12f58871437ba03391f80a506e447e3c6630cc37d0625bc25ff1c7b4d2"
   end
 
   resource "Scalar-List-Utils" do
     url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.47.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.47.tar.gz"
     sha256 "c483347372a96972d61fd186522a9dafc2da899ef2951964513b7e8efb37efe1"
   end
 
   resource "if" do
     url "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/if-0.0606.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/if-0.0606.tar.gz"
     sha256 "63d69282d6c4c9e76370b78d770ca720cea88cfe5ee5b612709240fc6078d50e"
   end
 
@@ -133,13 +114,11 @@ class PerlBuild < Formula
 
   resource "Devel::PatchPerl" do
     url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/Devel-PatchPerl-1.48.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/Devel-PatchPerl-1.48.tar.gz"
     sha256 "26a9bc8e52af739384cece2773921dd44d2371b6cdf92fe452ecc348eb0d90fe"
   end
 
   resource "File::Temp" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/File-Temp-0.2304.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/File-Temp-0.2304.tar.gz"
     sha256 "13415323e48f7c9f34efdedf3d35141a7c3435e2beb8c6b922229dc317d321ac"
   end
 
@@ -151,13 +130,11 @@ class PerlBuild < Formula
   # Pod::Usage dependency
   resource "Pod::Text" do
     url "https://cpan.metacpan.org/authors/id/R/RR/RRA/podlators-4.09.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/R/RR/RRA/podlators-4.09.tar.gz"
     sha256 "c86d9633487e47196bfea678622a042ac1c1f910d6f22a06ba4667239f2236ba"
   end
 
   resource "Pod::Usage" do
     url "https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Usage-1.69.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/M/MA/MAREKR/Pod-Usage-1.69.tar.gz"
     sha256 "1a920c067b3c905b72291a76efcdf1935ba5423ab0187b9a5a63cfc930965132"
   end
 

--- a/Formula/pulledpork.rb
+++ b/Formula/pulledpork.rb
@@ -16,13 +16,11 @@ class Pulledpork < Formula
 
   resource "Switch" do
     url "https://cpan.metacpan.org/authors/id/C/CH/CHORNY/Switch-2.17.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CH/CHORNY/Switch-2.17.tar.gz"
     sha256 "31354975140fe6235ac130a109496491ad33dd42f9c62189e23f49f75f936d75"
   end
 
   resource "Crypt::SSLeay" do
     url "https://cpan.metacpan.org/authors/id/N/NA/NANIS/Crypt-SSLeay-0.72.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/N/NA/NANIS/Crypt-SSLeay-0.72.tar.gz"
     sha256 "f5d34f813677829857cf8a0458623db45b4d9c2311daaebe446f9e01afa9ffe8"
   end
 

--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -14,7 +14,6 @@ class Resty < Formula
 
   resource "JSON" do
     url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-2.94.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-2.94.tar.gz"
     sha256 "12271b5cee49943bbdde430eef58f1fe64ba6561980b22c69585e08fc977dc6d"
   end
 

--- a/Formula/sslmate.rb
+++ b/Formula/sslmate.rb
@@ -32,7 +32,6 @@ class Sslmate < Formula
   if MacOS.version <= :mountain_lion
     resource "JSON::PP" do
       url "https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA/JSON-PP-2.27300.tar.gz"
-      mirror "http://search.cpan.org/CPAN/authors/id/M/MA/MAKAMAKA/JSON-PP-2.27300.tar.gz"
       sha256 "5feef3067be4acd99ca0ebb29cf1ac1cdb338fe46977585bd1e473ea4bab71a3"
     end
   end

--- a/Formula/texapp.rb
+++ b/Formula/texapp.rb
@@ -15,7 +15,6 @@ class Texapp < Formula
 
   resource "Term::ReadLine::TTYtter" do
     url "https://cpan.metacpan.org/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz"
     sha256 "ac373133cee1b2122a8273fe7b4244613d0eecefe88b668bd98fe71d1ec4ac93"
   end
 

--- a/Formula/winexe.rb
+++ b/Formula/winexe.rb
@@ -26,7 +26,6 @@ class Winexe < Formula
   # versions of Perl
   resource "Perl4::CoreLibs" do
     url "https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz"
-    mirror "http://search.cpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz"
     sha256 "55c9b2b032944406dbaa2fd97aa3692a1ebce558effc457b4e800dabfaad9ade"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Ref: https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html

Homebrew core formulae used search.cpan.org download URLs solely as mirrors for the HTTPS-enabled cpan.metacpan.org ones. When the retiring process ends, existing search.cpan.org URLs will get redirected to the latter alternative — the ones used in Harbour formulae as a primary URL already.
This PR removes the soon to be redundant / retired mirror URLs.

Preexisting audit issue:
```
winexe:
  * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
Error: 1 problem in 1 formula
```

Open PR:
namazu: https://github.com/Homebrew/homebrew-core/pull/27344 (likely non-colliding)
