### PR TITLE
fontconfig: simplify the handling of downloadable fonts

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -49,10 +49,8 @@ class Fontconfig < Formula
       ~/Library/Fonts
     ]
 
-    if MacOS.version == :sierra
-      font_dirs << "/System/Library/Assets/com_apple_MobileAsset_Font3"
-    elsif MacOS.version >= :high_sierra
-      font_dirs << "/System/Library/Assets/com_apple_MobileAsset_Font4"
+    if MacOS.version >= :sierra
+      font_dirs << Dir["/System/Library/Assets/com_apple_MobileAsset_Font*"].max
     end
 
     system "autoreconf", "-iv" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow up #28957, the directory was changed again from `/System/Library/Assets/com_apple_MobileAsset_Font4` to `/System/Library/Assets/com_apple_MobileAsset_Font5` since macOS Mojave Developer Beta 3. Instead of hardcoding all these directories every single time, picking up the latest one automatically would be nicer.