### PR TITLE
iperf 2.0.12 (change upstream)

### DIFF
--- a/Formula/iperf.rb
+++ b/Formula/iperf.rb
@@ -1,8 +1,8 @@
 class Iperf < Formula
   desc "Tool to measure maximum TCP and UDP bandwidth"
-  homepage "https://iperf.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/iperf/iperf-2.0.5.tar.gz"
-  sha256 "636b4eff0431cea80667ea85a67ce4c68698760a9837e1e9d13096d20362265b"
+  homepage "https://sourceforge.net/projects/iperf2/"
+  url "https://downloads.sourceforge.net/project/iperf2/iperf-2.0.12.tar.gz"
+  sha256 "367f651fb1264b13f6518e41b8a7e08ce3e41b2a1c80e99ff0347561eed32646"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,15 +16,7 @@ class Iperf < Formula
   end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-
-    # Otherwise this definition confuses system headers on 10.13
-    # https://github.com/Homebrew/homebrew-core/issues/14418#issuecomment-324082915
-    if MacOS.version >= :high_sierra
-      inreplace "config.h", "#define bool int", ""
-    end
-
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- iperf2 is no longer maintained by the original maintainers after 2.0.5 in favor of iperf3. iperf3 maintainer's [README](https://github.com/esnet/iperf#changes-from-iperf-2x) and [FAQ](https://software.es.net/iperf/faq.html) points to this new upstream for iperf2. The same FAQ also notes iperf2's continued usefulness today:
  > We recommend using iperf2 for parallel streams.

- Removed the `--disable-debug` flag as I cannot find such option in either 2.0.5 or 2.0.12, only `--enable-debuginfo` (which is not enabled).
- I was able to build this on Mojave 18A384a without the patch for 2.0.5 (#17177) so I removed it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
