### PR TITLE
hub: depend on ruby at build-time for Sierra

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -17,8 +17,8 @@ class Hub < Formula
 
   depends_on "go" => :build
 
-  # The build needs Ruby 1.9 or higher.
-  depends_on "ruby" => :build if MacOS.version <= :mountain_lion
+  # System Ruby uses old TLS versions no longer supported by RubyGems.
+  depends_on "ruby" => :build if MacOS.version <= :sierra
 
   def install
     if build.with? "docs"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

System Ruby uses old TLS versions no longer supported by RubyGems.

I suspect this will affect more formulae than just this one, if you haven't seen it already.

```
==> gem install bundler
ERROR:  Could not find a valid gem 'bundler' (>= 0), here is why:
          Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: tlsv1 alert protocol version (https://rubygems.org/latest_specs.4.8.gz)
```