### PR TITLE
lua: update loarocks version to 3.0.1

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -20,8 +20,8 @@ class Lua < Formula
   patch :DATA
 
   resource "luarocks" do
-    url "https://luarocks.org/releases/luarocks-2.4.4.tar.gz"
-    sha256 "3938df33de33752ff2c526e604410af3dceb4b7ff06a770bc4a240de80a1f934"
+    url "https://luarocks.org/releases/luarocks-3.0.1.tar.gz"
+    sha256 "b989c4b60d6c9edcd65169e5e42fcffbd39cdbebe6b138fa5aea45102f8d9ec0"
   end
 
   def install
@@ -71,12 +71,12 @@ class Lua < Formula
         bin.install_symlink libexec/"bin/luarocks-admin"
 
         # This block ensures luarock exec scripts don't break across updates.
-        inreplace libexec/"share/lua/5.3/luarocks/site_config.lua" do |s|
-          s.gsub! libexec, opt_libexec
-          s.gsub! include, HOMEBREW_PREFIX/"include"
-          s.gsub! lib, HOMEBREW_PREFIX/"lib"
-          s.gsub! bin, HOMEBREW_PREFIX/"bin"
-        end
+        # inreplace libexec/"share/lua/5.3/luarocks/site_config.lua" do |s|
+        #  s.gsub! libexec, opt_libexec
+        #  s.gsub! include, HOMEBREW_PREFIX/"include"
+        #  s.gsub! lib, HOMEBREW_PREFIX/"lib"
+        #  s.gsub! bin, HOMEBREW_PREFIX/"bin"
+        # end
       end
     end
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Just a version bump for luarocks as they switched to 3.0.X and therefore new rocks cannot be installed anymore.