### PR TITLE
Added optional support for X11

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -39,6 +39,8 @@ class Emacs < Formula
   depends_on "imagemagick@6" => :optional
   depends_on "mailutils" => :optional
 
+  depends_on :x11 => :optional
+
   def install
     args = %W[
       --disable-dependency-tracking
@@ -47,8 +49,14 @@ class Emacs < Formula
       --infodir=#{info}/emacs
       --prefix=#{prefix}
       --with-gnutls
-      --without-x
     ]
+
+    if build.with? "x11"
+      args << "--with-x"
+      args << "--with-gif=no"
+    else
+      args << "--without-x"
+    end
 
     if build.with? "libxml2"
       args << "--with-xml2"


### PR DESCRIPTION
`brew install --with-x11 emacs` now adds `--with-x --with-gif=no` to emacs's configure script and adds a dependency on x11.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
