### PR TITLE
jack: fix build on 10.12

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -24,10 +24,12 @@ class Jack < Formula
   depends_on "libsamplerate"
 
   def install
+    sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
+
     # Makefile hardcodes Carbon header location
     inreplace Dir["drivers/coreaudio/Makefile.{am,in}"],
       "/System/Library/Frameworks/Carbon.framework/Headers/Carbon.h",
-      "#{MacOS.sdk_path}/System/Library/Frameworks/Carbon.framework/Headers/Carbon.h"
+      "#{sdk}/System/Library/Frameworks/Carbon.framework/Headers/Carbon.h"
 
     ENV["LINKFLAGS"] = ENV.ldflags
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
use CLT when it's installed instead of mixing Xcode and CLT headers


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----