### PR TITLE
Add versioned formulae for terraform

### DIFF
--- a/Aliases/terraform@0.11
+++ b/Aliases/terraform@0.11
@@ -1,0 +1,1 @@
+../Formula/terraform.rb

--- a/Formula/terraform@0.11.7.rb
+++ b/Formula/terraform@0.11.7.rb
@@ -1,0 +1,86 @@
+require "language/go"
+
+class TerraformAT0117 < Formula
+  desc "Tool to build, change, and version infrastructure"
+  homepage "https://www.terraform.io/"
+  url "https://github.com/hashicorp/terraform/archive/v0.11.7.tar.gz"
+  sha256 "f9a2730dcd68dad754cf0efa017d51929a7f333a89d07ddff3c6ff7b2d1e8be3"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "5c2d32e91e2df76b10986da53eb62e0eee97e253522796be99ccdd366042117d" => :high_sierra
+    sha256 "24ca453d247297d7c07bfcc46387d817e5e5b177a6b4ee1e89dbcfc26d7e4233" => :sierra
+    sha256 "1c1d6a0a47e34a28fdc4a57a144228f4e74a0c9286bef0cf3d854ffe6b71e1a5" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+  depends_on "gox" => :build
+
+  # stringer is a build tool dependency
+  go_resource "golang.org/x/tools" do
+    url "https://go.googlesource.com/tools.git",
+        :branch => "release-branch.go1.10"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+
+    dir = buildpath/"src/github.com/hashicorp/terraform"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+    Language::Go.stage_deps resources, buildpath/"src"
+
+    cd "src/golang.org/x/tools/cmd/stringer" do
+      system "go", "install"
+    end
+
+    cd dir do
+      # v0.6.12 - source contains tests which fail if these environment variables are set locally.
+      ENV.delete "AWS_ACCESS_KEY"
+      ENV.delete "AWS_SECRET_KEY"
+
+      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = arch
+      system "make", "test", "bin"
+
+      bin.install "pkg/darwin_#{arch}/terraform"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    minimal = testpath/"minimal.tf"
+    minimal.write <<~EOS
+      variable "aws_region" {
+          default = "us-west-2"
+      }
+
+      variable "aws_amis" {
+          default = {
+              eu-west-1 = "ami-b1cf19c6"
+              us-east-1 = "ami-de7ab6b6"
+              us-west-1 = "ami-3f75767a"
+              us-west-2 = "ami-21f78e11"
+          }
+      }
+
+      # Specify the provider and access details
+      provider "aws" {
+          access_key = "this_is_a_fake_access"
+          secret_key = "this_is_a_fake_secret"
+          region = "${var.aws_region}"
+      }
+
+      resource "aws_instance" "web" {
+        instance_type = "m1.small"
+        ami = "${lookup(var.aws_amis, var.aws_region)}"
+        count = 4
+      }
+    EOS
+    system "#{bin}/terraform", "init"
+    system "#{bin}/terraform", "graph"
+  end
+end


### PR DESCRIPTION
Including alias for terraform 0.11.8

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes issues for people on terraform enterprise, which may or may not be updated so often.

Does not pass `--strict` audit because of an upstream problem:

```
terraform@0.11.7:
  * C: 22: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
Error: 1 problem in 1 formula
```