### PR TITLE
gnupg 2.2.9

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -1,8 +1,8 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.8.tar.bz2"
-  sha256 "777b4cb8ced21965a5053d4fa20fe11484f0a478f3d011cef508a1a49db50dcd"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.9.tar.bz2"
+  sha256 "6278eaabffa1ebc9fa2ceb3dc53eea9a1505ab02a668a86dd6fec06951af2164"
 
   bottle do
     sha256 "ab5c3a5c825bc37847da76ea6b339a233af45b63a59dc28b26b827ecfc3ab3d5" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
Noteworthy changes in version 2.2.9
===================================

  * dirmngr: Fix recursive resolver mode and other bugs in the libdns
    code.  [#3374,#3803,#3610]

  * dirmngr: When using libgpg-error 1.32 or later a GnuPG build with
    NTBTLS support (e.g. the standard Windows installer) does not
    anymore block for dozens of seconds before returning data.  If you
    still have problems on Windows, please consider to use one of the
    options disable-ipv4 or disable-ipv6.

  * gpg: Fix bug in --show-keys which actually imported revocation
    certificates.  [#4017]

  * gpg: Ignore too long user-ID and comment packets.  [#4022]

  * gpg: Fix crash due to bad German translation.  Improved printf
    format compile time check.

  * gpg: Handle missing ISSUER sub packet gracefully in the presence of
    the new ISSUER_FPR.  [#4046]

  * gpg: Allow decryption using several passphrases in most cases.
    [#3795,#4050]

  * gpg: Command --show-keys now enables the list options
    show-unusable-uids, show-unusable-subkeys, show-notations and
    show-policy-urls by default.

  * gpg: Command --show-keys now prints revocation certificates. [#4018]

  * gpg: Add revocation reason to the "rev" and "rvs" records of the
    option --with-colons.  [#1173]

  * gpg: Export option export-clean does now remove certain expired
    subkeys; export-minimal removes all expired subkeys.  [#3622]

  * gpg: New "usage" property for the drop-subkey filters.  [#4019]
```