### PR TITLE
jasper: add --without-doc option

### DIFF
--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -10,15 +10,23 @@ class Jasper < Formula
     sha256 "c481b8887b8d29e3c63735dd2151c9246e08f21bf50334033de4a054f700a6db" => :el_capitan
   end
 
+  option "without-doc", "Disable the building of the documentation (which requires LaTeX)"
+
   depends_on "cmake" => :build
   depends_on "jpeg"
 
   def install
+    cmake_args = std_cmake_args
+
+    if build.without? "doc"
+      cmake_args << "-DJAS_ENABLE_DOC=false"
+    end
+
     mkdir "build" do
       # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
       # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
       glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
-      system "cmake", "..", "-DGLUT_glut_LIBRARY=#{glut_lib}", *std_cmake_args
+      system "cmake", "..", "-DGLUT_glut_LIBRARY=#{glut_lib}", *cmake_args
       system "make"
       system "make", "test"
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in the following issue: https://github.com/Linuxbrew/homebrew-core/issues/1427, building jasper will fail in an incomplete LaTeX environment. I also am faced with the issue in my CentOS6 environment using [Linuxbrew](http://linuxbrew.sh/), a fork of Homebrew. Therefore, disabling the building of the documentation of jasper is useful for users in such an environment.
Although the issue originated from Linuxbrew, I believe it is very useful to offer an option `--without-doc` at Homebrew.

Build options for jasper are listed at https://github.com/mdadams/jasper/blob/master/INSTALL.
`brew install --build-from-source jasper --without-doc` was done and succeeded on my MacOS.