### PR TITLE
wartremover: use Java 8 specifically

### DIFF
--- a/Formula/wartremover.rb
+++ b/Formula/wartremover.rb
@@ -3,6 +3,7 @@ class Wartremover < Formula
   homepage "https://github.com/wartremover/wartremover"
   url "https://github.com/wartremover/wartremover/archive/v2.1.1.tar.gz"
   sha256 "4c789ee33ecff2b655bc839c5ebc7b20d581f99529f8f553628ed38d9615e553"
+  revision 1
   head "https://github.com/wartremover/wartremover.git"
 
   bottle do
@@ -14,13 +15,13 @@ class Wartremover < Formula
   end
 
   depends_on "sbt" => :build
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8"
 
   def install
     system "./sbt", "-sbt-jar", Formula["sbt"].opt_libexec/"bin/sbt-launch.jar",
                     "core/assembly"
     libexec.install "wartremover-assembly.jar"
-    bin.write_jar_script libexec/"wartremover-assembly.jar", "wartremover"
+    bin.write_jar_script libexec/"wartremover-assembly.jar", "wartremover", :java_version => "1.8"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #19696 by requiring Java 8 specifically.