### PR TITLE
Remove options, n+1

### DIFF
--- a/Formula/afio.rb
+++ b/Formula/afio.rb
@@ -16,20 +16,7 @@ class Afio < Formula
     sha256 "7ff316d9e43e5a55b95d381f13f0429a87ff36d39425fb62ec2af2cb00fc22af" => :lion
   end
 
-  # Note - The Freecode website is no longer being updated and alternative
-  # links should be found from now on.
-
-  option "with-bzip2", "Use bzip2(1) instead of gzip(1) for compression/decompression"
-  deprecated_option "bzip2" => "with-bzip2"
-
   def install
-    if build.with? "bzip2"
-      inreplace "Makefile", "-DPRG_COMPRESS='\"gzip\"'", "-DPRG_COMPRESS='\"bzip2\"'"
-      inreplace "afio.c", "with -o: gzip files", "with -o: bzip2 files"
-      inreplace "afio.1", "gzip", "bzip2"
-      inreplace "afio.1", "bzip2, bzip2,", "gzip, bzip2,"
-    end
-
     system "make", "DESTDIR=#{prefix}"
     bin.install "afio"
     man1.install "afio.1"

--- a/Formula/apache-ctakes.rb
+++ b/Formula/apache-ctakes.rb
@@ -6,26 +6,13 @@ class ApacheCtakes < Formula
 
   bottle :unneeded
 
-  option "with-ctakes-resources", "Install prebuilt dictionaries and models"
-
   depends_on :java => "1.8+"
-
-  resource "ctakes-resources" do
-    url "https://downloads.sourceforge.net/project/ctakesresources/ctakes-resources-4.0-bin.zip"
-    sha256 "c72b5f64e1572c207c139f1dfbe6fa8b5e3708bc66e1f5d6f4c8863055121351"
-  end
 
   def install
     rm_f Dir["bin/*.bat", "bin/*.cmd", "bin/ctakes.profile", "bin/ctakes-ytex",
              "libexec/*.bat", "libexec/*.cmd"]
     libexec.install %w[bin config desc lib resources]
     pkgshare.install_symlink libexec/"resources/org/apache/ctakes/examples"
-
-    if build.with? "ctakes-resources"
-      resource("ctakes-resources").stage do
-        system "ditto", "resources", libexec/"resources"
-      end
-    end
 
     bin.write_exec_script Dir["#{libexec}/bin/*"]
   end

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -3,6 +3,7 @@ class Avfs < Formula
   homepage "https://avf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avf/avfs/1.0.5/avfs-1.0.5.tar.bz2"
   sha256 "e5ce6b1f4193c37148b1b8a021f4f3d05e88f725cf11b16b95a58e8fdae50176"
+  revision 1
 
   bottle do
     sha256 "18dd2a2958a2a07b74309e3ec832dcc4c99de70b73e5d5b263be8833cc820ebb" => :high_sierra
@@ -11,25 +12,24 @@ class Avfs < Formula
 
   depends_on "pkg-config" => :build
   depends_on :macos => :sierra # needs clock_gettime
+  depends_on "openssl"
   depends_on :osxfuse
-  depends_on "xz" => :recommended # Upstream recommends building with lzma support.
-  depends_on "openssl" => :optional
+  depends_on "xz"
 
   # Fix scripts to work on Mac OS X.
   # Nothing the patch fixes has been changed in 1.0.2, so still necessary.
   patch :DATA
 
   def install
