### PR TITLE
automake: add patch for python(3) issue

### DIFF
--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -4,6 +4,7 @@ class Automake < Formula
   url "https://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/automake/automake-1.16.1.tar.xz"
   sha256 "5d05bb38a23fd3312b10aea93840feec685bdf4a41146e78882848165d3ae921"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,6 +14,13 @@ class Automake < Formula
   end
 
   depends_on "autoconf"
+
+  # http://gnu-automake.7480.n7.nabble.com/bug-31222-automake-1-16-1-am-pep3147-tweak-bug-td22937.html
+  # Remove this when applying any future 1.16.2 update.
+  patch do
+    url "https://git.savannah.gnu.org/cgit/automake.git/patch/?id=a348d830659fffd2cfc42994524783b07e69b4b5"
+    sha256 "7a57ca2b91f7f3c0b168cf5ffbc8a1b2168f3886bcadcc15412281472dace3ce"
+  end
 
   def install
     ENV["PERL"] = "/usr/bin/perl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

This isn't a bug we'd see inside Homebrew but it's a bug a whole bunch of people are encountering due to Travis using Homebrew, and I think that's a legitimate reason to squash it now there's a fix available.