### PR TITLE
travis: check whether `fgrep` matches `/usr/bin/fgrep` in `test`

### DIFF
--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -121,5 +121,7 @@ class Travis < Formula
     assert_match "valid", output
     output = shell_output("#{bin}/travis init 2>&1", 1)
     assert_match "Can't figure out GitHub repo name", output
+
+    assert_match shell_output("fgrep --version"), shell_output("/usr/bin/fgrep --version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Just want to verify the situation mentioned in Homebrew/brew#4800.