### PR TITLE
hbase, opentsdb: make lzo mandatory

### DIFF
--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -1,17 +1,3 @@
-class HbaseLZORequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) { Tab.for_name("hbase").with?("lzo") }
-
-  def message; <<~EOS
-    hbase must not have disabled lzo compression to use it in opentsdb:
-      brew install hbase
-      not
-      brew install hbase --without-lzo
-    EOS
-  end
-end
-
 class Opentsdb < Formula
   desc "Scalable, distributed Time Series Database"
   homepage "http://opentsdb.net/"
@@ -28,8 +14,7 @@ class Opentsdb < Formula
 
   depends_on "hbase"
   depends_on :java => "1.8"
-  depends_on "lzo" => :recommended
-  depends_on HbaseLZORequirement if build.with?("lzo")
+  depends_on "lzo"
   depends_on "gnuplot" => :optional
 
   def install
@@ -46,7 +31,7 @@ class Opentsdb < Formula
 
     env = {
       :HBASE_HOME => Formula["hbase"].opt_libexec,
-      :COMPRESSION => (build.with?("lzo") ? "LZO" : "NONE"),
+      :COMPRESSION => "LZO",
     }
     env = Language::Java.java_home_env("1.8").merge(env)
     create_table = pkgshare/"tools/create_table_with_env.sh"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

What do you think about making lzo mandatory instead of `:recommended` for hbase and opentsdb? This simplifies the formulae, removes one more formula option from homebrew-core, and lets opentsdb pass `brew audit --strict`.

The reason for it being optional was to support hbase and opentsdb on 32-bit systems. But since we now require Java 8 for them, they can't be installed on 32-bit systems anyway, so we're not losing anything. See #670.

No revision bump necessary, since this doesn't change the files present in the default installation.