### PR TITLE
makensis: pass compiler as SCons arguments

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -48,7 +48,7 @@ class Makensis < Formula
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
       "STRIP=0",
       "VERSION=#{version}",
-      "ZLIB_W32=#{@zlib_path}"
+      "ZLIB_W32=#{@zlib_path}",
     ]
     args << "NSIS_CONFIG_LOG=yes" if build.with? "advanced-logging"
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -11,15 +11,6 @@ class Makensis < Formula
     sha256 "f4516cec938568eb2bea2b162247a10cbd68dedd85c439f5d77170dbc7c5b81b" => :el_capitan
   end
 
-  # From https://nsis.sourceforge.io/Special_Builds#Advanced_logging
-  option "with-advanced-logging", "Enable advanced logging of all installer actions"
-
-  # Build makensis so installers can handle strings > 1024 characters
-  # From https://nsis.sourceforge.io/Special_Builds#Large_strings
-  # Upstream RFE to make this default the default behavior is
-  # https://sourceforge.net/p/nsis/feature-requests/542/
-  option "with-large-strings", "Enable strings up to 8192 characters instead of default 1024"
-
   depends_on "mingw-w64" => :build
   depends_on "scons" => :build
 
@@ -50,8 +41,6 @@ class Makensis < Formula
       "VERSION=#{version}",
       "ZLIB_W32=#{@zlib_path}",
     ]
-    args << "NSIS_CONFIG_LOG=yes" if build.with? "advanced-logging"
-    args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     scons "makensis", *args
     bin.install "build/urelease/makensis/makensis"
     (share/"nsis").install resource("nsis")

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -45,9 +45,14 @@ class Makensis < Formula
       @zlib_path = Dir.pwd
     end
 
-    # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
-    args = ["STRIP=0", "ZLIB_W32=#{@zlib_path}", "SKIPUTILS=NSIS Menu",
-            "PREFIX_DOC=#{share}/nsis/Docs", "VERSION=#{version}"]
+    args = [
+      "PREFIX_DOC=#{share}/nsis/Docs",
+      "SKIPUTILS=NSIS Menu",
+      # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
+      "STRIP=0",
+      "VERSION=#{version}",
+      "ZLIB_W32=#{@zlib_path}"
+    ]
     args << "NSIS_CONFIG_LOG=yes" if build.with? "advanced-logging"
     args << "NSIS_MAX_STRLEN=8192" if build.with? "large-strings"
     scons "makensis", *args
@@ -78,12 +83,12 @@ index a344456..37c575b 100755
 +import os
 +
  Import('defenv')
- 
+
  ### Configuration options
 @@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
  env = Environment()
  cfg.Update(env)
- 
+
 +defenv['CC'] = os.environ['CC']
 +defenv['CXX'] = os.environ['CXX']
 +

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -46,6 +46,8 @@ class Makensis < Formula
     end
 
     args = [
+      "CC=#{ENV.cc}",
+      "CXX=#{ENV.cxx}",
       "PREFIX_DOC=#{share}/nsis/Docs",
       "SKIPUTILS=NSIS Menu",
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
@@ -73,24 +75,3 @@ class Makensis < Formula
     system "#{bin}/makensis", "#{testpath}/test.nsi"
   end
 end
-
-__END__
-diff --git a/SCons/config.py b/SCons/config.py
-index a344456..37c575b 100755
---- a/SCons/config.py
-+++ b/SCons/config.py
-@@ -1,3 +1,5 @@
-+import os
-+
- Import('defenv')
-
- ### Configuration options
-@@ -440,6 +442,9 @@ Help(cfg.GenerateHelpText(defenv))
- env = Environment()
- cfg.Update(env)
-
-+defenv['CC'] = os.environ['CC']
-+defenv['CXX'] = os.environ['CXX']
-+
- def AddValuedDefine(define):
-   defenv.Append(NSIS_CPPDEFINES = [(define, env[define])])

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -34,11 +34,6 @@ class Makensis < Formula
     sha256 "a03fd15af45e91964fb980a30422073bc3f3f58683e9fdafadad3f7db10762b1"
   end
 
-  # scons appears to have no builtin way to override the compiler selection,
-  # and the only options supported on macOS are 'gcc' and 'g++'.
-  # Use the right compiler by forcibly altering the scons config to set these
-  patch :DATA
-
   def install
     # requires zlib (win32) to build utils
     resource("zlib-win32").stage do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR removes the patching of `SCons/config.py` and passes the compiler to SCons as arguments instead