### PR TITLE
graph-tool: use upstream Python 3.7 fix

### DIFF
--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -28,8 +28,11 @@ class GraphTool < Formula
   depends_on "python"
   depends_on "scipy"
 
-  # Python 3.7 compat
-  patch :DATA
+  # Upstream commit from 3 Jul 2018 "Fix incompatibility with Python 3.7"
+  patch do
+    url "https://git.skewed.de/count0/graph-tool/commit/0407f41a.patch"
+    sha256 "6ff5d8729bc2dcad9fafe9f2417a60c10ad09d91ea76a3a48031c9171c57ba44"
+  end
 
   resource "Cycler" do
     url "https://files.pythonhosted.org/packages/c2/4b/137dea450d6e1e3d474e1d873cd1d4f7d3beed7e0dc973b06e8e10d32488/cycler-0.10.0.tar.gz"
@@ -102,27 +105,3 @@ class GraphTool < Formula
     system "python3", "test.py"
   end
 end
-
-__END__
-diff --git a/src/graph_tool/draw/gtk_draw.py b/src/graph_tool/draw/gtk_draw.py
-index 9f60075..c65bc32 100644
---- a/src/graph_tool/draw/gtk_draw.py
-+++ b/src/graph_tool/draw/gtk_draw.py
-@@ -1182,7 +1182,7 @@ _window_list = []
- 
- def interactive_window(g, pos=None, vprops=None, eprops=None, vorder=None,
-                        eorder=None, nodesfirst=False, geometry=(500, 400),
--                       update_layout=True, async=False, no_main=False, **kwargs):
-+                       update_layout=True, async_=False, no_main=False, **kwargs):
-     r"""
-     Display an interactive GTK+ window containing the given graph.
- 
-@@ -1244,7 +1244,7 @@ def interactive_window(g, pos=None, vprops=None, eprops=None, vorder=None,
-     win.show_all()
-     _window_list.append(win)
-     if not no_main:
--        if async:
-+        if async_:
-             # just a placeholder for a proper main loop integration with gtk3 when
-             # ipython implements it
-             import IPython.lib.inputhook


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

use upstream fix now that there is one