### PR TITLE
trafficserver: fails with clang 800 for head build

### DIFF
--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -1,8 +1,13 @@
 class Trafficserver < Formula
   desc "HTTP/1.1 compliant caching proxy server"
   homepage "https://trafficserver.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-7.1.3.tar.bz2"
-  sha256 "41c7e02ab55cb478222ef2259e918b89e5d1ef9778d7fa1d0ec492b26944d420"
+
+  stable do
+    url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-7.1.3.tar.bz2"
+    sha256 "41c7e02ab55cb478222ef2259e918b89e5d1ef9778d7fa1d0ec492b26944d420"
+
+    needs :cxx11
+  end
 
   bottle do
     sha256 "34d24867b84b672d3ba4c07066c15b2db0ee3fab29469e916f54728c808f4200" => :high_sierra
@@ -16,6 +21,11 @@ class Trafficserver < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool"  => :build
+
+    fails_with :clang do
+      build 800
+      cause "needs C++17"
+    end
   end
 
   option "with-experimental-plugins", "Enable experimental plugins"
@@ -23,10 +33,8 @@ class Trafficserver < Formula
   depends_on "openssl"
   depends_on "pcre"
 
-  needs :cxx11
-
   def install
-    ENV.cxx11
+    ENV.cxx11 if build.stable?
 
     # Needed for OpenSSL headers
     if MacOS.version <= :lion


### PR DESCRIPTION
--HEAD needs C++17


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

CC @rottegift