### PR TITLE
sfcgal: fix build with CGAL 4.12

### DIFF
--- a/Formula/sfcgal.rb
+++ b/Formula/sfcgal.rb
@@ -16,6 +16,20 @@ class Sfcgal < Formula
   depends_on "gmp"
   depends_on "mpfr"
 
+  # These two upstream commits fix build failures with CGAL 4.12.
+  # Remove with next version.
+  # https://github.com/Oslandia/SFCGAL/pull/168
+  patch do
+    url "https://github.com/Oslandia/SFCGAL/commit/e47828f7.diff?full_index=1"
+    sha256 "5ce8b251a73f9a2f1803ca5d8a455007baedf1a2b278a2d3465af9955d79c09e"
+  end
+
+  # https://github.com/Oslandia/SFCGAL/pull/169
+  patch do
+    url "https://github.com/Oslandia/SFCGAL/commit/2ef10f25.diff?full_index=1"
+    sha256 "bc53ce8405b0400d8c37af7837a945dfd96d73cd4a876114f48441fbaeb9d96d"
+  end
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
Build has been broken from source for some time, and is why we couldn't build a Mojave bottle.