### PR TITLE
octave: move sundials dep from devel to stable

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,7 +4,6 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-4.4.0.tar.gz"
   mirror "https://ftpmirror.gnu.org/octave/octave-4.4.0.tar.gz"
   sha256 "72f846379fcec7e813d46adcbacd069d72c4f4d8f6003bcd92c3513aafcd6e96"
-  revision 1
 
   bottle do
     sha256 "749a05f276092a3d77357883465dccae17e6dc168dcff988437461a9d9013cca" => :high_sierra
@@ -48,8 +47,8 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "readline"
-  depends_on "sundials"
   depends_on "suite-sparse"
+  depends_on "sundials"
   depends_on "veclibfort"
 
   # Dependencies use Fortran, leading to spurious messages about GCC

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,6 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-4.4.0.tar.gz"
   mirror "https://ftpmirror.gnu.org/octave/octave-4.4.0.tar.gz"
   sha256 "72f846379fcec7e813d46adcbacd069d72c4f4d8f6003bcd92c3513aafcd6e96"
+  revision 1
 
   bottle do
     sha256 "749a05f276092a3d77357883465dccae17e6dc168dcff988437461a9d9013cca" => :high_sierra
@@ -19,7 +20,6 @@ class Octave < Formula
     depends_on "bison" => :build
     depends_on "icoutils" => :build
     depends_on "librsvg" => :build
-    depends_on "sundials"
   end
 
   # Complete list of dependencies at https://wiki.octave.org/Building
@@ -48,6 +48,7 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "readline"
+  depends_on "sundials"
   depends_on "suite-sparse"
   depends_on "veclibfort"
 
@@ -68,7 +69,7 @@ class Octave < Formula
                           "--enable-shared",
                           "--disable-static",
                           "--disable-docs",
-                          "--without-OSMesa",
+                          "--without-osmesa",
                           "--without-qt",
                           "--with-hdf5-includedir=#{Formula["hdf5"].opt_include}",
                           "--with-hdf5-libdir=#{Formula["hdf5"].opt_lib}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sundials was introduced as a devel dependency for octave in https://github.com/Homebrew/homebrew-core/pull/16815. The current stable version of Octave now supports sundials, so it seems like it's time to move that dependency down in to the stable dependencies.

Also fixes a capitalization error in `--without-osmesa`, removing a `configure` warning.