### PR TITLE
qt: depend on mysql-client optionally instead of mysql

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -21,9 +21,11 @@ class Qt < Formula
   option "with-examples", "Build examples"
   option "without-proprietary-codecs", "Don't build with proprietary codecs (e.g. mp3)"
 
+  deprecated_option "with-mysql" => "with-mysql-client"
+
   depends_on "pkg-config" => :build
   depends_on :xcode => :build
-  depends_on "mysql" => :optional
+  depends_on "mysql-client" => :optional
   depends_on "postgresql" => :optional
 
   # Restore `.pc` files for framework-based build of Qt 5 on macOS, partially
@@ -56,7 +58,7 @@ class Qt < Formula
 
     args << "-nomake" << "examples" if build.without? "examples"
 
-    if build.with? "mysql"
+    if build.with? "mysql-client"
       args << "-plugin-sql-mysql"
       (buildpath/"brew_shim/mysql_config").write <<~EOS
         #!/bin/sh


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #29013

The current Qt 5.11.0 seems to be targeting MySQL 5.7, and the new
MySQL 8 release is not compatible at the source level. `brew install qt --with-mysql` is currently broken.

This PR fixes it by pinning the mysql dependency to version 5.7.

No revision bump necessary, since this only affects non-default options. You can probably kill the CI build for it, too; it's a long build.

Audit is failing for me, but it appears to be a transient error with a mirror host.

```
$ brew audit --strict --online qt
qt:
  * Stable: The URL https://qt.mirror.constant.com/archive/qt/5.11/5.11.0/single/qt-everywhere-src-5.11.0.tar.xz is not reachable
Error: 1 problem in 1 formula
```