### PR TITLE
Another batch of options

### DIFF
--- a/Formula/hyperestraier.rb
+++ b/Formula/hyperestraier.rb
@@ -1,58 +1,3 @@
-class EucjpMecabIpadicRequirement < Requirement
-  fatal true
-
-  def initialize(tags = [])
-    super
-    @mecab_ipadic_installed = Formula["mecab-ipadic"].installed?
-  end
-
-  satisfy(:build_env => false) { @mecab_ipadic_installed && mecab_dic_charset == "euc" }
-
-  def message
-    if @mecab_ipadic_installed
-      <<~EOS
-        Hyper Estraier supports only the EUC-JP version of MeCab-IPADIC.
-        However, you have installed the #{mecab_dic_charset} version so far.
-
-        You have to reinstall your mecab-ipadic package manually with the
-        --with-charset=euc option before resuming the hyperestraier installation,
-        or you have to build hyperestraier without MeCab support.
-
-        To reinstall your mecab-ipadic and resume the hyperestraier installation:
-
-            $ brew uninstall mecab-ipadic
-            $ brew install mecab-ipadic --with-charset=euc
-            $ brew install hyperestraier --enable-mecab
-
-        To build hyperestraier without MeCab support:
-
-            $ brew install hyperestraier
-      EOS
-    else
-      <<~EOS
-        An EUC-JP version of MeCab-IPADIC is required. You have to install your
-        mecab-ipadic package manually with the --with-charset=euc option before
-        resuming the hyperestraier installation, or you have to build hyperestraier
-        without MeCab support.
-
-        To install an EUC-JP version of mecab-ipadic and resume the hyperestraier
-        installation:
-
-            $ brew install mecab-ipadic --with-charset=euc
-            $ brew install hyperestraier --enable-mecab
-
-        To build hyperestraier without MeCab support:
-
-            $ brew install hyperestraier
-      EOS
-    end
-  end
-
-  def mecab_dic_charset
-    /^charset:\t(\S+)$/ =~ `mecab -D` && Regexp.last_match[1]
-  end
-end
-
 class Hyperestraier < Formula
   desc "Full-text search system for communities"
   homepage "http://fallabs.com/hyperestraier/index.html"
@@ -70,25 +15,10 @@ class Hyperestraier < Formula
   end
 
   depends_on "qdbm"
-  depends_on "mecab" => :optional
-
-  if build.with? "mecab"
-    depends_on "mecab-ipadic"
-    depends_on EucjpMecabIpadicRequirement
-  end
-
-  deprecated_option "enable-mecab" => "with-mecab"
 
   def install
-    args = %W[
-      --disable-debug
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-    ]
-
-    args << "--enable-mecab" if build.with? "mecab"
-
-    system "./configure", *args
+    system "./configure", "--disable-debug", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking"
     system "make", "mac"
     system "make", "check-mac"
     system "make", "install-mac"

--- a/Formula/idnits.rb
+++ b/Formula/idnits.rb
@@ -6,9 +6,6 @@ class Idnits < Formula
 
   bottle :unneeded
 
-  depends_on "aspell" => :optional
-  depends_on "languagetool" => :optional
-
   resource "test" do
     url "https://tools.ietf.org/id/draft-ietf-tcpm-undeployed-03.txt"
     sha256 "34e72c2c089409dc1935e18f75351025af3cfc253dee50db042d188b46733550"

--- a/Formula/imageworsener.rb
+++ b/Formula/imageworsener.rb
@@ -21,9 +21,8 @@ class Imageworsener < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "libpng" => :recommended
-  depends_on "jpeg" => :recommended
-  depends_on "webp" => :optional
+  depends_on "libpng"
+  depends_on "jpeg"
 
   def install
     if build.head?
