### PR TITLE
Update hcloud cli to 1.6.0

### DIFF
--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -1,8 +1,8 @@
 class Hcloud < Formula
   desc "Command-line interface for Hetzner Cloud"
   homepage "https://github.com/hetznercloud/cli"
-  url "https://github.com/hetznercloud/cli/archive/v1.5.0.tar.gz"
-  sha256 "cc09f03c6a776a086ee9219e9ee70749e2ef5cda6171dd042cb1c623cccd6dfa"
+  url "https://github.com/hetznercloud/cli/archive/v1.6.0.tar.gz"
+  sha256 "8ada1db53f812774666d579722bce1d63cfd0212a70dd0d3ca734608610584b1"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR updated the hcloud cli to the latest version 1.6.0 (https://github.com/hetznercloud/cli/releases/tag/v1.6.0)