### PR TITLE
puppet-bolt 0.20.3 (new formula)

### DIFF
--- a/Formula/puppet-bolt.rb
+++ b/Formula/puppet-bolt.rb
@@ -1,0 +1,31 @@
+class PuppetBolt < Formula
+  desc "Utility to execute commands, scripts, and tasks on remote systems"
+  homepage "https://github.com/puppetlabs/bolt"
+  version "0.20.3"
+
+  if MacOS.version == :el_capitan
+    @image_name = "puppet-bolt-#{version}-1.osx10.11"
+    url "http://downloads.puppetlabs.com/mac/10.11/PC1/x86_64/#{@image_name}.dmg"
+    sha256 "d4cbc0a9c824cfa05dd540f7eaa5c036484bd651613a60ec7a929a22fb099441"
+  elsif MacOS.version == :sierra
+    @image_name = "puppet-bolt-#{version}-1.osx10.12"
+    url "http://downloads.puppetlabs.com/mac/10.12/PC1/x86_64/#{@image_name}.dmg"
+    sha256 "ca2407e8b258705d998b6d3143dcfb6d208a5453b02b09ab945ce5b21dd93d00"
+  elsif MacOS.version == :high_sierra
+    @image_name = "puppet-bolt-#{version}-1.osx10.13"
+    url "http://downloads.puppetlabs.com/mac/10.13/PC1/x86_64/#{@image_name}.dmg"
+    sha256 "d623713f352a318fcdbc105a03c87faa055190819b171f1604e5e147579be21a"
+  end
+
+  def install
+    system "hdiutil", "attach", "#{@image_name}.dmg"
+    # `installer` requires root, but this command doesn't succeed for me locally.
+    # I'm not sure what to do?
+    system "sudo", "installer", "-package", "/Volumes/#{@image_name}/puppet-bolt-#{version}-1-installer.pkg", "-target", "/"
+    system "hdiutil", "detach", "/Volumes/#{@image_name}"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("bolt --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **I'm having trouble with this since installer requires root**
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I apologize in advance -- I'm new to homebrew and am not native to Apple products, and know this PR probably breaks a number of formatting guidelines.

We originally proposed adding this package to homebrew-cask [here](https://github.com/Homebrew/homebrew-cask/pull/47600), and since it's an open source CLI tool they suggested we submit it here first. While it is indeed an open source CLI tool, we package it along with some gem dependencies and a minimum ruby version, so would really like to install from the `.dmg`.  We'll try to shoe-horn it in here, but it's already proving difficult.

Thank you for the consideration, and please let me know what you think we should do!