### PR TITLE
pinentry-mac: Patch header files for macOS 10.14

### DIFF
--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -17,6 +17,12 @@ class PinentryMac < Formula
 
   depends_on :xcode => :build
 
+  patch do
+    # patch header locations for macOS 10.14
+    url "https://github.com/GPGTools/pinentry-mac/pull/7.patch?full_index=1"
+    sha256 "d4bcf2003fa1345ecb1809461140179a3737e8e03eb49d623435beb3c2f09b64"
+  end
+
   def install
     system "make"
     prefix.install "build/Release/pinentry-mac.app"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This applies a [patch](https://github.com/GPGTools/pinentry-mac/pull/7) to pinentry-mac so that compiles correctly on 10.14.

Tested on 10.14 & 10.13