### PR TITLE
Simplify some options

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -24,12 +24,10 @@ class Graphviz < Formula
     depends_on "libtool" => :build
   end
 
-  option "with-bindings", "Build Perl/Python/Ruby/etc. bindings"
-  option "with-pango", "Build with Pango/Cairo for alternate PDF output"
   option "with-app", "Build GraphViz.app (requires full XCode install)"
   option "with-gts", "Build with GNU GTS support (required by prism)"
+  option "with-pango", "Build with Pango/Cairo for alternate PDF output"
 
-  deprecated_option "with-x" => "with-x11"
   deprecated_option "with-pangocairo" => "with-pango"
 
   depends_on "pkg-config" => :build
@@ -37,18 +35,9 @@ class Graphviz < Formula
   depends_on "gd"
   depends_on "libpng"
   depends_on "libtool"
-  depends_on "freetype" => :optional
   depends_on "gts" => :optional
   depends_on "librsvg" => :optional
   depends_on "pango" => :optional
-  depends_on :x11 => :optional
-
-  if build.with? "bindings"
-    depends_on "swig" => :build
-    depends_on :java
-    depends_on "python@2"
-    depends_on "ruby"
-  end
 
   def install
     # Only needed when using superenv, which causes qfrexp and qldexp to be
@@ -60,27 +49,19 @@ class Graphviz < Formula
     # Alternative fixes include using stdenv or using "xcrun make"
     inreplace "lib/sfio/features/sfio", "lib qfrexp\nlib qldexp\n", ""
 
-    if build.with? "bindings"
-      # the ruby pkg-config file is version specific
-      inreplace "configure" do |s|
-        s.gsub! "ruby-1.9", "ruby-#{Formula["ruby"].stable.version.to_f}"
-        s.gsub! "if test `$SWIG -php7 2>&1", "if test `$SWIG -php0 2>&1"
-      end
-    end
-
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --without-qt
-      --with-quartz
       --disable-php
+      --disable-swig
+      --with-quartz
+      --without-freetype2
+      --without-qt
+      --without-x
     ]
     args << "--with-gts" if build.with? "gts"
-    args << "--disable-swig" if build.without? "bindings"
     args << "--without-pangocairo" if build.without? "pango"
-    args << "--without-freetype2" if build.without? "freetype"
-    args << "--without-x" if build.without? "x11"
     args << "--without-rsvg" if build.without? "librsvg"
 
     if build.head?

--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -12,22 +12,9 @@ class Libav < Formula
     sha256 "d91489215ba05ef1a9c93c3c18d6c13e20fdc901fad4e9d6c47922775be77ecb" => :el_capitan
   end
 
-  option "without-faac", "Disable AAC encoder via faac"
-  option "without-lame", "Disable MP3 encoder via libmp3lame"
-  option "without-libvorbis", "Disable Vorbis encoding via libvorbis"
-  option "without-libvpx", "Disable VP8 de/encoding via libvpx"
-  option "without-x264", "Disable H.264 encoder via x264"
-  option "without-xvid", "Disable Xvid MPEG-4 video encoder via xvid"
-
-  option "with-opencore-amr", "Enable AMR-NB de/encoding and AMR-WB decoding " \
-    "via libopencore-amrnb and libopencore-amrwb"
   option "with-openssl", "Enable SSL support"
-  option "with-rtmpdump", "Enable RTMP protocol support"
-  option "with-schroedinger", "Enable Dirac video format"
   option "with-sdl", "Enable avplay"
-  option "with-speex", "Enable Speex de/encoding via libspeex"
   option "with-theora", "Enable Theora encoding via libtheora"
-  option "with-libvo-aacenc", "Enable VisualOn AAC encoder"
 
   depends_on "pkg-config" => :build
   depends_on "yasm" => :build
@@ -35,26 +22,18 @@ class Libav < Formula
   # manpages won't be built without texi2html
   depends_on "texi2html" => :build if MacOS.version >= :mountain_lion
 
