### PR TITLE
Remove test options

### DIFF
--- a/Formula/audiofile.rb
+++ b/Formula/audiofile.rb
@@ -34,10 +34,6 @@ class Audiofile < Formula
     depends_on "libtool" => :build
   end
 
-  option "with-test", "Run the test suite during install (~30sec)"
-
-  deprecated_option "with-check" => "with-test"
-
   # These have all been reported upstream but beside
   # 03_CVE-2015-7747 not yet merged or fixed.
   # https://github.com/mpruett/audiofile/issues/31
@@ -75,7 +71,6 @@ class Audiofile < Formula
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
     system configure, *args
     system "make"
-    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 

--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -17,9 +17,6 @@ class Caf < Formula
   needs :cxx11
 
   option "with-opencl", "build with support for OpenCL actors"
-  option "without-test", "skip unit tests (not recommended)"
-
-  deprecated_option "without-check" => "without-test"
 
   depends_on "cmake" => :build
 
@@ -29,7 +26,7 @@ class Caf < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "test" if build.with? "test"
+    system "make", "test"
     system "make", "install"
   end
 

--- a/Formula/freexl.rb
+++ b/Formula/freexl.rb
@@ -3,6 +3,7 @@ class Freexl < Formula
   homepage "https://www.gaia-gis.it/fossil/freexl/index"
   url "https://www.gaia-gis.it/gaia-sins/freexl-sources/freexl-1.0.5.tar.gz"
   sha256 "3dc9b150d218b0e280a3d6a41d93c1e45f4d7155829d75f1e5bf3e0b0de6750d"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,23 +13,17 @@ class Freexl < Formula
     sha256 "a93a9e687fd78a6eb8129896a068f0e982664bf75a06eae236a79fcfbfe0f6ce" => :el_capitan
   end
 
-  option "without-test", "Skip compile-time make checks"
-
-  deprecated_option "without-check" => "without-test"
-
-  depends_on "doxygen" => [:optional, :build]
+  depends_on "doxygen" => :build
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
                           "--disable-silent-rules"
 
-    system "make", "check" if build.with? "test"
+    system "make", "check"
     system "make", "install"
 
-    if build.with? "doxygen"
-      system "doxygen"
-      doc.install "html"
-    end
+    system "doxygen"
+    doc.install "html"
   end
 
   test do

--- a/Formula/ghc@8.2.rb
+++ b/Formula/ghc@8.2.rb
@@ -17,14 +17,9 @@ class GhcAT82 < Formula
 
   keg_only :versioned_formula
 
-  option "with-test", "Verify the build using the testsuite"
-  option "without-docs", "Do not build documentation (including man page)"
-  deprecated_option "tests" => "with-test"
-  deprecated_option "with-tests" => "with-test"
-
   depends_on :macos => :lion
-  depends_on "python" => :build if build.bottle? || build.with?("test")
-  depends_on "sphinx-doc" => :build if build.with? "docs"
+  depends_on "python" => :build if build.bottle?
+  depends_on "sphinx-doc" => :build
 
   resource "gmp" do
     url "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
@@ -119,7 +114,7 @@ class GhcAT82 < Formula
     system "./configure", "--prefix=#{prefix}", *args
     system "make"
 
-    if build.bottle? || build.with?("test")
+    if build.bottle?
       resource("testsuite").stage { buildpath.install Dir["*"] }
       cd "testsuite" do
         system "make", "clean"

--- a/Formula/gnu-smalltalk.rb
+++ b/Formula/gnu-smalltalk.rb
@@ -20,23 +20,20 @@ class GnuSmalltalk < Formula
     sha256 "13a7480553c182dbb8092bd4f215781b9ec871758d1db7045c2d8587e4d1bef9"
   end
 
-  option "with-test", "Verify the build with make check (this may hang)"
   option "with-tcltk", "Build the Tcl/Tk module that requires X11"
 
-  deprecated_option "tests" => "with-test"
-  deprecated_option "with-tests" => "with-test"
   deprecated_option "tcltk" => "with-tcltk"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "libtool"
