### PR TITLE
Python: set flags for CLT on 10.14

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -94,15 +94,21 @@ class Python < Formula
     ldflags  = []
     cppflags = []
 
-    unless MacOS::CLT.installed?
+    if !MacOS::CLT.installed? || MacOS.version == :mojave
+      if !MacOS::CLT.installed?
+        sdk_path = MacOS.sdk_path
+      else
+        sdk_path = "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX10.14.sdk"
+      end
+
       # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-      cflags   << "-isysroot #{MacOS.sdk_path}"
-      ldflags  << "-isysroot #{MacOS.sdk_path}"
-      cppflags << "-I#{MacOS.sdk_path}/usr/include" # find zlib
+      cflags  << "-isysroot #{sdk_path}"
+      cflags  << "-I/usr/include" # find zlib
+      ldflags << "-isysroot #{sdk_path}"
       # For the Xlib.h, Python needs this header dir with the system Tk
       if build.without? "tcl-tk"
-        cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+        cflags << "-I/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
       end
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html

--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -103,15 +103,21 @@ class PythonAT2 < Formula
     ldflags  = []
     cppflags = []
 
-    unless MacOS::CLT.installed?
+    if !MacOS::CLT.installed? || MacOS.version == :mojave
+      if !MacOS::CLT.installed?
+        sdk_path = MacOS.sdk_path
+      else
+        sdk_path = "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX10.14.sdk"
+      end
+
       # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-      cflags   << "-isysroot #{MacOS.sdk_path}"
-      ldflags  << "-isysroot #{MacOS.sdk_path}"
-      cppflags << "-I#{MacOS.sdk_path}/usr/include" # find zlib
+      cflags  << "-isysroot #{sdk_path}"
+      cflags  << "-I/usr/include" # find zlib
+      ldflags << "-isysroot #{sdk_path}"
       # For the Xlib.h, Python needs this header dir with the system Tk
       if build.without? "tcl-tk"
-        cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+        cflags << "-I/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This helps Python find certain of its dependencies, in particular zlib. It's very similar to the Xcode-only flags, since the current version of the CLT is missing headers in `/usr/include` and in the system frameworks. I have a radar open for that.

We might not necessarily want to merge this as-is, but I opened it as documentation.

cc @ilovezfs 