### PR TITLE
nuttcp: fix checksum

### DIFF
--- a/Formula/nuttcp.rb
+++ b/Formula/nuttcp.rb
@@ -2,7 +2,7 @@ class Nuttcp < Formula
   desc "Network performance measurement tool"
   homepage "https://www.nuttcp.net/nuttcp"
   url "https://www.nuttcp.net/nuttcp/nuttcp-8.1.4.tar.bz2"
-  sha256 "5c5f4f6ae04adb8a86d11e1995939c1308b90e1946ebc77c9988b5eb85961bb5"
+  sha256 "737f702ec931ec12fcf54e66c4c1d5af72bd3631439ffa724ed2ac40ab2de78d"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
See #31779

Confirmed that the new tarball has almost the same content as the old one (of copy of which can be found at http://216.165.129.135/distfiles/nuttcp-8.1.4.tar.bz2). The only file changed is the `README`:

```
diff -pur /tmp/nuttcp-8.1.4/README nuttcp-8.1.4/README
--- /tmp/nuttcp-8.1.4/README	2016-11-02 00:32:10.000000000 +0100
+++ nuttcp-8.1.4/README	2018-07-19 15:57:26.000000000 +0200
@@ -35,9 +35,9 @@ Sample xinetd configuration files can be
 
 2.  Add entries like the following to the /etc/services file.
 
-nuttcp          5100/tcp
+nuttcp          5000/tcp
 nuttcp-data     5101/tcp
-nuttcp6         5100/tcp
+nuttcp6         5000/tcp
 nuttcp6-data    5101/tcp
 
 For inetd it may be necessary to run the IPv4 and IPv6 servers on
```