### PR TITLE
hexgui: require Java 8 exactly

### DIFF
--- a/Formula/hexgui.rb
+++ b/Formula/hexgui.rb
@@ -14,12 +14,12 @@ class Hexgui < Formula
   end
 
   depends_on "ant" => :build
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8"
 
   def install
     system "ant"
     libexec.install Dir["*"]
-    (bin/"hexgui").write_env_script libexec/"bin/hexgui", Language::Java.java_home_env("1.6+")
+    (bin/"hexgui").write_env_script libexec/"bin/hexgui", Language::Java.java_home_env("1.8")
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696 by requiring Java 8 exactly.