### PR TITLE
httpd: do not opportunistically pick up lua

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -61,7 +61,9 @@ class Httpd < Formula
                           "--with-mpm=prefork",
                           "--with-nghttp2=#{Formula["nghttp2"].opt_prefix}",
                           "--with-ssl=#{Formula["openssl"].opt_prefix}",
-                          "--with-pcre=#{Formula["pcre"].opt_prefix}"
+                          "--with-pcre=#{Formula["pcre"].opt_prefix}",
+                          "--disable-lua",
+                          "--disable-luajit"
     system "make", "install"
 
     # suexec does not install without root


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

httpd will opportunistically pick up lua/luajit if they're installed, but fail to actually build with them because their headers are filtered out by superenv.