### PR TITLE
flac: depend on libogg

### DIFF
--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -4,6 +4,7 @@ class Flac < Formula
   url "https://downloads.xiph.org/releases/flac/flac-1.3.2.tar.xz"
   mirror "https://downloads.sourceforge.net/project/flac/flac-src/flac-1.3.2.tar.xz"
   sha256 "91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f"
+  revision 1
 
   bottle do
     cellar :any
@@ -22,7 +23,7 @@ class Flac < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "libogg" => :optional
+  depends_on "libogg"
 
   fails_with :clang do
     build 500
@@ -38,7 +39,6 @@ class Flac < Formula
     ]
 
     args << "--disable-asm-optimizations" if Hardware::CPU.is_32_bit?
-    args << "--without-ogg" if build.without? "libogg"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -39,7 +39,7 @@ class GstPluginsGood < Formula
   depends_on "gdk-pixbuf" => :optional
   depends_on "aalib" => :optional
   depends_on "cairo" => :optional
-  depends_on "flac" => [:optional, "with-libogg"]
+  depends_on "flac" => :optional
   depends_on "gtk+3" => :optional
   depends_on "libcaca" => :optional
   depends_on "libdv" => :optional
@@ -51,8 +51,6 @@ class GstPluginsGood < Formula
   depends_on "libvpx" => :optional
   depends_on "pulseaudio" => :optional
   depends_on "jack" => :optional
-
-  depends_on "libogg" if build.with? "flac"
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/Homebrew/homebrew-core/issues/13133

`libogg` is tiny and seems to be a common dependency of `flac` in other package managers.