### PR TITLE
isync: add '-a' option to service

### DIFF
--- a/Formula/isync.rb
+++ b/Formula/isync.rb
@@ -55,6 +55,7 @@ class Isync < Formula
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/mbsync</string>
+          <string>-a</string>
           <string>Periodic</string>
         </array>
         <key>StartInterval</key>


### PR DESCRIPTION
Without channels as arguments or '-a' mbsync exits abnormally and the
service fails to sync. With '-a', all configured channels are synced.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
