### PR TITLE
gtk-mac-integration: Apply latest patches to fix a bug and add support for --HEAD

### DIFF
--- a/Formula/gtk-mac-integration.rb
+++ b/Formula/gtk-mac-integration.rb
@@ -10,6 +10,15 @@ class GtkMacIntegration < Formula
     sha256 "23213e9b20f36cc8c95a344064e29968cd3dbca73f1d433c25636b6056e357ac" => :el_capitan
   end
 
+  head do
+    url "https://github.com/jralls/gtk-mac-integration.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gtk-doc" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
@@ -28,7 +37,11 @@ class GtkMacIntegration < Formula
     ]
 
     args << (build.without?("gtk+3") ? "--without-gtk3" : "--with-gtk3")
-    system "./configure", *args
+    if build.head?
+      system "./autogen.sh", *args
+    else
+      system "./configure", *args
+    end
     system "make", "install"
   end
 

--- a/Formula/gtk-mac-integration.rb
+++ b/Formula/gtk-mac-integration.rb
@@ -1,8 +1,20 @@
 class GtkMacIntegration < Formula
   desc "Integrates GTK macOS applications with the Mac desktop"
   homepage "https://wiki.gnome.org/Projects/GTK+/OSX/Integration"
-  url "https://download.gnome.org/sources/gtk-mac-integration/2.1/gtk-mac-integration-2.1.2.tar.xz"
-  sha256 "68e682a3ba952e7d4b1cfa2c7147c5fcd76f8bd9792a567e175a619af5954af1"
+  stable do
+    url "https://download.gnome.org/sources/gtk-mac-integration/2.1/gtk-mac-integration-2.1.2.tar.xz"
+    sha256 "68e682a3ba952e7d4b1cfa2c7147c5fcd76f8bd9792a567e175a619af5954af1"
+
+    patch :p1 do
+      url "https://github.com/jralls/gtk-mac-integration/pull/11.patch?full_index=1"
+      sha256 "4523207ea652b9048d01a58c05369c871def4e187db267ab7bad85ae1e102c31"
+    end
+
+    patch :p1 do
+      url "https://github.com/jralls/gtk-mac-integration/pull/13.patch?full_index=1"
+      sha256 "b0ecfb9a3c5cd9651584b33191b69915627cc9e09e78fb4623fcaa64915ee13d"
+    end
+  end
 
   bottle do
     sha256 "7c6926dc885b7c031398552069dc16bd63d2fe938d281d3f18a90a80de48ce16" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently the released versions have [a bug](https://github.com/jralls/gtk-mac-integration/pull/11) that crashes an application. Installing HEAD fixes the issue.