### PR TITLE
Make curl compile with Lion.

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -37,7 +37,7 @@ class Curl < Formula
   # HTTP/2 support requires OpenSSL 1.0.2+ or LibreSSL 2.1.3+ for ALPN Support
   # which is currently not supported by Secure Transport (DarwinSSL).
   if MacOS.version < :mountain_lion || build.with?("nghttp2")
-    ENV['CFLAGS']='-mmacosx-version-min=10.7'
+    ENV["CFLAGS"]="-mmacosx-version-min=10.7"
     depends_on "openssl"
   else
     option "with-openssl", "Build with OpenSSL instead of Secure Transport"

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -53,9 +53,8 @@ class Curl < Formula
   def install
     system "./buildconf" if build.head?
 
-  if MacOS.version < :mountain_lion
-    ENV["CFLAGS"]="-mmacosx-version-min=10.7"
-  end
+    # Allow to build on Lion, lowering from the upstream setting of 10.8
+    ENV.append_to_cflags "-mmacosx-version-min=10.7" if MacOS.version <= :lion
 
     args = %W[
       --disable-debug

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -37,7 +37,6 @@ class Curl < Formula
   # HTTP/2 support requires OpenSSL 1.0.2+ or LibreSSL 2.1.3+ for ALPN Support
   # which is currently not supported by Secure Transport (DarwinSSL).
   if MacOS.version < :mountain_lion || build.with?("nghttp2")
-    ENV["CFLAGS"]="-mmacosx-version-min=10.7"
     depends_on "openssl"
   else
     option "with-openssl", "Build with OpenSSL instead of Secure Transport"
@@ -53,6 +52,10 @@ class Curl < Formula
 
   def install
     system "./buildconf" if build.head?
+
+  if MacOS.version < :mountain_lion
+    ENV["CFLAGS"]="-mmacosx-version-min=10.7"
+  end
 
     args = %W[
       --disable-debug

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -37,6 +37,7 @@ class Curl < Formula
   # HTTP/2 support requires OpenSSL 1.0.2+ or LibreSSL 2.1.3+ for ALPN Support
   # which is currently not supported by Secure Transport (DarwinSSL).
   if MacOS.version < :mountain_lion || build.with?("nghttp2")
+    ENV['CFLAGS']='-mmacosx-version-min=10.7'
     depends_on "openssl"
   else
     option "with-openssl", "Build with OpenSSL instead of Secure Transport"


### PR DESCRIPTION
This is a follow-up to https://github.com/Homebrew/homebrew-core/issues/17567#issuecomment-379583627 – the patch given in this comment *does* work, assuming that you have a working `git` and `curl` program to reach the point of homebrew building curl itself (I use https://try.gitea.io/donbright/lm for that purpose).

Reason is that the curl maintainers raised the deployment version from 10.5 to 10.8 due to problems with `darwinssl`.  However, AFAICS, homebrew uses `openssl` instead, thus deploying 10.7 should be fine.

Cf. https://github.com/curl/curl/commit/d14538d2501ef0da2e15cf98b79889f3eb5f4d5c
