### PR TITLE
Pin Zig 0.2.0 to llvm@6

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -3,6 +3,7 @@ class Zig < Formula
   homepage "https://ziglang.org/"
   url "https://github.com/ziglang/zig/archive/0.2.0.tar.gz"
   sha256 "09843a3748bf8a5f1742fe93dbf45699f92051ecf479b23272b067dfc3837cc7"
+  revision 1
   head "https://github.com/ziglang/zig.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm"
+  depends_on "llvm@6"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Zig 0.2.0 will not build with llvm 7, which is what `llvm` now points
to.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
