### PR TITLE
gradle@2.14: depend on java 8, add keg_only

### DIFF
--- a/Formula/gradle@2.14.rb
+++ b/Formula/gradle@2.14.rb
@@ -6,9 +6,13 @@ class GradleAT214 < Formula
 
   bottle :unneeded
 
+  keg_only :versioned_formula
+
+  depends_on :java => "1.8"
+
   def install
     libexec.install %w[bin lib]
-    bin.install_symlink libexec+"bin/gradle"
+    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.java_home_env("1.8")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
