### PR TITLE
redshift: tweak caveats for config location change

### DIFF
--- a/Formula/redshift.rb
+++ b/Formula/redshift.rb
@@ -46,7 +46,7 @@ class Redshift < Formula
     A sample .conf file has been installed to #{opt_pkgshare}.
 
     Please note redshift expects to read its configuration file from
-    #{ENV["HOME"]}/.config
+    #{ENV["HOME"]}/.config/redshift/redshift.conf
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream has deprecated the old config location.