### PR TITLE
znapzend: add service plist

### DIFF
--- a/Formula/znapzend.rb
+++ b/Formula/znapzend.rb
@@ -25,7 +25,7 @@ class Znapzend < Formula
     (var/"run/znapzend").mkpath
   end
 
-  plist_options(:startup => true, :manual => "sudo znapzend --daemonize")
+  plist_options :startup => true, :manual => "sudo znapzend --daemonize"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/znapzend.rb
+++ b/Formula/znapzend.rb
@@ -20,6 +20,49 @@ class Znapzend < Formula
     system "make", "install"
   end
 
+  def post_install
+    (var/"log/znapzend").mkpath
+    (var/"run/znapzend").mkpath
+  end
+
+  plist_options(:startup => true, :manual => "sudo znapzend --daemonize")
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>PATH</key>
+          <string>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:#{HOMEBREW_PREFIX}/bin</string>
+        </dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/znapzend</string>
+          <string>--connectTimeout=120</string>
+          <string>--logto=#{var}/log/znapzend/znapzend.log</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/znapzend/znapzend.err.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/znapzend/znapzend.out.log</string>
+        <key>ThrottleInterval</key>
+        <integer>30</integer>
+        <key>WorkingDirectory</key>
+        <string>#{var}/run/znapzend</string>
+      </dict>
+    </plist>
+  EOS
+  end
+
   test do
     fake_zfs = testpath/"zfs"
     fake_zfs.write <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR introduces a plist for the znapzend service so it can be used with `brew services`.

Note that the timeout for SSH connections has been set to 120 seconds, a value I have tuned during a few months of real-world testing on several Macs. (In particular, delays in excess of one minute have been observed in a Time-Machine-like scenario, e. g. the receiving zpool is on another Mac on the local network, which may need time to wake up first before serving the SSH connection.)
