### PR TITLE
libofx: Fix detection of OpenSP

### DIFF
--- a/Formula/libofx.rb
+++ b/Formula/libofx.rb
@@ -14,7 +14,10 @@ class Libofx < Formula
   depends_on "open-sp"
 
   def install
+    opensp = Formula["open-sp"]
     system "./configure", "--disable-dependency-tracking",
+                          "--with-opensp-includes=#{opensp.opt_include}/OpenSP",
+                          "--with-opensp-libs=#{opensp.opt_lib}",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
If homebrew is not installed in /usr/local, libofx would not find
open-sp. Fix it by explicitly setting open-sp include and lib
directories.


- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----