### PR TITLE
kettle 8.1.0.0-365

### DIFF
--- a/Formula/kettle.rb
+++ b/Formula/kettle.rb
@@ -1,8 +1,8 @@
 class Kettle < Formula
   desc "Pentaho Data Integration software"
-  homepage "https://community.hds.com/docs/DOC-1009855"
-  url "https://downloads.sourceforge.net/project/pentaho/Data%20Integration/6.1/pdi-ce-6.1.0.1-196.zip"
-  sha256 "ef5076c09e8481d1ab4cfc5f7d4701437f80f2b97a3bf19dfa74821de9524495"
+  homepage "https://community.hitachivantara.com/docs/DOC-1009931-downloads"
+  url "https://downloads.sourceforge.net/project/pentaho/Pentaho%208.1/client-tools/pdi-ce-8.1.0.0-365.zip"
+  sha256 "8bb578bafbef66141b59938ca880a08151c6b84a285abc23d6dce73e04bbc814"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi everyone.

I also followed [these guidelines on how to open a pull request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request).

This is the output of the described `brew` commands (I ran them twice, they worked on both):

```shell
$ brew install --build-from-source kettle
Warning: kettle 8.1.0.0-365 is already installed and up-to-date
To reinstall 8.1.0.0-365, run `brew reinstall kettle`

$ brew reinstall --build-from-source kettle
==> Reinstalling kettle
==> Downloading https://downloads.sourceforge.net/project/pentaho/Pentaho%208.1/client-tools/pdi-ce-8.1.0.0-365.zip
Already downloaded: /Users/andreoliwa/Library/Caches/Homebrew/kettle--8.1.0.0-365.zip
==> Caveats
To have launchd start kettle now and restart at login:
  brew services start kettle
Or, if you don't want/need a background service you can just run:
  pdicarte /usr/local/etc/kettle/carte-config.xml
==> Summary
🍺  /usr/local/Cellar/kettle/8.1.0.0-365: 1,881 files, 1GB, built in 33 seconds

$ brew test kettle
Testing kettle
==> /usr/local/Cellar/kettle/8.1.0.0-365/bin/pdipan -file=/usr/local/Cellar/kettle/8.1.0.0-365/libexec/samples/transformations/Encrypt Password.ktr -level=RowLevel

$ brew audit --strict kettle

$
```