### PR TITLE
llvm: add Xcode CLT notice

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -168,6 +168,13 @@ class Llvm < Formula
     build.with?("libcxx") || !MacOS::CLT.installed?
   end
 
+  # Clang can't find "stdio.h", "stdlib.h" etc. if Xcode CLT
+  # is not installed.
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
+  end
+
   def install
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -168,8 +168,7 @@ class Llvm < Formula
     build.with?("libcxx") || !MacOS::CLT.installed?
   end
 
-  # Clang can't find "stdio.h", "stdlib.h" etc. if Xcode CLT
-  # is not installed.
+  # Clang cannot find system headers if Xcode CLT is not installed
   pour_bottle? do
     reason "The bottle needs the Xcode CLT to be installed."
     satisfy { MacOS::CLT.installed? }


### PR DESCRIPTION
Because I didn't want to use Apple's outdated things, I didn't have Xcode CLT installed. I installed LLVM, it said "can't find stdio.h". I built LLVM, the same error. I built LLVM with --with-toolchain, the same error. Installing Xcode CLT later solved the issue.