### PR TITLE
soci: fix mysql dependency handling.

### DIFF
--- a/Formula/soci.rb
+++ b/Formula/soci.rb
@@ -1,8 +1,8 @@
 class Soci < Formula
   desc "Database access library for C++"
   homepage "https://soci.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/soci/soci/soci-3.2.3/soci-3.2.3.zip"
-  sha256 "ab0f82873b0c5620e0e8eb2ff89abad6517571fd63bae4bdcac64dd767ac9a05"
+  url "https://github.com/SOCI/soci/archive/3.2.3.tar.gz"
+  sha256 "1166664d5d7c4552c4c2abf173f98fa4427fbb454930fd04de3a39782553199e"
 
   bottle do
     sha256 "2e20ceced92132166cffae968a007d5150a6e620c1059e54e82ae0938eaf42ed" => :mojave
@@ -21,6 +21,12 @@ class Soci < Formula
   depends_on "cmake" => :build
   depends_on "boost" => [:build, :optional]
   depends_on "sqlite" if MacOS.version <= :snow_leopard
+  depends_on "mysql-client" if build.with?("mysql")
+
+  patch do
+    url "https://github.com/SOCI/soci/commit/165737c4be7d6c9acde92610b92e8f42a4cfe933.diff?full_index=1"
+    sha256 "29e90baac2d8fa3412485352b0c0ce393cd3a482b951268833ae1dc32336ae0e"
+  end
 
   fails_with :clang do
     build 421
@@ -28,7 +34,8 @@ class Soci < Formula
   end
 
   def install
-    args = std_cmake_args + %w[.. -DWITH_SQLITE3:BOOL=ON]
+    args = std_cmake_args + %w[../src -DWITH_SQLITE3:BOOL=ON]
+    args += %W[-DMYSQL_DIR=#{Formula["mysql-client"].opt_prefix}] if build.with?("mysql")
 
     %w[boost mysql oracle odbc pg].each do |arg|
       arg_var = (arg == "pg") ? "postgresql" : arg


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`brew audit --strict soci` fails with
```
soci:
  * C: 1: col 1: A `test do` test block should be added
  * `Use :optional` or `:recommended` instead of `depends_on "mysql-client" if build.with?("mysql")`
```

-----

This PR makes soci with mysql support buildable with a new toolchain. Because mysql-client is a keg-only formula, soci build would not find mysql libraries and an installation `--with-mysql` would not actually produce the needed soci libs. Passing `-DMYSQL_DIR` to CMake is the most reliable way to link these two formulas together.

The PR also includes a patch to fix mysql backend compilation. The version 3.2.3 is 3 years old and compiler warnings have evolved a lot in the meantime. soci builds with `-werror`, and once mysql libs were actually found, the build would fail because of an errorenous order comparison between a pointer and 0. This was [fixed upstream soon after 3.2.3 release](https://github.com/SOCI/soci/commit/165737c4be7d6c9acde92610b92e8f42a4cfe933), but no commits have been tagged since.

-----

I've changed the source archive from a SourceForge release (+ inline patch) to a GitHub release (+ hosted patch) because the former was based on CRLF line feeds and the inline patch was mangled when git-checked out on Jenkins machines (CRLF were converted to LF and the hunk no longer applied).