### PR TITLE
update log4cxx to be thread safe

### DIFF
--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -1,9 +1,9 @@
 class Log4cxx < Formula
   desc "Library of C++ classes for flexible logging"
   homepage "https://logging.apache.org/log4cxx/index.html"
-  url "https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
-  sha256 "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
-  revision 1
+  url "https://github.com/kekkokk/logging-log4cxx/releases/download/0.10.0_with_fixes/log4cxx_latest_stable.tar.gz"
+  sha256 "d0e57ecaa61980f450677783736a6d71f549ef0c75adfd209e87fb0db6119f8c"
+  revision 2
 
   bottle do
     cellar :any
@@ -19,25 +19,8 @@ class Log4cxx < Formula
 
   depends_on "apr-util"
 
-  # Incorporated upstream, remove on next version update
-  # https://issues.apache.org/jira/browse/LOGCXX-400 (r1414037)
-  # https://issues.apache.org/jira/browse/LOGCXX-404 (r1414037)
-  patch :p0 do
-    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/be8b4e610a1e21b34aaaf8fb4151362dcfb782ff/LOGCXX-400,LOGCXX-404---r1414037.patch"
-    sha256 "822c24f4eebd970aa284672eec2f71c6f8e192a85d78edb15a232c15011a52d4"
-  end
-
-  # https://issues.apache.org/jira/browse/LOGCXX-417 (r1556413)
-  patch :p0 do
-    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/4188731bd771a961a91fcfbe561f3999b555b9c3/LOG4CXX-417---r1556413.patch"
-    sha256 "eca194ec349b4925d0ad53d2b67c18b6a1aa7a979e7bd8729cfd1ed1ef4994c7"
-  end
-
-  # https://issues.apache.org/jira/browse/LOGCXX-400 (reported)
-  patch :p1 do
-    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/f33998566cccf91fb84133e101f5a92a14b31aed/LOGCXX-404---domtestcase.cpp.patch"
-    sha256 "3eaf321e1df8e8e4a0a507a96646727180e7e721b2c42af22a5d40962d3dbecc"
-  end
+  # Fix to build LOGCXX-225
+  patch :DATA
 
   def install
     ENV.O2 # Using -Os causes build failures on Snow Leopard.
@@ -92,3 +75,21 @@ class Log4cxx < Formula
     assert_match /ERROR.*Foo/, shell_output("./test", 1)
   end
 end
+
+__END__
+diff --git a/src/main/include/log4cxx/helpers/simpledateformat.h b/src/main/include/log4cxx/helpers/simpledateformat.h
+index 9c27f68..39da173 100644
+--- a/src/main/include/log4cxx/helpers/simpledateformat.h
++++ b/src/main/include/log4cxx/helpers/simpledateformat.h
+@@ -27,10 +27,9 @@
+
+ #include <log4cxx/helpers/dateformat.h>
+ #include <vector>
++#include <locale>
+ #include <time.h>
+
+-namespace std { class locale; }
+-
+ namespace log4cxx
+ {
+         namespace helpers

--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -1,8 +1,8 @@
 class Log4cxx < Formula
   desc "Library of C++ classes for flexible logging"
   homepage "https://logging.apache.org/log4cxx/index.html"
-  url "https://github.com/kekkokk/logging-log4cxx/releases/download/0.10.0_with_fixes/log4cxx_latest_stable.tar.gz"
-  sha256 "d0e57ecaa61980f450677783736a6d71f549ef0c75adfd209e87fb0db6119f8c"
+  url "https://www.apache.org/dyn/closer.cgi?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
+  sha256 "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
   revision 2
 
   bottle do
@@ -19,8 +19,32 @@ class Log4cxx < Formula
 
   depends_on "apr-util"
 
-  # Fix to build LOGCXX-225
-  patch :DATA
+  # Incorporated upstream, remove on next version update
+  # https://issues.apache.org/jira/browse/LOGCXX-400 (r1414037)
+  # https://issues.apache.org/jira/browse/LOGCXX-404 (r1414037)
+  patch :p0 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/be8b4e610a1e21b34aaaf8fb4151362dcfb782ff/LOGCXX-400,LOGCXX-404---r1414037.patch"
+    sha256 "822c24f4eebd970aa284672eec2f71c6f8e192a85d78edb15a232c15011a52d4"
+  end
+
+  # https://issues.apache.org/jira/browse/LOGCXX-417 (r1556413)
+  patch :p0 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/4188731bd771a961a91fcfbe561f3999b555b9c3/LOG4CXX-417---r1556413.patch"
+    sha256 "eca194ec349b4925d0ad53d2b67c18b6a1aa7a979e7bd8729cfd1ed1ef4994c7"
+  end
+
+  # https://issues.apache.org/jira/browse/LOGCXX-394
+  # https://github.com/apache/logging-log4cxx/commit/a522f99209a63fedc852b31d133b2b30918fc3ed
+  patch :p1 do
+    url "https://gist.githubusercontent.com/kekkokk/dde9192bec36c94005b1a1b14f74e341/raw/84c8718c56f918f1df6dde7f78d3617679a93e46/LOG4CXX-394.patch"
+    sha256 "6fc7386470f335f14250ebb8ce962d68c77e9e6eccca8bcc6fec78cbed0ec42d"
+  end
+
+  # https://issues.apache.org/jira/browse/LOGCXX-400 (reported)
+  patch :p1 do
+    url "https://gist.githubusercontent.com/cawka/b4a79f6b883c46ac1672/raw/f33998566cccf91fb84133e101f5a92a14b31aed/LOGCXX-404---domtestcase.cpp.patch"
+    sha256 "3eaf321e1df8e8e4a0a507a96646727180e7e721b2c42af22a5d40962d3dbecc"
+  end
 
   def install
     ENV.O2 # Using -Os causes build failures on Snow Leopard.
@@ -75,21 +99,3 @@ class Log4cxx < Formula
     assert_match /ERROR.*Foo/, shell_output("./test", 1)
   end
 end
-
-__END__
-diff --git a/src/main/include/log4cxx/helpers/simpledateformat.h b/src/main/include/log4cxx/helpers/simpledateformat.h
-index 9c27f68..39da173 100644
---- a/src/main/include/log4cxx/helpers/simpledateformat.h
-+++ b/src/main/include/log4cxx/helpers/simpledateformat.h
-@@ -27,10 +27,9 @@
-
- #include <log4cxx/helpers/dateformat.h>
- #include <vector>
-+#include <locale>
- #include <time.h>
-
--namespace std { class locale; }
--
- namespace log4cxx
- {
-         namespace helpers


### PR DESCRIPTION
update log4cxx to follow the current latest_stable branch which points to:

https://github.com/apache/logging-log4cxx/commit/a0a28253d9c3b8da0d15aa41a8f5b6375c50c96e

0.10.0 build suffers from many problems like the one that is not thread safe and many other problem.
This is not the official 0.11.0 build but should contains these fixes
https://logging.apache.org/log4cxx/next_stable/changes-report.html#a0.11.0

- [ HOPE SO ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ YUP ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ YUP ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ NOT REALLY ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
log4cxx:
  * Stable: version (latest) is set to a string without a digit
  * stable version should not decrease (from 0.10.0 to latest)
  * revisions should only increment by 1
but it follows the pattern of the old one. please check (it's my first pr)
```
-----
