### PR TITLE
rubberband: fix versioned dylib installation

### DIFF
--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -3,6 +3,7 @@ class Rubberband < Formula
   homepage "https://breakfastquay.com/rubberband/"
   url "https://breakfastquay.com/files/releases/rubberband-1.8.2.tar.bz2"
   sha256 "86bed06b7115b64441d32ae53634fcc0539a50b9b648ef87443f936782f6c3ca"
+  revision 1
   head "https://bitbucket.org/breakfastquay/rubberband/", :using => :hg
 
   bottle do
@@ -18,8 +19,12 @@ class Rubberband < Formula
 
   def install
     system "make", "-f", "Makefile.osx"
+    # HACK: Manual install because "make install" is broken
+    # https://github.com/Homebrew/homebrew-core/issues/28660
     bin.install "bin/rubberband"
-    lib.install "lib/librubberband.dylib"
+    lib.install "lib/librubberband.dylib" => "librubberband.2.1.1.dylib"
+    lib.install_symlink lib/"librubberband.2.1.1.dylib" => "librubberband.2.dylib"
+    lib.install_symlink lib/"librubberband.2.1.1.dylib" => "librubberband.dylib"
     include.install "rubberband"
 
     cp "rubberband.pc.in", "rubberband.pc"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/28660

This revised manual installation mimics the results of rubberband's `make install`, providing so-versioned dylibs.

This is intended as a temporary workaround; hopefully upstream will provide a fixed `make install` target we can use. https://bitbucket.org/breakfastquay/rubberband/issues/24/macos-install-target-depends-on-all-not