### PR TITLE
skinny 3.0.0-1 (revising #30560)

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/3.0.0/skinny-3.0.0.tar.gz"
-  sha256 "b66baeee852249b3ccb177d0fd114a6bc69dd3638f2369ca2005071da7b592f8"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/3.0.0/skinny-3.0.0-1.tar.gz"
+  sha256 "f5861281ff34153ffd2052ed2335ad18d7887eaa0545638c36a56ccb5a167337"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
The binary specified in #30560 had an issue. We've revised it and published the revised one as 3.0.0-1. Sorry for bothering you.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source Formula/skinny.rb
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/3.0.0/skinny-3.0.0-1.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/837cd908-9314-11e8-9c3a-54fe1c4c9747?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180729%2Fus-east-1%2Fs3%2
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/3.0.0-1: 592 files, 65.5MB, built in 52 seconds
$ brew audit --strict skinny
$
```