### PR TITLE
libheif: add build from git repository

### DIFF
--- a/Formula/libheif.rb
+++ b/Formula/libheif.rb
@@ -3,6 +3,7 @@ class Libheif < Formula
   homepage "http://www.libheif.org"
   url "https://github.com/strukturag/libheif/releases/download/v1.2.0/libheif-1.2.0.tar.gz"
   sha256 "2e7d40f81d1bbe6089b1e0f27800b97cf6a195e093ef86199edfb6e59e2fa8fa"
+  head "https://github.com/strukturag/libheif.git"
 
   bottle do
     cellar :any
@@ -11,6 +12,9 @@ class Libheif < Formula
     sha256 "7d7caae49f70d6c16ee6ba257289ba5dfbba3435818d16334f0987d2a3edfe6b" => :el_capitan
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libde265"
@@ -18,6 +22,7 @@ class Libheif < Formula
   depends_on "x265"
 
   def install
+    system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
---

This pull request enables Homebrew to install `libheif` from its GitHub repository. This library is needed to build [Krita's HEIF filter](https://krita.org/en), and the latest release (1.2.0) is too old for this purpose.
