### PR TITLE
remove unnecessary `buildpath` from `cd do`

### DIFF
--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -24,7 +24,7 @@ class Chamber < Formula
     path = buildpath/"src/github.com/segmentio/chamber"
     path.install Dir["{*,.git}"]
 
-    cd buildpath/"src/github.com/segmentio/chamber" do
+    cd "src/github.com/segmentio/chamber" do
       system "govendor", "sync"
       system "go", "build", "-o", bin/"chamber",
                    "-ldflags", "-X main.Version=#{version}"

--- a/Formula/frugal.rb
+++ b/Formula/frugal.rb
@@ -17,7 +17,7 @@ class Frugal < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/Workiva/frugal").install buildpath.children
-    cd buildpath/"src/github.com/Workiva/frugal" do
+    cd "src/github.com/Workiva/frugal" do
       system "glide", "install"
       system "go", "build", "-o", bin/"frugal"
       prefix.install_metafiles

--- a/Formula/godep.rb
+++ b/Formula/godep.rb
@@ -18,7 +18,7 @@ class Godep < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/tools/godep").install buildpath.children
-    cd buildpath/"src/github.com/tools/godep" do
+    cd "src/github.com/tools/godep" do
       system "go", "build", "-o", bin/"godep"
       prefix.install_metafiles
     end

--- a/Formula/leaps.rb
+++ b/Formula/leaps.rb
@@ -18,7 +18,7 @@ class Leaps < Formula
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/jeffail/leaps").install buildpath.children
-    cd buildpath/"src/github.com/jeffail/leaps" do
+    cd "src/github.com/jeffail/leaps" do
       system "dep", "ensure", "-vendor-only"
       system "go", "build", "-o", bin/"leaps", "./cmd/leaps"
       prefix.install_metafiles

--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -19,7 +19,7 @@ class Syncthing < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/syncthing/syncthing").install buildpath.children
     ENV.append_path "PATH", buildpath/"bin"
-    cd buildpath/"src/github.com/syncthing/syncthing" do
+    cd "src/github.com/syncthing/syncthing" do
       system "./build.sh", "noupgrade"
       bin.install "syncthing"
       man1.install Dir["man/*.1"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
