### PR TITLE
Recommend --new-formula on existing formulae

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ First time contributing to Homebrew? Read our [Code of Conduct](https://github.c
 
 * `brew edit foo` and make edits
 * leave the [`bottle`](http://www.rubydoc.info/github/Homebrew/brew/master/Formula#bottle-class_method) as-is
-* `brew uninstall --force foo`, `brew install --build-from-source foo`, `brew test foo`, and `brew audit --strict foo`
+* `brew uninstall --force foo`, `brew install --build-from-source foo`, `brew test foo`, and `brew audit --new-formula --strict foo`
 * `git commit` with message formatted `foo: <insert details>`
 * [open a pull request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) and fix any failing tests
 


### PR DESCRIPTION
For existing formulae that are being edited, `brew audit --new-formula --strict foo` should be run to make sure the the style is correct moving forward.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-----