### PR TITLE
Rubocop 0.57.1 style fixes

### DIFF
--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -37,7 +37,7 @@ class Activemq < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/aiccu.rb
+++ b/Formula/aiccu.rb
@@ -66,7 +66,7 @@ class Aiccu < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/aircrack-ng.rb
+++ b/Formula/aircrack-ng.rb
@@ -33,7 +33,7 @@ class AircrackNg < Formula
 
   def caveats; <<~EOS
     Run `airodump-ng-oui-update` install or update the Airodump-ng OUI file.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/alluxio.rb
+++ b/Formula/alluxio.rb
@@ -18,7 +18,7 @@ class Alluxio < Formula
   def caveats; <<~EOS
     To configure alluxio, edit
       #{etc}/alluxio/alluxio-env.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -31,7 +31,7 @@ class AmqpCpp < Formula
       {
         return 0;
       }
-      EOS
+    EOS
     system ENV.cxx, "test.cpp", "-std=c++11", "-L#{lib}", "-o",
                     "test", "-lc++", "-lamqpcpp"
     system "./test"

--- a/Formula/ansible@1.9.rb
+++ b/Formula/ansible@1.9.rb
@@ -553,7 +553,7 @@ class AnsibleAT19 < Formula
     execution environment, which is inherited by Python scripts invoked
     by ansible. If this causes problems, you can modify your playbooks
     to invoke python with -E, which causes python to ignore PYTHONPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ansible@2.0.rb
+++ b/Formula/ansible@2.0.rb
@@ -596,7 +596,7 @@ class AnsibleAT20 < Formula
     execution environment, which is inherited by Python scripts invoked
     by ansible. If this causes problems, you can modify your playbooks
     to invoke python with -E, which causes python to ignore PYTHONPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/antigen.rb
+++ b/Formula/antigen.rb
@@ -14,7 +14,7 @@ class Antigen < Formula
   def caveats; <<~EOS
     To activate antigen, add the following to your ~/.zshrc:
       source #{HOMEBREW_PREFIX}/share/antigen/antigen.zsh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/antiword.rb
+++ b/Formula/antiword.rb
@@ -32,7 +32,7 @@ class Antiword < Formula
 
   def caveats; <<~EOS
     You can install mapping files in ~/.antiword
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/apache-archiva.rb
+++ b/Formula/apache-archiva.rb
@@ -51,7 +51,7 @@ class ApacheArchiva < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ape.rb
+++ b/Formula/ape.rb
@@ -30,7 +30,7 @@ class Ape < Formula
   def caveats; <<~EOS
     The default configuration file is stored in #{etc}. You should load aped with:
       aped --cfg #{etc}/ape.conf
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/apollo.rb
+++ b/Formula/apollo.rb
@@ -47,7 +47,7 @@ class Apollo < Formula
   def caveats; <<~EOS
     To create the broker:
         #{bin}/apollo create #{var}/apollo
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/var/apollo/bin/apollo-broker run"
@@ -72,7 +72,7 @@ class Apollo < Formula
         <string>#{var}/apollo</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -81,7 +81,7 @@ class Arangodb < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -21,7 +21,7 @@ class ArchiSteamFarm < Formula
 
   def caveats; <<~EOS
     Config: #{etc}/asf/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/arx-libertatis.rb
+++ b/Formula/arx-libertatis.rb
@@ -82,7 +82,7 @@ class ArxLibertatis < Formula
       the game data with:
 
         arx-install-data /path/to/setup_arx_fatalis.exe
-      EOS
+    EOS
     end
   end
 

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -32,7 +32,7 @@ class Asdf < Formula
 
     If you use Fish shell, add the following line to your fish config (e.g. ~/.config/fish/config.fish)
          source #{opt_prefix}/asdf.fish
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -95,7 +95,7 @@ class Audacious < Formula
     audtool does not work due to a broken dbus implementation on macOS, so is not built
     coreaudio output has been disabled as it does not work (Fails to set audio unit input property.)
     GTK+ gui is not built by default as the QT gui has better integration with macOS, and when built, the gtk gui takes precedence
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -37,7 +37,7 @@ class Augeas < Formula
   def caveats; <<~EOS
     Lenses have been installed to:
       #{HOMEBREW_PREFIX}/share/augeas/lenses/dist
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/autoenv.rb
+++ b/Formula/autoenv.rb
@@ -14,7 +14,7 @@ class Autoenv < Formula
   def caveats; <<~EOS
     To finish the installation, source activate.sh in your shell:
       source #{opt_prefix}/activate.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -31,7 +31,7 @@ class Autojump < Formula
 
     If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
       [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ]; and source #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/automysqlbackup.rb
+++ b/Formula/automysqlbackup.rb
@@ -25,7 +25,7 @@ class Automysqlbackup < Formula
     to set AutoMySQLBackup up to find your database and backup directory.
 
     The included plist file will run AutoMySQLBackup every day at 04:00.
-    EOS
+  EOS
   end
 
   plist_options :manual => "automysqlbackup"
@@ -56,7 +56,7 @@ class Automysqlbackup < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/autopsy.rb
+++ b/Formula/autopsy.rb
@@ -45,7 +45,7 @@ class Autopsy < Formula
 
     # Evidence locker location
     $LOCKDIR = '#{var}/lib/autopsy';
-    EOS
+  EOS
   end
 
   def install
@@ -62,7 +62,7 @@ class Autopsy < Formula
   def caveats; <<~EOS
     By default, the evidence locker is in:
       #{var}/lib/autopsy
-    EOS
+  EOS
   end
 end
 

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -43,7 +43,7 @@ class Awscli < Formula
   def caveats; <<~EOS
     The "examples" directory has been installed to:
       #{HOMEBREW_PREFIX}/share/awscli/examples
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -40,7 +40,7 @@ class BashCompletion < Formula
   def caveats; <<~EOS
     Add the following line to your ~/.bash_profile:
       [ -f #{etc}/bash_completion ] && . #{etc}/bash_completion
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -29,7 +29,7 @@ class BashCompletionAT2 < Formula
       if [ -f #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion ]; then
         . #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion
       fi
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bash-git-prompt.rb
+++ b/Formula/bash-git-prompt.rb
@@ -22,7 +22,7 @@ class BashGitPrompt < Formula
         __GIT_PROMPT_DIR="#{opt_share}"
         source "#{opt_share}/gitprompt.sh"
       fi
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bash-preexec.rb
+++ b/Formula/bash-preexec.rb
@@ -15,7 +15,7 @@ class BashPreexec < Formula
   def caveats; <<~EOS
     Add the following line to your bash profile (e.g. ~/.bashrc, ~/.profile, or ~/.bash_profile)
       [ -f #{etc}/profile.d/bash-preexec.sh ] && . #{etc}/profile.d/bash-preexec.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -73,7 +73,7 @@ class Bash < Formula
   def caveats; <<~EOS
     In order to use this build of bash as your login shell,
     it must be added to /etc/shells.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/beansdb.rb
+++ b/Formula/beansdb.rb
@@ -61,7 +61,7 @@ class Beansdb < Formula
       <string>#{var}/log/beansdb.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/beanstalkd.rb
+++ b/Formula/beanstalkd.rb
@@ -44,7 +44,7 @@ class Beanstalkd < Formula
         <string>#{var}/log/beanstalkd.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bettercap.rb
+++ b/Formula/bettercap.rb
@@ -29,7 +29,7 @@ class Bettercap < Formula
   def caveats; <<~EOS
     bettercap requires root privileges so you will need to run `sudo bettercap`.
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -110,7 +110,7 @@ class Bind < Formula
                     print-time yes;
             };
     };
-    EOS
+  EOS
   end
 
   def localhost_zone; <<~EOS
@@ -125,7 +125,7 @@ class Bind < Formula
 
                 1D IN NS    @
                 1D IN A        127.0.0.1
-    EOS
+  EOS
   end
 
   def named_local; <<~EOS
@@ -139,7 +139,7 @@ class Bind < Formula
                   IN      NS      localhost.
 
     1       IN      PTR     localhost.
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -166,7 +166,7 @@ class Bind < Formula
       <false/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bitchx.rb
+++ b/Formula/bitchx.rb
@@ -38,7 +38,7 @@ class Bitchx < Formula
       (or a similar, compatible encoding)
     * A font capable of extended ASCII characters:
       See: https://www.google.com/search?q=perfect+dos+vga+437
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -62,7 +62,7 @@ class Bitcoin < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bitlbee.rb
+++ b/Formula/bitlbee.rb
@@ -113,7 +113,7 @@ class Bitlbee < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/blazegraph.rb
+++ b/Formula/blazegraph.rb
@@ -31,7 +31,7 @@ class Blazegraph < Formula
         <string>#{opt_prefix}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -44,7 +44,7 @@ class Blitz < Formula
         A = 17, 2, 97;
         cout << "A = " << A << endl;
         return 0;}
-      EOS
+    EOS
     system ENV.cxx, "testfile.cpp", "-o", "testfile"
     output = shell_output("./testfile")
     var = "/A\ =\ \(0,2\)\ x\ \(0,0\)\n\[\ 17\ \n\ \ 2\ \n\ \ 97\ \]\n\n/"

--- a/Formula/boot2docker.rb
+++ b/Formula/boot2docker.rb
@@ -77,7 +77,7 @@ class Boot2docker < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/brogue.rb
+++ b/Formula/brogue.rb
@@ -42,7 +42,7 @@ class Brogue < Formula
   def caveats; <<~EOS
     If you are upgrading from 1.7.2, you need to copy your highscores file:
         cp #{HOMEBREW_PREFIX}/Cellar/#{name}/1.7.2/BrogueHighScores.txt #{var}/brogue/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/bubbros.rb
+++ b/Formula/bubbros.rb
@@ -62,7 +62,7 @@ class Bubbros < Formula
     #!/bin/bash
     cd "#{prefix}"
     python "#{target}" "$@"
-    EOS
+  EOS
   end
 
   def caveats

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -59,7 +59,7 @@ class Burp < Formula
   def caveats; <<~EOS
     Before installing the launchd entry you should configure your burp client in
       #{etc}/burp/burp.conf
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -87,7 +87,7 @@ class Burp < Formula
       <string>#{HOMEBREW_PREFIX}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/byobu.rb
+++ b/Formula/byobu.rb
@@ -37,7 +37,7 @@ class Byobu < Formula
   def caveats; <<~EOS
     Add the following to your shell configuration file:
       export BYOBU_PREFIX=#{HOMEBREW_PREFIX}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/c2048.rb
+++ b/Formula/c2048.rb
@@ -24,7 +24,7 @@ class C2048 < Formula
       2048 blackwhite
     For the blue-to-red:
       2048 bluered
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -48,7 +48,7 @@ class Caddy < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -36,7 +36,7 @@ class Carrot2 < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -145,7 +145,7 @@ class Cassandra < Formula
         <string>#{var}/lib/cassandra</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -116,7 +116,7 @@ class CassandraAT21 < Formula
         <string>#{var}/lib/cassandra</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cassandra@2.2.rb
+++ b/Formula/cassandra@2.2.rb
@@ -110,7 +110,7 @@ class CassandraAT22 < Formula
         <string>#{var}/lib/cassandra</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -83,7 +83,7 @@ class Cayley < Formula
         <string>#{var}/log/cayley.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -52,7 +52,7 @@ class Ccache < Formula
 
     NOTE: ccache can prevent some software from compiling.
     ALSO NOTE: The brew command, by design, will never use ccache.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cctools.rb
+++ b/Formula/cctools.rb
@@ -150,7 +150,7 @@ class Cctools < Formula
 
   def caveats; <<~EOS
     cctools's version of ld was not built.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/chisel.rb
+++ b/Formula/chisel.rb
@@ -30,7 +30,7 @@ class Chisel < Formula
   def caveats; <<~EOS
     Add the following line to ~/.lldbinit to load chisel when Xcode launches:
       command script import #{opt_libexec}/fblldb.py
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/chocolate-doom.rb
+++ b/Formula/chocolate-doom.rb
@@ -43,6 +43,6 @@ class ChocolateDoom < Formula
     Otherwise, there are tons of free levels available online.
     Try starting here:
       #{homepage}
-    EOS
+  EOS
   end
 end

--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -67,7 +67,7 @@ class Chronograf < Formula
         <string>#{var}/log/chronograf.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -26,7 +26,7 @@ class Chruby < Formula
     To enable auto-switching of Rubies specified by .ruby-version files,
     add the following to ~/.bash_profile or ~/.zshrc:
       source #{opt_pkgshare}/auto.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ckan.rb
+++ b/Formula/ckan.rb
@@ -18,7 +18,7 @@ class Ckan < Formula
 
   def caveats; <<~EOS
     To use the CKAN GUI, install the ckan-app cask.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -54,7 +54,7 @@ class Clamav < Formula
   def caveats; <<~EOS
     To finish installation & run clamav you will need to edit
     the example conf files at #{etc}/clamav/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/clipper.rb
+++ b/Formula/clipper.rb
@@ -45,7 +45,7 @@ class Clipper < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/clog.rb
+++ b/Formula/clog.rb
@@ -24,7 +24,7 @@ class Clog < Formula
   def caveats; <<~EOS
     Next step is to create a .clogrc file in your home directory. See 'man clog'
     for details and a sample file.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/clojurescript.rb
+++ b/Formula/clojurescript.rb
@@ -17,7 +17,7 @@ class Clojurescript < Formula
   def caveats; <<~EOS
     This formula is useful if you need to use the ClojureScript compiler directly.
     For a more integrated workflow use Leiningen, Boot, or Maven.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -34,7 +34,7 @@ class Cmigemo < Formula
   def caveats; <<~EOS
     See also https://github.com/emacs-jp/migemo to use cmigemo with Emacs.
     You will have to save as migemo.el and put it in your load-path.
-    EOS
+  EOS
   end
 end
 

--- a/Formula/cntlm.rb
+++ b/Formula/cntlm.rb
@@ -48,6 +48,6 @@ class Cntlm < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -33,7 +33,7 @@ class Cockroach < Formula
     mode and may expose data publicly in e.g. a DNS rebinding attack. To run
     CockroachDB securely, please see:
       #{Formatter.url("https://www.cockroachlabs.com/docs/secure-a-cluster.html")}
-    EOS
+  EOS
   end
 
   plist_options :manual => "cockroach start --insecure"
@@ -62,7 +62,7 @@ class Cockroach < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -87,7 +87,7 @@ class Collectd < Formula
         <string>#{var}/log/collectd.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/colorsvn.rb
+++ b/Formula/colorsvn.rb
@@ -44,7 +44,7 @@ class Colorsvn < Formula
     to your bash profile.
 
     So when you type "svn" you'll run "colorsvn".
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -69,7 +69,7 @@ class Consul < Formula
         <string>#{var}/log/consul.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -6,7 +6,7 @@ class Camlp5TransitionalModeRequirement < Requirement
   def message; <<~EOS
     camlp5 must be compiled in transitional mode (instead of --strict mode):
       brew install camlp5
