### PR TITLE
heroku: disable migrator

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -6,6 +6,7 @@ class Heroku < Formula
   # heroku should only be updated every 10 releases on multiples of 10
   url "https://registry.npmjs.org/heroku/-/heroku-7.5.0.tgz"
   sha256 "e3e66b26167379b4d6ce6f40d7ca3f3bc89beadf75c26d01add8f84c41eb0381"
+  revision 1
   head "https://github.com/heroku/cli.git"
 
   bottle do
@@ -18,6 +19,16 @@ class Heroku < Formula
   depends_on "node"
 
   def install
+    # disable migrator
+    inreplace "lib/hooks/update/brew.js", "if (this.config.platform !== 'darwin')",
+                                          "if (true)"
+
+    # disable outdated check
+    inreplace "package.json", /.*plugin-warn-if-update-available.*$\n/, ""
+
+    # replace `heroku update` messaging
+    inreplace "bin/run", "npm update -g heroku", "brew upgrade heroku"
+
     inreplace "bin/run", "#!/usr/bin/env node",
                          "#!#{Formula["node"].opt_bin}/node"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- disables the migrator behavior of `heroku update` that was
  uninstalling the Homebrew/homebrew-core formula and replacing it with
  binaries from a third-party tap
- disables the check for whether the CLI is outdated and update nagging
- prints a message about `brew upgrade` if the user runs `heroku update`

```
$ heroku update
heroku: Updating CLI... update with: "brew upgrade heroku"
```

Ref https://github.com/heroku/homebrew-brew/issues/5#issuecomment-401040558

CC @jdxcode @MikeMcQuaid