### PR TITLE
naturaldocs 2.0.2

### DIFF
--- a/Formula/naturaldocs.rb
+++ b/Formula/naturaldocs.rb
@@ -1,18 +1,21 @@
 class Naturaldocs < Formula
   desc "Extensible, multi-language documentation generator"
   homepage "https://www.naturaldocs.org/"
-  url "https://downloads.sourceforge.net/project/naturaldocs/Stable%20Releases/1.52/NaturalDocs-1.52.zip"
-  sha256 "3f13c99e15778afe6c5555084a083f856e93567b31b08acd1fd81afb10082681"
+  url "https://downloads.sourceforge.net/project/naturaldocs/Stable%20Releases/2.0.2/Natural_Docs_2.0.2.zip"
+  sha256 "4a8be89d1c749fa40611193404556d408f414e03df8c397b970e045b57a54d4d"
 
   bottle :unneeded
 
-  def install
-    # Remove Windows files
-    rm_rf Dir["*.bat"]
+  depends_on "mono"
 
+  def install
     libexec.install Dir["*"]
-    chmod 0755, libexec+"NaturalDocs"
-    bin.install_symlink libexec+"NaturalDocs"
+    (bin/"naturaldocs").write <<~EOS
+      #!/bin/bash
+      mono #{libexec}/NaturalDocs.exe "$@"
+    EOS
+
+    libexec.install_symlink etc/"naturaldocs" => "config"
   end
 
   test do


### PR DESCRIPTION
NaturalDocs 2.0.2 uses a .exe file, so adding mono as a dependency and updating the formula to account for windows EXE.

- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
