### PR TITLE
libcanberra: remove gtk options

### DIFF
--- a/Formula/libcanberra.rb
+++ b/Formula/libcanberra.rb
@@ -30,8 +30,6 @@ class Libcanberra < Formula
   depends_on "libvorbis"
   depends_on "pulseaudio" => :optional
   depends_on "gstreamer" => :optional
-  depends_on "gtk+" => :optional
-  depends_on "gtk+3" => :optional
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

-----
They explicitly require GTK+/GTK+3 built with X11, which isn't something Homebrew does any more.

Closes https://github.com/Homebrew/homebrew-core/issues/30476.