### PR TITLE
usbutils 007 (new formula): provides 'lsusb' tool

### DIFF
--- a/Formula/usbutils.rb
+++ b/Formula/usbutils.rb
@@ -1,0 +1,38 @@
+class Usbutils < Formula
+  desc "Provides 'lsusb' tool for getting detailed info about USB devices"
+  # Homepage for multiple Linux USB tools, 'usbutils' is one of them.
+  homepage "https://linux-usb.sourceforge.io"
+  # The latest version we can use is 007 (from 2013), because the later
+  # versions depend on 'libudev': part of Systemd and not in Homebrew.
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/usb/usbutils/usbutils-007.tar.xz"
+  sha256 "7593a01724bbc0fd9fe48e62bc721ceb61c76654f1d7b231b3c65f6dfbbaefa4"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    # Clear AM_LDFLAGS to remove unsupported "-Wl,--as-needed"
+    # Also, clear/override several other variables, to avoid
+    # building/installing linux-specific utilities that rely on sysfs.
+    system "make", "install", "AM_LDFLAGS=", "SUBDIRS=", "bin_SCRIPTS=",
+                              "man_MANS=lsusb.8"
+  end
+
+  test do
+    # Run --version only. The normal 'lsusb' run may exit
+    # with 1 if executed on a Virtual Machine.
+    system "#{bin}/lsusb", "--version"
+    # Make sure nothing shows up on stderr - 'lsusb' would print
+    # a message if it could not find the USB ids file:
+    _, stderr, status = Open3.capture3("#{bin}/lsusb")
+    assert_true status.exited?
+    assert_equal "", stderr
+  end
+end


### PR DESCRIPTION
The 'lsusb' tools allows listing connected USB devices and
printing detailed information about the devices' USB descriptors,
such as configurations, interfaces, and endpoints.
These details are not available from standard
Mac OS tools, such as ioreg or system_profiler.

Note, the 'usbutils' is available on Macports, and it would be great to have it in the Homebrew as well.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
 -- YES
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 -- YES
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 -- YES
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  -- YES
-----
