### PR TITLE
rabbitmq: Add more logging for brew service

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -59,6 +59,7 @@ class Rabbitmq < Formula
     CONFIG_FILE=#{etc}/rabbitmq/rabbitmq
     NODE_IP_ADDRESS=127.0.0.1
     NODENAME=rabbit@localhost
+    RABBITMQ_LOG_BASE=#{var}/log/rabbitmq
   EOS
   end
 
@@ -84,8 +85,6 @@ class Rabbitmq < Formula
           <!-- specify the path to the rabbitmq-env.conf file -->
           <key>CONF_ENV_FILE</key>
           <string>#{etc}/rabbitmq/rabbitmq-env.conf</string>
-          <key>HOME</key>
-          <string>#{var}/lib/rabbitmq/</string>
         </dict>
         <key>StandardErrorPath</key>
         <string>#{var}/log/rabbitmq/std_error.log</string>

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -16,7 +16,6 @@ class Rabbitmq < Formula
     # Setup the lib files
     (var/"lib/rabbitmq").mkpath
     (var/"log/rabbitmq").mkpath
-    (var/"home/rabbitmq").mkpath
 
     # Correct SYS_PREFIX for things like rabbitmq-plugins
     erlang = Formula["erlang"]
@@ -86,7 +85,7 @@ class Rabbitmq < Formula
           <key>CONF_ENV_FILE</key>
           <string>#{etc}/rabbitmq/rabbitmq-env.conf</string>
           <key>HOME</key>
-          <string>#{var}/home/rabbitmq/</string>
+          <string>#{var}/lib/rabbitmq/</string>
         </dict>
         <key>StandardErrorPath</key>
         <string>#{var}/log/rabbitmq/std_error.log</string>

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -16,6 +16,7 @@ class Rabbitmq < Formula
     # Setup the lib files
     (var/"lib/rabbitmq").mkpath
     (var/"log/rabbitmq").mkpath
+    (var/"home/rabbitmq").mkpath
 
     # Correct SYS_PREFIX for things like rabbitmq-plugins
     erlang = Formula["erlang"]
@@ -84,7 +85,13 @@ class Rabbitmq < Formula
           <!-- specify the path to the rabbitmq-env.conf file -->
           <key>CONF_ENV_FILE</key>
           <string>#{etc}/rabbitmq/rabbitmq-env.conf</string>
+          <key>HOME</key>
+          <string>#{var}/home/rabbitmq/</string>
         </dict>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/rabbitmq/std_error.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/rabbitmq/std_out.log</string>
       </dict>
     </plist>
   EOS


### PR DESCRIPTION
In order to diagnose why the rabbitmq service didn't start was that I added more logging configuration in order to help diagnose any issues while starting the service:
- standard out and standard error output to logging
- RABBITMQ_LOG_BASE set to the homebrew prefixed var folder

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
