### PR TITLE
lsof: update to 4.91 and remove download strategy.

### DIFF
--- a/Formula/lsof.rb
+++ b/Formula/lsof.rb
@@ -1,17 +1,8 @@
-class LsofDownloadStrategy < CurlDownloadStrategy
-  def stage
-    super
-    safe_system "/usr/bin/tar", "xf", "#{name}_#{version}_src.tar"
-    cd "#{name}_#{version}_src"
-  end
-end
-
 class Lsof < Formula
   desc "Utility to list open files"
   homepage "https://people.freebsd.org/~abe/"
-  url "https://mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_4.89.tar.bz2",
-    :using => LsofDownloadStrategy
-  sha256 "81ac2fc5fdc944793baf41a14002b6deb5a29096b387744e28f8c30a360a3718"
+  url "https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_4.91.tar.bz2"
+  sha256 "c9da946a525fbf82ff80090b6d1879c38df090556f3fe0e6d782cb44172450a3"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,26 +12,28 @@ class Lsof < Formula
     sha256 "8a63b65f74b992e4a70ac3e18a7e4b810a73e183b13086b40f30286256e646e0" => :yosemite
   end
 
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c3acbb8/lsof/lsof-489-darwin-compile-fix.patch"
-    sha256 "997d8c147070987350fc12078ce83cd6e9e159f757944879d7e4da374c030755"
-  end
-
   def install
-    ENV["LSOF_INCLUDE"] = "#{MacOS.sdk_path}/usr/include"
+    system "tar", "xf", "lsof_#{version}_src.tar"
+    cd "lsof_#{version}_src" do
+      inreplace "dialects/darwin/libproc/dfile.c",
+                "#extern\tstruct pff_tab\tPgf_tab[];", "extern\tstruct pff_tab\tPgf_tab[];"
 
-    # Source hardcodes full header paths at /usr/include
-    inreplace %w[
-      dialects/darwin/kmem/dlsof.h
-      dialects/darwin/kmem/machine.h
-      dialects/darwin/libproc/machine.h
-    ], "/usr/include", "#{MacOS.sdk_path}/usr/include"
+      ENV["LSOF_INCLUDE"] = "#{MacOS.sdk_path}/usr/include"
 
-    mv "00README", "README"
-    system "./Configure", "-n", `uname -s`.chomp.downcase
-    system "make"
-    bin.install "lsof"
-    man8.install "lsof.8"
+      # Source hardcodes full header paths at /usr/include
+      inreplace %w[
+        dialects/darwin/kmem/dlsof.h
+        dialects/darwin/kmem/machine.h
+        dialects/darwin/libproc/machine.h
+      ], "/usr/include", "#{MacOS.sdk_path}/usr/include"
+
+      mv "00README", "README"
+      system "./Configure", "-n", "darwin"
+      system "make"
+      bin.install "lsof"
+      man8.install "lsof.8"
+      prefix.install_metafiles
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
