### PR TITLE
liblas: fix build

### DIFF
--- a/Formula/liblas.rb
+++ b/Formula/liblas.rb
@@ -16,7 +16,6 @@ class Liblas < Formula
   depends_on "boost"
   depends_on "gdal"
   depends_on "libgeotiff"
-  depends_on "laszip" => :optional
 
   # Fix build for Xcode 9 with upstream commit
   # Remove in next version
@@ -25,17 +24,28 @@ class Liblas < Formula
     sha256 "5590aef61a58768160051997ae9753c2ae6fc5b7da8549707dfd9a682ce439c8"
   end
 
+  # Fix compilation against GDAL 2.3
+  # Remove in next version
+  patch do
+    url "https://github.com/libLAS/libLAS/commit/ec10e274.diff?full_index=1"
+    sha256 "3f5cc283d3e908d991b05b4dcf5cc0440824441ec270396e11738f96a0a23a9f"
+  end
+
+  needs :cxx11
+
   def install
+    ENV.cxx11
+
     mkdir "macbuild" do
       # CMake finds boost, but variables like this were set in the last
       # version of this formula. Now using the variables listed here:
       #   https://liblas.org/compilation.html
       ENV["Boost_INCLUDE_DIR"] = "#{HOMEBREW_PREFIX}/include"
       ENV["Boost_LIBRARY_DIRS"] = "#{HOMEBREW_PREFIX}/lib"
-      args = ["-DWITH_GEOTIFF=ON", "-DWITH_GDAL=ON"] + std_cmake_args
-      args << "-DWITH_LASZIP=ON" if build.with? "laszip"
 
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args,
+                            "-DWITH_GDAL=ON",
+                            "-DWITH_GEOTIFF=ON"
       system "make"
       system "make", "test" if build.bottle?
       system "make", "install"


### PR DESCRIPTION
This should fix the build with recent gdal versions.
Also, given `laszip` is frequently used and has no further dependencies, make it default:

```
install events in the last 30 days
================================================================================
1 | liblas                                                       |  86 |  80.37%
2 | liblas --with-laszip                                         |  19 |  17.76%
3 | liblas --HEAD                                                |   2 |   1.87%
================================================================================
Total                                                            | 107 |    100%
```