-  depends_on "faac" => :recommended
-  depends_on "fdk-aac" => :recommended
-  depends_on "freetype" => :recommended
-  depends_on "lame" => :recommended
-  depends_on "libvorbis" => :recommended
-  depends_on "libvpx" => :recommended
-  depends_on "opus" => :recommended
-  depends_on "x264" => :recommended
-  depends_on "xvid" => :recommended
+  depends_on "faac"
+  depends_on "fdk-aac"
+  depends_on "freetype"
+  depends_on "lame"
+  depends_on "libvorbis"
+  depends_on "libvpx"
+  depends_on "opus"
+  depends_on "x264"
+  depends_on "xvid"
 
-  depends_on "fontconfig" => :optional
-  depends_on "frei0r" => :optional
-  depends_on "gnutls" => :optional
-  depends_on "libvo-aacenc" => :optional
-  depends_on "opencore-amr" => :optional
   depends_on "openssl" => :optional
-  depends_on "rtmpdump" => :optional
-  depends_on "schroedinger" => :optional
   depends_on "sdl" => :optional
-  depends_on "speex" => :optional
   depends_on "theora" => :optional
 
   # https://bugzilla.libav.org/show_bug.cgi?id=1033
@@ -64,39 +43,30 @@ class Libav < Formula
   end
 
   def install
