### PR TITLE
wp-cli-completion: rename from wpcli-completion

### DIFF
--- a/Aliases/wpcli-completion
+++ b/Aliases/wpcli-completion
@@ -1,0 +1,1 @@
+../Formula/wp-cli-completion.rb

--- a/Formula/wp-cli-completion.rb
+++ b/Formula/wp-cli-completion.rb
@@ -1,4 +1,4 @@
-class WpcliCompletion < Formula
+class WpCliCompletion < Formula
   desc "Bash completion for Wpcli"
   homepage "https://github.com/wp-cli/wp-cli"
   # Checksum mismatch for 1.5.1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I think we should rename this formula according to main formula name: `wp-cli`.