### PR TITLE
lastpass-cli: add zsh completion script

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -25,6 +25,7 @@ class LastpassCli < Formula
     system "make", "MANDIR=#{man}", "install-doc"
 
     bash_completion.install "contrib/lpass_bash_completion"
+    zsh_completion.install "contrib/lpass_zsh_completion" => "_lpass"
     fish_completion.install "contrib/completions-lpass.fish"
   end
 


### PR DESCRIPTION
Added to the formula the code to install the zsh completion script.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
