### PR TITLE
mallet 2.0.8 (new formula)

### DIFF
--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -8,7 +8,6 @@ class Mallet < Formula
 
   def install
     rm Dir["bin/*.{bat,dll,exe}"] # Remove all windows files
-    prefix.install_metafiles
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env)

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -4,6 +4,8 @@ class Mallet < Formula
   url "http://mallet.cs.umass.edu/dist/mallet-2.0.8.tar.gz"
   sha256 "5b2d6fb9bcf600b1836b09881821a6781dd45a7d3032e61d7500d027a5b34faf"
 
+  bottle :unneeded
+
   depends_on :java
 
   def install

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -9,8 +9,8 @@ class Mallet < Formula
   depends_on :java
 
   resource "testdata" do
-    url "https://github.com/mimno/Mallet/blob/master/sample-data/stackexchange/tsv/testing.tsv"
-    sha256 "281c76b87c3fa4edc6d9c46a0660ceda74e9a76ac1855da563490b211265a7c9"
+    url "https://raw.githubusercontent.com/mimno/Mallet/master/sample-data/stackexchange/tsv/testing.tsv"
+    sha256 "06b4a0b3f27afa532ded841e8304449764a604fb202ba60eb762eaa79e9e02f3"
   end
 
   def install

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -1,0 +1,29 @@
+class Mallet < Formula
+  desc "MAchine Learning for LanguagE Toolkit"
+  homepage "http://mallet.cs.umass.edu/"
+  url "http://mallet.cs.umass.edu/dist/mallet-2.0.8.tar.gz"
+  sha256 "5b2d6fb9bcf600b1836b09881821a6781dd45a7d3032e61d7500d027a5b34faf"
+  head "https://github.com/mimno/Mallet.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "da32cef7b10fcbfc1f5fc7878f779a5000d88f3363342b6c9ff1830f29d85803" => :sierra
+    sha256 "f870d8dac822eeda26296f069d488547cb415c2eaaeb0fd0e822595308c0b390" => :el_capitan
+    sha256 "f870d8dac822eeda26296f069d488547cb415c2eaaeb0fd0e822595308c0b390" => :yosemite
+    sha256 "d2556a240155cfc90259839cb5861d7c4d1e8e58d3210b934bbd5b1cf5897495" => :x86_64_linux
+  end
+
+  depends_on :java
+
+  def install
+    rm Dir["bin/*.{bat,dll,exe}"] # Remove all windows files
+    prefix.install_metafiles
+    libexec.install Dir["*"]
+    bin.install Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env)
+  end
+
+  test do
+    system "#{bin}/mallet | grep Mallet"
+  end
+end

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -3,15 +3,6 @@ class Mallet < Formula
   homepage "http://mallet.cs.umass.edu/"
   url "http://mallet.cs.umass.edu/dist/mallet-2.0.8.tar.gz"
   sha256 "5b2d6fb9bcf600b1836b09881821a6781dd45a7d3032e61d7500d027a5b34faf"
-  head "https://github.com/mimno/Mallet.git"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "da32cef7b10fcbfc1f5fc7878f779a5000d88f3363342b6c9ff1830f29d85803" => :sierra
-    sha256 "f870d8dac822eeda26296f069d488547cb415c2eaaeb0fd0e822595308c0b390" => :el_capitan
-    sha256 "f870d8dac822eeda26296f069d488547cb415c2eaaeb0fd0e822595308c0b390" => :yosemite
-    sha256 "d2556a240155cfc90259839cb5861d7c4d1e8e58d3210b934bbd5b1cf5897495" => :x86_64_linux
-  end
 
   depends_on :java
 

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -8,6 +8,11 @@ class Mallet < Formula
 
   depends_on :java
 
+  resource "testdata" do
+    url "https://github.com/mimno/Mallet/blob/master/sample-data/stackexchange/tsv/testing.tsv"
+    sha256 "281c76b87c3fa4edc6d9c46a0660ceda74e9a76ac1855da563490b211265a7c9"
+  end
+
   def install
     rm Dir["bin/*.{bat,dll,exe}"] # Remove all windows files
     libexec.install Dir["*"]
@@ -16,6 +21,10 @@ class Mallet < Formula
   end
 
   test do
-    system "#{bin}/mallet | grep Mallet"
+    resource("testdata").stage do
+      system "#{bin}/mallet import-file --input testing.tsv --keep-sequence"
+      out = shell_output("#{bin}/mallet train-topics --input text.vectors --show-topics-interval 0 --num-iterations 100 2>&1")
+      assert_equal "seconds", out.split.last
+    end
   end
 end

--- a/Formula/mallet.rb
+++ b/Formula/mallet.rb
@@ -22,7 +22,7 @@ class Mallet < Formula
 
   test do
     resource("testdata").stage do
-      system "#{bin}/mallet import-file --input testing.tsv --keep-sequence"
+      system "#{bin}/mallet", "import-file", "--input", "testing.tsv", "--keep-sequence"
       out = shell_output("#{bin}/mallet train-topics --input text.vectors --show-topics-interval 0 --num-iterations 100 2>&1")
       assert_equal "seconds", out.split.last
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a formula from the deprecated homebrew-science tap that was listed among those notable enough to be migrated to core. (See details at the [migration issue](https://github.com/Homebrew/homebrew-science/issues/6331) there.)

A link to the project site is [here](http://mallet.cs.umass.edu/) and project code is [here](https://github.com/mimno/Mallet).
