### PR TITLE
cargo-completion: remove conflicts with rust

### DIFF
--- a/Formula/cargo-completion.rb
+++ b/Formula/cargo-completion.rb
@@ -8,8 +8,6 @@ class CargoCompletion < Formula
 
   bottle :unneeded
 
-  conflicts_with "rust", :because => "both install shell completion for cargo"
-
   def install
     bash_completion.install "src/etc/cargo.bashcomp.sh" => "cargo"
     zsh_completion.install "src/etc/_cargo"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`rust` does not install either of these.