### PR TITLE
ps2eps: fixed positional argument parsing

### DIFF
--- a/Formula/ps2eps.rb
+++ b/Formula/ps2eps.rb
@@ -23,7 +23,7 @@ class Ps2eps < Formula
     (libexec/"bin").install "bin/ps2eps"
     (bin/"ps2eps").write <<~EOS
       #!/bin/sh
-      perl -S #{libexec}/bin/ps2eps $*
+      perl -S #{libexec}/bin/ps2eps \"$@\"
     EOS
     share.install "doc/man"
     doc.install "doc/pdf", "doc/html"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Changed `$*` to `$@` in the formula so that the perl script created during install (that calls the 'real' ps2eps) can properly handle positional arguments with spaces.

Before:
```
ps2eps demo2.ps demo\ 3.ps
Input files: demo2.ps demo 3.ps
Processing: demo2.ps
Rendering with existing %%BoundingBox: 90 252 522 540
Calculating Bounding Box...ready. %%BoundingBox: 143 273 432 288
Creating output file demo2.eps ... ready.
Processing: demo
ps2eps: Can't open demo: No such file or directory
Processing: 3.ps
ps2eps: Can't open 3.ps: No such file or directory
```

After:
```
ps2eps demo2.ps demo\ 3.ps
Input files: demo2.ps demo 3.ps
Processing: demo2.ps
Rendering with existing %%BoundingBox: 90 252 522 540
Calculating Bounding Box...ready. %%BoundingBox: 143 273 432 288
Creating output file demo2.eps ... ready.
Processing: demo 3.ps
Calculating Bounding Box...ready. %%BoundingBox: 143 273 432 288
Creating output file demo 3.eps ... ready.
```

PS - This is my first PR with Homebrew.  So this is all new to me, and I've quite possible done something incorrectly.