### PR TITLE
aterm: correct description

### DIFF
--- a/Formula/aterm.rb
+++ b/Formula/aterm.rb
@@ -1,5 +1,5 @@
 class Aterm < Formula
-  desc "AfterStep terminal emulator"
+  desc "Annotated Term for tree-like ADT exchange"
   homepage "https://strategoxt.org/Tools/ATermFormat"
   url "http://www.meta-environment.org/releases/aterm-2.8.tar.gz"
   sha256 "bab69c10507a16f61b96182a06cdac2f45ecc33ff7d1b9ce4e7670ceeac504ef"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Audit fails, but it looks like a transient network problem, and was not introduced by this change.

```
$ brew audit --strict --online aterm                                                  aterm-description
aterm:
  * The URL https://strategoxt.org/Tools/ATermFormat is not reachable
Error: 1 problem in 1 formula
```

-----

Fixes #30098.
