### PR TITLE
pgFormatter: Added head url

### DIFF
--- a/Formula/pgformatter.rb
+++ b/Formula/pgformatter.rb
@@ -3,6 +3,7 @@ class Pgformatter < Formula
   homepage "https://sqlformat.darold.net/"
   url "https://github.com/darold/pgFormatter/archive/v3.0.tar.gz"
   sha256 "8cf2452d0e4a6448e86b80e9a0dbc9252729544150f3141d14192e33bc86fedb"
+  head "https://github.com/darold/pgFormatter.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

pgFormatter is updated quite often, but new releases are created only very rarely. This commit adds the [head url](https://github.com/darold/pgFormatter) to the pgFormatter formula.

With kind regards,
Philip Trauner