### PR TITLE
tap_migrations.json: remove outdated

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -22,7 +22,6 @@
   "grads": "homebrew/cask",
   "gtkwave": "homebrew/cask",
   "helios": "spotify/public",
-  "hexchat": "homebrew/cask",
   "horndis": "homebrew/cask",
   "inkscape": "homebrew/cask",
   "jsl": "homebrew/cask",
@@ -34,7 +33,6 @@
   "pdf-tools": "dunn/emacs",
   "pebble-sdk": "pebble/pebble-sdk",
   "quassel": "homebrew/cask",
-  "sqlitebrowser": "homebrew/cask",
   "transmission-remote-gtk": "homebrew/cask/transmission-remote-gui",
   "tuntap": "homebrew/cask"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- `hexchat` has been removed from cask
- `sqlitebrowser` cask was renamed last year, so it hasn't been working anyway.