### PR TITLE
libimagequant 2.12.1 (new formula)

### DIFF
--- a/Formula/libimagequant.rb
+++ b/Formula/libimagequant.rb
@@ -1,0 +1,30 @@
+class Libimagequant < Formula
+  desc "Palette quantization library extracted from pnquant2"
+  homepage "https://pngquant.org/lib/"
+  url "https://github.com/ImageOptim/libimagequant/archive/2.12.1.tar.gz"
+  sha256 "7035eb281bc9a49cf36db8db807b713d03a0ffe8c5abfbb17a9ea8a038f21d5e"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libimagequant.h>
+
+      int main()
+      {
+        liq_attr *attr = liq_attr_create();
+        if (!attr) {
+          return 1;
+        } else {
+          liq_attr_destroy(attr);
+          return 0;
+        }
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-limagequant", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This adds libimagequant which was extracted from pngquant2 as a separate formula and supercedes PR #27788.

In comparison to #27788 this PR uses the standalone github repo for libimagequant as the source instead of installing the vendored copy that's shipped with the pngquant2 source.

~~The Makefile is hand-rolled and required a few workaround to work correctly on macOS. I hope to get the required changes integrated upstream soon.~~ No longer needed, changes integrated upstream, see:

* ImageOptim/libimagequant#22
* ImageOptim/libimagequant#23
* ImageOptim/libimagequant#24

This library is useful for tools like Python's Pillow which want to support high quality RGBA to 8-Bit + alpha paletted PNG without depending on forking out to pngquant or similar tools to do the job.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----