### PR TITLE
qd: update checksum

### DIFF
--- a/Formula/qd.rb
+++ b/Formula/qd.rb
@@ -2,7 +2,8 @@ class Qd < Formula
   desc "C++/Fortran-90 double-double and quad-double package"
   homepage "https://crd.lbl.gov/~dhbailey/mpdist/"
   url "https://crd.lbl.gov/~dhbailey/mpdist/qd-2.3.20.tar.gz"
-  sha256 "72900ae5d3047719624701878abd8ed88fe3e4bc844c6fd614161ad926518385"
+  sha256 "da24571ceaad08abe9257ab4f45df939d17ecc9ba30df53458ec0b629a7c9167"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
It looks like upstream re-released the same package based on `file`'s output:
```
/usr/local/var/homebrewcache/qd--2.3.20.tar.gz: gzip compressed data, was "qd-2.3.20.tar", last modified: Mon Aug  6 03:08:24 2018, from Unix, original size 10953216
```
but I haven't verified this with them as legit yet, so very much a _"do not merge"_ till that confirmation is available. Formula last went through CI with this version back in April: https://github.com/Homebrew/homebrew-core/pull/26641.