### PR TITLE
wskdeploy 0.9.7 (new formula)

### DIFF
--- a/Formula/wskdeploy.rb
+++ b/Formula/wskdeploy.rb
@@ -1,0 +1,37 @@
+class Wskdeploy < Formula
+  desc "Apache OpenWhisk project deployment utility"
+  homepage "http://openwhisk.org/"
+  url "https://github.com/apache/incubator-openwhisk-wskdeploy/archive/0.9.7.tar.gz"
+  sha256 "15f586aeb3221e67b583941b988fcc572eebafc64c58d4a2df2787007344f064"
+
+  depends_on "go" => :build
+  depends_on "godep" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/apache/incubator-openwhisk-wskdeploy").install buildpath.children
+    cd "src/github.com/apache/incubator-openwhisk-wskdeploy" do
+      system "godep", "restore"
+      system "go", "build", "-o", bin/"wskdeploy",
+                   "-ldflags", "-X main.Version=#{version}"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/wskdeploy version")
+
+    (testpath/"manifest.yaml").write <<~EOS
+      packages:
+        hello_world_package:
+          version: 1.0
+          license: Apache-2.0
+    EOS
+
+    system bin/"wskdeploy", "-v",
+                            "--apihost", "openwhisk.ng.bluemix.net",
+                            "--preview",
+                            "-m", (testpath/"manifest.yaml"),
+                            "-u", "abcd"
+  end
+end


### PR DESCRIPTION
`wskdeploy` is Apache OpenWhisk's tool to manage and deploy OpenWhisk projects.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
