### PR TITLE
aws-apigateway-importer: require Java 8 specifically

### DIFF
--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -19,7 +19,7 @@ class AwsApigatewayImporter < Formula
     sha256 "bbe12dac66d033674840eace741bcf5c3549e7317ab9ca6fa9f349418a6c9861" => :yosemite
   end
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
   depends_on "maven" => :build
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696 by requiring Java 8 specifically.