### PR TITLE
Options, again

### DIFF
--- a/Formula/cabocha.rb
+++ b/Formula/cabocha.rb
@@ -15,20 +15,9 @@ class Cabocha < Formula
     sha256 "b1aaf6623ac7332459c795ebd992ed92224b0d0b9e20fb57dd0313fbeea7647c" => :mountain_lion
   end
 
-  option "with-charset=", "choose default charset: EUC-JP, CP932, UTF8"
-  option "with-posset=", "choose default posset: IPA, JUMAN, UNIDIC"
-
-  deprecated_option "charset=" => "with-charset="
-  deprecated_option "posset=" => "with-posset="
-
   depends_on "crf++"
   depends_on "mecab"
-
-  # To see which dictionaries are available, run:
-  #     ls `mecab-config --libs-only-L`/mecab/dic/
-  depends_on "mecab-ipadic" => :recommended
-  depends_on "mecab-jumandic" => :optional
-  depends_on "mecab-unidic" => :optional
+  depends_on "mecab-ipadic"
 
   def install
     ENV["LIBS"] = "-liconv"
@@ -38,14 +27,11 @@ class Cabocha < Formula
       s.change_make_var! "CXXFLAGS", ENV.cflags
     end
 
-    charset = ARGV.value("with-charset") || "UTF8"
-    posset = ARGV.value("with-posset") || "IPA"
-
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --with-charset=#{charset}
-      --with-posset=#{posset}
+      --with-charset=UTF8
+      --with-posset=IPA
     ]
 
     system "./configure", *args

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -11,8 +11,6 @@ class GdkPixbuf < Formula
     sha256 "cafc68c2bfb6013f6f6f0fad456eb6454065346f38679b11c23a2fed75e714e6" => :el_capitan
   end
 
-  option "with-included-loaders=", "Build the specified loaders into gdk-pixbuf"
-
   depends_on "gobject-introspection" => :build
   depends_on "meson-internal" => :build
   depends_on "ninja" => :build
@@ -58,9 +56,6 @@ class GdkPixbuf < Formula
     ]
 
     args << "-Djasper=true" if build.with?("jasper")
-
-    included_loaders = ARGV.value("with-included-loaders")
-    args << "-Dbuiltin_loaders=#{included_loaders}" if included_loaders
 
     ENV["DESTDIR"] = "/"
     mkdir "build" do

--- a/Formula/libtomcrypt.rb
+++ b/Formula/libtomcrypt.rb
@@ -12,21 +12,7 @@ class Libtomcrypt < Formula
     sha256 "9ecd9f9965864d6c58970ebd6d0c3b1871e38ef787ed8732ef12072a651fd3c3" => :el_capitan
   end
 
-  option "with-gmp", "enable gmp as MPI provider"
-  option "with-libtommath", "enable libtommath as MPI provider"
-
-  depends_on "gmp" => :optional
-  depends_on "libtommath" => :optional
-
   def install
-    if build.with? "gmp"
-      ENV.append "CFLAGS", "-DUSE_GMP -DGMP_DESC"
-      ENV.append "EXTRALIBS", "-lgmp"
-    end
-    if build.with? "libtommath"
-      ENV.append "CFLAGS", "-DUSE_LTM -DLTM_DESC"
-      ENV.append "EXTRALIBS", "-ltommath"
-    end
     system "make", "test"
     system "make", "install", "PREFIX=#{prefix}"
     pkgshare.install "test"

