### PR TITLE
mingw-w64: fix build, bump versions

### DIFF
--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -3,6 +3,7 @@ class MingwW64 < Formula
   homepage "https://mingw-w64.org/"
   url "https://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v5.0.4.tar.bz2"
   sha256 "5527e1f6496841e2bb72f97a184fc79affdcd37972eaa9ebf7a5fd05c31ff803"
+  revision 1
 
   bottle do
     sha256 "8e771aba7e63de9862159c3f93c2056e261b5b10fa7b7627d741fcab87f0348f" => :high_sierra
@@ -10,7 +11,7 @@ class MingwW64 < Formula
     sha256 "72afbecb32b3ffacf0ffd441a326329cd2cefbcd2e9664504330e66775dabdb1" => :el_capitan
   end
 
-  option "with-posix", "Compile with posix thread model"
+  option "without-posix", "Compile without posix thread model support"
 
   depends_on "gmp"
   depends_on "mpfr"
@@ -21,15 +22,19 @@ class MingwW64 < Formula
   depends_on "texinfo" => :build
 
   resource "binutils" do
-    url "https://ftp.gnu.org/gnu/binutils/binutils-2.30.tar.gz"
-    mirror "https://ftpmirror.gnu.org/binutils/binutils-2.30.tar.gz"
-    sha256 "8c3850195d1c093d290a716e20ebcaa72eda32abf5e3d8611154b39cff79e9ea"
+    url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz"
+    mirror "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.gz"
+    sha256 "e88f8d36bd0a75d3765a4ad088d819e35f8d7ac6288049780e2fefcad18dde88"
   end
 
   resource "gcc" do
-    url "https://ftp.gnu.org/gnu/gcc/gcc-8.1.0/gcc-8.1.0.tar.xz"
-    mirror "https://ftpmirror.gnu.org/gcc/gcc-8.1.0/gcc-8.1.0.tar.xz"
-    sha256 "1d1866f992626e61349a1ccd0b8d5253816222cdc13390dcfaa74b093aa2b153"
+    url "https://ftp.gnu.org/gnu/gcc/gcc-8.2.0/gcc-8.2.0.tar.xz"
+    mirror "https://ftpmirror.gnu.org/gcc/gcc-8.2.0/gcc-8.2.0.tar.xz"
+    sha256 "196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080"
+
+    # isl 0.20 compatibility
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724
+    patch :DATA
   end
 
   def target_archs
@@ -82,10 +87,10 @@ class MingwW64 < Formula
         --with-isl=#{Formula["isl"].opt_prefix}
         --disable-multilib
       ]
-      if build.with? "posix"
-        args << "--enable-threads=posix"
-      else
+      if build.without? "posix"
         args << "--enable-threads=win32"
+      else
+        args << "--enable-threads=posix"
       end
 
       mkdir "#{buildpath}/gcc/build-#{arch}" do
@@ -175,3 +180,17 @@ class MingwW64 < Formula
     end
   end
 end
+
+__END__
+diff --git a/gcc/graphite.h b/gcc/graphite.h
+index 4e0e58c..be0a22b 100644
+--- a/gcc/graphite.h
++++ b/gcc/graphite.h
+@@ -37,6 +37,8 @@ along with GCC; see the file COPYING3.  If not see
+ #include <isl/schedule.h>
+ #include <isl/ast_build.h>
+ #include <isl/schedule_node.h>
++#include <isl/id.h>
++#include <isl/space.h>
+
+ typedef struct poly_dr *poly_dr_p;

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -14,9 +14,9 @@ class MingwW64 < Formula
   option "without-posix", "Compile without posix thread model support"
 
   depends_on "gmp"
-  depends_on "mpfr"
-  depends_on "libmpc"
   depends_on "isl"
+  depends_on "libmpc"
+  depends_on "mpfr"
 
   # Apple's makeinfo is old and has bugs
   depends_on "texinfo" => :build
@@ -32,7 +32,7 @@ class MingwW64 < Formula
     mirror "https://ftpmirror.gnu.org/gcc/gcc-8.2.0/gcc-8.2.0.tar.xz"
     sha256 "196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080"
 
-    # isl 0.20 compatibility
+    # isl 0.20 compatibility, remove in next GCC version
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724
     patch :DATA
   end
@@ -87,10 +87,10 @@ class MingwW64 < Formula
         --with-isl=#{Formula["isl"].opt_prefix}
         --disable-multilib
       ]
-      if build.without? "posix"
-        args << "--enable-threads=win32"
-      else
+      if build.with? "posix"
         args << "--enable-threads=posix"
+      else
+        args << "--enable-threads=win32"
       end
 
       mkdir "#{buildpath}/gcc/build-#{arch}" do


### PR DESCRIPTION
Bump gcc to 8.2.0 and add the isl 0.20 build patch from #30639.

Bump binutils to 2.31.1.

Change the option --with-posix to --without-posix, the rationale being
that most people use this software to port unix code to windows and do
want -lpthread available, preferrably without having to build gcc twice
on their computer, also as far as I understand it doesn't hurt anything
to have it be enabled.

Set revision to 1 because version of mingw did not change.

- [ y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
