### PR TITLE
mpv 0.29.0

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -57,13 +57,10 @@ class Mpv < Formula
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
 
-    # Prevents a conflict between python2 and python3 when
-    # gobject-introspection is using brewed python.
-    ENV.delete("PYTHONPATH") if MacOS.version <= :mavericks
-
-    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
     resource("docutils").stage do
-      system "python2.7", *Language::Python.setup_install_args(buildpath/"vendor")
+      system "python3", *Language::Python.setup_install_args(buildpath/"vendor")
     end
     ENV.prepend_path "PATH", buildpath/"vendor/bin"
 

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -48,7 +48,7 @@ class Mpv < Formula
 
   patch do
     url "https://github.com/mpv-player/mpv/pull/6004.patch?full_index=1"
-    sha256 "8467cafdcf1d724b4bd1103179a9f29da58ee303aebb506bff43e78f90c99bf0"
+    sha256 "65bfeac2e02847d72d54ac55e9da0011556fd4a6466151927e0535d2355a8ffd"
   end
 
   def install

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -1,8 +1,8 @@
 class Mpv < Formula
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io"
-  url "https://github.com/mpv-player/mpv/archive/v0.28.2.tar.gz"
-  sha256 "aada14e025317b5b3e8e58ffaf7902e8b6e4ec347a93d25a7c10d3579426d795"
+  url "https://github.com/mpv-player/mpv/archive/v0.29.0.tar.gz"
+  sha256 "772af878cee5495dcd342788a6d120b90c5b1e677e225c7198f1e76506427319"
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
@@ -15,7 +15,7 @@ class Mpv < Formula
   option "with-lgpl", "Build with LGPLv2.1 or later license"
 
   depends_on "pkg-config" => :build
-  depends_on "python@2" => :build
+  depends_on "python" => :build
 
   depends_on "libass"
   depends_on "ffmpeg"
@@ -42,8 +42,8 @@ class Mpv < Formula
   depends_on :macos => :mountain_lion
 
   resource "docutils" do
-    url "https://files.pythonhosted.org/packages/05/25/7b5484aca5d46915493f1fd4ecb63c38c333bd32aa9ad6e19da8d08895ae/docutils-0.13.1.tar.gz"
-    sha256 "718c0f5fb677be0f34b781e04241c4067cbd9327b66bdd8e763201130f5175be"
+    url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
+    sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
   end
 
   def install
@@ -87,11 +87,11 @@ class Mpv < Formula
     end
 
     system "./bootstrap.py"
-    system "python", "waf", "configure", *args
-    system "python", "waf", "install"
+    system "python3", "waf", "configure", *args
+    system "python3", "waf", "install"
 
     if build.with? "bundle"
-      system "python", "TOOLS/osxbundle.py", "build/mpv"
+      system "python3", "TOOLS/osxbundle.py", "build/mpv"
       prefix.install "build/mpv.app"
     end
   end

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -46,6 +46,11 @@ class Mpv < Formula
     sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
   end
 
+  patch do
+    url "https://github.com/mpv-player/mpv/pull/6004.patch?full_index=1"
+    sha256 "8467cafdcf1d724b4bd1103179a9f29da58ee303aebb506bff43e78f90c99bf0"
+  end
+
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since


### PR DESCRIPTION
depend on python at build time instead of python@2

Reverts https://github.com/Homebrew/homebrew-core/commit/b314a662626e0a7fd61fb8f2a5e12fbbb04651e6