### PR TITLE
vim: add support for building with system python

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -22,6 +22,7 @@ class Vim < Formula
   LANGUAGES_DEFAULT  = %w[python].freeze
 
   option "with-python@2", "Build vim with python@2 instead of python[3] support"
+  option "with-system-python", "Build vim with system python for python support"
   LANGUAGES_OPTIONAL.each do |language|
     option "with-#{language}", "Build vim with #{language} support"
   end
@@ -31,7 +32,7 @@ class Vim < Formula
 
   depends_on "perl"
   depends_on "ruby"
-  depends_on "python" => :recommended if build.without? "python@2"
+  depends_on "python" => :recommended if build.without?("python@2") && build.without?("system-python")
   depends_on "gettext" => :optional
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
@@ -42,7 +43,7 @@ class Vim < Formula
     :because => "vim and ex-vi both install bin/ex and bin/view"
 
   def install
-    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin" if build.without? "system-python"
 
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")
@@ -57,6 +58,10 @@ class Vim < Formula
       if build.with? language
         opts << "--enable-#{feature.fetch(language, language)}interp"
       end
+    end
+
+    if build.with? "system-python"
+      opts << "--enable-pythoninterp"
     end
 
     if opts.include?("--enable-pythoninterp") && opts.include?("--enable-python3interp")
@@ -120,7 +125,7 @@ class Vim < Formula
   end
 
   test do
-    if build.with? "python@2"
+    if build.with?("python@2") || build.with?("system-python")
       (testpath/"commands.vim").write <<~EOS
         :python import vim; vim.current.buffer[0] = 'hello world'
         :wq


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

add `--with-system-python` option for building with system python.