### PR TITLE
gssh: require Java 8 specifically

### DIFF
--- a/Formula/gssh.rb
+++ b/Formula/gssh.rb
@@ -3,6 +3,7 @@ class Gssh < Formula
   homepage "https://github.com/int128/groovy-ssh"
   url "https://github.com/int128/groovy-ssh/archive/2.9.0.tar.gz"
   sha256 "9199c675b91041858a246eee156c6ed0d65d153efafb62820f66d3722b9d17bf"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,13 +13,13 @@ class Gssh < Formula
     sha256 "62ca0404e4429f62df84b96dba7b0219db9d883595f31a4427bd884a2e45b705" => :yosemite
   end
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
 
   def install
     ENV["CIRCLE_TAG"] = version
     system "./gradlew", "shadowJar"
     libexec.install "cli/build/libs/gssh.jar"
-    bin.write_jar_script libexec/"gssh.jar", "gssh"
+    bin.write_jar_script libexec/"gssh.jar", "gssh", :java_version => "1.8"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696 by requiring Java 8 specifically.