### PR TITLE
xsane: Replace dead url (404)

### DIFF
--- a/Formula/xsane.rb
+++ b/Formula/xsane.rb
@@ -1,7 +1,7 @@
 class Xsane < Formula
   desc "Graphical scanning frontend"
   homepage "http://www.xsane.org"
-  url "http://www.xsane.org/download/xsane-0.999.tar.gz"
+  url "https://fossies.org/linux/misc/xsane-0.999.tar.gz"
   sha256 "5782d23e67dc961c81eef13a87b17eb0144cae3d1ffc5cf7e0322da751482b4b"
   revision 3
 

--- a/Formula/xsane.rb
+++ b/Formula/xsane.rb
@@ -1,7 +1,8 @@
 class Xsane < Formula
   desc "Graphical scanning frontend"
   homepage "http://www.xsane.org"
-  url "https://fossies.org/linux/misc/xsane-0.999.tar.gz"
+  url "https://ftp.osuosl.org/pub/blfs/conglomeration/xsane/xsane-0.999.tar.gz"
+  mirror "https://fossies.org/linux/misc/xsane-0.999.tar.gz"
   sha256 "5782d23e67dc961c81eef13a87b17eb0144cae3d1ffc5cf7e0322da751482b4b"
   revision 3
 


### PR DESCRIPTION
Replaced with a Fossies url.

The tarball has the same hash and we use Fossies elsewhere, so I figured that this was slightly preferred over graveyarding.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
