### PR TITLE
ruby: ignore global gem cache in `test`

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -193,9 +193,13 @@ class Ruby < Formula
   test do
     hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
     assert_equal "hello\n", hello_text
+
     ENV["GEM_HOME"] = testpath
+    ENV["GEM_SPEC_CACHE"] = testpath/"specs"
     system "#{bin}/gem", "install", "json"
 
+    ENV["BUNDLE_PATH"] = testpath
+    ENV["BUNDLE_DISABLE_SHARED_GEMS"] = "true"
     (testpath/"Gemfile").write <<~EOS
       source 'https://rubygems.org'
       gem 'gemoji'

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -17,7 +17,7 @@ class Ruby < Formula
   end
 
   head do
-    url "https://svn.ruby-lang.org/repos/ruby/trunk/"
+    url "https://github.com/ruby/ruby.git"
     depends_on "autoconf" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

On Mojave,

```
==> /usr/local/bin/bundle install --binstubs=/private/tmp/ruby-test-20180902-83862-3nemqf/bin
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 1.16.1
Fetching gemoji 3.0.0
Bundler::GemspecError: Could not read gem at
/private/tmp/ruby-test-20180902-83862-3nemqf/cache/gemoji-3.0.0.gem. It may be
corrupted.
An error occurred while installing gemoji (3.0.0), and Bundler cannot continue.
Make sure that `gem install gemoji -v '3.0.0'` succeeds before bundling.

In Gemfile:
  gemoji
```

Just want to find out whether the gem cache on those Mojave nodes is corrupted.