### PR TITLE
gst-plugins-good: Fixes --with-gtk+3 option.

### DIFF
--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -63,7 +63,7 @@ class GstPluginsGood < Formula
       --disable-silent-rules
     ]
 
-    args << "--with-gtk=3.0" if build.with? "gtk+3"
+    args << "--enable-gtk3" if build.with? "gtk+3"
 
     if build.with? "x11"
       args << "--with-x"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello,

In gst-plugins-good, version 1.14.x, the gtksink plugin went from bad to good [[0]](https://gstreamer.freedesktop.org/releases/1.14/). When it was in bad, the option to build it was `--with-gtk=x.0`. In good, the option to not build it is `--disable-gtk` which this formula passes to `./configure` when using the `--with-gtk+3` option. This fixes the issue and builds the gtksink plugin.

```bash
gst-inspect-1.0 | grep -i gtk
gtk:  gtksink: Gtk Video Sink
```

Note that `--with-gtk=3.0` is not a configure option. `--enable-gtk3` is a configure option.

```bash
./configure --help | grep -i gtk
  --enable-gtk-doc        use gtk-doc to build documentation [[default=no]]
  --enable-gtk-doc-html   build documentation in html format [[default=yes]]
  --enable-gtk-doc-pdf    build documentation in pdf format [[default=no]]
  --disable-gtk3
```

```bash
ag 'enable-gtk'

configure
2160:  --enable-gtk-doc        use gtk-doc to build documentation [[default=no]]
2161:  --enable-gtk-doc-html   build documentation in html format [[default=yes]]
2162:  --enable-gtk-doc-pdf    build documentation in pdf format [[default=no]]
23393:    # Check whether --enable-gtk-doc was given.
23582:    # Check whether --enable-gtk-doc-html was given.
23589:    # Check whether --enable-gtk-doc-pdf was given.
32845:# Check whether --enable-gtk3 was given.
32850:      *) as_fn_error $? "bad value ${enableval} for --enable-gtk3" "$LINENO" 5 ;;
```

This fixes downstream apps [Movie Monad](https://github.com/lettier/movie-monad), [Gifcurry](https://github.com/lettier/gifcurry), and possibly others. 

:+1: 
