### PR TITLE
sqoop: change url to point to official mirror

### DIFF
--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -1,7 +1,7 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz"
+  url "https://archive.apache.org/dist/sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz"
   version "1.4.6"
   sha256 "d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496"
   revision 1


### PR DESCRIPTION
Change url to point at official archive - some mirrors removed 1.4.6 from them, so they are not reliable.