### PR TITLE
Vert.x 3.5.3

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.2-full.tar.gz"
-  sha256 "c9815434c9fc9474ec8eef4ef171c96f454fb08c2728ec855592ecbabb348e0b"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.3-full.tar.gz"
+  sha256 "10562ad91a3ccaa9a975e8e52d1f782c0aed6ba402e53d24d50686b1cbdb535c"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.5.3.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note: The Vert.x web page is not yet updated as having the homebrew formula is part of the release process. However, the artifacts are already available (so the formula works). Once the formula is merged, the website will be updated with the new version.
