### PR TITLE
llvm: enable wasm target

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -222,6 +222,7 @@ class Llvm < Formula
       -DWITH_POLLY=ON
       -DLINK_POLLY_INTO_TOOLS=ON
       -DLLVM_TARGETS_TO_BUILD=all
+      -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
     ]
     args << "-DLIBOMP_ARCH=x86_64"
     args << "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON" if build.with? "compiler-rt"


### PR DESCRIPTION
The packages from https://apt.llvm.org/ have the WebAssembly target
enabled but the Homebrew package does not, making it inconvenient to
test WASM-related changes across platforms.  Easy fix: enable it!

See https://github.com/ziglang/zig/pull/1112.

Signed-off-by: Ben Noordhuis <info@bnoordhuis.nl>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apropos the last two checkboxes, the environment where I would like to test in (but can't) is Travis CI, hence I left them unchecked.