### PR TITLE
Fix sqoop by exposing hadoop's libexec files

### DIFF
--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -3,6 +3,7 @@ class Hadoop < Formula
   homepage "https://hadoop.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-3.1.0/hadoop-3.1.0.tar.gz"
   sha256 "670d2ced595fa42d9fa1a93c4e39b39f47002cad1553d9df163ee828ca5143e7"
+  revision 1
 
   bottle :unneeded
 
@@ -15,6 +16,9 @@ class Hadoop < Formula
     libexec.install %w[bin sbin libexec share etc]
     bin.write_exec_script Dir["#{libexec}/bin/*"]
     sbin.write_exec_script Dir["#{libexec}/sbin/*"]
+    libexec.write_exec_script Dir["#{libexec}/libexec/*.sh"]
+    # Temporary fix until https://github.com/Homebrew/brew/pull/4512 is fixed
+    chmod 0755, Dir["#{libexec}/*.sh"]
   end
 
   test do

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -4,6 +4,7 @@ class Sqoop < Formula
   url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz"
   version "1.4.6"
   sha256 "d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496"
+  revision 1
 
   bottle :unneeded
 
@@ -23,10 +24,12 @@ class Sqoop < Formula
 
   def sqoop_envs
     <<~EOS
-      export HADOOP_HOME="#{HOMEBREW_PREFIX}"
+      export HADOOP_HOME="#{Formula["hadoop"].opt_prefix}"
       export HBASE_HOME="#{HOMEBREW_PREFIX}"
       export HIVE_HOME="#{HOMEBREW_PREFIX}"
+      export HCAT_HOME="#{HOMEBREW_PREFIX}"
       export ZOOCFGDIR="#{etc}/zookeeper"
+      export ZOOKEEPER_HOME="#{Formula["zookeeper"].opt_prefix}"
     EOS
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Addresses #28760.
Depends on https://github.com/Homebrew/brew/pull/4470.

`brew test sqoop` is [currently failing](https://gist.github.com/ilovezfs/42eb68ded89dc0f12879550c715354cd) because sqoop cannot find hadoop's `hadoop-config.sh`. That `hadoop-config.sh` is in hadoop's `libexec`. But because we're stuffing all of hadoop into `libexec`, it ends up in `libexec/libexec`.

Current behavior:

```
$ /usr/local/Cellar/sqoop/1.4.6_1/libexec/bin/sqoop version
Warning: /usr/local/Cellar/sqoop/1.4.6_1/libexec/bin/../../hcatalog does not exist! HCatalog jobs will fail.
Please set $HCAT_HOME to the root of your HCatalog installation.
Warning: /usr/local/Cellar/sqoop/1.4.6_1/libexec/bin/../../accumulo does not exist! Accumulo imports will fail.
Please set $ACCUMULO_HOME to the root of your Accumulo installation.
Warning: /usr/local/Cellar/sqoop/1.4.6_1/libexec/bin/../../zookeeper does not exist! Accumulo imports will fail.
Please set $ZOOKEEPER_HOME to the root of your Zookeeper installation.
ERROR: Cannot execute /usr/local/libexec/hadoop-config.sh.
$ brew test sqoop                                                                                                                          master
Testing sqoop
==> /usr/local/Cellar/sqoop/1.4.6/bin/sqoop version
Error: sqoop: failed
<0> expected but was
<1>.
```

This PR re-exposes Hadoop's libexec scripts by write_exec_script'ing them back into the top libexec dir. It then points sqoop at Hadoop's `opt_prefix` so sqoop can find hadoop's config scripts.

This also sets HCAT_HOME and ZOOKEEPER_HOME in the sqoop wrapper script to fix some warnings it's currently issuing.

New behavior:

```
$ sqoop version                                                                                                                         fix-sqoop
Warning: /usr/local/Cellar/sqoop/1.4.6_1/libexec/bin/../../accumulo does not exist! Accumulo imports will fail.
Please set $ACCUMULO_HOME to the root of your Accumulo installation.
[/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula]
$ echo $?                                                                                                                               fix-sqoop
0
$ brew test sqoop                                                                                                                       fix-sqoop
Testing sqoop
==> /usr/local/Cellar/sqoop/1.4.6_1/bin/sqoop version
[/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula]
$
```