### PR TITLE
Haproxy: creates hundreds of processes if run as a service

### DIFF
--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -50,7 +50,7 @@ class Haproxy < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
-        <key>KeepAlive</key>
+        <key>RunAtLoad</key>
         <true/>
         <key>ProgramArguments</key>
         <array>


### PR DESCRIPTION
The launch daemon plist is misconfigured, because it will try to keep the haproxy service alive, which in this case results in multiple processes created. After running for some time the maximum limit of processes is reached on macOS and system becomes unusable.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
