### PR TITLE
Update gnu-smalltalk.rb with an update repository

### DIFF
--- a/Formula/gnu-smalltalk.rb
+++ b/Formula/gnu-smalltalk.rb
@@ -5,7 +5,7 @@ class GnuSmalltalk < Formula
   mirror "https://ftpmirror.gnu.org/smalltalk/smalltalk-3.2.5.tar.xz"
   sha256 "819a15f7ba8a1b55f5f60b9c9a58badd6f6153b3f987b70e7b167e7755d65acc"
   revision 7
-  head "https://github.com/bonzini/smalltalk.git"
+  head "https://github.com/gnu-smalltalk/smalltalk.git"
 
   bottle do
     sha256 "9d086ae46e600651c937a8602fbb3a2c1fbe44be15517fe210dd46d21d7a391c" => :high_sierra


### PR DESCRIPTION
I think that this is the maintaned github repository for smalltalk, https://github.com/gnu-smalltalk

- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
