### PR TITLE
smlnj 110.83

### DIFF
--- a/Formula/smlnj.rb
+++ b/Formula/smlnj.rb
@@ -1,8 +1,8 @@
 class Smlnj < Formula
   desc "Standard ML of New Jersey"
   homepage "https://www.smlnj.org/"
-  url "https://www.smlnj.org/dist/working/110.82/config.tgz"
-  sha256 "ceff9288e8106d94ce813181d6f4c4da02e4abf808875b27b78d9f6258d016de"
+  url "https://www.smlnj.org/dist/working/110.83/config.tgz"
+  sha256 "997d74d1a3e7e6b22c3002bf69a6003173c856d59baba79e93073f9c7f3eacaa"
 
   bottle do
     sha256 "4abfb70ad672ac4e14ff71d160800ba393a1ebb18dd94b141151622935d84faf" => :high_sierra
@@ -10,99 +10,103 @@ class Smlnj < Formula
     sha256 "1b3e5a9a3f7583f3920f36f99726578be29f943eda6bee9e61e08257ea5beab1" => :el_capitan
   end
 
+  # Mojave doesn't support 32-bit builds, and thus smlnj fails to compile.
+  # This will only be safe to remove when upstream support 64-bit builds.
+  depends_on MaximumMacOSRequirement => :high_sierra
+
   resource "cm" do
-    url "https://www.smlnj.org/dist/working/110.82/cm.tgz"
-    sha256 "682fd43ef9021bb3beb62cc95fc60b47b4bf79458f4e3ca20029f1e1d57db207"
+    url "https://www.smlnj.org/dist/working/110.83/cm.tgz"
+    sha256 "89ccb520252097d83b8bdd70acc6f8bfbb662880f71bd0e516518c390454b2ca"
   end
 
   resource "compiler" do
-    url "https://www.smlnj.org/dist/working/110.82/compiler.tgz"
-    sha256 "f7fb742608efa1ef4ed34a8791a1014c831708faa83e11d47f9d4242fbd69862"
+    url "https://www.smlnj.org/dist/working/110.83/compiler.tgz"
+    sha256 "4887d767566a2dc5276315ae51c84ae4d2317523c0683f91c7df7e8a4300b463"
   end
 
   resource "runtime" do
-    url "https://www.smlnj.org/dist/working/110.82/runtime.tgz"
-    sha256 "39cff4308c4dea8ae59883be651478a49174ff0473edb67ff46420aaa2cddb71"
+    url "https://www.smlnj.org/dist/working/110.83/runtime.tgz"
+    sha256 "0254a24e4438a4b19e4d97a44306d0aa3063dfc5ab2606c7efaa664778c47173"
   end
 
   resource "system" do
-    url "https://www.smlnj.org/dist/working/110.82/system.tgz"
-    sha256 "dee67036542d4cd0cbe18cb323db45de41083fc988f10e26c5c467c69f0d7321"
+    url "https://www.smlnj.org/dist/working/110.83/system.tgz"
+    sha256 "1d30c9e7ff386b7f09b98863c3778e2a008c9404a50d20f105f3d3dfb950f091"
   end
 
   resource "bootstrap" do
-    url "https://www.smlnj.org/dist/working/110.82/boot.x86-unix.tgz"
-    sha256 "89e66f5a7fe7c811877d3cec4c1e3e4eb909ecca905248c2bf5f7105e2a4f9a5"
+    url "https://www.smlnj.org/dist/working/110.83/boot.x86-unix.tgz"
+    sha256 "5830522e5981ba9fb6d01201db53f26285e6a251bedaf9dd87db0b9edf540b09"
   end
 
   resource "mlrisc" do
-    url "https://www.smlnj.org/dist/working/110.82/MLRISC.tgz"
-    sha256 "fb5b7e781ae2b7aef2c873bb778c08dad99b816e98d737116b79e7210213fbf2"
+    url "https://www.smlnj.org/dist/working/110.83/MLRISC.tgz"
+    sha256 "1842f9c6db8aa3e685af5b3fa73ab1162b3ce4aefb28a9d1b46f070564152455"
   end
 
   resource "lib" do
