### PR TITLE
node@8 8.11.4, node@6 6.14.4

### DIFF
--- a/Formula/node@6.rb
+++ b/Formula/node@6.rb
@@ -1,8 +1,8 @@
 class NodeAT6 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v6.14.3/node-v6.14.3.tar.xz"
-  sha256 "e3f187729f7e4b13d9c053f70cc12717d6e6734e0544cb8ba935aa72d07479c9"
+  url "https://nodejs.org/dist/v6.14.4/node-v6.14.4.tar.xz"
+  sha256 "9a4bfc99787f8bdb07d5ae8b1f00ec3757e7b09c99d11f0e8a5e9a16a134ec0f"
 
   bottle do
     sha256 "f291232380137e55151587da07e54b7e504d1889446bb8d6c96774bfe36b1e00" => :high_sierra
@@ -40,7 +40,7 @@ class NodeAT6 < Formula
     args = ["--prefix=#{prefix}"]
     args << "--without-npm" if build.without? "npm"
     args << "--debug" if build.with? "debug"
-    args << "--shared-openssl" if build.with? "openssl"
+    args << "--shared-openssl" << "--openssl-use-def-ca-store" if build.with? "openssl"
 
     if build.with? "full-icu"
       resource("icu4c").stage buildpath/"deps/icu"

--- a/Formula/node@8.rb
+++ b/Formula/node@8.rb
@@ -1,9 +1,8 @@
 class NodeAT8 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
-  url "https://nodejs.org/dist/v8.11.3/node-v8.11.3.tar.xz"
-  sha256 "577c751fdca91c46c60ffd8352e5b465881373bfdde212c17c3a3c1bd2616ee0"
-  revision 1
+  url "https://nodejs.org/dist/v8.11.4/node-v8.11.4.tar.xz"
+  sha256 "fbce7de6d96b0bcb0db0bf77f0e6ea999b6755e6930568aedaab06847552a609"
 
   bottle do
     sha256 "8972065cc254cd688996153d2b352480ddb06c97d071298e19ac089ed75fd718" => :high_sierra
@@ -40,7 +39,7 @@ class NodeAT8 < Formula
     args << "--without-npm" if build.without? "npm"
     args << "--debug" if build.with? "debug"
     args << "--with-intl=system-icu" if build.with? "icu4c"
-    args << "--shared-openssl" if build.with? "openssl"
+    args << "--shared-openssl" << "--openssl-use-def-ca-store" if build.with? "openssl"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Node August 2018 Security Releases Part 2.
This PR also backports #31062 to these release lines for consistency.

We might also consider deleting `node@4` form homebrew-core, because it's EOL since April and didn't receive the two latest security updates (through there is no vulnerability with high criticality yet).