@@ -31,15 +30,8 @@ class Imageworsener < Formula
       system "./scripts/autogen.sh"
     end
 
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-    ]
-    args << "--without-png" if build.without? "libpng"
-    args << "--without-jpeg" if build.without? "jpeg"
-    args << "--without-webp" if build.without? "webp"
-
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}", "--without-webp"
     system "make", "install"
     pkgshare.install "tests"
   end

--- a/Formula/imgur-screenshot.rb
+++ b/Formula/imgur-screenshot.rb
@@ -7,10 +7,6 @@ class ImgurScreenshot < Formula
 
   bottle :unneeded
 
-  option "with-terminal-notifier", "Needed for macOS Notifications"
-
-  depends_on "terminal-notifier" => :optional
-
   def install
     bin.install "imgur-screenshot.sh"
   end

--- a/Formula/irods.rb
+++ b/Formula/irods.rb
@@ -16,9 +16,6 @@ class Irods < Formula
     sha256 "6b0aa76607c2fec9b0007a6ad4fdca8ab53e7615edc01e3dccd35facbea9bb39" => :mountain_lion
   end
 
-  option "with-osxfuse", "Install iRODS FUSE client"
-
-  depends_on :osxfuse => :optional
   depends_on "openssl"
 
   conflicts_with "sleuthkit", :because => "both install `ils`"
@@ -35,21 +32,6 @@ class Irods < Formula
 
       system "make"
       bin.install Dir["clients/icommands/bin/*"].select { |f| File.executable? f }
-
-      # patch in order to use osxfuse
-      if build.with? "osxfuse"
-        inreplace "config/config.mk" do |s|
-          s.gsub! "# IRODS_FS = 1", "IRODS_FS = 1"
-          s.gsub! "fuseHomeDir=/home/mwan/adil/fuse-2.7.0", "fuseHomeDir=#{HOMEBREW_PREFIX}"
-        end
-        inreplace "clients/fuse/Makefile" do |s|
-          s.gsub! "lfuse", "losxfuse"
-          s.gsub! "-I$(fuseHomeDir)/include", "-I$(fuseHomeDir)/include/osxfuse"
-        end
-
-        system "make", "-C", "clients/fuse"
-        bin.install Dir["clients/fuse/bin/*"].select { |f| File.executable? f }
-      end
     end
   end
 

--- a/Formula/john-jumbo.rb
+++ b/Formula/john-jumbo.rb
@@ -16,8 +16,6 @@ class JohnJumbo < Formula
     sha256 "b36f66b0469b5c6cde95f780671db5b32e4e4dd7c16c4e7e591043bfdef2b65c" => :mavericks
   end
 
-  option "without-completion", "bash/zsh completion will not be installed"
-
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "gmp"
@@ -61,10 +59,8 @@ class JohnJumbo < Formula
     (share/"john").install Dir["run/*"]
     bin.install_symlink share/"john/john"
 
-    if build.with? "completion"
-      bash_completion.install share/"john/john.bash_completion" => "john.bash"
-      zsh_completion.install share/"john/john.zsh_completion" => "_john"
-    end
+    bash_completion.install share/"john/john.bash_completion" => "john.bash"
+    zsh_completion.install share/"john/john.zsh_completion" => "_john"
 
     # Source code defaults to "john.ini", so rename
     mv share/"john/john.conf", share/"john/john.ini"

--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -12,13 +12,12 @@ class Lensfun < Formula
     sha256 "a057800dfa6b88a006cab751aa2708579b7d2f1816ac3c59c24fc4b12e4e4b76" => :el_capitan
   end
 
-  depends_on "python"
-  depends_on "pkg-config" => :build
   depends_on "cmake" => :build
-  depends_on "glib"
+  depends_on "pkg-config" => :build
   depends_on "gettext"
+  depends_on "glib"
   depends_on "libpng"
-  depends_on "doxygen" => :optional
+  depends_on "python"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/libagg.rb
+++ b/Formula/libagg.rb
@@ -21,7 +21,6 @@ class Libagg < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "sdl"
-  depends_on "freetype" => :optional
 
   # Fix build with clang; last release was in 2006
   patch :DATA

