### PR TITLE
pyside 5.11.0 (new formula)

### DIFF
--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -43,11 +43,10 @@ class Pyside < Formula
     system "python3", *Language::Python.setup_install_args(prefix), *common_args, *py3_args
     (py3_dest_path/"homebrew-pyside.pth").write "#{py3_dest_path}\n"
 
-    py2_version = "2.7"
     py2_args = %W[
-      --install-lib #{lib}/python#{py2_version}/site-packages
+      --install-lib #{lib}/python2.7/site-packages
     ]
-    py2_dest_path=lib/"python#{py2_version}/site-packages"
+    py2_dest_path=lib/"python2.7/site-packages"
     py2_dest_path.mkpath
 
     system "python2", *Language::Python.setup_install_args(prefix), *common_args, *py2_args

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -1,5 +1,5 @@
 class Pyside < Formula
-  desc "Official python bindings for Qt"
+  desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.11.0-src/pyside-setup-everywhere-src-5.11.0.tar.xz"
   sha256 "fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922"
@@ -36,10 +36,10 @@ class Pyside < Formula
     xy = Language::Python.major_minor_version "python3"
 
     system "python3", *Language::Python.setup_install_args(prefix),
-           "--install-lib #{lib}/python#{xy}/site-packages", *args
+           "--install-lib", "#{lib}/python#{xy}/site-packages", *args
 
     system "python2", *Language::Python.setup_install_args(prefix),
-           "--install-lib #{lib}/python2.7/site-packages", *args
+           "--install-lib", "#{lib}/python2.7/site-packages", *args
   end
 
   test do

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -4,7 +4,7 @@ class Pyside < Formula
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.11.0-src/pyside-setup-everywhere-src-5.11.0.tar.xz"
   sha256 "fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922"
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
   depends_on "llvm"
   depends_on "python"
   depends_on "python@2"
@@ -41,8 +41,7 @@ class Pyside < Formula
     system "python2", *Language::Python.setup_install_args(prefix),
            "--install-lib", lib/"python2.7/site-packages", *args
 
-    pkgshare.install "examples/samplebinding"
-    pkgshare.install "examples/utils"
+    pkgshare.install "examples/samplebinding", "examples/utils"
   end
 
   test do
@@ -62,15 +61,14 @@ class Pyside < Formula
       ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
     end
     ["python@2", "python"].each do |python|
-      ENV.prepend_path "PATH", Formula[python].opt_libexec/"bin"
-      cmake_test_args = [
-        "-H#{pkgshare}/samplebinding",
-        "-B.",
-        "-G",
-        "Unix Makefiles",
-        "-DCMAKE_BUILD_TYPE=Release",
-      ]
-      system "cmake", *cmake_test_args
+      if python == "python"
+        ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+      end
+      system "cmake", "-H#{pkgshare}/samplebinding",
+                      "-B.",
+                      "-G",
+                      "Unix Makefiles",
+                      "-DCMAKE_BUILD_TYPE=Release"
       system "make"
     end
   end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -1,0 +1,51 @@
+class Pyside < Formula
+  desc "Qt binding for Python"
+  homepage "https://wiki.qt.io/Qt_for_Python"
+  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.11.0-src/pyside-setup-everywhere-src-5.11.0.tar.xz"
+  sha256 "fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922"
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => :build
+  depends_on "python@2"
+  depends_on "qt"
+
+  # Patch to correct clang header include issue in PySide 5.11.0
+  # https://bugreports.qt.io/browse/PYSIDE-731
+  patch do
+    url "http://syncplay.s3.amazonaws.com/pyside-clang-header.diff"
+    sha256 "d3472787b0b67b60d1f7882f2871404b1826677cd96188de9cb0b54f1f4285fc"
+  end
+
+  def install
+    dest_path=lib/"python2.7/site-packages"
+    dest_path.mkpath
+
+    args = %W[
+      install
+      --ignore-git
+      --no-examples
+      --macos-use-libc++
+      --jobs=#{ENV.make_jobs}
+      --install-lib #{lib}/python2.7/site-packages
+      --install-scripts #{bin}
+    ]
+    system "python", *Language::Python.setup_install_args(prefix), *args
+    (dest_path/"homebrew-pyside.pth").write "#{dest_path}\n"
+  end
+
+  test do
+    system "python", "-c", "import PySide2"
+    %w[
+      Core
+      Gui
+      Location
+      Multimedia
+      Network
+      Quick
+      Svg
+      WebEngineWidgets
+      Widgets
+      Xml
+    ].each { |mod| system "python", "-c", "import PySide2.Qt#{mod}" }
+  end
+end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -5,7 +5,7 @@ class Pyside < Formula
   sha256 "fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922"
 
   depends_on "cmake" => :build
