### PR TITLE
pango: remove redundant argument

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -34,7 +34,6 @@ class Pango < Formula
                           "--prefix=#{prefix}",
                           "--with-html-dir=#{share}/doc",
                           "--enable-introspection=yes",
-                          "--enable-man",
                           "--enable-static",
                           "--without-xft"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-----

Was removed upstream in https://gitlab.gnome.org/GNOME/pango/commit/fa6dfc688c293fa02c36ee89ac5611fd5e0131a5. 

Building everything from source on my 10.14 VM is proving a solid way to spot these long-dead arguments we're still passing, given how shouty `configure` tends to be.