-  depends_on "pkg-config" => :build
   depends_on "gawk" => :build
-  depends_on "readline"
-  depends_on "gnutls"
+  depends_on "pkg-config" => :build
   depends_on "gdbm"
-  depends_on "libffi" => :recommended
-  depends_on "libsigsegv" => :recommended
+  depends_on "gnutls"
+  depends_on "libffi"
+  depends_on "libsigsegv"
+  depends_on "libtool"
+  depends_on "readline"
   depends_on "glew" => :optional
   depends_on :x11 if build.with? "tcltk"
 
@@ -61,15 +58,12 @@ class GnuSmalltalk < Formula
       args << "--without-tcl" << "--without-tk" << "--without-x"
     end
 
-    # disable generational gc in 32-bit and if libsigsegv is absent
-    if !MacOS.prefer_64_bit? || build.without?("libsigsegv")
-      args << "--disable-generational-gc"
-    end
+    # Disable generational gc in 32-bit
+    args << "--disable-generational-gc" if !MacOS.prefer_64_bit?
 
     system "autoreconf", "-ivf"
     system "./configure", *args
     system "make"
-    system "make", "-j1", "check" if build.with? "test"
     system "make", "install"
   end
 

--- a/Formula/gnuplot@4.rb
+++ b/Formula/gnuplot@4.rb
@@ -17,22 +17,17 @@ class GnuplotAT4 < Formula
   option "with-pdflib-lite", "Build the PDF terminal using pdflib-lite"
   option "with-wxmac", "Build the wxWidgets terminal using pango"
   option "with-cairo", "Build the Cairo based terminals"
-  option "without-lua@5.1", "Build without the lua/TikZ terminal"
-  option "with-test", "Verify the build with make check (1 min)"
-  option "without-emacs", "Do not build Emacs lisp files"
   option "with-aquaterm", "Build with AquaTerm support"
   option "with-x11", "Build with X11 support"
 
-  deprecated_option "without-lua" => "without-lua@5.1"
-
   depends_on "pkg-config" => :build
-  depends_on "lua@5.1" => :recommended
-  depends_on "gd" => :recommended
-  depends_on "readline"
-  depends_on "libpng"
-  depends_on "jpeg"
-  depends_on "libtiff"
   depends_on "fontconfig"
+  depends_on "gd"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "lua@5.1"
+  depends_on "readline"
   depends_on "pango" if (build.with? "cairo") || (build.with? "wxmac")
   depends_on "pdflib-lite" => :optional
   depends_on "wxmac" => :optional
@@ -51,29 +46,24 @@ class GnuplotAT4 < Formula
       inreplace "configure", "-laquaterm", ""
     end
 
-    # Help configure find libraries
-    readline = Formula["readline"].opt_prefix
-    pdflib = Formula["pdflib-lite"].opt_prefix
-    gd = Formula["gd"].opt_prefix
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-readline=#{readline}
+      --with-gd=#{Formula["gd"].opt_prefix}
+      --with-lispdir=#{elisp}
+      --with-readline=#{Formula["readline"].opt_prefix}
       --without-latex
     ]
 
+    pdflib = Formula["pdflib-lite"].opt_prefix
     args << "--with-pdf=#{pdflib}" if build.with? "pdflib-lite"
-    args << (build.with?("gd") ? "--with-gd=#{gd}" : "--without-gd")
 
     if build.without? "wxmac"
       args << "--disable-wxwidgets"
       args << "--without-cairo" if build.without? "cairo"
     end
 
-    args << "--without-lua" if build.without? "lua@5.1"
-    args << (build.with?("emacs") ? "--with-lispdir=#{elisp}" : "--without-lisp-files")
     args << (build.with?("aquaterm") ? "--with-aquaterm" : "--without-aquaterm")
     args << (build.with?("x11") ? "--with-x" : "--without-x")
 
@@ -86,7 +76,6 @@ class GnuplotAT4 < Formula
     system "./configure", *args
     ENV.deparallelize # or else emacs tries to edit the same file with two threads
     system "make"
