### PR TITLE
wireguard-tools: remove bash dependency

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -14,7 +14,6 @@ class WireguardTools < Formula
     sha256 "631fa59397ceddfa898bdf18b76107f38908fe3aa6fd808c2d560e25269bc6b9" => :el_capitan
   end
 
-  depends_on "bash"
   depends_on "wireguard-go"
 
   def install


### PR DESCRIPTION
wireguard-tools has bash completion files, but that doesn't
necessitate a dependency on bash. (See the node formula, for example.)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
