### PR TITLE
hdf5 1.10.3

### DIFF
--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -3,6 +3,7 @@ class Armadillo < Formula
   homepage "https://arma.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/arma/armadillo-9.100.5.tar.xz"
   sha256 "7e7dc6f1e876b8243c27a003b037559663371b42885436b1087757e652db41cd"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -3,7 +3,7 @@ class Caffe < Formula
   homepage "https://caffe.berkeleyvision.org/"
   url "https://github.com/BVLC/caffe/archive/1.0.tar.gz"
   sha256 "71d3c9eb8a183150f965a465824d01fe82826c22505f7aa314f700ace03fa77f"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "37b3112edbfcdf5ded4d914d10fe29c9b676fb339f18fd9bc7f361be80083aa0" => :high_sierra

--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -3,7 +3,7 @@ class Dartsim < Formula
   homepage "https://dartsim.github.io/"
   url "https://github.com/dartsim/dart/archive/v6.6.1.tar.gz"
   sha256 "86cc3249938602754f773e0843f415c290bd2608729ab3e219de78f90bdd4d6b"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "16ffea1569e6e599a3f8989086677f4f6471201fddcc2321aa21af8c7f18a0a8" => :high_sierra

--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -3,7 +3,7 @@ class Dynare < Formula
   homepage "https://www.dynare.org/"
   url "https://www.dynare.org/release/source/dynare-4.5.6.tar.xz"
   sha256 "a4ff0ee5892a044d169ead2778e96fefcf617535fab28d25b977d8d008c7fe87"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "70f0b0ca9e2be1e832f9daf1de297dcec8039f3cd3369bbe3a6fba1bb8b77155" => :high_sierra

--- a/Formula/field3d.rb
+++ b/Formula/field3d.rb
@@ -3,7 +3,7 @@ class Field3d < Formula
   homepage "https://sites.google.com/site/field3d/"
   url "https://github.com/imageworks/Field3D/archive/v1.7.2.tar.gz"
   sha256 "8f7c33ecb4489ed626455cf3998d911a079b4f137f86814d9c37c5765bf4b020"
-  revision 6
+  revision 7
 
   bottle do
     cellar :any

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -3,7 +3,7 @@ class Flann < Formula
   homepage "https://www.cs.ubc.ca/research/flann/"
   url "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
   sha256 "b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,6 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-5.4.4-src.tar.xz"
   mirror "https://fossies.org/linux/misc/GMT/gmt-5.4.4-src.tar.xz"
   sha256 "30fe868c91df30c51a637d54cb9ac52a64fe57e15daa9e08a73a4d1f0847e69f"
+  revision 1
 
   bottle do
     sha256 "b22c034be3134b652cd00914dfcbf0c35a7f30c9157e5a6aec675d42e7d33651" => :mojave

--- a/Formula/gmt@4.rb
+++ b/Formula/gmt@4.rb
@@ -5,6 +5,7 @@ class GmtAT4 < Formula
   mirror "https://fossies.org/linux/misc/GMT/gmt-4.5.18-src.tar.bz2"
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-4.5.18-src.tar.bz2"
   sha256 "27c30b516c317fed8e44efa84a0262f866521d80cfe76a61bf12952efb522b63"
+  revision 1
 
   bottle do
     sha256 "248b76386487b09b1a61088683386be7123a66f3e4212746358a557955ccfc41" => :high_sierra

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -1,9 +1,8 @@
 class Hdf5 < Formula
   desc "File format designed to store large amounts of data"
   homepage "https://www.hdfgroup.org/HDF5"
-  url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.2/src/hdf5-1.10.2.tar.bz2"
-  sha256 "1cad5b7bfdf128dfc53cd16fba48f6e7ae4e93c75c371d9ec8dfc4df0c1fcb71"
-  revision 1
+  url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.3/src/hdf5-1.10.3.tar.bz2"
+  sha256 "c65cdcce4724a57fd3f8da9f0d109b497be30092acb9fac634d1291190d905a9"
 
   bottle do
     sha256 "cfeca5869568190f998d813ad67add1f8b7e23fe0a6574544f26445c649ebd86" => :mojave

