### PR TITLE
miniserve 0.2.0

### DIFF
--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -1,8 +1,8 @@
 class Miniserve < Formula
   desc "High performance static file server"
   homepage "https://github.com/svenstaro/miniserve"
-  url "https://github.com/svenstaro/miniserve/archive/v0.1.5.tar.gz"
-  sha256 "b435471cd08f3dbe080e26a0b6937c824502a87659948f49b5d2e54f07de64e0"
+  url "https://github.com/svenstaro/miniserve/archive/v0.2.0.tar.gz"
+  sha256 "2a0d4c7563b3b1b75ba0cccc69236976dc916378a41e7f994e28f8a766bded4c"
 
   depends_on "rust" => :build
 
@@ -18,7 +18,7 @@ class Miniserve < Formula
     server.close
 
     pid = fork do
-      exec "#{bin}/miniserve", "#{bin}/miniserve", "--interface", "127.0.0.1", "--port", port.to_s
+      exec "#{bin}/miniserve", "#{bin}/miniserve", "--if", "127.0.0.1", "--port", port.to_s
     end
 
     sleep 2

--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -1,0 +1,18 @@
+class Miniserve < Formula
+  desc "High performance static file server"
+  homepage "https://github.com/svenstaro/miniserve"
+  url "https://github.com/svenstaro/miniserve/archive/v0.1.5.tar.gz"
+  sha256 "b435471cd08f3dbe080e26a0b6937c824502a87659948f49b5d2e54f07de64e0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix
+  end
+
+  test do
+    # miniserve has no options that do not immediately start listening on ports
+    # that may already be in use.
+    system "#{bin}/miniserve", "-V"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There's one caveat: no real test. Miniserve does not have an meaningful option that does not start a listening server on a port that may already be listening. It feels weird to contrive a test where we start the app, issue an HTTP request, check for success, and shut down the app. So, it's -V which outputs the version.

Fixes https://github.com/svenstaro/miniserve/issues/15