### PR TITLE
weechat: remove deprecated python option

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -18,8 +18,6 @@ class Weechat < Formula
   option "with-debug", "Build with debug information"
   option "without-tcl", "Do not build the tcl module"
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "asciidoctor" => :build
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is causing a dependency conflict/mix-up since https://github.com/Homebrew/homebrew-core/pull/30228 due to the added `with-python` option, which is getting remapped by the `deprecated_option` onto `python@2`.