### PR TITLE
sleuthkit: require optional deps

### DIFF
--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -13,11 +13,11 @@ class Sleuthkit < Formula
   end
 
   option "with-jni", "Build Sleuthkit with JNI bindings"
-  option "with-debug", "Build debug version"
 
-  depends_on "afflib" => :optional
-  depends_on "libewf" => :optional
+  depends_on "afflib"
+  depends_on "libewf"
   depends_on "libpq"
+  depends_on "sqlite"
 
   if build.with? "jni"
     depends_on :java
@@ -29,8 +29,6 @@ class Sleuthkit < Formula
     :because => "both install a 'ffind' executable."
 
   def install
-    ENV.append_to_cflags "-DNDEBUG" if build.without? "debug"
-
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
     args << "--disable-java" if build.without? "jni"
 

--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -3,6 +3,7 @@ class Sleuthkit < Formula
   homepage "https://www.sleuthkit.org/"
   url "https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.6.1/sleuthkit-4.6.1.tar.gz"
   sha256 "1f68f3b5983acdb871a30592fb735a32f4db93f041fcf318bcf3ec87128ab433"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,7 @@ class Sleuthkit < Formula
 
   depends_on "afflib" => :optional
   depends_on "libewf" => :optional
+  depends_on "libpq"
 
   if build.with? "jni"
     depends_on :java


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This would help with updating `autopsy` to `4.7.0`, the current version `2.24` is eight years old.

https://github.com/sleuthkit/autopsy/blob/develop/Running_Linux_OSX.txt#L28

Also removed the barely used debug option.
```
install events in the last 365 days
================================================================================
 1 | sleuthkit                                                | 13,587 |  97.78%
 2 | sleuthkit --with-jni --with-afflib --with-libewf         |     93 |   0.67%
 3 | sleuthkit --with-afflib --with-libewf                    |     82 |   0.59%
 4 | sleuthkit --with-libewf                                  |     77 |   0.55%
 5 | sleuthkit --with-jni --with-debug --with-afflib --with-l |     15 |   0.11%
 6 | sleuthkit --with-afflib                                  |     12 |   0.09%
 7 | sleuthkit --with-jni                                     |     10 |   0.07%
 8 | sleuthkit --with-jni --with-debug                        |     10 |   0.07%
 9 | sleuthkit --with-debug --with-afflib --with-libewf       |      4 |   0.03%
10 | sleuthkit --with-jni --with-afflib                       |      3 |   0.02%
11 | sleuthkit --with-debug                                   |      1 |   0.01%
12 | sleuthkit --with-jni --with-libewf                       |      1 |   0.01%
================================================================================
Total                                                         | 13,895 |    100%

```