### PR TITLE
ocrmypdf: remove special install step for pybind11

### DIFF
--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -89,10 +89,7 @@ class Ocrmypdf < Formula
       venv.pip_install Pathname.pwd
     end
 
-    # pybind11 must be installed before pikepdf
-    venv.pip_install "pybind11"
-
-    res = resources.map(&:name).to_set - ["Pillow", "pybind11"]
+    res = resources.map(&:name).to_set - ["Pillow"]
     res.each do |r|
       venv.pip_install resource(r)
     end


### PR DESCRIPTION
Due to upstream changes, the workaround for installing pybind11 is no longer necessary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