-    args = [
-      "--disable-debug",
-      "--disable-shared",
-      "--disable-indev=jack",
-      "--prefix=#{prefix}",
-      "--enable-gpl",
-      "--enable-nonfree",
-      "--enable-version3",
-      "--enable-vda",
-      "--cc=#{ENV.cc}",
-      "--host-cflags=#{ENV.cflags}",
-      "--host-ldflags=#{ENV.ldflags}",
+    args = %W[
+      --disable-debug
+      --disable-shared
+      --disable-indev=jack
+      --prefix=#{prefix}
+      --cc=#{ENV.cc}
+      --host-cflags=#{ENV.cflags}
+      --host-ldflags=#{ENV.ldflags}
+      --enable-gpl
+      --enable-libfaac
+      --enable-libfdk-aac
+      --enable-libfreetype
+      --enable-libmp3lame
+      --enable-libopus
+      --enable-libvorbis
+      --enable-libvpx
+      --enable-libx264
+      --enable-libxvid
+      --enable-nonfree
+      --enable-vda
+      --enable-version3
     ]
 
-    args << "--enable-frei0r" if build.with? "frei0r"
-    args << "--enable-gnutls" if build.with? "gnutls"
-    args << "--enable-libfaac" if build.with? "faac"
-    args << "--enable-libfdk-aac" if build.with? "fdk-aac"
-    args << "--enable-libfontconfig" if build.with? "fontconfig"
-    args << "--enable-libfreetype" if build.with? "freetype"
-    args << "--enable-libmp3lame" if build.with? "lame"
-    args << "--enable-libopencore-amrnb" if build.with? "opencore-amr"
-    args << "--enable-libopencore-amrwb" if build.with? "opencore-amr"
-    args << "--enable-libopus" if build.with? "opus"
-    args << "--enable-librtmp" if build.with? "rtmpdump"
-    args << "--enable-libschroedinger" if build.with? "schroedinger"
-    args << "--enable-libspeex" if build.with? "speex"
     args << "--enable-libtheora" if build.with? "theora"
-    args << "--enable-libvo-aacenc" if build.with? "libvo-aacenc"
-    args << "--enable-libvorbis" if build.with? "libvorbis"
-    args << "--enable-libvpx" if build.with? "libvpx"
-    args << "--enable-libx264" if build.with? "x264"
-    args << "--enable-libxvid" if build.with? "xvid"
     args << "--enable-openssl" if build.with? "openssl"
 
     system "./configure", *args

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -3,6 +3,7 @@ class Mpd < Formula
   homepage "https://www.musicpd.org/"
   url "https://www.musicpd.org/download/mpd/0.20/mpd-0.20.21.tar.xz"
   sha256 "8322764dc265c20f05c8c8fdfdd578b0722e74626bef56fcd8eebfb01acc58dc"
+  revision 1
 
   bottle do
     sha256 "e8745fde74d53001ceab4881a52b8484d2251e9bd695a7ca0b49fd2fdd1fcdf0" => :mojave
@@ -17,56 +18,26 @@ class Mpd < Formula
     depends_on "automake" => :build
   end
 
-  option "with-wavpack", "Build with wavpack support (for .wv files)"
-  option "with-lastfm", "Build with last-fm support (for experimental Last.fm radio)"
-  option "with-lame", "Build with lame support (for MP3 encoding when streaming)"
-  option "with-two-lame", "Build with two-lame support (for MP2 encoding when streaming)"
-  option "with-flac", "Build with flac support (for Flac encoding when streaming)"
-  option "with-libvorbis", "Build with vorbis support (for Ogg encoding)"
-  option "with-yajl", "Build with yajl support (for playing from soundcloud)"
-  option "with-opus", "Build with opus support (for Opus encoding and decoding)"
-  option "with-libmodplug", "Build with modplug support (for decoding modules supported by MODPlug)"
-  option "with-pulseaudio", "Build with PulseAudio support (for sending audio output to a PulseAudio sound server)"
-  option "with-upnp", "Build with upnp database plugin support"
-
-  deprecated_option "with-vorbis" => "with-libvorbis"
-
-  depends_on "pkg-config" => :build
   depends_on "boost" => :build
+  depends_on "pkg-config" => :build
+  depends_on "expat"
+  depends_on "faad2"
+  depends_on "ffmpeg"
+  depends_on "flac"
+  depends_on "fluid-synth"
   depends_on "glib"
-  depends_on "libid3tag"
-  depends_on "sqlite"
-  depends_on "libsamplerate"
   depends_on "icu4c"
+  depends_on "lame"
+  depends_on "libao"
+  depends_on "libid3tag"
+  depends_on "libmpdclient"
+  depends_on "libsamplerate"
+  depends_on "libupnp"
+  depends_on "libvorbis"
+  depends_on "opus"
+  depends_on "sqlite"
 
   needs :cxx11
-
-  depends_on "libmpdclient"
-  depends_on "ffmpeg" # lots of codecs
-  # mpd also supports mad, mpg123, libsndfile, and audiofile, but those are
-  # redundant with ffmpeg
-  depends_on "fluid-synth"              # MIDI
-  depends_on "faad2"                    # MP4/AAC
-  depends_on "wavpack" => :optional     # WavPack
-  depends_on "libshout" => :optional    # Streaming (also pulls in Vorbis encoding)
-  depends_on "lame" => :optional        # MP3 encoding
-  depends_on "two-lame" => :optional    # MP2 encoding
-  depends_on "flac" => :optional        # Flac encoding
-  depends_on "jack" => :optional        # Output to JACK
-  depends_on "libmms" => :optional      # MMS input
-  depends_on "libzzip" => :optional     # Reading from within ZIPs
-  depends_on "yajl" => :optional        # JSON library for SoundCloud
-  depends_on "opus" => :optional        # Opus support
-  depends_on "libvorbis" => :optional
-  depends_on "libnfs" => :optional
-  depends_on "mad" => :optional
-  depends_on "libmodplug" => :optional  # MODPlug decoder
-  depends_on "pulseaudio" => :optional
-  depends_on "libao" => :optional       # Output to libao
-  if build.with? "upnp"
-    depends_on "expat"
-    depends_on "libupnp"
-  end
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -81,28 +52,19 @@ class Mpd < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --sysconfdir=#{etc}
+      --disable-libwrap
+      --disable-mad
+      --disable-mpc
+      --disable-soundcloud
+      --enable-ao
       --enable-bzip2
+      --enable-expat
       --enable-ffmpeg
       --enable-fluidsynth
       --enable-osx
-      --disable-libwrap
-      --disable-mpc
+      --enable-upnp
+      --enable-vorbis-encoder
     ]
-
-    args << "--disable-mad" if build.without? "mad"
-    args << "--enable-zzip" if build.with? "libzzip"
-    args << "--enable-lastfm" if build.with? "lastfm"
-    args << "--disable-lame-encoder" if build.without? "lame"
-    args << "--disable-soundcloud" if build.without? "yajl"
-    args << "--enable-vorbis-encoder" if build.with? "libvorbis"
-    args << "--enable-nfs" if build.with? "libnfs"
-    args << "--enable-modplug" if build.with? "libmodplug"
-    args << "--enable-pulse" if build.with? "pulseaudio"
-    args << "--enable-ao" if build.with? "libao"
-    if build.with? "upnp"
-      args << "--enable-upnp"
-      args << "--enable-expat"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -12,18 +12,6 @@ class MysqlCluster < Formula
     sha256 "29692861b897e6b013d01396bd0cea9541b109a7d691007ddb67a64de91d0a44" => :yosemite
   end
 
