### PR TITLE
blitz: depend on python@2 at build time for head

### DIFF
--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -19,6 +19,7 @@ class Blitz < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    depends_on "python2" => :build
   end
 
   def install

--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -19,7 +19,7 @@ class Blitz < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "python2" => :build
+    depends_on "python@2" => :build
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apologies, but hard to match all above expectations not being an OSX user, but still hope this will help!

For more discussion on the issue, see: https://github.com/blitzpp/blitz/pull/31

For an example fail case log, see: https://travis-ci.org/igfuw/libmpdataxx/jobs/388702067