--- a/Formula/little-cms.rb
+++ b/Formula/little-cms.rb
@@ -14,24 +14,13 @@ class LittleCms < Formula
     sha256 "bc02c8267bf616ef0dcfc27db97a849b0f79e8211164ea4a955482b964255a7e" => :yosemite
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
-  depends_on "python@2" => :optional
-  depends_on "jpeg" => :recommended
-  depends_on "libtiff" => :recommended
+  depends_on "jpeg"
+  depends_on "libtiff"
 
   def install
     args = %W[--disable-dependency-tracking --disable-debug --prefix=#{prefix}]
-    args << "--without-tiff" if build.without? "libtiff"
-    args << "--without-jpeg" if build.without? "jpeg"
-    if build.with? "python@2"
-      args << "--with-python"
-      inreplace "python/Makefile.in" do |s|
-        s.change_make_var! "pkgdir", lib/"python2.7/site-packages"
-      end
-    end
-
     system "./configure", *args
+
     system "make"
     ENV.deparallelize
     system "make", "install"

--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -15,13 +15,11 @@ class LittleCms2 < Formula
     sha256 "fa72bb1ce13889405ee93519be86ff1cede056d8c74e1d1671cca52013762ec0" => :el_capitan
   end
 
-  depends_on "jpeg" => :recommended
-  depends_on "libtiff" => :recommended
+  depends_on "jpeg"
+  depends_on "libtiff"
 
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-    args << "--without-tiff" if build.without? "libtiff"
-    args << "--without-jpeg" if build.without? "jpeg"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -15,20 +15,11 @@ class Luajit < Formula
   devel do
     url "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
     sha256 "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-
-    option "with-gc64", "Build with 64-bit support"
   end
 
   head do
     url "https://luajit.org/git/luajit-2.0.git", :branch => "v2.1"
-
-    option "with-gc64", "Build with 64-bit support"
   end
-
-  deprecated_option "enable-debug" => "with-debug"
-
-  option "with-debug", "Build with debugging symbols"
-  option "with-52compat", "Build with additional Lua 5.2 compatibility"
 
   def install
     # 1 - Override the hardcoded gcc.
@@ -47,14 +38,8 @@ class Luajit < Formula
 
     args = %W[PREFIX=#{prefix}]
 
-    cflags = []
-    cflags << "-DLUAJIT_ENABLE_LUA52COMPAT" if build.with? "52compat"
-    cflags << "-DLUAJIT_ENABLE_GC64" if !build.stable? && build.with?("gc64")
-
-    args << "XCFLAGS=#{cflags.join(" ")}" unless cflags.empty?
-
-    # This doesn't yet work under superenv because it removes "-g"
-    args << "CCDEBUG=-g" if build.with? "debug"
+    # Build with 64-bit support
+    args << "XCFLAGS=-DLUAJIT_ENABLE_GC64" unless build.stable?
 
     # The development branch of LuaJIT normally does not install "luajit".
     args << "INSTALL_TNAME=luajit" if build.devel?
@@ -74,7 +59,7 @@ class Luajit < Formula
               "INSTALL_LMOD=#{HOMEBREW_PREFIX}/share/lua/${abiver}"
       s.gsub! "INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}",
               "INSTALL_CMOD=#{HOMEBREW_PREFIX}/${multilib}/lua/${abiver}"
-      if build.without? "gc64"
+      if build.stable?
         s.gsub! "Libs:",
                 "Libs: -pagezero_size 10000 -image_base 100000000"
       end

--- a/Formula/mecab-ipadic.rb
+++ b/Formula/mecab-ipadic.rb
@@ -18,22 +18,16 @@ class MecabIpadic < Formula
     sha256 "c70d627c447086a66b6eaca37cd98e1da099f65bfb6b87f2c47d1901d5e4a090" => :mountain_lion
   end
 
-  # Via ./configure --help, valid choices are utf8 (default), euc-jp, sjis
-  option "with-charset=", "Select charset: utf8 (default), euc-jp, or sjis"
-
-  deprecated_option "charset=" => "with-charset="
-
   depends_on "mecab"
 
   link_overwrite "lib/mecab/dic"
 
   def install
-    charset = ARGV.value("with-charset") || "utf8"
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --with-charset=#{charset}
+      --with-charset=utf8
       --with-dicdir=#{lib}/mecab/dic/ipadic
     ]
 

--- a/Formula/mecab-jumandic.rb
+++ b/Formula/mecab-jumandic.rb
@@ -14,22 +14,16 @@ class MecabJumandic < Formula
     sha256 "4b821839b99982c506a1e262c9fa8b650620bc546a8725a5eaa1dc54b45e4822" => :yosemite
   end
 
-  # Via ./configure --help, valid choices are utf8 (default), euc-jp, sjis
-  option "with-charset=", "Select charset: utf8 (default), euc-jp, or sjis"
-
-  deprecated_option "charset=" => "with-charset="
-
   depends_on "mecab"
 
   link_overwrite "lib/mecab/dic"
 
   def install
-    charset = ARGV.value("with-charset") || "utf8"
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --with-charset=#{charset}
+      --with-charset=utf8
       --with-dicdir=#{lib}/mecab/dic/jumandic
     ]
 

--- a/Formula/nuxeo.rb
+++ b/Formula/nuxeo.rb
@@ -6,14 +6,12 @@ class Nuxeo < Formula
 
   bottle :unneeded
 
-  depends_on "poppler" => :recommended
-  depends_on "pdftohtml" => :optional
-  depends_on "imagemagick"
-  depends_on "ghostscript"
-  depends_on "ufraw"
-  depends_on "libwpd"
   depends_on "exiftool"
-  depends_on "ffmpeg" => :optional
+  depends_on "ghostscript"
+  depends_on "imagemagick"
+  depends_on "libwpd"
+  depends_on "poppler"
+  depends_on "ufraw"
 
   def install
     libexec.install Dir["#{buildpath}/*"]