-  option "with-test", "Build with unit tests"
-  option "with-embedded", "Build the embedded server"
-  option "with-libedit", "Compile with editline wrapper instead of readline"
-  option "with-archive-storage-engine", "Compile with the ARCHIVE storage engine enabled"
-  option "with-blackhole-storage-engine", "Compile with the BLACKHOLE storage engine enabled"
-  option "with-local-infile", "Build with local infile loading support"
-  option "with-debug", "Build with debug support"
-
-  deprecated_option "with-tests" => "with-test"
-  deprecated_option "enable-local-infile" => "with-local-infile"
-  deprecated_option "enable-debug" => "with-debug"
-
   depends_on :java => "1.8"
   depends_on "cmake" => :build
   depends_on "pidof" unless MacOS.version >= :mountain_lion
@@ -65,38 +53,15 @@ class MysqlCluster < Formula
             "-DWITH_SSL=yes",
             "-DDEFAULT_CHARSET=utf8",
             "-DDEFAULT_COLLATION=utf8_general_ci",
-            "-DSYSCONFDIR=#{etc}"]
+            "-DSYSCONFDIR=#{etc}",
+            "-DWITH_UNIT_TESTS=OFF",
+            "-DWITH_READLINE=yes"]
 
     # mysql-cluster >5.7.x mandates Boost as a requirement to build & has a
     # strict version check in place to ensure it only builds against expected
     # release.
     (buildpath/"boost_1_59_0").install resource("boost")
     args << "-DWITH_BOOST=#{buildpath}/boost_1_59_0"
-
-    # To enable unit testing at build, we need to download the unit testing suite
-    if build.with? "test"
-      args << "-DENABLE_DOWNLOADS=ON"
-    else
-      args << "-DWITH_UNIT_TESTS=OFF"
-    end
-
-    # Build the embedded server
-    args << "-DWITH_EMBEDDED_SERVER=ON" if build.with? "embedded"
-
-    # Compile with readline unless libedit is explicitly chosen
-    args << "-DWITH_READLINE=yes" if build.without? "libedit"
-
-    # Compile with ARCHIVE engine enabled if chosen
-    args << "-DWITH_ARCHIVE_STORAGE_ENGINE=1" if build.with? "archive-storage-engine"
-
-    # Compile with BLACKHOLE engine enabled if chosen
-    args << "-DWITH_BLACKHOLE_STORAGE_ENGINE=1" if build.with? "blackhole-storage-engine"
-
-    # Build with local infile loading support
-    args << "-DENABLED_LOCAL_INFILE=1" if build.with? "local-infile"
-
-    # Build with debug support
-    args << "-DWITH_DEBUG=1" if build.with? "debug"
 
     system "cmake", *args
     system "make"

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -13,33 +13,25 @@ class Subversion < Formula
   end
 
   deprecated_option "java" => "with-java"
-  deprecated_option "perl" => "with-perl"
-  deprecated_option "ruby" => "with-ruby"
-  deprecated_option "with-gpg-agent" => "with-gnupg"
 
   option "with-java", "Build Java bindings"
-  option "without-ruby", "Build without Ruby bindings"
-  option "without-perl", "Build without Perl bindings"
-  option "with-gnupg", "Build with support for GPG Agent"
 
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
   depends_on "apr-util"
   depends_on "apr"
 
-  # Always build against Homebrew versions instead of system versions for consistency.
+  # Always build against Homebrew versions for consistency
   depends_on "lz4"
+  depends_on "perl"
   depends_on "sqlite"
   depends_on "utf8proc"
-  depends_on "perl" => :recommended
 
   # For Serf
   depends_on "scons" => :build
   depends_on "openssl"
 
   # Other optional dependencies
-  depends_on "gnupg" => :optional
-  depends_on "gettext" => :optional
   depends_on :java => ["1.8", :optional]
 
   resource "serf" do
@@ -53,14 +45,12 @@ class Subversion < Formula
   # Prevent linking into a Python Framework
   patch :DATA
 
