### PR TITLE
apcupsd 3.14.14 (Fix Audit)

### DIFF
--- a/Formula/apcupsd.rb
+++ b/Formula/apcupsd.rb
@@ -26,7 +26,7 @@ class Apcupsd < Formula
 
     cd "platforms/darwin" do
       # Install launch daemon and kernel extension to subdirectories of `prefix`.
-      inreplace "Makefile", "/Library/LaunchDaemons", "#{prefix}/Library/LaunchDaemons"
+      inreplace "Makefile", "/Library/LaunchDaemons", "#{lib}/LaunchDaemons"
       inreplace "Makefile", "/System/Library/Extensions", kext_prefix
 
       # Use appropriate paths for launch daemon and launch script.


### PR DESCRIPTION
- Fixes Audit Test for Library Path Prefix.
`apcupsd:
C: 29: col 66: "#{prefix}/Lib" should be "#{lib}"
Error: 1 problem in 1 formula`