### PR TITLE
Fix bug #32464

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -21,6 +21,7 @@ class Macvim < Formula
   depends_on :xcode => :build
   depends_on "cscope"
   depends_on "python" => :recommended
+  depends_on "ruby" => :recommended
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
   depends_on "python@2" => :optional
@@ -50,6 +51,9 @@ class Macvim < Formula
       --with-local-dir=#{HOMEBREW_PREFIX}
       --enable-cscope
     ]
+    
+    # Fix bug with ruby on macOS Mojave 
+    args << "--with-ruby-command=#{Formula["ruby"].opt_prefix}/bin/ruby"
 
     if build.with? "lua"
       args << "--enable-luainterp"


### PR DESCRIPTION
Fix  Macvim install fails on MacOS 10.14 (#32464)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
