### PR TITLE
etcher-cli: 1.4.4 (new formula)

### DIFF
--- a/Formula/etcher-cli.rb
+++ b/Formula/etcher-cli.rb
@@ -4,8 +4,8 @@ require "json"
 class EtcherCli < Formula
   desc "Flash OS images to SD cards & USB drives, safely and easily"
   homepage "https://etcher.io/"
-  url "https://github.com/resin-io/etcher/archive/v1.4.5.tar.gz"
-  sha256 "82122253333b3bf5dc6f8909a5877a3218a2e677aff09159e5a4819be9e0edb9"
+  url "https://github.com/balena-io/etcher/archive/v1.4.6.tar.gz"
+  sha256 "746063814a8293a547e1195be5987601772c29a7b49623d2e8d0bac50509f60c"
 
   depends_on "python" => :build
   depends_on "node"
@@ -17,8 +17,8 @@ class EtcherCli < Formula
 
   def install
     pkg_json = JSON.parse(IO.read("package.json"))
-    pkg_json["dependencies"]["lzma-native"] = "^4.0.1" # upgrading lzma-native for Node 10 support
-    pkg_json["dependencies"].delete("usb") # delete node-usb (no node 10 support and not needed for cli)
+    pkg_json["dependencies"]["lzma-native"] = "^4.0.1" # upgrading lzma-native for Node 11 support
+    pkg_json["dependencies"].delete("usb") # delete node-usb (no node 11 support and not needed for cli)
     IO.write("package.json", JSON.pretty_generate(pkg_json))
     rm "npm-shrinkwrap.json"
 

--- a/Formula/etcher-cli.rb
+++ b/Formula/etcher-cli.rb
@@ -4,8 +4,8 @@ require "json"
 class EtcherCli < Formula
   desc "Flash OS images to SD cards & USB drives, safely and easily"
   homepage "https://etcher.io/"
-  url "https://github.com/resin-io/etcher/archive/v1.4.4.tar.gz"
-  sha256 "02082bc1caac746e1cdcd95c2892c9b41ff8d45a672b52f8467548cad4850f5d"
+  url "https://github.com/resin-io/etcher/archive/v1.4.5.tar.gz"
+  sha256 "82122253333b3bf5dc6f8909a5877a3218a2e677aff09159e5a4819be9e0edb9"
 
   depends_on "python" => :build
   depends_on "node"

--- a/Formula/etcher-cli.rb
+++ b/Formula/etcher-cli.rb
@@ -4,8 +4,8 @@ require "json"
 class EtcherCli < Formula
   desc "Flash OS images to SD cards & USB drives, safely and easily"
   homepage "https://etcher.io/"
-  url "https://github.com/balena-io/etcher/archive/v1.4.6.tar.gz"
-  sha256 "746063814a8293a547e1195be5987601772c29a7b49623d2e8d0bac50509f60c"
+  url "https://github.com/balena-io/etcher/archive/v1.4.7.tar.gz"
+  sha256 "368bada1f23ba5877d1f6ba6fa1d46e0d39f2289a8eb7d2c5cd7de37d80dda8a"
 
   depends_on "python" => :build
   depends_on "node"

