### PR TITLE
various: update for codeplex's demise

### DIFF
--- a/Formula/git-tf.rb
+++ b/Formula/git-tf.rb
@@ -1,28 +1,15 @@
 class GitTf < Formula
   desc "Share changes between TFS and git"
-  homepage "https://gittf.codeplex.com/"
+  homepage "https://archive.codeplex.com/?p=gittf"
   url "https://download.microsoft.com/download/A/E/2/AE23B059-5727-445B-91CC-15B7A078A7F4/git-tf-2.0.3.20131219.zip"
   sha256 "91fd12e7db19600cc908e59b82104dbfbb0dbfba6fd698804a8330d6103aae74"
-
-  head do
-    url "https://git01.codeplex.com/gittf", :using => :git
-    depends_on "maven" => :build
-  end
 
   bottle :unneeded
 
   def install
-    if build.stable?
-      install_prefix = ""
-    else
-      system "mvn", "assembly:assembly"
-      system "unzip", Dir["target/git-tf-*.zip"], "-dtarget"
-      install_prefix = Dir["target/git-tf-*/"].first.to_s
-    end
-
-    libexec.install install_prefix + "git-tf"
-    libexec.install install_prefix + "lib"
-    (libexec + "native").install install_prefix + "native/macosx"
+    libexec.install "git-tf"
+    libexec.install "lib"
+    (libexec/"native").install "native/macosx"
 
     bin.write_exec_script libexec/"git-tf"
     doc.install Dir["Git-TF_*", "ThirdPartyNotices*"]

--- a/Formula/jxrlib.rb
+++ b/Formula/jxrlib.rb
@@ -1,10 +1,9 @@
 class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
-  homepage "https://jxrlib.codeplex.com/"
+  homepage "https://archive.codeplex.com/?p=jxrlib"
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   sha256 "c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303"
-  head "https://git01.codeplex.com/jxrlib", :using => :git
 
   bottle do
     cellar :any_skip_relocation
@@ -16,18 +15,14 @@ class Jxrlib < Formula
   end
 
   def install
-    if build.head?
-      system "make", "install", "DIR_INSTALL=#{prefix}"
-    else
-      system "make"
-      # The current stable release (1.1) doesn't have a make 'install' target
-      lib.install %w[libjxrglue.a libjpegxr.a]
-      bin.install %w[JxrEncApp JxrDecApp]
-      include.install %w[common image]
-      include.install "jxrgluelib" => "glue"
-      include.install "jxrtestlib" => "test"
-      doc.install Dir["doc/*"]
-    end
+    system "make"
+    # The current stable release (1.1) doesn't have a make 'install' target
+    lib.install %w[libjxrglue.a libjpegxr.a]
+    bin.install %w[JxrEncApp JxrDecApp]
+    include.install %w[common image]
+    include.install "jxrgluelib" => "glue"
+    include.install "jxrtestlib" => "test"
+    doc.install Dir["doc/*"]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`codeplex` has gone to a read-only/archive state. I assume nobody's going to miss either of these `HEAD` options because neither will have worked for _months now_ & it hasn't been reported AFAIK.