### PR TITLE
libimobiledevice: Adds --with-debug-code option

### DIFF
--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -27,14 +27,25 @@ class Libimobiledevice < Formula
   depends_on "usbmuxd"
   depends_on "openssl"
 
+  option "with-debug-code", "Enables debug message reporting in library"
+
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          # As long as libplist builds without Cython
-                          # bindings, libimobiledevice must as well.
-                          "--without-cython"
+
+    args = [
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      # As long as libplist builds without Cython
+      # bindings, libimobiledevice must as well.
+      "--without-cython"
+    ]
+
+    if build.with? "debug-code"
+      args << "--enable-debug-code"
+    end
+
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -21,13 +21,13 @@ class Libimobiledevice < Formula
     depends_on "libxml2"
   end
 
+  option "with-debug-code", "Enables debug message reporting in library"
+
   depends_on "pkg-config" => :build
   depends_on "libtasn1"
   depends_on "libplist"
   depends_on "usbmuxd"
   depends_on "openssl"
-
-  option "with-debug-code", "Enables debug message reporting in library"
 
   def install
     system "./autogen.sh" if build.head?
@@ -38,7 +38,7 @@ class Libimobiledevice < Formula
       "--prefix=#{prefix}",
       # As long as libplist builds without Cython
       # bindings, libimobiledevice must as well.
-      "--without-cython"
+      "--without-cython",
     ]
 
     if build.with? "debug-code"

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -3,7 +3,7 @@ class Libimobiledevice < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://www.libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
   sha256 "786b0de0875053bf61b5531a86ae8119e320edab724fc62fe2150cc931f11037"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -21,8 +21,6 @@ class Libimobiledevice < Formula
     depends_on "libxml2"
   end
 
-  option "with-debug-code", "Enables debug message reporting in library"
-
   depends_on "pkg-config" => :build
   depends_on "libtasn1"
   depends_on "libplist"
@@ -31,21 +29,13 @@ class Libimobiledevice < Formula
 
   def install
     system "./autogen.sh" if build.head?
-
-    args = [
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}",
-      # As long as libplist builds without Cython
-      # bindings, libimobiledevice must as well.
-      "--without-cython",
-    ]
-
-    if build.with? "debug-code"
-      args << "--enable-debug-code"
-    end
-
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          # As long as libplist builds without Cython
+                          # bindings, libimobiledevice must as well.
+                          "--without-cython",
+                          "--enable-debug-code"
     system "make", "install"
   end
 


### PR DESCRIPTION
Allows to pass --enable-debug-code to libimobiledevice, so --debug flag works.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