-    EOS
+  EOS
   end
 end
 

--- a/Formula/corectl.rb
+++ b/Formula/corectl.rb
@@ -64,7 +64,7 @@ class Corectl < Formula
 
     $ corectld start
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -82,7 +82,7 @@ class Coreutils < Formula
 
         MANPATH="#{opt_libexec}/gnuman:$MANPATH"
 
-    EOS
+  EOS
   end
 
   def coreutils_filenames(dir)

--- a/Formula/couchdb-lucene.rb
+++ b/Formula/couchdb-lucene.rb
@@ -37,7 +37,7 @@ class CouchdbLucene < Formula
     #!/bin/bash
     export CL_BASEDIR=#{libexec}/bin
     exec "$CL_BASEDIR/#{target}" "$@"
-    EOS
+  EOS
   end
 
   def ini_path
@@ -47,7 +47,7 @@ class CouchdbLucene < Formula
   def ini_file; <<~EOS
     [httpd_global_handlers]
     _fti = {couch_httpd_proxy, handle_proxy_req, <<"http://127.0.0.1:5985">>}
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
@@ -57,7 +57,7 @@ class CouchdbLucene < Formula
     can add a "clbin" directory to your PATH from your bashrc like:
 
         PATH="#{opt_libexec}/clbin:$PATH"
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/couchdb-lucene/bin/cl_run"
@@ -89,7 +89,7 @@ class CouchdbLucene < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -168,7 +168,7 @@ class Couchdb < Formula
       brew uninstall couchdb
       brew install couchdb
     To see these instructions again, just run 'brew info couchdb'.
-    EOS
+  EOS
   end
 
   plist_options :manual => "couchdb"
@@ -190,7 +190,7 @@ class Couchdb < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/couchpotatoserver.rb
+++ b/Formula/couchpotatoserver.rb
@@ -38,7 +38,7 @@ class Couchpotatoserver < Formula
         <string>#{`whoami`.chomp}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def startup_script; <<~EOS
@@ -47,7 +47,7 @@ class Couchpotatoserver < Formula
            "--pid_file=#{var}/run/couchpotatoserver.pid"\
            "--data_dir=#{etc}/couchpotatoserver"\
            "$@"
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cpansearch.rb
+++ b/Formula/cpansearch.rb
@@ -26,6 +26,6 @@ class Cpansearch < Formula
   def caveats; <<~EOS
     For usage instructions:
         more #{opt_prefix}/README.md
-    EOS
+  EOS
   end
 end

--- a/Formula/csmith.rb
+++ b/Formula/csmith.rb
@@ -25,7 +25,7 @@ class Csmith < Formula
   def caveats; <<~EOS
     It is recommended that you set the environment variable 'CSMITH_PATH' to
       #{include}/csmith-#{version}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/cvs2svn.rb
+++ b/Formula/cvs2svn.rb
@@ -34,7 +34,7 @@ class Cvs2svn < Formula
 
     Contrib scripts and example options files are installed in:
       #{opt_prefix}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/datomic.rb
+++ b/Formula/datomic.rb
@@ -69,7 +69,7 @@ class Datomic < Formula
         <string>#{var}/log/datomic/output.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/davmail.rb
+++ b/Formula/davmail.rb
@@ -42,6 +42,6 @@ class Davmail < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 end

--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -50,7 +50,7 @@ class Ddclient < Formula
     You can adjust the execution interval by changing the value of
     StartInterval (in seconds) in /Library/LaunchDaemons/#{plist_path.basename},
     and then
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -80,7 +80,7 @@ class Ddclient < Formula
       <string>#{etc}/ddclient</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/derby.rb
+++ b/Formula/derby.rb
@@ -46,7 +46,7 @@ class Derby < Formula
       <string>#{var}/derby</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dgen.rb
+++ b/Formula/dgen.rb
@@ -40,7 +40,7 @@ class Dgen < Formula
   def caveats; <<~EOS
     If some keyboard inputs do not work, try modifying configuration:
       ~/.dgen/dgenrc
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/distcc.rb
+++ b/Formula/distcc.rb
@@ -65,7 +65,7 @@ class Distcc < Formula
         <string>#{opt_prefix}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -80,7 +80,7 @@ class DnscryptProxy < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dnsmasq.rb
+++ b/Formula/dnsmasq.rb
@@ -80,7 +80,7 @@ class Dnsmasq < Formula
   def caveats; <<~EOS
     To configure dnsmasq, take the default example configuration at
       #{etc}/dnsmasq.conf and edit to taste.
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -105,7 +105,7 @@ class Dnsmasq < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -89,6 +89,6 @@ class Docbook < Formula
     you need to add the following to your ~/.bashrc:
 
     export XML_CATALOG_FILES="#{etc}/xml/catalog"
-    EOS
+  EOS
   end
 end

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -79,7 +79,7 @@ class DockerMachineDriverXhyve < Formula
     enable, execute
         sudo chown root:wheel #{opt_prefix}/bin/docker-machine-driver-xhyve
         sudo chmod u+s #{opt_prefix}/bin/docker-machine-driver-xhyve
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -64,7 +64,7 @@ class Dosbox < Formula
 
   def caveats; <<~EOS
     DOSBox is not built for optimal performance due to unstability on 64-bit platform.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -76,7 +76,7 @@ class Dovecot < Formula
   def caveats; <<~EOS
     For Dovecot to work, you may need to create a dovecot user
     and group depending on your configuration file options.
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -113,7 +113,7 @@ class Dovecot < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -65,7 +65,7 @@ class Dpkg < Formula
   def caveats; <<~EOS
     This installation of dpkg is not configured to install software, so
     commands such as `dpkg -i`, `dpkg --configure` will fail.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dvm.rb
+++ b/Formula/dvm.rb
@@ -31,7 +31,7 @@ class Dvm < Formula
     dvm is a shell function, and must be sourced before it can be used.
     Add the following command to your bash profile:
         [ -f #{opt_prefix}/dvm.sh ] && . #{opt_prefix}/dvm.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dwm.rb
+++ b/Formula/dwm.rb
@@ -35,7 +35,7 @@ class Dwm < Formula
 
     See also https://gist.github.com/311377 for a handful of tips and tricks
     for running dwm on Mac OS X.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -65,7 +65,7 @@ class Dynare < Formula
   def caveats; <<~EOS
     To get started with Dynare, open Octave and type
       addpath #{opt_lib}/dynare/matlab
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ed.rb
+++ b/Formula/ed.rb
@@ -31,7 +31,7 @@ class Ed < Formula
     if build.without? "default-names" then <<~EOS
       The command has been installed with the prefix "g".
       If you do not want the prefix, reinstall using the "with-default-names" option.
-      EOS
+    EOS
     end
   end
 

--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -56,7 +56,7 @@ class Ejabberd < Formula
     If you face nodedown problems, concat your machine name to:
       /private/etc/hosts
     after 'localhost'.
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/sbin/ejabberdctl start"
@@ -84,7 +84,7 @@ class Ejabberd < Formula
       <string>#{var}/lib/ejabberd</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -69,7 +69,7 @@ class ElasticsearchAT24 < Formula
     Plugins: #{libexec}/plugins/
     Config:  #{etc}/elasticsearch/
     plugin script: #{libexec}/bin/plugin
-    EOS
+  EOS
   end
 
   plist_options :manual => "elasticsearch"

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -113,7 +113,7 @@ class Emacs < Formula
     if build.with? "cocoa" then <<~EOS
       Please try the Cask for a better-supported Cocoa version:
         brew cask install emacs
-      EOS
+    EOS
     end
   end
 
@@ -135,7 +135,7 @@ class Emacs < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -90,7 +90,7 @@ class Emscripten < Formula
       #{opt_libexec}/llvm/bin
     and comment out BINARYEN_ROOT
     in ~/.emscripten after running `emcc` for the first time.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -101,7 +101,7 @@ class Erlang < Formula
       #{opt_lib}/erlang/man
 
     Access them with `erl -man`, or add this directory to MANPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/erlang@17.rb
+++ b/Formula/erlang@17.rb
@@ -109,7 +109,7 @@ class ErlangAT17 < Formula
       #{opt_lib}/erlang/man
 
     Access them with `erl -man`, or add this directory to MANPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -121,7 +121,7 @@ class ErlangAT18 < Formula
     Man pages can be found in:
       #{opt_lib}/erlang/man
     Access them with `erl -man`, or add this directory to MANPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/erlang@19.rb
+++ b/Formula/erlang@19.rb
@@ -118,7 +118,7 @@ class ErlangAT19 < Formula
     Man pages can be found in:
       #{opt_lib}/erlang/man
     Access them with `erl -man`, or add this directory to MANPATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/etcd.rb
+++ b/Formula/etcd.rb
@@ -47,7 +47,7 @@ class Etcd < Formula
         <string>#{var}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -82,14 +82,14 @@ class Exim < Formula
       exit 1
       ;;
     esac
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
     Start with:
       exim_ctl start
     Don't forget to run it as root to be able to bind port 25.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/exult.rb
+++ b/Formula/exult.rb
@@ -63,7 +63,7 @@ class Exult < Formula
 
       To use CoreAudio, set `driver` to `CoreAudio`.
       To use audio pack, set `use_oggs` to `yes`.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fastbit.rb
+++ b/Formula/fastbit.rb
@@ -40,7 +40,7 @@ class Fastbit < Formula
       Potter,Harry
       Granger,Hermione
       Weasley,Ron
-     EOS
+    EOS
     system bin/"ardea", "-d", testpath,
            "-m", "a:t,b:t", "-t", testpath/"test.csv"
   end

--- a/Formula/fastqc.rb
+++ b/Formula/fastqc.rb
@@ -20,7 +20,7 @@ class Fastqc < Formula
       CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
       +SRR098281.1 HWUSI-EAS1599_1:2:1:0:318 length=35
       #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-     EOS
+    EOS
     assert_match "Analysis complete for test.fasta", shell_output("#{bin}/fastqc test.fasta")
   end
 end

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -45,7 +45,7 @@ class Fceux < Formula
     (bin/"fceux").write <<~EOS
       #!/bin/bash
       LUA_PATH=#{pkgshare}/luaScripts/?.lua #{libexec}/fceux "$@"
-      EOS
+    EOS
   end
 
   test do

--- a/Formula/fdclone.rb
+++ b/Formula/fdclone.rb
@@ -36,6 +36,6 @@ class Fdclone < Formula
         install -c -m 0644 #{share}/fd2rc.dist ~/.fd2rc
     To set application messages to Japanese, edit your .fd2rc:
         MESSAGELANG="ja"
-    EOS
+  EOS
   end
 end

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -357,7 +357,7 @@ class Fdroidserver < Formula
     base path of the Android SDK is set in the standard environment variable
     ANDROID_HOME.  To install them from the command line, run:
     android update sdk --no-ui --all --filter tools,platform-tools,build-tools-25.0.0
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -192,7 +192,7 @@ class FfmpegAT28 < Formula
       Or:
         brew reinstall ffmpeg28 --with-fdk-aac
         ffmpeg -i input.wav -c:a libfdk_aac output.m4a
-      EOS
+    EOS
     end
   end
 

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -58,7 +58,7 @@ class Fish < Formula
     Then run:
       chsh -s #{HOMEBREW_PREFIX}/bin/fish
     to make fish your default shell.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/flatbuffers.rb
+++ b/Formula/flatbuffers.rb
@@ -47,7 +47,7 @@ class Flatbuffers < Formula
 
       root_type Monster;
 
-      EOS
+    EOS
     end
     (testpath/"test.fbs").write(testfbs)
 
@@ -61,7 +61,7 @@ class Flatbuffers < Formula
         hp: 80,
         name: "MyMonster"
       }
-      EOS
+    EOS
     end
     (testpath/"test.json").write(testjson)
 

--- a/Formula/flatcc.rb
+++ b/Formula/flatcc.rb
@@ -52,7 +52,7 @@ class Flatcc < Formula
 
       root_type Monster;
 
-      EOS
+    EOS
 
     system bin/"flatcc", "-av", "--json", "test.fbs"
   end

--- a/Formula/fmsx.rb
+++ b/Formula/fmsx.rb
@@ -85,7 +85,7 @@ class Fmsx < Formula
     Bundled ROM files are located the following directory:
       #{pkgshare}
     You may want to use this directory to set `-home` option.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -82,7 +82,7 @@ class Fontforge < Formula
 
     Alternatively, install with Homebrew-Cask:
       brew cask install fontforge
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fourstore.rb
+++ b/Formula/fourstore.rb
@@ -48,7 +48,7 @@ class Fourstore < Formula
         4s-httpd -p 8000 -D mydb
 
     See https://4store.danielknoell.de/trac/wiki/Documentation/ for more information.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/freediameter.rb
+++ b/Formula/freediameter.rb
@@ -57,7 +57,7 @@ class Freediameter < Formula
       http://www.freediameter.net/trac/wiki/Configuration
 
     Other potentially useful files can be found in #{opt_pkgshare}/contrib.
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -80,7 +80,7 @@ class Freediameter < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -226,7 +226,7 @@ class Freeswitch < Formula
         <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fstar.rb
+++ b/Formula/fstar.rb
@@ -85,7 +85,7 @@ class Fstar < Formula
     To compile the generated F# (.NET) code, you must install
     the 'mono' package that includes the fsharp compiler:
     - brew install mono
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/funcoeszz.rb
+++ b/Formula/funcoeszz.rb
@@ -18,7 +18,7 @@ class Funcoeszz < Formula
       source "$ZZPATH"
 
     Usage of a newer Bash than the macOS default is required.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fuseki.rb
+++ b/Formula/fuseki.rb
@@ -50,7 +50,7 @@ class Fuseki < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -37,7 +37,7 @@ class Fzf < Formula
 
     To use fzf in Vim, add the following line to your .vimrc:
       set rtp+=#{opt_prefix}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/g2.rb
+++ b/Formula/g2.rb
@@ -26,6 +26,6 @@ class G2 < Formula
     NOTE: This will install a new ~/.gitconfig, backing up any existing
     file first. For more information view:
       #{prefix}/README.md
-    EOS
+  EOS
   end
 end

--- a/Formula/ganglia.rb
+++ b/Formula/ganglia.rb
@@ -57,7 +57,7 @@ class Ganglia < Formula
   def caveats; <<~EOS
     If you didn't have a default config file, one was created here:
       #{etc}/gmond.conf
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -84,7 +84,7 @@ class Gdb < Formula
     On 10.12 (Sierra) or later with SIP, you need to run this:
 
       echo "set startup-with-shell off" >> ~/.gdbinit
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gearman.rb
+++ b/Formula/gearman.rb
@@ -95,7 +95,7 @@ class Gearman < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/geoserver.rb
+++ b/Formula/geoserver.rb
@@ -21,7 +21,7 @@ class Geoserver < Formula
   def caveats; <<~EOS
     To start geoserver:
       geoserver path/to/data/dir
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/git-archive-all.rb
+++ b/Formula/git-archive-all.rb
@@ -21,7 +21,7 @@ class GitArchiveAll < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     touch "homebrew"
     system "git", "add", "homebrew"

