### PR TITLE
inkscape 0.92.3 (new formula)

### DIFF
--- a/Formula/inkscape.rb
+++ b/Formula/inkscape.rb
@@ -1,0 +1,58 @@
+class Inkscape < Formula
+  desc "Professional vector graphics editor"
+  homepage "https://inkscape.org/"
+  url "https://inkscape.org/en/gallery/item/12187/inkscape-0.92.3.tar.bz2"
+  sha256 "063296c05a65d7a92a0f627485b66221487acfc64a24f712eb5237c4bd7816b2"
+
+  depends_on "boost-build" => :build
+  depends_on "cmake" => :build
+  depends_on "intltool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "bdw-gc"
+  depends_on "boost"
+  depends_on "cairomm"
+  depends_on "gettext"
+  depends_on "glibmm"
+  depends_on "gsl"
+  depends_on "gtkmm"
+  depends_on "hicolor-icon-theme"
+  depends_on "libsoup"
+  depends_on "little-cms"
+  depends_on "pango"
+  depends_on "poppler"
+  depends_on "popt"
+  depends_on "potrace"
+
+  needs :cxx11
+
+  # Fix for poppler 0.65, remove in next version
+  # https://gitlab.com/inkscape/inkscape/commit/fa1c469a
+  patch do
+    url "https://gitlab.com/inkscape/inkscape/commit/fa1c469aa8c005e07bb8676d72af9f7c16fae3e0.diff"
+    sha256 "c53ebb25f6e1e4153c837c7e2ce8ce270256c9c121cd96fe1add922f5df66992"
+  end
+
+  # Fix for poppler 0.64, remove in next version
+  # https://gitlab.com/inkscape/inkscape/commit/a600c643
+  patch do
+    url "https://gitlab.com/inkscape/inkscape/commit/a600c6438fef2f4c06f9a4a7d933d99fb054a973.diff"
+    sha256 "510861d5a242c2456e8bfd6d0eb666b5a192c02bb435f9beeee114af77a9aaa5"
+  end
+
+  def install
+    ENV.cxx11
+    ENV.append "LDFLAGS", "-liconv"
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/inkscape", "-z", "-f", test_fixtures("test.svg"),
+                              "--export-eps=test.eps"
+    assert_predicate testpath/"test.eps", :exist?
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -23,7 +23,6 @@
   "helios": "spotify/public",
   "hexchat": "homebrew/cask",
   "horndis": "homebrew/cask",
-  "inkscape": "homebrew/cask",
   "jsl": "homebrew/cask",
   "kdiff3": "homebrew/cask",
   "keybase": "homebrew/cask",


### PR DESCRIPTION
- There is currently a formula, maintained in a tap, which has 4000 installs a month and fails to build: https://formulae.brew.sh/analytics/build-error/30d/
- The cask is stuck at the previous version, because upstream is always very late in releasing macOS binaries (when they release them): https://github.com/Homebrew/homebrew-cask/blob/master/Casks/inkscape.rb

I think it makes sense to provide this to our users, as it builds from source relatively straightforwardly (the two patches are for the latest poppler versions, and are merged upstream).