--- a/Formula/kallisto.rb
+++ b/Formula/kallisto.rb
@@ -3,7 +3,7 @@ class Kallisto < Formula
   homepage "https://pachterlab.github.io/kallisto/"
   url "https://github.com/pachterlab/kallisto/archive/v0.44.0.tar.gz"
   sha256 "35a81201a56f4557697e6fe693dc6b701bbbd0a7b2b6e1c6c845ef816d67ca29"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/libbi.rb
+++ b/Formula/libbi.rb
@@ -3,6 +3,7 @@ class Libbi < Formula
   homepage "https://libbi.org/"
   url "https://github.com/libbi/LibBi/archive/1.4.2.tar.gz"
   sha256 "17824f6b466777a02d6bc6bb4704749fb64ce56ec4468b936086bc9901b5bf78"
+  revision 1
   head "https://github.com/libbi/LibBi.git"
 
   bottle do

--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -3,7 +3,7 @@ class Libmatio < Formula
   homepage "https://matio.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/matio/matio/1.5.12/matio-1.5.12.tar.gz"
   sha256 "8695e380e465056afa5b5e20128935afe7d50e03830f9f7778a72e1e1894d8a9"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/nco.rb
+++ b/Formula/nco.rb
@@ -3,6 +3,7 @@ class Nco < Formula
   homepage "https://nco.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nco/nco-4.7.6.tar.gz"
   sha256 "c7926163b204573b7bf7b6e3c9bcfa15b2cc04c0f494dbc0c6829ee8c2f015b3"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -4,7 +4,7 @@ class Netcdf < Formula
   url "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.6.1.tar.gz"
   mirror "https://www.gfd-dennou.org/library/netcdf/unidata-mirror/netcdf-4.6.1.tar.gz"
   sha256 "89c7957458740b763ae828c345240b8a1d29c2c1fed0f065f99b73181b0b2642"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "fa3169a43279f6d11ffad65cd2ed8bbd7ddc0780d3f10ddcc12db302cdcf8c62" => :mojave

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,6 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-4.4.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/octave/octave-4.4.1.tar.xz"
   sha256 "7e4e9ac67ed809bd56768fb69807abae0d229f4e169db63a37c11c9f08215f90"
+  revision 1
 
   bottle do
     sha256 "1591b93a6ea1f8d04c92adfc05e3068e80129340fa4e9d4041696bdaf9a86572" => :mojave

--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -1,7 +1,7 @@
 class Pcl < Formula
   desc "Library for 2D/3D image and point cloud processing"
   homepage "http://www.pointclouds.org/"
-  revision 3
+  revision 4
   head "https://github.com/PointCloudLibrary/pcl.git"
 
   stable do

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -3,6 +3,7 @@ class Pdal < Formula
   homepage "https://www.pdal.io/"
   url "https://github.com/PDAL/PDAL/archive/1.7.2.tar.gz"
   sha256 "cedfefbe54ca61cbb33d100d619c53873d84f480ff53deec2cf6dd91580f6a61"
+  revision 1
   head "https://github.com/PDAL/PDAL.git"
 
   bottle do

--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -3,6 +3,7 @@ class Sratoolkit < Formula
   homepage "https://github.com/ncbi/sra-tools"
   url "https://github.com/ncbi/sra-tools/archive/2.9.2.tar.gz"
   sha256 "e055091ee1c0b8163c6e470d24e11575884a3c7e829759be38d2239366c3cf3b"
+  revision 1
   head "https://github.com/ncbi/sra-tools.git"
 
   bottle do

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -3,6 +3,7 @@ class Vtk < Formula
   homepage "https://www.vtk.org/"
   url "https://www.vtk.org/files/release/8.1/VTK-8.1.1.tar.gz"
   sha256 "71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324"
+  revision 1
   head "https://github.com/Kitware/VTK.git"
 
   bottle do


### PR DESCRIPTION
Revision bumps copied from https://github.com/Homebrew/homebrew-core/pull/26819. Upstream release notes note API tweaks, so I'm assuming necessary again... yay? 🍾 

`hdf5 1.10.3` fixes, amongst other things, the following CVEs:
* CVE-2018-11202
* CVE-2018-11203
* CVE-2018-11204
* CVE-2018-11206
* CVE-2018-11207