--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -23,7 +23,7 @@ class GitExtras < Formula
   def caveats; <<~EOS
     To load Zsh completions, add the following to your .zschrc:
       source #{opt_pkgshare}/git-extras-completion.zsh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/git-fixup.rb
+++ b/Formula/git-fixup.rb
@@ -23,7 +23,7 @@ class GitFixup < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     (testpath/"test").write "foo"
     system "git", "add", "test"

--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -39,7 +39,7 @@ class GitLfs < Formula
 
       # Update system git config
       $ git lfs install --system
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/git-octopus.rb
+++ b/Formula/git-octopus.rb
@@ -23,7 +23,7 @@ class GitOctopus < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     touch "homebrew"
     system "git", "add", "."

--- a/Formula/git-tf.rb
+++ b/Formula/git-tf.rb
@@ -30,7 +30,7 @@ class GitTf < Formula
 
   def caveats; <<~EOS
     This release removes support for TFS 2005 and 2008. Use a previous version if needed.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -24,7 +24,7 @@ class Gitbucket < Formula
 
   def caveats; <<~EOS
     Note: When using launchctl the port will be 8080.
-    EOS
+  EOS
   end
 
   plist_options :manual => "java -jar #{HOMEBREW_PREFIX}/opt/gitbucket/libexec/gitbucket.war"

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -54,7 +54,7 @@ class Gitfs < Formula
     repo_path argument.
 
     Also make sure OSXFUSE is properly installed by running brew info osxfuse.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -89,7 +89,7 @@ class GitlabRunner < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/glbinding.rb
+++ b/Formula/glbinding.rb
@@ -35,7 +35,7 @@ class Glbinding < Formula
       {
         glbinding::Binding::initialize();
       }
-      EOS
+    EOS
     system ENV.cxx, "-o", "test", "test.cpp", "-std=c++11", "-stdlib=libc++",
                     "-I#{include}/glbinding", "-I#{lib}/glbinding", "-framework", "OpenGL",
                     "-L#{lib}", "-lglbinding", *ENV.cflags.to_s.split

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -113,7 +113,7 @@ class Glib < Formula
 
           return (strcmp(str, result_2) == 0) ? 0 : 1;
       }
-      EOS
+    EOS
     system ENV.cc, "-o", "test", "test.c", "-I#{include}/glib-2.0",
                    "-I#{lib}/glib-2.0/include", "-L#{lib}", "-lglib-2.0"
     system "./test"

--- a/Formula/globjects.rb
+++ b/Formula/globjects.rb
@@ -33,7 +33,7 @@ class Globjects < Formula
       {
         globjects::init();
       }
-      EOS
+    EOS
     system ENV.cxx, "-o", "test", "test.cpp", "-std=c++11", "-stdlib=libc++",
            "-I#{include}/globjects", "-I#{Formula["glm"].include}/glm", "-I#{lib}/globjects",
            "-L#{lib}", "-lglobjects", "-lglbinding", *ENV.cflags.to_s.split

--- a/Formula/gmime.rb
+++ b/Formula/gmime.rb
@@ -44,7 +44,7 @@ class Gmime < Formula
           return 1;
         }
       }
-      EOS
+    EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     pcre = Formula["pcre"]

--- a/Formula/gnatsd.rb
+++ b/Formula/gnatsd.rb
@@ -38,7 +38,7 @@ class Gnatsd < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gnu-sed.rb
+++ b/Formula/gnu-sed.rb
@@ -43,7 +43,7 @@ class GnuSed < Formula
       Additionally, you can access their man pages with normal names if you add
       the "gnuman" directory to your MANPATH from your bashrc as well:
         MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-      EOS
+    EOS
     end
   end
 

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -49,7 +49,7 @@ class GnuTar < Formula
 
           MANPATH="#{opt_libexec}/gnuman:$MANPATH"
 
-      EOS
+    EOS
     end
   end
 

--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -70,7 +70,7 @@ class Gnupg < Formula
 
     For full details on each change and how it could impact you please see
       https://www.gnupg.org/faq/whats-new-in-2.1.html
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gnupg@1.4.rb
+++ b/Formula/gnupg@1.4.rb
@@ -59,7 +59,7 @@ class GnupgAT14 < Formula
 
     Note that doing so may interfere with GPG-using formulae installed via
     Homebrew.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -80,7 +80,7 @@ class Go < Formula
 
     You may wish to add the GOROOT-based install location to your PATH:
       export PATH=$PATH:#{opt_libexec}/bin
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/go@1.4.rb
+++ b/Formula/go@1.4.rb
@@ -88,7 +88,7 @@ class GoAT14 < Formula
 
     You may wish to add the GOROOT-based install location to your PATH:
       export PATH=$PATH:#{opt_libexec}/bin
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/go@1.8.rb
+++ b/Formula/go@1.8.rb
@@ -69,7 +69,7 @@ class GoAT18 < Formula
 
     You may wish to add the GOROOT-based install location to your PATH:
       export PATH=$PATH:#{opt_libexec}/bin
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -70,7 +70,7 @@ class GoAT19 < Formula
 
     You may wish to add the GOROOT-based install location to your PATH:
       export PATH=$PATH:#{opt_libexec}/bin
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/google-authenticator-libpam.rb
+++ b/Formula/google-authenticator-libpam.rb
@@ -34,7 +34,7 @@ class GoogleAuthenticatorLibpam < Formula
       "nullok" | sudo tee -a /etc/pam.d/sshd
 
     (Or just manually edit /etc/pam.d/sshd)
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gpsd.rb
+++ b/Formula/gpsd.rb
@@ -24,7 +24,7 @@ class Gpsd < Formula
     need to force it to connect to your GPS:
 
       GPSD_SOCKET="#{var}/gpsd.sock" #{sbin}/gpsdctl add /dev/tty.usbserial-XYZ
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/sbin/gpsd -N -F #{HOMEBREW_PREFIX}/var/gpsd.sock /dev/tty.usbserial-XYZ"
@@ -55,7 +55,7 @@ class Gpsd < Formula
       <string>#{var}/log/gpsd.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -87,7 +87,7 @@ class Grafana < Formula
         </dict>
       </dict>
     </plist>
-   EOS
+  EOS
   end
 
   test do

--- a/Formula/grails.rb
+++ b/Formula/grails.rb
@@ -15,7 +15,7 @@ class Grails < Formula
   def caveats; <<~EOS
     The GRAILS_HOME directory is:
       #{opt_libexec}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -38,7 +38,7 @@ class Grc < Formula
   def caveats; <<~EOS
     New shell sessions will use GRC if you add the relevant file to your profile e.g.:
       . #{etc}/grc.bashrc
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/greed.rb
+++ b/Formula/greed.rb
@@ -27,7 +27,7 @@ class Greed < Formula
   def caveats; <<~EOS
     High scores will be stored in the following location:
       #{var}/greed/greed.hs
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -59,7 +59,7 @@ class Grep < Formula
       Additionally, you can access their man pages with normal names if you add
       the "gnuman" directory to your MANPATH from your bashrc as well:
         MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-      EOS
+    EOS
     end
   end
 

--- a/Formula/griffon.rb
+++ b/Formula/griffon.rb
@@ -15,7 +15,7 @@ class Griffon < Formula
   def caveats; <<~EOS
     You should set the environment variable GRIFFON_HOME to:
       #{libexec}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -42,7 +42,7 @@ class Gromacs < Formula
   def caveats; <<~EOS
     GMXRC and other scripts installed to:
       #{HOMEBREW_PREFIX}/share/gromacs
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gst-python.rb
+++ b/Formula/gst-python.rb
@@ -50,7 +50,7 @@ class GstPython < Formula
         gi.require_version('Gst', '1.0')
         from gi.repository import Gst
         print (Gst.Fraction(num=3, denom=5))
-        EOS
+      EOS
     end
   end
 end

--- a/Formula/gstreamer.rb
+++ b/Formula/gstreamer.rb
@@ -59,7 +59,7 @@ class Gstreamer < Formula
 
     The gst-plugins-* packages contain gstreamer-video-1.0, gstreamer-audio-1.0,
     and other components needed by most gstreamer applications.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/gtk-engines.rb
+++ b/Formula/gtk-engines.rb
@@ -28,7 +28,7 @@ class GtkEngines < Formula
     You will need to set:
       GTK_PATH=#{HOMEBREW_PREFIX}/lib/gtk-2.0
     as by default GTK looks for modules in Cellar.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/h2.rb
+++ b/Formula/h2.rb
@@ -10,7 +10,7 @@ class H2 < Formula
   def script; <<~EOS
     #!/bin/sh
     cd #{libexec} && bin/h2.sh "$@"
-    EOS
+  EOS
   end
 
   def install
@@ -56,7 +56,7 @@ class H2 < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -54,14 +54,14 @@ class H2o < Formula
         paths:
           /:
             file.dir: #{var}/h2o/
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
     A basic example configuration file has been placed in #{etc}/h2o.
 
     You can find fuller, unmodified examples in #{opt_pkgshare}/examples.
-    EOS
+  EOS
   end
 
   plist_options :manual => "h2o"
@@ -85,7 +85,7 @@ class H2o < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -64,7 +64,7 @@ class Haproxy < Formula
         <string>#{var}/log/haproxy.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hardlink-osx.rb
+++ b/Formula/hardlink-osx.rb
@@ -25,7 +25,7 @@ class HardlinkOsx < Formula
     `hln source directory` to target directory under the same root you will get an error!
 
     Also, remember the binary is named `hln` due to a naming conflict.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -64,7 +64,7 @@ class Haxe < Formula
   def caveats; <<~EOS
     Add the following line to your .bashrc or equivalent:
       export HAXE_STD_PATH="#{HOMEBREW_PREFIX}/lib/haxe/std"
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hbase.rb
+++ b/Formula/hbase.rb
@@ -150,7 +150,7 @@ class Hbase < Formula
       <string>#{var}/hbase/hbase.err</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -96,7 +96,7 @@ class Hdf5 < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-      EOS
+    EOS
     system "#{bin}/h5fc", "test.f90"
     assert_equal version.to_s, shell_output("./a.out").chomp
   end

--- a/Formula/hdf5@1.8.rb
+++ b/Formula/hdf5@1.8.rb
@@ -101,7 +101,7 @@ class Hdf5AT18 < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-      EOS
+    EOS
     system "#{bin}/h5fc", "test.f90"
     assert_equal version.to_s, shell_output("./a.out").chomp
   end

--- a/Formula/headphones.rb
+++ b/Formula/headphones.rb
@@ -28,7 +28,7 @@ class Headphones < Formula
     #!/bin/bash
     export PYTHONPATH="#{libexec}/lib/python2.7/site-packages:$PYTHONPATH"
     python "#{libexec}/Headphones.py" --datadir="#{etc}/headphones" "$@"
-    EOS
+  EOS
   end
 
   def install
@@ -71,7 +71,7 @@ class Headphones < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/henplus.rb
+++ b/Formula/henplus.rb
@@ -33,7 +33,7 @@ class Henplus < Formula
   def caveats; <<~EOS
     You may need to set JAVA_HOME:
       export JAVA_HOME="$(/usr/libexec/java_home)"
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hg-flow.rb
+++ b/Formula/hg-flow.rb
@@ -28,7 +28,7 @@ class HgFlow < Formula
         [flow]
         autoshelve = true
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hive.rb
+++ b/Formula/hive.rb
@@ -25,7 +25,7 @@ class Hive < Formula
 
     If you want to use HCatalog with Pig, set $HCAT_HOME in your profile:
       export HCAT_HOME=#{opt_libexec}/hcatalog
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hornetq.rb
+++ b/Formula/hornetq.rb
@@ -27,6 +27,6 @@ class Hornetq < Formula
 
     `run.sh` and `stop.sh` have been wrapped as`hornet-start` and `hornet-stop`
     to avoid naming conflicts.
-    EOS
+  EOS
   end
 end

--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -33,7 +33,7 @@ class Htop < Formula
     htop requires root privileges to correctly display all running processes,
     so you will need to run `sudo htop`.
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -131,7 +131,7 @@ class Httpd < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hunspell.rb
+++ b/Formula/hunspell.rb
@@ -39,7 +39,7 @@ class Hunspell < Formula
     provides no dictionaries for Hunspell, but you can download
     compatible dictionaries from other sources, such as
     https://wiki.openoffice.org/wiki/Dictionaries .
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/hyperspec.rb
+++ b/Formula/hyperspec.rb
@@ -24,7 +24,7 @@ class Hyperspec < Formula
          (setq common-lisp-hyperspec-issuex-table
                (concat common-lisp-hyperspec-root "Data/Map_IssX.txt"))))
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/icecream.rb
+++ b/Formula/icecream.rb
@@ -46,7 +46,7 @@ class Icecream < Formula
     To have launchd start the icecc daemon at login:
       cp #{opt_prefix}/org.opensuse.icecc.plist ~/Library/LaunchAgents/
       launchctl load -w ~/Library/LaunchAgents/org.opensuse.icecc.plist
-    EOS
+  EOS
   end
 
   def iceccd_plist; <<~EOS
@@ -65,7 +65,7 @@ class Icecream < Formula
         <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def scheduler_plist; <<~EOS
@@ -84,7 +84,7 @@ class Icecream < Formula
         <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/iftop.rb
+++ b/Formula/iftop.rb
@@ -32,7 +32,7 @@ class Iftop < Formula
   def caveats; <<~EOS
     iftop requires root privileges so you will need to run `sudo iftop`.
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -38,7 +38,7 @@ class Igraph < Formula
         printf("Diameter = %d\\n", (int) diameter);
         igraph_destroy(&graph);
       }
-      EOS
+    EOS
     system ENV.cc, "test.c", "-I#{include}/igraph", "-L#{lib}",
                    "-ligraph", "-o", "test"
     assert_match "Diameter = 9", shell_output("./test")

--- a/Formula/imapfilter.rb
+++ b/Formula/imapfilter.rb
@@ -35,7 +35,7 @@ class Imapfilter < Formula
     You will need to create a ~/.imapfilter/config.lua file.
     Samples can be found in:
       #{prefix}/samples
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -68,7 +68,7 @@ class Inetutils < Formula
       the "gnuman" directory to your MANPATH from your bashrc as well:
 
           MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-      EOS
+    EOS
     end
   end
 

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -83,7 +83,7 @@ class Influxdb < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -43,7 +43,7 @@ class Ipfs < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ircd-hybrid.rb
+++ b/Formula/ircd-hybrid.rb
@@ -32,7 +32,7 @@ class IrcdHybrid < Formula
   def caveats; <<~EOS
     You'll more than likely need to edit the default settings in the config file:
       #{etc}/ircd.conf
