### PR TITLE
SDL, SDL_mixer wav file crash fixes.

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -54,6 +54,13 @@ class Sdl < Formula
     sha256 "ee7eccb51cefff15c6bf8313a7cc7a3f347dc8e9fdba7a3c3bd73f958070b3eb"
   end
 
+  # BEXT wave files crash fix.
+  # https://bugzilla.libsdl.org/show_bug.cgi?id=1673
+  patch do
+    url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3273"
+    sha256 "2c6b6b0d4b5e62e1b4c4548c79a33b09619ff5a52cb7e56b7f6eff09228d9143"
+  end
+
   def install
     # we have to do this because most build scripts assume that all sdl modules
     # are installed to the same prefix. Consequently SDL stuff cannot be


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These issues are fixed in hg but don't have a release in the SDL 1.2 series.
- https://bugzilla.libsdl.org/show_bug.cgi?id=1673 https://github.com/pygame/pygame/issues/459
- https://bugzilla.libsdl.org/show_bug.cgi?id=1418 https://github.com/pygame/pygame/issues/406