### PR TITLE
remove unnecessary `stable do` blocks

### DIFF
--- a/Formula/boost@1.55.rb
+++ b/Formula/boost@1.55.rb
@@ -1,34 +1,9 @@
 class BoostAT155 < Formula
   desc "Collection of portable C++ source libraries"
   homepage "https://www.boost.org"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
+  sha256 "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52"
   revision 1
-
-  stable do
-    url "https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
-    sha256 "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52"
-
-    # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
-    # https://github.com/Homebrew/homebrew/issues/27396
-    # https://github.com/Homebrew/homebrew/pull/27436
-    patch :p2 do
-      url "https://github.com/boostorg/atomic/commit/6bb71fdd.diff?full_index=1"
-      sha256 "1574ef5c1c3ec28cf3786e40e4a8608f2bbb1c426ef2f14a2515e7a1a9313fab"
-    end
-
-    patch :p2 do
-      url "https://github.com/boostorg/atomic/commit/e4bde20f.diff?full_index=1"
-      sha256 "fa6676d83993c59e3566fff105f7e99c193a54ef7dba5c3b327ebdb5b6dcba37"
-    end
-
-    # Patch fixes upstream issue reported here (https://svn.boost.org/trac/boost/ticket/9698).
-    # Will be fixed in Boost 1.56 and can be removed once that release is available.
-    # See this issue (https://github.com/Homebrew/homebrew/issues/30592) for more details.
-
-    patch :p2 do
-      url "https://github.com/boostorg/chrono/commit/143260d.diff?full_index=1"
-      sha256 "96ba2f3a028df323e9bdffb400cc7c30c0c67e3d681c8c5a867c40ae0549cb62"
-    end
-  end
 
   bottle do
     cellar :any
@@ -60,6 +35,28 @@ class BoostAT155 < Formula
     else
       depends_on "icu4c"
     end
+  end
+
+  # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
+  # https://github.com/Homebrew/homebrew/issues/27396
+  # https://github.com/Homebrew/homebrew/pull/27436
+  patch :p2 do
+    url "https://github.com/boostorg/atomic/commit/6bb71fdd.diff?full_index=1"
+    sha256 "1574ef5c1c3ec28cf3786e40e4a8608f2bbb1c426ef2f14a2515e7a1a9313fab"
+  end
+
+  patch :p2 do
+    url "https://github.com/boostorg/atomic/commit/e4bde20f.diff?full_index=1"
+    sha256 "fa6676d83993c59e3566fff105f7e99c193a54ef7dba5c3b327ebdb5b6dcba37"
+  end
+
+  # Patch fixes upstream issue reported here (https://svn.boost.org/trac/boost/ticket/9698).
+  # Will be fixed in Boost 1.56 and can be removed once that release is available.
+  # See this issue (https://github.com/Homebrew/homebrew/issues/30592) for more details.
+
+  patch :p2 do
+    url "https://github.com/boostorg/chrono/commit/143260d.diff?full_index=1"
+    sha256 "96ba2f3a028df323e9bdffb400cc7c30c0c67e3d681c8c5a867c40ae0549cb62"
   end
 
   def install

--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -5,38 +5,8 @@ class Elm < Formula
 
   desc "Functional programming language for building browser-based GUIs"
   homepage "http://elm-lang.org"
-
-  stable do
-    url "https://github.com/elm/compiler/archive/0.18.0.tar.gz"
-    sha256 "7f941f4b9c066aea70a24a195f9920d61415b27540770b497f922561460cf6d0"
-
-    resource "elm-package" do
-      url "https://github.com/elm-lang/elm-package/archive/0.18.0.tar.gz"
-      sha256 "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9"
-
-      # Fix two "Not in scope" errors
-      # Upstream PR from 3 Oct 2017 "Paths.hs: fix build failure"
-      patch do
-        url "https://github.com/elm-lang/elm-package/pull/287.patch?full_index=1"
-        sha256 "3f922d7962a41217e760361ad444d00676aff0e40c3741fd536b39d2961165d3"
-      end
-    end
-
-    resource "elm-make" do
-      url "https://github.com/elm-lang/elm-make/archive/0.18.0.tar.gz"
-      sha256 "00c2d40128ca86454251d6672f49455265011c02aa3552a857af3109f337dbea"
-    end
-
-    resource "elm-repl" do
-      url "https://github.com/elm-lang/elm-repl/archive/0.18.0.tar.gz"
-      sha256 "be2b05d022ffa766fe186d5ad5da14385cec41ba7a4b2c18f2e0018351c99376"
-    end
-
-    resource "elm-reactor" do
-      url "https://github.com/elm-lang/elm-reactor/archive/0.18.0.tar.gz"
-      sha256 "736f84a08b10df07cfd3966aa5c7802957ab35d6d74f6322d4a69a0b9d75f4fe"
-    end
-  end
+  url "https://github.com/elm/compiler/archive/0.18.0.tar.gz"
+  sha256 "7f941f4b9c066aea70a24a195f9920d61415b27540770b497f922561460cf6d0"
 
   bottle do
     sha256 "4a7232fc62d4c340ddf49f6e63924734f66f5cb0861ea4fc042d41cebc139884" => :high_sierra