-    args = [
-      "--prefix=#{prefix}",
-      "--disable-debug",
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--enable-fuse",
-      "--enable-library",
+    args = %W[
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --enable-fuse
+      --enable-library
+      --with-ssl=#{Formula["openssl"].opt_prefix}
     ]
-
-    args << "--with-ssl=#{Formula["openssl"].opt_prefix}" if build.with? "openssl"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/cnats.rb
+++ b/Formula/cnats.rb
@@ -3,6 +3,7 @@ class Cnats < Formula
   homepage "https://github.com/nats-io/cnats"
   url "https://github.com/nats-io/cnats/archive/v1.7.6.tar.gz"
   sha256 "9155102243c6c7a3e9a6b37b259f7587bcfbad5f9521fbe466be58a4517df769"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,13 +14,14 @@ class Cnats < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "libevent"
+  depends_on "libuv"
   depends_on "openssl"
-  depends_on "libevent" => :optional
-  depends_on "libuv" => :optional
 
   def install
-    local_cmake_args = ["-DNATS_INSTALL_PREFIX=#{prefix}", "-DBUILD_TESTING=OFF"]
-    system "cmake", ".", *local_cmake_args, *std_cmake_args
+    local_cmake_args = 
+    system "cmake", ".", "-DNATS_INSTALL_PREFIX=#{prefix}",
+                         "-DBUILD_TESTING=OFF", *std_cmake_args
     system "make", "install"
   end
 

--- a/Formula/cpmtools.rb
+++ b/Formula/cpmtools.rb
@@ -3,6 +3,7 @@ class Cpmtools < Formula
   homepage "http://www.moria.de/~michael/cpmtools/"
   url "http://www.moria.de/~michael/cpmtools/files/cpmtools-2.20.tar.gz"
   sha256 "d8c7e78a9750994124f3aab6e461da8fa0021acc7dbad76eafbac8b0ed8279d3"
+  revision 1
 
   bottle do
     rebuild 1
@@ -14,13 +15,10 @@ class Cpmtools < Formula
     sha256 "b810122c220af6b36ab9316deec811adca68313d4371f8a0121239c40b94a015" => :mavericks
   end
 
-  depends_on "libdsk" => :optional
+  depends_on "libdsk"
 
   def install
-    args = %W[--prefix=#{prefix}]
-    args << "--with-libdsk" if build.with? "libdsk"
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--with-libdsk"
 
     bin.mkpath
     man1.mkpath

--- a/Formula/ctunnel.rb
+++ b/Formula/ctunnel.rb
@@ -16,10 +16,11 @@ class Ctunnel < Formula
   end
 
   depends_on "openssl"
-  depends_on :tuntap => :optional
 
   def install
-    inreplace "Makefile.cfg", "TUNTAP=yes", "TUNTAP=no" if build.without? "tuntap"
+    # Do not require tuntap
+    inreplace "Makefile.cfg", "TUNTAP=yes", "TUNTAP=no"
+
     system "make"
     bin.mkpath
     system "make", "-B", "install", "PREFIX=#{prefix}"

--- a/Formula/dgen.rb
+++ b/Formula/dgen.rb
@@ -19,10 +19,6 @@ class Dgen < Formula
     depends_on "automake" => :build
   end
 
-  option "with-docs", "Build documentation"
-  option "with-debugger", "Enable debugger"
-
-  depends_on "doxygen" if build.with? "docs"
   depends_on "libarchive"
   depends_on "sdl"
 
@@ -33,7 +29,6 @@ class Dgen < Formula
       --disable-sdltest
       --prefix=#{prefix}
     ]
-    args << "--enable-debugger" if build.with? "debugger"
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make", "install"

--- a/Formula/docker-machine-driver-vultr.rb
+++ b/Formula/docker-machine-driver-vultr.rb
@@ -16,7 +16,7 @@ class DockerMachineDriverVultr < Formula
 
   depends_on "go" => :build
   depends_on "godep" => :build
-  depends_on "docker-machine" => :recommended
+  depends_on "docker-machine"
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Formula/es.rb
+++ b/Formula/es.rb
@@ -15,25 +15,13 @@ class Es < Formula
     sha256 "14f203383d01f581bdb63e7240ff57d1174553467314351d49ea41d3052148f9" => :mavericks
   end
 
-  option "with-readline", "Use readline instead of libedit"
-
-  depends_on "readline" => :optional
-
   def install
-    args = %W[--prefix=#{prefix}]
-
-    if build.with? "readline"
-      args << "--with-readline"
-    else
-      args << "--with-editline"
-    end
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--with-editline"
     system "make"
 
-    man1.install "doc/es.1"
     bin.install "es"
     doc.install %w[CHANGES README trip.es examples]
+    man1.install "doc/es.1"
   end
 
   test do

--- a/Formula/fobis.rb
+++ b/Formula/fobis.rb
@@ -14,11 +14,9 @@ class Fobis < Formula
     sha256 "9be1a5d77e8c9d546b2eb129b4ecf607fd501eb1ad2e025276261c4144d0bf02" => :el_capitan
   end
 
-  option "without-pygooglechart", "Disable support for coverage charts generated with pygooglechart"
-
   depends_on "gcc" # for gfortran
+  depends_on "graphviz"
   depends_on "python@2"
-  depends_on "graphviz" => :recommended
 
   resource "pygooglechart" do
     url "https://files.pythonhosted.org/packages/95/88/54f91552de1e1b0085c02b96671acfba6e351915de3a12a398533fc82e20/pygooglechart-0.4.0.tar.gz"
@@ -32,8 +30,8 @@ class Fobis < Formula
 
   def install
     venv = virtualenv_create(libexec)
-    venv.pip_install "pygooglechart" if build.with? "pygooglechart"
-    venv.pip_install "graphviz" if build.with? "graphviz"
+    venv.pip_install "pygooglechart"
+    venv.pip_install "graphviz"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/freediameter.rb
+++ b/Formula/freediameter.rb
@@ -13,28 +13,15 @@ class Freediameter < Formula
     sha256 "ae4a0a662111c28c542ba2b15f2ff5f0d6955dd62c474b7216f12bda8a54041c" => :el_capitan
   end
 
-  option "with-all-extensions", "Enable all extensions"
-
   depends_on "cmake" => :build
   depends_on "gnutls"
   depends_on "libgcrypt"
   depends_on "libidn"
 
-  if build.with? "all-extensions"
-    depends_on "swig" => :build
-    depends_on "postgresql"
-    depends_on "mysql"
-  end
-
   def install
-    args = std_cmake_args + %W[
-      -DDEFAULT_CONF_PATH=#{etc}
-      -DDISABLE_SCTP=ON
-    ]
-    args << "-DALL_EXTENSIONS=ON" if build.with? "all-extensions"
-
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args, "-DDEFAULT_CONF_PATH=#{etc}",
+                      "-DDISABLE_SCTP=ON"
       system "make"
       system "make", "install"
     end

--- a/Formula/genders.rb
+++ b/Formula/genders.rb
@@ -14,16 +14,8 @@ class Genders < Formula
     sha256 "c455a536ad6b100887fbc6badf0e054157cf961ea02802f67a694c5e8dd30b96" => :mavericks
   end
 
-  option "with-non-shortened-hostnames", "Allow non shortened hostnames that can include dots e.g. www.google.com"
-
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --with-java-extensions=no
-    ]
-    args << "--with-non-shortened-hostnames" if build.with? "non-shortened-hostnames"
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}", "--with-java-extensions=no"
     system "make", "install"
   end
 end

