### PR TITLE
shellcheck 0.5.0

### DIFF
--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -5,8 +5,8 @@ class Shellcheck < Formula
 
   desc "Static analysis and lint tool, for (ba)sh scripts"
   homepage "https://www.shellcheck.net/"
-  url "https://github.com/koalaman/shellcheck/archive/v0.4.7.tar.gz"
-  sha256 "3fd7ebec821b96585ba9137b7b8c7bd9410876490f4ec89f2cca9975080a8206"
+  url "https://github.com/koalaman/shellcheck/archive/v0.5.0.tar.gz"
+  sha256 "348a3f7892c1f28a44f188c00ac82f1b3bf899d9f81d14ddb0e306db26c937bb"
   head "https://github.com/koalaman/shellcheck.git"
 
   bottle do
@@ -17,7 +17,7 @@ class Shellcheck < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.2" => :build
+  depends_on "ghc" => :build
   depends_on "pandoc" => :build
 
   def install


### PR DESCRIPTION
depend on ghc at build time instead of ghc@8.2


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/koalaman/shellcheck/issues/1157
https://github.com/Homebrew/homebrew-core/issues/25568