### PR TITLE
gst-editing-services: add gobject-introspection build-time dependency

### DIFF
--- a/Formula/gst-editing-services.rb
+++ b/Formula/gst-editing-services.rb
@@ -3,6 +3,7 @@ class GstEditingServices < Formula
   homepage "https://gstreamer.freedesktop.org/modules/gst-editing-services.html"
   url "https://gstreamer.freedesktop.org/src/gst-editing-services/gstreamer-editing-services-1.14.2.tar.xz"
   sha256 "05b280d19eb637f17634d32eb3b5ac8963fc9b667aeff29dab3594dbdfc61f34"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,6 +12,7 @@ class GstEditingServices < Formula
     sha256 "ac06a59d8c48026c42c86c8ee216b98e0ca4b490144c4b9c5c4efd59cef0c84d" => :el_capitan
   end
 
+  depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
   depends_on "gstreamer"
   depends_on "gst-plugins-base"


### PR DESCRIPTION
Closes #30607.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
