### PR TITLE
emacs: run daemon in foreground

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -129,7 +129,7 @@ class Emacs < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/emacs</string>
-        <string>--daemon</string>
+        <string>--fg-daemon</string>
       </array>
       <key>RunAtLoad</key>
       <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Finally, Emacs 26 has the option to start the daemon in the foreground instead of forking the process. According to the [changelog](https://www.gnu.org/software/emacs/news/NEWS.26.1):


>** New option '--fg-daemon'.  This is the same as '--daemon', except
it runs in the foreground and does not fork.  This is intended for
modern init systems such as systemd, which manage many of the traditional
aspects of daemon behavior themselves.  '--bg-daemon' is now an alias
for '--daemon'.

This feature is much needed indeed as launchd loses control after starting the service with the `--daemon` option:

```
$ brew services start emacs

$ ps -ax | grep Emacs
64261 ??         0:10.24 /usr/local/Cellar/emacs/26.1_1/Emacs.app/Contents/MacOS/Emacs --bg-daemon=\0123,4\012
$ brew services stop emacs
Stopping `emacs`... (might take a while)
==> Successfully stopped `emacs` (label: homebrew.mxcl.emacs)
$ ps -ax | grep Emacs
64261 ??         0:10.24 /usr/local/Cellar/emacs/26.1_1/Emacs.app/Contents/MacOS/Emacs --bg-daemon=\0123,4\012

# Emacs still there!
$ brew services stop emacs
Error: Service `emacs` is not started.
```

Fortunately `--fg-daemon` fixes this. After the proposed change, when the stop command is called, launchd properly kills the daemon:

```
$ brew services start emacs
==> Successfully started `emacs` (label: homebrew.mxcl.emacs)

$ ps -ax | grep Emacs
65797 ??         0:08.01 /usr/local/Cellar/emacs/26.1_1/Emacs.app/Contents/MacOS/Emacs --fg-daemon
$ brew services stop emacs
Stopping `emacs`... (might take a while)
==> Successfully stopped `emacs` (label: homebrew.mxcl.emacs)
$ ps -ax | grep Emacs
$ brew services stop emacs
Error: Service `emacs` is not started.
```

This means that `stop` and `restart` commands will finally work as expected. 😌