### PR TITLE
mage 1.4.0 (new formula)

### DIFF
--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -8,7 +8,7 @@ class Mage < Formula
   depends_on "go"
 
   def install
-    ENV["GOPATH"] = buildpath
+    ENV["GOPATH"] = prefix
     (buildpath/"src/github.com/magefile/mage").install buildpath.children
 
     cd "src/github.com/magefile/mage" do
@@ -16,8 +16,6 @@ class Mage < Formula
       system "go", "run", "bootstrap.go"
       prefix.install_metafiles
     end
-
-    bin.install buildpath/"bin/mage"
   end
 
   test do

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -9,13 +9,7 @@ class Mage < Formula
 
   def install
     ENV["GOPATH"] = prefix
-    (buildpath/"src/github.com/magefile/mage").install buildpath.children
-
-    cd "src/github.com/magefile/mage" do
-      # bootstraps itself without the need of another mage version installed
-      system "go", "run", "bootstrap.go"
-      prefix.install_metafiles
-    end
+    system "go", "run", "bootstrap.go"
   end
 
   test do

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -1,0 +1,38 @@
+class Mage < Formula
+  desc "Make/rake-like build tool using Go"
+  homepage "https://magefile.org/"
+  url "https://github.com/magefile/mage.git",
+      :tag => "v1.4.0",
+      :revision => "49bafb86c808d73cabc5353d9ec040745dfab453"
+
+  depends_on "go"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/magefile/mage").install buildpath.children
+
+    cd "src/github.com/magefile/mage" do
+      # bootstraps itself without the need of another mage version installed
+      system "go", "run", "bootstrap.go"
+      prefix.install_metafiles
+    end
+
+    bin.install buildpath/"bin/mage"
+  end
+
+  test do
+    assert_match /^Mage Build Tool v#{version}/, shell_output("#{bin}/mage --version 2>&1")
+
+    (testpath/"magefile.go").write <<~EOS
+      // +build mage
+
+      package main
+      import "fmt"
+      func Build() {
+        fmt.Println("hi build!")
+      }
+    EOS
+    assert_match "hi build!", shell_output("#{bin}/mage build")
+    assert_match "Targets:\n  build    \n", shell_output("#{bin}/mage -l")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This build system is used in the newer releases of the `go` based elastic formulae. Getting this merged would make getting the new build system working as easy as adding a `depends_on "mage" => :build`. (Through getting the OSS only build to work seems still non trivial, but this is a first step toward making it work.) Refs: https://github.com/Homebrew/homebrew-core/pull/28995#issuecomment-419969991
