### PR TITLE
jags: Add missing dependency

### DIFF
--- a/Formula/jags.rb
+++ b/Formula/jags.rb
@@ -12,7 +12,7 @@ class Jags < Formula
     sha256 "6c82f61d6cacec46e7863f9b9cb92f33eac63339822fd196e6a029a75dfb01f7" => :el_capitan
   end
 
-  depends_on "libtool" => :build
+  depends_on "libtool"
   depends_on "gcc" # for gfortran
 
   def install

--- a/Formula/jags.rb
+++ b/Formula/jags.rb
@@ -13,6 +13,7 @@ class Jags < Formula
   end
 
   depends_on "gcc" # for gfortran
+  depends_on "libtool" => :build
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/jags.rb
+++ b/Formula/jags.rb
@@ -12,8 +12,8 @@ class Jags < Formula
     sha256 "6c82f61d6cacec46e7863f9b9cb92f33eac63339822fd196e6a029a75dfb01f7" => :el_capitan
   end
 
-  depends_on "gcc" # for gfortran
   depends_on "libtool" => :build
+  depends_on "gcc" # for gfortran
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
Dependencies for `jags-terminal` aren't met.
```
❯ jags
dyld: Library not loaded: /usr/local/opt/libtool/lib/libltdl.7.dylib
  Referenced from: /usr/local/Cellar/jags/4.3.0_2/libexec/jags-terminal
  Reason: image not found
Abort trap: 6
```
This PR adds the missing dependency on `libtool`
```
❯ brew install libtool
❯ jags
Welcome to JAGS 4.3.0 on Fri Jun 22 08:14:05 2018
JAGS is free software and comes with ABSOLUTELY NO WARRANTY
Loading module: basemod: ok
Loading module: bugs: ok
```
