### PR TITLE
openssl@1.1 1.1.1-pre7 (devel)

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -14,8 +14,8 @@ class OpensslAT11 < Formula
   end
 
   devel do
-    url "https://www.openssl.org/source/openssl-1.1.1-pre6.tar.gz"
-    sha256 "01f91c5370fe210f7172d863c5bdc5dee2450c3faa98b4af2627ee6f7e128d87"
+    url "https://www.openssl.org/source/openssl-1.1.1-pre7.tar.gz"
+    sha256 "e4a54e1eba2900004a2e39cde62aeaf1f1fa0442169f849faf14e735136ad6cc"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

FYI, OpenSSL have [decided](https://www.openssl.org/blog/blog/2018/05/18/new-lts/) the 1.1.1 release will become the new LTS and support for 1.0.2 & 1.1.0 will not be extended beyond 2019.

In essence this confirms what we already suspected: Before December 31st 2019 Homebrew will need to transition everything over to `openssl@1.1` or risk being stuck indefinitely with an `openssl` no longer receiving security updates.