### PR TITLE
hadolint: depend on ghc at build time

### DIFF
--- a/Formula/hadolint.rb
+++ b/Formula/hadolint.rb
@@ -16,7 +16,7 @@ class Hadolint < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.2" => :build
+  depends_on "ghc" => :build
 
   def install
     cabal_sandbox do


### PR DESCRIPTION
instead of ghc@8.2


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/issues/25568
https://github.com/koalaman/shellcheck/issues/1157