### PR TITLE
wiremock-standalone 2.18.0 (new formula)

### DIFF
--- a/Formula/wiremock-standalone.rb
+++ b/Formula/wiremock-standalone.rb
@@ -1,0 +1,36 @@
+class WiremockStandalone < Formula
+  desc "WireMock is a simulator for HTTP-based APIs"
+  homepage "http://wiremock.org/docs/running-standalone/"
+  url "https://search.maven.org/remotecontent?filepath=com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar"
+  sha256 "b6ca6b6c9e0dbbf8ec6d6752f93f61beb99325c88fe067377e4250fd390c03c9"
+
+  bottle :unneeded
+
+  depends_on :java => "1.8+"
+
+  def install
+    libexec.install "wiremock-standalone-#{version}.jar"
+    bin.write_jar_script libexec / "wiremock-standalone-#{version}.jar", "wiremock"
+  end
+
+  test do
+    require "socket"
+
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    server.close
+
+    wiremock = fork do
+      exec "#{bin}/wiremock", "-port", port.to_s
+    end
+
+    loop do
+      Utils.popen_read("curl", "-s", "http://localhost:#{port}/__admin/", "-X", "GET")
+      break if $CHILD_STATUS.exitstatus.zero?
+    end
+
+    system "curl", "-s", "http://localhost:#{port}/__admin/shutdown", "-X", "POST"
+
+    Process.wait(wiremock)
+  end
+end

--- a/Formula/wiremock-standalone.rb
+++ b/Formula/wiremock-standalone.rb
@@ -1,5 +1,5 @@
 class WiremockStandalone < Formula
-  desc "WireMock is a simulator for HTTP-based APIs"
+  desc "Simulator for HTTP-based APIs"
   homepage "http://wiremock.org/docs/running-standalone/"
   url "https://search.maven.org/remotecontent?filepath=com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar"
   sha256 "b6ca6b6c9e0dbbf8ec6d6752f93f61beb99325c88fe067377e4250fd390c03c9"
@@ -10,7 +10,7 @@ class WiremockStandalone < Formula
 
   def install
     libexec.install "wiremock-standalone-#{version}.jar"
-    bin.write_jar_script libexec / "wiremock-standalone-#{version}.jar", "wiremock"
+    bin.write_jar_script libexec/"wiremock-standalone-#{version}.jar", "wiremock"
   end
 
   test do


### PR DESCRIPTION
This formula installs wiremock-standalone and provides the tests.
It's a follow up the (closed) issue #22033.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