-    EOS
+  EOS
   end
 
   plist_options :manual => "ircd"
@@ -58,7 +58,7 @@ class IrcdHybrid < Formula
       <string>#{var}/ircd.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ircd-irc2.rb
+++ b/Formula/ircd-irc2.rb
@@ -82,7 +82,7 @@ class IrcdIrc2 < Formula
       <string>#{var}/ircd.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/isc-dhcp.rb
+++ b/Formula/isc-dhcp.rb
@@ -86,7 +86,7 @@ class IscDhcp < Formula
       DHCPv6: #{etc}/dhcpd6.conf
 
     Sample config files may be found in #{etc}.
-    EOS
+  EOS
   end
 
   plist_options :startup => true

--- a/Formula/isync.rb
+++ b/Formula/isync.rb
@@ -66,7 +66,7 @@ class Isync < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -57,7 +57,7 @@ class Jack < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -17,7 +17,7 @@ class JenkinsLts < Formula
 
   def caveats; <<~EOS
     Note: When using launchctl the port will be 8080.
-    EOS
+  EOS
   end
 
   plist_options :manual => "jenkins-lts"
@@ -46,7 +46,7 @@ class JenkinsLts < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/jpcsp.rb
+++ b/Formula/jpcsp.rb
@@ -31,6 +31,6 @@ class Jpcsp < Formula
 
     To avoid any incidental wipeout upon future updates, change it to
     a safe location (under Options > Settings > General > UMD path folders).
-    EOS
+  EOS
   end
 end

--- a/Formula/jupyter.rb
+++ b/Formula/jupyter.rb
@@ -297,7 +297,7 @@ class Jupyter < Formula
   def caveats; <<~EOS
     Additional kernels can be installed into the shared jupyter directory
       #{etc}/jupyter
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -73,7 +73,7 @@ class Kafka < Formula
         <string>#{var}/log/kafka/kafka_output.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -71,7 +71,7 @@ class Kapacitor < Formula
         <string>#{var}/log/kapacitor.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/kettle.rb
+++ b/Formula/kettle.rb
@@ -52,7 +52,7 @@ class Kettle < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -60,7 +60,7 @@ class Kibana < Formula
     If you wish to preserve your plugins upon upgrade, make a copy of
     #{opt_prefix}/plugins before upgrading, and copy it into the
     new keg location after upgrading.
-    EOS
+  EOS
   end
 
   plist_options :manual => "kibana"

--- a/Formula/kibana@4.4.rb
+++ b/Formula/kibana@4.4.rb
@@ -73,7 +73,7 @@ class KibanaAT44 < Formula
     If you wish to preserve your plugins upon upgrade, make a copy of
     #{prefix}/installedPlugins before upgrading, and copy it into the
     new keg location after upgrading.
-    EOS
+  EOS
   end
 
   plist_options :manual => "kibana"

--- a/Formula/kibana@5.6.rb
+++ b/Formula/kibana@5.6.rb
@@ -61,7 +61,7 @@ class KibanaAT56 < Formula
     If you wish to preserve your plugins upon upgrade, make a copy of
     #{opt_prefix}/plugins before upgrading, and copy it into the
     new keg location after upgrading.
-    EOS
+  EOS
   end
 
   plist_options :manual => "kibana"

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -51,7 +51,7 @@ class KnotResolver < Formula
   def root_keys; <<~EOS
     . IN DS 19036 8 2 49aac11d7b6f6446702e54a1607371607a1a41855200fd2ce1cdde32f24e8fb5
     . IN DS 20326 8 2 e06d44b80b8f1d39a95c0b0d7c65d08458e880409bbc683457104237c7f8ec8d
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -81,7 +81,7 @@ class KnotResolver < Formula
       <string>#{var}/log/kresd.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -73,7 +73,7 @@ class Knot < Formula
     template:
       - id: "default"
         storage: "#{var}/knot"
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -103,7 +103,7 @@ class Knot < Formula
       <string>#{var}/log/knot.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/kobalt.rb
+++ b/Formula/kobalt.rb
@@ -19,7 +19,7 @@ class Kobalt < Formula
     (testpath/"src/main/kotlin/com/A.kt").write <<~EOS
       package com
       class A
-      EOS
+    EOS
 
     (testpath/"kobalt/src/Build.kt").write <<~EOS
       import com.beust.kobalt.*

--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -1,4 +1,3 @@
-
 class Ksh < Formula
   desc "KornShell, ksh93"
   homepage "http://www.kornshell.com"

--- a/Formula/kube-ps1.rb
+++ b/Formula/kube-ps1.rb
@@ -22,7 +22,7 @@ class KubePs1 < Formula
       For Bash:
       source "#{opt_share}/kube-ps1.sh"
       PS1="[\$(kube_ps1)]\$ "
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -10,7 +10,7 @@ class Languagetool < Formula
   def server_script(server_jar); <<~EOS
     #!/bin/bash
     exec java -cp #{server_jar} org.languagetool.server.HTTPServer "$@"
-    EOS
+  EOS
   end
 
   def install

--- a/Formula/launchdns.rb
+++ b/Formula/launchdns.rb
@@ -26,7 +26,7 @@ class Launchdns < Formula
   def caveats; <<~EOS
     To have *.localhost resolved to 127.0.0.1:
       sudo ln -s #{HOMEBREW_PREFIX}/etc/resolver /etc
-    EOS
+  EOS
   end
 
   plist_options :manual => "launchdns"
@@ -62,7 +62,7 @@ class Launchdns < Formula
         <string>#{var}/log/launchdns.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/leafnode.rb
+++ b/Formula/leafnode.rb
@@ -23,7 +23,7 @@ class Leafnode < Formula
       ln -s #{opt_prefix}/homebrew.mxcl.{fetchnews,texpire}.plist ~/Library/LaunchAgents
     And to start the services,
       launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.{fetchnews,texpire}.plist
-    EOS
+  EOS
   end
 
   plist_options :manual => "leafnode"
@@ -56,7 +56,7 @@ class Leafnode < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def fetchnews_plist; <<~EOS
@@ -76,7 +76,7 @@ class Leafnode < Formula
         <string>#{var}/spool/news</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def texpire_plist; <<~EOS
@@ -96,7 +96,7 @@ class Leafnode < Formula
         <string>#{var}/spool/news</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/legit.rb
+++ b/Formula/legit.rb
@@ -88,7 +88,7 @@ class Legit < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     (testpath/"foo").write("woof")
     system "git", "add", "foo"

--- a/Formula/leiningen.rb
+++ b/Formula/leiningen.rb
@@ -37,7 +37,7 @@ class Leiningen < Formula
     Dependencies will be installed to:
       $HOME/.m2/repository
     To play around with Clojure run `lein repl` or `lein help`.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -34,7 +34,7 @@ class Libetpan < Formula
       {
         printf("version is %d.%d",libetpan_get_version_major(), libetpan_get_version_minor());
       }
-      EOS
+    EOS
     system ENV.cc, "test.c", "-L#{lib}", "-letpan", "-o", "test"
     system "./test"
   end

--- a/Formula/libforensic1394.rb
+++ b/Formula/libforensic1394.rb
@@ -33,7 +33,7 @@ class Libforensic1394 < Formula
         forensic1394_destroy(bus);
         return 0;
       }
-      EOS
+    EOS
     system ENV.cc, "test.c", "-L#{lib}", "-lforensic1394", "-o", "test"
     system "./test"
   end

--- a/Formula/libgxps.rb
+++ b/Formula/libgxps.rb
@@ -65,20 +65,20 @@ class Libgxps < Formula
       <FixedDocumentSequence>
       <DocumentReference Source="/Documents/1/FixedDocument.fdoc"/>
       </FixedDocumentSequence>
-      EOS
+    EOS
     (testpath/"Documents/1/FixedDocument.fdoc").write <<~EOS
       <FixedDocument>
       <PageContent Source="/Documents/1/Pages/1.fpage"/>
       </FixedDocument>
-      EOS
+    EOS
     (testpath/"Documents/1/Pages/1.fpage").write <<~EOS
       <FixedPage Width="1" Height="1" xml:lang="und" />
-      EOS
+    EOS
     (testpath/"_rels/.rels").write <<~EOS
       <Relationships>
       <Relationship Target="/FixedDocumentSequence.fdseq" Type="http://schemas.microsoft.com/xps/2005/06/fixedrepresentation"/>
       </Relationships>
-      EOS
+    EOS
     [
       "_rels/FixedDocumentSequence.fdseq.rels",
       "Documents/1/_rels/FixedDocument.fdoc.rels",
@@ -86,7 +86,7 @@ class Libgxps < Formula
     ].each do |f|
       (testpath/f).write <<~EOS
         <Relationships />
-        EOS
+      EOS
     end
 
     Dir.chdir(testpath) do

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -66,6 +66,6 @@ class Libid3tag < Formula
     Conflicts:
     Libs: -L${libdir} -lid3tag -lz
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 end

--- a/Formula/libomp.rb
+++ b/Formula/libomp.rb
@@ -34,7 +34,7 @@ class Libomp < Formula
     For CMake, the following flags will cause the OpenMP::OpenMP_CXX target to
     be set up correctly:
       -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I#{opt_include}" -DOpenMP_CXX_LIB_NAMES="omp" -DOpenMP_omp_LIBRARY=#{opt_lib}/libomp.dylib
-    EOS
+  EOS
   end
 
   test do
@@ -53,7 +53,7 @@ class Libomp < Formula
         else
             return 1;
       }
-      EOS
+    EOS
     system ENV.cxx, "-Werror", "-Xpreprocessor", "-fopenmp", "test.cpp",
                     "-L#{lib}", "-lomp", "-o", "test"
     system "./test"

--- a/Formula/libreadline-java.rb
+++ b/Formula/libreadline-java.rb
@@ -78,7 +78,7 @@ class LibreadlineJava < Formula
   def caveats; <<~EOS
     You may need to set JAVA_HOME:
       export JAVA_HOME="$(/usr/libexec/java_home)"
-    EOS
+  EOS
   end
 
   # Testing libreadline-java (can we execute and exit libreadline without exceptions?)

--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -70,7 +70,7 @@ class Libressl < Formula
 
     and run
       #{opt_bin}/openssl certhash #{etc}/libressl/certs
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/libstrophe.rb
+++ b/Formula/libstrophe.rb
@@ -47,7 +47,7 @@ class Libstrophe < Formula
         xmpp_shutdown();
         return 0;
       }
-      EOS
+    EOS
     flags = ["-I#{include}/", "-L#{lib}", "-lstrophe"]
     system ENV.cc, "-o", "test", "test.c", *(flags + ENV.cflags.to_s.split)
     system "./test"

--- a/Formula/libtool.rb
+++ b/Formula/libtool.rb
@@ -31,7 +31,7 @@ class Libtool < Formula
   def caveats; <<~EOS
     In order to prevent conflicts with Apple's own libtool we have prepended a "g"
     so, you have instead: glibtool and glibtoolize.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/libvbucket.rb
+++ b/Formula/libvbucket.rb
@@ -34,7 +34,7 @@ class Libvbucket < Formula
     expected = <<~EOS
       key: hello master: server1:11211 vBucketId: 0 couchApiBase: (null) replicas: server2:11210 server3:11211
       key: world master: server2:11210 vBucketId: 3 couchApiBase: (null) replicas: server3:11211 server1:11211
-      EOS
+    EOS
 
     output = pipe_output("#{bin}/vbuckettool - hello world", json)
     assert_equal expected, output

--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -46,7 +46,7 @@ class Libxslt < Formula
   def caveats; <<~EOS
     To allow the nokogiri gem to link against this libxslt run:
       gem install nokogiri -- --with-xslt-dir=#{opt_prefix}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/lighttpd.rb
+++ b/Formula/lighttpd.rb
@@ -101,7 +101,7 @@ class Lighttpd < Formula
 
     The default port has been set in #{config_path}/lighttpd.conf to 8080 so that
     lighttpd can run without sudo.
-    EOS
+  EOS
   end
 
   plist_options :manual => "lighttpd -f #{HOMEBREW_PREFIX}/etc/lighttpd/lighttpd.conf"
@@ -142,7 +142,7 @@ class Lighttpd < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/lincity-ng.rb
+++ b/Formula/lincity-ng.rb
@@ -47,7 +47,7 @@ class LincityNg < Formula
   def caveats; <<~EOS
     If you have problem with fullscreen, try running in windowed mode:
       lincity-ng -w
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/linkerd.rb
+++ b/Formula/linkerd.rb
@@ -55,7 +55,7 @@ class Linkerd < Formula
         <string>#{var}/log/linkerd/linkerd.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/liquibase.rb
+++ b/Formula/liquibase.rb
@@ -18,7 +18,7 @@ class Liquibase < Formula
   def caveats; <<~EOS
     You should set the environment variable LIQUIBASE_HOME to
       #{opt_libexec}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -21,7 +21,7 @@ class Liquidprompt < Formula
     If you'd like to reconfigure options, you may do so in ~/.liquidpromptrc.
     A sample file you may copy and modify has been installed to
       #{HOMEBREW_PREFIX}/share/liquidpromptrc-dist
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/llnode.rb
+++ b/Formula/llnode.rb
@@ -66,7 +66,7 @@ class Llnode < Formula
         mkdir -p ~/Library/Application\\ Support/LLDB/PlugIns
         ln -sf #{opt_prefix}/llnode.dylib \\
             ~/Library/Application\\ Support/LLDB/PlugIns/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/llvm@3.7.rb
+++ b/Formula/llvm@3.7.rb
@@ -200,7 +200,7 @@ class LlvmAT37 < Formula
       CXX="clang++-#{ver} -stdlib=libc++"
       CXXFLAGS="$CXXFLAGS -nostdinc++ -I#{opt_lib}/llvm-#{ver}/include/c++/v1"
       LDFLAGS="$LDFLAGS -L#{opt_lib}/llvm-#{ver}/lib"
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/logentries.rb
+++ b/Formula/logentries.rb
@@ -42,7 +42,7 @@ class Logentries < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/logrotate.rb
+++ b/Formula/logrotate.rb
@@ -50,7 +50,7 @@ class Logrotate < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -30,7 +30,7 @@ class Logstash < Formula
   def caveats; <<~EOS
     Please read the getting started guide located at:
       https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html
-    EOS
+  EOS
   end
 
   plist_options :manual => "logstash"

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -101,7 +101,7 @@ class Lua < Formula
     Requires:
     Libs: -L${libdir} -llua -lm
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
@@ -111,7 +111,7 @@ class Lua < Formula
     This is, for now, unavoidable. If this is troublesome for you, you can build
     rocks with the `--tree=` command to a special, non-conflicting location and
     then add that to your `$PATH`.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -121,7 +121,7 @@ class LuaAT51 < Formula
     This is, for now, unavoidable. If this is troublesome for you, you can build
     rocks with the `--tree=` command to a special, non-conflicting location and
     then add that to your `$PATH`.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/luabind.rb
