### PR TITLE
Fix octave sundials dep

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,7 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-4.4.0.tar.gz"
   mirror "https://ftpmirror.gnu.org/octave/octave-4.4.0.tar.gz"
   sha256 "72f846379fcec7e813d46adcbacd069d72c4f4d8f6003bcd92c3513aafcd6e96"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "9229aecdfaa4539e9954e234e0d4af6e13b1930d482af464e4e75d6ad2987c19" => :high_sierra
@@ -49,7 +49,7 @@ class Octave < Formula
   depends_on "qrupdate"
   depends_on "readline"
   depends_on "suite-sparse"
-  depends_on "sundials"
+  depends_on "sundials@2"
   depends_on "texinfo"
   depends_on "veclibfort"
 
@@ -61,6 +61,8 @@ class Octave < Formula
     # inserted into every oct/mex build. This is unnecessary and can cause
     # cause linking problems.
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
+
+    ENV.append "CFLAGS", "-I#{Formula["sundials@2"].opt_include}"
 
     system "./bootstrap" if build.head?
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/sundials@2.rb
+++ b/Formula/sundials@2.rb
@@ -7,12 +7,12 @@ class SundialsAT2 < Formula
   keg_only :versioned_formula
 
   option "with-openmp", "Enable OpenMP multithreading"
-  option "without-mpi", "Do not build with MPI"
+  deprecated_option "without-mpi" => "without-open-mpi"
 
   depends_on "cmake" => :build
   depends_on "python" => :build
   depends_on "gcc" # for gfortran
-  depends_on "open-mpi" if build.with? "mpi"
+  depends_on "open-mpi" => :recommended
   depends_on "suite-sparse"
   depends_on "openblas"
 
@@ -30,7 +30,7 @@ class SundialsAT2 < Formula
       -DLAPACK_LIBRARIES=#{blas};#{blas}
     ]
     args << "-DOPENMP_ENABLE=ON" if build.with? "openmp"
-    args << "-DMPI_ENABLE=ON" if build.with? "mpi"
+    args << "-DMPI_ENABLE=ON" if build.with? "open-mpi"
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/sundials@2.rb
+++ b/Formula/sundials@2.rb
@@ -1,0 +1,48 @@
+class SundialsAT2 < Formula
+  desc "Nonlinear and differential/algebraic equations solver"
+  homepage "https://computation.llnl.gov/casc/sundials/main.html"
+  url "https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz"
+  sha256 "d39fcac7175d701398e4eb209f7e92a5b30a78358d4a0c0fcc23db23c11ba104"
+
+  keg_only :versioned_formula
+
+  option "with-openmp", "Enable OpenMP multithreading"
+  option "without-mpi", "Do not build with MPI"
+
+  depends_on "cmake" => :build
+  depends_on "python" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "open-mpi" if build.with? "mpi"
+  depends_on "suite-sparse"
+  depends_on "openblas"
+
+  fails_with :clang if build.with? "openmp"
+
+  def install
+    blas = "-L#{Formula["veclibfort"].opt_lib} -lvecLibFort"
+    args = std_cmake_args + %W[
+      -DCMAKE_C_COMPILER=#{ENV["CC"]}
+      -DBUILD_SHARED_LIBS=ON
+      -DKLU_ENABLE=ON
+      -DKLU_LIBRARY_DIR=#{Formula["suite-sparse"].opt_lib}
+      -DKLU_INCLUDE_DIR=#{Formula["suite-sparse"].opt_include}
+      -DLAPACK_ENABLE=ON
+      -DLAPACK_LIBRARIES=#{blas};#{blas}
+    ]
+    args << "-DOPENMP_ENABLE=ON" if build.with? "openmp"
+    args << "-DMPI_ENABLE=ON" if build.with? "mpi"
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    cp Dir[prefix/"examples/nvector/serial/*"], testpath
+    system ENV.cc, "-I#{include}", "test_nvector.c", "sundials_nvector.c",
+                   "test_nvector_serial.c", "-L#{lib}", "-lsundials_nvecserial", "-lm"
+    assert_match "SUCCESS: NVector module passed all tests",
+                 shell_output("./a.out 42 0")
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Per https://savannah.gnu.org/bugs/?52475, Octave 4.4.0 is not actually compatible with SUNDIALS 3.x, even though there's no check to prevent it from building against the incompatible 3.x series.

This PR changes Octave to build against SUNDIALS 2.x, and introduces a versioned `sundials@2` formula to provide it.