### PR TITLE
hfstospell: prevent from compiling under C++17 mode

### DIFF
--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -17,6 +17,12 @@ class Hfstospell < Formula
   depends_on "libarchive"
   depends_on "libxml++"
 
+  # https://github.com/hfst/hfst-ospell/pull/41
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/674a62d/hfstospell/no-cxx17.diff"
+    sha256 "0a3146e871ac0e3c71248b8671d09f6d8a8a69713b6f4857eab7bdb684709083"
+  end
+
   needs :cxx11
 
   def install

--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -17,7 +17,9 @@ class Hfstospell < Formula
   depends_on "libarchive"
   depends_on "libxml++"
 
-  # https://github.com/hfst/hfst-ospell/pull/41
+  # Fix "error: no template named 'auto_ptr' in namespace 'std'"
+  # Upstream PR 20 Jun 2018 "C++14 (C++1y) should be the highest supported standard."
+  # See https://github.com/hfst/hfst-ospell/pull/41
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/674a62d/hfstospell/no-cxx17.diff"
     sha256 "0a3146e871ac0e3c71248b8671d09f6d8a8a69713b6f4857eab7bdb684709083"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`hfst-ospell` currently requires `libxml++2`, `libxml++2` uses `std::auto_ptr` which was deprecated since C++11 and has been removed as of C++17.

Reported upstream as hfst/hfst-ospell#41.