### PR TITLE
Rename cdiff to ydiff

### DIFF
--- a/Formula/ydiff.rb
+++ b/Formula/ydiff.rb
@@ -6,8 +6,6 @@ class Ydiff < Formula
 
   bottle :unneeded
 
-  depends_on "python@2"
-
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
     system "python", *Language::Python.setup_install_args(libexec)

--- a/Formula/ydiff.rb
+++ b/Formula/ydiff.rb
@@ -1,15 +1,12 @@
-class Cdiff < Formula
+class Ydiff < Formula
   desc "View colored diff with side by side and auto pager support"
-  homepage "https://github.com/ymattw/cdiff"
-  url "https://github.com/ymattw/cdiff/archive/1.0.tar.gz"
-  sha256 "d9aa95299973cf25cba9d62a41df845ec4c5d391b9aca4d84f32fcefecccd846"
-  head "https://github.com/ymattw/cdiff.git"
+  homepage "https://github.com/ymattw/ydiff"
+  url "https://github.com/ymattw/ydiff/archive/1.1.tar.gz"
+  sha256 "4c749204d1368557e74392845de22155201484edb2fdb5f97730cd6282c2dcca"
 
   bottle :unneeded
 
   depends_on "python@2"
-
-  conflicts_with "colordiff", :because => "both install `cdiff` binaries"
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
@@ -21,6 +18,6 @@ class Cdiff < Formula
   test do
     diff_fixture = test_fixtures("test.diff").read
     assert_equal diff_fixture,
-      pipe_output("#{bin}/cdiff -cnever", diff_fixture)
+      pipe_output("#{bin}/ydiff -cnever", diff_fixture)
   end
 end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -24,6 +24,7 @@
   "camlistore": "perkeep",
   "cassandra21": "cassandra@2.1",
   "cassandra22": "cassandra@2.2",
+  "cdiff": "ydiff",
   "clang-format38": "clang-format@3.8",
   "cloog-ppl015": "cloog@0.15",
   "cloog018": "cloog",


### PR DESCRIPTION
Per user request I renamed the package to ydiff to avoid binary name
conflict on major Linux distributions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
