### PR TITLE
crystal: fix dependency to llvm@6

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,6 +1,7 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
+  revision 1
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.26.1.tar.gz"
@@ -33,7 +34,7 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "llvm"
+  depends_on "llvm@6"
   depends_on "pcre"
 
   resource "boot" do


### PR DESCRIPTION
llvm 7.0.0 introduced some breaking changes that are not supported by the released crystal 0.26.1.

Until a new release with llvm 7 support comes the formula should state that llvm@6 which was used to build the binaries by homebrew should be downloaded. Otherwise new comers are not able to use crystal.

I am surprised that is not brew responsibility to kept which version of dependencies was used during the build of a formula.
