### PR TITLE
rebar3: rename from rebar@3

### DIFF
--- a/Aliases/rebar@2
+++ b/Aliases/rebar@2
@@ -1,1 +1,0 @@
-../Formula/rebar.rb

--- a/Formula/rebar3.rb
+++ b/Formula/rebar3.rb
@@ -1,16 +1,8 @@
-class RebarAT3 < Formula
+class Rebar3 < Formula
   desc "Erlang build tool"
   homepage "https://github.com/erlang/rebar3"
   url "https://github.com/erlang/rebar3/archive/3.6.1.tar.gz"
   sha256 "40b3c85440f3235c7b149578d0211bdf57d1c66390f888bb771704f8abc71033"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "2aa772910fdc0e58935b3c9d59d18790a357ee8ea20fcf61acedc91ca22a9c1b" => :mojave
-    sha256 "93810f629b55e7bb96b63596b98aa1914c0d06091c988af2b03a7ea33ee74fe8" => :high_sierra
-    sha256 "f6316f92f20c6a266c412ac49ec731743f7b43afecc44939049802c45ebee4e4" => :sierra
-    sha256 "461a1ba52650feef1ed4ef6d831cfacc752b126298565ac6b469d067740b7e3b" => :el_capitan
-  end
 
   depends_on "erlang"
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -155,7 +155,7 @@
   "qt5": "qt",
   "qt55": "qt@5.5",
   "racket": "minimal-racket",
-  "rebar3": "rebar@3",
+  "rebar@3": "rebar3",
   "recipes": "gnome-recipes",
   "redis26": "redis@2.6",
   "redis28": "redis@2.8",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`rebar3` is the current "erlang build tool", `rebar` is deprecated and the repo has been archived.

Upstream call it `rebar3` and it's packaged by others as `rebar3`. 

https://github.com/erlang/rebar3
https://github.com/rebar/rebar

http://www.rebar3.org/docs/from-rebar-2x-to-rebar3

https://repology.org/metapackage/rebar3/versions
https://repology.org/metapackage/rebar/versions
