### PR TITLE
carla 1.9.9 (new formula)

### DIFF
--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -13,8 +13,8 @@ class Carla < Formula
 
   def install
     args = []
-    if ENV.compiler == :clang and MacOS.version <= :mountain_lion
-        args << "MACOS_OLD=true"
+    if ENV.compiler == :clang && MacOS.version <= :mountain_lion
+      args << "MACOS_OLD=true"
     end
 
     system "make", *args

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -5,10 +5,10 @@ class Carla < Formula
   revision 0
 
   depends_on "pkg-config" => :build
-  depends_on :macos => :mavericks
   depends_on "fluid-synth"
   depends_on "liblo"
   depends_on "libmagic"
+  depends_on :macos => :mavericks
   depends_on "pyqt"
   depends_on "python"
 
@@ -17,7 +17,6 @@ class Carla < Formula
       PREFIX=#{prefix}
     ]
 
-    # list all available carla features based on dependencies
     system "make"
     system "make", "install", *args
   end

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -1,6 +1,4 @@
 class Carla < Formula
-  include Language::Python::Virtualenv
-
   desc "Audio plugin host supporting LADSPA, LV2, VST2/3, SF2 and more"
   homepage "https://kxstudio.linuxaudio.org/Applications:Carla"
   url "https://github.com/falkTX/carla", :using => :git, :tag => "v1.9.9", :revision => "c03571a9ef95ac0e9564b95347f5de819aa7fb54"

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -6,11 +6,11 @@ class Carla < Formula
 
   depends_on "pkg-config" => :build
   depends_on :macos => :mavericks
-  depends_on "fluid-synth" => :recommended
-  depends_on "liblo" => :recommended
-  depends_on "libmagic" => :recommended
-  depends_on "pyqt" => :recommended
-  depends_on "python" => :recommended
+  depends_on "fluid-synth"
+  depends_on "liblo"
+  depends_on "libmagic"
+  depends_on "pyqt"
+  depends_on "python"
 
   def install
     args = %W[

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -1,0 +1,30 @@
+class Carla < Formula
+  include Language::Python::Virtualenv
+  
+  desc "Audio plugin host supporting LADSPA, DSSI, LV2, VST2/3, AU, GIG, SF2 and SFZ"
+  homepage "http://kxstudio.linuxaudio.org/Applications:Carla"
+  revision 0
+  url "https://github.com/falkTX/carla", :using => :git, :tag => "v1.9.9", :revision => "c03571a9ef95ac0e9564b95347f5de819aa7fb54"
+
+  depends_on :macos => :mavericks
+  depends_on "pkg-config" => :build
+  depends_on "python" => :recommended
+  depends_on "pyqt" => :recommended
+  depends_on "libmagic" => :recommended
+  depends_on "liblo" => :recommended
+  depends_on "fluid-synth" => :recommended
+  
+  def install
+    args = %W[
+      PREFIX=#{prefix}
+    ]
+    
+    # list all available carla features based on dependencies
+    system "make"
+    system "make", "install", *args
+  end
+
+  test do
+    system bin/"carla", "--version"
+  end
+end

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -1,24 +1,24 @@
 class Carla < Formula
   include Language::Python::Virtualenv
-  
-  desc "Audio plugin host supporting LADSPA, DSSI, LV2, VST2/3, AU, GIG, SF2 and SFZ"
-  homepage "http://kxstudio.linuxaudio.org/Applications:Carla"
-  revision 0
-  url "https://github.com/falkTX/carla", :using => :git, :tag => "v1.9.9", :revision => "c03571a9ef95ac0e9564b95347f5de819aa7fb54"
 
-  depends_on :macos => :mavericks
+  desc "Audio plugin host supporting LADSPA, LV2, VST2/3, SF2 and more"
+  homepage "https://kxstudio.linuxaudio.org/Applications:Carla"
+  url "https://github.com/falkTX/carla", :using => :git, :tag => "v1.9.9", :revision => "c03571a9ef95ac0e9564b95347f5de819aa7fb54"
+  revision 0
+
   depends_on "pkg-config" => :build
-  depends_on "python" => :recommended
-  depends_on "pyqt" => :recommended
-  depends_on "libmagic" => :recommended
-  depends_on "liblo" => :recommended
+  depends_on :macos => :mavericks
   depends_on "fluid-synth" => :recommended
-  
+  depends_on "liblo" => :recommended
+  depends_on "libmagic" => :recommended
+  depends_on "pyqt" => :recommended
+  depends_on "python" => :recommended
+
   def install
     args = %W[
       PREFIX=#{prefix}
     ]
-    
+
     # list all available carla features based on dependencies
     system "make"
     system "make", "install", *args

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -1,27 +1,28 @@
 class Carla < Formula
   desc "Audio plugin host supporting LADSPA, LV2, VST2/3, SF2 and more"
   homepage "https://kxstudio.linuxaudio.org/Applications:Carla"
-  url "https://github.com/falkTX/carla", :using => :git, :tag => "v1.9.9", :revision => "c03571a9ef95ac0e9564b95347f5de819aa7fb54"
-  revision 0
+  url "https://github.com/falkTX/Carla/archive/v1.9.9.tar.gz"
+  sha256 "13cff6febb0879190e4e8906f8cbb0e6a61ac1344cd8dbec0331598b59576548"
 
   depends_on "pkg-config" => :build
   depends_on "fluid-synth"
   depends_on "liblo"
   depends_on "libmagic"
-  depends_on :macos => :mavericks
   depends_on "pyqt"
   depends_on "python"
 
   def install
-    args = %W[
-      PREFIX=#{prefix}
-    ]
+    args = []
+    if ENV.compiler == :clang and MacOS.version <= :mountain_lion
+        args << "MACOS_OLD=true"
+    end
 
-    system "make"
-    system "make", "install", *args
+    system "make", *args
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
     system bin/"carla", "--version"
+    system bin/"carla-discovery-native", internal, :all
   end
 end

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -23,6 +23,6 @@ class Carla < Formula
 
   test do
     system bin/"carla", "--version"
-    system bin/"carla-discovery-native", internal, :all
+    system lib/"carla/carla-discovery-native", "internal", ":all"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds Carla, an audio plugin host for several audio plugin formats (LV2, VST, etc).

Also adds `pkg-config` support, libraries and headers for projects building against the carla library.

**Edit:** Despite the similarities to a cask, this package is intended to provide as a `pkg-config` driven build library for C++ projects, etc.