### PR TITLE
pypy.rb: remove unnecessary tar option ('z')

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -67,7 +67,7 @@ class Pypy < Formula
       package_args = %w[--archive-name pypy --targetdir .]
       package_args << "--without-gdbm" if build.without? "gdbm"
       system python, "package.py", *package_args
-      system "tar", "-C", libexec.to_s, "--strip-components", "1", "-xzf", "pypy.tar.bz2"
+      system "tar", "-C", libexec.to_s, "--strip-components", "1", "-xf", "pypy.tar.bz2"
     end
 
     (libexec/"lib").install libexec/"bin/libpypy-c.dylib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`-z` is ignored by `tar` when extracting archives (even then it should've been `j` because we're dealing with `bz2`). 
 
From `man tar`

>     -z      (c mode only) Compress the resulting archive with gzip(1).  In extract or
>             list modes, this option is ignored.  Note that, unlike other tar implementa-
>             tions, this implementation recognizes gzip compression automatically when
>             reading archives