### PR TITLE
New formula for Petsc complex to replace now missing option

### DIFF
--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -17,7 +17,7 @@ class PetscComplex < Formula
   depends_on "open-mpi"
   depends_on "scalapack"
   depends_on "suite-sparse"
-  conflicts_with "petsc", :because => "petsc must be installed with either real or complex support"
+  conflicts_with "petsc", :because => "petsc must be installed with either real or complex support, not both"
 
   def install
     ENV["CC"] = "mpicc"

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -1,4 +1,4 @@
-class Petsc < Formula
+class PetscComplex < Formula
   desc "Portable, Extensible Toolkit for Scientific Computation"
   homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz"
@@ -30,7 +30,7 @@ class Petsc < Formula
       --with-debugging=0
       --with-x=0
     ]
-    system "./configure", "--with-scalar-type=real", *args
+    system "./configure", "--with-scalar-type=complex", *args
     system "make", "all"
     system "make", "install"
   end

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -1,14 +1,8 @@
 class PetscComplex < Formula
-  desc "Portable, Extensible Toolkit for Scientific Computation"
+  desc "Portable, Extensible Toolkit for Scientific Computation (with complex support)"
   homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz"
   sha256 "8828fe1221f038d78a8eee3325cdb22ad1055a2f0671871815ee9f47365f93bb"
-
-  bottle do
-    sha256 "733080c80cec9ad2c7da2fb5d922f94889421779eac6c291c9a62152f333fb6b" => :high_sierra
-    sha256 "e8858a1cec95cc42417773aac1b7e85db1c4938e149f7b27a20ad739a51cb395" => :sierra
-    sha256 "4b8ddec36720b2778df1fcdcf765bcf7a847abbeec6a7df9f09067b4ca4fb505" => :el_capitan
-  end
 
   depends_on "hdf5"
   depends_on "hwloc"
@@ -17,6 +11,7 @@ class PetscComplex < Formula
   depends_on "open-mpi"
   depends_on "scalapack"
   depends_on "suite-sparse"
+
   conflicts_with "petsc", :because => "petsc must be installed with either real or complex support, not both"
 
   def install
@@ -24,13 +19,10 @@ class PetscComplex < Formula
     ENV["CXX"] = "mpicxx"
     ENV["F77"] = "mpif77"
     ENV["FC"] = "mpif90"
-
-    args = %W[
-      --prefix=#{prefix}
-      --with-debugging=0
-      --with-x=0
-    ]
-    system "./configure", "--with-scalar-type=complex", *args
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-debugging=0",
+                          "--with-scalar-type=complex",
+                          "--with-x=0"
     system "make", "all"
     system "make", "install"
   end

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -1,5 +1,5 @@
 class PetscComplex < Formula
-  desc "Portable, Extensible Toolkit for Scientific Computation (with complex support)"
+  desc "Portable, Extensible Toolkit for Scientific Computation (complex)"
   homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz"
   sha256 "8828fe1221f038d78a8eee3325cdb22ad1055a2f0671871815ee9f47365f93bb"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -17,7 +17,7 @@ class Petsc < Formula
   depends_on "open-mpi"
   depends_on "scalapack"
   depends_on "suite-sparse"
-  conflicts_with "petsc", :because => "petsc must be installed with either real or complex support"
+  conflicts_with "petsc-complex", :because => "petsc must be installed with either real or complex support, not both"
 
   def install
     ENV["CC"] = "mpicc"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -1,5 +1,5 @@
 class Petsc < Formula
-  desc "Portable, Extensible Toolkit for Scientific Computation"
+  desc "Portable, Extensible Toolkit for Scientific Computation (real)"
   homepage "https://www.mcs.anl.gov/petsc/"
   url "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz"
   sha256 "8828fe1221f038d78a8eee3325cdb22ad1055a2f0671871815ee9f47365f93bb"

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -17,6 +17,7 @@ class Petsc < Formula
   depends_on "open-mpi"
   depends_on "scalapack"
   depends_on "suite-sparse"
+
   conflicts_with "petsc-complex", :because => "petsc must be installed with either real or complex support, not both"
 
   def install
@@ -24,19 +25,16 @@ class Petsc < Formula
     ENV["CXX"] = "mpicxx"
     ENV["F77"] = "mpif77"
     ENV["FC"] = "mpif90"
-
-    args = %W[
-      --prefix=#{prefix}
-      --with-debugging=0
-      --with-x=0
-    ]
-    system "./configure", "--with-scalar-type=real", *args
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-debugging=0",
+                          "--with-scalar-type=real",
+                          "--with-x=0"
     system "make", "all"
     system "make", "install"
   end
 
   test do
-    test_case = "#{share}/petsc/examples/ksp/ksp/examples/tutorials/ex1.c"
+    test_case = "#{pkgshare}/examples/ksp/ksp/examples/tutorials/ex1.c"
     system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
     output = shell_output("./test")
     # This PETSc example prints several lines of output. The last line contains


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a continuation of https://github.com/Homebrew/homebrew-core/issues/29737.

Petsc must be compiled with either real or complex support. This amounts to simply changing `"--with-scalar-type=real"` to `"--with-scalar-type=complex"`, otherwise everything else is identical. There used to be an option to choose one of these in Brew, but it was taken away a few months ago. There are two potential ways forward:

1) Have a single formula that installs both versions of the library, with some way to select between them. I tried to create something like this, but was unsuccessful.

2) Have two formulae and the user can install either `petsc` (should it be `petsc-real`?) or `petsc-complex`. They conflict with each other.

This PR successfully implements 2). For whatever it is worth, Ubuntu provides two packages, with `update-alternatives` being used to select between them.