### PR TITLE
brew-cask-completion: remove bash completion

### DIFF
--- a/Formula/brew-cask-completion.rb
+++ b/Formula/brew-cask-completion.rb
@@ -1,19 +1,18 @@
 class BrewCaskCompletion < Formula
-  desc "Bash & Fish completion for brew-cask"
+  desc "Fish completion for brew-cask"
   homepage "https://github.com/xyb/homebrew-cask-completion"
   url "https://github.com/xyb/homebrew-cask-completion/archive/v2.1.tar.gz"
   sha256 "27c7ea3b7f7c060f5b5676a419220c4ce6ebf384237e859a61c346f61c8f7a1b"
+  revision 1
   head "https://github.com/xyb/homebrew-cask-completion.git"
 
   bottle :unneeded
 
   def install
-    bash_completion.install "homebrew-cask-completion.bash" => "brew-cask"
     fish_completion.install "brew-cask.fish"
   end
 
   test do
-    assert_match "-F _brew_cask",
-      shell_output("source #{bash_completion}/brew-cask && complete -p brew-cask")
+    assert_predicate fish_completion/"brew-cask.fish", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Bash completion for cask was added to `brew` in https://github.com/Homebrew/brew/pull/3646

Fish completion for cask has been merged into fish-shell upstream so this formula can be removed after the next `fish` release.