-  if build.with?("perl") || build.with?("ruby")
-    # When building Perl or Ruby bindings, need to use a compiler that
-    # recognizes GCC-style switches, since that's what the system languages
-    # were compiled against.
-    fails_with :clang do
-      build 318
-      cause "core.c:1: error: bad value (native) for -march= switch"
-    end
+  # When building Perl or Ruby bindings, need to use a compiler that
+  # recognizes GCC-style switches, since that's what the system languages
+  # were compiled against.
+  fails_with :clang do
+    build 318
+    cause "core.c:1: error: bad value (native) for -march= switch"
   end
 
   def install
@@ -94,26 +84,22 @@ class Subversion < Formula
       --prefix=#{prefix}
       --disable-debug
       --enable-optimize
-      --with-zlib=/usr
-      --with-sqlite=#{Formula["sqlite"].opt_prefix}
-      --with-apr=#{Formula["apr"].opt_prefix}
-      --with-apr-util=#{Formula["apr-util"].opt_prefix}
-      --with-apxs=no
-      --with-serf=#{serf_prefix}
       --disable-mod-activation
+      --disable-nls
+      --with-apr-util=#{Formula["apr-util"].opt_prefix}
+      --with-apr=#{Formula["apr"].opt_prefix}
+      --with-apxs=no
+      --with-ruby-sitedir=#{lib}/ruby
+      --with-serf=#{serf_prefix}
+      --with-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-zlib=/usr
       --without-apache-libexecdir
       --without-berkeley-db
+      --without-gpg-agent
+      RUBY=/usr/bin/ruby
     ]
 
     args << "--enable-javahl" << "--without-jikes" if build.with? "java"
-    args << "--without-gpg-agent" if build.without? "gnupg"
-    args << "--disable-nls" if build.without? "gettext"
-
-    if build.with? "ruby"
-      args << "--with-ruby-sitedir=#{lib}/ruby"
-      # Peg to system Ruby
-      args << "RUBY=/usr/bin/ruby"
-    end
 
     # The system Python is built with llvm-gcc, so we override this
     # variable to prevent failures due to incompatible CFLAGS
@@ -135,62 +121,48 @@ class Subversion < Formula
     system "make", "install-swig-py"
     (lib/"python2.7/site-packages").install_symlink Dir["#{lib}/svn-python/*"]
 
-    if build.with? "perl"
-      # In theory SWIG can be built in parallel, in practice...
-      ENV.deparallelize
+    # In theory SWIG can be built in parallel, in practice...
+    ENV.deparallelize
 
-      archlib = Utils.popen_read("perl -MConfig -e 'print $Config{archlib}'")
-      perl_core = Pathname.new(archlib)/"CORE"
-      onoe "'#{perl_core}' does not exist" unless perl_core.exist?
+    archlib = Utils.popen_read("perl -MConfig -e 'print $Config{archlib}'")
+    perl_core = Pathname.new(archlib)/"CORE"
+    onoe "'#{perl_core}' does not exist" unless perl_core.exist?
 
-      inreplace "Makefile" do |s|
-        s.change_make_var! "SWIG_PL_INCLUDES",
-          "$(SWIG_INCLUDES) -arch #{MacOS.preferred_arch} -g -pipe -fno-common -DPERL_DARWIN -fno-strict-aliasing -I#{HOMEBREW_PREFIX}/include -I#{perl_core}"
-      end
-      system "make", "swig-pl"
-      system "make", "install-swig-pl"
-
-      # This is only created when building against system Perl, but it isn't
-      # purged by Homebrew's post-install cleaner because that doesn't check
-      # "Library" directories. It is however pointless to keep around as it
-      # only contains the perllocal.pod installation file.
-      rm_rf prefix/"Library/Perl"
+    inreplace "Makefile" do |s|
+      s.change_make_var! "SWIG_PL_INCLUDES",
+        "$(SWIG_INCLUDES) -arch #{MacOS.preferred_arch} -g -pipe -fno-common -DPERL_DARWIN -fno-strict-aliasing -I#{HOMEBREW_PREFIX}/include -I#{perl_core}"
     end
+    system "make", "swig-pl"
+    system "make", "install-swig-pl"
+
+    # This is only created when building against system Perl, but it isn't
+    # purged by Homebrew's post-install cleaner because that doesn't check
+    # "Library" directories. It is however pointless to keep around as it
+    # only contains the perllocal.pod installation file.
+    rm_rf prefix/"Library/Perl"
 
     if build.with? "java"
       system "make", "javahl"
       system "make", "install-javahl"
     end
 
