### PR TITLE
megatools 1.10.1

### DIFF
--- a/Formula/megatools.rb
+++ b/Formula/megatools.rb
@@ -1,8 +1,8 @@
 class Megatools < Formula
   desc "Command-line client for Mega.co.nz"
   homepage "https://megatools.megous.com/"
-  url "https://megatools.megous.com/builds/megatools-1.9.98.tar.gz"
-  sha256 "9b0521a4d27dbc417fc8e12610ac1e1da729bf6d6eb5bef927ef3670b372a16f"
+  url "https://megatools.megous.com/builds/megatools-1.10.0.tar.gz"
+  sha256 "788a51d0977db95c371c97917aee3d39e145044b6bb70d671bc76c2ea6c4171b"
 
   bottle do
     cellar :any

--- a/Formula/megatools.rb
+++ b/Formula/megatools.rb
@@ -1,8 +1,8 @@
 class Megatools < Formula
   desc "Command-line client for Mega.co.nz"
   homepage "https://megatools.megous.com/"
-  url "https://megatools.megous.com/builds/megatools-1.10.0.tar.gz"
-  sha256 "788a51d0977db95c371c97917aee3d39e145044b6bb70d671bc76c2ea6c4171b"
+  url "https://megatools.megous.com/builds/megatools-1.10.1.tar.gz"
+  sha256 "9938127db27b579d49aa8722bfdddd17833fe90668aa2670ce88d1c889452d67"
 
   bottle do
     cellar :any


### PR DESCRIPTION
1.9.98 had broken megaput

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
