### PR TITLE
vice 3.2

### DIFF
--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -16,10 +16,10 @@ class Vice < Formula
   head do
     url "https://svn.code.sf.net/p/vice-emu/code/trunk/vice"
 
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
   depends_on "yasm" => :build


### PR DESCRIPTION
- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a version bump to the latest release of VICE. 

There is also a rework of the way the Formula operates. It installs everything in /usr/local/bin/ as expected without building app bundles as the previous build did. 

Also added is the ability to build the new GTK+3 based UI from VICE's Subversion trunk.