### PR TITLE
kube-ps1: fix instructions in caveats

### DIFF
--- a/Formula/kube-ps1.rb
+++ b/Formula/kube-ps1.rb
@@ -14,14 +14,9 @@ class KubePs1 < Formula
   end
 
   def caveats; <<~EOS
-    Make sure kube-ps1 is loaded from your ~/.zshrc or ~/.bashrc:
-      For zsh:
+    Make sure kube-ps1 is loaded from your ~/.zshrc and/or ~/.bashrc:
       source "#{opt_share}/kube-ps1.sh"
-      PROMPT='$(kube_ps1)'$PROMPT
-
-      For Bash:
-      source "#{opt_share}/kube-ps1.sh"
-      PS1="[\$(kube_ps1)]\$ "
+      PS1='$(kube_ps1)'$PS1
   EOS
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #28879.

This fixes the bash variant of the installation instructions in the kube-ps1 caveats, and simplifies the instructions by merging the zsh and bash variants together. (Which can be done because `$PROMPT` is an alias for `$PS1` in zsh.)