### PR TITLE
knot 2.7.1 and knot-resolver 3.0.0

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -1,8 +1,8 @@
 class KnotResolver < Formula
   desc "Minimalistic, caching, DNSSEC-validating DNS resolver"
   homepage "https://www.knot-resolver.cz"
-  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-2.4.1.tar.xz"
-  sha256 "e8044316cd897ad29b3c5284de06652e1568c4d5861e3147ec2191fbacd8d9ff"
+  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-3.0.0.tar.xz"
+  sha256 "68a0137e0e15061ee7dec53a2e424aa3266611720db3843853c6e7774a414f40"
   head "https://gitlab.labs.nic.cz/knot/knot-resolver.git"
 
   bottle do
@@ -12,8 +12,6 @@ class KnotResolver < Formula
   end
 
   option "without-nettle", "Compile without DNS cookies support"
-  option "with-hiredis", "Compile with Redis cache storage support"
-  option "with-libmemcached", "Compile with memcached cache storage support"
 
   depends_on "cmocka" => :build
   depends_on "pkg-config" => :build
@@ -23,8 +21,6 @@ class KnotResolver < Formula
   depends_on "libuv"
   depends_on "lmdb"
   depends_on "nettle" => :recommended
-  depends_on "hiredis" => :optional
-  depends_on "libmemcached" => :optional
 
   def install
     # Since we don't run `make install` or `make etc-install`, we need to

--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -1,8 +1,8 @@
 class Knot < Formula
   desc "High-performance authoritative-only DNS server"
   homepage "https://www.knot-dns.cz/"
-  url "https://secure.nic.cz/files/knot-dns/knot-2.6.8.tar.xz"
-  sha256 "0daee8efd6262f10c54ee6f5fb99ca4d0f72e275513ec0902032af594cac1b15"
+  url "https://secure.nic.cz/files/knot-dns/knot-2.7.1.tar.xz"
+  sha256 "7d6ae20ada0f0ee7700d5df17f47f86b49eb21ee34977d0d70de6a0947371381"
 
   bottle do
     sha256 "adb2144d662f4d163e52ffb1bcdb6038f6e436280583a413a9f0aa3e8d2c99e4" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates `knot` and `knot-resolver` formulas. Both formulas need to be updated at once due to incompatible changes in libknot library provided by knot and consumed by knot-resolver.

Also, hiredis and memcached build dependencies have been dropped from knot-resolver as the features that required these libraries were removed in version 2.0.0.