### PR TITLE
agda 2.5.4

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -5,15 +5,14 @@ class Agda < Formula
 
   desc "Dependently typed functional programming language"
   homepage "http://wiki.portal.chalmers.se/agda/"
-  revision 3
 
   stable do
-    url "https://hackage.haskell.org/package/Agda-2.5.3/Agda-2.5.3.tar.gz"
-    sha256 "aa14d4a3582013100f71e64d71c5deff6caa2a286083e20fc16f6dbb0fdf0065"
+    url "https://hackage.haskell.org/package/Agda-2.5.4/Agda-2.5.4.tar.gz"
+    sha256 "b40971e3312461771e36a11aaf4002424178301cf315b21a679f527b79c09e09"
 
     resource "stdlib" do
       url "https://github.com/agda/agda-stdlib.git",
-          :revision => "c06437e4ebb5365d502fb0a79775e5c591ab8ae5" # v0.15
+          :revision => "209626953d56294e9bd3d8892eda43b844b0edf9"
     end
   end
 
@@ -31,18 +30,18 @@ class Agda < Formula
     end
   end
 
-  deprecated_option "without-ghc" => "without-ghc@8.2"
-  deprecated_option "without-malonzo" => "without-ghc@8.2"
+  deprecated_option "without-ghc@8.2" => "without-ghc"
+  deprecated_option "without-malonzo" => "without-ghc"
 
   option "without-stdlib", "Don't install the Agda standard library"
-  option "without-ghc@8.2", "Disable the GHC backend"
+  option "without-ghc", "Disable the GHC backend"
 
-  depends_on "ghc@8.2" => :recommended
-  if build.with? "ghc@8.2"
+  depends_on "ghc" => :recommended
+  if build.with? "ghc"
     depends_on "cabal-install" => [:build, :test]
   else
     depends_on "cabal-install" => :build
-    depends_on "ghc@8.2" => :build
+    depends_on "ghc" => :build
   end
 
   depends_on "emacs" => :recommended
@@ -167,8 +166,7 @@ class Agda < Formula
     system bin/"agda", "--js", simpletest
 
     # test the GHC backend
-    if build.with? "ghc@8.2"
-      ENV.prepend_path "PATH", Formula["ghc@8.2"].opt_bin
+    if build.with? "ghc"
       cabal_sandbox do
         cabal_install "text", "ieee754"
         dbpath = Dir["#{testpath}/.cabal-sandbox/*-packages.conf.d"].first


### PR DESCRIPTION
depend on ghc at build time instead of ghc@8.2


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/issues/25568

CC @mietek