### PR TITLE
Fix phpcbf version to match phpcs in php-code-sniffer 3.3.0

### DIFF
--- a/Formula/php-code-sniffer.rb
+++ b/Formula/php-code-sniffer.rb
@@ -7,8 +7,8 @@ class PhpCodeSniffer < Formula
   bottle :unneeded
 
   resource "phpcbf.phar" do
-    url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.2.3/phpcbf.phar"
-    sha256 "34a94620615b674ef4ed44ab1648a9f1c874b35b4d48239e81a177a803a0e002"
+    url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.3.0/phpcbf.phar"
+    sha256 "9a9e93310a4e9de509aa06648e69fc91b8141661abb818aeb421e4fa5f3100aa"
   end
 
   def install

--- a/Formula/php-code-sniffer.rb
+++ b/Formula/php-code-sniffer.rb
@@ -3,6 +3,7 @@ class PhpCodeSniffer < Formula
   homepage "https://github.com/squizlabs/PHP_CodeSniffer/"
   url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.3.0/phpcs.phar"
   sha256 "90442ce92ffccfad906f411919d26be54005064463707ea4beba3684d92e83fe"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
This was omitted in the previous update https://github.com/Homebrew/homebrew-core/pull/28746

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
