### PR TITLE
mysql-cluster: require Java 8 specifically

### DIFF
--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -23,7 +23,7 @@ class MysqlCluster < Formula
   deprecated_option "enable-local-infile" => "with-local-infile"
   deprecated_option "enable-debug" => "with-debug"
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
   depends_on "cmake" => :build
   depends_on "pidof" unless MacOS.version >= :mountain_lion
   depends_on "openssl"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696 by requiring Java 8 specifically.

The `brew test mysql-cluster` is actually failing on my machine with this:

```
==> curl 127.0.0.1:3306
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   104    0   104    0     0  17983      0 --:--:-- --:--:-- --:--:-- 20800
Error: mysql-cluster: failed
</7\.5\.7/> expected to be =~
<"5.7.22\x00\x03\x00\x00\x00dmf&z\x06a:\x00\xFF\xFF!\x02\x00\xFF\xC1\x15\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00=\x10Foo%eJ\x01a5C\x00mysql_native_password\x00\e\x00\x00\x01\xFF\x84\x04Got packets out of order">.
```

But I'm hoping that out-of-order packet thing is just a fluke local to my machine (I have some other MySQL stuff installed which may well be conflicting with it), and the tests will work on the server. Sorry for using up test-bot time if this isn't the case.