--- a/Formula/git-if.rb
+++ b/Formula/git-if.rb
@@ -15,26 +15,12 @@ class GitIf < Formula
     sha256 "e727f112e350e8a12b87094715800e9c2abc03f2d45ad521c0d78e4c6bfff3ad" => :yosemite
   end
 
-  option "with-glkterm", "Build with glkterm (without wide character support)"
-
-  depends_on "cheapglk" => [:build, :optional]
-  depends_on "glkterm" => [:build, :optional]
-  depends_on "glktermw" => :build if build.without?("cheapglk") && build.without?("glkterm")
+  depends_on "glktermw" => :build
 
   def install
-    if build.with?("cheapglk") && build.with?("glkterm")
-      odie "Options --with-cheapglk and --with-glkterm are mutually exclusive."
-    end
+    glk = Formula["glktermw"]
 
-    if build.with? "cheapglk"
-      glk = Formula["cheapglk"]
-    elsif build.with? "glkterm"
-      glk = Formula["glkterm"]
-    else
-      glk = Formula["glktermw"]
-    end
-
-    inreplace "Makefile", "GLK = cheapglk", "GLK = #{glk.name}" if build.without? "cheapglk"
+    inreplace "Makefile", "GLK = cheapglk", "GLK = #{glk.name}"
     inreplace "Makefile", "GLKINCLUDEDIR = ../$(GLK)", "GLKINCLUDEDIR = #{glk.include}"
     inreplace "Makefile", "GLKLIBDIR = ../$(GLK)", "GLKLIBDIR = #{glk.lib}"
     inreplace "Makefile", /^OPTIONS = /, "OPTIONS = -DUSE_MMAP -DUSE_INLINE"
