### PR TITLE
php: Add patch for bad system lib linking

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -10,6 +10,12 @@ class Php < Formula
     sha256 "2caaa197e42d56794f44d1bfc71363b435920cfe5fdafb6f64af3812e58ceb00" => :el_capitan
   end
 
+  # Bad system lib linking: https://bugs.php.net/bug.php?id=76403
+  patch do
+    url "https://gist.githubusercontent.com/kabel/910ab767aba08cc450b32efc7ffac549/raw/484a5692ddd53ef9bad9e030860fb9fc99d9f47b/acinclude-macos.patch"
+    sha256 "6969363b717d4d70c434fe898cca53516e48299b5d5a9345869adf2dfb25138b"
+  end
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -41,6 +47,9 @@ class Php < Formula
     if MacOS.version == :el_capitan || MacOS.version == :sierra
       ENV["SDKROOT"] = MacOS.sdk_path
     end
+
+    # Bad system lib linking: https://bugs.php.net/bug.php?id=76403
+    system "./buildconf", "--force"
 
     inreplace "configure" do |s|
       s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Patch requires buildconf to be run to regenerate the configure script.

Fixes #28398.