### PR TITLE
cairo: Add devel version (1.15.12)

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -12,6 +12,11 @@ class Cairo < Formula
     sha256 "bec85433a35605164bdbf5f8913e29eb6d9ceb5acc5569dd9d864706ae6c8d49" => :el_capitan
   end
 
+  devel do
+    url "https://cairographics.org/snapshots/cairo-1.15.12.tar.xz"
+    sha256 "7623081b94548a47ee6839a7312af34e9322997806948b6eec421a8c6d0594c9"
+  end
+
   head do
     url "https://anongit.freedesktop.org/git/cairo", :using => :git
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

e.g. `librsvg` needs at least Cairo 1.15.4 and doesn't work with the 1.14.x release line.