+++ b/Formula/luabind.rb
@@ -72,7 +72,7 @@ class Luabind < Formula
     Version: 0.9.1
     Libs: -L${libdir} -lluabind
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/luaver.rb
+++ b/Formula/luaver.rb
@@ -16,7 +16,7 @@ class Luaver < Formula
   def caveats; <<~EOS
     Add the following at the end of the correct file yourself:
       if which luaver > /dev/null; then . `which luaver`; fi
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mad.rb
+++ b/Formula/mad.rb
@@ -35,6 +35,6 @@ class Mad < Formula
     Conflicts:
     Libs: -L${libdir} -lmad -lm
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 end

--- a/Formula/magnetix.rb
+++ b/Formula/magnetix.rb
@@ -35,7 +35,7 @@ class Magnetix < Formula
   def caveats; <<~EOS
     Install games in the following directory:
       ~/Library/Application Support/magnetiX/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mailhog.rb
+++ b/Formula/mailhog.rb
@@ -159,7 +159,7 @@ class Mailhog < Formula
       <string>#{var}/log/mailhog.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -105,7 +105,7 @@ class Mapserver < Formula
         extension="#{opt_lib}/php/extensions/php_mapscript.so"
       * Execute "php -m"
       * You should see MapScript in the module list
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -144,7 +144,7 @@ class Mariadb < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "mysql.server start"
@@ -169,7 +169,7 @@ class Mariadb < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mariadb@10.0.rb
+++ b/Formula/mariadb@10.0.rb
@@ -129,7 +129,7 @@ class MariadbAT100 < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mariadb@10.0/bin/mysql.server start"
@@ -154,7 +154,7 @@ class MariadbAT100 < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mariadb@10.1.rb
+++ b/Formula/mariadb@10.1.rb
@@ -138,7 +138,7 @@ class MariadbAT101 < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mariadb@10.1/bin/mysql.server start"
@@ -163,7 +163,7 @@ class MariadbAT101 < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -138,7 +138,7 @@ class MariadbAT102 < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mariadb@10.2/bin/mysql.server start"
@@ -163,7 +163,7 @@ class MariadbAT102 < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mcabber.rb
+++ b/Formula/mcabber.rb
@@ -57,7 +57,7 @@ class Mcabber < Formula
       #{opt_pkgshare}/mcabberrc.example
     And there is a Getting Started Guide you will need to setup Mcabber:
       https://wiki.mcabber.com/#index2h1
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mediatomb.rb
+++ b/Formula/mediatomb.rb
@@ -81,7 +81,7 @@ class Mediatomb < Formula
 
   def caveats; <<~EOS
     Edit the config file ~/.mediatomb/config.xml before running mediatomb.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/memcached.rb
+++ b/Formula/memcached.rb
@@ -53,7 +53,7 @@ class Memcached < Formula
       <string>#{HOMEBREW_PREFIX}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/metabase.rb
+++ b/Formula/metabase.rb
@@ -56,7 +56,7 @@ class Metabase < Formula
       <string>/dev/null</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/minbif.rb
+++ b/Formula/minbif.rb
@@ -59,7 +59,7 @@ class Minbif < Formula
         minbif #{etc}/minbif/minbif.conf
 
     Learn more about minbif: https://symlink.me/projects/minbif/wiki/Quick_start
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/minidlna.rb
+++ b/Formula/minidlna.rb
@@ -88,7 +88,7 @@ class Minidlna < Formula
         <string>#{var}/log/minidlnad.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -52,7 +52,7 @@ class MinimalRacket < Formula
 
     The full Racket distribution is available as a cask:
       brew cask install racket
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mksh.rb
+++ b/Formula/mksh.rb
@@ -23,7 +23,7 @@ class Mksh < Formula
     To allow using mksh as a login shell, run this as root:
         echo #{HOMEBREW_PREFIX}/bin/mksh >> /etc/shells
     Then, any user may run `chsh` to change their shell.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/modules.rb
+++ b/Formula/modules.rb
@@ -36,7 +36,7 @@ class Modules < Formula
       source #{opt_prefix}/init/zsh
     You will also need to reload your .zshrc:
       source ~/.zshrc
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -9,7 +9,7 @@ class RRequirement < Requirement
     - install R
     -- run brew install r or brew cask install r-app
     - remove the --with-r option
-    EOS
+  EOS
   end
 end
 

--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -120,7 +120,7 @@ class Mongodb < Formula
       dbPath: #{var}/mongodb
     net:
       bindIp: 127.0.0.1
-    EOS
+  EOS
   end
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
@@ -160,7 +160,7 @@ class Mongodb < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mongodb@3.0.rb
+++ b/Formula/mongodb@3.0.rb
@@ -86,7 +86,7 @@ class MongodbAT30 < Formula
       dbPath: #{var}/mongodb
     net:
       bindIp: 127.0.0.1
-    EOS
+  EOS
   end
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
@@ -126,7 +126,7 @@ class MongodbAT30 < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mongodb@3.2.rb
+++ b/Formula/mongodb@3.2.rb
@@ -96,7 +96,7 @@ class MongodbAT32 < Formula
       dbPath: #{var}/mongodb
     net:
       bindIp: 127.0.0.1
-    EOS
+  EOS
   end
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
@@ -136,7 +136,7 @@ class MongodbAT32 < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mongodb@3.4.rb
+++ b/Formula/mongodb@3.4.rb
@@ -97,7 +97,7 @@ class MongodbAT34 < Formula
       dbPath: #{var}/mongodb
     net:
       bindIp: 127.0.0.1
-    EOS
+  EOS
   end
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
@@ -137,7 +137,7 @@ class MongodbAT34 < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -70,7 +70,7 @@ class Mono < Formula
       export MONO_GAC_PREFIX="#{HOMEBREW_PREFIX}"
     Note that the 'mono' formula now includes F#. If you have
     the 'fsharp' formula installed, remove it with 'brew uninstall fsharp'.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/montage.rb
+++ b/Formula/montage.rb
@@ -24,7 +24,7 @@ class Montage < Formula
     Montage is under the Caltech/JPL non-exclusive, non-commercial software
     licence agreement available at:
       http://montage.ipac.caltech.edu/docs/download.html
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -33,7 +33,7 @@ class Mosquitto < Formula
     mosquitto has been installed with a default configuration file.
     You can make changes to the configuration by editing:
         #{etc}/mosquitto/mosquitto.conf
-    EOS
+  EOS
   end
 
   plist_options :manual => "mosquitto -c #{HOMEBREW_PREFIX}/etc/mosquitto/mosquitto.conf"
@@ -59,7 +59,7 @@ class Mosquitto < Formula
       <string>#{var}/mosquitto</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/moz-git-tools.rb
+++ b/Formula/moz-git-tools.rb
@@ -34,7 +34,7 @@ class MozGitTools < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     (testpath/"myfile").write("my file")
     system "git", "add", "myfile"

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -135,7 +135,7 @@ class Mpd < Formula
         <string>Interactive</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mpdscribble.rb
+++ b/Formula/mpdscribble.rb
@@ -23,7 +23,7 @@ class Mpdscribble < Formula
 
   def caveats; <<~EOS
     The configuration file was placed in #{etc}/mpdscribble.conf
-    EOS
+  EOS
   end
 
   plist_options :manual => "mpdscribble"
@@ -48,7 +48,7 @@ class Mpdscribble < Formula
         <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mspdebug.rb
+++ b/Formula/mspdebug.rb
@@ -24,7 +24,7 @@ class Mspdebug < Formula
     You may need to install a kernel extension if you're having trouble with
     RF2500-like devices such as the TI Launchpad:
       https://dlbeer.co.nz/mspdebug/faq.html#rf2500_osx
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mstch.rb
+++ b/Formula/mstch.rb
@@ -34,7 +34,7 @@ class Mstch < Formula
     Version: 1.0.1
     Libs: -L${libdir} -lmstch
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mtr.rb
+++ b/Formula/mtr.rb
@@ -36,7 +36,7 @@ class Mtr < Formula
   def caveats; <<~EOS
     mtr requires root privileges so you will need to run `sudo mtr`.
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -58,7 +58,7 @@ class Mu < Formula
     Existing mu users are recommended to run the following after upgrading:
 
       mu index --rebuild
-    EOS
+  EOS
   end
 
   # Regression test for:

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -169,7 +169,7 @@ class MysqlCluster < Formula
 
       mysqladmin -u root -p shutdown
       ndb_mgm -e shutdown
-    EOS
+  EOS
   end
 
   def my_cnf; <<~EOS
@@ -180,7 +180,7 @@ class MysqlCluster < Formula
     port=5000
     # Only allow connections from localhost
     bind-address = 127.0.0.1
-    EOS
+  EOS
   end
 
   def config_ini; <<~EOS
@@ -203,7 +203,7 @@ class MysqlCluster < Formula
 
     [mysqld]
     NodeId=50
-    EOS
+  EOS
   end
 
   # Override Formula#plist_name
@@ -238,7 +238,7 @@ class MysqlCluster < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def ndb_mgmd_startup_plist(name); <<~EOS
@@ -267,7 +267,7 @@ class MysqlCluster < Formula
       <string>#{var}/mysql-cluster/#{name}.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def ndbd_startup_plist(name); <<~EOS
@@ -294,7 +294,7 @@ class MysqlCluster < Formula
       <string>#{var}/mysql-cluster/#{name}.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -173,7 +173,7 @@ class Mysql < Formula
       <string>#{datadir}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -135,7 +135,7 @@ class MysqlAT55 < Formula
 
     To connect:
         #{opt_bin}/mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mysql@5.5/bin/mysql.server start"
@@ -160,7 +160,7 @@ class MysqlAT55 < Formula
       <string>#{datadir}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -135,7 +135,7 @@ class MysqlAT56 < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mysql@5.6/bin/mysql.server start"
@@ -160,7 +160,7 @@ class MysqlAT56 < Formula
       <string>#{datadir}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -102,7 +102,7 @@ class Nagios < Formula
 
       open http://localhost/nagios
 
-    EOS
+  EOS
   end
 
   plist_options :startup => true, :manual => "nagios #{HOMEBREW_PREFIX}/etc/nagios/nagios.cfg"
@@ -129,7 +129,7 @@ class Nagios < Formula
       <string>/dev/null</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nats-streaming-server.rb
+++ b/Formula/nats-streaming-server.rb
@@ -39,7 +39,7 @@ class NatsStreamingServer < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -35,7 +35,7 @@ class Neko < Formula
       s << <<~EOS
         You must add the following line to your .bashrc or equivalent:
           export NEKOPATH="#{HOMEBREW_PREFIX}/lib/neko"
-        EOS
+      EOS
     end
     s
   end

--- a/Formula/neo4j.rb
+++ b/Formula/neo4j.rb
@@ -63,7 +63,7 @@ class Neo4j < Formula
         <string>#{var}/log/neo4j.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -135,7 +135,7 @@ class Netcdf < Formula
           if (status /= nf90_noerr) call abort
         end subroutine check
       end program test
-      EOS
+    EOS
     system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
                        "-o", "testf"
     system "./testf"

--- a/Formula/netdata.rb
+++ b/Formula/netdata.rb
@@ -54,7 +54,7 @@ class Netdata < Formula
         <string>#{var}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/newlisp.rb
+++ b/Formula/newlisp.rb
@@ -32,7 +32,7 @@ class Newlisp < Formula
   def caveats; <<~EOS
     If you have brew in a custom prefix, the included examples
     will need to be be pointed to your newlisp executable.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nexus.rb
+++ b/Formula/nexus.rb
@@ -35,7 +35,7 @@ class Nexus < Formula
       <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -127,7 +127,7 @@ class Nginx < Formula
     To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the 'http' context:
       passenger_root #{Formula["passenger"].opt_libexec}/src/ruby_supportlib/phusion_passenger/locations.ini;
       passenger_ruby /usr/bin/ruby;
-    EOS
+  EOS
   end
 
   def caveats
@@ -166,7 +166,7 @@ class Nginx < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nodebrew.rb
+++ b/Formula/nodebrew.rb
@@ -22,7 +22,7 @@ class Nodebrew < Formula
 
     To use Homebrew's directories rather than ~/.nodebrew add to your profile:
       export NODEBREW_ROOT=#{var}/nodebrew
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/noweb.rb
+++ b/Formula/noweb.rb
@@ -50,6 +50,6 @@ class Noweb < Formula
       #{texpath}
 
     You may need to add the directory to TEXINPUTS to run noweb properly.
-    EOS
+  EOS
   end
 end

--- a/Formula/np2.rb
+++ b/Formula/np2.rb
@@ -44,7 +44,7 @@ class Np2 < Formula
 
   def caveats; <<~EOS
     A Japanese TTF file named `default.ttf` should be in the working directory.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/npush.rb
+++ b/Formula/npush.rb
@@ -19,6 +19,6 @@ class Npush < Formula
     (bin/"npush").write <<~EOS
       #!/bin/sh
       cd "#{pkgshare}" && exec ./npush $@
-      EOS
+    EOS
   end
 end

--- a/Formula/nrpe.rb
+++ b/Formula/nrpe.rb
@@ -69,7 +69,7 @@ class Nrpe < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -85,7 +85,7 @@ class Nss < Formula
       *) exit 1;;
     esac
     pkg-config "$opt" nss
-    EOS
+  EOS
   end
 
   def pc_file; <<~EOS
@@ -100,6 +100,6 @@ class Nss < Formula
     Requires: nspr >= 4.12
     Libs: -L${libdir} -lnss3 -lnssutil3 -lsmime3 -lssl3
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 end

--- a/Formula/nuvie.rb
+++ b/Formula/nuvie.rb
@@ -48,6 +48,6 @@ class Nuvie < Formula
       #{var}/nuvie/savegames/
     Config file will be located at:
       #{var}/nuvie/nuvie.cfg
-    EOS
+  EOS
   end
 end

--- a/Formula/nuxeo.rb
+++ b/Formula/nuxeo.rb
@@ -42,7 +42,7 @@ class Nuxeo < Formula
     You need to edit #{etc}/nuxeo.conf file to configure manually the server.
     Also, in case of upgrade, run 'nuxeoctl mp-upgrade' to ensure all
     downloaded addons are up to date.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/nxengine.rb
+++ b/Formula/nxengine.rb
@@ -58,6 +58,6 @@ class Nxengine < Formula
   def caveats; <<~EOS
     When the game runs first time, it will extract data files into the following directory:
       #{var}/nxengine
-    EOS
+  EOS
   end
 end

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -79,7 +79,7 @@ class Nzbget < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -29,7 +29,7 @@ class Oauth2Proxy < Formula
 
   def caveats; <<~EOS
     #{etc}/oauth2_proxy/oauth2_proxy.cfg must be filled in.