-    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 

--- a/Formula/google-sparsehash.rb
+++ b/Formula/google-sparsehash.rb
@@ -14,14 +14,10 @@ class GoogleSparsehash < Formula
     sha256 "570c4d250a4fe18d99f11167653a501a1d8a82ff74d2413336a85bc7fa8cbb81" => :mavericks
   end
 
-  option "without-test", "Skip build-time tests (not recommended)"
-
-  deprecated_option "without-check" => "without-test"
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make", "check" if build.with? "test"
+    system "make", "check"
     system "make", "install"
   end
 end

--- a/Formula/jbigkit.rb
+++ b/Formula/jbigkit.rb
@@ -18,20 +18,10 @@ class Jbigkit < Formula
     sha256 "0afb6297101bc3269f0ebca1590cda66a62cbd90e3fdbec38dc011131711d32b" => :mountain_lion
   end
 
-  option "with-test", "Verify the library during install"
-
-  deprecated_option "with-check" => "with-test"
-
   conflicts_with "netpbm", :because => "both install `pbm.5` and `pgm.5` files"
 
   def install
     system "make", "CC=#{ENV.cc}", "CCFLAGS=#{ENV.cflags}"
-
-    if build.with? "test"
-      # It needs j1 to make the tests happen in sequence.
-      ENV.deparallelize
-      system "make", "test"
-    end
 
     cd "pbmtools" do
       bin.install %w[pbmtojbg jbgtopbm pbmtojbg85 jbgtopbm85]

--- a/Formula/libdap.rb
+++ b/Formula/libdap.rb
@@ -19,10 +19,8 @@ class Libdap < Formula
     depends_on "libtool" => :build
   end
 
-  option "without-test", "Skip build-time tests (Not recommended)"
-
-  depends_on "pkg-config" => :build
   depends_on "bison" => :build
+  depends_on "pkg-config" => :build
   depends_on "libxml2"
   depends_on "openssl"
 
@@ -50,7 +48,7 @@ class Libdap < Formula
     system "autoreconf", "-fvi" if build.head?
     system "./configure", *args
     system "make"
-    system "make", "check" if build.with? "test"
+    system "make", "check"
     system "make", "install"
 
     # Ensure no Cellar versioning of libxml2 path in dap-config entries

--- a/Formula/libiscsi.rb
+++ b/Formula/libiscsi.rb
@@ -3,6 +3,7 @@ class Libiscsi < Formula
   homepage "https://github.com/sahlberg/libiscsi"
   url "https://sites.google.com/site/libiscsitarballs/libiscsitarballs/libiscsi-1.18.0.tar.gz"
   sha256 "367ad1514d1640e4e72ca6754275ec226650a128ca108f61a86d766c94d63d23"
+  revision 1
   head "https://github.com/sahlberg/libiscsi.git"
 
   bottle do
@@ -14,23 +15,12 @@ class Libiscsi < Formula
     sha256 "c89e40197b9aebd712c67d43fbe7a4e085ddb7a1b58861c6e98444271fd9e383" => :yosemite
   end
 
-  option "with-noinst", "Install the noinst binaries (examples, tests)"
-  option "with-cunit", "Install iscsi-test-cu, the iSCSI target test suite"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "cunit" => :optional
+  depends_on "cunit"
 
   def install
-    if build.without? "cunit"
-      inreplace "test-tool/Makefile.am", "bin_PROGRAMS =", "noinst_PROGRAMS ="
-    end
-    if build.with? "noinst"
-      # Install the noinst binaries
-      inreplace ["tests/Makefile.am", "examples/Makefile.am"], "noinst_PROGRAMS =", "bin_PROGRAMS ="
-    end
-
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
@@ -39,7 +29,6 @@ class Libiscsi < Formula
 
   test do
     system bin/"iscsi-ls", "--usage"
-    system bin/"iscsi-test-cu", "--list" if build.with? "cunit"
-    system bin/"prog_noop_reply", "--usage" if build.with? "noinst"
+    system bin/"iscsi-test-cu", "--list"
   end
 end

