### PR TITLE
git-lfs: depends on Ruby for <= Sierra

### DIFF
--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -13,6 +13,9 @@ class GitLfs < Formula
 
   depends_on "go" => :build
 
+  # System Ruby uses old TLS versions no longer supported by RubyGems.
+  depends_on "ruby" => :build if MacOS.version <= :sierra
+
   def install
     begin
       deleted = ENV.delete "SDKROOT"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See #29564. I did a search through homebrew-core for other affected packages, and this was the only other one I found. cc @ilovezfs