### PR TITLE
wpscan: now works with multiple Rubies installed

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -33,8 +33,9 @@ class Wpscan < Formula
 
     (bin/"wpscan").write <<~EOS
       #!/bin/bash
-      GEM_HOME=#{libexec} BUNDLE_GEMFILE=#{libexec}/Gemfile \
-        exec #{bundle} exec ruby #{libexec}/wpscan.rb "$@"
+      GEM_HOME="#{libexec}" BUNDLE_GEMFILE="#{libexec}/Gemfile" \\
+        exec "#{bundle}" exec "#{Formula["ruby"].opt_bin}/ruby" \\
+        "#{libexec}/wpscan.rb" "$@"
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes an error that would occur at both post-install and runtime if the frontmost Ruby in the `PATH` is not Homebrew’s Ruby:

```
/usr/local/Cellar/wpscan/2.9.4/libexec/gems/bundler-1.16.4/lib/bundler/spec_set.rb:91:in `block in materialize': Could not find ffi-1.9.25 in any of the sources (Bundler::GemNotFound)
        from /usr/local/Cellar/wpscan/2.9.4/libexec/gems/bundler-1.16.4/lib/bundler/spec_set.rb:85:in `map!'
        from /usr/local/Cellar/wpscan/2.9.4/libexec/gems/bundler-1.16.4/lib/bundler/spec_set.rb:85:in `materialize'
[…]
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:49:in `write': Broken pipe (Errno::EPIPE)
        from /usr/local/Homebrew/Library/Homebrew/utils/fork.rb:49:in `puts'
[…]
        from /usr/local/Homebrew/Library/Homebrew/brew.rb:89:in `<main>'
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall wpscan`
```

The error is in the shim script. It executes `bundle exec ruby`, which causes Bundler to use the frontmost Ruby in the `PATH`, expecting vendored gems to fit that Ruby version.

Because the formula `depends_on "ruby"`, vendored gems are pinned to the version of the Homebrew-installed Ruby at install time. If the Homebrew-installed Ruby is not identical to the frontmost Ruby in the `PATH`, any invocation of `wpscan` will fail, including the one in `post_install`. The same happens if a Ruby version manager like `rbenv` is installed.

The fix is to modify the shim script so it always uses the Homebrew-installed Ruby.
