### PR TITLE
cockroach: rebuild v2.0.4

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -3,7 +3,8 @@ class Cockroach < Formula
   homepage "https://www.cockroachlabs.com"
   url "https://binaries.cockroachdb.com/cockroach-v2.0.4.src.tgz"
   version "2.0.4"
-  sha256 "3636017029fccf48b23ee1c45a3412adc36803f53df254035e6e2f82af45fb50"
+  sha256 "9d0985e175cc8527826ab4fa9d427159dc625e05fc365948be20c3e421b981de"
+  revision 1
   head "https://github.com/cockroachdb/cockroach.git"
 
   bottle do


### PR DESCRIPTION
The v2.0.4 source archive had to be rebuilt due to an error in our
(upstream's) release pipeline.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
