### PR TITLE
bats-core 1.0.1 (new formula)

### DIFF
--- a/Formula/bats-core.rb
+++ b/Formula/bats-core.rb
@@ -1,0 +1,24 @@
+class BatsCore < Formula
+  desc "Bash Automated Testing System"
+  homepage "https://github.com/bats-core/bats-core"
+  url "https://github.com/bats-core/bats-core/archive/v1.0.1.tar.gz"
+  sha256 "821626f1e5058a4f25a95722399b460942f27535186a815a279e518b503f8de7"
+
+  bottle :unneeded
+
+  conflicts_with "bats", :because => "both install `bats` executables"
+
+  def install
+    system "./install.sh", prefix
+  end
+
+  test do
+    (testpath/"test.sh").write <<~EOS
+      @test "addition using bc" {
+        result="$(echo 2+2 | bc)"
+        [ "$result" -eq 4 ]
+      }
+    EOS
+    assert_match "addition", shell_output("#{bin}/bats test.sh")
+  end
+end

--- a/Formula/bats.rb
+++ b/Formula/bats.rb
@@ -7,6 +7,8 @@ class Bats < Formula
 
   bottle :unneeded
 
+  conflicts_with "bats-core", :because => "both install `bats` executables"
+
   def install
     system "./install.sh", prefix
   end


### PR DESCRIPTION
This is an updated version from closed PR https://github.com/Homebrew/homebrew-core/pull/20073
(keeping the commit from @btamayo)

Now that [bats-core](https://github.com/bats-core/bats-core/releases) has a stable release, it is time to create a formula for it.

I propose creating an alias `bats` and removing the existing formula `bats`
 once `bats-core` has had a few more stable releases.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
