### PR TITLE
Rename crystal-lang to crystal

### DIFF
--- a/Aliases/crystal-lang
+++ b/Aliases/crystal-lang
@@ -1,0 +1,1 @@
+../Formula/crystal.rb

--- a/Formula/amber.rb
+++ b/Formula/amber.rb
@@ -10,7 +10,7 @@ class Amber < Formula
     sha256 "4479e087a87ec39b344a0f8b1b6f0d2f09c6277d919e6d397ce84cbb9fa084c8" => :el_capitan
   end
 
-  depends_on "crystal-lang"
+  depends_on "crystal"
 
   def install
     system "shards", "install"

--- a/Formula/crystal-icr.rb
+++ b/Formula/crystal-icr.rb
@@ -11,7 +11,7 @@ class CrystalIcr < Formula
     sha256 "b0ecff4280242c2d91aa2bdb383fbbb60f682522b42ded34286c0b55616b2494" => :el_capitan
   end
 
-  depends_on "crystal-lang"
+  depends_on "crystal"
   depends_on "readline"
 
   def install

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,4 +1,4 @@
-class CrystalLang < Formula
+class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -30,7 +30,7 @@
   "cloog018": "cloog",
   "commonmark": "cmark",
   "cppformat": "fmt",
-  "crystal": "autocode",
+  "crystal-lang": "crystal",
   "cv": "progress",
   "cyassl": "wolfssl",
   "d-bus": "dbus",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It seems "crystal" was renamed to "autocode" two years ago, so dropping that alias should be fine by now. In turn, "crystal-lang" could stay as an alias for a while, at least until we update the docs on our side.