### PR TITLE
Enhancement: Allow to install composer in different versions

### DIFF
--- a/Aliases/composer@1.7.0
+++ b/Aliases/composer@1.7.0
@@ -1,0 +1,1 @@
+../Formula/composer.rb

--- a/Formula/composer@1.6.5.rb
+++ b/Formula/composer@1.6.5.rb
@@ -1,0 +1,59 @@
+class ComposerAT165 < Formula
+  desc "Dependency Manager for PHP"
+  homepage "https://getcomposer.org/"
+  url "https://getcomposer.org/download/1.6.5/composer.phar"
+  sha256 "67bebe9df9866a795078bb2cf21798d8b0214f2e0b2fd81f2e907a8ef0be3434"
+
+  bottle :unneeded
+
+  def install
+    bin.install "composer.phar" => "composer"
+  end
+
+  test do
+    (testpath/"composer.json").write <<~EOS
+      {
+        "name": "homebrew/test",
+        "authors": [
+          {
+            "name": "Homebrew"
+          }
+        ],
+        "require": {
+          "php": ">=5.3.4"
+          },
+        "autoload": {
+          "psr-0": {
+            "HelloWorld": "src/"
+          }
+        }
+      }
+    EOS
+
+    (testpath/"src/HelloWorld/greetings.php").write <<~EOS
+      <?php
+
+      namespace HelloWorld;
+
+      class Greetings {
+        public static function sayHelloWorld() {
+          return 'HelloHomebrew';
+        }
+      }
+    EOS
+
+    (testpath/"tests/test.php").write <<~EOS
+      <?php
+
+      // Autoload files using the Composer autoloader.
+      require_once __DIR__ . '/../vendor/autoload.php';
+
+      use HelloWorld\\Greetings;
+
+      echo Greetings::sayHelloWorld();
+    EOS
+
+    system "#{bin}/composer", "install"
+    assert_match /^HelloHomebrew$/, shell_output("php tests/test.php")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR

* [x] adds a formula `composer@1.6.5` for installing `composer` in version `1.6.5` (exact copy of [`Formula/composer.rb@7d094e6d01b5f6167ac06277519cc642f75dad06`](https://github.com/ilovezfs/homebrew-core/blob/7d094e6d01b5f6167ac06277519cc642f75dad06/Formula/composer.rb))
* [x] adds an alias for `composer@1.7.0`

💁‍♂️ Note that the reason for this submission is that at least two more people have spotted a bug in `composer@1.7.0`, and it would be nice to be able to install a different version, rather than the most recent version.

For reference, see https://github.com/composer/composer/issues/7516#issuecomment-410445775.
