### PR TITLE
gsettings-desktop-schemas: remove python@2 dependency

### DIFF
--- a/Formula/gsettings-desktop-schemas.rb
+++ b/Formula/gsettings-desktop-schemas.rb
@@ -17,7 +17,6 @@ class GsettingsDesktopSchemas < Formula
   depends_on "glib"
   depends_on "gettext"
   depends_on "libffi"
-  depends_on "python@2"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #28082.

It looks to me like this dependency is actually a run-time dependency of the build tool
gobject-introspection, and does not appear to be directly needed by
gsettings-desktop-schemas.

I've tested locally by installing with/without `-s` with this setting, and with `python@2` removed after `gobject-introspection` installation, and tests still succeed. Based on manual inspection of the `gsettings-desktop-schemas` source, I'd say that Python is only needed at build time, and only for interaction with the `gobject-introspection` stuff (even though there are some `*.py` files in the `gsettings-desktop-schemas` source tree).

Might be a style call as to whether you actually want to remove this dependency vs demote it to a `:build` dep, but IMHO it makes sense, because it means that users can install `gsettings-deskstop-schemas` from a bottle without pulling in `python@2`, and because the `*.py` files don't seem to be executed directly; they're used as inputs to `gobject-introspection` commands.