### PR TITLE
darcs: depend on ghc at build time

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -16,11 +16,15 @@ class Darcs < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.2" => :build
+  depends_on "ghc" => :build
   depends_on "gmp"
 
   def install
-    install_cabal_package
+    # GHC 8.4.x compatibility; remove the extra arguments for darcs > 2.14.0
+    install_cabal_package "--allow-newer=darcs:async",
+                          "--constraint", "async < 2.3",
+                          "--allow-newer=darcs:graphviz",
+                          "--constraint", "graphviz < 2999.20.1"
   end
 
   test do


### PR DESCRIPTION
instead of ghc@8.2


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/issues/25568