### PR TITLE
plantuml: add option to build with pdf support

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -7,8 +7,15 @@ class Plantuml < Formula
 
   bottle :unneeded
 
+  option "with-pdf-support", "Downloads additional JAR files for PDF export functionality"
+
   depends_on "graphviz"
   depends_on :java
+
+  resource "batik-and-fop" do
+    url "http://beta.plantuml.net/batikAndFop.zip"
+    sha256 "c1f328a9aacfd954c6cd90650cefd924baea358d6e27520de7ccf9b30a681877"
+  end
 
   def install
     jar = "plantuml.jar"
@@ -18,6 +25,12 @@ class Plantuml < Formula
       GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{libexec}/#{jar} "$@"
     EOS
     chmod 0555, bin/"plantuml"
+
+    if build.with? "pdf-support"
+      resources.each do |r|
+        libexec.install r
+      end
+    end
   end
 
   test do

--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -25,7 +25,7 @@ class Plantuml < Formula
       GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{libexec}/#{jar} "$@"
     EOS
     chmod 0555, bin/"plantuml"
-    libexec.install resource("pdf-support") if build.with? "pdf-support"
+    libexec.install resource("batik-and-fop") if build.with? "pdf-support"
   end
 
   test do

--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -25,12 +25,7 @@ class Plantuml < Formula
       GRAPHVIZ_DOT="#{Formula["graphviz"].opt_bin}/dot" exec java -jar #{libexec}/#{jar} "$@"
     EOS
     chmod 0555, bin/"plantuml"
-
-    if build.with? "pdf-support"
-      resources.each do |r|
-        libexec.install r
-      end
-    end
+    libexec.install resource("pdf-support") if build.with? "pdf-support"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to [PlantUML documentation](http://plantuml.com/pdf), you need to download some additional JAR files to enable PDF export. Although the page says that the archive is "for testing purposes", the maintainers suggest [on the forum](http://forum.plantuml.net/6497/create-generates-error-cannot-access-transcoder-application) that it is safe to use this archive.

This PR adds an option to the PlantUML formula that will download the aforementioned archive, so that PlantUML users can have PDF export capabilities without performing additional manual actions.