### PR TITLE
wine: no devel or head on High Sierra and Mojave

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -43,6 +43,9 @@ class Wine < Formula
       url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi"
       sha256 "2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa"
     end
+
+    # Does not build with Xcode 10, used on High Sierra and Mojave
+    depends_on MaximumMacOSRequirement => :sierra
   end
 
   head do
@@ -52,6 +55,9 @@ class Wine < Formula
       url "https://dl.winehq.org/wine/wine-mono/4.7.1/wine-mono-4.7.1.msi"
       sha256 "2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa"
     end
+
+    # Does not build with Xcode 10, used on High Sierra and Mojave
+    depends_on MaximumMacOSRequirement => :sierra
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Reflect that we can't build Wine from source with Xcode 10 and macOS 10.14 SDK, which are found on High Sierra and Mojave. Existing bottles are fine.

Is there a more clever way to do this?