### PR TITLE
qscintilla2: make pyqt and sip deps conditional on python

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -15,11 +15,13 @@ class Qscintilla2 < Formula
   option "without-python", "Do not build Python3 bindings"
   option "without-python@2", "Do not build Python2 bindings"
 
-  depends_on "pyqt"
   depends_on "qt"
-  depends_on "sip"
   depends_on "python" => :recommended
   depends_on "python@2" => :recommended
+  if build.with?("python") || build.with?("python@2")
+    depends_on "pyqt"
+    depends_on "sip"
+  end
 
   def install
     spec = (ENV.compiler == :clang && MacOS.version >= :mavericks) ? "macx-clang" : "macx-g++"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `pyqt` and `sip` dependencies of `qscintilla2` are only needed if building the Python bindings. This PR makes them conditional on that.

I ran in to this when trying to build a Python-free build of octave. The unconditional dependencies here pulled in Py stuff, and were also a bit confusing to me.