### PR TITLE
[libccd] Use correct option for double precision

### DIFF
--- a/Formula/libccd.rb
+++ b/Formula/libccd.rb
@@ -3,7 +3,7 @@ class Libccd < Formula
   homepage "http://libccd.danfis.cz/"
   url "https://github.com/danfis/libccd/archive/v2.0.tar.gz"
   sha256 "1b4997e361c79262cf1fe5e1a3bf0789c9447d60b8ae2c1f945693ad574f9471"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -15,14 +15,19 @@ class Libccd < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", "-DENABLE_DOUBLE_PRECISION=ON", *std_cmake_args
+    system "cmake", ".", "-DCCD_DOUBLE=ON", *std_cmake_args
     system "make", "install"
   end
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <cassert>
+      #include <ccd/config.h>
       #include <ccd/vec3.h>
       int main() {
+      #ifndef CCD_DOUBLE
+        assert(false);
+      #endif
         ccdVec3PointSegmentDist2(
           ccd_vec3_origin, ccd_vec3_origin,
           ccd_vec3_origin, NULL);

--- a/Formula/libccd.rb
+++ b/Formula/libccd.rb
@@ -21,7 +21,7 @@ class Libccd < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <cassert>
+      #include <assert.h>
       #include <ccd/config.h>
       #include <ccd/vec3.h>
       int main() {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The `libccd` version in this formulae is `v2.0`, and the correct option for double precision is `-DCCD_DOUBLE=ON`. `-DENABLE_DOUBLE_PRECISION=ON` is for the master branch, which is not released yet. (see: https://github.com/flexible-collision-library/fcl/issues/291#issuecomment-392869991)

cc @scpeters 