### PR TITLE
pango: Update the SHA-256 of the patch

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -30,7 +30,7 @@ class Pango < Formula
   # This fixes a font-size problem in gtk
   # For discussion, see https://bugzilla.gnome.org/show_bug.cgi?id=787867
   patch do
-    url "https://gitlab.gnome.org/tschoonj/pango/commit/60df2b006e5d4553abc7bb5fe9a99539c91b0022.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e0aa10/pango/pango_font_size.patch"
     sha256 "d5ece753cf393ef507dd2b0415721b4381159da5e2f40793c6d85741b1b163bc"
   end
 


### PR DESCRIPTION
Is gitlab.gnome.org having a SHApocalypse?

```
==> Downloading https://gitlab.gnome.org/tschoonj/pango/commit/60df2b006e5d4553a
Downloaded to: /Users/sjackman/Library/Caches/Homebrew/pango--patch--d5ece753cf393ef507dd2b0415721b4381159da5e2f40793c6d85741b1b163bc.patch
SHA256: a31188c253b3b57b134d1fee1bfaa7d45c55986aa76165a1ebacd184f2b16439
Warning: Patch reports different SHA256: d5ece753cf393ef507dd2b0415721b4381159da5e2f40793c6d85741b1b163bc
```