### PR TITLE
imageoptim-cli: build nexe node from source

### DIFF
--- a/Formula/imageoptim-cli.rb
+++ b/Formula/imageoptim-cli.rb
@@ -5,6 +5,7 @@ class ImageoptimCli < Formula
   homepage "https://jamiemason.github.io/ImageOptim-CLI/"
   url "https://github.com/JamieMason/ImageOptim-CLI/archive/2.0.3.tar.gz"
   sha256 "47fc8a1f14478389cb71dc8a03ac6b3176ba311d1a2390867b792b60ef209fb3"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,8 +16,18 @@ class ImageoptimCli < Formula
 
   depends_on "node" => :build
 
+  resource "node" do
+    url "https://nodejs.org/dist/v10.9.0/node-v10.9.0.tar.xz"
+    sha256 "d17ef8eb72d6a31f50a663d554beb9bcb55aa2ce57cf189abfc9b1ba20530d02"
+  end
+
   def install
-    system "npm", "install", *Language::Node.local_npm_install_args
+    # build node from source instead of downloading precompiled nexe node binary
+    resource("node").stage buildpath/".brew_home/.nexe"
+    inreplace "package.json", "\"build:bin\": \"nexe --target 'mac-x64-10.0.0' --input",
+      "\"build:bin\": \"nexe --build --target 'mac-x64-#{resource("node").version}' --loglevel=verbose --input"
+
+    system "npm", "ci", *Language::Node.local_npm_install_args
     system "npm", "run-script", "build"
     libexec.install "dist", "osascript"
     bin.install_symlink libexec/"dist/imageoptim"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR switches `imageoptim-cli` *from* downloading a precompiled binary of nexe node 10.0.0 and just putting the transpiled js file into it *to* actual building the nexe node code from souce and in a more up to date version. With this we are more aligned with homebrew-core's policy to actual build stuff from source instead of downloading precompiled binaries and doing minimal effort with them. Also this enables us to build against more recent versions of node 10 (with security fixes).

An alternative approve to this PR would be to run `imageoptim-cli` against our `node` (as a runtime dependency). But this would atm either require a language/node [with support for prepare scripts](https://gist.github.com/chrmoritz/0a4f37d0b3e8f52e3243f3c0c89bf8a6/33a1cc55e4315402716ad8c0ecc6cb23707ae38f) (which I want to [PR to brew](https://github.com/chrmoritz/brew/commit/fd3073989453f7b3629d0cbf7b9fbd35856effc8) hopefully soon) or adding this support [by moving quite complex logic from language/node to formula logic](https://gist.github.com/chrmoritz/0a4f37d0b3e8f52e3243f3c0c89bf8a6/d71914168a9cea7bafcc0a5b3a98ca5e264d25fc) (check the links for some older prototypes).