### PR TITLE
Cassandra-reaper 1.3.0 (new formula)

### DIFF
--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,6 +4,8 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.3.0/cassandra-reaper-1.3.0-release.tar.gz"
   sha256 "79c190c51c3404c2efc7f7f1aafa7cfd91f2280cbb1fe719e668966836904efd"
 
+  depends_on :java => "1.8"
+
   def install
     prefix.install "bin"
     share.install "server/target" => "cassandra-reaper"

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,9 +4,8 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
-
   patch :p3 do
-    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.diff"
+    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.diff?full_index=1"
     sha256 "0b1812e1121225fdcaaf97c2a9db00010ddc055ea14efd9674e5621fd4510bf9"
   end
 
@@ -17,7 +16,6 @@ class CassandraReaper < Formula
     mv "resource", "cassandra-reaper"
     etc.install "cassandra-reaper"
   end
-
 
   test do
     begin
@@ -31,5 +29,4 @@ class CassandraReaper < Formula
       Process.kill("KILL", pid)
     end
   end
-
 end

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,6 +4,8 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
+  # The inline patch is temporary to update the 'cassandra-reaper' script for brew.
+  # Since PR [thelastpickle/cassandra-reaper#533](https://github.com/thelastpickle/cassandra-reaper/pull/533) is merged, it will be obsolete once next version is released.
   patch :p3 do
     url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.diff?full_index=1"
     sha256 "0b1812e1121225fdcaaf97c2a9db00010ddc055ea14efd9674e5621fd4510bf9"

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -1,5 +1,5 @@
 class CassandraReaper < Formula
-  desc "Manager for Cassandra"
+  desc "A management interface for Cassandra"
   homepage "http://cassandra-reaper.io"
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -11,7 +11,7 @@ class CassandraReaper < Formula
     etc.install "resource" => "cassandra-reaper"
     inreplace prefix/"cassandra-reaper", "etc", etc
     env={ :CLASS_PATH => "#{pkgshare}/cassandra-reaper-?.?.?.jar" }
-    (bin/"reaper").write_env_script(prefix/"cassandra-reaper", env)
+    (bin/"cassandra-reaper").write_env_script(prefix/"cassandra-reaper", env)
   end
 
   test do

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,6 +4,8 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.3.0/cassandra-reaper-1.3.0-release.tar.gz"
   sha256 "79c190c51c3404c2efc7f7f1aafa7cfd91f2280cbb1fe719e668966836904efd"
 
+  bottle :unneeded
+
   depends_on :java => "1.8"
 
   def install

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,17 +4,14 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
-  # The inline patch is temporary to update the 'cassandra-reaper' script for reading from /usr/local/.
-  # Since PR [thelastpickle/cassandra-reaper#533](https://github.com/thelastpickle/cassandra-reaper/pull/533) is merged, it will be obsolete once next version is released.
-  patch :p3 do
-    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.patch?full_index=1"
-    sha256 "7fdea1d12524e121db191c70effa91825948fa08b24b2c914d51dbfdceff485a"
-  end
-
   def install
-    bin.install_symlink "bin/cassandra-reaper"
-    share.install "server/target" => "cassandra-reaper"
+    prefix.install "bin/cassandra-reaper"
+    mv "server/target", "cassandra-reaper"
+    share.install "cassandra-reaper"
     etc.install "resource" => "cassandra-reaper"
+    inreplace prefix/"cassandra-reaper", "etc", etc
+    env={ :CLASS_PATH => "#{pkgshare}/cassandra-reaper-?.?.?.jar" }
+    (bin/"reaper").write_env_script(prefix/"cassandra-reaper", env)
   end
 
   test do

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,6 +4,12 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
+
+  patch :p3 do
+    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.diff"
+    sha256 "0b1812e1121225fdcaaf97c2a9db00010ddc055ea14efd9674e5621fd4510bf9"
+  end
+
   def install
     prefix.install "bin"
     mv "server/target", "cassandra-reaper"
@@ -11,4 +17,19 @@ class CassandraReaper < Formula
     mv "resource", "cassandra-reaper"
     etc.install "cassandra-reaper"
   end
+
+
+  test do
+    begin
+      pid = fork do
+        exec "/usr/local/bin/cassandra-reaper"
+      end
+      sleep 10
+      output = shell_output("curl -Im3 -o- http://localhost:8080/webui/")
+      assert_match /200 OK.*/m, output
+    ensure
+      Process.kill("KILL", pid)
+    end
+  end
+
 end

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -7,8 +7,8 @@ class CassandraReaper < Formula
   # The inline patch is temporary to update the 'cassandra-reaper' script for brew.
   # Since PR [thelastpickle/cassandra-reaper#533](https://github.com/thelastpickle/cassandra-reaper/pull/533) is merged, it will be obsolete once next version is released.
   patch :p3 do
