### PR TITLE
libgeotiff: fix test

### DIFF
--- a/Formula/libgeotiff.rb
+++ b/Formula/libgeotiff.rb
@@ -63,8 +63,10 @@ class Libgeotiff < Formula
       }
     EOS
 
-    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltiff", "-lgeotiff", "-o", "test"
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lgeotiff",
+                   "-L#{Formula["libtiff"].opt_lib}", "-ltiff", "-o", "test"
     system "./test", "test.tif"
-    assert_match /GeogInvFlatteningGeoKey.*123.456/, shell_output("#{bin}/listgeo test.tif")
+    output = shell_output("#{bin}/listgeo test.tif")
+    assert_match /GeogInvFlatteningGeoKey.*123.456/, output
   end
 end


### PR DESCRIPTION
Fix the test for Mojave, which doesn't go looking for libraries in `/usr/local/lib` anymore.