### PR TITLE
opencv: use upstream Python 3.7 fix

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -26,8 +26,12 @@ class Opencv < Formula
 
   needs :cxx11
 
-  # Python 3.7 compat
-  patch :DATA
+  # Remove for > 3.4.1
+  # Upstream commit from 2 Jul 2018 "Python 3.7 compatability"
+  patch do
+    url "https://github.com/opencv/opencv/commit/0c4328fbf3d.patch?full_index=1"
+    sha256 "67c45080fbba9756b92f9dbceec6749f476f72a5485dcd9e163beaaa755a4b54"
+  end
 
   resource "contrib" do
     url "https://github.com/opencv/opencv_contrib/archive/3.4.1.tar.gz"
@@ -122,18 +126,3 @@ class Opencv < Formula
     end
   end
 end
-
-__END__
-diff --git a/modules/python/src2/cv2.cpp b/modules/python/src2/cv2.cpp
-index fab60fd..2c48041 100644
---- a/modules/python/src2/cv2.cpp
-+++ b/modules/python/src2/cv2.cpp
-@@ -886,7 +886,7 @@ bool pyopencv_to(PyObject* obj, String& value, const char* name)
-     (void)name;
-     if(!obj || obj == Py_None)
-         return true;
--    char* str = PyString_AsString(obj);
-+    const char* str = PyString_AsString(obj);
-     if(!str)
-         return false;
-     value = String(str);


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

use upstream commit, which is identical to the patch :DATA