### PR TITLE
Unison@2.48

### DIFF
--- a/Formula/unison@2.48.rb
+++ b/Formula/unison@2.48.rb
@@ -1,0 +1,23 @@
+class UnisonAT248 < Formula
+  desc "File synchronization tool for OSX"
+  homepage "https://www.cis.upenn.edu/~bcpierce/unison/"
+  url "https://github.com/bcpierce00/unison/archive/v2.48.15v4.tar.gz"
+  sha256 "f8c7e982634bbe1ed6510fe5b36b6c5c55c06caefddafdd9edc08812305fdeec"
+
+  keg_only :versioned_formula
+
+  depends_on "ocaml" => :build
+
+  def install
+    ENV.deparallelize
+    ENV.delete "CFLAGS" # ocamlopt reads CFLAGS but doesn't understand common options
+    ENV.delete "NAME" # https://github.com/Homebrew/homebrew/issues/28642
+    system "make", "UISTYLE=text"
+    bin.install "src/unison"
+    prefix.install_metafiles "src"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/unison -version")
+  end
+end


### PR DESCRIPTION
Some servers haven't been updated to 2.51 and there are problems if the
server and client versions don't match. This is a versioned formula to
allow 2.48 to be installed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
