### PR TITLE
krakend 0.5.0

### DIFF
--- a/Formula/krakend.rb
+++ b/Formula/krakend.rb
@@ -47,7 +47,7 @@ class Krakend < Formula
         "bad": file
       }
     EOS
-    assert_match "ERROR", shell_output("#{bin}/krakend check -c krakend_incomplete.json 2>&1")
+    assert_match "ERROR", shell_output("#{bin}/krakend check -c krakend_bad_file.json 2>&1")
 
     (testpath/"krakend.json").write <<~EOS
       {

--- a/Formula/krakend.rb
+++ b/Formula/krakend.rb
@@ -1,8 +1,8 @@
 class Krakend < Formula
   desc "Ultra-High performance API Gateway built in Go"
   homepage "http://www.krakend.io/"
-  url "https://github.com/devopsfaith/krakend-ce/archive/0.4.2.tar.gz"
-  sha256 "5243037a757fbdbb0bf1bbfd5ad8e018cf2aad6ece30e6f8a58c7c24f36b19b1"
+  url "https://github.com/devopsfaith/krakend-ce/archive/0.5.0.tar.gz"
+  sha256 "f97485df9f8549517da983df338e013dfe0b0f86db5423285163193267df6fa8"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Hi @ilovezfs,

We have now formally released to 0.5.0. I will take into account for future releases that tagging our repo triggers the version bump on the core package, so I can execute the tests before doing it.

In this case the output of the software changed when the configuration file is invalid so tests failed.

Thanks for your patience.