### PR TITLE
Remove Mac dependency from linuxbrew postgres 9.6

### DIFF
--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -69,15 +69,7 @@ class PostgresqlAT96 < Formula
     end
     ENV["PYTHON"] = which_python
 
-    # The CLT is required to build Tcl support on 10.7 and 10.8 because
-    # tclConfig.sh is not part of the SDK
-    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
-      args << "--with-tcl"
-
-      if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
-        args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
-      end
-    end
+    args << "--with-tcl"
 
     args << "--enable-dtrace" if build.with? "dtrace"
     args << "--with-uuid=e2fs"


### PR DESCRIPTION
Currently, trying to brew install postgresql@9.6, chokes on: "undefined method `sdk_path' for OS::Mac:Module" these changes remove the MacOS sdk_path dependency.

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
