### PR TITLE
protobuf: add Python 3.7 compatibility

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -33,7 +33,7 @@ class Protobuf < Formula
 
   needs :cxx11
 
-  # Python 3.7 compat
+  # Upstream PR from 3 Jul 2018 "Add Python 3.7 compatibility"
   patch do
     url "https://github.com/google/protobuf/pull/4862.patch?full_index=1"
     sha256 "4b1fe1893c40cdcef531c31746ddd18759c9ce3564c89ddcc0ec934ea5dbf377"

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -33,6 +33,12 @@ class Protobuf < Formula
 
   needs :cxx11
 
+  # Python 3.7 compat
+  patch do
+    url "https://github.com/google/protobuf/pull/4862.patch?full_index=1"
+    sha256 "4b1fe1893c40cdcef531c31746ddd18759c9ce3564c89ddcc0ec934ea5dbf377"
+  end
+
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279


### PR DESCRIPTION
If built using --with-python, compilation fails with
Python 3.7 because the Python folks changed their C
API such that PyUnicode_AsUTF8AndSize() now returns
a const char* rather than a char*. Add a patch to
work around.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x]  Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
