### PR TITLE
python: Fix building from sources

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -21,7 +21,6 @@ class Python < Formula
   deprecated_option "with-brewed-tk" => "with-tcl-tk"
 
   depends_on "pkg-config" => :build
-  depends_on "sphinx-doc" => :build
   depends_on "gdbm"
   depends_on "openssl"
   depends_on "readline"
@@ -189,7 +188,8 @@ class Python < Formula
     end
 
     cd "Doc" do
-      system "make", "html"
+      system "make", "venv", "PYTHON=#{bin}/python3"
+      system "make", "html", "PYTHON=#{bin}/python3"
       doc.install Dir["build/html/*"]
     end
 


### PR DESCRIPTION
New process absolutely requires custom venv for docs.

See https://devguide.python.org/documenting/#using-make-make-bat