### PR TITLE
Add large image support option to jasper

### DIFF
--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -3,6 +3,7 @@ class Jasper < Formula
   homepage "https://www.ece.uvic.ca/~frodo/jasper/"
   url "https://github.com/mdadams/jasper/archive/version-2.0.14.tar.gz"
   sha256 "85266eea728f8b14365db9eaf1edc7be4c348704e562bb05095b9a077cf1a97b"
+  revision 1
 
   bottle do
     sha256 "086de22e8e8a01299962f3bea5374c90490b66e84b7e10a4078f172e64b0079f" => :high_sierra
@@ -10,10 +11,15 @@ class Jasper < Formula
     sha256 "c481b8887b8d29e3c63735dd2151c9246e08f21bf50334033de4a054f700a6db" => :el_capitan
   end
 
+  option "with-large-image-support", "Allows handling inputs with more than 67108864 samples (Allows 536870912 samples)."
+
   depends_on "cmake" => :build
   depends_on "jpeg"
 
   def install
+    if build.with?("large-image-support")
+      inreplace "src/libjasper/include/jasper/jas_config.h.in", "(64 * ((size_t) 1048576))", "(512 * ((size_t) 1048576))"
+    end
     mkdir "build" do
       # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
       # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
@@ -31,3 +37,4 @@ class Jasper < Formula
     assert_predicate testpath/"test.bmp", :exist?
   end
 end
+


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
By default, the homebrew version of gdal uses stock jasper for jpeg2000 support, which is needed for processing Sentinel tiles.

Stock jasper only allows images that contain 67108864 samples, which is fewer than contained in a Sentinel-2 tile. This is considered to be not a bug in jasper: mdadams/jasper#127

This PR adds an option to the formula to increase the number of samples that jasper will allow so that Sentinel-2 tiles can be processed natively on a Mac.