### PR TITLE
dartsim: Remove unnecessary dependency of freeglut

### DIFF
--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -31,7 +31,8 @@ class Dartsim < Formula
   def install
     ENV.cxx11
     # Force to link to system GLUT (see: https://cmake.org/Bug/view.php?id=16045)
-    system "cmake", ".", *std_cmake_args, "-DGLUT_glut_LIBRARY=/System/Library/Frameworks/GLUT.framework"
+    system "cmake", ".", "-DGLUT_glut_LIBRARY=/System/Library/Frameworks/GLUT.framework",
+                         *std_cmake_args
     system "make", "install"
 
     # Avoid revision bumps whenever fcl's or libccd's Cellar paths change

--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -3,7 +3,7 @@ class Dartsim < Formula
   homepage "https://dartsim.github.io/"
   url "https://github.com/dartsim/dart/archive/v6.5.0.tar.gz"
   sha256 "b4c7f4d800ae5696e6ada04bd91b299f4a5e4ff9e8e07deeed79c6923747e274"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "b7c4adad128053abce97c8ec8ad1fc1ad0e714a1118944e86054fc9707a660b8" => :high_sierra
@@ -19,7 +19,6 @@ class Dartsim < Formula
   depends_on "eigen"
   depends_on "fcl"
   depends_on "flann"
-  depends_on "freeglut"
   depends_on "libccd"
   depends_on "nlopt"
   depends_on "ode"

--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -30,7 +30,8 @@ class Dartsim < Formula
 
   def install
     ENV.cxx11
-    system "cmake", ".", *std_cmake_args
+    # Force to link to system GLUT (see: https://cmake.org/Bug/view.php?id=16045)
+    system "cmake", ".", *std_cmake_args, "-DGLUT_glut_LIBRARY=/System/Library/Frameworks/GLUT.framework"
     system "make", "install"
 
     # Avoid revision bumps whenever fcl's or libccd's Cellar paths change


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR removes the dependency of `freeglut` per [@ilovezfs's suggestion](https://github.com/Homebrew/homebrew-core/pull/29620#issuecomment-405043890).