### PR TITLE
sbt instead of SBT at caveats

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -28,7 +28,7 @@ class Sbt < Formula
   end
 
   def caveats;  <<~EOS
-    You can use $SBT_OPTS to pass additional JVM options to SBT.
+    You can use $SBT_OPTS to pass additional JVM options to sbt.
     Project specific options should be placed in .sbtopts in the root of your project.
     Global settings should be placed in #{etc}/sbtopts
   EOS


### PR DESCRIPTION
[Based on the FAQ of sbt site](https://www.scala-sbt.org/1.0/docs/Faq.html#What+does+the+name+%E2%80%9Csbt%E2%80%9D+stand+for%2C+and+why+shouldn%E2%80%99t+it+be+written+%E2%80%9CSBT%E2%80%9D%3F), we simply call sbt "sbt" instead of "SBT".
/cc @eed3si9n and @dwijnand 
