### PR TITLE
sqoop 1.4.7

### DIFF
--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -15,6 +15,7 @@ class Hadoop < Formula
     libexec.install %w[bin sbin libexec share etc]
     bin.write_exec_script Dir["#{libexec}/bin/*"]
     sbin.write_exec_script Dir["#{libexec}/sbin/*"]
+    libexec.write_exec_script Dir["#{libexec}/libexec/*"]
   end
 
   test do

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -1,9 +1,9 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.7/sqoop-1.4.7.tar.gz"
   version "1.4.7"
-  sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
+  sha256 "0278dc4e0cd6f3797d8c9cb7c205994f5aaed050b86afe59fb0e9328739231c7"
   revision 1
 
   bottle :unneeded

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -1,9 +1,9 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz"
-  version "1.4.6"
-  sha256 "d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496"
+  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
+  version "1.4.7"
+  sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
 
   bottle :unneeded
 
@@ -13,13 +13,6 @@ class Sqoop < Formula
   depends_on "hive"
   depends_on "zookeeper"
   depends_on "coreutils"
-
-  # Patch for readlink -f missing on macOS. Should be fixed in 1.4.7.
-  # https://issues.apache.org/jira/browse/SQOOP-2531
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/77adf73/sqoop/1.4.6.patch"
-    sha256 "f13af5c6525f5bf8f3b993c3ece4f21133680fdbebb663fd4b7b6db9039b07b4"
-  end
 
   def sqoop_envs
     <<~EOS

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -4,6 +4,7 @@ class Sqoop < Formula
   url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
   version "1.4.7"
   sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
+  revision 1
 
   bottle :unneeded
 
@@ -16,10 +17,12 @@ class Sqoop < Formula
 
   def sqoop_envs
     <<~EOS
-      export HADOOP_HOME="#{HOMEBREW_PREFIX}"
+      export HADOOP_HOME="#{Formula["hadoop"].opt_prefix}"
       export HBASE_HOME="#{HOMEBREW_PREFIX}"
       export HIVE_HOME="#{HOMEBREW_PREFIX}"
+      export HCAT_HOME="#{HOMEBREW_PREFIX}"
       export ZOOCFGDIR="#{etc}/zookeeper"
+      export ZOOKEEPER_HOME="#{Formula["zookeeper"].opt_prefix}"
     EOS
   end
 


### PR DESCRIPTION
Sqoop formula was outdated, 1.4.6 is no longer available, updating to 1.4.7
----
- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
