### PR TITLE
flake8: depends on `python` instead of `python@2`

### DIFF
--- a/Formula/flake8.rb
+++ b/Formula/flake8.rb
@@ -15,10 +15,10 @@ class Flake8 < Formula
     sha256 "cfbc382496c31b5c57e31ac2487d022a07673d9efd2d64cbc956d3e05c8d9afe" => :el_capitan
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   def install
-    venv = virtualenv_create(libexec)
+    venv = virtualenv_create(libexec, "python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name
@@ -26,6 +26,7 @@ class Flake8 < Formula
   end
 
   test do
-    system "#{bin}/flake8", "#{libexec}/lib/python2.7/site-packages/flake8"
+    xy = Language::Python.major_minor_version "python3"
+    system "#{bin}/flake8", "#{libexec}/lib/python#{xy}/site-packages/flake8"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
