### PR TITLE
creduce: Add missing clang-format dependency

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -3,8 +3,8 @@ class Creduce < Formula
   homepage "https://embed.cs.utah.edu/creduce/"
   url "https://embed.cs.utah.edu/creduce/creduce-2.8.0.tar.gz"
   sha256 "77f622453a7fc52aa061a89aed457f23ab538b12270df0a2a79b6957fd381def"
-  head "https://github.com/csmith-project/creduce.git"
   revision 1
+  head "https://github.com/csmith-project/creduce.git"
 
   bottle do
     cellar :any

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -15,6 +15,7 @@ class Creduce < Formula
   depends_on "astyle"
   depends_on "delta"
   depends_on "llvm"
+  depends_on "clang-format"
 
   depends_on :macos => :mavericks
 

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -4,6 +4,7 @@ class Creduce < Formula
   url "https://embed.cs.utah.edu/creduce/creduce-2.8.0.tar.gz"
   sha256 "77f622453a7fc52aa061a89aed457f23ab538b12270df0a2a79b6957fd381def"
   head "https://github.com/csmith-project/creduce.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,9 +14,9 @@ class Creduce < Formula
   end
 
   depends_on "astyle"
+  depends_on "clang-format"
   depends_on "delta"
   depends_on "llvm"
-  depends_on "clang-format"
 
   depends_on :macos => :mavericks
 


### PR DESCRIPTION
clang-format is required by the `pass_indent` pass.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I currently have a reduction with creduce running, so I feel uncomfortable reinstalling it just right now.