### PR TITLE
abcl: coexist with JDK 9

### DIFF
--- a/Formula/abcl.rb
+++ b/Formula/abcl.rb
@@ -3,6 +3,7 @@ class Abcl < Formula
   homepage "https://abcl.org/"
   url "https://abcl.org/releases/1.5.0/abcl-src-1.5.0.tar.gz"
   sha256 "920ee7d634a7f4ceca0a469d431d3611a321c566814d5ddb92d75950c0631bc2"
+  revision 1
   head "https://abcl.org/svn/trunk/abcl/", :using => :svn
 
   bottle do
@@ -14,15 +15,19 @@ class Abcl < Formula
   end
 
   depends_on "ant"
-  depends_on :java => "1.5+"
+  depends_on :java => "1.8"
   depends_on "rlwrap" => :recommended
 
   def install
+    cmd = Language::Java.java_home_cmd("1.8")
+    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+
     system "ant"
 
     libexec.install "dist/abcl.jar", "dist/abcl-contrib.jar"
     (bin/"abcl").write <<~EOS
       #!/bin/sh
+      export JAVA_HOME=$(#{cmd})
       #{"rlwrap " if build.with?("rlwrap")}java -cp #{libexec}/abcl.jar:"$CLASSPATH" org.armedbear.lisp.Main "$@"
     EOS
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes `abcl` to coexist with JDK 9 installations.

Addresses #19696.