### PR TITLE
cmake 3.11.4 (new formula)

### DIFF
--- a/Formula/cmake@3.11.rb
+++ b/Formula/cmake@3.11.rb
@@ -1,0 +1,65 @@
+class CmakeAT311 < Formula
+  desc "Cross-platform make"
+  homepage "https://www.cmake.org/"
+  url "https://cmake.org/files/v3.11/cmake-3.11.4.tar.gz"
+  sha256 "8f864e9f78917de3e1483e256270daabc4a321741592c5b36af028e72bff87f5"
+  head "https://cmake.org/cmake.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "19de409c20d3e357cf3ae2cb11408dd32e2e6f74084e07c7ca38a38894207cd7" => :high_sierra
+    sha256 "e618e6dd6696dec2deba7927ee3b3a302f944cfa8208a5405ee60346ac00c534" => :sierra
+    sha256 "0401ace628c67133f7c061bce0e3a3f71f491ffc9e38f22a8fdb8bb8854c8a1c" => :el_capitan
+  end
+
+  option "without-docs", "Don't build man pages"
+  option "with-completion", "Install Bash completion (Has potential problems with system bash)"
+
+  depends_on "sphinx-doc" => :build if build.with? "docs"
+
+  # The `with-qt` GUI option was removed due to circular dependencies if
+  # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
+  # For the GUI application please instead use `brew cask install cmake`.
+
+  needs :cxx11
+
+  def install
+    ENV.cxx11 if MacOS.version < :mavericks
+
+    args = %W[
+      --prefix=#{prefix}
+      --no-system-libs
+      --parallel=#{ENV.make_jobs}
+      --datadir=/share/cmake
+      --docdir=/share/doc/cmake
+      --mandir=/share/man
+      --system-zlib
+      --system-bzip2
+      --system-curl
+    ]
+
+    if build.with? "docs"
+      # There is an existing issue around macOS & Python locale setting
+      # See https://bugs.python.org/issue18378#msg215215 for explanation
+      ENV["LC_ALL"] = "en_US.UTF-8"
+      args << "--sphinx-man" << "--sphinx-build=#{Formula["sphinx-doc"].opt_bin}/sphinx-build"
+    end
+
+    system "./bootstrap", *args, "--", "-DCMAKE_BUILD_TYPE=Release"
+    system "make"
+    system "make", "install"
+
+    if build.with? "completion"
+      cd "Auxiliary/bash-completion/" do
+        bash_completion.install "ctest", "cmake", "cpack"
+      end
+    end
+
+    elisp.install "Auxiliary/cmake-mode.el"
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write("find_package(Ruby)")
+    system bin/"cmake", "."
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
👉 I got `Formulae should not have an unstable spec`. I may need some help to fix that.
-----
My project build failed because of an incompatibility with cmake 3.12. I'd like to make cmake 3.11 still available with a new "versioned formula". It is pretty much the same file as the one changed in #30187. I've just renamed the class.