-    url "https://www.smlnj.org/dist/working/110.82/smlnj-lib.tgz"
-    sha256 "2c008ebea14d193ecea4969dcff7001b107ec724bc05562b7dde1e3dd5d4d1ae"
+    url "https://www.smlnj.org/dist/working/110.83/smlnj-lib.tgz"
+    sha256 "eabb1eee5a4ca09bc5d244625c1a58ad51199df682c572a322b296921d3b2364"
   end
 
   resource "ckit" do
-    url "https://www.smlnj.org/dist/working/110.82/ckit.tgz"
-    sha256 "3db4e2aa95002698096b2e90c1979fedebb5c3ab0feacc374c0dfecbcb953632"
+    url "https://www.smlnj.org/dist/working/110.83/ckit.tgz"
+    sha256 "6ab5db28b154c925e538b6cde886d7e0eee0bff24a3e01b950a2bfbdc8866921"
   end
 
   resource "nlffi" do
-    url "https://www.smlnj.org/dist/working/110.82/nlffi.tgz"
-    sha256 "7789f2c2e2aee03664e69414385f09356a8779c4cf1af74caa8a49f1d913df6b"
+    url "https://www.smlnj.org/dist/working/110.83/nlffi.tgz"
+    sha256 "eabcb899e9d16720ce2f44dda074236691aa5dacac05af8741a288e0d2c2dd5b"
   end
 
   resource "cml" do
-    url "https://www.smlnj.org/dist/working/110.82/cml.tgz"
-    sha256 "092399af4825f0c352ed1cfe783bb42a44853fa8798bf8463e4279e41758d2ff"
+    url "https://www.smlnj.org/dist/working/110.83/cml.tgz"
+    sha256 "28e9bff3598dfa0bc58b7aa4d9031509109fbb3b2bb17fc389f4f7c669d531d9"
   end
 
   resource "exene" do
-    url "https://www.smlnj.org/dist/working/110.82/eXene.tgz"
-    sha256 "7a32f77ceefef8c69c38aa9599b777fa073c68dcfb142165f5116f476174381a"
+    url "https://www.smlnj.org/dist/working/110.83/eXene.tgz"
+    sha256 "569f39e2468c1fd699092272cfe5f56e5d6d7a010f17881061d242d443f0d508"
   end
 
   resource "ml-lpt" do
-    url "https://www.smlnj.org/dist/working/110.82/ml-lpt.tgz"
-    sha256 "fd107fcc3c51aa44b59f464bfb92bfff22131b18ddee29f361d01765f51ff286"
+    url "https://www.smlnj.org/dist/working/110.83/ml-lpt.tgz"
+    sha256 "ec9f407659fca997fb0714edafd4079e8d356463f9e6b7cdf787b6bf8b35fdec"
   end
 
   resource "ml-lex" do
-    url "https://www.smlnj.org/dist/working/110.82/ml-lex.tgz"
-    sha256 "de7699715b0bbe1e9b67aa5bea5515dfe6aa0e5b2e74abe1f97168a8ad6a0ab5"
+    url "https://www.smlnj.org/dist/working/110.83/ml-lex.tgz"
+    sha256 "beb1ef366db2034966eb9832bf6f8168513f58f18f34b38a6b7ab92f960b2e7e"
   end
 
   resource "ml-yacc" do
-    url "https://www.smlnj.org/dist/working/110.82/ml-yacc.tgz"
-    sha256 "1ef667a170fa9c3ec87345f53b7579842c93342b4af8f8c10993551b55f4a366"
+    url "https://www.smlnj.org/dist/working/110.83/ml-yacc.tgz"
+    sha256 "2789f4f7b1e1b6ac0874d2232ea4d7aa44adccb655934227058b3153f9be2607"
   end
 
   resource "ml-burg" do