@@ -44,10 +30,6 @@ class GitIf < Formula
   end
 
   test do
-    if build.with? "cheapglk"
-      assert shell_output("#{bin}/git-if").start_with? "usage: git gamefile.ulx"
-    else
-      assert pipe_output("#{bin}/git-if -v").start_with? "GlkTerm, library version"
-    end
+    assert pipe_output("#{bin}/git-if -v").start_with? "GlkTerm, library version"
   end
 end

--- a/Formula/gloox.rb
+++ b/Formula/gloox.rb
@@ -3,6 +3,7 @@ class Gloox < Formula
   homepage "https://camaya.net/gloox/"
   url "https://camaya.net/download/gloox-1.0.21.tar.bz2"
   sha256 "3c13155c10e3182a1a57779134cc524efb3657545849534b2831fae0e2c3a7cc"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,8 +15,8 @@ class Gloox < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libidn"
   depends_on "openssl"
-  depends_on "libidn" => :optional
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/gmediaserver.rb
+++ b/Formula/gmediaserver.rb
@@ -17,8 +17,6 @@ class Gmediaserver < Formula
   depends_on "pkg-config" => :build
   depends_on "libmagic"
   depends_on "libupnp"
-  depends_on "id3lib" => :optional
-  depends_on "taglib" => :optional
 
   # Patching gmediaserver because sigwaitinfo is not available on
   # OS X Snow Leopard, using sigwait instead.

--- a/Formula/htmlcompressor.rb
+++ b/Formula/htmlcompressor.rb
@@ -6,27 +6,9 @@ class Htmlcompressor < Formula
 
   bottle :unneeded
 
-  option "with-yuicompressor", "Use YUICompressor for JS/CSS compression"
-  option "with-closure-compiler", "Use Closure Compiler for JS optimization"
-
-  deprecated_option "yuicompressor" => "with-yuicompressor"
-  deprecated_option "closure-compiler" => "with-closure-compiler"
-
-  depends_on "closure-compiler" => :optional
-  depends_on "yuicompressor" => :optional
-
   def install
     libexec.install "htmlcompressor-#{version}.jar"
     bin.write_jar_script libexec/"htmlcompressor-#{version}.jar", "htmlcompressor"
-
-    if build.with? "yuicompressor"
-      yui = Formula["yuicompressor"]
-      libexec.install_symlink yui.opt_libexec/"yuicompressor-#{yui.version}.jar"
-    end
-
-    if build.with? "closure-compiler"
-      libexec.install_symlink Formula["closure-compiler"].opt_libexec/"build/compiler.jar"
-    end
   end
 
   test do

--- a/Formula/kyoto-tycoon.rb
+++ b/Formula/kyoto-tycoon.rb
@@ -13,23 +13,14 @@ class KyotoTycoon < Formula
   end
 
   depends_on "kyoto-cabinet"
-  depends_on "lua" => :recommended
+  depends_on "lua"
 
   patch :DATA if MacOS.version >= :mavericks
 
   def install
-    # Locate kyoto-cabinet for non-/usr/local builds
-    cabinet = Formula["kyoto-cabinet"].opt_prefix
-    args = ["--prefix=#{prefix}", "--with-kc=#{cabinet}"]
-
-    if build.with? "lua"
-      lua = Formula["lua"].opt_prefix
-      args << "--with-lua=#{lua}"
-    else
-      args << "--enable-lua"
-    end
-
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-kc=#{Formula["kyoto-cabinet"].opt_prefix}",
+                          "--with-lua=#{Formula["lua"].opt_prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/libquantum.rb
+++ b/Formula/libquantum.rb
@@ -20,12 +20,9 @@ class Libquantum < Formula
     sha256 "d8e3c4407076558f87640f1e618501ec85bc5f4c5a84db4117ceaec7105046e5"
   end
 
-  option "with-quobtools", "Install quobtools for debug"
-
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
-    system "make", "quobtools_install" if build.with? "quobtools"
   end
 
   test do

