### PR TITLE
arangodb: Build arangodb command

### DIFF
--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -48,6 +48,11 @@ class Arangodb < Formula
         inreplace etc/"arangodb3/#{f}.conf", pkgshare, opt_pkgshare
       end
     end
+
+    cd "3rdParty/arangodb-starter" do
+      system "make", "NODOCKER=1", "local"
+      bin.install "arangodb"
+    end
   end
 
   def post_install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This builds the `arangodb` helper command used for rapidly setting up test clusters. It looks like the intent was for this command to be built since go is listed as a build dependency but doesn't otherwise appear to be required.