### PR TITLE
clang-format@5 5.0.2 (new formula)

### DIFF
--- a/Formula/clang-format@5.rb
+++ b/Formula/clang-format@5.rb
@@ -51,5 +51,20 @@ class ClangFormatAT5 < Formula
 
     assert_equal "int main(char *args) { printf(\"hello\"); }\n",
         shell_output("#{bin}/clang-format -style=Google test.c")
+
+    # below code is messily formatted on purpose.
+    (testpath/"test2.h").write <<~EOS
+      #import  "package/file.h"
+      @interface SomePlugin   : NSObject  < ParentPlugin >
+      @end
+    EOS
+
+    # NOTE! different formatting depending on version
+    # clang-format 5.x
+    #     @interface SomePlugin : NSObject<ParentPlugin>
+    # clang-format 6.x, 7.x
+    #     @interface SomePlugin : NSObject <ParentPlugin>
+    assert_equal "#import \"package/file.h\"\n@interface SomePlugin : NSObject<ParentPlugin>\n@end\n",
+        shell_output("#{bin}/clang-format -style=Google test2.h")
   end
 end

--- a/Formula/clang-format@5.rb
+++ b/Formula/clang-format@5.rb
@@ -3,48 +3,23 @@ class ClangFormatAT5 < Formula
   homepage "https://releases.llvm.org/5.0.2/tools/clang/docs/ClangFormat.html"
   version "5.0.2"
 
-  stable do
-    if MacOS.version >= :sierra
-      url "https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
-    else
-      url "http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
-    end
-
-    resource "clang" do
-      if MacOS.version >= :sierra
-        url "https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
-      else
-        url "http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
-      end
-    end
-  end
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "d45589054615e47aca8acc51c84c484a8b3428a3d89079aa19457c3cae475653" => :high_sierra
-    sha256 "aab479b0747bb1f48b7efebb1477b6dad2f93a5cabdb44aaf2428d74aea3a6a4" => :sierra
-    sha256 "9751ab418b3b7760513b3e56e97c705f9fda45b84a4885cf1ce21fbf81dcd8a3" => :el_capitan
-  end
-
-  head do
-    if MacOS.version >= :sierra
-      url "https://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
-    else
-      url "http://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
-    end
-
-    resource "clang" do
-      if MacOS.version >= :sierra
-        url "https://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
-      else
-        url "http://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
-      end
-    end
+  if MacOS.version >= :sierra
+    url "https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
+  else
+    url "http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
   end
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "subversion" => :build
+
+  resource "clang" do
+    if MacOS.version >= :sierra
+      url "https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
+    else
+      url "http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
+    end
+  end
 
   resource "libcxx" do
     url "https://releases.llvm.org/5.0.0/libcxx-5.0.0.src.tar.xz"

--- a/Formula/clang-format@5.rb
+++ b/Formula/clang-format@5.rb
@@ -1,0 +1,80 @@
+class ClangFormatAT5 < Formula
+  desc "Formatting tool for C/C++/Java/JavaScript/Objective-C/Protobuf"
+  homepage "https://releases.llvm.org/5.0.2/tools/clang/docs/ClangFormat.html"
+  version "5.0.2"
+
+  stable do
+    if MacOS.version >= :sierra
+      url "https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
+    else
+      url "http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_502/final/", :using => :svn
+    end
+
+    resource "clang" do
+      if MacOS.version >= :sierra
+        url "https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
+      else
+        url "http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_502/final/", :using => :svn
+      end
+    end
+  end
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "d45589054615e47aca8acc51c84c484a8b3428a3d89079aa19457c3cae475653" => :high_sierra
+    sha256 "aab479b0747bb1f48b7efebb1477b6dad2f93a5cabdb44aaf2428d74aea3a6a4" => :sierra
+    sha256 "9751ab418b3b7760513b3e56e97c705f9fda45b84a4885cf1ce21fbf81dcd8a3" => :el_capitan
+  end
+
+  head do
+    if MacOS.version >= :sierra
+      url "https://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
+    else
+      url "http://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
+    end
+
+    resource "clang" do
+      if MacOS.version >= :sierra
+        url "https://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
+      else
+        url "http://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
+      end
+    end
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "subversion" => :build
+
+  resource "libcxx" do
+    url "https://releases.llvm.org/5.0.0/libcxx-5.0.0.src.tar.xz"
+    sha256 "eae5981e9a21ef0decfcac80a1af584ddb064a32805f95a57c7c83a5eb28c9b1"
+  end
+
+  def install
+    (buildpath/"projects/libcxx").install resource("libcxx")
+    (buildpath/"tools/clang").install resource("clang")
+
+    mkdir "build" do
+      args = std_cmake_args
+      args << "-DCMAKE_OSX_SYSROOT=/" unless MacOS::Xcode.installed?
+      args << "-DLLVM_ENABLE_LIBCXX=ON"
+      args << ".."
+      system "cmake", "-G", "Ninja", *args
+      system "ninja", "clang-format"
+      bin.install "bin/clang-format"
+    end
+    bin.install "tools/clang/tools/clang-format/git-clang-format"
+    (share/"clang").install Dir["tools/clang/tools/clang-format/clang-format*"]
+  end
+
+  test do
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format -style=Google test.c")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There is a PR to clang-format (#30313), but that one is related to the latest version, this one is related to the version 5.

Having a specific version formula of clang-format is important as some projects do not update their CI's frequently, then formatting ends up being done with an old version of clang-format - and there are differences! I made a test for one of these differences in this formula.

It would nice to switch versions of clang-format depending on the project you are working at the moment.