### PR TITLE
ice: patch for Xcode 10

### DIFF
--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -1,9 +1,8 @@
 class Ice < Formula
   desc "Comprehensive RPC framework"
   homepage "https://zeroc.com"
-  url "https://github.com/zeroc-ice/ice/archive/v3.7.1-xcode10.tar.gz"
-  version "3.7.1"
-  sha256 "cecc7d92a37b57a24c1cd092f083a7ead8812b867f7ac7df2f2324b4c192a718"
+  url "https://github.com/zeroc-ice/ice/archive/v3.7.1.tar.gz"
+  sha256 "b1526ab9ba80a3d5f314dacf22674dff005efb9866774903d0efca5a0fab326d"
   revision 1
 
   bottle do
@@ -11,6 +10,11 @@ class Ice < Formula
     sha256 "a6a580aed075a7edcb9f59886bc59b0e6da888623dbf6d81c98f26c4fc472613" => :high_sierra
     sha256 "73cb8a7d1af848b1832d1e837f2a3ec6c35846a8b7431748fd8e175442261df8" => :sierra
     sha256 "319fa13dfe77aa352dd84fb5495fd548fc7d870305fd7c3ee2137c2f298cbf5e" => :el_capitan
+  end
+
+  patch do
+    url "https://github.com/zeroc-ice/ice/compare/v3.7.1..v3.7.1-xcode10.patch?full_index=1"
+    sha256 "25cbdd9a87ccb0a2c0633e90dc9327d7a73c242c00e686d268d812e89a909f5f"
   end
 
   option "with-java", "Build Ice for Java and the IceGrid GUI app"

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -1,8 +1,10 @@
 class Ice < Formula
   desc "Comprehensive RPC framework"
   homepage "https://zeroc.com"
-  url "https://github.com/zeroc-ice/ice/archive/v3.7.1.tar.gz"
-  sha256 "b1526ab9ba80a3d5f314dacf22674dff005efb9866774903d0efca5a0fab326d"
+  url "https://github.com/zeroc-ice/ice/archive/v3.7.1-xcode10.tar.gz"
+  sha256 "cecc7d92a37b57a24c1cd092f083a7ead8812b867f7ac7df2f2324b4c192a718"
+  version "3.7.1"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -13,14 +13,7 @@ class Ice < Formula
     sha256 "319fa13dfe77aa352dd84fb5495fd548fc7d870305fd7c3ee2137c2f298cbf5e" => :el_capitan
   end
 
-  #
-  # NOTE: we don't build slice2py, slice2js, slice2rb by default to prevent clashes with
-  # the translators installed by the PyPI/GEM/npm packages.
-  #
-
-  option "with-additional-compilers", "Build additional Slice compilers (slice2py, slice2js, slice2rb)"
   option "with-java", "Build Ice for Java and the IceGrid GUI app"
-  option "without-xcode-sdk", "Build without the Xcode SDK for iOS development (includes static libs)"
 
   depends_on "lmdb"
   depends_on :macos => :mavericks
@@ -37,9 +30,11 @@ class Ice < Formula
       "V=1",
       "MCPP_HOME=#{Formula["mcpp"].opt_prefix}",
       "LMDB_HOME=#{Formula["lmdb"].opt_prefix}",
-      "CONFIGS=shared cpp11-shared #{build.with?("xcode-sdk") ? "xcodesdk cpp11-xcodesdk" : ""}",
+      "CONFIGS=shared cpp11-shared xcodesdk cpp11-xcodesdk",
       "PLATFORMS=all",
-      "SKIP=slice2confluence #{build.without?("additional-compilers") ? "slice2py slice2rb slice2js" : ""}",
+      # We don't build slice2py, slice2js, slice2rb to prevent clashes with
+      # the translators installed by the PyPI/GEM/npm packages.
+      "SKIP=slice2confluence slice2py slice2rb slice2js",
       "LANGUAGES=cpp objective-c #{build.with?("java") ? "java java-compat" : ""}",
     ]
     system "make", "install", *args

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -2,8 +2,8 @@ class Ice < Formula
   desc "Comprehensive RPC framework"
   homepage "https://zeroc.com"
   url "https://github.com/zeroc-ice/ice/archive/v3.7.1-xcode10.tar.gz"
-  sha256 "cecc7d92a37b57a24c1cd092f083a7ead8812b867f7ac7df2f2324b4c192a718"
   version "3.7.1"
+  sha256 "cecc7d92a37b57a24c1cd092f083a7ead8812b867f7ac7df2f2324b4c192a718"
   revision 1
 
   bottle do

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -12,17 +12,17 @@ class Ice < Formula
     sha256 "319fa13dfe77aa352dd84fb5495fd548fc7d870305fd7c3ee2137c2f298cbf5e" => :el_capitan
   end
 
-  patch do
-    url "https://github.com/zeroc-ice/ice/compare/v3.7.1..v3.7.1-xcode10.patch?full_index=1"
-    sha256 "25cbdd9a87ccb0a2c0633e90dc9327d7a73c242c00e686d268d812e89a909f5f"
-  end
-
   option "with-java", "Build Ice for Java and the IceGrid GUI app"
 
   depends_on "lmdb"
   depends_on :macos => :mavericks
   depends_on "mcpp"
   depends_on :java => ["1.8+", :optional]
+
+  patch do
+    url "https://github.com/zeroc-ice/ice/compare/v3.7.1..v3.7.1-xcode10.patch?full_index=1"
+    sha256 "28eff5dd6cb6065716a7664f3973213a2e5186ddbdccb1c1c1d832be25490f1b"
+  end
 
   def install
     ENV.O2 # Os causes performance issues


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Upstream (where I work) has released a patch for Xcode 10. It's at a new tag `v3.7.1-xcode10`. A rebuild is necessary for anyone using Xcode 10 as the patch fixes compilation issues as well as code generation issues for users of Ice (their Xcode 10 projects may not compile in some circumstances).

Brew audit complains that the SHA was changed without changing the version, not sure if the way I've structured my PR is the best approach. However, this is the way we've done brew patches in the past.