--- a/Formula/etcher-cli.rb
+++ b/Formula/etcher-cli.rb
@@ -1,0 +1,68 @@
+require "language/node"
+require "json"
+
+class EtcherCli < Formula
+  desc "Flash OS images to SD cards & USB drives, safely and easily"
+  homepage "https://etcher.io/"
+  url "https://github.com/resin-io/etcher/archive/v1.4.4.tar.gz"
+  sha256 "02082bc1caac746e1cdcd95c2892c9b41ff8d45a672b52f8467548cad4850f5d"
+
+  depends_on "python" => :build
+  depends_on "node@8"
+
+  def install
+    # use npm from node@8 here, because we don't depend on node (can't use language/node)
+    ENV.prepend_path "PATH", Formula["node@8"].bin
+    system "npm", "install", "--production", "-ddd", "--build-from-source",
+           "--#{Language::Node.npm_cache_config}"
+    system "npm", "install", "pkg@4.3.0", "-ddd", "--build-from-source",
+           "--#{Language::Node.npm_cache_config}", "--prefix=#{buildpath}/pkg"
+
+    cd "pkg" do
+      # get list of for the CLI required dependencies using pkg's AST tree walker
+      (buildpath/"pkg/get-cli-deps.js").write <<~EOS
+        const w = require("pkg/lib-es5/walker.js").default, p = "../lib/cli/etcher.js";
+        w({config: {}, base: "../lib/cli", configPath: p}, p).then(r => {
+          let d = Object.keys(r.records).map(s => /\\/node_modules\\/([^\\/]*)\\//.exec(s));
+          console.log(Array.from(new Set(d.filter(s => s).map(s => s[1]))).join("\\n"));
+        });
+      EOS
+      cli_deps = Utils.popen_read("node get-cli-deps.js").chomp.split("\n")
+
+      # Patch package.json the generate cli build instead of electron build
+      pkg_json = JSON.parse(IO.read("../package.json"))
+      pkg_json["bin"] = { :etcher => "./bin/etcher" } # set bin entry point
+      pkg_json["dependencies"].each do |dep, _| # ignore some electron releated dependencies
+        pkg_json["dependencies"].delete(dep) unless cli_deps.include? dep
+      end
+      # bundle the already installed depedencies and ignore electron related source files
+      pkg_json["bundledDependencies"] = pkg_json["dependencies"].keys
+      pkg_json["files"] = %w[bin build lib/cli lib/sdk lib/shared binding.gyp]
+      IO.write("../package.json", JSON.pretty_generate(pkg_json))
+    end
+
+    # remove shrinkwrap because it would override our patched package.json
+    rm "npm-shrinkwrap.json"
+    # patch shebang to always run againts our node@8
+    inreplace "bin/etcher", "#!/usr/bin/env node", "#!#{Formula["node@8"].opt_bin}/node"
+
+    # can't use language/node here, because we have to run with our node@8 here
+    pack = Utils.popen_read("npm pack --ignore-scripts").lines.last.chomp
+    system "npm", "install", "-ddd", "--global", "--production", "--build-from-source",
+           "--#{Language::Node.npm_cache_config}", "--prefix=#{libexec}", buildpath/pack
+
+    bin.install_symlink libexec/"bin/etcher"
+  end
+
+  test do
+    # Writing a functionality test would require sudo and access to hdiutil,
+    # which is both not possible inside brews sandbox. Manual test with:
+    # $ curl -o /tmp/mini.iso http://archive.ubuntu.com/ubuntu/dists/xenial/main/installer-i386/current/images/netboot/mini.iso
+    # $ hdiutil create -size 100m -fs HFS+ -volname Test /tmp/test.dmg
+    # $ hdiutil attach -imagekey diskimage-class=CRawDiskImage -nomount /tmp/test.dmg
+    # $ sudo etcher -d <devname> -cu /tmp/mini.iso
+    # $ hdiutil detach <devname> && rm /tmp/{mini.iso,test.dmg}
+    # (replace <devname> with first path printed by hdiutil attach)
+    assert_equal pipe_output("#{bin}/etcher --version").chomp, version
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR is a followup to the now stale #31239 which tries to combine the advantages to the 2 proposed formula versions over there:
* https://github.com/chrmoritz/homebrew-core/commit/f52479dd48229e8cd7df2ba1b465093ddfa715c6 While the first version was able to run against our homebrew provided node executable at runtime, it had the disadvantage of having the maintenance overhead for managing the electron only dependency blacklist.
* https://github.com/chrmoritz/homebrew-core/commit/9579dcfacb6a368387c762cdc7cc1575b639668a Otherwise the second version used `pkg` to bundle things up and figure out the required dependencies at build time on it's own, but had the disadvantage of unnecessarily embedding the result in a custom node executable instead of using our node at runtime.

Refs: https://github.com/Homebrew/homebrew-core/pull/31239#issuecomment-416034829 and following comments

This PR tries to only combine the advantages of both versions by:
* only using `pkg`'s AST walker to dynamically figuring out the required dependencies at build time (and printed the result to stdout without embedding anything)
* and then using these as a filter list for patching the `package.json` to build a version of the cli as a 'normal' npm module, which runs against or `node@8` executable at runtime.

*(The only disadvantage is, that the installation method might use some form of black magic. :laughing:)*
