### PR TITLE
dartsim 6.6.1: update SHA256

### DIFF
--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -2,7 +2,8 @@ class Dartsim < Formula
   desc "Dynamic Animation and Robotics Toolkit"
   homepage "https://dartsim.github.io/"
   url "https://github.com/dartsim/dart/archive/v6.6.1.tar.gz"
-  sha256 "4000ad91dc20a5fee89f2252c9eb28cef62c89df88bff218374b70f38245a61c"
+  sha256 "86cc3249938602754f773e0843f415c290bd2608729ab3e219de78f90bdd4d6b"
+  revision 1
 
   bottle do
     sha256 "fa6a8387829bde1eef29583c3619d0064110a0fa5f6aae3362351497e333c61c" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/pull/30979 was created when DART v6.6.1 was tagged but not yet released. Because we re-tagged v6.6.1 and released it, the SHA256 is now invalid. This PR updates the incorrect SHA256.

Related issue: https://github.com/dartsim/dart/issues/1105