### PR TITLE
platformio 3.5.3

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/7c/95/899efc1264c63d1ba1d32b4160b2fe3d48020de00f7b8c91dc5b712aa05f/platformio-3.5.2.tar.gz"
-  sha256 "bb311ce5b8f12c95bc45c2071626a4887a3632fb2472b4d69a873b2acfc2e4ec"
+  url "https://files.pythonhosted.org/packages/eb/6f/378c272c27309b3b862b8544dba81f220f682e8fb2155bd142ece4e99c86/platformio-3.5.3.tar.gz"
+  sha256 "21809f0d7e7ab368946dc3b939bca03992bfe3bfeaa759d53107a61b60179ad0"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,8 +21,8 @@ class Platformio < Formula
   end
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz"
-    sha256 "edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+    url "https://files.pythonhosted.org/packages/4d/9c/46e950a6f4d6b4be571ddcae21e7bc846fcbb88f1de3eff0f6dd0a6be55d/certifi-2018.4.16.tar.gz"
+    sha256 "13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
   end
 
   resource "chardet" do


### PR DESCRIPTION
* [PlatformIO Home](http://docs.platformio.org/page/home/index.html) - interact with PlatformIO ecosystem using modern and cross-platform GUI:
  - "Recent News" block on "Welcome" page
  - Direct import of development platform's example
* Simplify configuration for [PIO Unit Testing](http://docs.platformio.org/page/plus/unit-testing.html): separate main program from a test build process, drop requirement for ``#ifdef UNIT_TEST`` guard
* Override any option from board manifest in [Project Configuration File "platformio.ini"](http://docs.platformio.org/page/projectconf/section_env_board.html#more-options) ([issue #1612](https://github.com/platformio/platformio-core/issues/1612))
* Configure a custom path to SVD file using [debug_svd_path](http://docs.platformio.org/page/projectconf/section_env_debug.html#debug-svd-path) option
* Custom project [description](http://docs.platformio.org/en/latest/projectconf/section_platformio.html#description) which will be used by [PlatformIO Home](http://docs.platformio.org/page/home/index.html)
* Updated Unity tool to 2.4.3
* Improved support for Black Magic Probe in "uploader" mode
* Renamed "monitor_baud" option to "monitor_speed"
* Fixed issue when a custom [lib_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#lib-dir) was not handled correctly ([issue #1473](https://github.com/platformio/platformio-core/issues/1473))
* Fixed issue with useless project rebuilding for case insensitive file systems (Windows)
* Fixed issue with ``build_unflags`` option when a macro contains value (e.g., ``-DNAME=VALUE``)
* Fixed issue which did not allow to override runtime build environment using extra POST script
* Fixed "RuntimeError: maximum recursion depth exceeded" for library manager ([issue #1528](https://github.com/platformio/platformio-core/issues/1528))