### PR TITLE
kubernetes-helm: depend on gox at build time

### DIFF
--- a/Formula/kubernetes-helm.rb
+++ b/Formula/kubernetes-helm.rb
@@ -15,6 +15,7 @@ class KubernetesHelm < Formula
 
   depends_on "mercurial" => :build
   depends_on "go" => :build
+  depends_on "gox" => :build
   depends_on "glide" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`make bootstrap` runs `go get` if `gox` isn't installed.