### PR TITLE
atomicparsley: return to upstream repo

### DIFF
--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -1,8 +1,9 @@
 class Atomicparsley < Formula
   desc "MPEG-4 command-line tool"
   homepage "https://bitbucket.org/wez/atomicparsley/overview/"
-  url "https://bitbucket.org/dinkypumpkin/atomicparsley/downloads/atomicparsley-0.9.6.tar.bz2"
-  sha256 "49187a5215520be4f732977657b88b2cf9203998299f238067ce38f948941562"
+  url "https://bitbucket.org/wez/atomicparsley/get/0.9.6.tar.bz2"
+  sha256 "e28d46728be86219e6ce48695ea637d831ca0170ca6bdac99810996a8291ee50"
+  revision 1
   head "https://bitbucket.org/wez/atomicparsley", :using => :hg
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Source tarball was uploaded to a fork a few years ago because of unstable checksums when downloading from tag reference in upstream repo on Bitbucket. The fork repo is soon to be removed and checksums shouldn't be a problem these days, so formula should reference source from upstream repo. Revision number was added to indicate change in source location, though will remove if unnecessary. `brew audit` complains about change in checksum without corresponding change in version number, but the version number shouldn't change in this case (code is identical but top-level dir name in tarball is different). If there is some other way to handle that, please advise.