### PR TITLE
liquidprompt: HEAD points to branch "develop"

### DIFF
--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -3,7 +3,7 @@ class Liquidprompt < Formula
   homepage "https://github.com/nojhan/liquidprompt"
   url "https://github.com/nojhan/liquidprompt/archive/v_1.11.tar.gz"
   sha256 "669dde6b8274a57b3e39dc41539d157a86252e40e39bcc4c3102b5a81bd8f2f5"
-  head "https://github.com/nojhan/liquidprompt.git"
+  head "https://github.com/nojhan/liquidprompt.git", :branch => "develop"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updating the `liquidprompt` formula to point HEAD at the `develop` branch in the project. The `develop` branch received a lot of updates today that should be included in a HEAD build.