### PR TITLE
Peru 1.1.4 (new formula)

### DIFF
--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -30,5 +30,7 @@ class Peru < Formula
         url: https://github.com/buildinspace/peru.git
     EOS
     system "#{bin}/peru", "sync"
+    assert_predicate testpath/".peru", :exist?
+    assert_predicate testpath/"peru", :exist?
   end
 end

--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -19,7 +19,6 @@ class Peru < Formula
   end
 
   def install
-    virtualenv_create(libexec, "python3")
     virtualenv_install_with_resources
   end
 

--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -1,0 +1,29 @@
+class Peru < Formula
+  include Language::Python::Virtualenv
+
+  desc "Dependency retriever for version control and archives"
+  homepage "https://github.com/buildinspace/peru"
+  url "https://github.com/buildinspace/peru/archive/1.1.4.tar.gz"
+  sha256 "aa93ba4d7663f597c05a14dc39cac57ddcdaa70b876c90ebe46bf205240b0784"
+
+  depends_on "python"
+
+  def install
+    venv = virtualenv_create(libexec, "python3")
+    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
+                              "--ignore-installed", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", name
+    venv.pip_install_and_link buildpath
+  end
+
+  test do
+    peru_yaml = <<~PERU
+      imports:
+        peru: peru
+      git module peru:
+        url: https://github.com/buildinspace/peru.git
+    PERU
+    File.write("peru.yaml", peru_yaml)
+    system "#{bin}/peru", "sync"
+  end
+end

--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -23,13 +23,12 @@ class Peru < Formula
   end
 
   test do
-    peru_yaml = <<~PERU
+    (testpath/"peru.yaml").write <<~EOS
       imports:
         peru: peru
       git module peru:
         url: https://github.com/buildinspace/peru.git
-    PERU
-    File.write("peru.yaml", peru_yaml)
+    EOS
     system "#{bin}/peru", "sync"
   end
 end

--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -3,17 +3,24 @@ class Peru < Formula
 
   desc "Dependency retriever for version control and archives"
   homepage "https://github.com/buildinspace/peru"
-  url "https://github.com/buildinspace/peru/archive/1.1.4.tar.gz"
-  sha256 "aa93ba4d7663f597c05a14dc39cac57ddcdaa70b876c90ebe46bf205240b0784"
+  url "https://files.pythonhosted.org/packages/8e/db/ad9aa0e58bffc4f6f306d40608a7a755777ef283c28dee5a4c6a4dc47cad/peru-1.1.4.tar.gz"
+  sha256 "d899e1376009f7f95d220863ea79ca51712cd4bf769fff48973c239bf54e56d4"
 
   depends_on "python"
 
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz"
+    sha256 "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf"
+  end
+
   def install
-    venv = virtualenv_create(libexec, "python3")
-    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
-                              "--ignore-installed", buildpath
-    system libexec/"bin/pip", "uninstall", "-y", name
-    venv.pip_install_and_link buildpath
+    virtualenv_create(libexec, "python3")
+    virtualenv_install_with_resources
   end
 
   test do


### PR DESCRIPTION
Fixes buildinspace/peru#130

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Peru is a dependency retriever that can include other VCS repos and archives within a project's build dependencies in a VCS and build system-agnostic way.
