### PR TITLE
dash: fix newline escaping

### DIFF
--- a/Formula/dash.rb
+++ b/Formula/dash.rb
@@ -24,8 +24,7 @@ class Dash < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--with-libedit",
                           "--disable-dependency-tracking",
-                          "--enable-fnmatch",
-                          "--enable-glob"
+                          "--enable-fnmatch"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Currently, if you build dash with `--enable-fnmatch` and `--enable-glob`
at the same time, backslashes in printf are borked. It's weird.

![comparison](https://i.imgur.com/AkeaUYl.png)

This also broke configure scripts, giving the following message
(the backslash bug is also visible here):

```
positional parameters were not saved.
configure\: This script requires a shell more modern than all
configure\: the shells that I found on your system.
configure\: Please tell bug\-autoconf@gnu.org and
configure\: hisham@gobolinux.org about your system, including any
configure\: error possibly output before this message. Then install
configure\: a modern shell, or manually run the script under such a
configure\: shell if you do have one.
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----