### PR TITLE
libewf: avoid opportunistic linkage to osxfuse

### DIFF
--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -5,7 +5,7 @@ class Libewf < Formula
   mirror "https://mirrors.kernel.org/debian/pool/main/libe/libewf/libewf_20140608.orig.tar.gz"
   version "20140608"
   sha256 "d14030ce6122727935fbd676d0876808da1e112721f3cb108564a4d9bf73da71"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -31,15 +31,23 @@ class Libewf < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
+  depends_on :osxfuse => :optional
 
   def install
     if build.head?
       system "./synclibs.sh"
       system "./autogen.sh"
     end
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
+
+    args << "--with-libfuse=no" if build.without? "osxfuse"
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
Missing libraries:
  /usr/local/lib/libosxfuse.2.dylib
```
```
$ ewfmount
dyld: Library not loaded: /usr/local/lib/libosxfuse.2.dylib
  Referenced from: /usr/local/bin/ewfmount
  Reason: image not found
[1]    60489 abort      ewfmount
```