### PR TITLE
libreadline-java: require Java 8 specifically for compilation

### DIFF
--- a/Formula/libreadline-java.rb
+++ b/Formula/libreadline-java.rb
@@ -14,7 +14,7 @@ class LibreadlineJava < Formula
   end
 
   depends_on "readline"
-  depends_on :java => "1.6+"
+  depends_on :java => "1.8"
 
   # Fix "non-void function should return a value"-Error
   # https://sourceforge.net/p/java-readline/patches/2/


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a compile-time only dependency, because it needs `javah`, which
was removed in Java 10. Runs fine under Java 10.

Addresses #28760
