### PR TITLE
node: fix compiler/Xcode detection for upcoming versions

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -40,6 +40,24 @@ class Node < Formula
     sha256 "be8bb5fdb52e5af8a62988ad32f51c688d1327f62412c4410b30c29c8d66a85f"
   end
 
+  # Patch node-gyp to support detecting double-digit Xcode versions
+  patch do
+    url "https://github.com/nodejs/node/commit/a9e70d7d0b50ed615428e8344d510effb6713f02.patch?full_index=1"
+    sha256 "e6c2a617f7550c1c6b36809ddea4a40a9f4ec612fe853c460b98368f72c646b2"
+  end
+
+  # Patch configure to support detecting double-digit Xcode versions
+  patch do
+    url "https://github.com/nodejs/node/commit/400df22c6bfefc3c3f54ebd7c5fd0d38f5137841.patch?full_index=1"
+    sha256 "a1ac0e2589c8b9e98bf4712723a6ef28bc23dcd1aa1891d045b5a5e3a329cb36"
+  end
+
+  # Patch configure to fix a buggy compiler version comparison
+  patch do
+    url "https://github.com/nodejs/node/commit/641d4a4159aaa96eece8356e03ec6c7248ae3e73.patch?full_index=1"
+    sha256 "c193ab8edf2084a94265762d9ace419c0680eda87986e30dc7325df55044cb1b"
+  end
+
   def install
     # Never install the bundled "npm", always prefer our
     # installation from tarball for better packaging control.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This backports several upstream patches to fix configuring and building node on systems with a) double-digit major compiler versions, and b) double-digit major Xcode versions.

While this does update node's bundled node-gyp, npm also bundles node-gyp and the current version will still break on upcoming Xcode releases. We can't really do anything about that until a new npm version is released. Nonetheless, node installs fine and can install any npm modules that don't contain native code.