### PR TITLE
'source-hightlight' needs C++11.

### DIFF
--- a/Formula/source-highlight.rb
+++ b/Formula/source-highlight.rb
@@ -16,6 +16,8 @@ class SourceHighlight < Formula
 
   depends_on "boost"
 
+  needs :cxx11
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
I stumbled upon this while compiling with Lion.

I guess that the `needs :cxx11` tag should be added to all packages that depend on `boost`.  Or even better, depending on `boost` should automatically set the `:cxx11` tag.