### PR TITLE
luarocks 3.0.1 (new formula)

### DIFF
--- a/Formula/corsixth.rb
+++ b/Formula/corsixth.rb
@@ -12,6 +12,7 @@ class Corsixth < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "luarocks" => :build
   depends_on :xcode => :build
   depends_on "ffmpeg"
   depends_on "freetype"

--- a/Formula/lmod.rb
+++ b/Formula/lmod.rb
@@ -12,6 +12,7 @@ class Lmod < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "luarocks" => :build
   depends_on "lua"
 
   resource "luafilesystem" do

--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -1,0 +1,57 @@
+class Luarocks < Formula
+  desc "Package manager for the Lua programming language"
+  homepage "https://luarocks.org/"
+  url "https://luarocks.org/releases/luarocks-3.0.1.tar.gz"
+  sha256 "b989c4b60d6c9edcd65169e5e42fcffbd39cdbebe6b138fa5aea45102f8d9ec0"
+
+  depends_on "lua"
+  depends_on "lua@5.1" => :test
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--rocks-tree=#{HOMEBREW_PREFIX}"
+    system "make", "install"
+  end
+
+  def caveats; <<~EOS
+    LuaRocks supports multiple versions of Lua. By default it is configured
+    to use Lua5.3, but you can require it to use another version at runtime
+    with the `--lua-dir` flag, like this:
+
+      luarocks --lua-dir=#{Formula["lua@5.1"].opt_prefix} install say
+  EOS
+  end
+
+  test do
+    ENV["LUA_PATH"] = "#{testpath}/share/lua/5.3/?.lua"
+    ENV["LUA_CPATH"] = "#{testpath}/lib/lua/5.3/?.so"
+
+    (testpath/"lfs_53test.lua").write <<~EOS
+      require("lfs")
+      print(lfs.currentdir())
+    EOS
+
+    system "#{bin}/luarocks", "--tree=#{testpath}", "install", "luafilesystem"
+    system "lua", "-e", "require('lfs')"
+    assert_match testpath.to_s, shell_output("lua lfs_53test.lua")
+
+    if build.with? "lua@5.1"
+      ENV["LUA_PATH"] = "#{testpath}/share/lua/5.1/?.lua"
+      ENV["LUA_CPATH"] = "#{testpath}/lib/lua/5.1/?.so"
+
+      (testpath/"lfs_51test.lua").write <<~EOS
+        require("lfs")
+        lfs.mkdir("blank_space")
+      EOS
+
+      system "#{bin}/luarocks", "--tree=#{testpath}",
+                                "--lua-dir=#{Formula["lua@5.1"].opt_prefix}",
+                                "install", "luafilesystem"
+      system "lua5.1", "-e", "require('lfs')"
+      system "lua5.1", "lfs_51test.lua"
+      assert_predicate testpath/"blank_space", :directory?,
+        "Luafilesystem failed to create the expected directory"
+    end
+  end
+end

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -12,6 +12,7 @@ class Neovim < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "luarocks" => :build
   depends_on "lua@5.1" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
@@ -126,28 +127,35 @@ class Neovim < Formula
 
     ENV.prepend_path "LUA_PATH", "#{buildpath}/deps-build/share/lua/5.1/?.lua"
     ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
+    lua_path = "--lua-dir=#{Formula["lua@5.1"].opt_prefix}"
 
     cd "deps-build" do
-      system "luarocks-5.1", "build", "build/src/lpeg/lpeg-1.0.1-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/mpack/mpack-1.0.7-0.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/inspect/inspect-3.1.1-0.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luabitop/luabitop-1.0.2-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luafilesystem/luafilesystem-1.7.0-2.src.rock", "--tree=."
-      cd "build/src/penlight" do
-        system "luarocks-5.1", "make", "--tree=#{buildpath}/deps-build"
+      %w[
+        lpeg/lpeg-1.0.1-1.src.rock
+        mpack/mpack-1.0.7-0.rockspec
+        inspect/inspect-3.1.1-0.src.rock
+        luabitop/luabitop-1.0.2-1.src.rock
+        luafilesystem/luafilesystem-1.7.0-2.src.rock
+        lua_cliargs/lua_cliargs-3.0-1.src.rock
+        lua-term/lua-term-0.7-1.rockspec
+        luasystem/luasystem-0.2.1-0.src.rock
+        dkjson/dkjson-2.5-2.src.rock
+        say/say-1.3-1.rockspec
+        luassert/luassert-1.7.10-0.rockspec
+        mediator_lua/mediator_lua-1.1.2-0.rockspec
+        busted/busted-2.0.rc12-1.rockspec
+        luacheck/luacheck-0.21.2-1.src.rock
+        luv/luv-1.9.1-1.src.rock
+        coxpcall/coxpcall-1.17.0-1.src.rock
+        nvim-client/nvim-client-0.1.0-1.rockspec
+      ].each do |rock|
+        system "luarocks", "build", lua_path, "build/src/#{rock}", "--tree=."
       end
-      system "luarocks-5.1", "build", "build/src/lua_cliargs/lua_cliargs-3.0-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/lua-term/lua-term-0.7-1.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luasystem/luasystem-0.2.1-0.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/dkjson/dkjson-2.5-2.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/say/say-1.3-1.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luassert/luassert-1.7.10-0.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/mediator_lua/mediator_lua-1.1.2-0.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/busted/busted-2.0.rc12-1.rockspec", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luacheck/luacheck-0.21.2-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/luv/luv-1.9.1-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/coxpcall/coxpcall-1.17.0-1.src.rock", "--tree=."
-      system "luarocks-5.1", "build", "build/src/nvim-client/nvim-client-0.1.0-1.rockspec", "--tree=."
+
+      cd "build/src/penlight" do
+        system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+      end
+
       system "cmake", "../third-party", "-DUSE_BUNDLED=OFF", *std_cmake_args
       system "make"
     end

--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -21,6 +21,7 @@ class Sile < Formula
   depends_on "libtool" => :build
 
   depends_on "pkg-config" => :build
+  depends_on "luarocks" => :build
   depends_on "harfbuzz"
   depends_on "fontconfig"
   depends_on "libpng"

--- a/Formula/vis.rb
+++ b/Formula/vis.rb
@@ -12,6 +12,7 @@ class Vis < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "luarocks" => :build
   depends_on "libtermkey"
   depends_on "lua"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've been meaning to implement this since 3.x landed, but finally we have a `luarocks` that can switch between different versions of `lua` seamlessly at runtime and it kinda makes me wanna do a little dance.

This makes maintaining the `lua` formulae themselves _quite a bit_ easier, eliminates otherwise unnecessary `lua`/`lua@5.1` revision bumps for every `luarocks` update, and provides users a better experience with the ecosystem.

Needs: https://github.com/Homebrew/brew/pull/4729.
Closes #31289.