### PR TITLE
Fix Python 2 & 3 build on Mojave

### DIFF
--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -105,15 +105,22 @@ class PythonAT2 < Formula
     ldflags  = []
     cppflags = []
 
-    unless MacOS::CLT.installed?
-      # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
+    if !MacOS::CLT.installed? || MacOS.version >= :mojave
+      # Help Python's build system (setuptools/pip) to build things on
+      # Xcode-only systems or systems where headers are not in /usr/include
+      if !MacOS::CLT.installed?
+        sdk = MacOS.sdk_path
+      else
+        sdk = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      end
+
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-      cflags   << "-isysroot #{MacOS.sdk_path}"
-      ldflags  << "-isysroot #{MacOS.sdk_path}"
-      cppflags << "-I#{MacOS.sdk_path}/usr/include" # find zlib
+      cflags   << "-isysroot #{sdk}"
+      ldflags  << "-isysroot #{sdk}"
+      cppflags << "-I#{sdk}/usr/include" # find zlib
       # For the Xlib.h, Python needs this header dir with the system Tk
       if build.without? "tcl-tk"
-        cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+        cflags << "-I#{sdk}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
       end
     end
 
@@ -339,6 +346,7 @@ class PythonAT2 < Formula
     system "#{bin}/python", "-c", "import sqlite3"
     # Check if some other modules import. Then the linked libs are working.
     system "#{bin}/python", "-c", "import Tkinter; root = Tkinter.Tk()"
+    system "#{bin}/python", "-c", "import zlib"
     system "#{bin}/python", "-c", "import gdbm"
     system bin/"pip", "list", "--format=columns"
   end


### PR DESCRIPTION
Currently, both python 2 and python 3 build incorrectly on macOS 10.14 Mojave, because some headers are not detected. Thus modules are missing from the final builds, including zlib and tkinter. Taking the example of Python 3, currently the build outputs:

```
The necessary bits to build these optional modules were not found:
_dbm                  _uuid                 nis                
ossaudiodev           spwd                  zlib               

Failed to build these modules:
_tkinter                                                       
```

The issue is that headers (zlib, Tk, etc.) are not found in `/usr/include` anymore, even on Mojave systems which have the CLT installed. With the changes applied, builds of both Python 2 and Python 3 succeed on Mojave, and include all relevant modules:

```
The necessary bits to build these optional modules were not found:
ossaudiodev           spwd                                     
```