--- a/Formula/libuv.rb
+++ b/Formula/libuv.rb
@@ -13,14 +13,10 @@ class Libuv < Formula
     sha256 "c552a899dc8773720c3c1440dd845d259164933bef0d208ab4c2f9d8c3c92292" => :el_capitan
   end
 
-  option "with-test", "Execute compile time checks (Requires Internet connection)"
-
-  deprecated_option "with-check" => "with-test"
-
-  depends_on "pkg-config" => :build
-  depends_on "automake" => :build
   depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
 
   def install
@@ -37,7 +33,6 @@ class Libuv < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make"
-    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -13,18 +13,13 @@ class Ninja < Formula
     sha256 "675165ce642fa811e1a0a363be0ba66a7b907d46056f89fd20938aa33e7d59f7" => :el_capitan
   end
 
-  option "without-test", "Don't run build-time tests"
-
-  deprecated_option "without-tests" => "without-test"
-
   def install
     system "python", "configure.py", "--bootstrap"
 
-    if build.with? "test"
-      system "./configure.py"
-      system "./ninja", "ninja_test"
-      system "./ninja_test", "--gtest_filter=-SubprocessTest.SetWithLots"
-    end
+    # Quickly test the build
+    system "./configure.py"
+    system "./ninja", "ninja_test"
+    system "./ninja_test", "--gtest_filter=-SubprocessTest.SetWithLots"
 
     bin.install "ninja"
     bash_completion.install "misc/bash-completion" => "ninja-completion.sh"

--- a/Formula/protobuf@2.5.rb
+++ b/Formula/protobuf@2.5.rb
@@ -15,15 +15,11 @@ class ProtobufAT25 < Formula
 
   keg_only :versioned_formula
 
-  # this will double the build time approximately if enabled
-  option "with-test", "Run build-time check"
   option :cxx11
 
   deprecated_option "with-python" => "with-python@2"
 
   depends_on "python@2" => :optional
-
-  deprecated_option "with-check" => "with-test"
 
   def install
     # Don't build in debug mode. See:
@@ -36,7 +32,7 @@ class ProtobufAT25 < Formula
                           "--prefix=#{prefix}",
                           "--with-zlib"
     system "make"
-    system "make", "check" if build.with?("test") || build.bottle?
+    system "make", "check" if build.bottle?
     system "make", "install"
 
     # Install editor support and examples

--- a/Formula/protobuf@2.6.rb
+++ b/Formula/protobuf@2.6.rb
@@ -13,14 +13,11 @@ class ProtobufAT26 < Formula
 
   keg_only :versioned_formula
 
-  # this will double the build time approximately if enabled
-  option "with-test", "Run build-time check"
   option "without-python@2", "Build without python2 support"
   option :cxx11
 
   depends_on "python@2" => :recommended
 
-  deprecated_option "with-check" => "with-test"
   deprecated_option "without-python" => "without-python@2"
 
   resource "six" do
@@ -63,7 +60,7 @@ class ProtobufAT26 < Formula
            "--prefix=#{prefix}",
            "--with-zlib"
     system "make"
-    system "make", "check" if (build.with? "test") || build.bottle?
+    system "make", "check" if build.bottle?
     system "make", "install"
 
     # Install editor support and examples

--- a/Formula/protobuf@3.1.rb
+++ b/Formula/protobuf@3.1.rb
@@ -14,8 +14,6 @@ class ProtobufAT31 < Formula
 
   keg_only :versioned_formula
 
-  # this will double the build time approximately if enabled
-  option "with-test", "Run build-time check"
   option "without-python@2", "Build without python support"
   option :cxx11
 
@@ -94,7 +92,7 @@ class ProtobufAT31 < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-zlib"
     system "make"
-    system "make", "check" if build.with?("test") || build.bottle?
+    system "make", "check" if build.bottle?
     system "make", "install"
 
     # Install editor support and examples


### PR DESCRIPTION
Our policy has long been that we don't include those, except for security software and some rare cases (very fast checks, etc.).