### PR TITLE
pypy: depend on libressl

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -24,9 +24,9 @@ class Pypy < Formula
 
   depends_on :arch => :x86_64
   depends_on "pkg-config" => :build
+  depends_on "libressl"
   depends_on "gdbm" => :recommended
   depends_on "sqlite" => :recommended
-  depends_on "openssl"
 
   resource "bootstrap" do
     url "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-osx64.tar.bz2"


### PR DESCRIPTION
instead of openssl


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

PyPy needs comp.h but our OpenSSL 1.0 is built with `no-comp`. We're not
going to re-enable comp just for PyPy so let's lean on LibreSSL, which
we're still building with comp.