### PR TITLE
mg: use Bintray as primary url and GitHub for the homepage

### DIFF
--- a/Formula/mg.rb
+++ b/Formula/mg.rb
@@ -1,7 +1,9 @@
 class Mg < Formula
   desc "Small Emacs-like editor"
-  homepage "https://devio.us/~bcallah/mg/"
-  url "https://devio.us/~bcallah/mg/mg-20180421.tar.gz"
+  # https://devio.us/~bcallah/mg/ is temporarily offline
+  homepage "https://github.com/ibara/mg"
+  # https://devio.us/~bcallah/mg/mg-20180421.tar.gz is temporarily offline
+  url "https://dl.bintray.com/homebrew/mirror/mg-20180421.tar.gz"
   sha256 "11215613a360cf72ff16c2b241ea4e71b4b80b2be32c62a770c1969599e663b2"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

until https://devio.us/~bcallah/mg/ comes back online