--- a/Formula/libspnav.rb
+++ b/Formula/libspnav.rb
@@ -15,19 +15,14 @@ class Libspnav < Formula
     sha256 "0d0a4943d1eee96936b7ccf0a200d353a3fd35bbf67d46695e0e4e41d498df16" => :mountain_lion
   end
 
-  option "with-x11", "Enable support for sending mouse events through the x11 protocol"
-
-  depends_on :x11 => :optional
-
   def install
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
+      --disable-x11
     ]
-
-    args << "--disable-x11" if build.without? "x11"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -15,13 +15,12 @@ class Libswiften < Formula
   depends_on "scons" => :build
   depends_on "boost"
   depends_on "libidn"
-  depends_on "lua@5.1" => :recommended
-
-  deprecated_option "without-lua" => "without-lua@5.1"
+  depends_on "lua@5.1"
 
   def install
     boost = Formula["boost"]
     libidn = Formula["libidn"]
+    lua = Formula["lua@5.1"]
 
     args = %W[
       -j #{ENV.make_jobs}
@@ -36,17 +35,12 @@ class Libswiften < Formula
       libidn_libdir=#{libidn.lib}
       SWIFTEN_INSTALLDIR=#{prefix}
       openssl=no
+      SLUIFT_INSTALLDIR=#{prefix}
+      lua_includedir=#{lua.include}/lua-5.1
+      lua_libdir=#{lua.lib}
+      lua_libname=lua.5.1
+      #{prefix}
     ]
-
-    if build.with? "lua@5.1"
-      lua = Formula["lua@5.1"]
-      args << "SLUIFT_INSTALLDIR=#{prefix}"
-      args << "lua_includedir=#{lua.include}/lua-5.1"
-      args << "lua_libdir=#{lua.lib}"
-      args << "lua_libname=lua.5.1"
-    end
-
-    args << prefix
 
     scons *args
   end

--- a/Formula/lightning.rb
+++ b/Formula/lightning.rb
@@ -13,17 +13,11 @@ class Lightning < Formula
     sha256 "ddea1c93ea261eb8f49f998deb8769b8b67d44ec955e6dbbe8509d90f5ae9b6e" => :el_capitan
   end
 
-  depends_on "binutils" => [:build, :optional]
+  depends_on "binutils" => :build
 
   def install
-    args = [
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}",
-    ]
-    args << "--disable-disassembler" if build.without? "binutils"
-
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules", "--prefix=#{prefix}"
     system "make", "check", "-j1"
     system "make", "install"
   end

--- a/Formula/lsh.rb
+++ b/Formula/lsh.rb
@@ -18,7 +18,6 @@ class Lsh < Formula
   depends_on "automake" => :build
   depends_on "gmp"
   depends_on "nettle"
-  depends_on :x11 => :optional # For libXau library
 
   resource "liboop" do
     url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libo/liboop/liboop_1.0.orig.tar.gz"
@@ -80,13 +79,8 @@ class Lsh < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
+      --without-x
     ]
-
-    if build.with? "x11"
-      args << "--with-x"
-    else
-      args << "--without-x"
-    end
 
     # Find the sandboxed liboop.
     ENV.append "LDFLAGS", "-L#{libexec}/liboop/lib"

--- a/Formula/makefile2graph.rb
+++ b/Formula/makefile2graph.rb
@@ -16,11 +16,11 @@ class Makefile2graph < Formula
     sha256 "52dea69b4d18c1c6fa451ab834a43e1ca57ba64d9efb4c63972126a387682040" => :mountain_lion
   end
 
-  depends_on "graphviz" => :recommended
+  depends_on "graphviz"
 
   def install
     system "make"
-    system "make", "test" if build.with? "graphviz"
+    system "make", "test"
     bin.install "make2graph", "makefile2graph"
     man1.install "make2graph.1", "makefile2graph.1"
     doc.install "LICENSE", "README.md", "screenshot.png"

--- a/Formula/monitoring-plugins.rb
+++ b/Formula/monitoring-plugins.rb
@@ -13,8 +13,6 @@ class MonitoringPlugins < Formula
   end
 
   depends_on "openssl"
-  depends_on "mysql" => :optional
-  depends_on "postgresql" => :optional
 
   conflicts_with "nagios-plugins", :because => "nagios-plugins ships their plugins to the same folder."
 