-    url "https://www.smlnj.org/dist/working/110.82/ml-burg.tgz"
-    sha256 "7f9c300c2553bf95be7f8275bf159bfb1ac7c7e24a9921b375be15c8d6606ae9"
+    url "https://www.smlnj.org/dist/working/110.83/ml-burg.tgz"
+    sha256 "11e079d7ac5dde5e67457480053cd0e37dac343cb35fb0a7135df2bbb48426c5"
   end
 
   resource "pgraph" do
-    url "https://www.smlnj.org/dist/working/110.82/pgraph.tgz"
-    sha256 "ef40f8386f7fa138b7d5eb93ca3bf86abc072b564f9713f14755cd2b5e404ed9"
+    url "https://www.smlnj.org/dist/working/110.83/pgraph.tgz"
+    sha256 "a81a664aef82ad1f336cd9b320d1cd5351abb9bfd915f0179a62054508df6c0b"
   end
 
   resource "trace-debug-profile" do
-    url "https://www.smlnj.org/dist/working/110.82/trace-debug-profile.tgz"
-    sha256 "37a11feacb6ecd9e3d5a727fdd1bd2d0d908f25a03642f42b42bc61839bb29bf"
+    url "https://www.smlnj.org/dist/working/110.83/trace-debug-profile.tgz"
+    sha256 "1cb5559445805017f16f56df348e7e5c75352e060a8a43ea600e4300cab59a14"
   end
 
   resource "heap2asm" do
-    url "https://www.smlnj.org/dist/working/110.82/heap2asm.tgz"
-    sha256 "1751fe8f0b706181a55f109f2bd1292a406b72d09875df0a9fae727c27742554"
+    url "https://www.smlnj.org/dist/working/110.83/heap2asm.tgz"
+    sha256 "bf8a2fee9b1b345418b5252b05f059133afd3849b949b0249a7e9635fca43813"
   end
 
   resource "c" do
-    url "https://www.smlnj.org/dist/working/110.82/smlnj-c.tgz"
-    sha256 "f879f5354846b84ca3196dbd3ab99615f2a936cfaaa37470f083fa72beeededa"
+    url "https://www.smlnj.org/dist/working/110.83/smlnj-c.tgz"
+    sha256 "5974c86a9fda680247ad69b8afc8d3bd32831b8256ce64a231a5dcdefcb793fb"
   end
 
   def install


### PR DESCRIPTION
The `-mmacosx-version-min=10.14` below is my doing as part of testing this, but the rest fails whatever I take a whack at here so we're bringing `MaximumMacOSRequirement`s back into fashion 🎉. Handled a version bump whilst I was here, because why not.

```
cc -m32 -std=c99 -g -O2 -D_DARWIN_C_SOURCE -mmacosx-version-min=10.14 -DHOST_X86 -DTARGET_X86 -DOPSYS_UNIX -DOPSYS_DARWIN -DGNU_ASSEMBLER -DDLOPEN -DINDIRECT_CFUNC -I../config -I../objs -I../include -o gen-sizes ../config/gen-sizes.c gen-common.o
Undefined symbols for architecture i386:
  "___stderrp", referenced from:
      _main in gen-sizes-742a70.o
      _OpenFile in gen-common.o
      _main in gen-sizes-742a70.o
      _OpenFile in gen-common.o
  "_exit", referenced from:
      _main in gen-sizes-742a70.o
      _OpenFile in gen-common.o
  "_fclose", referenced from:
      _CloseFile in gen-common.o
  "_fopen$DARWIN_EXTSN", referenced from:
      _OpenFile in gen-common.o
  "_fprintf", referenced from:
      _main in gen-sizes-742a70.o
      _OpenFile in gen-common.o
      _CloseFile in gen-common.o
  "_fwrite$UNIX2003", referenced from:
      _main in gen-sizes-742a70.o
      _OpenFile in gen-common.o
      _CloseFile in gen-common.o
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [gen-sizes] Error 1
make: *** [all] Error 2
config/install.sh: !!! Run-time system build failed for some reason.
```