### PR TITLE
Increase plist file limit for mysql and mariadb

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -167,6 +167,11 @@ class Mariadb < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{var}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mariadb@10.0.rb
+++ b/Formula/mariadb@10.0.rb
@@ -152,6 +152,11 @@ class MariadbAT100 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{var}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mariadb@10.1.rb
+++ b/Formula/mariadb@10.1.rb
@@ -161,6 +161,11 @@ class MariadbAT101 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{var}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -161,6 +161,11 @@ class MariadbAT102 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{var}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -168,6 +168,11 @@ class Mysql < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{datadir}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -159,6 +159,11 @@ class MysqlAT55 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{datadir}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -159,6 +159,11 @@ class MysqlAT56 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{datadir}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -161,6 +161,11 @@ class MysqlAT57 < Formula
       <true/>
       <key>WorkingDirectory</key>
       <string>#{datadir}</string>
+      <key>SoftResourceLimits</key>
+      <dict>
+      <key>NumberOfFiles</key>
+        <integer>4096</integer>
+      </dict>
     </dict>
     </plist>
   EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I have a bunch of mysql databases and tables, and today I encountered errors because of it. After some debugging, I saw the following in the error log:

```
$ tail /usr/local/var/mysql/Stefans-MacBook-Pro.local.err
[...]

2018-08-29T21:42:24.268808Z 0 [Warning] File Descriptor 1296 exceeded FD_SETSIZE=1024
```

Here's how many files are in there:
```
$ find /usr/local/var/mysql/ -type f | wc -l
    1424
```

Adding `NumberOfFiles` to the plist seems to have fixed it. I decided to add it to all mysql and mariadb variants.

Please let me know if I made any mistake! :)