### PR TITLE
fakeroot 1.22 (update urls)

### DIFF
--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -1,8 +1,8 @@
 class Fakeroot < Formula
   desc "Provide a fake root environment"
   homepage "https://tracker.debian.org/pkg/fakeroot"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fakeroot/fakeroot_1.22.orig.tar.bz2"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.22.orig.tar.bz2"
+  url "http://archive.ubuntu.com/ubuntu/pool/main/f/fakeroot/fakeroot_1.22.orig.tar.bz2"
+  mirror "http://ftp.internat.freebsd.org/pub/FreeBSD/ports/distfiles/fakeroot_1.22.orig.tar.bz2"
   sha256 "bd806a4a1e641203eb3d4571a10089e8a038c10ec7e492fa1e061b03ae3ec6fe"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The URLs in the fakeroot formula are no longer valid.  This also tripped up arch linux, see https://bugs.archlinux.org/task/59298

While not too many people do --build-from-source, this problem is very noticeable indeed on mac os 10.14, which builds most things from source still.