### PR TITLE
Build the extended Hugo version

### DIFF
--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -3,6 +3,7 @@ class Hugo < Formula
   homepage "https://gohugo.io/"
   url "https://github.com/gohugoio/hugo/archive/v0.43.tar.gz"
   sha256 "6a263844847b9676a38b7a687fda77f47e7cc39cdff7a9c1234a7afeec7baddb"
+  revision 1
   head "https://github.com/gohugoio/hugo.git"
 
   bottle do
@@ -20,7 +21,7 @@ class Hugo < Formula
     (buildpath/"src/github.com/gohugoio/hugo").install buildpath.children
     cd "src/github.com/gohugoio/hugo" do
       system "dep", "ensure", "-vendor-only"
-      system "go", "build", "-o", bin/"hugo", "main.go"
+      system "go", "build", "-o", bin/"hugo", "-tags", "extended", "main.go"
 
       # Build bash completion
       system bin/"hugo", "gen", "autocomplete", "--completionfile=hugo.sh"


### PR DESCRIPTION
This change enables the SCSS/SASS feature introduced in Hugo 0.43. Powered by LibSASS.

Fixes #29898