### PR TITLE
Go: support all load commands

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -12,6 +12,13 @@ class Go < Formula
       url "https://go.googlesource.com/tools.git",
           :branch => "release-branch.go#{go_version}"
     end
+
+    # Backports the following commit from 1.10/1.11:
+    # https://github.com/golang/go/commit/1a92cdbfc10e0c66f2e015264a39159c055a5c15
+    patch do
+      url "https://github.com/golang/go/commit/1a92cdbfc10e0c66f2e015264a39159c055a5c15.patch?full_index=1"
+      sha256 "9b879e3e759d56093ca7660305c3e4f8aee8acdd87126dc10985360395704139"
+    end
   end
 
   bottle do

--- a/Formula/go@1.8.rb
+++ b/Formula/go@1.8.rb
@@ -22,6 +22,13 @@ class GoAT18 < Formula
         :branch => "release-branch.go1.8"
   end
 
+  # Backports the following commit from 1.10/1.11:
+  # https://github.com/golang/go/commit/1a92cdbfc10e0c66f2e015264a39159c055a5c15
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/e089e057dbb8aff7d0dc36a6c1933c29dca9c77e/go%401.9/go_19_load_commands.patch"
+    sha256 "771b67df44e3d5d5d7c01ea4a0d1693032bc880ea4f16cf82c1bacb42bfd9b10"
+  end
+
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -30,6 +30,13 @@ class GoAT19 < Formula
     sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
   end
 
+  # Backports the following commit from 1.10/1.11:
+  # https://github.com/golang/go/commit/1a92cdbfc10e0c66f2e015264a39159c055a5c15
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/e089e057dbb8aff7d0dc36a6c1933c29dca9c77e/go%401.9/go_19_load_commands.patch"
+    sha256 "771b67df44e3d5d5d7c01ea4a0d1693032bc880ea4f16cf82c1bacb42bfd9b10"
+  end
+
   def install
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes an issue where Go would trip up on unknown load commands when linking. This is more or less the same bug as https://github.com/Homebrew/ruby-macho/pull/90.

I've also backported the patch to 1.8 and 1.9. Content moved around between files, so the exact same patch wouldn't work.