### PR TITLE
mobiledevice: restore support for >= High Sierra

### DIFF
--- a/Formula/mobiledevice.rb
+++ b/Formula/mobiledevice.rb
@@ -13,9 +13,15 @@ class Mobiledevice < Formula
     sha256 "19eb775bc12305341abe780c06308cf32f5fd6060227fefa4cd0f2ef28a3dae2" => :mountain_lion
   end
 
-  depends_on MaximumMacOSRequirement => :sierra
+  # Upstream is pretty dead but this is a simple change
+  # that permits building on newer versions of macOS.
+  patch do
+    url "https://github.com/imkira/mobiledevice/pull/20.patch?full_index=1"
+    sha256 "adb46783a6cce1e988e2efd3440e2991ac5c5ce55f59b9049c9ccc2936ae8a02"
+  end
 
   def install
+    (buildpath/"symlink_framework.sh").chmod 0555
     system "make", "install", "CC=#{ENV.cc}", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This still does decent usage numbers despite lacking support for High Sierra, so I'm keen to keep this around & restore full support to the formula.