### PR TITLE
openssl: re-enable comp

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -9,7 +9,7 @@ class Openssl < Formula
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2o.tar.gz"
   mirror "http://artfiles.org/openssl.org/source/openssl-1.0.2o.tar.gz"
   sha256 "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "67a795f419adcc7f2cc9c204538f2606ed9cf11f2e9587dea9c4f8189a592dee" => :high_sierra
@@ -36,7 +36,6 @@ class Openssl < Formula
   def configure_args; %W[
     --prefix=#{prefix}
     --openssldir=#{openssldir}
-    no-comp
     no-ssl2
     no-ssl3
     no-zlib


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I no longer see a reason to build with `no-comp` since `no-zlib` is
actually independent of this option.

Note that Debian builds with

```
no-idea no-mdc2 no-rc5 no-zlib  enable-tlsext no-ssl2 no-ssl3
```

and that both our LibreSSL and OpenSSL 1.1.x have the `comp.h` header.