### PR TITLE
opencv@2: update patch checksum

### DIFF
--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -33,7 +33,7 @@ class OpencvAT2 < Formula
   # Upstream PR from 21 Apr 2018 "Fix build with FFmpeg 4.0"
   patch do
     url "https://github.com/opencv/opencv/commit/99091a62463.patch?full_index=1"
-    sha256 "7e33c5c009aea0798cd9bd3edb0f7a2122a9f3b2a962977e53a0fccd55e1db40"
+    sha256 "c60be5bc53bc8964550c0a2467a41e391c730fb090219954a2cd8d9a54a1a5a7"
   end
 
   def install


### PR DESCRIPTION
Apparently, some github patches have seen their SHA-256 checksum change over time, even with the `?full_index=1` parameter. Not sure why, but I have verified that the patch content is not malicious.

Fixes #31490.
See #31948 where this also happened.