--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -13,10 +13,9 @@ class Ocp < Formula
     sha256 "d2a095ce47bdea35fad3f6f7ffac500ccc4dc8dd149a9c1dbbae2bbf92809886" => :mavericks
   end
 
+  depends_on "flac"
   depends_on "libvorbis"
-  depends_on "mad" => :recommended
-  depends_on "flac" => :recommended
-  depends_on "adplug" => :optional
+  depends_on "mad"
 
   def install
     ENV.deparallelize
@@ -27,10 +26,6 @@ class Ocp < Formula
       --without-sdl
       --without-desktop_file_install
     ]
-
-    args << "--without-mad"  if build.without? "mad"
-    args << "--without-flac" if build.without? "flac"
-    args << "--with-adplug"  if build.with? "adplug"
 
     system "./configure", *args
     system "make"

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -14,22 +14,11 @@ class Openmsx < Formula
     sha256 "0789729f06a73ae5acd2a04df373f839a2ac7d14e5679a380f7a485a777124ff" => :el_capitan
   end
 
-  deprecated_option "without-opengl" => "without-glew"
-
-  option "without-glew", "Disable OpenGL post-processing renderer"
-  option "with-laserdisc", "Enable Laserdisc support"
-
+  depends_on "freetype"
+  depends_on "glew"
+  depends_on "libpng"
   depends_on "sdl"
   depends_on "sdl_ttf"
-  depends_on "freetype"
-  depends_on "libpng"
-  depends_on "glew" => :recommended
-
-  if build.with? "laserdisc"
-    depends_on "libogg"
-    depends_on "libvorbis"
-    depends_on "theora"
-  end
 
   def install
     # Fixes a clang crash; this is an LLVM/Apple bug, not an openmsx bug

--- a/Formula/pkgdiff.rb
+++ b/Formula/pkgdiff.rb
@@ -14,11 +14,9 @@ class Pkgdiff < Formula
     sha256 "a9ccac49037c91c63af967e67256daa24e878f38fd17959ba30fffb8e1fcc2a2" => :mavericks
   end
 
-  depends_on "wdiff"
+  depends_on "binutils"
   depends_on "gawk"
-  depends_on "binutils" => :recommended
-  depends_on "rpm" => :optional
-  depends_on "dpkg" => :optional
+  depends_on "wdiff"
 
   def install
     system "perl", "Makefile.pl", "--install", "--prefix=#{prefix}"

--- a/Formula/rxvt-unicode.rb
+++ b/Formula/rxvt-unicode.rb
@@ -13,11 +13,6 @@ class RxvtUnicode < Formula
     sha256 "9b674dd3738ab25fa6145680f92ca036df470ced089448abcb6647439320e075" => :yosemite
   end
 
-  option "without-iso14755", "Disable ISO 14775 Shift+Ctrl hotkey"
-  option "without-unicode3", "Disable 21-bit Unicode 3 (non-BMP) character support"
-
-  deprecated_option "disable-iso14755" => "without-iso14755"
-
   depends_on "pkg-config" => :build
   depends_on :x11
 
@@ -32,10 +27,8 @@ class RxvtUnicode < Formula
       --with-term=rxvt-unicode-256color
       --with-terminfo=/usr/share/terminfo
       --enable-smart-resize
+      --enable-unicode3
     ]
-
-    args << "--disable-iso14755" if build.without? "iso14755"
-    args << "--enable-unicode3" if build.with? "unicode3"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/telegram-cli.rb
+++ b/Formula/telegram-cli.rb
@@ -14,16 +14,12 @@ class TelegramCli < Formula
     sha256 "caabf1d19eb2b5b04560e9dc15583eb7dc3c0b0a733c732d73da09abf51dbbaf" => :el_capitan
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
-  depends_on "readline"
+  depends_on "jansson"
+  depends_on "libconfig"
   depends_on "libevent"
   depends_on "openssl"
-  depends_on "libconfig"
-  depends_on "jansson"
-  depends_on "lua" => :optional
-  depends_on "python@2" => :optional
+  depends_on "readline"
 
   # Look for the configuration file under /usr/local/etc rather than /etc on OS X.
   # Pull Request: https://github.com/vysheng/tg/pull/1306
@@ -38,10 +34,9 @@ class TelegramCli < Formula
       CFLAGS=-I#{Formula["readline"].include}
       CPPFLAGS=-I#{Formula["readline"].include}
       LDFLAGS=-L#{Formula["readline"].lib}
+      --disable-liblua"
+      --disable-python"
     ]
-
-    args << "--disable-liblua" if build.without? "lua"
-    args << "--disable-python" if build.without? "python@2"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Another series of seldom-used options. #31510 

Some of them were open-ended options, which could take any value, like `with-charset=`. With this PR, the only such option remaining is `fcitx-remote-for-osx`, because its option is actually *very* used.