@@ -47,6 +17,33 @@ class Elm < Formula
 
   depends_on "ghc@8.0" => :build
   depends_on "cabal-install" => :build
+
+  resource "elm-package" do
+    url "https://github.com/elm-lang/elm-package/archive/0.18.0.tar.gz"
+    sha256 "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9"
+
+    # Fix two "Not in scope" errors
+    # Upstream PR from 3 Oct 2017 "Paths.hs: fix build failure"
+    patch do
+      url "https://github.com/elm-lang/elm-package/pull/287.patch?full_index=1"
+      sha256 "3f922d7962a41217e760361ad444d00676aff0e40c3741fd536b39d2961165d3"
+    end
+  end
+
+  resource "elm-make" do
+    url "https://github.com/elm-lang/elm-make/archive/0.18.0.tar.gz"
+    sha256 "00c2d40128ca86454251d6672f49455265011c02aa3552a857af3109f337dbea"
+  end
+
+  resource "elm-repl" do
+    url "https://github.com/elm-lang/elm-repl/archive/0.18.0.tar.gz"
+    sha256 "be2b05d022ffa766fe186d5ad5da14385cec41ba7a4b2c18f2e0018351c99376"
+  end
+
+  resource "elm-reactor" do
+    url "https://github.com/elm-lang/elm-reactor/archive/0.18.0.tar.gz"
+    sha256 "736f84a08b10df07cfd3966aa5c7802957ab35d6d74f6322d4a69a0b9d75f4fe"
+  end
 
   def install
     # elm-compiler needs to be staged in a subdirectory for the build process to succeed

--- a/Formula/john-jumbo.rb
+++ b/Formula/john-jumbo.rb
@@ -1,20 +1,9 @@
 class JohnJumbo < Formula
   desc "Enhanced version of john, a UNIX password cracker"
   homepage "http://www.openwall.com/john/"
-
-  stable do
-    url "http://openwall.com/john/j/john-1.8.0-jumbo-1.tar.xz"
-    sha256 "bac93d025995a051f055adbd7ce2f1975676cac6c74a6c7a3ee4cfdd9c160923"
-    version "1.8.0"
-
-    # Previously john-jumbo ignored the value of $HOME; fixed
-    # upstream.  See
-    # https://github.com/magnumripper/JohnTheRipper/issues/1901
-    patch do
-      url "https://github.com/magnumripper/JohnTheRipper/commit/d29ad8aabaa9726eb08f440001c37611fa072e0c.diff?full_index=1"
-      sha256 "b3400f54c64dccce6fe4846872c945b280ec221c7a3d614b03c18029cba3695a"
-    end
-  end
+  url "http://openwall.com/john/j/john-1.8.0-jumbo-1.tar.xz"
+  version "1.8.0"
+  sha256 "bac93d025995a051f055adbd7ce2f1975676cac6c74a6c7a3ee4cfdd9c160923"
 
   bottle do
     cellar :any
@@ -41,6 +30,14 @@ class JohnJumbo < Formula
   # https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/doc/INSTALL#L133-L143
   fails_with :gcc do
     cause "Upstream have a hacky workaround for supporting gcc that we can't use."
+  end
+
+  # Previously john-jumbo ignored the value of $HOME; fixed
+  # upstream.  See
+  # https://github.com/magnumripper/JohnTheRipper/issues/1901
+  patch do
+    url "https://github.com/magnumripper/JohnTheRipper/commit/d29ad8aabaa9726eb08f440001c37611fa072e0c.diff?full_index=1"
+    sha256 "b3400f54c64dccce6fe4846872c945b280ec221c7a3d614b03c18029cba3695a"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Goes with https://github.com/Homebrew/brew/pull/4414

Preexisting audit failure for `boost@1.55`
```
* C: 34: col 30: Dependency icu4c should not use option c++11
```