-  depends_on "llvm" => :build
+  depends_on "llvm"
   depends_on "python"
   depends_on "python@2"
   depends_on "qt"
@@ -25,7 +25,7 @@ class Pyside < Formula
   end
 
   def install
-    common_args = %W[
+    args = %W[
       --ignore-git
       --no-examples
       --macos-use-libc++
@@ -33,16 +33,13 @@ class Pyside < Formula
       --install-scripts #{bin}
     ]
 
-    py3_version = Language::Python.major_minor_version "python3"
-    py3_args = %W[
-      --install-lib #{lib}/python#{py3_version}/site-packages
-    ]
-    system "python3", *Language::Python.setup_install_args(prefix), *common_args, *py3_args
+    xy = Language::Python.major_minor_version "python3"
 
-    py2_args = %W[
-      --install-lib #{lib}/python2.7/site-packages
-    ]
-    system "python2", *Language::Python.setup_install_args(prefix), *common_args, *py2_args
+    system "python3", *Language::Python.setup_install_args(prefix),
+           "--install-lib #{lib}/python#{xy}/site-packages", *args
+
+    system "python2", *Language::Python.setup_install_args(prefix),
+           "--install-lib #{lib}/python2.7/site-packages", *args
   end
 
   test do

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -36,10 +36,10 @@ class Pyside < Formula
     xy = Language::Python.major_minor_version "python3"
 
     system "python3", *Language::Python.setup_install_args(prefix),
-           "--install-lib", "#{lib}/python#{xy}/site-packages", *args
+           "--install-lib", lib/"python#{xy}/site-packages", *args
 
     system "python2", *Language::Python.setup_install_args(prefix),
-           "--install-lib", "#{lib}/python2.7/site-packages", *args
+           "--install-lib", lib/"python2.7/site-packages", *args
   end
 
   test do

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -6,42 +6,58 @@ class Pyside < Formula
 
   depends_on "cmake" => :build
   depends_on "llvm" => :build
-  depends_on "python@2"
   depends_on "qt"
+  depends_on "python" => :recommended
+  depends_on "python@2" => :recommended
+
+  # Edited patch to fix clang header include issue in 5.11.0, safe to remove once 5.11.1 is released
+  # http://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=5.11.0&id=5662706937bd6a1449538539e3a503c6cbc45399
+  patch do
+    url "http://syncplay.s3.amazonaws.com/pyside-homebrew.patch"
+    sha256 "3a6a62ae8d4a7ab34f9ca66b5358e45a5e08c66f327f635f901bb68d6f97c8a4"
+  end
+
+  # Patch to add Python 3.7 support on 5.11.0, safe to remove once 5.11.1 is released
+  # https://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=5.11&id=4a32f9d00b043b7255b590b95e9b35e9de44c4ed
+  patch do
+    url "https://code.qt.io/cgit/pyside/pyside-setup.git/patch/?id=4a32f9d00b043b7255b590b95e9b35e9de44c4ed"
+    sha256 "3b88c02242172c7f58626bcb670fd0e2ef3259f628d50b755967c5dfb37e8a3b"
+  end
 
   def install
-    inreplace "sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp", '|| cStringStartsWith("/usr/include/sys/_types", cFileName)', \
-    "|| cStringStartsWith(\"/usr/include/sys/_types\", cFileName)\n                || cStringStartsWith(\"#{HOMEBREW_PREFIX}/opt\", cFileName)"
+    Language::Python.each_python(build) do |python, version|
+      dest_path=lib/"python#{version}/site-packages"
+      dest_path.mkpath
 
-    dest_path=lib/"python2.7/site-packages"
-    dest_path.mkpath
-
-    args = %W[
-      install
-      --ignore-git
-      --no-examples
-      --macos-use-libc++
-      --jobs=#{ENV.make_jobs}
-      --install-lib #{lib}/python2.7/site-packages
-      --install-scripts #{bin}
-    ]
-    system "python", *Language::Python.setup_install_args(prefix), *args
-    (dest_path/"homebrew-pyside.pth").write "#{dest_path}\n"
+      args = %W[
+        --ignore-git
+        --no-examples
+        --macos-use-libc++
+        --jobs=#{ENV.make_jobs}
+        --install-lib #{lib}/python#{version}/site-packages
+        --install-scripts #{bin}
+        --skip-modules=UiTools
+      ]
+      system python, *Language::Python.setup_install_args(prefix), *args
+      (dest_path/"homebrew-pyside.pth").write "#{dest_path}\n"
+    end
   end
 
   test do
-    system "python", "-c", "import PySide2"
-    %w[
-      Core
-      Gui
-      Location
-      Multimedia
-      Network
-      Quick
-      Svg
-      WebEngineWidgets
-      Widgets
-      Xml
-    ].each { |mod| system "python", "-c", "import PySide2.Qt#{mod}" }
+    Language::Python.each_python(build) do |python, _version|
+      system python, "-c", "import PySide2"
+      %w[
+        Core
+        Gui
+        Location
+        Multimedia
+        Network
+        Quick
+        Svg
+        WebEngineWidgets
+        Widgets
+        Xml
+      ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
+    end
   end
 end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -13,7 +13,7 @@ class Pyside < Formula
   # Edited patch to fix clang header include issue in 5.11.0, safe to remove once 5.11.1 is released
   # http://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=5.11.0&id=5662706937bd6a1449538539e3a503c6cbc45399
   patch do
-    url "https://raw.githubusercontent.com/albertosottile/formula-patches/f327f197/pyside/pyside-homebrew.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/7895c8a/pyside/pyside-homebrew.patch"
     sha256 "3a6a62ae8d4a7ab34f9ca66b5358e45a5e08c66f327f635f901bb68d6f97c8a4"
   end
 

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -30,12 +30,12 @@ class Pyside < Formula
       --no-examples
       --macos-use-libc++
       --jobs=#{ENV.make_jobs}
+      --install-scripts #{bin}
     ]
 
     py3_version = Language::Python.major_minor_version "python3"
     py3_args = %W[
       --install-lib #{lib}/python#{py3_version}/site-packages
-      --install-scripts #{bin}
     ]
     py3_dest_path=lib/"python#{py3_version}/site-packages"
     py3_dest_path.mkpath
@@ -46,7 +46,6 @@ class Pyside < Formula
     py2_version = "2.7"
     py2_args = %W[
       --install-lib #{lib}/python#{py2_version}/site-packages
-      --install-scripts #{bin}
     ]
     py2_dest_path=lib/"python#{py2_version}/site-packages"
     py2_dest_path.mkpath

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -25,36 +25,33 @@ class Pyside < Formula
   end
 
   def install
-    py3_version = Language::Python.major_minor_version "python3"
-    py3_args = %W[
+    common_args = %W[
       --ignore-git
       --no-examples
       --macos-use-libc++
       --jobs=#{ENV.make_jobs}
+    ]
+
+    py3_version = Language::Python.major_minor_version "python3"
+    py3_args = %W[
       --install-lib #{lib}/python#{py3_version}/site-packages
       --install-scripts #{bin}
     ]
-
     py3_dest_path=lib/"python#{py3_version}/site-packages"
     py3_dest_path.mkpath
 
-    system "python3", *Language::Python.setup_install_args(prefix), *py3_args
+    system "python3", *Language::Python.setup_install_args(prefix), *common_args, *py3_args
     (py3_dest_path/"homebrew-pyside.pth").write "#{py3_dest_path}\n"
 
-    py2_version = Language::Python.major_minor_version "python2"
+    py2_version = "2.7"
     py2_args = %W[
-      --ignore-git
-      --no-examples
-      --macos-use-libc++
-      --jobs=#{ENV.make_jobs}
       --install-lib #{lib}/python#{py2_version}/site-packages
       --install-scripts #{bin}
     ]
-
     py2_dest_path=lib/"python#{py2_version}/site-packages"
     py2_dest_path.mkpath
 
-    system "python2", *Language::Python.setup_install_args(prefix), *py2_args
+    system "python2", *Language::Python.setup_install_args(prefix), *common_args, *py2_args
     (py2_dest_path/"homebrew-pyside.pth").write "#{py2_dest_path}\n"
   end
 

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -52,32 +52,20 @@ class Pyside < Formula
   end
 
   test do
-    system "python3", "-c", "import PySide2"
-    %w[
-      Core
-      Gui
-      Location
-      Multimedia
-      Network
-      Quick
-      Svg
-      WebEngineWidgets
-      Widgets
-      Xml
-    ].each { |mod| system "python3", "-c", "import PySide2.Qt#{mod}" }
-
-    system "python2", "-c", "import PySide2"
-    %w[
-      Core
-      Gui
-      Location
-      Multimedia
-      Network
-      Quick
-      Svg
-      WebEngineWidgets
-      Widgets
-      Xml
-    ].each { |mod| system "python2", "-c", "import PySide2.Qt#{mod}" }
+    ["python2", "python3"].each do |python|
+      system python, "-c", "import PySide2"
+      %w[
+        Core
+        Gui
+        Location
+        Multimedia
+        Network
+        Quick
+        Svg
+        WebEngineWidgets
+        Widgets
+        Xml
+      ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
+    end
   end
 end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -1,5 +1,5 @@
 class Pyside < Formula
-  desc "Qt binding for Python"
+  desc "Official python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.11.0-src/pyside-setup-everywhere-src-5.11.0.tar.xz"
   sha256 "fbc412c4544bca308291a08a5173a949ca530d801f00b8337902a5067e490922"
@@ -38,7 +38,6 @@ class Pyside < Formula
       --install-lib #{lib}/python#{py3_version}/site-packages
     ]
     py3_dest_path=lib/"python#{py3_version}/site-packages"
-    py3_dest_path.mkpath
 
     system "python3", *Language::Python.setup_install_args(prefix), *common_args, *py3_args
     (py3_dest_path/"homebrew-pyside.pth").write "#{py3_dest_path}\n"
@@ -47,7 +46,6 @@ class Pyside < Formula
       --install-lib #{lib}/python2.7/site-packages
     ]
     py2_dest_path=lib/"python2.7/site-packages"
-    py2_dest_path.mkpath
 
     system "python2", *Language::Python.setup_install_args(prefix), *common_args, *py2_args
     (py2_dest_path/"homebrew-pyside.pth").write "#{py2_dest_path}\n"

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -37,18 +37,12 @@ class Pyside < Formula
     py3_args = %W[
       --install-lib #{lib}/python#{py3_version}/site-packages
     ]
-    py3_dest_path=lib/"python#{py3_version}/site-packages"
-
     system "python3", *Language::Python.setup_install_args(prefix), *common_args, *py3_args
-    (py3_dest_path/"homebrew-pyside.pth").write "#{py3_dest_path}\n"
 
     py2_args = %W[
       --install-lib #{lib}/python2.7/site-packages
     ]
-    py2_dest_path=lib/"python2.7/site-packages"
-
     system "python2", *Language::Python.setup_install_args(prefix), *common_args, *py2_args
-    (py2_dest_path/"homebrew-pyside.pth").write "#{py2_dest_path}\n"
   end
 
   test do

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -40,6 +40,9 @@ class Pyside < Formula
 
     system "python2", *Language::Python.setup_install_args(prefix),
            "--install-lib", lib/"python2.7/site-packages", *args
+
+    pkgshare.install "examples/samplebinding"
+    pkgshare.install "examples/utils"
   end
 
   test do
@@ -57,6 +60,18 @@ class Pyside < Formula
         Widgets
         Xml
       ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
+    end
+    ["python@2", "python"].each do |python|
+      ENV.prepend_path "PATH", Formula[python].opt_libexec/"bin"
+      cmake_test_args = [
+        "-H#{pkgshare}/samplebinding",
+        "-B.",
+        "-G",
+        "Unix Makefiles",
+        "-DCMAKE_BUILD_TYPE=Release",
+      ]
+      system "cmake", *cmake_test_args
+      system "make"
     end
   end
 end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -9,14 +9,10 @@ class Pyside < Formula
   depends_on "python@2"
   depends_on "qt"
 
-  # Patch to correct clang header include issue in PySide 5.11.0
-  # https://bugreports.qt.io/browse/PYSIDE-731
-  patch do
-    url "http://syncplay.s3.amazonaws.com/pyside-clang-header.diff"
-    sha256 "d3472787b0b67b60d1f7882f2871404b1826677cd96188de9cb0b54f1f4285fc"
-  end
-
   def install
+    inreplace "sources/shiboken2/ApiExtractor/clangparser/clangbuilder.cpp", '|| cStringStartsWith("/usr/include/sys/_types", cFileName)', \
+    "|| cStringStartsWith(\"/usr/include/sys/_types\", cFileName)\n                || cStringStartsWith(\"#{HOMEBREW_PREFIX}/opt\", cFileName)"
+
     dest_path=lib/"python2.7/site-packages"
     dest_path.mkpath
 


### PR DESCRIPTION
Qt for Python (PySide2), a Python binding for Qt 5.11 licensed under LGPL.
Needs a patch to build inside "brew install". The issue has been patched upstream.
Uses a patch from upstream to allow compatibility with Python 3.7.
Depends on full llvm (the macOS binary is not enough) for the build phase.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
