### PR TITLE
node: remove no longer necessary npm workaround

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -69,12 +69,6 @@ class Node < Formula
       # These symlinks are never used & they've caused issues in the past.
       rm_rf libexec/"share"
 
-      # suppress incorrect node 10 incompatibility warning from npm
-      # remove during next npm upgrade (to npm 5.9+ or npm 6.0+)
-      inreplace libexec/"lib/node_modules/npm/lib/utils/unsupported.js",
-        "{ver: '9', min: '9.0.0'}",
-        "{ver: '9', min: '9.0.0'}, {ver: '10', min: '10.0.0'}"
-
       if build.with? "completion"
         bash_completion.install \
           bootstrap/"lib/utils/completion.sh" => "npm"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR removes a no longer necessary npm workaround (I've forgot to remove it during the npm 6.1.0 upgrade in #28437).

Our current `supportedNode` array in `HOMEBREW_PREFIX/lib/node_modules/npm/lib/utils/unsupported.js` looks like this (see the duplicated entry for node 10):
```js
var supportedNode = [
  {ver: '6', min: '6.0.0'},
  {ver: '8', min: '8.0.0'},
  {ver: '9', min: '9.0.0'}, {ver: '10', min: '10.0.0'},
  {ver: '10', min: '10.0.0'},
  {ver: '11', min: '11.0.0'}
]
```
