### PR TITLE
platypus: remove unnecessary `cd buildpath`

### DIFF
--- a/Formula/platypus.rb
+++ b/Formula/platypus.rb
@@ -23,9 +23,6 @@ class Platypus < Formula
                "install"
 
     man1.install "CommandLineTool/man/platypus.1"
-
-    cd buildpath
-
     bin.install "platypus_clt" => "platypus"
 
     cd "build/UninstalledProducts/macosx/ScriptExec.app/Contents" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
