### PR TITLE
ghostscript: Dump little-cms2 dependency.

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -22,7 +22,6 @@ class Ghostscript < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libtiff"
-  depends_on "little-cms2"
   depends_on :x11 => :optional
 
   # https://sourceforge.net/projects/gs-fonts/


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This hasn't actually been needed for a while.  Ghostscript uses
its own internal modified little-cms2, and it does so whether or
not a brewed little-cms2 is specified.
