### PR TITLE
logentries: revision after retag

### DIFF
--- a/Formula/logentries.rb
+++ b/Formula/logentries.rb
@@ -4,7 +4,8 @@ class Logentries < Formula
   desc "Utility for access to logentries logging infrastructure"
   homepage "https://logentries.com/doc/agent/"
   url "https://github.com/rapid7/le/archive/v1.4.43.tar.gz"
-  sha256 "e0f5c18600209bfcd5c5bfae5f8f02fc78fad3a4d6185f8c432b07c4aa5956f7"
+  sha256 "a2ee2eeb3f2e94e9c1c58f86d0206c688cc5332921d88e48e475b54da3b3e3ef"
+  revision 1
   head "https://github.com/rapid7/le.git"
 
   bottle do


### PR DESCRIPTION
Upstream retagged version 1.4.43: https://github.com/rapid7/le/commit/c1a8441384b306884ee0da8c8035b2d1f8d8c3bf

#31779