### PR TITLE
New formula: docker-credential-helper-ecr

### DIFF
--- a/Formula/docker-credential-helper-ecr.rb
+++ b/Formula/docker-credential-helper-ecr.rb
@@ -19,7 +19,7 @@ class DockerCredentialHelperEcr < Formula
   end
 
   test do
-    run_output = shell_output("#{bin}/docker-credential-ecr-login", 1)
-    assert_match %r{^Usage: .*/docker-credential-ecr-login.*}, run_output
+    output = shell_output("#{bin}/docker-credential-ecr-login", 1)
+    assert_match %r{^Usage: .*/docker-credential-ecr-login.*}, output
   end
 end

--- a/Formula/docker-credential-helper-ecr.rb
+++ b/Formula/docker-credential-helper-ecr.rb
@@ -3,7 +3,6 @@ class DockerCredentialHelperEcr < Formula
   homepage "https://github.com/awslabs/amazon-ecr-credential-helper"
   url "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.1.0.tar.gz"
   sha256 "fa8a1e442fea42aab777c318a0c211e5cfc4572cafe22cc0ac8d1fd23a271e50"
-  head "https://github.com/awslabs/amazon-ecr-credential-helper.git"
 
   depends_on "go" => :build
 

--- a/Formula/docker-credential-helper-ecr.rb
+++ b/Formula/docker-credential-helper-ecr.rb
@@ -1,0 +1,26 @@
+class DockerCredentialHelperEcr < Formula
+  desc "Docker Credential Helper for Amazon ECR"
+  homepage "https://github.com/awslabs/amazon-ecr-credential-helper"
+  url "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.1.0.tar.gz"
+  sha256 "fa8a1e442fea42aab777c318a0c211e5cfc4572cafe22cc0ac8d1fd23a271e50"
+  head "https://github.com/awslabs/amazon-ecr-credential-helper.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/awslabs/amazon-ecr-credential-helper"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "build"
+      bin.install "bin/local/docker-credential-ecr-login"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/docker-credential-ecr-login", 1)
+    assert_match %r{^Usage: .*/docker-credential-ecr-login.*}, run_output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Follow-up from #18914. Repository: https://github.com/awslabs/amazon-ecr-credential-helper