### PR TITLE
Eclipse Vert.x 3.5.2

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.1-full.tar.gz"
-  sha256 "a0809a04e62060d737f1784bdbbfd08e9baf38eb7931cfc69e8136f8da5fb3fd"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.2-full.tar.gz"
+  sha256 "c9815434c9fc9474ec8eef4ef171c96f454fb08c2728ec855592ecbabb348e0b"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the vert.x formula to 3.5.2.

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
