### PR TITLE
ark 0.8.2 (new formula)

### DIFF
--- a/Formula/ark.rb
+++ b/Formula/ark.rb
@@ -1,0 +1,29 @@
+class Ark < Formula
+  desc "Disaster recovery for Kubernetes cluster resources and persistent volumes"
+  homepage "https://github.com/heptio/ark"
+  url "https://github.com/heptio/ark/archive/v0.8.2.tar.gz"
+  sha256 "149b5262e9e113a8963cd97e1b32c6cfc1eea23b2cc45ffdda9b81a789da3e26"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/heptio/ark").install buildpath.children
+
+    cd "src/github.com/heptio/ark" do
+      system "go", "build", "-o", bin/"ark", "-installsuffix", "static",
+                   "-ldflags",
+                   "-X github.com/heptio/ark/pkg/buildinfo.Version=#{version}",
+                   "cmd/ark/main.go"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/ark 2>&1")
+    assert_match "Heptio Ark is a tool for managing disaster recovery", output
+    assert_match "Version: #{version}", shell_output("#{bin}/ark version 2>&1")
+    system bin/"ark", "client", "config", "set", "TEST=value"
+    assert_match "value", shell_output("#{bin}/ark client config get 2>&1")
+  end
+end

--- a/Formula/ark.rb
+++ b/Formula/ark.rb
@@ -14,7 +14,7 @@ class Ark < Formula
       system "go", "build", "-o", bin/"ark", "-installsuffix", "static",
                    "-ldflags",
                    "-X github.com/heptio/ark/pkg/buildinfo.Version=#{version}",
-                   "cmd/ark/main.go"
+                   "./cmd/ark"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
See https://github.com/heptio/ark.

The Makefile builds ark inside of a docker image. Since I did not want to add docker as a build dependency,
I'm just executing "go build" manually similar to https://github.com/heptio/ark/blob/master/hack/build.sh#L64.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
