### PR TITLE
gmt 5.4.4

### DIFF
--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -1,11 +1,10 @@
 class Gmt < Formula
   desc "Tools for processing and displaying xy and xyz datasets"
   homepage "https://gmt.soest.hawaii.edu/"
-  url "ftp://ftp.soest.hawaii.edu/gmt/gmt-5.4.3-src.tar.xz"
-  mirror "https://fossies.org/linux/misc/GMT/gmt-5.4.3-src.tar.xz"
-  mirror "https://mirrors.ustc.edu.cn/gmt/gmt-5.4.3-src.tar.xz"
-  sha256 "ed00e380c3dc94a3aef4b7aeaaac0f3681df703dc614e8a15a1864e20b3fa2c8"
-  revision 3
+  url "ftp://ftp.soest.hawaii.edu/gmt/gmt-5.4.4-src.tar.xz"
+  mirror "https://mirrors.ustc.edu.cn/gmt/gmt-5.4.4-src.tar.xz"
+  mirror "https://fossies.org/linux/misc/GMT/gmt-5.4.4-src.tar.xz"
+  sha256 "30fe868c91df30c51a637d54cb9ac52a64fe57e15daa9e08a73a4d1f0847e69f"
 
   bottle do
     sha256 "1a3ec4dd62997f9b9dd58eb93bcfb06d85053afb67ba1a025d4ee83c14165a00" => :high_sierra
@@ -21,15 +20,16 @@ class Gmt < Formula
 
   resource "gshhg" do
     url "ftp://ftp.soest.hawaii.edu/gmt/gshhg-gmt-2.3.7.tar.gz"
-    mirror "https://fossies.org/linux/misc/GMT/gshhg-gmt-2.3.7.tar.gz"
     mirror "https://mirrors.ustc.edu.cn/gmt/gshhg-gmt-2.3.7.tar.gz"
+    mirror "https://fossies.org/linux/misc/GMT/gshhg-gmt-2.3.7.tar.gz"
     sha256 "9bb1a956fca0718c083bef842e625797535a00ce81f175df08b042c2a92cfe7f"
   end
 
   resource "dcw" do
-    url "ftp://ftp.soest.hawaii.edu/gmt/dcw-gmt-1.1.3.tar.gz"
-    mirror "https://mirrors.ustc.edu.cn/gmt/dcw-gmt-1.1.3.tar.gz"
-    sha256 "1395e772c3f2d2900c78260ad4a9df2fecd9216e362ad141762f7499bfeb4f23"
+    url "ftp://ftp.soest.hawaii.edu/gmt/dcw-gmt-1.1.4.tar.gz"
+    mirror "https://mirrors.ustc.edu.cn/gmt/dcw-gmt-1.1.4.tar.gz"
+    mirror "https://fossies.org/linux/misc/GMT/dcw-gmt-1.1.4.tar.gz"
+    sha256 "8d47402abcd7f54a0f711365cd022e4eaea7da324edac83611ca035ea443aad3"
   end
 
   def install


### PR DESCRIPTION
Update formula to latest GMT version (v 5.4.4) and fix to mirrors.

The changes to the main URL/sha256 are needed to obtain the most recent version of GMT.  The changes to the mirrors for the main URL are needed because (1) the mirrors in the previous formula do not host the newest version of GMT, and (2) the updated mirrors are used by the GMT developers (these ftp sites will have a greater chance of continuing to host the most recent version of the software at later dates).  Updates were made to the URL, sha256 key, and mirrors for the 'dcw' software dependency. 

I have adhered to the checklist below when editing this formula.  Because the formula needed updates other than the main URL/sha256 key, 'brew edit' was used instead of 'brew bump-formula-pr'.

Thank you for your consideration!

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?