### PR TITLE
capstone requires pkg-config for build

### DIFF
--- a/Formula/capstone.rb
+++ b/Formula/capstone.rb
@@ -5,6 +5,8 @@ class Capstone < Formula
   sha256 "913dd695e7c5a2b972a6f427cb31f2e93677ec1c38f39dda37d18a91c70b6df1"
   head "https://github.com/aquynh/capstone.git"
 
+  depends_on "pkg-config" => :build
+  
   bottle do
     cellar :any
     sha256 "90c24c16624b06137aeec9cf9040c6cf91ccc5045a4fa5606c4ee39be8b06991" => :high_sierra

--- a/Formula/capstone.rb
+++ b/Formula/capstone.rb
@@ -6,7 +6,7 @@ class Capstone < Formula
   head "https://github.com/aquynh/capstone.git"
 
   depends_on "pkg-config" => :build
-  
+
   bottle do
     cellar :any
     sha256 "90c24c16624b06137aeec9cf9040c6cf91ccc5045a4fa5606c4ee39be8b06991" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source -v capstone
...
==> ./make.sh install
./make.sh: line 68: pkg-config: command not found
mkdir -p /usr/local/Cellar/capstone/3.0.5/lib
install -m0755 ./libcapstone.dylib /usr/local/Cellar/capstone/3.0.5/lib
cd /usr/local/Cellar/capstone/3.0.5/lib && mv libcapstone.dylib libcapstone.3.dylib && ln -s libcapstone.3.dylib libcapstone.dylib
install -m0644 ./libcapstone.a /usr/local/Cellar/capstone/3.0.5/lib
mkdir -p /usr/local/Cellar/capstone/3.0.5/include/capstone
install -m0644 include/*.h /usr/local/Cellar/capstone/3.0.5/include/capstone
mkdir -p /usr/local/Cellar/capstone/3.0.5/lib/pkgconfig
install -m0644 ./capstone.pc /usr/local/Cellar/capstone/3.0.5/lib/pkgconfig/
mkdir -p /usr/local/Cellar/capstone/3.0.5/bin
install -m0755 cstool/cstool /usr/local/Cellar/capstone/3.0.5/bin
...
```