### PR TITLE
crystal-lang 0.25.1

### DIFF
--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -39,7 +39,7 @@ class CrystalLang < Formula
   depends_on "libyaml" if build.with? "shards"
 
   resource "boot" do
-    url "https://8516-6887813-gh.circle-artifacts.com/0/dist_packages/crystal-0.25.0-2-darwin-x86_64.tar.gz"
+    url "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-2-darwin-x86_64.tar.gz"
     version "0.25.0-2"
     sha256 "4f538660c097b7e6607df2953f34a6d6a1693e5a984cf4b1b1e77024029dc8fb"
   end

--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -39,15 +39,9 @@ class CrystalLang < Formula
   depends_on "libyaml" if build.with? "shards"
 
   resource "boot" do
-    if MacOS.version <= :el_capitan # no clock_gettime
-      url "https://github.com/crystal-lang/crystal/releases/download/v0.24.1/crystal-0.24.1-2-darwin-x86_64.tar.gz"
-      version "0.24.1"
-      sha256 "2be256462f4388cd3bb14b1378ef94d668ab9d870944454e828b4145155428a0"
-    else
-      url "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-1-darwin-x86_64.tar.gz"
-      version "0.25.0"
-      sha256 "3e1ec645a2fd86917e9af86fe9352812ae3e6bd17622ac69b9b311948a14ce00"
-    end
+    url "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-1-darwin-x86_64.tar.gz"
+    version "0.25.0"
+    sha256 "3e1ec645a2fd86917e9af86fe9352812ae3e6bd17622ac69b9b311948a14ce00"
   end
 
   def install

--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -39,9 +39,9 @@ class CrystalLang < Formula
   depends_on "libyaml" if build.with? "shards"
 
   resource "boot" do
-    url "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-1-darwin-x86_64.tar.gz"
-    version "0.25.0"
-    sha256 "3e1ec645a2fd86917e9af86fe9352812ae3e6bd17622ac69b9b311948a14ce00"
+    url "https://8516-6887813-gh.circle-artifacts.com/0/dist_packages/crystal-0.25.0-2-darwin-x86_64.tar.gz"
+    version "0.25.0-2"
+    sha256 "4f538660c097b7e6607df2953f34a6d6a1693e5a984cf4b1b1e77024029dc8fb"
   end
 
   def install

--- a/Formula/crystal-lang.rb
+++ b/Formula/crystal-lang.rb
@@ -1,11 +1,10 @@
 class CrystalLang < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
-  revision 1
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.25.0.tar.gz"
-    sha256 "78cc53289bd983598133f8b789d95e01fad0bc95b512d7ccf60e33e36710ddde"
+    url "https://github.com/crystal-lang/crystal/archive/0.25.1.tar.gz"
+    sha256 "9b5a7bd2de67ab36cc5430133228a1e656a431fc7d928a37a61109bd8da77fc6"
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz"
@@ -45,9 +44,9 @@ class CrystalLang < Formula
       version "0.24.1"
       sha256 "2be256462f4388cd3bb14b1378ef94d668ab9d870944454e828b4145155428a0"
     else
-      url "https://github.com/crystal-lang/crystal/releases/download/0.24.2/crystal-0.24.2-1-darwin-x86_64.tar.gz"
-      version "0.24.2"
-      sha256 "05028a6ac8507b27a6dd5153f218deb255778d63ab7b45588cef3d974b5ce8ef"
+      url "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-1-darwin-x86_64.tar.gz"
+      version "0.25.0"
+      sha256 "3e1ec645a2fd86917e9af86fe9352812ae3e6bd17622ac69b9b311948a14ce00"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It _may be_ that the formula is not building on El Capitan & earlier. I'd like the CI to check, but I'm not sure how we would fix this issue if it's true.

Crystal 0.25.0 can't build on El Capitan due to the missing `clock_gettime` (see #28930), but 0.24.1 won't build 0.25.1 anymore due to syntax changes (if my test was correct).