### PR TITLE
imagemagick: revert "ship a safer default security policy" part 1

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -7,7 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick--7.0.8-11.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-7.0.8-11.tar.xz"
   sha256 "c15f14c054b4fde417e7b82c23950047203f81e582de7f1270cf3bdfa8a38a03"
-  revision 1
+  revision 2
   head "https://github.com/ImageMagick/ImageMagick.git"
 
   bottle do
@@ -65,17 +65,6 @@ class Imagemagick < Formula
 
   skip_clean :la
 
-  # This isn't an upstream issue and this patch should not be removed.
-  # Imagemagick delegate configuring secure defaults to users/packagers
-  # and ship the most "open" (and thus potentially unsafe) configuration
-  # possible out of the box. This policy is inspired by both Debian's and
-  # the advice on Imagemagick's related page:
-  # https://www.imagemagick.org/script/security-policy.php
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a95f9dd/imagemagick/imagemagick_safer_defaults.diff"
-    sha256 "3f22b13e206d2403b53692412b7b69d175530f5977350486b81da5027c548b44"
-  end
-
   def install
     args = %W[
       --disable-osx-universal-binary
@@ -116,14 +105,7 @@ class Imagemagick < Formula
       args << "--without-openjp2"
     end
 
-    if build.with? "ghostscript"
-      inreplace "config/policy.xml",
-                /.*EPS,PS2,PS3,PS,PDF,XPS.*$/,
-                "  <!-- \\0 -->"
-    else
-      args << "--without-gslib"
-    end
-
+    args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
     args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"
     args << "--without-magick-plus-plus" if build.without? "magick-plus-plus"
@@ -159,12 +141,5 @@ class Imagemagick < Formula
     %w[Modules freetype jpeg png tiff].each do |feature|
       assert_match feature, features
     end
-
-    # Check our security policy is working as expected.
-    cp test_fixtures("test.pdf"), testpath
-    output = shell_output("#{bin}/convert test.pdf test.jpg 2>&1", 1)
-    assert_match "not authorized", output
-    refute_predicate testpath/"test.jpg", :exist?,
-      "Imagemagick's security policy was not enforced as expected"
   end
 end

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -7,7 +7,7 @@ class ImagemagickAT6 < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick%406--6.9.10-11.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.10-11.tar.xz"
   sha256 "2d1c61999a9b1f663a085d6657cc4db4b1652af6462256d1aa3c467df3e9e6eb"
-  revision 1
+  revision 2
   head "https://github.com/imagemagick/imagemagick6.git"
 
   bottle do
@@ -63,17 +63,6 @@ class ImagemagickAT6 < Formula
 
   skip_clean :la
 
-  # This isn't an upstream issue and this patch should not be removed.
-  # Imagemagick delegate configuring secure defaults to users/packagers
-  # and ship the most "open" (and thus potentially unsafe) configuration
-  # possible out of the box. This policy is inspired by both Debian's and
-  # the advice on Imagemagick's related page:
-  # https://www.imagemagick.org/script/security-policy.php
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a95f9dd/imagemagick/imagemagick_safer_defaults.diff"
-    sha256 "3f22b13e206d2403b53692412b7b69d175530f5977350486b81da5027c548b44"
-  end
-
   def install
     args = %W[
       --disable-osx-universal-binary
@@ -114,14 +103,7 @@ class ImagemagickAT6 < Formula
       args << "--without-openjp2"
     end
 
-    if build.with? "ghostscript"
-      inreplace "config/policy.xml",
-                /.*EPS,PS2,PS3,PS,PDF,XPS.*$/,
-                "  <!-- \\0 -->"
-    else
-      args << "--without-gslib"
-    end
-
+    args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
     args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"
     args << "--without-magick-plus-plus" if build.without? "magick-plus-plus"
@@ -149,12 +131,5 @@ class ImagemagickAT6 < Formula
     %w[Modules freetype jpeg png tiff].each do |feature|
       assert_match feature, features
     end
-
-    # Check our security policy is working as expected.
-    cp test_fixtures("test.pdf"), testpath
-    output = shell_output("#{bin}/convert test.pdf test.jpg 2>&1", 1)
-    assert_match "not authorized", output
-    refute_predicate testpath/"test.jpg", :exist?,
-      "Imagemagick's security policy was not enforced as expected"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Closes #31984

Partially reverts #31558

Reverting the test changes separately as they don't need new bottles. #32150