### PR TITLE
Archey: fix bad `homebrew list` syntax

### DIFF
--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -3,7 +3,7 @@ class Archey < Formula
   homepage "https://obihann.github.io/archey-osx/"
   url "https://github.com/obihann/archey-osx/archive/1.6.0.tar.gz"
   sha256 "0f0ffcf8c5f07610b98f0351dcb38bb8419001f40906d5dc4bfd28ef12dbd0f8"
-  revision 1
+  revision 2
   head "https://github.com/obihann/archey-osx.git"
 
   bottle :unneeded
@@ -15,6 +15,9 @@ class Archey < Formula
   end
 
   def install
+    # Deal with homebrew syntax change, PR: https://github.com/obihann/archey-osx/pull/73
+    inreplace "bin/archey", "brew list -1", "brew list"
+
     bin.install "bin/archey"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Deal with homebrew syntax change, PR: https://github.com/obihann/archey-osx/pull/73