### PR TITLE
hub: depend on ruby at build time for Mountain Lion and below

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -18,6 +18,9 @@ class Hub < Formula
 
   depends_on "go" => :build
 
+  # The build needs Ruby 1.9 or higher.
+  depends_on "ruby" => :build if MacOS.version <= :mountain_lion
+
   def install
     if build.with? "docs"
       begin


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes

```
==> make man-pages
Last 15 lines from /Users/joe/Library/Logs/Homebrew/hub/02.make:
Fetching ffi 1.9.3
Installing ffi 1.9.3 with native extensions
NameError: undefined local variable or method `options' for
An error occurred while installing ffi (1.9.3), and Bundler cannot continue.
Make sure that `gem install ffi -v '1.9.3' --source 'https://rubygems.org/'` succeeds before
bundling.

In Gemfile:
  aruba was resolved to 0.5.4, which depends on
    childprocess was resolved to 0.5.3, which depends on
      ffi
Could not find ffi-1.9.3 in any of the sources
You need Ruby 1.9 or higher and Bundler to run hub tests
make: *** [bin/ronn] Error 1
```