### PR TITLE
root: only conditionally pour bottle

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -27,6 +27,18 @@ class Root < Formula
   depends_on "python" => :recommended
   depends_on "python@2" => :optional
 
+  # https://github.com/Homebrew/homebrew-core/issues/30726
+  # strings libCling.so | grep Xcode:
+  #  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
+  #  /Applications/Xcode.app/Contents/Developer
+  pour_bottle? do
+    reason "The bottle hardcodes locations inside Xcode.app"
+    satisfy do
+      MacOS::Xcode.installed? &&
+        MacOS::Xcode.prefix.to_s.include?("/Applications/Xcode.app/")
+    end
+  end
+
   needs :cxx11
 
   skip_clean "bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ref: https://github.com/Homebrew/homebrew-core/issues/30726.

And locally with `Xcode-beta.app`:
```
==> /bin/bash test.bash
ERROR in cling::CIFactory::createCI(): cannot extract standard library include paths!
Invoking:
  LC_ALL=C /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++   -O2 -DNDEBUG -xc++ -E -v /dev/null 2>&1 >/dev/null | awk '/^#include </,/^End of search/{if (!/^#include </ && !/^End of search/){ print }}' | GREP_OPTIONS= grep -E "(c|g)\+\+"
Results was:
With exit code 256
input_line_1:1:10: fatal error: 'new' file not found
#include <new>
         ^~~~~
input_line_3:37:10: fatal error: 'string' file not found
#include <string>
         ^~~~~~~~
input_line_9:1:10: fatal error: 'iostream' file not found
#include <iostream>
         ^~~~~~~~~~
In file included from input_line_10:1:
/private/tmp/root-test-20180806-72769-a6spq0/test.C:1:10: fatal error: 'iostream' file not found
#include <iostream>
         ^~~~~~~~~~
Error: root: failed
<0> expected but was
<1>.
```

Super fun!