### PR TITLE
autogen: Missing dependency 'libxml2' added. If not stated, super-env…

### DIFF
--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -15,6 +15,7 @@ class Autogen < Formula
 
   depends_on "pkg-config" => :build
   depends_on "guile"
+  depends_on "libxml2"
 
   # Allow guile 2.2 to be used
   patch do


### PR DESCRIPTION
… cannot find xml2-config.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
