### PR TITLE
ffmbc: use different source tarball

### DIFF
--- a/Formula/ffmbc.rb
+++ b/Formula/ffmbc.rb
@@ -1,9 +1,10 @@
 class Ffmbc < Formula
   desc "FFmpeg customized for broadcast and professional usage"
   homepage "https://code.google.com/p/ffmbc/"
-  url "https://drive.google.com/uc?export=download&id=0B0jxxycBojSwTEgtbjRZMXBJREU"
-  version "0.7.2"
-  sha256 "caaae2570c747077142db34ce33262af0b6d0a505ffbed5c4bdebce685d72e42"
+  # Original URL is: https://drive.google.com/uc?export=download&id=0B0jxxycBojSwTEgtbjRZMXBJREU
+  # whose content is identical to the github link below
+  url "https://github.com/darealshinji/ffmbc/archive/v0.7.2.tar.gz"
+  sha256 "0a3807160ba0701225bfe9cfcae8fba662990f46932b2eb105e434c751c8944f"
   revision 6
 
   bottle do


### PR DESCRIPTION
Brew does not recognise `ffmbc`'s URL as a tarball, thus failing to build. I couldn't find an exact mirror for this `.tar.bz2` file, so I am proposing that we move to this `.tar.gz` tarball found mirrored by another user on Github. I can confirm its content is exactly equivalent to that of the `ffmbc` upstream.

Fixes #31738

I found it is the "least bad" approach, though I don't like it. Happy to get others' opinion on it.