### PR TITLE
geogram 1.6.6 (new formula)

### DIFF
--- a/Formula/geogram.rb
+++ b/Formula/geogram.rb
@@ -1,0 +1,34 @@
+class Geogram < Formula
+  desc "Programming library of geometric algorithms"
+  homepage "http://alice.loria.fr/software/geogram/doc/html/index.html"
+  url "https://gforge.inria.fr/frs/download.php/file/37635/geogram_1.6.6.tar.gz"
+  sha256 "08211b1d6f21e14701e3fd5c79adbe331cdf66b8af84efdb54cd7048244691b5"
+
+  depends_on "cmake" => :build
+
+  resource "bunny" do
+    url "https://raw.githubusercontent.com/FreeCAD/Examples/be0b4f9/Point_cloud_ExampleFiles/PointCloud-Data_Stanford-Bunny.asc"
+    sha256 "4fc5496098f4f4aa106a280c24255075940656004c6ef34b3bf3c78989cbad08"
+  end
+
+  def install
+    # don't write directly into /usr/local/lib/cmake/modules
+    inreplace "CMakeLists.txt", "lib/cmake/modules", "#{share}/cmake/Modules"
+    # workaround for undefined _mm_set_pd1 in clang
+    inreplace "src/lib/geogram/numerics/predicates.cpp", "_mm_set_pd1", "_mm_set1_pd"
+
+    (buildpath/"CMakeOptions.txt").append_lines "set(CMAKE_INSTALL_PREFIX #{prefix})"
+
+    system "sh", "-f", "configure.sh"
+    cd "build/Darwin-clang-dynamic-Release" do
+      system "make", "install"
+    end
+  end
+
+  test do
+    testpath.install resource("bunny")
+    mv "PointCloud-Data_Stanford-Bunny.asc", "bunny.xyz"
+    system "#{bin}/vorpalite", "profile=reconstruct", "bunny.xyz", "bunny.meshb"
+    assert_predicate testpath/"bunny.meshb", :exist?, "bunny.meshb should exist!"
+  end
+end

--- a/Formula/geogram.rb
+++ b/Formula/geogram.rb
@@ -5,6 +5,7 @@ class Geogram < Formula
   sha256 "08211b1d6f21e14701e3fd5c79adbe331cdf66b8af84efdb54cd7048244691b5"
 
   depends_on "cmake" => :build
+  depends_on "glfw"
 
   resource "bunny" do
     url "https://raw.githubusercontent.com/FreeCAD/Examples/be0b4f9/Point_cloud_ExampleFiles/PointCloud-Data_Stanford-Bunny.asc"
@@ -12,22 +13,25 @@ class Geogram < Formula
   end
 
   def install
-    # don't write directly into /usr/local/lib/cmake/modules
-    inreplace "CMakeLists.txt", "lib/cmake/modules", "#{share}/cmake/Modules"
-    # workaround for undefined _mm_set_pd1 in clang
+    # Workaround for undefined _mm_set_pd1 in clang; fixed in next release.
+    # https://lists.gforge.inria.fr/pipermail/geogram-users/2018-August/000158.html
     inreplace "src/lib/geogram/numerics/predicates.cpp", "_mm_set_pd1", "_mm_set1_pd"
 
-    (buildpath/"CMakeOptions.txt").append_lines "set(CMAKE_INSTALL_PREFIX #{prefix})"
+    (buildpath/"CMakeOptions.txt").append_lines <<~EOS
+      set(CMAKE_INSTALL_PREFIX #{prefix})
+      set(GEOGRAM_USE_SYSTEM_GLFW3 ON)
+    EOS
 
-    system "sh", "-f", "configure.sh"
+    system "./configure.sh"
     cd "build/Darwin-clang-dynamic-Release" do
       system "make", "install"
     end
+
+    (share/"cmake/Modules").install Dir[lib/"cmake/modules/*"]
   end
 
   test do
-    testpath.install resource("bunny")
-    mv "PointCloud-Data_Stanford-Bunny.asc", "bunny.xyz"
+    resource("bunny").stage { testpath.install Dir["*"].first => "bunny.xyz" }
     system "#{bin}/vorpalite", "profile=reconstruct", "bunny.xyz", "bunny.meshb"
     assert_predicate testpath/"bunny.meshb", :exist?, "bunny.meshb should exist!"
   end


### PR DESCRIPTION
This adds Geogram, a programming library of geometric algorithms. This
is a dependency for programs such as AliceVision / Meshroom
(https://alicevision.github.io/).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
