### PR TITLE
game-music-emu: add player

### DIFF
--- a/Formula/game-music-emu.rb
+++ b/Formula/game-music-emu.rb
@@ -13,10 +13,25 @@ class GameMusicEmu < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "sdl" => :optional
 
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"
+
+    if build.with? "sdl"
+      cd "player" do
+        system "make"
+
+        # gme_player will have linked against the version of libgme in the buildpath,
+        # and we haven't yet fixed its dylib ID. Do that manually here because this
+        # won't be automatically fixable later.
+        dylib_id = MachO::MachOFile.new("#{buildpath}/gme/libgme.0.dylib").dylib_id
+        MachO::Tools.change_install_name("gme_player", dylib_id, "#{lib}/libgme.0.dylib")
+
+        bin.install "gme_player"
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This isn't installed by default, but game-music-emu includes a sample player which can be be built if SDL is present. To avoid adding an extra dependency, this makes the player an option instead of mandatory.