-    if build.with? "ruby"
-      # Peg to system Ruby
-      system "make", "swig-rb", "EXTRA_SWIG_LDFLAGS=-L/usr/lib"
-      system "make", "install-swig-rb"
-    end
+    # Peg to system Ruby
+    system "make", "swig-rb", "EXTRA_SWIG_LDFLAGS=-L/usr/lib"
+    system "make", "install-swig-rb"
   end
 
   def caveats
     s = <<~EOS
       svntools have been installed to:
         #{opt_libexec}
+
+      The perl bindings are located in various subdirectories of:
+        #{opt_lib}/perl5
+
+      If you wish to use the Ruby bindings you may need to add:
+        #{HOMEBREW_PREFIX}/lib/ruby
+      to your RUBYLIB.
     EOS
-
-    if build.with? "perl"
-      s += "\n"
-      s += <<~EOS
-        The perl bindings are located in various subdirectories of:
-          #{opt_lib}/perl5
-      EOS
-    end
-
-    if build.with? "ruby"
-      s += "\n"
-      s += <<~EOS
-        If you wish to use the Ruby bindings you may need to add:
-          #{HOMEBREW_PREFIX}/lib/ruby
-        to your RUBYLIB.
-      EOS
-    end
 
     if build.with? "java"
       s += "\n"


### PR DESCRIPTION
This deals with some of the formulas that have the largest number of options available. The aim is not to remove everything, but to simplify by deleting unused options. #31510 

Analytics behind the various removals:

- `mpd` incorporates some of its optional deps, to become optionless:

```
install_on_request events in the last 30 days
====================================================================================================
 1 | mpd                                                                             | 520 |  83.87%
 2 | mpd --with-flac                                                                 |   7 |   1.13%
 3 | mpd --with-libao                                                                |   5 |   0.81%
 4 | mpd --with-lame                                                                 |   4 |   0.65%
 5 | mpd --with-opus                                                                 |   4 |   0.65%
 6 | mpd --with-upnp                                                                 |   4 |   0.65%
```

- `subversion` looses some options, but keeps the often-used Java:

```
install_on_request events in the last 30 days
====================================================================================================
 1 | subversion                                                                    | 3,781 |  83.95%
 2 | subversion --with-java                                                        |   670 |  14.88%
 3 | subversion --with-gettext                                                     |    13 |   0.29%
 4 | subversion --with-java --with-gnupg --with-gettext                            |    11 |   0.24%
 5 | subversion --with-java --with-gnupg                                           |    10 |   0.22%
 6 | subversion --with-gnupg                                                       |     6 |   0.13%
```

- `libav` keeps its 3 most used options, the rest is dropped:

```
install_on_request events in the last 30 days
====================================================================================================
 1 | libav                                                                         | 1,178 |  93.72%
 2 | libav --with-sdl --with-theora                                                |    56 |   4.46%
 3 | libav --with-openssl                                                          |    10 |   0.80%
 4 | libav --with-opencore-amr --with-openssl --with-rtmpdump --with-schroedinger  |     3 |   0.24%
 5 | libav --with-sdl                                                              |     3 |   0.24%
 6 | libav --with-opencore-amr --with-openssl --with-rtmpdump --with-schroedinger  |     2 |   0.16%
 7 | libav --with-libvorbis --with-libvpx --with-freetype --with-fdk-aac --with-op |     1 |   0.08%
```

-  `graphviz` keeps 4 options:

```
install_on_request events in the last 30 days
====================================================================================================
 1 | graphviz                                                                     | 13,761 |  94.74%
 2 | graphviz --with-app                                                          |    371 |   2.55%
 3 | graphviz --with-pango                                                        |    127 |   0.87%
 4 | graphviz --with-pango --with-librsvg                                         |     66 |   0.45%
 5 | graphviz --with-gts                                                          |     54 |   0.37%
 6 | graphviz --with-pango --with-app --with-librsvg                              |     15 |   0.10%
 7 | graphviz --with-librsvg --with-freetype                                      |     14 |   0.10%
```

- `mysql-cluster` just happened to be there…

```
install_on_request events in the last 30 days
====================================================================================================
1 | mysql-cluster                                                                     | 17 | 100.00%
====================================================================================================
```