### PR TITLE
wireguard: bump to 0.0.20180524

### DIFF
--- a/Formula/wireguard-go.rb
+++ b/Formula/wireguard-go.rb
@@ -1,8 +1,8 @@
 class WireguardGo < Formula
   desc "Userspace Go implementation of WireGuard"
   homepage "https://www.wireguard.com/"
-  url "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-0.0.20180519.tar.xz"
-  sha256 "d2b0f43679b3559952cf8d244d537903d03699ed7c8a2c1e7fc37ee424e30439"
+  url "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-0.0.20180524.tar.xz"
+  sha256 "1d539f6c51dd33098a536af0285ef03c561db0ff343f23a75405207fcf48ec3e"
   head "https://git.zx2c4.com/wireguard-go", :using => :git
 
   bottle do
@@ -16,14 +16,7 @@ class WireguardGo < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/wireguard-go").install buildpath.children
-    cd "src/wireguard-go" do
-      system "dep", "ensure", "-vendor-only"
-      (buildpath/"gopath/src").install (buildpath/"src/wireguard-go/vendor").children
-      ENV["GOPATH"] = buildpath/"gopath"
-      system "make", "PREFIX=#{prefix}", "install"
-    end
+    system "make", "PREFIX=#{prefix}", "install"
   end
 
   test do

--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -3,8 +3,8 @@ class WireguardTools < Formula
   homepage "https://www.wireguard.com/"
   # Please only update version when the tools have been modified/updated,
   # since the Linux module aspect isn't of utility for us.
-  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180519.tar.xz"
-  sha256 "8846b3006c3f7e079bb38a4c985ccc2981e259f56c927b4cf47cbc1420e1c462"
+  url "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20180524.tar.xz"
+  sha256 "57614239c1f1a99a367f2c816153acda5bffada66a3b8e3b8215f1625784abc9"
   head "https://git.zx2c4.com/WireGuard", :using => :git
 
   bottle do


### PR DESCRIPTION
We've switched to using GOPATH properly internally, as
well as using dep in the right way, so now we can simplify
the build instructions to just a `make'.