-    EOS
+  EOS
   end
 
   plist_options :manual => "oauth2_proxy"
@@ -54,7 +54,7 @@ class Oauth2Proxy < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/offlineimap.rb
+++ b/Formula/offlineimap.rb
@@ -46,7 +46,7 @@ class Offlineimap < Formula
 
     * advanced configuration:
         cp -n #{etc}/offlineimap.conf ~/.offlineimaprc
-    EOS
+  EOS
   end
 
   plist_options :manual => "offlineimap"
@@ -82,7 +82,7 @@ class Offlineimap < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ogmtools.rb
+++ b/Formula/ogmtools.rb
@@ -35,6 +35,6 @@ class Ogmtools < Formula
     maintained or supported. There are several issues, especially on 64-bit
     architectures, which the author will not fix or accept patches for.
     Keep this in mind when deciding whether to use this software.
-    EOS
+  EOS
   end
 end

--- a/Formula/olsrd.rb
+++ b/Formula/olsrd.rb
@@ -47,7 +47,7 @@ class Olsrd < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -214,7 +214,7 @@ class Ooniprobe < Formula
 
   def caveats; <<~EOS
     Decks are installed to #{opt_pkgshare}/decks.
-    EOS
+  EOS
   end
 
   plist_options :startup => "true", :manual => "ooniprobe -i #{HOMEBREW_PREFIX}/share/ooniprobe/current.deck"

--- a/Formula/opam.rb
+++ b/Formula/opam.rb
@@ -115,7 +115,7 @@ class Opam < Formula
 
     Documentation and tutorials are available at https://opam.ocaml.org, or
     via "man opam" and "opam --help".
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/openrct2.rb
+++ b/Formula/openrct2.rb
@@ -34,7 +34,7 @@ class Openrct2 < Formula
     (bin/"openrct2").write <<~EOS
       #!/bin/bash
       exec "#{libexec}/openrct2" "$@" "--openrct-data-path=#{pkgshare}"
-      EOS
+    EOS
   end
 
   test do

--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -22,7 +22,7 @@ class Openrtsp < Formula
   def caveats; <<~EOS
     Testing executables have been placed in:
       #{libexec}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -102,7 +102,7 @@ class Openssl < Formula
 
     and run
       #{opt_bin}/c_rehash
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -98,7 +98,7 @@ class OpensslAT11 < Formula
 
     and run
       #{opt_bin}/c_rehash
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/opensyobon.rb
+++ b/Formula/opensyobon.rb
@@ -34,7 +34,7 @@ class Opensyobon < Formula
     (bin/"SyobonAction").write <<~EOS
       #!/bin/sh
       cd "#{pkgshare}" && exec ./SyobonAction "$@"
-      EOS
+    EOS
   end
 
   test do

--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -99,7 +99,7 @@ class Opentsdb < Formula
       <string>#{var}/opentsdb/opentsdb.err</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -91,7 +91,7 @@ class Openvpn < Formula
       <string>#{etc}/openvpn</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/orientdb.rb
+++ b/Formula/orientdb.rb
@@ -51,7 +51,7 @@ class Orientdb < Formula
   def caveats; <<~EOS
     The OrientDB root password was set to 'orientdb'. To reset it:
       https://orientdb.com/docs/2.2/Server-Security.html#restoring-the-servers-user-root
-    EOS
+  EOS
   end
 
   plist_options :manual => "orientdb start"
@@ -82,7 +82,7 @@ class Orientdb < Formula
         <string>/usr/local/var/log/orientdb/sout.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pam-u2f.rb
+++ b/Formula/pam-u2f.rb
@@ -35,7 +35,7 @@ class PamU2f < Formula
 
     For further installation instructions, please visit
     https://developers.yubico.com/pam-u2f/#installation.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -74,7 +74,7 @@ class Passenger < Formula
       To activate Phusion Passenger for Nginx, run:
         brew install nginx --with-passenger
 
-      EOS
+    EOS
 
     s += <<~EOS if build.with? "apache2-module"
       To activate Phusion Passenger for Apache, create /etc/apache2/other/passenger.conf:
@@ -82,7 +82,7 @@ class Passenger < Formula
         PassengerRoot #{opt_libexec}/src/ruby_supportlib/phusion_passenger/locations.ini
         PassengerDefaultRuby /usr/bin/ruby
 
-      EOS
+    EOS
     s
   end
 

--- a/Formula/pcre++.rb
+++ b/Formula/pcre++.rb
@@ -42,7 +42,7 @@ class Pcrexx < Formula
     The man page has been renamed to pcre++.3 to avoid conflicts with
     pcre in case-insensitive file system.  Please use "man pcre++"
     instead.
-    EOS
+  EOS
   end
 end
 

--- a/Formula/pdflib-lite.rb
+++ b/Formula/pdflib-lite.rb
@@ -36,6 +36,6 @@ class PdflibLite < Formula
     pdflib-lite is not open source software; usage restrictions apply!
     Be sure to understand and obey the license terms, which can be found at:
     https://www.pdflib.com/download/free-software/pdflib-lite-7/pdflib-lite-licensing/
-    EOS
+  EOS
   end
 end

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -82,7 +82,7 @@ class Pdns < Formula
       <string>system.preferences</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pdnsd.rb
+++ b/Formula/pdnsd.rb
@@ -38,7 +38,7 @@ class Pdnsd < Formula
     For other related utilities, e.g. pdnsd-ctl, to run, change the ownership
     to the user (default: nobody) running the service:
       sudo chown -R nobody #{var}/log/pdnsd.log #{var}/cache/pdnsd
-    EOS
+  EOS
   end
 
   plist_options :startup => true, :manual => "sudo pdnsd"
@@ -64,7 +64,7 @@ class Pdnsd < Formula
       <false/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/percona-server-mongodb.rb
+++ b/Formula/percona-server-mongodb.rb
@@ -149,7 +149,7 @@ class PerconaServerMongodb < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -189,7 +189,7 @@ class PerconaServer < Formula
       <string>#{datadir}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/percona-server@5.6.rb
+++ b/Formula/percona-server@5.6.rb
@@ -138,7 +138,7 @@ class PerconaServerAT56 < Formula
 
     To connect:
         mysql -uroot
-    EOS
+  EOS
   end
 
   plist_options :manual => "mysql.server start"
@@ -160,7 +160,7 @@ class PerconaServerAT56 < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -47,7 +47,7 @@ class Perkeep < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -70,7 +70,7 @@ class Perl < Formula
     You can set that up like this:
       PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
       echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"' >> #{shell_profile}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/perl@5.18.rb
+++ b/Formula/perl@5.18.rb
@@ -40,7 +40,7 @@ class PerlAT518 < Formula
   def caveats; <<~EOS
     By default Perl installs modules in your HOME dir. If this is an issue run:
       #{bin}/cpan o conf init
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pex.rb
+++ b/Formula/pex.rb
@@ -21,7 +21,7 @@ class Pex < Formula
   def caveats; <<~EOS
     If installing for the first time, perform the following in order to setup the necessary directory structure:
       pex init
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pgbadger.rb
+++ b/Formula/pgbadger.rb
@@ -39,7 +39,7 @@ class Pgbadger < Formula
       log_lock_waits = on
       log_temp_files = 0
       lc_messages = 'C'
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pgbouncer.rb
+++ b/Formula/pgbouncer.rb
@@ -34,7 +34,7 @@ class Pgbouncer < Formula
 
     The auth_file option should point to the #{etc}/userlist.txt file which
     can be populated by the #{bin}/mkauth.py script.
-    EOS
+  EOS
   end
 
   plist_options :manual => "pgbouncer -q #{HOMEBREW_PREFIX}/etc/pgbouncer.ini"

--- a/Formula/pgplot.rb
+++ b/Formula/pgplot.rb
@@ -67,7 +67,7 @@ class Pgplot < Formula
       SYSDIR="$SYSDIR"
       CSHARED_LIB="libcpgplot.dylib"
       CSHARED_LD="gfortan -dynamiclib -single_module $LDFLAGS -lX11"
-      EOS
+    EOS
 
     mkdir "build" do
       # activate drivers

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -286,7 +286,7 @@ class Php < Formula
         <string>#{var}/log/php-fpm.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -291,7 +291,7 @@ class PhpAT56 < Formula
         <string>#{var}/log/php-fpm.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -290,7 +290,7 @@ class PhpAT70 < Formula
         <string>#{var}/log/php-fpm.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -290,7 +290,7 @@ class PhpAT71 < Formula
         <string>#{var}/log/php-fpm.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -30,7 +30,7 @@ class Physfs < Formula
     (testpath/"test").write <<~EOS
       addarchive test.zip 1
       cat test.txt
-      EOS
+    EOS
     assert_match /Successful\.\nhomebrew/, shell_output("#{bin}/test_physfs < test 2>&1")
   end
 end

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -34,7 +34,7 @@ class Piknik < Formula
   def caveats; <<~EOS
     In order to get convenient shell aliases, put something like this in #{shell_profile}:
       . #{etc}/profile.d/piknik.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -50,7 +50,7 @@ class Pilosa < Formula
         <string>#{var}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pincaster.rb
+++ b/Formula/pincaster.rb
@@ -57,7 +57,7 @@ class Pincaster < Formula
         <string>#{var}/log/pincaster.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -28,7 +28,7 @@ class PinentryMac < Formula
 
     ~/.gnupg/gpg-agent.conf
         pinentry-program #{HOMEBREW_PREFIX}/bin/pinentry-mac
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pius.rb
+++ b/Formula/pius.rb
@@ -32,7 +32,7 @@ class Pius < Formula
     The path to gpg is hardcoded in pius as `/usr/bin/env gpg`.
     You can specify a different path by editing ~/.pius:
       gpg-path=/path/to/gpg
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/plan9port.rb
+++ b/Formula/plan9port.rb
@@ -35,7 +35,7 @@ class Plan9port < Formula
     "9", which has been installed into the Homebrew prefix bin.  For example,
     to run Plan 9's ls run:
         # 9 ls
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/platypus.rb
+++ b/Formula/platypus.rb
@@ -41,7 +41,7 @@ class Platypus < Formula
 
     Alternatively, install with Homebrew-Cask:
       brew cask install platypus
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/plenv.rb
+++ b/Formula/plenv.rb
@@ -21,7 +21,7 @@ class Plenv < Formula
       if which plenv > /dev/null; then eval "$(plenv init - zsh)"; fi
     With fish, add to your config.fish
       if plenv > /dev/null; plenv init - | source ; end
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pmd.rb
+++ b/Formula/pmd.rb
@@ -17,7 +17,7 @@ class Pmd < Formula
 
   def caveats; <<~EOS
     Run with `pmd` (instead of `run.sh` as described in the documentation).
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/podiff.rb
+++ b/Formula/podiff.rb
@@ -31,7 +31,7 @@ class Podiff < Formula
       *.po diff=podiff
 
     See `man podiff` for more information.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/polipo.rb
+++ b/Formula/polipo.rb
@@ -60,7 +60,7 @@ class Polipo < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -133,7 +133,7 @@ class Postgis < Formula
         #{HOMEBREW_PREFIX}/lib
       PostGIS extension modules installed to:
         #{HOMEBREW_PREFIX}/share/postgresql/extension
-      EOS
+    EOS
   end
 
   test do

--- a/Formula/postgres-xc.rb
+++ b/Formula/postgres-xc.rb
@@ -163,7 +163,7 @@ class PostgresXc < Formula
       FATAL:  could not create shared memory segment: Cannot allocate memory
     then you need to tweak your system's shared memory parameters:
       https://www.postgresql.org/docs/current/static/kernel-resources.html#SYSVIPC
-    EOS
+  EOS
   end
 
   plist_options :startup => true
@@ -203,7 +203,7 @@ class PostgresXc < Formula
       <string>#{var}/postgres-xc/#{name}/server.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def gtm_proxy_startup_plist(name); <<~EOS
@@ -237,7 +237,7 @@ class PostgresXc < Formula
       <string>#{var}/postgres-xc/#{name}/server.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def coordinator_startup_plist(name); <<~EOS
@@ -267,7 +267,7 @@ class PostgresXc < Formula
       <string>#{var}/postgres-xc/#{name}/server.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def datanode_startup_plist(name); <<~EOS
@@ -297,7 +297,7 @@ class PostgresXc < Formula
       <string>#{var}/postgres-xc/#{name}/server.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -102,7 +102,7 @@ class Postgresql < Formula
   def caveats; <<~EOS
     To migrate existing data from a previous major version of PostgreSQL run:
       brew postgresql-upgrade-database
-    EOS
+  EOS
   end
 
   plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres start"
@@ -132,7 +132,7 @@ class Postgresql < Formula
       <string>#{var}/log/postgres.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -127,7 +127,7 @@ class PostgresqlAT94 < Formula
       <string>#{var}/log/#{name}.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -106,7 +106,7 @@ class PostgresqlAT95 < Formula
 
       You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
       Do not run `brew cleanup postgresql@9.5` until you have performed the migration.
-    EOS
+  EOS
   end
 
   plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.5 start"
@@ -134,7 +134,7 @@ class PostgresqlAT95 < Formula
       <string>#{var}/log/#{name}.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -110,7 +110,7 @@ class PostgresqlAT96 < Formula
 
       You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
         Do not run `brew cleanup postgresql@9.6` until you have performed the migration.
-    EOS
+  EOS
   end
 
   plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.6 start"
@@ -138,7 +138,7 @@ class PostgresqlAT96 < Formula
       <string>#{var}/log/#{name}.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -64,7 +64,7 @@ class Presto < Formula
   def caveats; <<~EOS
     Add connectors to #{libexec}/etc/catalog/. See:
     https://prestodb.io/docs/current/connector.html
-    EOS
+  EOS
   end
 
   plist_options :manual => "presto-server run"
@@ -90,7 +90,7 @@ class Presto < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/privoxy.rb
+++ b/Formula/privoxy.rb
@@ -59,7 +59,7 @@ class Privoxy < Formula
       <string>#{var}/log/privoxy/logfile</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/proftpd.rb
+++ b/Formula/proftpd.rb
@@ -52,7 +52,7 @@ class Proftpd < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/proof-general.rb
+++ b/Formula/proof-general.rb
@@ -41,7 +41,7 @@ class ProofGeneral < Formula
 
   def caveats; <<~EOS
     HTML documentation is available in: #{HOMEBREW_PREFIX}/share/doc/proof-general
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -80,7 +80,7 @@ class Protobuf < Formula
   def caveats; <<~EOS
     Editor support and examples have been installed to:
       #{doc}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/protobuf@2.5.rb
+++ b/Formula/protobuf@2.5.rb
@@ -58,7 +58,7 @@ class ProtobufAT25 < Formula
   def caveats; <<~EOS
     Editor support and examples have been installed to:
       #{doc}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/protobuf@2.6.rb
