### PR TITLE
haskell-ide-engine 0.1.0.0 (new formula)

### DIFF
--- a/Formula/haskell-ide-engine.rb
+++ b/Formula/haskell-ide-engine.rb
@@ -1,0 +1,32 @@
+class HaskellIdeEngine < Formula
+  desc "The IDE engine and LSP server for Haskell. Not an IDE"
+  homepage "https://github.com/haskell/haskell-ide-engine"
+
+  url "https://github.com/haskell/haskell-ide-engine.git",
+      :revision => "8e0b60f3d47f6332c0f4415b9fff03815e229275"
+
+  version "0.1.0.0"
+  sha256 "e2195fc6bf01e4b9509e7be388e53fb4e0103658a3f26aca997b54cdd52273dd"
+
+  head "https://github.com/alanz/haskell-ide-engine.git"
+
+  option "without-hoogle", "Don't generate Hoogle documentation"
+
+  depends_on "haskell-stack" => :build
+  depends_on "icu4c" => :build # Needed for the text-icu cabal package
+
+  def install
+    ENV.deparallelize
+    if build.without? "hoogle"
+      system "make", "build"
+    else
+      system "make", "build-all"
+    end
+    bin.install Dir[".brew_home/.local/bin/*"]
+  end
+
+  test do
+    system "#{bin}/hie", "--version"
+    system "#{bin}/hie-wrapper", "--version"
+  end
+end

--- a/Formula/haskell-ide-engine.rb
+++ b/Formula/haskell-ide-engine.rb
@@ -1,23 +1,30 @@
 class HaskellIdeEngine < Formula
-  desc "The IDE engine and LSP server for Haskell. Not an IDE"
+  desc "The engine for haskell ide-integration. Not an IDE"
   homepage "https://github.com/haskell/haskell-ide-engine"
 
   url "https://github.com/haskell/haskell-ide-engine.git",
-      :revision => "8e0b60f3d47f6332c0f4415b9fff03815e229275"
+    :revision => "0.2.1.0"
 
-  version "0.1.0.0"
-  sha256 "e2195fc6bf01e4b9509e7be388e53fb4e0103658a3f26aca997b54cdd52273dd"
+  version "0.2.1.0"
 
-  depends_on "haskell-stack" => :build
+  depends_on "cabal-install" => :build
+  depends_on "ghc" => :build
 
   def install
-    ENV.deparallelize
-    system "make", "build-all"
-    bin.install Dir[".brew_home/.local/bin/*"]
+    system "git", "submodule", "update", "--init"
+    system "cabal", "new-update"
+    system "cabal", "new-configure"
+    system "cabal", "new-build"
+    bin.install Dir["dist-newstyle/build/x86_64-osx/ghc-*/haskell-ide-engine-*/x/hie/build/hie/hie"]
+  end
+
+  def caveats; <<~EOS
+    This version of hie is only compatible with projects built with the version of GHC used while building this.
+    Visit https://github.com/haskell/haskell-ide-engine for instructions on installing multiple versions.
+  EOS
   end
 
   test do
     system "#{bin}/hie", "--version"
-    system "#{bin}/hie-wrapper", "--version"
   end
 end

--- a/Formula/haskell-ide-engine.rb
+++ b/Formula/haskell-ide-engine.rb
@@ -8,20 +8,11 @@ class HaskellIdeEngine < Formula
   version "0.1.0.0"
   sha256 "e2195fc6bf01e4b9509e7be388e53fb4e0103658a3f26aca997b54cdd52273dd"
 
-  head "https://github.com/alanz/haskell-ide-engine.git"
-
-  option "without-hoogle", "Don't generate Hoogle documentation"
-
   depends_on "haskell-stack" => :build
-  depends_on "icu4c" => :build # Needed for the text-icu cabal package
 
   def install
     ENV.deparallelize
-    if build.without? "hoogle"
-      system "make", "build"
-    else
-      system "make", "build-all"
-    end
+    system "make", "build-all"
     bin.install Dir[".brew_home/.local/bin/*"]
   end
 

--- a/Formula/haskell-ide-engine.rb
+++ b/Formula/haskell-ide-engine.rb
@@ -4,6 +4,8 @@ class HaskellIdeEngine < Formula
 
   url "https://github.com/haskell/haskell-ide-engine.git",
     :revision => "0.2.1.0"
+  
+  head "https://github.com/haskell/haskell-ide-engine.git"
 
   version "0.2.1.0"
 


### PR DESCRIPTION
Add a new formula for [haskell-ide-engine](https://github.com/haskell/haskell-ide-engine/issues/529).
Requires stack to build, and has an option to skip generating a Hoogle database since it can take quite a while.
Needs icu4c be explicitly installed via homebrew as the default macOS installed one is not sufficient for the text-icu package.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----