### PR TITLE
Debian: handle alioth's demise

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -2,9 +2,8 @@
 # with 3.2.57. If you've upgraded bash, use bash-completion@2 instead.
 class BashCompletion < Formula
   desc "Programmable completion for Bash 3.2"
-  homepage "https://bash-completion.alioth.debian.org/"
-  url "https://bash-completion.alioth.debian.org/files/bash-completion-1.3.tar.bz2"
-  mirror "https://src.fedoraproject.org/repo/pkgs/bash-completion/bash-completion-1.3.tar.bz2/a1262659b4bbf44dc9e59d034de505ec/bash-completion-1.3.tar.bz2"
+  homepage "https://salsa.debian.org/debian/bash-completion"
+  url "https://src.fedoraproject.org/repo/pkgs/bash-completion/bash-completion-1.3.tar.bz2/a1262659b4bbf44dc9e59d034de505ec/bash-completion-1.3.tar.bz2"
   sha256 "8ebe30579f0f3e1a521013bcdd183193605dab353d7a244ff2582fb3a36f7bec"
   revision 3
 
@@ -19,15 +18,13 @@ class BashCompletion < Formula
   conflicts_with "bash-completion@2", :because => "Differing version of same formula"
 
   # Backports the following upstream patch from 2.x:
-  # https://anonscm.debian.org/gitweb/?p=bash-completion/bash-completion.git;a=commitdiff_plain;h=50ae57927365a16c830899cc1714be73237bdcb2
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740971
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/c1d87451da3b5b147bed95b2dc783a1b02520ac5/bash-completion/bug-740971.patch"
     sha256 "bd242a35b8664c340add068bcfac74eada41ed26d52dc0f1b39eebe591c2ea97"
   end
 
-  # Backports (a variant of) the following upstream patch to fix man completion:
-  # https://anonscm.debian.org/cgit/bash-completion/bash-completion.git/patch/completions/man?id=fb2d657fac6be93a1c4ffa76018d8042859e0a03
+  # Backports (a variant of) an upstream patch to fix man completion.
   patch :DATA
 
   def install

--- a/Formula/libhid.rb
+++ b/Formula/libhid.rb
@@ -1,6 +1,6 @@
 class Libhid < Formula
   desc "Library to access and interact with USB HID devices"
-  homepage "https://libhid.alioth.debian.org/"
+  homepage "https://directory.fsf.org/wiki/Libhid"
   url "http://distcache.freebsd.org/ports-distfiles/libhid-0.2.16.tar.gz"
   sha256 "f6809ab3b9c907cbb05ceba9ee6ca23a705f85fd71588518e14b3a7d9f2550e5"
 

--- a/Formula/logcheck.rb
+++ b/Formula/logcheck.rb
@@ -1,6 +1,6 @@
 class Logcheck < Formula
   desc "Mail anomalies in the system logfiles to the administrator"
-  homepage "https://logcheck.alioth.debian.org/"
+  homepage "https://packages.debian.org/sid/logcheck"
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
   sha256 "06294c092b2115eca3d054c57778718c91dd2e0fd1c46650b7343c2a92672ca9"

--- a/Formula/minicom.rb
+++ b/Formula/minicom.rb
@@ -1,7 +1,8 @@
 class Minicom < Formula
   desc "Menu-driven communications program"
-  homepage "https://alioth.debian.org/projects/minicom/"
-  url "https://alioth.debian.org/frs/download.php/file/4215/minicom-2.7.1.tar.gz"
+  homepage "https://packages.debian.org/sid/minicom"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minicom/minicom_2.7.1.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/minicom/minicom_2.7.1.orig.tar.gz"
   sha256 "532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1"
 
   bottle do

--- a/Formula/pcsc-lite.rb
+++ b/Formula/pcsc-lite.rb
@@ -1,7 +1,7 @@
 class PcscLite < Formula
   desc "Middleware to access a smart card using SCard API"
