### PR TITLE
sstp-client: fix SourceForge url path

### DIFF
--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -1,7 +1,7 @@
 class SstpClient < Formula
   desc "SSTP (Microsofts Remote Access Solution for PPP over SSL) client"
   homepage "https://sstp-client.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/1.0.12/sstp-client-1.0.12.tar.gz"
+  url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.12.tar.gz"
   sha256 "487eb406579689803ce0397f6102b18641e4572ac7bc9b9e5f3027c84dcf67ff"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Following up on #29291, keep the hostname (so we get mirror selection), but fix the path so we don't 404.

The previous URL was 404'ing for me when downloading on an old version of Mac OS X that didn't have a bottle (maybe Yosemite but I don't have that laptop in front of me right now to check):

```
$ brew install sstp-client
==> Downloading https://downloads.sourceforge.net/project/sstp-client/sstp-client/1.0.12/sstp-client-1.0.12.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "sstp-client"
Download failed: https://downloads.sourceforge.net/project/sstp-client/sstp-client/1.0.12/sstp-client-1.0.12.tar.gz
```