### PR TITLE
imagesnap: backport upstream 10.13 fix

### DIFF
--- a/Formula/imagesnap.rb
+++ b/Formula/imagesnap.rb
@@ -13,6 +13,20 @@ class Imagesnap < Formula
 
   depends_on :xcode => :build
 
+  # Fixes running on 10.13+: https://github.com/rharder/imagesnap/issues/16
+  # Merged into master, will be in the next release.
+  patch do
+    url "https://github.com/rharder/imagesnap/commit/cd33ff8963006c37170872a7bdd0f29a7eae9a29.patch?full_index=1"
+    sha256 "2747d93a27892fcc585e014365f6081e56904e23dcdb84c581ba94b0c061f41a"
+  end
+
+  # Fixes filename specification: https://github.com/rharder/imagesnap/issues/19
+  # Merged into master, will be in the next release.
+  patch do
+    url "https://github.com/rharder/imagesnap/commit/c727968f278d09a792fd0dbbb19903c48518ba24.patch?full_index=1"
+    sha256 "b43cb2be1a577a472af1bc990007411860c451c0bca9528340598eeb2cb36ff5"
+  end
+
   def install
     xcodebuild "-project", "ImageSnap.xcodeproj", "SYMROOT=build", "-sdk", MacOS.sdk_path
     bin.install "build/Release/imagesnap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
