### PR TITLE
jack: fixed plist template

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -56,7 +56,7 @@ class Jack < Formula
       <key>EnvironmentVariables</key>
       <dict>
         <key>PATH</key>
-        <string>#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/usr/bin:/bin:/usr/sbin:/sbin:#{HOMEBREW_PREFIX}/bin</string>
       </dict>
       <key>ProgramArguments</key>
       <array>

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -53,6 +53,11 @@ class Jack < Formula
       <string>#{plist_name}</string>
       <key>WorkingDirectory</key>
       <string>#{opt_prefix}</string>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>PATH</key>
+        <string>#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+      </dict>
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/jackd</string>


### PR DESCRIPTION
Jack doesn't start with the current plist because PATH env var is not set correctly. All credit goes to [Karim](https://elatov.github.io/2018/03/creating-a-launchd-plist-for-jackd/). I also checked the previous [PR](https://github.com/Homebrew/homebrew-core/pull/29341), TMPDIR var is in fact not needed.