### PR TITLE
imagemagick: ship a safer security policy

### DIFF
--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -7,6 +7,7 @@ class ImagemagickAT6 < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick%406--6.9.10-11.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.10-11.tar.xz"
   sha256 "2d1c61999a9b1f663a085d6657cc4db4b1652af6462256d1aa3c467df3e9e6eb"
+  revision 1
   head "https://github.com/imagemagick/imagemagick6.git"
 
   bottle do
@@ -62,6 +63,17 @@ class ImagemagickAT6 < Formula
 
   skip_clean :la
 
+  # This isn't an upstream issue and this patch should not be removed.
+  # Imagemagick delegate configuring secure defaults to users/packagers
+  # and ship the most "open" (and thus potentially unsafe) configuration
+  # possible out of the box. This policy is inspired by both Debian's and
+  # the advice on Imagemagick's related page:
+  # https://www.imagemagick.org/script/security-policy.php
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a95f9dd/imagemagick/imagemagick_safer_defaults.diff"
+    sha256 "3f22b13e206d2403b53692412b7b69d175530f5977350486b81da5027c548b44"
+  end
+
   def install
     args = %W[
       --disable-osx-universal-binary
@@ -102,7 +114,14 @@ class ImagemagickAT6 < Formula
       args << "--without-openjp2"
     end
 
-    args << "--without-gslib" if build.without? "ghostscript"
+    if build.with? "ghostscript"
+      inreplace "config/policy.xml",
+                /.*EPS,PS2,PS3,PS,PDF,XPS.*$/,
+                "  <!-- \\0 -->"
+    else
+      args << "--without-gslib"
+    end
+
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
     args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"
     args << "--without-magick-plus-plus" if build.without? "magick-plus-plus"
@@ -130,5 +149,12 @@ class ImagemagickAT6 < Formula
     %w[Modules freetype jpeg png tiff].each do |feature|
       assert_match feature, features
     end
+
+    # Check our security policy is working as expected.
+    cp test_fixtures("test.pdf"), testpath
+    output = shell_output("#{bin}/convert test.pdf test.jpg 2>&1", 1)
+    assert_match "not authorized", output
+    refute_predicate testpath/"test.jpg", :exist?,
+      "Imagemagick's security policy was not enforced as expected"
   end
 end

--- a/Formula/pdf-redact-tools.rb
+++ b/Formula/pdf-redact-tools.rb
@@ -28,13 +28,11 @@ class PdfRedactTools < Formula
   end
 
   test do
-    # Modifies the file in the directory the file is placed in.
-    cp test_fixtures("test.pdf"), "test.pdf"
-    system bin/"pdf-redact-tools", "-e", "test.pdf"
-    assert_predicate testpath/"test_pages/page-0.png", :exist?
-    rm_rf "test_pages"
-
-    system bin/"pdf-redact-tools", "-s", "test.pdf"
-    assert_predicate testpath/"test-final.pdf", :exist?
+    # Ensures pdf-redact-tools correctly recognises the file isn't a
+    # PDF and exits. Cannot test further than this without loosening
+    # our default imagemagick security policy.
+    cp test_fixtures("test.png"), "test"
+    output = shell_output("#{bin}/pdf-redact-tools --sanitize test 2>&1", 2)
+    assert_match "file must be a PDF", output
   end
 end

--- a/Formula/pdfsandwich.rb
+++ b/Formula/pdfsandwich.rb
@@ -1,9 +1,8 @@
 class Pdfsandwich < Formula
   desc "Generate sandwich OCR PDFs from scanned file"
   homepage "http://www.tobias-elze.de/pdfsandwich/"
-  url "https://downloads.sourceforge.net/project/pdfsandwich/pdfsandwich%200.1.6/pdfsandwich-0.1.6.tar.bz2"
-  sha256 "96831eb191bcd43e730dcce169d5c14b47bba0b6cd5152a8703e3b573013a2a2"
-  revision 1
+  url "https://downloads.sourceforge.net/project/pdfsandwich/pdfsandwich%200.1.7/pdfsandwich-0.1.7.tar.bz2"
+  sha256 "9795ffea84b9b6b501f38d49a4620cf0469ddf15aac31bac6dbdc9ec1716fa39"
   head "https://svn.code.sf.net/p/pdfsandwich/code/trunk/src"
 
   bottle do
@@ -33,9 +32,9 @@ class Pdfsandwich < Formula
   end
 
   test do
-    system "#{bin}/pdfsandwich", "-o", testpath/"test_ocr.pdf",
-           test_fixtures("test.pdf")
-    assert_predicate testpath/"test_ocr.pdf", :exist?,
-                     "Failed to create ocr file"
+    # Cannot test more than this without removing our default security
+    # policy for Imagemagick, which this formula isn't popular enough
+    # to justify doing.
+    assert_match version.to_s, shell_output("#{bin}/pdfsandwich -version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We used to do this back in 2016 (https://github.com/Homebrew/homebrew-core/pull/817, https://github.com/Homebrew/homebrew-core/pull/920, etc) but stopped. Since then `imagemagick` have delegated determining safe defaults to users/packagers and ship the most open/vulnerable configuration out-of-the-box themselves.

Debian patch this, and `imagemagick` themselves suggest changing the policy that is shipped by default, so I think we should get back into shipping a safer default configuration and nudge users that want something different to change the policy locally rather than reverting to a less safe set of defaults for everyone.