### PR TITLE
Add support to build kubectl with cgo

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -12,6 +12,8 @@ class KubernetesCli < Formula
     sha256 "ac6ea67a29a7e1b3581538c752097084734af77807831ed787084b081542a49f" => :el_capitan
   end
 
+  option "with-dynamic", "Build dynamic binary with CGO_ENABLED=1"
+
   # kubernetes-cli will not support go1.10 until version 1.11.x
   depends_on "go@1.9" => :build
 
@@ -27,6 +29,12 @@ class KubernetesCli < Formula
       ENV.deparallelize { system "make", "generated_files" }
 
       # Make binary
+      if build.with? "dynamic"
+        ENV["CGO_ENABLED"] = "1"
+        # Delete kubectl binary from KUBE_STATIC_LIBRARIES
+        inreplace "hack/lib/golang.sh", " kubectl", ""
+      end
+
       system "make", "kubectl"
       bin.install "_output/local/bin/darwin/#{arch}/kubectl"
 


### PR DESCRIPTION
Modify formula to support build dynamic binary with CGO_ENABLED=1.
Building kubectl without cgo breaks dns name resolution since it
uses /etc/resolv.conf for getting resolvers while nothing in macos
should use it for name resolution.
More information about this issue can be obtained here -
https://github.com/kubernetes/release/issues/469

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
