### PR TITLE
docker-credential-helper-ecr: Added caveats

### DIFF
--- a/Formula/docker-credential-helper-ecr.rb
+++ b/Formula/docker-credential-helper-ecr.rb
@@ -26,6 +26,23 @@ class DockerCredentialHelperEcr < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      You MUST update your Docker configuration for the ECR Login Helper to take effect.
+
+      Update your Docker configuration at
+        ~/.docker/config.json
+
+      Under the "auths" item add a new key for your ECR
+        "<aws-acct-no>.dkr.ecr.<aws-region>.amazonaws.com": {}
+
+      Under the "credHelpers" item add a new key for your ECR
+        "<aws-acct-no>.dkr.ecr.<aws-region>.amazonaws.com": "ecr-login"
+
+      See https://github.com/awslabs/amazon-ecr-credential-helper for more info.
+    EOS
+  end
+
   test do
     output = shell_output("#{bin}/docker-credential-ecr-login", 1)
     assert_match %r{^Usage: .*/docker-credential-ecr-login.*}, output


### PR DESCRIPTION
Docker config at ~/.docker/config.json must be altered in order for the ECR login helper to work as intented.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
