### PR TITLE
shadowsocks-libev: <Enable TCP fast open by default.>

### DIFF
--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -42,7 +42,7 @@ class ShadowsocksLibev < Formula
     system "make", "install"
   end
 
-  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json -u"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json --fast-open -u"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
@@ -56,6 +56,7 @@ class ShadowsocksLibev < Formula
           <string>#{opt_bin}/ss-local</string>
           <string>-c</string>
           <string>#{etc}/shadowsocks-libev.json</string>
+          <string>--fast-open</string>
           <string>-u</string>
         </array>
         <key>RunAtLoad</key>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

# Enable TCP fast open by default for shadowsocks-libev client.

# Reason

1. The shadowsocks-libev server program ss-server and client program ss-local support tcp-fast-open.
2. Many server programs (usually running on a remote Linux server) have this option (tcp fast open) enabled by default.
3. macOS supports tcp fast open out of box. If you run `sysctl net | grep fastopen` on macOS terminal, you will see `net.inet.tcp.fastopen: 3`.
4. The client (running on macOS, ss-local) should enable this option by default to reduce the delay.
5. If the server does not enable tcp fast open, it will not affect the client (ss-local).
6. However, if the server has enabled this option and the client is not enabled, it is a waste in some way.