--- a/Formula/libcanberra.rb
+++ b/Formula/libcanberra.rb
@@ -1,13 +1,8 @@
 class Libcanberra < Formula
   desc "Implementation of XDG Sound Theme and Name Specifications"
   homepage "http://0pointer.de/lennart/projects/libcanberra/"
-
-  stable do
-    url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
-    sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
-
-    depends_on "gtk-doc" => :optional
-  end
+  url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
+  sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
 
   bottle do
     sha256 "63be18f829bb64854eff3c78b7fc75a0bda59dcffa510f86f776734b178a8cc0" => :mojave
@@ -29,8 +24,6 @@ class Libcanberra < Formula
   depends_on "pkg-config" => :build
   depends_on "libtool"
   depends_on "libvorbis"
-  depends_on "pulseaudio" => :optional
-  depends_on "gstreamer" => :optional
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/libfishsound.rb
+++ b/Formula/libfishsound.rb
@@ -18,8 +18,6 @@ class Libfishsound < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libvorbis"
-  depends_on "speex" => :optional
-  depends_on "flac" => :optional
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/libkate.rb
+++ b/Formula/libkate.rb
@@ -16,15 +16,9 @@ class Libkate < Formula
     sha256 "473e0de088ba513006bb5212fd9ca21390d848c9cd5e33a7951ee3cba24220ac" => :yosemite
   end
 
-  option "with-docs", "Build documentation"
-  option "with-examples", "Build example streams"
-
   depends_on "pkg-config" => :build
-  depends_on "doxygen" => :build if build.with? "docs"
-  depends_on "oggz" if build.with? "examples"
-  depends_on "libpng"
   depends_on "libogg"
-  depends_on "wxmac" => :optional
+  depends_on "libpng"
 
   fails_with :gcc do
     build 5666

--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -14,7 +14,6 @@ class Libosinfo < Formula
   depends_on "gobject-introspection" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
-  depends_on "vala" => :optional
   depends_on "check"
   depends_on "gettext"
   depends_on "glib"
@@ -32,15 +31,10 @@ class Libosinfo < Formula
       --sysconfdir=#{etc}
       --disable-silent-rules
       --disable-udev
-      --enable-tests
+      --disable-vala
       --enable-introspection
+      --enable-tests
     ]
-
-    if build.with? "vala"
-      args << "--enable-vala"
-    else
-      args << "--disable-vala"
-    end
 
     system "./configure", *args
 

--- a/Formula/mdxmini.rb
+++ b/Formula/mdxmini.rb
@@ -15,10 +15,7 @@ class Mdxmini < Formula
     sha256 "d08a617e3a8791b9e5dc93426f3d471408550a4a0bab85e33a726ccdcdcb683c" => :mavericks
   end
 
-  option "with-lib-only", "Do not build commandline player"
-  deprecated_option "lib-only" => "with-lib-only"
-
-  depends_on "sdl" if build.without? "lib-only"
+  depends_on "sdl"
 
   resource "test_song" do
     url "https://ftp.modland.com/pub/modules/MDX/-%20unknown/Popful%20Mail/pop-00.mdx"
@@ -28,18 +25,14 @@ class Mdxmini < Formula
   def install
     # Specify Homebrew's cc
     inreplace "mak/general.mak", "gcc", ENV.cc
-    if build.with? "lib-only"
-      system "make", "-f", "Makefile.lib"
-    else
-      system "make"
-    end
+    system "make"
 
     # Makefile doesn't build a dylib
     system ENV.cc, "-dynamiclib", "-install_name", "#{lib}/libmdxmini.dylib",
                    "-o", "libmdxmini.dylib", "-undefined", "dynamic_lookup",
                    *Dir["obj/*"]
 
