### PR TITLE
hcloud 1.8.0

### DIFF
--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -15,6 +15,7 @@ class Hcloud < Formula
   depends_on "go" => :build
 
   def install
+    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
     (buildpath/"src/github.com/hetznercloud/cli").install buildpath.children
 
     cd "src/github.com/hetznercloud/cli" do

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -1,8 +1,8 @@
 class Hcloud < Formula
   desc "Command-line interface for Hetzner Cloud"
   homepage "https://github.com/hetznercloud/cli"
-  url "https://github.com/hetznercloud/cli/archive/v1.7.0.tar.gz"
-  sha256 "e48ca7f56ba8ffb70c1a14d1c20552f54c9b224f96b42d95230974fd63625838"
+  url "https://github.com/hetznercloud/cli/archive/v1.8.0.tar.gz"
+  sha256 "3745561c43816a8d01f8c4a8ec5d64de3d5da1501537425813ccf294e64b38ea"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -15,7 +15,6 @@ class Hcloud < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/hetznercloud/cli").install buildpath.children
 
     cd "src/github.com/hetznercloud/cli" do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/hetznercloud/cli/releases/tag/v1.8.0

Since we now uses golang 1.11 we does not need to overwrite the GOPATH Env anymore.