### PR TITLE
neovim: fix luarocks install order, update dep url

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -41,9 +41,14 @@ class Neovim < Formula
     sha256 "ea1f347663cebb523e88622b1d6fe38126c79436da4dbf442674208aa14a8f4c"
   end
 
+  resource "luabitop-rockspec" do
+    url "https://luarocks.org/manifests/luarocks/luabitop-1.0.2-3.rockspec"
+    sha256 "8cc12ebd2919b08765fef9f8738d2277204e8c6a7578e8e7f1abf6054380c21f"
+  end
+
   resource "luabitop" do
-    url "https://luarocks.org/luabitop-1.0.2-1.src.rock"
-    sha256 "fc7a8065a57462ee13bed7f95b0ab13f94ecd1bf846108c61ccf2c75548af26e"
+    url "https://github.com/LuaDist/luabitop/archive/1.0.2.tar.gz"
+    sha256 "d5f2ada780397e9bf8f885b811abdb4f86b7e7e7ee827e744efcf672882f4398"
   end
 
   resource "luafilesystem" do
@@ -132,12 +137,29 @@ class Neovim < Formula
     lua_path = "--lua-dir=#{Formula["lua@5.1"].opt_prefix}"
 
     cd "deps-build" do
+      # penlight depends on luafilesystem
+      cd "build/src/luafilesystem" do
+        output = Utils.popen_read("luarocks", "unpack", lua_path, "luafilesystem-1.7.0-2.src.rock", "--tree=#{buildpath}/deps-build")
+        unpack_dir = output.split("\n")[-2]
+        cd unpack_dir do
+          system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+        end
+      end
+
+      # busted depends on penlight
+      cd "build/src/penlight" do
+        system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+      end
+
+      cp "build/src/luabitop-rockspec/luabitop-1.0.2-3.rockspec", "build/src/luabitop/"
+      cd "build/src/luabitop/" do
+        system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+      end
+
       %w[
         lpeg/lpeg-1.0.1-1.src.rock
         mpack/mpack-1.0.7-0.rockspec
         inspect/inspect-3.1.1-0.src.rock
-        luabitop/luabitop-1.0.2-1.src.rock
-        luafilesystem/luafilesystem-1.7.0-2.src.rock
         lua_cliargs/lua_cliargs-3.0-1.src.rock
         lua-term/lua-term-0.7-1.rockspec
         luasystem/luasystem-0.2.1-0.src.rock
@@ -151,11 +173,14 @@ class Neovim < Formula
         coxpcall/coxpcall-1.17.0-1.src.rock
         nvim-client/nvim-client-0.1.0-1.rockspec
       ].each do |rock|
-        system "luarocks", "build", lua_path, "build/src/#{rock}", "--tree=."
-      end
-
-      cd "build/src/penlight" do
-        system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+        dir, rock = rock.split("/")
+        cd "build/src/#{dir}" do
+          output = Utils.popen_read("luarocks", "unpack", lua_path, rock, "--tree=#{buildpath}/deps-build")
+          unpack_dir = output.split("\n")[-2]
+          cd unpack_dir do
+            system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"
+          end
+        end
       end
 
       system "cmake", "../third-party", "-DUSE_BUNDLED=OFF", *std_cmake_args


### PR DESCRIPTION
    - penlight depends on luafilesystem, so install that first
    - busted depends on penlight, so penlight needs to be installed next
    - update the luabitop version and download link
    - use "luarocks make" instead of "luarocks build" since build will
    download and install other dependencies (we want to verify source
    checksums). "luarocks make" expects an unpacked rock, so we need to
    "luarocks unpack" first.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes: https://github.com/Homebrew/homebrew-core/issues/32144