### PR TITLE
opencv: add missing static libs

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -98,6 +98,7 @@ class Opencv < Formula
       system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *args
       system "make"
       lib.install Dir["lib/*.a"]
+      lib.install Dir["3rdparty/**/*.a"]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm terribly sorry, my PR earlier today I overlooked that opencv also builds a few 3rd party libraries that are needed to statically link an application. 

This PR adds the missing `libippicv.a`, `libippiw.a`, and `libittnotify.a` to the bottle.