### PR TITLE
rust: update cargo to 0.28.0

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -8,8 +8,8 @@ class Rust < Formula
 
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
-          :tag => "0.27.0",
-          :revision => "0e7c5a93159076952f609e05760e2458828d0d1f"
+          :tag => "0.28.0",
+          :revision => "1e95190e5ffd6e6b701ad87dab4671246b96a9ce"
     end
 
     resource "racer" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----