### PR TITLE
change FreeSwitch sounds dir from prefix to share

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -165,40 +165,40 @@ class Freeswitch < Formula
 
     if build.with?("moh")
       # Should be equivalent to: system "make", "cd-moh-install"
-      mkdir_p prefix/"sounds/music"
+      mkdir_p share/"freeswitch/sounds/music"
       [8, 16, 32, 48].each do |n|
         resource("sounds-music-#{n}000").stage do
-          cp_r ".", prefix/"sounds/music"
+          cp_r ".", share/"freeswitch/sounds/music"
         end
       end
     end
 
     if build.with?("sounds-en")
       # Should be equivalent to: system "make", "cd-sounds-install"
-      mkdir_p prefix/"sounds/en"
+      mkdir_p share/"freeswitch/sounds/en"
       [8, 16, 32, 48].each do |n|
         resource("sounds-en-us-callie-#{n}000").stage do
-          cp_r ".", prefix/"sounds/en"
+          cp_r ".", share/"freeswitch/sounds/en"
         end
       end
     end
 
     if build.with?("sounds-fr")
       # Should be equivalent to: system "make", "cd-sounds-fr-install"
-      mkdir_p prefix/"sounds/fr"
+      mkdir_p share/"freeswitch/sounds/fr"
       [8, 16, 32, 48].each do |n|
         resource("sounds-fr-ca-june-#{n}000").stage do
-          cp_r ".", prefix/"sounds/fr"
+          cp_r ".", share/"freeswitch/sounds/fr"
         end
       end
     end
 
     if build.with?("sounds-ru")
       # Should be equivalent to: system "make", "cd-sounds-ru-install"
-      mkdir_p prefix/"sounds/ru"
+      mkdir_p share/"freeswitch/sounds/ru"
       [8, 16, 32, 48].each do |n|
         resource("sounds-ru-RU-elena-#{n}000").stage do
-          cp_r ".", prefix/"sounds/ru"
+          cp_r ".", share/"freeswitch/sounds/ru"
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current version of formula has `sounds` dir in the wrong path
You can verify this claim by:

1) starting freeswitch without forking to the background
```
freeswitch -nc -nonat -nf -np -c
...
2018-09-25 19:26:01.222524 [CONSOLE] mod_local_stream.c:284 Can't open directory: /usr/local/Cellar/freeswitch/1.6.20/share/freeswitch/sounds/music/8000
2018-09-25 19:26:01.222524 [CONSOLE] mod_local_stream.c:284 Can't open directory: /usr/local/Cellar/freeswitch/1.6.20/share/freeswitch/sounds/music/16000
2018-09-25 19:26:01.222524 [CONSOLE] mod_local_stream.c:284 Can't open directory: /usr/local/Cellar/freeswitch/1.6.20/share/freeswitch/sounds/music/48000
2018-09-25 19:26:01.222524 [CONSOLE] mod_local_stream.c:284 Can't open directory: /usr/local/Cellar/freeswitch/1.6.20/share/freeswitch/sounds/music/8000
2018-09-25 19:26:01.222524 [CONSOLE] mod_local_stream.c:284 Can't open directory: /usr/local/Cellar/freeswitch/1.6.20/share/freeswitch/sounds/music/32000
```

2) checking build logs of `./configure` command for this formula
`cat /Users/USER/Library/Logs/Homebrew/freeswitch/02.configure`

```
-------------------------- FreeSWITCH configuration --------------------------

  Locations:

      prefix:          /usr/local/Cellar/freeswitch-mod/1.6.20
      exec_prefix:     /usr/local/Cellar/freeswitch-mod/1.6.20
      bindir:          ${exec_prefix}/bin
      confdir:         /usr/local/Cellar/freeswitch-mod/1.6.20/etc/freeswitch
      libdir:          /usr/local/Cellar/freeswitch-mod/1.6.20/lib
      datadir:         /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch
      localstatedir:   /usr/local/Cellar/freeswitch-mod/1.6.20/var/lib/freeswitch
      includedir:      /usr/local/Cellar/freeswitch-mod/1.6.20/include/freeswitch

      certsdir:        /usr/local/Cellar/freeswitch-mod/1.6.20/etc/freeswitch/tls
      dbdir:           /usr/local/Cellar/freeswitch-mod/1.6.20/var/lib/freeswitch/db
      grammardir:      /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/grammar
      htdocsdir:       /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/htdocs
      fontsdir:        /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/fonts
      logfiledir:      /usr/local/Cellar/freeswitch-mod/1.6.20/var/log/freeswitch
      modulesdir:      /usr/local/Cellar/freeswitch-mod/1.6.20/lib/freeswitch/mod
      pkgconfigdir:    /usr/local/lib/pkgconfig
      recordingsdir:   /usr/local/Cellar/freeswitch-mod/1.6.20/var/lib/freeswitch/recordings
      imagesdir:       /usr/local/Cellar/freeswitch-mod/1.6.20/var/lib/freeswitch/images
      runtimedir:      /usr/local/Cellar/freeswitch-mod/1.6.20/var/run/freeswitch
      scriptdir:       /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/scripts
      soundsdir:       /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/sounds
      storagedir:      /usr/local/Cellar/freeswitch-mod/1.6.20/var/lib/freeswitch/storage
      cachedir:        /usr/local/Cellar/freeswitch-mod/1.6.20/var/cache/freeswitch

------------------------------------------------------------------------------
```
where `soundsdir` is configured as follows
```
soundsdir:       /usr/local/Cellar/freeswitch-mod/1.6.20/share/freeswitch/sounds
```
but formula has it at `/usr/local/Cellar/freeswitch-mod/1.6.20/sounds`

This pull request fixes described issue.