@@ -25,8 +23,6 @@ class MonitoringPlugins < Formula
       --libexecdir=#{libexec}/sbin
       --with-openssl=#{Formula["openssl"].opt_prefix}
     ]
-
-    args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/namazu.rb
+++ b/Formula/namazu.rb
@@ -14,23 +14,7 @@ class Namazu < Formula
     sha256 "ca6e854a626eaafd4ac26661b9a3db86dc9bc140f4aa98effd5843882aba7ecb" => :mavericks
   end
 
-  option "with-japanese", "Support for japanese character encodings."
-
-  depends_on "kakasi" if build.with? "japanese"
-
-  resource "text-kakasi" do
-    url "https://cpan.metacpan.org/authors/id/D/DA/DANKOGAI/Text-Kakasi-2.04.tar.gz"
-    sha256 "844c01e78ba4bfb89c0702995a86f488de7c29b40a75e7af0e4f39d55624dba0"
-  end
-
   def install
-    if build.with? "japanese"
-      resource("text-kakasi").stage do
-        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
-        system "make", "install"
-      end
-    end
-
     cd "File-MMagic" do
       system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
       system "make", "install"

--- a/Formula/ncdc.rb
+++ b/Formula/ncdc.rb
@@ -20,24 +20,14 @@ class Ncdc < Formula
     depends_on "automake" => :build
   end
 
-  option "with-geoip", "Build with geoip support"
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gnutls"
   depends_on "sqlite"
-  depends_on "geoip" => :optional
 
   def install
     system "autoreconf", "-ivf" if build.head?
-
-    args = [
-      "--disable-dependency-tracking",
-      "--prefix=#{prefix}",
-    ]
-    args << "--with-geoip" if build.with? "geoip"
-
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/ogmtools.rb
+++ b/Formula/ogmtools.rb
@@ -16,7 +16,6 @@ class Ogmtools < Formula
 
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "libdvdread" => :optional
 
   # Borrow patch from MacPorts
   patch :p0 do

--- a/Formula/onioncat.rb
+++ b/Formula/onioncat.rb
@@ -12,7 +12,7 @@ class Onioncat < Formula
     sha256 "98acc41c8dc5fcefbe5a410266a762ddacbe12323e958a8fe6ca753ec51f33fe" => :el_capitan
   end
 
-  depends_on "tor" => :recommended
+  depends_on "tor"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/pazpar2.rb
+++ b/Formula/pazpar2.rb
@@ -20,8 +20,8 @@ class Pazpar2 < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "icu4c"
   depends_on "yaz"
-  depends_on "icu4c" => :recommended
 
   def install
     system "./buildconf.sh" if build.head?

--- a/Formula/pound.rb
+++ b/Formula/pound.rb
@@ -11,9 +11,9 @@ class Pound < Formula
     sha256 "d16c3c0aba3eafe8f50bc4e79401a0ce3129519860d0b3bca8cdfd10023ff7b5" => :el_capitan
   end
 
+  depends_on "gperftools"
   depends_on "openssl"
   depends_on "pcre"
-  depends_on "gperftools" => :recommended
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-tcmalloc"

--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -18,7 +18,7 @@ class ScummvmTools < Formula
   depends_on "libpng"
   depends_on "libvorbis"
   depends_on "mad"
-  depends_on "wxmac" => :recommended
+  depends_on "wxmac"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/somagic.rb
+++ b/Formula/somagic.rb
@@ -17,7 +17,6 @@ class Somagic < Formula
   depends_on "libgcrypt"
   depends_on "libusb"
   depends_on "somagic-tools"
-  depends_on "mplayer" => :optional
 
   def install
     system "make"

--- a/Formula/stone.rb
+++ b/Formula/stone.rb
@@ -14,17 +14,8 @@ class Stone < Formula
     sha256 "ab43aca5038bdf014c1a5aaadb9e526626c9c4369dcaeac045b9dce6514b30bc" => :mavericks
   end
 
-  deprecated_option "with-ssl" => "with-openssl"
-
-  depends_on "openssl" => :optional
-
   def install
