### PR TITLE
gloox: remove patch for openssl no-comp

### DIFF
--- a/Formula/gloox.rb
+++ b/Formula/gloox.rb
@@ -15,13 +15,6 @@ class Gloox < Formula
   depends_on "openssl"
   depends_on "libidn" => :optional
 
-  # Fix expectation that <openssl/comp.h> will always be available.
-  # Merged upstream; remove on next release.
-  patch do
-    url "https://mail.camaya.net/services/download/?app=whups&actionID=download_file&file=tlsopensslbase_comp_fix.diff&ticket=276&fn=%2Ftlsopensslbase_comp_fix.diff"
-    sha256 "509e8121cbefbad57e380f9156a088ebfdc93ebf28a53bd8e2053c12326e2e12"
-  end
-
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--with-zlib",


### PR DESCRIPTION
The `openssl` formula is built with comp again.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----