### PR TITLE
gcc@4.9, gcc@5: make `pour_bottle` consistent

### DIFF
--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -76,8 +76,9 @@ class GccAT49 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  def pour_bottle?
-    MacOS::CLT.installed?
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
   end
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -50,8 +50,9 @@ class GccAT5 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  def pour_bottle?
-    MacOS::CLT.installed?
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
   end
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
16 formulae have `pour_bottle?` but these two use `def pour_bottle?` rather than `pour_bottle? do`.