+++ b/Formula/protobuf@2.6.rb
@@ -96,7 +96,7 @@ class ProtobufAT26 < Formula
   def caveats; <<~EOS
     Editor support and examples have been installed to:
       #{doc}
-    EOS
+  EOS
   end
 
   test do
@@ -109,7 +109,7 @@ class ProtobufAT26 < Formula
         message Test {
           repeated TestCase case = 1;
         }
-        EOS
+      EOS
     (testpath/"test.proto").write(testdata)
     system bin/"protoc", "test.proto", "--cpp_out=."
     if build.with? "python@2"

--- a/Formula/protobuf@3.1.rb
+++ b/Formula/protobuf@3.1.rb
@@ -127,7 +127,7 @@ class ProtobufAT31 < Formula
   def caveats; <<~EOS
     Editor support and examples have been installed to:
       #{doc}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pspg.rb
+++ b/Formula/pspg.rb
@@ -26,7 +26,7 @@ class Pspg < Formula
       \\setenv PAGER pspg
       \\pset border 2
       \\pset linestyle unicode
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ptunnel.rb
+++ b/Formula/ptunnel.rb
@@ -23,7 +23,7 @@ class Ptunnel < Formula
 
     Alternatively, you can try using the -u flag to start ptunnel in 'unprivileged' mode,
     but this is not recommended. See https://www.cs.uit.no/~daniels/PingTunnel/ for details.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -88,7 +88,7 @@ class Pulseaudio < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -66,7 +66,7 @@ class PureFtpd < Formula
         <string>#{var}/log/pure-ftpd.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pyenv-virtualenv.rb
+++ b/Formula/pyenv-virtualenv.rb
@@ -18,7 +18,7 @@ class PyenvVirtualenv < Formula
   def caveats; <<~EOS
     To enable auto-activation add to your profile:
       if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -142,7 +142,7 @@ class Pypy < Formula
         pip_pypy install --upgrade pip setuptools
 
     See: https://docs.brew.sh/Homebrew-and-Python
-    EOS
+  EOS
   end
 
   # The HOMEBREW_PREFIX location of site-packages

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -171,7 +171,7 @@ class Pypy3 < Formula
         pip_pypy3 install --upgrade pip setuptools
 
     See: https://docs.brew.sh/Homebrew-and-Python
-    EOS
+  EOS
   end
 
   # The HOMEBREW_PREFIX location of site-packages

--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -328,7 +328,7 @@ class PythonAT2 < Formula
       #{site_packages}
 
     See: https://docs.brew.sh/Homebrew-and-Python
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/qdae.rb
+++ b/Formula/qdae.rb
@@ -25,7 +25,7 @@ class Qdae < Formula
   def caveats; <<~EOS
     Data files are located in the following directory:
       #{share}/QDAE
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -104,7 +104,7 @@ class Qt < Formula
   def caveats; <<~EOS
     We agreed to the Qt open source license for you.
     If this is unacceptable you should uninstall.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/qt@5.5.rb
+++ b/Formula/qt@5.5.rb
@@ -151,7 +151,7 @@ class QtAT55 < Formula
   def caveats; <<~EOS
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/quasi88.rb
+++ b/Formula/quasi88.rb
@@ -34,7 +34,7 @@ class Quasi88 < Formula
       -romdir ~/quasi88/rom/
       -diskdir ~/quasi88/disk/
       -tapedir ~/quasi88/tape/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/questdb.rb
+++ b/Formula/questdb.rb
@@ -53,7 +53,7 @@ class Questdb < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -51,14 +51,14 @@ class Rabbitmq < Formula
 
   def caveats; <<~EOS
     Management Plugin enabled by default at http://localhost:15672
-    EOS
+  EOS
   end
 
   def rabbitmq_env; <<~EOS
     CONFIG_FILE=#{etc}/rabbitmq/rabbitmq
     NODE_IP_ADDRESS=127.0.0.1
     NODENAME=rabbit@localhost
-    EOS
+  EOS
   end
 
   plist_options :manual => "rabbitmq-server"
@@ -86,7 +86,7 @@ class Rabbitmq < Formula
         </dict>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/radamsa.rb
+++ b/Formula/radamsa.rb
@@ -28,7 +28,7 @@ class Radamsa < Formula
     Tests can be run with:
       $ make .seal-of-quality
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -68,7 +68,7 @@ class Redis < Formula
         <string>#{var}/log/redis.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/redis@2.8.rb
+++ b/Formula/redis@2.8.rb
@@ -63,7 +63,7 @@ class RedisAT28 < Formula
         <string>#{var}/log/redis28.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -70,7 +70,7 @@ class RedisAT32 < Formula
         <string>#{var}/log/redis.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/redshift.rb
+++ b/Formula/redshift.rb
@@ -47,7 +47,7 @@ class Redshift < Formula
 
     Please note redshift expects to read its configuration file from
     #{ENV["HOME"]}/.config/redshift/redshift.conf
-    EOS
+  EOS
   end
 
   plist_options :manual => "redshift"
@@ -73,7 +73,7 @@ class Redshift < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/reposurgeon.rb
+++ b/Formula/reposurgeon.rb
@@ -29,7 +29,7 @@ class Reposurgeon < Formula
       [user]
         name = Real Person
         email = notacat@hotmail.cat
-      EOS
+    EOS
     system "git", "init"
     system "git", "commit", "--allow-empty", "--message", "brewing"
 

--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -37,7 +37,7 @@ class Resty < Formula
   def caveats; <<~EOS
     To activate the resty, add the following at the end of your #{shell_profile}:
     source #{opt_pkgshare}/resty
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -75,7 +75,7 @@ class Rethinkdb < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/riemann.rb
+++ b/Formula/riemann.rb
@@ -33,7 +33,7 @@ class Riemann < Formula
       riemann-client
       riemann-tools
       riemann-dash
-    EOS
+  EOS
   end
 
   plist_options :manual => "riemann"
@@ -61,7 +61,7 @@ class Riemann < Formula
         <string>#{var}/log/riemann.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -123,7 +123,7 @@ class Root < Formula
       pushd #{HOMEBREW_PREFIX} >/dev/null; . bin/thisroot.sh; popd >/dev/null
     For csh/tcsh users:
       source #{HOMEBREW_PREFIX}/bin/thisroot.csh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/rsyslog.rb
+++ b/Formula/rsyslog.rb
@@ -90,6 +90,6 @@ class Rsyslog < Formula
         <string>#{var}/log/rsyslogd.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 end

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -63,7 +63,7 @@ class Rtags < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/rtf2latex2e.rb
+++ b/Formula/rtf2latex2e.rb
@@ -18,7 +18,7 @@ class Rtf2latex2e < Formula
   def caveats; <<~EOS
     Configuration files have been installed to:
       #{opt_pkgshare}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -187,7 +187,7 @@ class Ruby < Formula
         "#{opt_bin}/ruby"
       end
     end
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ruby@2.0.rb
+++ b/Formula/ruby@2.0.rb
@@ -142,7 +142,7 @@ class RubyAT20 < Formula
         "#{opt_bin}/ruby"
       end
     end
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
@@ -150,7 +150,7 @@ class RubyAT20 < Formula
       #{rubygems_bindir}
 
     You may want to add this to your PATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ruby@2.2.rb
+++ b/Formula/ruby@2.2.rb
@@ -146,7 +146,7 @@ class RubyAT22 < Formula
         "#{opt_bin}/ruby"
       end
     end
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
@@ -154,7 +154,7 @@ class RubyAT22 < Formula
       #{rubygems_bindir}
 
     You may want to add this to your PATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ruby@2.3.rb
+++ b/Formula/ruby@2.3.rb
@@ -147,7 +147,7 @@ class RubyAT23 < Formula
         "#{opt_bin}/ruby"
       end
     end
-    EOS
+  EOS
   end
 
   def caveats; <<~EOS
@@ -155,7 +155,7 @@ class RubyAT23 < Formula
       #{rubygems_bindir}
 
     You may want to add this to your PATH.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/runit.rb
+++ b/Formula/runit.rb
@@ -43,6 +43,6 @@ class Runit < Formula
          runsvdir -P #{var}/service
 
     Depending on the services managed by runit, this may need to start as root.
-    EOS
+  EOS
   end
 end

--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -34,7 +34,7 @@ class S3fs < Formula
     details:
 
       https://code.google.com/p/s3fs/issues/detail?id=73
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/saltstack.rb
+++ b/Formula/saltstack.rb
@@ -138,7 +138,7 @@ class Saltstack < Formula
   def caveats; <<~EOS
     Sample configuration files have been placed in #{etc}/saltstack.
     Saltstack will not use these by default.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sbcl.rb
