### PR TITLE
Grakn 1.4.0 Revision 1 - updating the SHA to match the re-uploaded zip

### DIFF
--- a/Formula/grakn.rb
+++ b/Formula/grakn.rb
@@ -2,7 +2,8 @@ class Grakn < Formula
   desc "The distributed hyper-relational database for knowledge engineering"
   homepage "https://grakn.ai"
   url "https://github.com/graknlabs/grakn/releases/download/v1.4.0/grakn-core-1.4.0.zip"
-  sha256 "b88d75265ff238ecad6ad7e2505fc2b0223b803e798eea29a9649ccde2e6d850"
+  sha256 "b52b758f01dc861b3f8628afeb48fb7dfba23ee8025a2de23f448e60cf0b42a0"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Grakn 1.4.0 Revision 1 - updating the SHA to match the re-uploaded zip distribution. The zip file of Grakn 1.4.0 had to be re-uploaded and thus the SHA changes as it is a new zip file.

This PR updates the package with the new SHA.

FYI, during `brew audit --strict grakn` we received the following output, which I assume is to be expected given that this PR updates the SHA:

```
grakn:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 1 problem in 1 formula detected
```