### PR TITLE
Adding --gui mode to octave

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -54,6 +54,8 @@ class Octave < Formula
   depends_on "texinfo"
   depends_on "veclibfort"
 
+  depends_on "qt" => :optional
+
   # Dependencies use Fortran, leading to spurious messages about GCC
   cxxstdlib_check :skip
 
@@ -63,6 +65,9 @@ class Octave < Formula
     # cause linking problems.
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
 
+    args = []
+    args << "--without-qt" if build.without? "qt"
+
     system "./bootstrap" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
@@ -71,13 +76,13 @@ class Octave < Formula
                           "--enable-shared",
                           "--disable-static",
                           "--without-osmesa",
-                          "--without-qt",
                           "--with-hdf5-includedir=#{Formula["hdf5"].opt_include}",
                           "--with-hdf5-libdir=#{Formula["hdf5"].opt_lib}",
                           "--with-x=no",
                           "--with-blas=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort",
                           "--with-portaudio",
-                          "--with-sndfile"
+                          "--with-sndfile",
+                          *args
     system "make", "all"
 
     # Avoid revision bumps whenever fftw's or gcc's Cellar paths change


### PR DESCRIPTION
This adds GUI support to HomeBrew's Octave. It was originally discussed in #15986, but at the time (Octave 4.2) it required several patches to support and a special Qt version. Now it is supported in Octave 4.4 by default.

Note that if you actually run `octave --gui`, then (at least for me) it works fine but then hangs when you try to exit. This is an [upstream problem](https://savannah.gnu.org/bugs/?50025), and not a fault of the build, I believe. Hopefully making it easier to activate support for the GUI will also make it easier to debug upstream.