### PR TITLE
wireguard-go: simplify unit test

### DIFF
--- a/Formula/wireguard-go.rb
+++ b/Formula/wireguard-go.rb
@@ -20,6 +20,6 @@ class WireguardGo < Formula
   end
 
   test do
-    assert_match "be utun", pipe_output("WG_PROCESS_FOREGROUND=1 #{bin}/wireguard-go notrealutun")
+    system "#{bin}/wireguard-go", "--version"
   end
 end


### PR DESCRIPTION
The current unit test doesn't do much: it tests for a substring of
some error message when setting certain environment variables, which might
possibly change in future versions. This commit changes the formula to
do something just as basic but more reliable -- `wireguard-go --version`.