### PR TITLE
Abort upgrade when pg_upgrade fails

### DIFF
--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -65,7 +65,7 @@ begin
   initdb_run = true
 
   (var/"log").cd do
-    Homebrew.safe_system "#{bin}/pg_upgrade",
+    safe_system "#{bin}/pg_upgrade",
       "-r",
       "-b", old_bin,
       "-B", bin,

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -65,7 +65,7 @@ begin
   initdb_run = true
 
   (var/"log").cd do
-    system "#{bin}/pg_upgrade",
+    raise unless system "#{bin}/pg_upgrade",
       "-r",
       "-b", old_bin,
       "-B", bin,

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -65,7 +65,7 @@ begin
   initdb_run = true
 
   (var/"log").cd do
-    raise unless system "#{bin}/pg_upgrade",
+    Homebrew.safe_system "#{bin}/pg_upgrade",
       "-r",
       "-b", old_bin,
       "-B", bin,


### PR DESCRIPTION
#31087

`pg_upgrade` returns a non zero code in case of failure. `system` returns false in this case. 

By raising on a falsy system, we jump to the ensure block which handles the abort of the upgrade.