-    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.diff?full_index=1"
-    sha256 "0b1812e1121225fdcaaf97c2a9db00010ddc055ea14efd9674e5621fd4510bf9"
+    url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.patch?full_index=1"
+    sha256 "7fdea1d12524e121db191c70effa91825948fa08b24b2c914d51dbfdceff485a"
   end
 
   def install

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -1,16 +1,13 @@
 class CassandraReaper < Formula
   desc "Management interface for Cassandra"
   homepage "http://cassandra-reaper.io"
-  url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
-  sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
+  url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.3.0/cassandra-reaper-1.3.0-release.tar.gz"
+  sha256 "79c190c51c3404c2efc7f7f1aafa7cfd91f2280cbb1fe719e668966836904efd"
 
   def install
-    inreplace "bin/cassandra-reaper", "etc", etc
-    libexec.install "bin/cassandra-reaper"
+    prefix.install "bin"
     share.install "server/target" => "cassandra-reaper"
     etc.install "resource" => "cassandra-reaper"
-    env = { :CLASS_PATH => "#{pkgshare}/cassandra-reaper-?.?.?.jar" }
-    (bin/"cassandra-reaper").write_env_script(libexec/"cassandra-reaper", env)
   end
 
   test do

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -1,5 +1,5 @@
 class CassandraReaper < Formula
-  desc "A management interface for Cassandra"
+  desc "Management interface for Cassandra"
   homepage "http://cassandra-reaper.io"
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
@@ -12,11 +12,9 @@ class CassandraReaper < Formula
   end
 
   def install
-    prefix.install "bin"
-    mv "server/target", "cassandra-reaper"
-    share.install "cassandra-reaper"
-    mv "resource", "cassandra-reaper"
-    etc.install "cassandra-reaper"
+    bin.install_symlink "bin/cassandra-reaper"
+    share.install "server/target" => "cassandra-reaper"
+    etc.install "resource" => "cassandra-reaper"
   end
 
   test do

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -1,10 +1,10 @@
 class CassandraReaper < Formula
-  desc "CassandraReaper manager for Homebrew"
+  desc "Manager for Cassandra"
   homepage "http://cassandra-reaper.io"
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
-  # The inline patch is temporary to update the 'cassandra-reaper' script for brew.
+  # The inline patch is temporary to update the 'cassandra-reaper' script for reading from /usr/local/.
   # Since PR [thelastpickle/cassandra-reaper#533](https://github.com/thelastpickle/cassandra-reaper/pull/533) is merged, it will be obsolete once next version is released.
   patch :p3 do
     url "https://github.com/thelastpickle/cassandra-reaper/commit/4e26e1c70de8aa564e57ada287fffd6e7544914f.patch?full_index=1"

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -1,0 +1,14 @@
+class CassandraReaper < Formula
+  desc "CassandraReaper manager for Homebrew"
+  homepage "http://cassandra-reaper.io"
+  url "https://github.com/thelastpickle/cassandra-reaper/releases/download/1.2.2/cassandra-reaper-1.2.2-release.tar.gz"
+  sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
+
+  def install
+    prefix.install "bin"
+    mv "server/target", "cassandra-reaper"
+    share.install "cassandra-reaper"
+    mv "resource", "cassandra-reaper"
+    etc.install "cassandra-reaper"
+  end
+end

--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -5,19 +5,18 @@ class CassandraReaper < Formula
   sha256 "720aff69e3205301bc07399afc46dae3568d8effffa3712f1852a169ce9801db"
 
   def install
-    prefix.install "bin/cassandra-reaper"
-    mv "server/target", "cassandra-reaper"
-    share.install "cassandra-reaper"
+    inreplace "bin/cassandra-reaper", "etc", etc
+    libexec.install "bin/cassandra-reaper"
+    share.install "server/target" => "cassandra-reaper"
     etc.install "resource" => "cassandra-reaper"
-    inreplace prefix/"cassandra-reaper", "etc", etc
-    env={ :CLASS_PATH => "#{pkgshare}/cassandra-reaper-?.?.?.jar" }
-    (bin/"cassandra-reaper").write_env_script(prefix/"cassandra-reaper", env)
+    env = { :CLASS_PATH => "#{pkgshare}/cassandra-reaper-?.?.?.jar" }
+    (bin/"cassandra-reaper").write_env_script(libexec/"cassandra-reaper", env)
   end
 
   test do
     begin
       pid = fork do
-        exec "/usr/local/bin/cassandra-reaper"
+        exec "#{bin}/cassandra-reaper"
       end
       sleep 10
       output = shell_output("curl -Im3 -o- http://localhost:8080/webui/")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Since this formula produce cross-platform binaries (Java), it does not use `brew install --build-from-source <formula>`.

The inline patch is temporary to update the 'cassandra-reaper' script for brew.
Since PR [thelastpickle/cassandra-reaper#533](https://github.com/thelastpickle/cassandra-reaper/pull/533) is merged, it will be obsolete once next version is released.