### PR TITLE
gdal: Add zstandard compression support

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -3,7 +3,7 @@ class Gdal < Formula
   homepage "https://www.gdal.org/"
   url "https://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.xz"
   sha256 "9c4625c45a3ee7e49a604ef221778983dd9fd8104922a87f20b99d9bedb7725a"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "5fa9c5dde1d07ca4b273bb39eba94e7e10060299ce3784777d8d5689781c3586" => :mojave
@@ -40,6 +40,7 @@ class Gdal < Formula
   depends_on "python"
   depends_on "python@2"
   depends_on "sqlite" # To ensure compatibility with SpatiaLite
+  depends_on "zstd"
 
   depends_on "mysql" => :optional
 
@@ -92,6 +93,7 @@ class Gdal < Formula
       "--with-spatialite=#{Formula["libspatialite"].opt_prefix}",
       "--with-sqlite3=#{Formula["sqlite"].opt_prefix}",
       "--with-static-proj4=#{Formula["proj"].opt_prefix}",
+      "--with-zstd=#{Formula["zstd"].opt_prefix}",
 
       # Explicitly disable some features
       "--without-grass",


### PR DESCRIPTION
Adds zstandard compression support via a dependency on the existing `zstd` brew formula.

Background: http://osgeo-org.1560.x6.nabble.com/gdal-dev-ZSTD-compression-for-GeoTIFF-td5354009.html

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
