### PR TITLE
v8 6.9.427.22

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -3,8 +3,8 @@ class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
   url "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-      :revision => "e323bd9d2263bec69e692526123bacfc2cb84b16"
-  version "6.9.427.19" # the version of the v8 checkout, not a depot_tools version
+      :revision => "0425ebd2b395dd754606e3639c296c5619757451"
+  version "6.9.427.22" # the version of the v8 checkout, not a depot_tools version
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR upgrades `v8` to version `6.9.427.22` following the latest Chrome stable update (with some wasm fixes).