### PR TITLE
zbar-0.20.1

### DIFF
--- a/Formula/zbar.rb
+++ b/Formula/zbar.rb
@@ -1,16 +1,10 @@
 class Zbar < Formula
   desc "Suite of barcodes-reading tools"
   homepage "https://zbar.sourceforge.io"
-  revision 9
 
   stable do
-    url "https://downloads.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
-    sha256 "234efb39dbbe5cef4189cc76f37afbe3cfcfb45ae52493bfe8e191318bdbadc6"
-
-    # Fix JPEG handling using patch from
-    # https://sourceforge.net/p/zbar/discussion/664596/thread/58b8d79b#8f67
-    # already applied upstream but not present in the 0.10 release
-    patch :DATA
+    url "https://www.linuxtv.org/downloads/zbar/zbar-0.20.1.tar.bz2"
+    sha256 "a0081a9b473d9e44e029d948a8d7f22deb1bf128980f3fc4e185298066e62a6c"
   end
 
   bottle do
@@ -21,41 +15,32 @@ class Zbar < Formula
   end
 
   head do
-    url "https://github.com/ZBar/ZBar.git"
-
-    depends_on "gettext" => :build
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
-    depends_on "libtool" => :build
-    depends_on "xmlto" => :build
+    url "https://git.linuxtv.org/zbar.git"
   end
 
-  depends_on :x11 => :optional
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "gettext" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "xmlto" => :build
+
+  depends_on :x11 => :optional
   depends_on "jpeg"
-  depends_on "imagemagick"
+  depends_on "graphicsmagick"
   depends_on "ufraw"
   depends_on "xz"
   depends_on "freetype"
   depends_on "libtool"
 
   def install
-    if build.head?
-      inreplace "configure.ac", "-Werror", ""
-      gettext = Formula["gettext"]
-      system "autoreconf", "-fvi", "-I", "#{gettext.opt_share}/aclocal"
-    end
-
-    # ImageMagick 7 compatibility
-    # Reported 20 Jun 2016 https://sourceforge.net/p/zbar/support-requests/156/
-    inreplace ["configure", "zbarimg/zbarimg.c"],
-      "wand/MagickWand.h",
-      "ImageMagick-7/MagickWand/MagickWand.h"
+    gettext = Formula["gettext"]
+    system "autoreconf", "-fvi", "-I", "#{gettext.opt_share}/aclocal"
 
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --without-python
+      --without-python2
       --without-qt
       --disable-video
       --without-gtk
@@ -75,27 +60,3 @@ class Zbar < Formula
     system bin/"zbarimg", "-h"
   end
 end
-
-__END__
-diff --git a/zbar/jpeg.c b/zbar/jpeg.c
-index fb566f4..d1c1fb2 100644
---- a/zbar/jpeg.c
-+++ b/zbar/jpeg.c
-@@ -79,8 +79,15 @@ int fill_input_buffer (j_decompress_ptr cinfo)
- void skip_input_data (j_decompress_ptr cinfo,
-                       long num_bytes)
- {
--    cinfo->src->next_input_byte = NULL;
--    cinfo->src->bytes_in_buffer = 0;
-+    if (num_bytes > 0) {
-+        if (num_bytes < cinfo->src->bytes_in_buffer) {
-+            cinfo->src->next_input_byte += num_bytes;
-+            cinfo->src->bytes_in_buffer -= num_bytes;
-+        }
-+        else {
-+            fill_input_buffer(cinfo);
-+        }
-+    }
- }
- 
- void term_source (j_decompress_ptr cinfo)


### PR DESCRIPTION
zbar is back under active development. Mainstream linux distributions
such as Fedora are picking up the new version: https://www.spinics.net/lists/fedora-package-announce/msg248310.html

This new version incorporates changes that eliminate the need for some patching that was applied in the previous Formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
