### PR TITLE
mkvtoolnix: fix HEAD url

### DIFF
--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -11,7 +11,7 @@ class Mkvtoolnix < Formula
   end
 
   head do
-    url "https://github.com/mbunkus/mkvtoolnix.git"
+    url "https://gitlab.com/mbunkus/mkvtoolnix.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
The project has been moved to [GitLab](https://gitlab.com/mbunkus/mkvtoolnix).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
