### PR TITLE
Download allure from github releases

### DIFF
--- a/Formula/allure.rb
+++ b/Formula/allure.rb
@@ -2,6 +2,7 @@ class Allure < Formula
   desc "Flexible lightweight test report tool"
   homepage "https://github.com/allure-framework/allure2"
   url "https://github.com/allure-framework/allure2/releases/download/2.7.0/allure-2.7.0.zip"
+  sha256 "https://github.com/allure-framework/allure2/releases/download/2.7.0/allure-2.7.0.zip"
 
   bottle :unneeded
 

--- a/Formula/allure.rb
+++ b/Formula/allure.rb
@@ -1,8 +1,7 @@
 class Allure < Formula
   desc "Flexible lightweight test report tool"
   homepage "https://github.com/allure-framework/allure2"
-  url "https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/2.7.0/allure-2.7.0.zip"
-  sha256 "9408ff5c11abda7491431539b38a724689b2172a1fdd1b1dacca5f4ab77a402b"
+  url "https://github.com/allure-framework/allure2/releases/download/2.7.0/allure-2.7.0.zip"
 
   bottle :unneeded
 

--- a/Formula/allure.rb
+++ b/Formula/allure.rb
@@ -2,7 +2,7 @@ class Allure < Formula
   desc "Flexible lightweight test report tool"
   homepage "https://github.com/allure-framework/allure2"
   url "https://github.com/allure-framework/allure2/releases/download/2.7.0/allure-2.7.0.zip"
-  sha256 "https://github.com/allure-framework/allure2/releases/download/2.7.0/allure-2.7.0.zip"
+  sha256 "5e0a979f3060c05610ba1168e4b1ff1a9e85d85098f41c49bbf74594acf58a0c"
 
   bottle :unneeded
 


### PR DESCRIPTION
Bintray URL is dead, so download zip from GitHub releases URL, see: [allure#832](https://github.com/allure-framework/allure2/issues/832)