### PR TITLE
wkhtmltopdf 0.12.5 (new formula)

### DIFF
--- a/Aliases/wkhtmltoimage
+++ b/Aliases/wkhtmltoimage
@@ -1,0 +1,1 @@
+../Formula/wkhtmltopdf.rb

--- a/Formula/wkhtmltopdf.rb
+++ b/Formula/wkhtmltopdf.rb
@@ -1,0 +1,29 @@
+class Wkhtmltopdf < Formula
+  desc "Command-line tools to render HTML into PDF and various image formats"
+  homepage "https://wkhtmltopdf.org/"
+  version "0.12.5"
+  url "https://downloads.wkhtmltopdf.org/#{version.to_s.split(".")[0]}.#{version.to_s.split(".")[1]}/#{version}/wkhtmltox-#{version}-1.macos-cocoa.pkg"
+  sha256 "2718c057249a133fe413b3c8cfb33b755a2e18a8e233329168f1af462cd6de5f"
+
+  def install
+    major, minor, = version.to_s.split(".")
+    system "pkgutil", "--expand-full", "wkhtmltox-#{version}-1.macos-cocoa.pkg", "pkg"
+    system "tar", "xzf", "pkg/Payload/usr/local/share/wkhtmltox-installer/wkhtmltox.tar.gz"
+
+    bin.install "bin/wkhtmltoimage", "bin/wkhtmltopdf"
+    include.install "include/wkhtmltox"
+    lib.install "lib/libwkhtmltox.dylib", "lib/libwkhtmltox.#{major}.dylib", "lib/libwkhtmltox.#{major}.#{minor}.dylib"
+    lib.install "lib/libwkhtmltox.#{version}.dylib"
+    man1.install "share/man/man1/wkhtmltoimage.1.gz", "share/man/man1/wkhtmltopdf.1.gz"
+  end
+
+  test do
+    (testpath/"test.html").write <<~EOS
+      <html><body>Test File</body></html>
+    EOS
+
+    system "#{bin}/wkhtmltopdf", "test.html", "test.pdf"
+    output = shell_output("file test.pdf")
+    assert_match /PDF document/, output
+  end
+end


### PR DESCRIPTION
This commit extends homebrew-core with **wkhtmltopdf**
It already exists as a **Cask**, but this installs to `/usr/local` which is discouraged by homebrew which prefer installed to its own **Keg** inside **Cellar**

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
