### PR TITLE
protobuf formulae: use canonical repository URLs

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -1,10 +1,10 @@
 class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
-  homepage "https://github.com/google/protobuf/"
-  url "https://github.com/google/protobuf.git",
+  homepage "https://github.com/protocolbuffers/protobuf/"
+  url "https://github.com/protocolbuffers/protobuf.git",
       :tag => "v3.6.0",
       :revision => "ab8edf1dbe2237b4717869eaab11a2998541ad8d"
-  head "https://github.com/google/protobuf.git"
+  head "https://github.com/protocolbuffers/protobuf.git"
 
   bottle do
     sha256 "dffa48f050afeca2debd445de6751c9c61c000524f9ffc512179e7a3e282003d" => :mojave
@@ -36,14 +36,14 @@ class Protobuf < Formula
 
   # Upstream PR from 3 Jul 2018 "Add Python 3.7 compatibility"
   patch do
-    url "https://github.com/google/protobuf/pull/4862.patch?full_index=1"
+    url "https://github.com/protocolbuffers/protobuf/pull/4862.patch?full_index=1"
     sha256 "4b1fe1893c40cdcef531c31746ddd18759c9ce3564c89ddcc0ec934ea5dbf377"
   end
 
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
-    # https://github.com/google/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
+    # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
     ENV.prepend "CXXFLAGS", "-DNDEBUG"
     ENV.cxx11
 

--- a/Formula/protobuf@2.5.rb
+++ b/Formula/protobuf@2.5.rb
@@ -1,7 +1,7 @@
 class ProtobufAT25 < Formula
   desc "Protocol buffers (Google's data interchange format)"
-  homepage "https://github.com/google/protobuf"
-  url "https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.bz2"
+  homepage "https://github.com/protocolbuffers/protobuf"
+  url "https://github.com/protocolbuffers/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.bz2"
   sha256 "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677"
 
   bottle do

--- a/Formula/protobuf@2.6.rb
+++ b/Formula/protobuf@2.6.rb
@@ -1,7 +1,7 @@
 class ProtobufAT26 < Formula
   desc "Protocol buffers - Google data interchange format"
-  homepage "https://github.com/google/protobuf/"
-  url "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2"
+  homepage "https://github.com/protocolbuffers/protobuf/"
+  url "https://github.com/protocolbuffers/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2"
   sha256 "ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910"
 
   bottle do
@@ -48,13 +48,13 @@ class ProtobufAT26 < Formula
   end
 
   # Fixes the unexpected identifier error when compiling software against protobuf:
-  # https://github.com/google/protobuf/issues/549
+  # https://github.com/protocolbuffers/protobuf/issues/549
   patch :p1, :DATA
 
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
-    # https://github.com/google/protobuf/blob/e9a122eb19ec54dbca15da80355ed0c17cada9b1/configure.ac#L71-L74
+    # https://github.com/protocolbuffers/protobuf/blob/e9a122eb19ec54dbca15da80355ed0c17cada9b1/configure.ac#L71-L74
     ENV.prepend "CXXFLAGS", "-DNDEBUG"
     ENV.cxx11 if build.cxx11?
 

--- a/Formula/protobuf@3.1.rb
+++ b/Formula/protobuf@3.1.rb
@@ -1,7 +1,7 @@
 class ProtobufAT31 < Formula
   desc "Protocol buffers (Google's data interchange format)"
-  homepage "https://github.com/google/protobuf/"
-  url "https://github.com/google/protobuf/archive/v3.1.0.tar.gz"
+  homepage "https://github.com/protocolbuffers/protobuf/"
+  url "https://github.com/protocolbuffers/protobuf/archive/v3.1.0.tar.gz"
   sha256 "fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d"
 
   bottle do
@@ -83,7 +83,7 @@ class ProtobufAT31 < Formula
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
-    # https://github.com/google/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
+    # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
     ENV.prepend "CXXFLAGS", "-DNDEBUG"
     ENV.cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
