### PR TITLE
Bring back gptfdisk

### DIFF
--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -25,5 +25,11 @@ class Gptfdisk < Formula
   test do
     assert_match /GPT fdisk \(gdisk\) version #{Regexp.escape(version)}/,
                  pipe_output("#{sbin}/gdisk", "\n")
+
+    output = pipe_output(
+      "/usr/bin/hdiutil create -size 128k test.dmg " \
+      "&& #{sbin}/gdisk -l test.dmg", nil, 0
+    )
+    assert_match /^Found valid GPT with protective MBR/, output
   end
 end

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -1,6 +1,6 @@
 class Gptfdisk < Formula
   desc "Text-mode partitioning tools"
-  homepage "http://www.rodsbooks.com/gdisk/"
+  homepage "https://www.rodsbooks.com/gdisk"
   url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
   sha256 "5b66956743a799fc0471cdb032665c1391e82f9c5b3f1d7d726d29fe2ba01d6c"
   revision 1
@@ -13,8 +13,8 @@ class Gptfdisk < Formula
     sha256 "95593d9ce977a9529b11c9de8ee1089e56c67d76a642e13bdac31097aa5c7f69" => :mountain_lion
   end
 
-  depends_on "popt"
   depends_on "icu4c"
+  depends_on "popt"
 
   def install
     system "make", "-f", "Makefile.mac"

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -1,0 +1,29 @@
+class Gptfdisk < Formula
+  desc "Text-mode partitioning tools"
+  homepage "http://www.rodsbooks.com/gdisk/"
+  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
+  sha256 "5b66956743a799fc0471cdb032665c1391e82f9c5b3f1d7d726d29fe2ba01d6c"
+  revision 1
+
+  bottle do
+    cellar :any
+    sha256 "5fac6a86a0775f5ee1b964c424943f89a80fcb381020e2b2b9150e2027aa4696" => :el_capitan
+    sha256 "5c8f8f714cd50ece24a4a126e2c28ca9d69874c04dd4dfc436f2d62a610c7dbc" => :yosemite
+    sha256 "7925fc5b193566014430e59c2a109b557e46750f80555cd4b045b1447be1a282" => :mavericks
+    sha256 "95593d9ce977a9529b11c9de8ee1089e56c67d76a642e13bdac31097aa5c7f69" => :mountain_lion
+  end
+
+  depends_on "popt"
+  depends_on "icu4c"
+
+  def install
+    system "make", "-f", "Makefile.mac"
+    sbin.install "gdisk", "cgdisk", "sgdisk", "fixparts"
+    man8.install Dir["*.8"]
+  end
+
+  test do
+    assert_match /GPT fdisk \(gdisk\) version #{Regexp.escape(version)}/,
+                 pipe_output("#{sbin}/gdisk", "\n")
+  end
+end

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -4,7 +4,6 @@ class Gptfdisk < Formula
   url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.4/gptfdisk-1.0.4.tar.gz"
   sha256 "b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d"
 
-  depends_on "icu4c"
   depends_on "popt"
 
   def install

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -1,17 +1,8 @@
 class Gptfdisk < Formula
   desc "Text-mode partitioning tools"
   homepage "https://www.rodsbooks.com/gdisk"
-  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
-  sha256 "5b66956743a799fc0471cdb032665c1391e82f9c5b3f1d7d726d29fe2ba01d6c"
-  revision 1
-
-  bottle do
-    cellar :any
-    sha256 "5fac6a86a0775f5ee1b964c424943f89a80fcb381020e2b2b9150e2027aa4696" => :el_capitan
-    sha256 "5c8f8f714cd50ece24a4a126e2c28ca9d69874c04dd4dfc436f2d62a610c7dbc" => :yosemite
-    sha256 "7925fc5b193566014430e59c2a109b557e46750f80555cd4b045b1447be1a282" => :mavericks
-    sha256 "95593d9ce977a9529b11c9de8ee1089e56c67d76a642e13bdac31097aa5c7f69" => :mountain_lion
-  end
+  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.4/gptfdisk-1.0.4.tar.gz"
+  sha256 "b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d"
 
   depends_on "icu4c"
   depends_on "popt"

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -9,7 +9,7 @@ class Gptfdisk < Formula
   def install
     system "make", "-f", "Makefile.mac"
     %w[cgdisk fixparts gdisk sgdisk].each do |program|
-      bin.install program   
+      bin.install program
       man8.install "#{program}.8"
     end
   end

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -8,18 +8,15 @@ class Gptfdisk < Formula
 
   def install
     system "make", "-f", "Makefile.mac"
-    sbin.install "gdisk", "cgdisk", "sgdisk", "fixparts"
-    man8.install Dir["*.8"]
+    %w[cgdisk fixparts gdisk sgdisk].each do |program|
+      bin.install program   
+      man8.install "#{program}.8"
+    end
   end
 
   test do
-    assert_match /GPT fdisk \(gdisk\) version #{Regexp.escape(version)}/,
-                 pipe_output("#{sbin}/gdisk", "\n")
-
-    output = pipe_output(
-      "/usr/bin/hdiutil create -size 128k test.dmg " \
-      "&& #{sbin}/gdisk -l test.dmg", nil, 0
-    )
-    assert_match /^Found valid GPT with protective MBR/, output
+    system "hdiutil", "create", "-size", "128k", "test.dmg"
+    output = shell_output("#{bin}/gdisk -l test.dmg")
+    assert_match "Found valid GPT with protective MBR", output
   end
 end

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -1,6 +1,6 @@
 class Gptfdisk < Formula
   desc "Text-mode partitioning tools"
-  homepage "https://www.rodsbooks.com/gdisk"
+  homepage "https://www.rodsbooks.com/gdisk/"
   url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.4/gptfdisk-1.0.4.tar.gz"
   sha256 "b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR [revives](https://github.com/Homebrew/legacy-homebrew/pull/46398) gptfdisk, as upstream kindly [heeded our plea](https://sourceforge.net/p/gptfdisk/code/merge-requests/8/) and [fixed the long-standing ncurses issue](https://sourceforge.net/p/gptfdisk/code/ci/0c15ad9015db90c856f9a4301c66af13be93935c/tree/NEWS) with gptfdisk 1.0.4.

In addition, starting with gptfdisk 0.8.6, [the icu4c library is no longer required](https://sourceforge.net/p/gptfdisk/code/ci/d8eed4629449a325999808a0170dbda53bd4a6df/tree/NEWS?diff=4307ef2e863cbec357df56197046c6b679fc5d2d) to build gptfdisk on macOS. This PR therefore removes the icu4c dependency for the time being.

(Note: To this day, upstream still offers an optional build variant that includes icu4c, and @samangh volunteered to add that option to the formula in #3889 two years ago. However, this build variant [seems currently broken](https://sourceforge.net/p/gptfdisk/discussion/939590/thread/a17f594f/). I suggest that we hold off on adding @samangh’s changes until the issue is fixed upstream.)
