### PR TITLE
Fix JACK launchd plist

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -45,6 +45,13 @@ class Jack < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
+      <key>EnvironmentVariables</key>
+      <dict>
+           <key>TMPDIR</key>
+           <string>/tmp</string>
+           <key>PATH</key>
+           <string>#{opt_bin}</string>
+      </dict>
       <key>WorkingDirectory</key>
       <string>#{prefix}</string>
       <key>ProgramArguments</key>


### PR DESCRIPTION
Adds environment variables to allow jackd to start successfully as described in https://elatov.github.io/2018/03/creating-a-launchd-plist-for-jackd/
