### PR TITLE
glib.rb: Make it work with Lion.

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -25,6 +25,9 @@ class Glib < Formula
   depends_on "libffi"
   depends_on "pcre"
 
+  # Cocoa detection fails, cf. https://gitlab.gnome.org/GNOME/glib/issues/1381
+  fails_with :gcc if MacOS.version <= :lion
+
   # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
   # but needed to fix an assumption about the location of the d-bus machine
   # id file.


### PR DESCRIPTION
I'm not sure I've coded this right: On Lion, it should _not_ be built with `gcc` (I have actually installed `gcc@7`; `gcc@8` currently fails to build); it should rather be built with the clang compiler that comes with XCode.