### PR TITLE
docker-machine-driver-xhyve: update to opam 2+

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -44,7 +44,7 @@ class DockerMachineDriverXhyve < Formula
 
       if build.with? "qcow2"
         build_tags << " qcow2"
-        system "opam", "init", "--no-setup"
+        system "opam", "init", "--no-setup", "--disable-sandboxing"
         opam_dir = "#{buildpath}/.brew_home/.opam"
         ENV["CAML_LD_LIBRARY_PATH"] = "#{opam_dir}/system/lib/stublibs:/usr/local/lib/ocaml/stublibs"
         ENV["OPAMUTF8MSGS"] = "1"
@@ -52,10 +52,7 @@ class DockerMachineDriverXhyve < Formula
         ENV["OCAML_TOPLEVEL_PATH"] = "#{opam_dir}/system/lib/toplevel"
         ENV.prepend_path "PATH", "#{opam_dir}/system/bin"
 
-        inreplace "#{opam_dir}/compilers/4.05.0/4.05.0/4.05.0.comp",
-          '["./configure"', '["./configure" "-no-graph"' # Avoid X11
-
-        ENV.deparallelize { system "opam", "switch", "4.05.0" }
+        ENV.deparallelize { system "opam", "switch", "create", "4.05.0" }
 
         system "opam", "config", "exec", "--",
                "opam", "install", "-y", "uri", "qcow-format", "io-page.1.6.1",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With the release of `opam` version 2.0.0 they introduced two major changes that broke this formula: new compiler management system and built-in sandboxing for builds. The following changes make the formula act as it would have before the changes.

It could be argued that the sandboxing feature should be established for the formula, but I simply do not have the time to learn how to do that right now.

This formula is a requirement to run `minishift` on macOS.