### PR TITLE
jooby-bootstrap: require Java 8 exactly

### DIFF
--- a/Formula/jooby-bootstrap.rb
+++ b/Formula/jooby-bootstrap.rb
@@ -3,14 +3,16 @@ class JoobyBootstrap < Formula
   homepage "https://github.com/jooby-project/jooby-bootstrap"
   url "https://github.com/jooby-project/jooby-bootstrap/archive/0.2.2.tar.gz"
   sha256 "ba662dcbe9022205cdb147a1c4e0931191eb902477ca40f3cba0170dfad54fda"
+  revision 1
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
   depends_on "maven"
 
   def install
-    bin.install "jooby"
+    libexec.install "jooby"
+    (bin/"jooby").write_env_script libexec/"jooby", Language::Java.java_home_env("1.8")
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes `jooby-bootstrap` to work in presence of Java 9 installations.

Addresses #19696.