### PR TITLE
ruby: enhance compatibility for older macOS

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -56,6 +56,7 @@ class Ruby < Formula
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
       --with-opt-dir=#{paths.join(":")}
+      ac_cv_func_clock_gettime=no
     ]
     args << "--disable-dtrace" unless MacOS::CLT.installed?
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`clock_gettime()` is a function that was implemented in macOS 10.12, and as such, programs that use it [cannot run on 10.11 and below](https://github.com/GooborgStudios/synglechance/issues/30). Ruby uses this function, however it can be disabled using an argument.  This patch is meant to disable `clock_gettime()` so that Ruby versions compiled on 10.12 and above can still support 10.11 and below.