### PR TITLE
jump: add man page for j

### DIFF
--- a/Formula/jump.rb
+++ b/Formula/jump.rb
@@ -22,6 +22,7 @@ class Jump < Formula
 
     system "go", "build", "-o", "#{bin}/jump"
     man1.install "man/jump.1"
+    man1.install "man/j.1"
   end
 
   test do


### PR DESCRIPTION
The jump formula is used through the `j` helper shell function. We have
a man page for it as well.
