### PR TITLE
mpv: depend on python@2 at build time instead of python

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -15,7 +15,7 @@ class Mpv < Formula
   option "with-lgpl", "Build with LGPLv2.1 or later license"
 
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@2" => :build
 
   depends_on "libass"
   depends_on "ffmpeg"
@@ -87,11 +87,11 @@ class Mpv < Formula
     end
 
     system "./bootstrap.py"
-    system "python3", "waf", "configure", *args
-    system "python3", "waf", "install"
+    system "python", "waf", "configure", *args
+    system "python", "waf", "install"
 
     if build.with? "bundle"
-      system "python3", "TOOLS/osxbundle.py", "build/mpv"
+      system "python", "TOOLS/osxbundle.py", "build/mpv"
       prefix.install "build/mpv.app"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #29619.