### PR TITLE
libfaketime: add test

### DIFF
--- a/Formula/libfaketime.rb
+++ b/Formula/libfaketime.rb
@@ -17,12 +17,17 @@ class Libfaketime < Formula
   # https://github.com/Homebrew/homebrew-core/issues/26568
   depends_on "coreutils"
 
-  depends_on :macos => :lion
+  depends_on :macos => :sierra
 
   def install
     system "make", "-C", "src", "-f", "Makefile.OSX", "PREFIX=#{prefix}"
     bin.install "src/faketime"
     (lib/"faketime").install "src/libfaketime.1.dylib"
     man1.install "man/faketime.1"
+  end
+
+  test do
+    cp "/bin/date", testpath/"date" # Work around SIP.
+    assert_match "1230106542", shell_output(%Q(TZ=UTC #{bin}/faketime -f "2008-12-24 08:15:42" #{testpath}/date +%s)).strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This chips away at #11898, and might help confirm an upstream bug affecting OS X 10.11 (mentioned in wolfcw/libfaketime#129 and #27867).