### PR TITLE
Mysql: fix datadir conflicts between versioned and non-versioned formulae

### DIFF
--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -3,6 +3,7 @@ class MysqlAT55 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.5/en/"
   url "https://dev.mysql.com/get/Downloads/MySQL-5.5/mysql-5.5.61.tar.gz"
   sha256 "62a7f8aeb9c6c4d5a127f7254500878d9d172b70ad9639b098f3c01731f1fbf0"
+  revision 1
 
   bottle do
     sha256 "34989af26f90153946aa5df913fab80fcb715203f66feb1915acf17c6f5624db" => :high_sierra
@@ -30,7 +31,7 @@ class MysqlAT55 < Formula
   depends_on "openssl"
 
   def datadir
-    var/"mysql"
+    var/"mysql@5.5"
   end
 
   def install

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -3,6 +3,7 @@ class MysqlAT56 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
   url "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.41.tar.gz"
   sha256 "4a223c3daed88f8450fa2fc8fd0e7afe2b1a122dd58b74c4ea6526d6a72563ce"
+  revision 1
 
   bottle do
     sha256 "f38c2f721f15779682345a364ed5adf2550163986a1dd50e7bfc945ddc3b68cf" => :high_sierra
@@ -30,7 +31,7 @@ class MysqlAT56 < Formula
   depends_on "openssl"
 
   def datadir
-    var/"mysql"
+    var/"mysql@5.6"
   end
 
   def install

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -3,6 +3,7 @@ class MysqlAT57 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-boost-5.7.23.tar.gz"
   sha256 "d05700ec5c1c6dae9311059dc1713206c29597f09dbd237bf0679b3c6438e87a"
+  revision 1
 
   bottle do
     sha256 "3a61ff9bfcac9cf5170b44442387be162938181c42e1fe5e5e1e303cf18b23b3" => :high_sierra
@@ -31,7 +32,7 @@ class MysqlAT57 < Formula
   depends_on "openssl"
 
   def datadir
-    var/"mysql"
+    var/"mysql@5.7"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Mysql: fix datadir conflicts between versioned and non-versioned formulae