### PR TITLE
Gradle 3.5 (new formula) 

### DIFF
--- a/Formula/gradle@3.5.rb
+++ b/Formula/gradle@3.5.rb
@@ -10,7 +10,7 @@ class GradleAT35 < Formula
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
     libexec.install %w[docs media samples src] if build.with? "all"
-    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
+    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.java_home_env("1.7+")
   end
   test do
     assert_match version.to_s, shell_output("#{bin}/gradle --version")

--- a/Formula/gradle@3.5.rb
+++ b/Formula/gradle@3.5.rb
@@ -3,7 +3,6 @@ class GradleAT35 < Formula
   homepage "https://www.gradle.org/"
   url "https://services.gradle.org/distributions/gradle-3.5-all.zip"
   sha256 "d84bf6b6113da081d0082bcb63bd8547824c6967fe68704d1e3a6fde822b7212"
-
   bottle :unneeded
   option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
   depends_on :java => "1.7+"
@@ -14,6 +13,6 @@ class GradleAT35 < Formula
     (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
   end
   test do
-    assert_match version.to_s, shell_output("%w{bin}/gradle --version")
+    assert_match version.to_s, shell_output("#{bin}/gradle --version")
   end
 end

--- a/Formula/gradle@3.5.rb
+++ b/Formula/gradle@3.5.rb
@@ -5,19 +5,15 @@ class GradleAT35 < Formula
   sha256 "d84bf6b6113da081d0082bcb63bd8547824c6967fe68704d1e3a6fde822b7212"
 
   bottle :unneeded
-  
   option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
-
-
-
+  depends_on :java => "1.7+"
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
     libexec.install %w[docs media samples src] if build.with? "all"
     (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
   end
-
   test do
-	assert_match version.to_s, shell_output("%w{bin}/gradle --version")
+    assert_match version.to_s, shell_output("%w{bin}/gradle --version")
   end
 end

--- a/Formula/gradle@3.5.rb
+++ b/Formula/gradle@3.5.rb
@@ -1,18 +1,23 @@
 class GradleAT35 < Formula
   desc "Gradle build automation tool"
   homepage "https://www.gradle.org/"
-  url "https://services.gradle.org/distributions/gradle-3.5-bin.zip"
-  sha256 "0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110"
+  url "https://services.gradle.org/distributions/gradle-3.5-all.zip"
+  sha256 "d84bf6b6113da081d0082bcb63bd8547824c6967fe68704d1e3a6fde822b7212"
 
   bottle :unneeded
   
+  option "with-all", "Installs Javadoc, examples, and source in addition to the binaries"
+
+
+
   def install
+    rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
-    bin.install_symlink libexec+"bin/gradle"
+    libexec.install %w[docs media samples src] if build.with? "all"
+    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
   end
 
   test do
-    ENV["GRADLE_USER_HOME"] = testpath
-    assert_match "Gradle #{version}", shell_output("#{bin}/gradle --version")
+	assert_match version.to_s, shell_output("%w{bin}/gradle --version")
   end
 end

--- a/Formula/gradle@3.5.rb
+++ b/Formula/gradle@3.5.rb
@@ -1,0 +1,18 @@
+class GradleAT35 < Formula
+  desc "Gradle build automation tool"
+  homepage "https://www.gradle.org/"
+  url "https://services.gradle.org/distributions/gradle-3.5-bin.zip"
+  sha256 "0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110"
+
+  bottle :unneeded
+  
+  def install
+    libexec.install %w[bin lib]
+    bin.install_symlink libexec+"bin/gradle"
+  end
+
+  test do
+    ENV["GRADLE_USER_HOME"] = testpath
+    assert_match "Gradle #{version}", shell_output("#{bin}/gradle --version")
+  end
+end


### PR DESCRIPTION
Resolved the Jenkins build failure. 

Action Item: Adding gradle@3.5.rb formula

Summary: Currently brew supports 4.9 (latest version) and 2.14 version of Gradle. Between these 2 versions there is another major version ie. gradle 3.5. 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----