### PR TITLE
glibmm: apply upstream patch for wchar conversion with libc++

### DIFF
--- a/Formula/glibmm.rb
+++ b/Formula/glibmm.rb
@@ -3,6 +3,7 @@ class Glibmm < Formula
   homepage "https://www.gtkmm.org/"
   url "https://download.gnome.org/sources/glibmm/2.56/glibmm-2.56.0.tar.xz"
   sha256 "6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,6 +15,14 @@ class Glibmm < Formula
   depends_on "pkg-config" => :build
   depends_on "libsigc++"
   depends_on "glib"
+
+  # Remove for > 2.56.0
+  # Upstream commit from 26 Apr 2018 "ustring: Fix wchar conversion on macOS with libc++"
+  # See https://bugzilla.gnome.org/show_bug.cgi?id=795338
+  patch do
+    url "https://github.com/GNOME/glibmm/commit/f1530eca.patch?full_index=1"
+    sha256 "ae8990b93e29b47903da7eed8676cf806b34fd3b45d6bd5fb3d7a4f040b9f4c9"
+  end
 
   needs :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/GNOME/glibmm/commit/f1530eca20452c0ce4f9086b033e0bd85c088de7
https://trac.macports.org/ticket/56214
https://github.com/caskformula/homebrew-caskformula/issues/54