### PR TITLE
cmdshelf 2.0.0 (new formula)

### DIFF
--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -13,7 +13,7 @@ class Cmdshelf < Formula
   end
 
   test do
-    system "#{bin}/cmdshelf remote add test git@github.com:toshi0383/scripts.git"
+    system "#{bin}/cmdshelf", "remote", "add", "test", "git@github.com:toshi0383/scripts.git"
     list_output = shell_output("#{bin}/cmdshelf remote list").chomp
     assert_equal "test:git@github.com:toshi0383/scripts.git", list_output
   end

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -1,0 +1,20 @@
+class Cmdshelf < Formula
+  desc "Better scripting life with cmdshelf 📚"
+  homepage "https://github.com/toshi0383/cmdshelf"
+  url "https://github.com/toshi0383/cmdshelf/archive/2.0.0.tar.gz"
+  sha256 "3edb610cb512e147aa32e3e27e4c2d01a18ef738626304c42751c16a5b0fe309"
+  head "https://github.com/toshi0383/cmdshef.git"
+
+  depends_on "rust" => :build
+
+  def install
+    ENV["SHELL_COMPLETIONS_DIR"] = buildpath
+    system "cargo", "install", "--root", prefix, "--path", "."
+    man.install "docs/man"
+    bash_completion.install "cmdshelf-completion.bash"
+  end
+
+  test do
+    assert_equal "2.0.0", shell_output("#{bin}/cmdshelf --version").chomp
+  end
+end

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -7,7 +7,6 @@ class Cmdshelf < Formula
   depends_on "rust" => :build
 
   def install
-    ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", "--root", prefix, "--path", "."
     man.install Dir["docs/man/*"]
     bash_completion.install "cmdshelf-completion.bash"

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -13,6 +13,8 @@ class Cmdshelf < Formula
   end
 
   test do
-    assert_equal "2.0.0", shell_output("#{bin}/cmdshelf --version").chomp
+    system "#{bin}/cmdshelf remote add test git@github.com:toshi0383/scripts.git"
+    list_output = shell_output("#{bin}/cmdshelf remote list").chomp
+    assert_equal "test:git@github.com:toshi0383/scripts.git", list_output
   end
 end

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -1,16 +1,15 @@
 class Cmdshelf < Formula
-  desc "Better scripting life with cmdshelf 📚"
+  desc "Better scripting life with cmdshelf"
   homepage "https://github.com/toshi0383/cmdshelf"
   url "https://github.com/toshi0383/cmdshelf/archive/2.0.0.tar.gz"
   sha256 "3edb610cb512e147aa32e3e27e4c2d01a18ef738626304c42751c16a5b0fe309"
-  head "https://github.com/toshi0383/cmdshef.git"
 
   depends_on "rust" => :build
 
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", "--root", prefix, "--path", "."
-    man.install "docs/man"
+    man.install Dir["docs/man/*"]
     bash_completion.install "cmdshelf-completion.bash"
   end
 


### PR DESCRIPTION
Creates a new formula for `cmdshelf`, a scripts manager for general use.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?