-    if build.with? "openssl"
-      inreplace "Makefile", "SSL=/usr", "SSL=#{Formula["openssl"].opt_prefix}"
-      system "make", "macosx-ssl"
-    else
-      system "make", "macosx"
-    end
+    system "make", "macosx"
     bin.install "stone"
   end
 

--- a/Formula/sword.rb
+++ b/Formula/sword.rb
@@ -11,12 +11,6 @@ class Sword < Formula
     sha256 "032c83b3302b78c198d1e346258a1d09c542a1361e1b0f000f82306d8c82acb4" => :el_capitan
   end
 
-  option "with-clucene", "Use clucene for text searching capabilities"
-  option "with-icu4c", "Use icu4c for unicode support"
-
-  depends_on "clucene" => :optional
-  depends_on "icu4c" => :optional
-
   def install
     args = %W[
       --prefix=#{prefix}
@@ -24,19 +18,9 @@ class Sword < Formula
       --disable-profile
       --disable-tests
       --with-curl
+      --without-icu
+      --without-clucene
     ]
-
-    if build.with? "icu4c"
-      args << "--with-icu"
-    else
-      args << "--without-icu"
-    end
-
-    if build.with? "clucene"
-      args << "--with-clucene"
-    else
-      args << "--without-clucene"
-    end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/twemcache.rb
+++ b/Formula/twemcache.rb
@@ -13,25 +13,13 @@ class Twemcache < Formula
     sha256 "fd57a26c75cb67d097894a9c757bd50b2799b1a6e8ba20510345a1f1ef5eee61" => :el_capitan
   end
 
-  option "with-debug", "Debug mode with assertion panics enabled"
-
-  deprecated_option "enable-debug" => "with-debug"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libevent"
 
   def install
-    args = %W[--prefix=#{prefix}]
-
-    if build.with? "debug"
-      ENV.O0
-      ENV.append "CFLAGS", "-ggdb3"
-      args << "--enable-debug=full"
-    end
-
     system "autoreconf", "-fvi"
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/whitedb.rb
+++ b/Formula/whitedb.rb
@@ -15,18 +15,11 @@ class Whitedb < Formula
     sha256 "aa86b2acca68b9999ecb4cb9da7c64f659a97ffbd50d7aeb78c021df13866474" => :mountain_lion
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
-  depends_on "python@2" => :optional
-
   def install
     # https://github.com/priitj/whitedb/issues/15
     ENV.append "CFLAGS", "-std=gnu89"
 
-    args = ["--prefix=#{prefix}"]
-    args << "--with-python" if build.with? "python@2"
-    system "./configure", *args
-
+    system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/zebra.rb
+++ b/Formula/zebra.rb
@@ -11,8 +11,8 @@ class Zebra < Formula
     sha256 "fff03bacc2fdde279fc891f1ebe8ba4a6c50285d2697eebf50634712cdad1753" => :el_capitan
   end
 
+  depends_on "icu4c"
   depends_on "yaz"
-  depends_on "icu4c" => :recommended
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -12,9 +12,6 @@ class Zorba < Formula
     sha256 "9dc07aa5daadc49cbbdeee1fee3ef14800a604069e996859ec58b441c1738bdd" => :el_capitan
   end
 
-  option "with-big-integer", "Use 64 bit precision instead of arbitrary precision for performance"
-  option "with-ssl-verification", "Enable SSL peer certificate verification"
-
   depends_on "cmake" => :build
   depends_on "flex"
   depends_on "icu4c"
@@ -32,8 +29,6 @@ class Zorba < Formula
     ENV.cxx11
 
     args = std_cmake_args
-    args << "-DZORBA_VERIFY_PEER_SSL_CERTIFICATE=ON" if build.with? "ssl-verification"
-    args << "-DZORBA_WITH_BIG_INTEGER=ON" if build.with? "big-integer"
 
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # usual superenv fix doesn't work since zorba doesn't use HAVE_CLOCK_GETTIME


### PR DESCRIPTION
All these formulas have very low install count (≤ 7 installs per month). Unused options were removed, the others ones (a minority) were added as new dependencies to provide feature-full formulas without options.

#31510 

After merging, the following formulas will need new bottles built and pulled: `avfs cnats cpmtools gloox`