### PR TITLE
git-lfs 2.5.0

### DIFF
--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -17,14 +17,6 @@ class GitLfs < Formula
   depends_on "ruby" => :build if MacOS.version <= :sierra
 
   def install
-    begin
-      deleted = ENV.delete "SDKROOT"
-      deleted_gopath = ENV.delete "GOPATH"
-    ensure
-      ENV["SDKROOT"] = deleted
-      ENV["GOPATH"] = deleted_gopath
-    end
-
     ENV["GOPATH"] = buildpath
     ENV["GIT_LFS_SHA"] = ""
     ENV["VERSION"] = version

--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -1,8 +1,8 @@
 class GitLfs < Formula
   desc "Git extension for versioning large files"
   homepage "https://github.com/git-lfs/git-lfs"
-  url "https://github.com/git-lfs/git-lfs/archive/v2.4.2.tar.gz"
-  sha256 "130a552a27c8f324ac0548baf9db0519c4ae96c26a85f926c07ebe0f15a69fc2"
+  url "https://github.com/git-lfs/git-lfs/archive/v2.5.0.tar.gz"
+  sha256 "a09304d8bc767643469d738d3a1defbe5b3627dd4777bc668517a6a4f6018373"
 
   bottle do
     cellar :any_skip_relocation
@@ -19,19 +19,29 @@ class GitLfs < Formula
   def install
     begin
       deleted = ENV.delete "SDKROOT"
-      ENV["GEM_HOME"] = buildpath/"gem_home"
-      system "gem", "install", "ronn"
-      ENV.prepend_path "PATH", buildpath/"gem_home/bin"
+      deleted_gopath = ENV.delete "GOPATH"
     ensure
       ENV["SDKROOT"] = deleted
+      ENV["GOPATH"] = deleted_gopath
     end
 
-    system "./script/bootstrap"
-    system "./script/man"
+    ENV["GOPATH"] = buildpath
+    ENV["GIT_LFS_SHA"] = ""
+    ENV["VERSION"] = version
 
-    bin.install "bin/git-lfs"
-    man1.install Dir["man/*.1"]
-    doc.install Dir["man/*.html"]
+    (buildpath/"src/github.com/git-lfs/git-lfs").install buildpath.children
+    cd "src/github.com/git-lfs/git-lfs" do
+      ENV["GEM_HOME"] = ".gem_home"
+      system "gem", "install", "ronn"
+
+      system "make"
+      system "make", "man", "RONN=.gem_home/bin/ronn"
+
+      bin.install "bin/git-lfs"
+      man1.install Dir["man/*.1"]
+      man5.install Dir["man/*.5"]
+      doc.install Dir["man/*.html"]
+    end
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
👋 lovely Homebrew folks! Here's another Git LFS release. We updated our build process slightly to no longer use `script/bootstrap` (instead replacing it with `make`), so I made a few changes to ensure that:

1. The build is done inside a valid `GOPATH` (taken from `Formula/git-sizer.rb`).
2. The environment variables are set outside of the `begin` block, which made a difference when running this locally with `--install-from-source`. I'm not a Ruby expert, so scrutiny is definitely welcome on the diff below.

##

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----