### PR TITLE
woff2: fix test on Mojave and broken dynamic library links

### DIFF
--- a/Formula/woff2.rb
+++ b/Formula/woff2.rb
@@ -44,6 +44,6 @@ class Woff2 < Formula
     resource("roboto_2").stage testpath
     system "#{bin}/woff2_decompress", "KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2"
     output = shell_output("file --brief KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.ttf")
-    assert_match "TrueType font data", output
+    assert_match(/TrueType font data/i, output)
   end
 end

--- a/Formula/woff2.rb
+++ b/Formula/woff2.rb
@@ -26,7 +26,12 @@ class Woff2 < Formula
   end
 
   def install
-    system "cmake", ".", *std_cmake_args
+    args = std_cmake_args + %W[
+      -DCMAKE_INSTALL_NAME_DIR=#{opt_lib}
+      -DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON
+    ]
+
+    system "cmake", ".", *args
     system "make", "install"
 
     # make install does not install binaries


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Mojave has upgraded its bundled `file(1)`, so `file --brief /path/to/some.ttf` now reports `TrueType Font data` rather than `TrueType font data`.

https://github.com/Homebrew/homebrew-core/pull/32241#issuecomment-422999347