### PR TITLE
bochs 2.6.9: fix error enabling gdb stub

### DIFF
--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -51,7 +51,6 @@ class Bochs < Formula
       --enable-clgd54xx
       --enable-avx
       --enable-vmx=2
-      --enable-smp
       --enable-long-phy-address
       --with-term
     ]
@@ -62,6 +61,7 @@ class Bochs < Formula
       args << "--enable-gdb-stub"
     else
       args << "--enable-debugger"
+      args << "--enable-smp"
     end
 
     system "./configure", *args


### PR DESCRIPTION
There is a conflict between the option "--enable-gdb-stub" and "--enable-smp".

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Installing bochs with the parameter "--with-gdb-stub" will lead to this error.

error log:
```
../../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.In file included from init.cc:24:
../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
In file included from avx.cc:25:
../../bochs.h:414:2: In file included from devices.cc:26error:
: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
 ^

#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check. ^

 ^
In file included from ./iodev.h:28:
../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
 ^
1 error generated.
make[1]: *** [devices.o] Error 1
make: *** [iodev/libiodev.a] Error 2
make: *** Waiting for unfinished jobs....
clang++ -c -I.. -I../.. -I./.. -I./../.. -I../../instrument/stubs -I./../../instrument/stubs -fpascal-strings -fno-common -Wno-four-char-constants -Wno-unknown-pragmas -Dmacintosh -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES   avx_pfp.cc -o avx_pfp.o
1 error generated.
make[1]: *** [intel/pentium.o] Error 1
make: *** [cpu/cpudb/libcpudb.a] Error 2
clang++ -c -I.. -I./.. -I../instrument/stubs -I./../instrument/stubs -fpascal-strings -fno-common -Wno-four-char-constants -Wno-unknown-pragmas -Dmacintosh -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES   cpu.cc -o cpu.o
1 error generated.
make[1]: *** [init.o] Error 1
make[1]: *** Waiting for unfinished jobs....
clang++ -c -I.. -I../.. -I./.. -I./../.. -I../../instrument/stubs -I./../../instrument/stubs -fpascal-strings -fno-common -Wno-four-char-constants -Wno-unknown-pragmas -Dmacintosh -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES   avx_cvt.cc -o avx_cvt.o
1 error generated.
make[1]: *** [avx.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from avx_pfp.cc:25:
../../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
 ^
In file included from cpu.cc:23:
../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
 ^
In file included from avx_cvt.cc:25:
../../bochs.h:414:2: error: GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
#error GDB stub was written for single processor support.  If multiprocessor support is added, then we can remove this check.
 ^
1 error generated.
make[1]: *** [cpu.o] Error 1
make: *** [cpu/libcpu.a] Error 2
1 error generated.
make[1]: *** [avx_pfp.o] Error 1
1 error generated.
make[1]: *** [avx_cvt.o] Error 1
make: *** [cpu/avx/libavx.a] Error 2
```