### PR TITLE
diceware 0.9.5 (new formula)

### DIFF
--- a/Formula/diceware.rb
+++ b/Formula/diceware.rb
@@ -1,0 +1,18 @@
+class Diceware < Formula
+  include Language::Python::Virtualenv
+
+  desc "Passphrases to remember"
+  homepage "https://github.com/ulif/diceware"
+  url "https://github.com/ulif/diceware/archive/v0.9.5.tar.gz"
+  sha256 "70c5884eed7f9d55204075cc8816ef7259000a0548f930a98d51132eef5c90ad"
+
+  depends_on "python"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match(/(\w+)(\-(\w+)){5}/, shell_output("#{bin}/diceware -d-"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

Diceware is a method for generating passphrases using ordinary d6 dice
and a predefined word list[1].

This changeset adds Uli Fouquet's `diceware` application, which
implements Diceware for the command line.

References:

  1. https://en.wikipedia.org/wiki/Diceware