### PR TITLE
gnu-tar: add head

### DIFF
--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -11,6 +11,14 @@ class GnuTar < Formula
     sha256 "1a559b78e6f1a6594b18a9ba2aa2e9828af2736aacc4aec07911fe7638e80e68" => :el_capitan
   end
 
+  head do
+    url "https://git.savannah.gnu.org/git/tar.git"
+
+    depends_on "automake" => :build
+    depends_on "autoconf" => :build
+    depends_on "gettext" => :build
+  end
+
   option "with-default-names", "Do not prepend 'g' to the binary"
 
   def install
@@ -25,6 +33,7 @@ class GnuTar < Formula
     args = ["--prefix=#{prefix}", "--mandir=#{man}"]
     args << "--program-prefix=g" if build.without? "default-names"
 
+    system "./bootstrap" if build.head?
     system "./configure", *args
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
It seems that something is broken in bottle code. I see this in log
```
brew upgrade gnu-tar --HEAD -v
...
==> Not running post_install as we're building a bottle
You can run it manually using `brew postinstall gnu-tar`
```

```
brew audit --strict --online gnu-tar
gnu-tar:
  * `bottle` is not defined
```