### PR TITLE
mpd: fixed plist file to use the configuration file

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -112,7 +112,7 @@ class Mpd < Formula
     (etc/"mpd").install "doc/mpdconf.example" => "mpd.conf"
   end
 
-  plist_options :manual => "mpd #{(HOMEBREW_PREFIX/"etc/mpd/mpd.conf")}"
+  plist_options :manual => "mpd #{HOMEBREW_PREFIX}/etc/mpd/mpd.conf"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -112,7 +112,7 @@ class Mpd < Formula
     (etc/"mpd").install "doc/mpdconf.example" => "mpd.conf"
   end
 
-  plist_options :manual => "mpd"
+  plist_options :manual => "mpd #{(HOMEBREW_PREFIX/"etc/mpd/mpd.conf")}"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
@@ -127,6 +127,7 @@ class Mpd < Formula
         <array>
             <string>#{opt_bin}/mpd</string>
             <string>--no-daemon</string>
+            <string>#{etc}/mpd/mpd.conf</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since mpd won't start up when neither --no-config nor a valid path to a conf file has been provided as an argument, I've added the default path to configuration file as an argument in plist file.