### PR TITLE
tiger-vnc revision bump and test

### DIFF
--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -1,8 +1,9 @@
 class TigerVnc < Formula
   desc "High-performance, platform-neutral implementation of VNC"
-  homepage "http://tigervnc.org/"
+  homepage "https://tigervnc.org/"
   url "https://github.com/TigerVNC/tigervnc/archive/v1.9.0.tar.gz"
   sha256 "f15ced8500ec56356c3bf271f52e58ed83729118361c7103eab64a618441f740"
+  revision 1
 
   bottle do
     sha256 "d182b89bdf904b1f17cf494bf69cbd218f0159b8b1df5fb0da9ed7221ef4465f" => :mojave
@@ -27,5 +28,10 @@ class TigerVnc < Formula
     ]
     system "cmake", *args
     system "make", "install"
+  end
+
+  test do
+    output = shell_output("#{bin}/vncviewer -h 2>&1", 1)
+    assert_match "TigerVNC Viewer 64-bit v#{version}", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This adds a very basic test to tiger-vnc because it didn't have any yet. It also bumps the version so it'll have a rebuild bottle with jpeg-turbo 2.0 support. Fixing #32120