### PR TITLE
wireshark: fix qt 5.11 compatibility

### DIFF
--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -1,10 +1,20 @@
 class Wireshark < Formula
   desc "Graphical network analyzer and capture tool"
   homepage "https://www.wireshark.org"
-  url "https://www.wireshark.org/download/src/all-versions/wireshark-2.6.1.tar.xz"
-  mirror "https://1.eu.dl.wireshark.org/src/wireshark-2.6.1.tar.xz"
-  sha256 "ab6e5bbc3464c956347b8671ce8397950ad5daff3bf9964c967d495f4ddbcd88"
   head "https://code.wireshark.org/review/wireshark", :using => :git
+
+  stable do
+    url "https://www.wireshark.org/download/src/all-versions/wireshark-2.6.1.tar.xz"
+    mirror "https://1.eu.dl.wireshark.org/src/wireshark-2.6.1.tar.xz"
+    sha256 "ab6e5bbc3464c956347b8671ce8397950ad5daff3bf9964c967d495f4ddbcd88"
+
+    # Fix header includes for Qt 5.11.
+    # TODO: Committed upstream, remove on next .z release.
+    patch do
+      url "https://github.com/wireshark/wireshark/commit/b8e8aa87f43c12ad564426b3359f593305cd45a1.patch?full_index=1"
+      sha256 "39ff775cabc2cc31d8c2152b78a0b05a0a7686fd3b5dd0807d359493c3681c9a"
+    end
+  end
 
   bottle do
     sha256 "0b3c8f3dec1fb90c9704d7009adcb09281491583eb92fc3f38e1210d6ef895b0" => :high_sierra


### PR DESCRIPTION
This commit pulls in a patch from Wireshark upstream that fixes some missing
Qt header includes that are required to build wireshark --with-qt against
Qt 5.11.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