-  homepage "https://pcsclite.alioth.debian.org"
-  url "https://alioth.debian.org/frs/download.php/file/4235/pcsc-lite-1.8.23.tar.bz2"
+  homepage "https://pcsclite.apdu.fr/"
+  url "https://pcsclite.apdu.fr/files/pcsc-lite-1.8.23.tar.bz2"
   sha256 "5a27262586eff39cfd5c19aadc8891dd71c0818d3d629539bd631b958be689c9"
 
   bottle do

--- a/Formula/pinfo.rb
+++ b/Formula/pinfo.rb
@@ -1,7 +1,7 @@
 class Pinfo < Formula
   desc "User-friendly, console-based viewer for Info documents"
-  homepage "https://alioth.debian.org/projects/pinfo/"
-  url "https://alioth.debian.org/frs/download.php/file/3351/pinfo-0.6.10.tar.bz2"
+  homepage "https://packages.debian.org/sid/pinfo"
+  url "https://mirrorservice.org/sites/distfiles.macports.org/pinfo/pinfo-0.6.10.tar.bz2"
   sha256 "122180a0c23d11bc9eb569a4de3ff97d3052af96e32466fa62f2daf46ff61c5d"
 
   bottle do

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -1,12 +1,11 @@
 class SaneBackends < Formula
   desc "Backends for scanner access"
   homepage "http://www.sane-project.org/"
-  url "https://alioth.debian.org/frs/download.php/file/4224/sane-backends-1.0.27.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+  url "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   revision 4
-  head "https://anonscm.debian.org/cgit/sane/sane-backends.git"
+  head "https://salsa.debian.org/debian/sane-backends.git"
 
   bottle do
     sha256 "687b773de141d0d79fbf16d882be2066a2fcdf4056ba86803fb40669752e2c79" => :high_sierra

--- a/Formula/surfraw.rb
+++ b/Formula/surfraw.rb
@@ -1,7 +1,7 @@
 class Surfraw < Formula
   desc "Shell Users' Revolutionary Front Rage Against the Web"
-  homepage "https://surfraw.alioth.debian.org/"
-  url "https://surfraw.alioth.debian.org/dist/surfraw-2.3.0.tar.gz"
+  homepage "https://packages.debian.org/sid/surfraw"
+  url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/surfraw-2.3.0.tar.gz"
   sha256 "ad0420583c8cdd84a31437e59536f8070f15ba4585598d82638b950e5c5c3625"
 
   bottle do
@@ -11,15 +11,7 @@ class Surfraw < Formula
     sha256 "69920395cbde5fdc2492aa27fc765d4dafe910e26d9d3a05777888425310a0a9" => :el_capitan
   end
 
-  head do
-    url "https://anonscm.debian.org/git/surfraw/surfraw.git", :shallow => false
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
-
   def install
-    system "./prebuild" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--with-graphical-browser=open"

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -144,8 +144,7 @@ class Wine < Formula
   end
 
   resource "sane-backends" do
-    url "https://alioth.debian.org/frs/download.php/file/4224/sane-backends-1.0.27.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+    url "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
     mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
     sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-----

Well this is fun. It's been coming for a while but a bunch of upstreams nonetheless have just... vanished, or moved. FWIW, `libhid` is left out because I cannot find a new homepage for it anywhere, not even a Debian packages reference to point at.

```
Hi, 

after more than two years of preperation I am happy to say that
alioth is history now. I finished the archiving of all vcs repos
yesterday - they are now archived [1]. 

SSH logins on alioth are now disabled, if you find that you are missing
something and think it is *really* urgent - get in touch with me and I should
be able to help you. In a few days we will shutdown and delete the vm. 

The redirector was moved to a DSA managed box, updates to the map will still
happen, but only once a week. 

Whats left?

- deleting the vm
- remove alioth from our docs
- update vcs entries in packages
- improve the salsa docs
- deploy the new sso.debian.org backend

Thats it folks

Thanks to all helping hands

especially ganneff and waldi

Alex - former alioth admin
```