-    bin.install "mdxplay" if build.without? "lib-only"
+    bin.install "mdxplay"
     lib.install "libmdxmini.dylib"
     (include/"libmdxmini").install Dir["src/*.h"]
   end

--- a/Formula/mftrace.rb
+++ b/Formula/mftrace.rb
@@ -19,9 +19,9 @@ class Mftrace < Formula
     depends_on "autoconf" => :build
   end
 
+  depends_on "fontforge"
   depends_on "potrace"
   depends_on "t1utils"
-  depends_on "fontforge" => :recommended
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/mydumper.rb
+++ b/Formula/mydumper.rb
@@ -13,11 +13,9 @@ class Mydumper < Formula
     sha256 "f470b334ba765d77a9df8193f2333f43fa617d0a1a95b38d1325ddb4b5c5f47c" => :el_capitan
   end
 
-  option "without-docs", "Don't build man pages"
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "sphinx-doc" => :build if build.with? "docs"
+  depends_on "sphinx-doc" => :build
   depends_on "glib"
   depends_on "mysql-client"
   depends_on "pcre"
@@ -30,11 +28,7 @@ class Mydumper < Formula
   patch :p0, :DATA
 
   def install
-    args = std_cmake_args
-
-    args << "-DBUILD_DOCS=OFF" if build.without? "docs"
-
-    system "cmake", ".", *args
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
   end
 

--- a/Formula/oscats.rb
+++ b/Formula/oscats.rb
@@ -14,18 +14,12 @@ class Oscats < Formula
     sha256 "e83b19660fe00ed2c05e228646a931ad3837dafd74855921da25009833d5f387" => :yosemite
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
-  depends_on "gsl"
   depends_on "glib"
-  depends_on "python@2" => :optional
-  depends_on "pygobject" if build.with? "python@2"
+  depends_on "gsl"
 
   def install
-    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-    args << "--enable-python-bindings" if build.with? "python@2"
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
 end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -12,12 +12,8 @@ class Sipp < Formula
     sha256 "f2c60af09d5edba1322541c8484c01291b948b2cb2cf78cbc4e0aa854faf0931" => :el_capitan
   end
 
-  depends_on "openssl" => :optional
-
   def install
-    args = ["--with-pcap"]
-    args << "--with-openssl" if build.with? "openssl"
-    system "./configure", *args
+    system "./configure", "--with-pcap"
     system "make", "DESTDIR=#{prefix}"
     bin.install "sipp"
   end

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -14,7 +14,7 @@ class Tasksh < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "task" => :recommended
+  depends_on "task"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/tig.rb
+++ b/Formula/tig.rb
@@ -20,7 +20,7 @@ class Tig < Formula
     depends_on "xmlto" => :build
   end
 
-  depends_on "readline" => :recommended
+  depends_on "readline"
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -14,7 +14,6 @@ class Wimlib < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "ntfs-3g" => :optional
   depends_on "openssl"
 
   def install
@@ -23,11 +22,10 @@ class Wimlib < Formula
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
-      --without-fuse
       --prefix=#{prefix}
+      --without-fuse
+      --without-ntfs-3g
     ]
-
-    args << "--without-ntfs-3g" if build.without? "ntfs-3g"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/xboard.rb
+++ b/Formula/xboard.rb
@@ -20,12 +20,12 @@ class Xboard < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "fairymax" => :recommended
-  depends_on "polyglot" => :recommended
-  depends_on "gettext"
   depends_on "cairo"
-  depends_on "librsvg"
+  depends_on "fairymax"
+  depends_on "gettext"
   depends_on "gtk+"
+  depends_on "librsvg"
+  depends_on "polyglot"
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
See #31510, based on analytics.

`hyperestraier` is a special case. With the option, it required `mecab-ipadic` to be specifically installed with the `--with-charset=euc` option, which is not the default. This is deprecated behaviour (although the ways it is implemented, with the requirement, means it wasn't caught by our previous audits).