+++ b/Formula/sbcl.rb
@@ -74,7 +74,7 @@ class Sbcl < Formula
         (setf (logical-pathname-translations "SYS")
           '(("SYS:SRC;**;*.*.*" #p"#{pkgshare}/src/**/*.*")
             ("SYS:CONTRIB;**;*.*.*" #p"#{pkgshare}/contrib/**/*.*")))
-        EOS
+      EOS
     end
   end
 

--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -31,7 +31,7 @@ class Sbt < Formula
     You can use $SBT_OPTS to pass additional JVM options to SBT.
     Project specific options should be placed in .sbtopts in the root of your project.
     Global settings should be placed in #{etc}/sbtopts
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sbt@0.13.rb
+++ b/Formula/sbt@0.13.rb
@@ -38,7 +38,7 @@ class SbtAT013 < Formula
     This formula uses the standard Lightbend sbt launcher script.
     Project specific options should be placed in .sbtopts in the root of your project.
     Global settings should be placed in #{etc}/sbtopts
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/scala.rb
+++ b/Formula/scala.rb
@@ -75,7 +75,7 @@ class Scala < Formula
   def caveats; <<~EOS
     To use with IntelliJ, set the Scala home to:
       #{opt_prefix}/idea
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/scm-manager.rb
+++ b/Formula/scm-manager.rb
@@ -62,7 +62,7 @@ class ScmManager < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -43,7 +43,7 @@ class Scrcpy < Formula
 
     You can install adb from Homebrew Cask:
       brew cask install android-platform-tools
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sdlpop.rb
+++ b/Formula/sdlpop.rb
@@ -29,12 +29,12 @@ class Sdlpop < Formula
     (bin/"prince").write <<~EOS
       #!/bin/bash
       cd "#{pkgvar}" && exec "#{libexec}/prince" $@
-      EOS
+    EOS
   end
 
   def caveats; <<~EOS
     Save and replay files are stored in the following directory:
       #{var}/sdlpop
-    EOS
+  EOS
   end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -40,7 +40,7 @@ class SeleniumServerStandalone < Formula
       <string>#{var}/log/selenium-output.log</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ser2net.rb
+++ b/Formula/ser2net.rb
@@ -32,7 +32,7 @@ class Ser2net < Formula
 
   def caveats; <<~EOS
     To configure ser2net, edit the example configuration in #{etc}/ser2net.conf
-    EOS
+  EOS
   end
 
   plist_options :manual => "ser2net -p 12345"
@@ -58,7 +58,7 @@ class Ser2net < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
   test do
     assert_match version.to_s, shell_output("#{sbin}/ser2net -v")

--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -64,7 +64,7 @@ class ShadowsocksLibev < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -90,7 +90,7 @@ class ShibbolethSp < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sickbeard.rb
+++ b/Formula/sickbeard.rb
@@ -67,7 +67,7 @@ class Sickbeard < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   def startup_script; <<~EOS
@@ -77,6 +77,6 @@ class Sickbeard < Formula
            "--pidfile=#{var}/run/sickbeard.pid"\
            "--datadir=#{etc}/sickbeard"\
            "$@"
-    EOS
+  EOS
   end
 end

--- a/Formula/siege.rb
+++ b/Formula/siege.rb
@@ -37,7 +37,7 @@ class Siege < Formula
         net.inet.tcp.msl: 15000 -> 1000
 
     Run siege.config to create the ~/.siegerc config file.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/skipfish.rb
+++ b/Formula/skipfish.rb
@@ -38,6 +38,6 @@ class Skipfish < Formula
 
     Use this command to print usage information:
       skipfish -h
-    EOS
+  EOS
   end
 end

--- a/Formula/sleepwatcher.rb
+++ b/Formula/sleepwatcher.rb
@@ -56,6 +56,6 @@ class Sleepwatcher < Formula
       #{Dir["#{prefix}/*.plist"].join("\n      ")}
 
     These are the examples provided by the author.
-    EOS
+  EOS
   end
 end

--- a/Formula/slimerjs.rb
+++ b/Formula/slimerjs.rb
@@ -19,7 +19,7 @@ class Slimerjs < Formula
   def caveats; <<~EOS
     The configuration file was installed in:
       #{libexec}/application.ini
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -62,7 +62,7 @@ class Snort < Formula
     so that they can be read by non-root users.  This can be done manually using:
         sudo chmod o+r /dev/bpf*
     or you could create a startup item to do this for you.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sntop.rb
+++ b/Formula/sntop.rb
@@ -28,7 +28,7 @@ class Sntop < Formula
     sntop uses fping by default and fping can only be run by root by default.
     You can run `sudo sntop` (or `sntop -p` which uses standard ping).
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -35,7 +35,7 @@ class Sonarqube < Formula
         <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sphinx.rb
+++ b/Formula/sphinx.rb
@@ -99,7 +99,7 @@ class Sphinx < Formula
 
     We don't install these for you when you install this formula, as
     we don't know which datasource you intend to use.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/spoof-mac.rb
+++ b/Formula/spoof-mac.rb
@@ -45,7 +45,7 @@ class SpoofMac < Formula
         <string>en0</string>
     to e.g.:
         <string>en1</string>
-    EOS
+  EOS
   end
 
   plist_options :startup => true, :manual => "spoof-mac"
@@ -71,7 +71,7 @@ class SpoofMac < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -45,7 +45,7 @@ class Sqoop < Formula
   def caveats; <<~EOS
     Hadoop, Hive, HBase and ZooKeeper must be installed and configured
     for Sqoop to work.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/squid.rb
+++ b/Formula/squid.rb
@@ -73,7 +73,7 @@ class Squid < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/squirrel.rb
+++ b/Formula/squirrel.rb
@@ -44,7 +44,7 @@ class Squirrel < Formula
     Requires:
     Libs: -L${libdir} -lsquirrel -lsqstdlib
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/ssdb.rb
+++ b/Formula/ssdb.rb
@@ -74,7 +74,7 @@ class Ssdb < Formula
         <string>#{var}/log/ssdb.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -58,7 +58,7 @@ class Sshguard < Formula
         block in quick on $ext_if proto tcp from <sshguard> to any port 22 label "ssh bruteforce"
 
       Then run sudo pfctl -f /etc/pf.conf to reload the rules.
-      EOS
+    EOS
     end
   end
 
@@ -81,7 +81,7 @@ class Sshguard < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -31,7 +31,7 @@ class SstpClient < Formula
     does not exist yet, type the following command to create it:
 
     sudo touch /etc/ppp/options
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/stk.rb
+++ b/Formula/stk.rb
@@ -54,7 +54,7 @@ class Stk < Formula
       #include \"stk/FileWvOut.h\"
 
     src/ projects/ and rawwaves/ have all been copied to #{opt_pkgshare}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -52,7 +52,7 @@ class Stubby < Formula
         <string>#{var}/log/stubby/stubby.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/supermodel.rb
+++ b/Formula/supermodel.rb
@@ -40,7 +40,7 @@ class Supermodel < Formula
   def caveats; <<~EOS
     Config, Saves, and NVRAM are located in the following directory:
       #{var}/supermodel/
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/syncthing-inotify.rb
+++ b/Formula/syncthing-inotify.rb
@@ -51,7 +51,7 @@ class SyncthingInotify < Formula
         <string>#{var}/log/syncthing-inotify.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -59,7 +59,7 @@ class Syncthing < Formula
         <string>#{var}/log/syncthing.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tcptraceroute.rb
+++ b/Formula/tcptraceroute.rb
@@ -38,7 +38,7 @@ class Tcptraceroute < Formula
     tcptraceroute requires root privileges so you will need to run
     `sudo tcptraceroute`.
     You should be certain that you trust any software you grant root privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -65,7 +65,7 @@ class Telegraf < Formula
         <string>#{var}/log/telegraf.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -56,7 +56,7 @@ class Thefuck < Formula
       eval $(thefuck --alias)
 
     For other shells, check https://github.com/nvbn/thefuck/wiki/Shell-aliases
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tig.rb
+++ b/Formula/tig.rb
@@ -39,7 +39,7 @@ class Tig < Formula
       #{opt_pkgshare}/examples/tigrc
     to override the system-wide default configuration, copy the sample to:
       #{etc}/tigrc
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tika.rb
+++ b/Formula/tika.rb
@@ -30,7 +30,7 @@ class Tika < Formula
 
     See the Tika homepage for more documentation:
       brew home tika
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tile38.rb
+++ b/Formula/tile38.rb
@@ -33,7 +33,7 @@ class Tile38 < Formula
 
   def caveats; <<~EOS
     To connect: tile38-cli
-    EOS
+  EOS
   end
 
   plist_options :manual => "tile38-server -d #{HOMEBREW_PREFIX}/var/tile38/data"
@@ -66,7 +66,7 @@ class Tile38 < Formula
         <string>#{var}/log/tile38.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -74,7 +74,7 @@ class Tinyproxy < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tinyxml.rb
+++ b/Formula/tinyxml.rb
@@ -54,7 +54,7 @@ class Tinyxml < Formula
     Version: #{version}
     Libs: -L${libdir} -ltinyxml
     Cflags: -I${includedir}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -50,7 +50,7 @@ class Tmux < Formula
   def caveats; <<~EOS
     Example configuration has been installed to:
       #{opt_pkgshare}
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/todo-txt.rb
+++ b/Formula/todo-txt.rb
@@ -16,7 +16,7 @@ class TodoTxt < Formula
   def caveats; <<~EOS
     To configure, copy the default config to your HOME and edit it:
       cp #{prefix}/todo.cfg ~/.todo.cfg
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomcat-native.rb
+++ b/Formula/tomcat-native.rb
@@ -42,6 +42,6 @@ class TomcatNative < Formula
       CATALINA_OPTS=\"$CATALINA_OPTS -Djava.library.path=#{opt_lib}\"
 
     If $CATALINA_HOME/bin/setenv.sh doesn't exist, create it and make it executable.
-    EOS
+  EOS
   end
 end

--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -47,7 +47,7 @@ class Tomcat < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomcat@6.rb
+++ b/Formula/tomcat@6.rb
@@ -31,7 +31,7 @@ class TomcatAT6 < Formula
     These are likely to conflict with support scripts used by other Java-based
     server software.
     You can add #{bin} to your PATH instead.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomcat@8.rb
+++ b/Formula/tomcat@8.rb
@@ -51,7 +51,7 @@ class TomcatAT8 < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomee-jax-rs.rb
+++ b/Formula/tomee-jax-rs.rb
@@ -23,7 +23,7 @@ class TomeeJaxRs < Formula
       #{opt_libexec}
     To run Apache TomEE:
       #{opt_libexec}/bin/tomee-jax-rs-startup
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomee-plume.rb
+++ b/Formula/tomee-plume.rb
@@ -23,7 +23,7 @@ class TomeePlume < Formula
       #{opt_libexec}
     To run Apache TomEE:
       #{opt_libexec}/bin/tomee-plume-startup
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomee-plus.rb
+++ b/Formula/tomee-plus.rb
@@ -23,7 +23,7 @@ class TomeePlus < Formula
       #{opt_libexec}
     To run Apache TomEE:
       #{opt_libexec}/bin/tomee-plus-startup
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tomee-webprofile.rb
+++ b/Formula/tomee-webprofile.rb
@@ -30,7 +30,7 @@ class TomeeWebprofile < Formula
       #{opt_libexec}
     To run Apache TomEE:
       #{opt_libexec}/bin/tomee-webprofile-startup
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -57,7 +57,7 @@ class Tor < Formula
         <string>#{var}/log/tor.log</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/tracebox.rb
+++ b/Formula/tracebox.rb
@@ -38,7 +38,7 @@ class Tracebox < Formula
 
     You should be certain that you trust any software you are executing with
     elevated privileges.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/translate-shell.rb
+++ b/Formula/translate-shell.rb
@@ -27,7 +27,7 @@ class TranslateShell < Formula
     `say' command. This functionality may be improved in certain cases by
     installing one of mplayer, mpv, or mpg123, all of which are available
     through `brew install'.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/transmission.rb
+++ b/Formula/transmission.rb
@@ -45,7 +45,7 @@ class Transmission < Formula
 
     Alternatively, install with Homebrew-Cask:
       brew cask install transmission
-    EOS
+  EOS
   end
 
   plist_options :manual => "transmission-daemon --foreground"
@@ -76,7 +76,7 @@ class Transmission < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/twoping.rb
+++ b/Formula/twoping.rb
@@ -52,7 +52,7 @@ class Twoping < Formula
         <true/>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/udpxy.rb
+++ b/Formula/udpxy.rb
@@ -41,6 +41,6 @@ class Udpxy < Formula
       <string>#{HOMEBREW_PREFIX}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 end

--- a/Formula/uftp.rb
+++ b/Formula/uftp.rb
@@ -43,7 +43,7 @@ class Uftp < Formula
       <string>#{var}</string>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -79,7 +79,7 @@ class Unbound < Formula
         <string>/dev/null</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/unoconv.rb
+++ b/Formula/unoconv.rb
@@ -20,6 +20,6 @@ class Unoconv < Formula
 
   def caveats; <<~EOS
     In order to use unoconv, a copy of LibreOffice between versions 3.6.0.1 - 4.3.x must be installed.
-    EOS
+  EOS
   end
 end

--- a/Formula/uptimed.rb
+++ b/Formula/uptimed.rb
@@ -53,7 +53,7 @@ class Uptimed < Formula
         </array>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/uru.rb
+++ b/Formula/uru.rb
@@ -25,7 +25,7 @@ class Uru < Formula
   def caveats; <<~EOS
     Append to ~/.profile on Ubuntu, or to ~/.zshrc on Zsh
     $ echo 'eval "$(uru_rt admin install)"' >> ~/.bash_profile
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/uwsgi.rb
+++ b/Formula/uwsgi.rb
@@ -172,7 +172,7 @@ class Uwsgi < Formula
         <string>#{HOMEBREW_PREFIX}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/vf.rb
+++ b/Formula/vf.rb
@@ -16,7 +16,7 @@ class Vf < Formula
   def caveats; <<~EOS
     To complete installation, add the following line to your shell's rc file:
       source #{opt_prefix}/vf.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/vimpager.rb
+++ b/Formula/vimpager.rb
@@ -25,7 +25,7 @@ class Vimpager < Formula
   def caveats; <<~EOS
     To use vimpager as your default pager, add `export PAGER=vimpager` to your
     shell configuration.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/virtuoso.rb
+++ b/Formula/virtuoso.rb
@@ -40,7 +40,7 @@ class Virtuoso < Formula
   def caveats; <<~EOS
     NOTE: the Virtuoso server will start up several times on port 1111
     during the install process.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/vnstat.rb
+++ b/Formula/vnstat.rb
@@ -39,7 +39,7 @@ class Vnstat < Formula
 
   def caveats; <<~EOS
     To monitor interfaces other than "en0" edit #{etc}/vnstat.conf
-    EOS
+  EOS
   end
 
   plist_options :startup => true, :manual => "#{HOMEBREW_PREFIX}/opt/vnstat/bin/vnstatd --nodaemon --config #{HOMEBREW_PREFIX}/etc/vnstat.conf"
@@ -68,7 +68,7 @@ class Vnstat < Formula
         <string>Background</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/vsftpd.rb
+++ b/Formula/vsftpd.rb
@@ -76,7 +76,7 @@ class Vsftpd < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -120,7 +120,7 @@ class Vtk < Formula
     from python. Alternatively, you can integrate the RenderWindowInteractor
     in PyQt5, Tk or Wx at runtime. Read more:
       import vtk.qt5; help(vtk.qt5) or import vtk.wx; help(vtk.wx)
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/webdis.rb
+++ b/Formula/webdis.rb
@@ -55,7 +55,7 @@ class Webdis < Formula
         <string>#{var}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wemux.rb
+++ b/Formula/wemux.rb
@@ -36,7 +36,7 @@ class Wemux < Formula
 
     Either edit the file in your text editor of choice or run `wemux conf` to
     open the file in your $EDITOR.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -30,7 +30,7 @@ class Whois < Formula
   def caveats; <<~EOS
     Debian whois has been installed as `whois` and may shadow the
     system binary of the same name.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wildfly-as.rb
+++ b/Formula/wildfly-as.rb
@@ -21,7 +21,7 @@ class WildflyAs < Formula
     You may want to add the following to your .bash_profile:
       export JBOSS_HOME=#{opt_libexec}
       export PATH=${PATH}:${JBOSS_HOME}/bin
-    EOS
+  EOS
   end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/wildfly-as/libexec/bin/standalone.sh --server-config=standalone.xml"
@@ -54,7 +54,7 @@ class WildflyAs < Formula
       </dict>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -250,7 +250,7 @@ class Wine < Formula
             #ifdef __#{arch}__
             #{(Pathname.pwd/"build-#{arch}/opensslconf.h").read}
             #endif
-            EOS
+          EOS
         end
         (libexec/"include/openssl/opensslconf.h").atomic_write confs.join("\n")
       end
@@ -472,7 +472,7 @@ class Wine < Formula
   def caveats; <<~EOS
     You may also want winetricks:
       brew install winetricks
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/winetricks.rb
+++ b/Formula/winetricks.rb
@@ -23,7 +23,7 @@ class Winetricks < Formula
   def caveats; <<~EOS
     winetricks is a set of utilities for wine, which is installed separately:
       brew install wine
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -118,7 +118,7 @@ class Wireshark < Formula
     (default macOS behavior), install ChmodBPF:
 
       brew cask install wireshark-chmodbpf
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -46,7 +46,7 @@ class Wpscan < Formula
 
   def caveats; <<~EOS
     Logs are saved to #{var}/cache/wpscan/log.txt by default.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/wrk-trello.rb
+++ b/Formula/wrk-trello.rb
@@ -12,7 +12,7 @@ class WrkTrello < Formula
     #!/bin/sh
     export WRK_HOME="#{libexec}"
     exec "#{libexec}/bin/wrk" "$@"
-    EOS
+  EOS
   end
 
   def install
@@ -25,6 +25,6 @@ class WrkTrello < Formula
     https://trello.com/1/authorize?key=8d56bbd601877abfd13150a999a840d0&name=Wrk&expiration=never&response_type=token&scope=read,write
     and save it to ~/.wrk/token
     Start `wrk` for more information.
-    EOS
+  EOS
   end
 end

--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -30,7 +30,7 @@ class Wxmaxima < Formula
     in ~/.maxima/maxima-init.mac:
       gnuplot_command:"#{HOMEBREW_PREFIX}/bin/gnuplot"$
       draw_command:"#{HOMEBREW_PREFIX}/bin/gnuplot"$
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -33,7 +33,7 @@ class Xdotool < Formula
 
     For the source of this useful hint:
       https://stackoverflow.com/questions/1264210/does-mac-x11-have-the-xtest-extension
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/z.rb
+++ b/Formula/z.rb
@@ -16,7 +16,7 @@ class Z < Formula
   def caveats; <<~EOS
     For Bash or Zsh, put something like this in your $HOME/.bashrc or $HOME/.zshrc:
       . #{etc}/profile.d/z.sh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/znc.rb
+++ b/Formula/znc.rb
@@ -73,7 +73,7 @@ class Znc < Formula
         <integer>300</integer>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -155,7 +155,7 @@ class Zookeeper < Formula
         <string>#{var}</string>
       </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zplug.rb
+++ b/Formula/zplug.rb
@@ -20,7 +20,7 @@ class Zplug < Formula
     In order to use zplug, please add the following to your .zshrc:
       export ZPLUG_HOME=#{opt_prefix}
       source $ZPLUG_HOME/init.zsh
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zpython.rb
+++ b/Formula/zpython.rb
@@ -64,7 +64,7 @@ class Zpython < Formula
 
     After reloading your shell you can test with:
       zmodload zsh/zpython && zpython 'print "hello world"'
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zsh-git-prompt.rb
+++ b/Formula/zsh-git-prompt.rb
@@ -13,7 +13,7 @@ class ZshGitPrompt < Formula
   def caveats; <<~EOS
     Make sure zsh-git-prompt is loaded from your .zshrc:
       source "#{opt_prefix}/zshrc.sh"
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zsh-navigation-tools.rb
+++ b/Formula/zsh-navigation-tools.rb
@@ -22,7 +22,7 @@ class ZshNavigationTools < Formula
 
     You will also need to force reload of your .zshrc:
       source ~/.zshrc
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/zurl.rb
+++ b/Formula/zurl.rb
@@ -41,7 +41,7 @@ class Zurl < Formula
       in_req_spec=ipc://#{ipcfile}
       defpolicy=allow
       timeout=10
-      EOS
+    EOS
                   )
 
     runfile.write(<<~EOS
@@ -85,7 +85,7 @@ class Zurl < Formula
       resp = json.loads(sock.recv()[1:])
       assert('type' not in resp)
       assert(resp['body'] == 'test response\\n')
-      EOS
+    EOS
                  )
 
     pid = fork do


### PR DESCRIPTION
Realign trailing EOS.

I'd rather see the `def caveats; <<-EOS` weird pattern changed but I'm open to either approach, really.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----