### PR TITLE
rust: remove conflicts with cargo-completion

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -48,8 +48,6 @@ class Rust < Formula
   depends_on "pkg-config"
   depends_on "llvm" => :optional
 
-  conflicts_with "cargo-completion", :because => "both install shell completion for cargo"
-
   # According to the official readme, GCC 4.7+ is required
   fails_with :gcc_4_0
   fails_with :gcc


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow up #32304, I've forgotten to remove the `conflicts_with` from `rust` itself.