### PR TITLE
Update texi2html for 10.14 compatibility

### DIFF
--- a/Formula/texi2html.rb
+++ b/Formula/texi2html.rb
@@ -1,8 +1,8 @@
 class Texi2html < Formula
   desc "Convert TeXinfo files to HTML"
   homepage "https://www.nongnu.org/texi2html/"
-  url "https://download.savannah.gnu.org/releases/texi2html/texi2html-5.0.tar.gz"
-  sha256 "e60edd2a9b8399ca615c6e81e06fa61946ba2f2406c76cd63eb829c91d3a3d7d"
+  url "http://mirror.lihnidos.org/GNU/savannah/texi2html/texi2html-5.0.zip"
+  sha256 "3a609cddc3fca3c342da85d0ae3b7806d8b42086cf7106947a8c9d8307a49dfe"
 
   bottle do
     rebuild 1

--- a/Formula/texi2html.rb
+++ b/Formula/texi2html.rb
@@ -1,7 +1,7 @@
 class Texi2html < Formula
   desc "Convert TeXinfo files to HTML"
   homepage "https://www.nongnu.org/texi2html/"
-  url "http://mirror.lihnidos.org/GNU/savannah/texi2html/texi2html-5.0.zip"
+  url "https://download.savannah.gnu.org/releases/texi2html/texi2html-5.0.zip"
   sha256 "3a609cddc3fca3c342da85d0ae3b7806d8b42086cf7106947a8c9d8307a49dfe"
 
   bottle do


### PR DESCRIPTION
- [+] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [+] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [+] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [+] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've tried on macos 10.14. It doesn't unpack `tar.gz` version at all in any "unzip" application or utility