### PR TITLE
gtkglext: fix build with Xcode 10

### DIFF
--- a/Formula/gtkglext.rb
+++ b/Formula/gtkglext.rb
@@ -69,6 +69,11 @@ class Gtkglext < Formula
     sha256 "0d112b417d6c51022e31701037aa49ea50f270d3a34c263599ac0ef64c2f6743"
   end
 
+  patch :p0 do
+    url "https://trac.macports.org/raw-attachment/ticket/56260/patch-index-gdkglshapes-osx.diff"
+    sha256 "699ddd676b12a6c087e3b0a7064cc9ef391eac3d84c531b661948bf1699ebcc5"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
Build otherwise fails with:

```
gdkglshapes.c:552:12: error: redefinition of 'index' as different kind of symbol
static int index[20][3] =
           ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/strings.h:73:7: note: previous definition is here
char    *index(const char *, int) __POSIX_C_DEPRECATED(200112L);
         ^
```

Patch is from MacPorts: https://trac.macports.org/ticket/56260
Upstream does not have a bug reporting system anymore :(