### PR TITLE
kubernetes-service-catalog 0.1.23 (new formula)

### DIFF
--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -18,11 +18,12 @@ class KubernetesServiceCatalogClient < Formula
       ldflags = "-s -w -X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=v#{version}"
       system "go", "build", "-ldflags", ldflags, "-o", "bin/svcat", "./cmd/svcat"
       bin.install "bin/svcat"
+      prefix.install_metafiles
     end
   end
 
   test do
     version_output = shell_output("#{bin}/svcat version --client 2>&1")
-    assert_match "Client Version: v0.1.23", version_output
+    assert_match "Client Version: v#{version}", version_output
   end
 end

--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -1,5 +1,5 @@
 class KubernetesServiceCatalogClient < Formula
-  desc "Kubernetes Service Catalog Client: Consume services in Kuberentes using the OSB AP"
+  desc "Consume Services in k8s using the OSB API"
   homepage "https://svc-cat.io/"
   url "https://github.com/kubernetes-incubator/service-catalog.git",
       :tag => "v0.1.23",

--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -1,11 +1,10 @@
-class KubernetesServiceCatalog < Formula
-  desc "Consume services in K8s using the OSB API"
+class KubernetesServiceCatalogClient < Formula
+  desc "Kubernetes Service Catalog Client: Consume services in Kuberentes using the OSB AP"
   homepage "https://svc-cat.io/"
   url "https://github.com/kubernetes-incubator/service-catalog.git",
       :tag => "v0.1.23",
       :revision => "87a5db0e1e0359ce372037a235ce4448944c8611"
 
-  depends_on "coreutils" => :build
   depends_on "go" => :build
 
   def install
@@ -16,8 +15,7 @@ class KubernetesServiceCatalog < Formula
     dir.install buildpath.children
 
     cd dir do
-      ldflags = "-s -w -X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=#{version}"
-      system "make", ".generate_files"
+      ldflags = "-s -w -X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=v#{version}"
       system "go", "build", "-ldflags", ldflags, "-o", "bin/svcat", "./cmd/svcat"
       bin.install "bin/svcat"
     end
@@ -25,6 +23,6 @@ class KubernetesServiceCatalog < Formula
 
   test do
     version_output = shell_output("#{bin}/svcat version --client 2>&1")
-    assert_match "Client Version: 0.1.23", version_output
+    assert_match "Client Version: v0.1.23", version_output
   end
 end

--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -15,8 +15,12 @@ class KubernetesServiceCatalogClient < Formula
     dir.install buildpath.children
 
     cd dir do
-      ldflags = "-s -w -X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=v#{version}"
-      system "go", "build", "-ldflags", ldflags, "-o", "bin/svcat", "./cmd/svcat"
+      ldflags = %W[
+        -s -w -X
+        github.com/kubernetes-incubator/service-catalog/pkg.VERSION=v#{version}
+      ]
+      system "go", "build", "-ldflags", ldflags.join(" "), "-o",
+             "bin/svcat", "./cmd/svcat"
       bin.install "bin/svcat"
       prefix.install_metafiles
     end

--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -2,16 +2,16 @@ class KubernetesServiceCatalogClient < Formula
   desc "Consume Services in k8s using the OSB API"
   homepage "https://svc-cat.io/"
   url "https://github.com/kubernetes-incubator/service-catalog.git",
-      :tag => "v0.1.23",
-      :revision => "87a5db0e1e0359ce372037a235ce4448944c8611"
+      :tag => "v0.1.28",
+      :revision => "0aaf02aba556b945a357fce4e82f62122d158f2a"
 
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     ENV["NO_DOCKER"] = "1"
-    dir = buildpath/"src/github.com/kubernetes-incubator/service-catalog"
 
+    dir = buildpath/"src/github.com/kubernetes-incubator/service-catalog"
     dir.install buildpath.children
 
     cd dir do
@@ -20,8 +20,7 @@ class KubernetesServiceCatalogClient < Formula
         github.com/kubernetes-incubator/service-catalog/pkg.VERSION=v#{version}
       ]
       system "go", "build", "-ldflags", ldflags.join(" "), "-o",
-             "bin/svcat", "./cmd/svcat"
-      bin.install "bin/svcat"
+             bin/"svcat", "./cmd/svcat"
       prefix.install_metafiles
     end
   end

--- a/Formula/kubernetes-service-catalog.rb
+++ b/Formula/kubernetes-service-catalog.rb
@@ -1,0 +1,30 @@
+class KubernetesServiceCatalog < Formula
+  desc "Consume services in K8s using the OSB API"
+  homepage "https://svc-cat.io/"
+  url "https://github.com/kubernetes-incubator/service-catalog.git",
+      :tag => "v0.1.23",
+      :revision => "87a5db0e1e0359ce372037a235ce4448944c8611"
+
+  depends_on "coreutils" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["NO_DOCKER"] = "1"
+    dir = buildpath/"src/github.com/kubernetes-incubator/service-catalog"
+
+    dir.install buildpath.children
+
+    cd dir do
+      ldflags = "-s -w -X github.com/kubernetes-incubator/service-catalog/pkg.VERSION=#{version}"
+      system "make", ".generate_files"
+      system "go", "build", "-ldflags", ldflags, "-o", "bin/svcat", "./cmd/svcat"
+      bin.install "bin/svcat"
+    end
+  end
+
+  test do
+    version_output = shell_output("#{bin}/svcat version --client 2>&1")
+    assert_match "Client Version: 0.1.23", version_output
+  end
+end


### PR DESCRIPTION
This formula is for kubernetes service catalog client called svcat

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
