### PR TITLE
xarexec 18.07.12 (new formula)

### DIFF
--- a/Formula/xar.rb
+++ b/Formula/xar.rb
@@ -1,0 +1,32 @@
+class Xar < Formula
+  desc "The eXecutable Archive Format"
+  homepage "https://github.com/facebookincubator/xar"
+  url "https://github.com/facebookincubator/xar/archive/v18.07.12.tar.gz"
+  sha256 "517414281f02af5c304cb87f08c855e3e5ca812580ff94ff48972d68ec75558d"
+
+  depends_on "cmake" => :build
+  depends_on :osxfuse
+  depends_on "squashfuse"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    def pid_exists?(pid)
+      Process.kill 0, pid
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    begin
+      pid = fork { exec "#{bin}/xarexec_fuse", "--help" }
+      _, status = Process.wait2 pid
+      assert_equal 1, status.exitstatus
+    ensure
+      Process.kill "TERM", pid if pid_exists? pid
+    end
+  end
+end

--- a/Formula/xarexec.rb
+++ b/Formula/xarexec.rb
@@ -1,4 +1,4 @@
-class Xar < Formula
+class Xarexec < Formula
   desc "The eXecutable Archive Format"
   homepage "https://github.com/facebookincubator/xar"
   url "https://github.com/facebookincubator/xar/archive/v18.07.12.tar.gz"


### PR DESCRIPTION
Introduces Facebook's new [XAR](https://code.fb.com/data-infrastructure/xars-a-more-efficient-open-source-system-for-self-contained-executables/) self-contained executable packaging format. This formula builds and packages the C++ runtime program necessary to mount, extract, and unmount XAR archives.

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
