### PR TITLE
git-flow-avh: Install fish completions

### DIFF
--- a/Formula/git-flow-avh.rb
+++ b/Formula/git-flow-avh.rb
@@ -1,7 +1,7 @@
 class GitFlowAvh < Formula
   desc "AVH edition of git-flow"
   homepage "https://github.com/petervanderdoes/gitflow-avh"
-  revision 1
+  revision 2
 
   stable do
     url "https://github.com/petervanderdoes/gitflow-avh/archive/1.11.0.tar.gz"
@@ -44,6 +44,7 @@ class GitFlowAvh < Formula
     resource("completion").stage do
       bash_completion.install "git-flow-completion.bash"
       zsh_completion.install "git-flow-completion.zsh"
+      fish_completion.install "git.fish"
     end
   end
 

--- a/Formula/git-flow-avh.rb
+++ b/Formula/git-flow-avh.rb
@@ -1,7 +1,7 @@
 class GitFlowAvh < Formula
   desc "AVH edition of git-flow"
   homepage "https://github.com/petervanderdoes/gitflow-avh"
-  revision 2
+  revision 1
 
   stable do
     url "https://github.com/petervanderdoes/gitflow-avh/archive/1.11.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The completions repo for git-flow-avh (https://github.com/petervanderdoes/git-flow-completion) includes fish completions (https://github.com/petervanderdoes/git-flow-completion/blob/develop/git.fish), which are currently not installed by the formula. This adds them in, so that fish can get git-flow-avh completions on install.