### PR TITLE
ssh-vault: depend on go@1.9 at build time

### DIFF
--- a/Formula/ssh-vault.rb
+++ b/Formula/ssh-vault.rb
@@ -15,7 +15,7 @@ class SshVault < Formula
   end
 
   depends_on "dep" => :build
-  depends_on "go" => :build
+  depends_on "go@1.9" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
instead of go


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes Go 1.10.x build failure
```
==> go build -ldflags -s -w -X main.version=0.12.3 -o /usr/local/Cellar/ssh-vault/0.12.3/bin/ssh-vault cmd/ssh-vault/main.go
ld: warning: text-based stub file /System/Library/Frameworks//Security.framework/Security.tbd and library file /System/Library/Frameworks//Security.framework/Security are out of sync. Falling back to library file for linking.
ld: warning: text-based stub file /System/Library/Frameworks//Security.framework/Security.tbd and library file /System/Library/Frameworks//Security.framework/Security are out of sync. Falling back to library file for linking.
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:29: cannot use nil as type _Ctype_CFDataRef in return argument
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:36: cannot convert nil to type _Ctype_CFDataRef
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:37: cannot use nil as type _Ctype_CFDataRef in return argument
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:62: cannot convert nil to type _Ctype_CFDictionaryRef
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:63: cannot use nil as type _Ctype_CFDictionaryRef in return argument
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:74: cannot convert &keys[0] (type *_Ctype_CFTypeRef) to type *unsafe.Pointer
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:74: cannot convert &values[0] (type *_Ctype_CFTypeRef) to type *unsafe.Pointer
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:87: cannot use nil as type _Ctype_CFStringRef in return argument
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:90: cannot use nil as type _Ctype_CFStringRef in return argument
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:141: cannot convert &a[0] (type *_Ctype_CFTypeRef) to type *unsafe.Pointer
vendor/github.com/ssh-vault/go-keychain/corefoundation.go:141: too many errors
```