### PR TITLE
Update live.gnome.org URLs

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -1,6 +1,6 @@
 class GobjectIntrospection < Formula
   desc "Generate introspection data for GObject libraries"
-  homepage "https://live.gnome.org/GObjectIntrospection"
+  homepage "https://wiki.gnome.org/Projects/GObjectIntrospection"
   url "https://download.gnome.org/sources/gobject-introspection/1.56/gobject-introspection-1.56.1.tar.xz"
   sha256 "5b2875ccff99ff7baab63a34b67f8c920def240e178ff50add809e267d9ea24b"
 

--- a/Formula/goocanvas.rb
+++ b/Formula/goocanvas.rb
@@ -1,6 +1,6 @@
 class Goocanvas < Formula
   desc "Canvas widget for GTK+ using the Cairo 2D library for drawing"
-  homepage "https://live.gnome.org/GooCanvas"
+  homepage "https://wiki.gnome.org/Projects/GooCanvas"
   url "https://download.gnome.org/sources/goocanvas/2.0/goocanvas-2.0.4.tar.xz"
   sha256 "c728e2b7d4425ae81b54e1e07a3d3c8a4bd6377a63cffa43006045bceaa92e90"
   revision 1

--- a/Formula/gucharmap.rb
+++ b/Formula/gucharmap.rb
@@ -1,6 +1,6 @@
 class Gucharmap < Formula
   desc "GNOME Character Map, based on the Unicode Character Database"
-  homepage "https://live.gnome.org/Gucharmap"
+  homepage "https://wiki.gnome.org/Apps/Gucharmap"
   url "https://download.gnome.org/sources/gucharmap/10.0/gucharmap-10.0.4.tar.xz"
   sha256 "bb266899266b2f2dcdbaf9f45cafd74c6f4e540132d3f0b068d37343291df001"
   revision 1

--- a/Formula/json-glib.rb
+++ b/Formula/json-glib.rb
@@ -1,6 +1,6 @@
 class JsonGlib < Formula
   desc "Library for JSON, based on GLib"
-  homepage "https://live.gnome.org/JsonGlib"
+  homepage "https://wiki.gnome.org/Projects/JsonGlib"
   url "https://download.gnome.org/sources/json-glib/1.4/json-glib-1.4.2.tar.xz"
   sha256 "2d7709a44749c7318599a6829322e081915bdc73f5be5045882ed120bb686dc8"
 

--- a/Formula/libgxps.rb
+++ b/Formula/libgxps.rb
@@ -1,6 +1,6 @@
 class Libgxps < Formula
   desc "GObject based library for handling and rendering XPS documents"
-  homepage "https://live.gnome.org/libgxps"
+  homepage "https://wiki.gnome.org/Projects/libgxps"
   url "https://download.gnome.org/sources/libgxps/0.2/libgxps-0.2.5.tar.xz"
   sha256 "3e7594c5c9b077171ec9ccd3ff2b4f4c4b29884d26d4f35e740c8887b40199a0"
   revision 2

--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -1,6 +1,6 @@
 class Librsvg < Formula
   desc "Library to render SVG files using Cairo"
-  homepage "https://live.gnome.org/LibRsvg"
+  homepage "https://wiki.gnome.org/Projects/LibRsvg"
   url "https://download.gnome.org/sources/librsvg/2.42/librsvg-2.42.2.tar.xz"
   sha256 "0c550a0bffef768a436286116c03d9f6cd3f97f5021c13e7f093b550fac12562"
   revision 2

--- a/Formula/libsoup.rb
+++ b/Formula/libsoup.rb
@@ -1,6 +1,6 @@
 class Libsoup < Formula
   desc "HTTP client/server library for GNOME"
-  homepage "https://live.gnome.org/LibSoup"
+  homepage "https://wiki.gnome.org/Projects/libsoup"
   url "https://download.gnome.org/sources/libsoup/2.62/libsoup-2.62.2.tar.xz"
   sha256 "9e536fe3da60b25d2c63addb84a9d5072d00b0d8b8cbeabc629a6bcd63f879b6"
 

--- a/Formula/pygobject.rb
+++ b/Formula/pygobject.rb
@@ -1,6 +1,6 @@
 class Pygobject < Formula
   desc "GLib/GObject/GIO Python bindings for Python 2"
-  homepage "https://live.gnome.org/PyGObject"
+  homepage "https://wiki.gnome.org/Projects/PyGObject"
   url "https://download.gnome.org/sources/pygobject/2.28/pygobject-2.28.7.tar.xz"
   sha256 "bb9d25a3442ca7511385a7c01b057492095c263784ef31231ffe589d83a96a5a"
   revision 1

--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -1,6 +1,6 @@
 class Pygobject3 < Formula
   desc "GNOME Python bindings (based on GObject Introspection)"
-  homepage "https://live.gnome.org/PyGObject"
+  homepage "https://wiki.gnome.org/Projects/PyGObject"
   url "https://download.gnome.org/sources/pygobject/3.28/pygobject-3.28.3.tar.xz"
   sha256 "3dd3e21015d06e00482ea665fc1733b77e754a6ab656a5db5d7f7bfaf31ad0b0"
   revision 1

--- a/Formula/vala.rb
+++ b/Formula/vala.rb
@@ -1,6 +1,6 @@
 class Vala < Formula
   desc "Compiler for the GObject type system"
-  homepage "https://live.gnome.org/Vala"
+  homepage "https://wiki.gnome.org/Projects/Vala"
   url "https://download.gnome.org/sources/vala/0.40/vala-0.40.7.tar.xz"
   sha256 "bee662f60ab3a0d5266c1dd66f508cd9ed3254d74622d23c2d6bd94c91990aec"
 

--- a/Formula/zenity.rb
+++ b/Formula/zenity.rb
@@ -1,6 +1,6 @@
 class Zenity < Formula
   desc "GTK+ dialog boxes for the command-line"
-  homepage "https://live.gnome.org/Zenity"
+  homepage "https://wiki.gnome.org/Projects/Zenity"
   url "https://download.gnome.org/sources/zenity/3.28/zenity-3.28.1.tar.xz"
   sha256 "db179354721fb4e2d5c418e0dc41f09c831a6b2dd440e33f7743dfc266de8a6b"
 


### PR DESCRIPTION
This domain was retired a few years ago.

Most pages now redirect to wiki.gnome.org