### PR TITLE
fortio switch to it's own github org and paths; v1.2.0

### DIFF
--- a/Formula/fortio.rb
+++ b/Formula/fortio.rb
@@ -1,8 +1,8 @@
 class Fortio < Formula
   desc "HTTP and gRPC load testing and visualization tool and server"
-  homepage "https://github.com/istio/fortio"
-  url "https://github.com/istio/fortio.git",
-      :tag => "v1.1.0",
+  homepage "https://fortio.org/"
+  url "https://github.com/fortio/fortio.git",
+      :tag => "v1.1.1",
       :revision => "d13f3b92c63db22136bac4e0896562404bd4ef6e"
 
   bottle do
@@ -16,8 +16,8 @@ class Fortio < Formula
   def install
     ENV["GOPATH"] = buildpath
 
-    (buildpath/"src/istio.io/fortio").install buildpath.children
-    cd "src/istio.io/fortio" do
+    (buildpath/"src/fortio.org/fortio").install buildpath.children
+    cd "src/fortio.org/fortio" do
       system "make", "official-build", "OFFICIAL_BIN=#{bin}/fortio",
              "LIB_DIR=#{lib}", "DATA_DIR=."
       lib.install "ui/static", "ui/templates"

--- a/Formula/fortio.rb
+++ b/Formula/fortio.rb
@@ -2,8 +2,8 @@ class Fortio < Formula
   desc "HTTP and gRPC load testing and visualization tool and server"
   homepage "https://fortio.org/"
   url "https://github.com/fortio/fortio.git",
-      :tag => "v1.1.1",
-      :revision => "d13f3b92c63db22136bac4e0896562404bd4ef6e"
+      :tag => "v1.2.0",
+      :revision => "36bffaa50c7cc47038fc7572c83221640a603425"
 
   bottle do
     sha256 "9f383a159618023334af96f850ca159115f4be8c52cd9ff0bb752d79fd962ea5" => :high_sierra


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
there is a redirect from old to new but the src dir in go should match the vanity package url
(which shouldn't change anymore)
