### PR TITLE
ettercap: fix build on Mojave

### DIFF
--- a/Formula/ettercap.rb
+++ b/Formula/ettercap.rb
@@ -25,6 +25,7 @@ class Ettercap < Formula
   depends_on "cmake" => :build
   depends_on "curl" if MacOS.version <= :mountain_lion # requires >= 7.26.0.
   depends_on "libnet"
+  depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
   depends_on "openssl"
   depends_on "pcre"
   depends_on "gtk+" => :optional


### PR DESCRIPTION
On Mojave, the system curses library does not have all necessary symbols. The build then fails to link with:

```
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang -O2 -w -D_FORTIFY_SOURCE=2 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl CMakeFiles/ettercap.dir/ec_parser.c.o CMakeFiles/ettercap.dir/ec_main.c.o  -o ettercap interfaces/libec_interfaces.a libettercap.0.0.0.dylib /usr/lib/libncurses.dylib /usr/lib/libform.dylib /usr/lib/libncurses.dylib /usr/lib/libform.dylib /usr/lib/libpanel.dylib /usr/lib/libmenu.dylib /usr/local/opt/openssl/lib/libssl.dylib /usr/local/opt/openssl/lib/libcrypto.dylib /usr/lib/libz.dylib /usr/lib/libiconv.dylib /usr/lib/libpcap.dylib /usr/local/lib/libnet.dylib /usr/lib/libresolv.dylib /usr/local/lib/libpcre.dylib 
Undefined symbols for architecture x86_64:
  "_current_item", referenced from:
      _wdg_file_driver in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_driver in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_get_msg in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_menu_destroy in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_refresh in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_driver in libec_interfaces.a(wdg_list.c.o)
  "_free_item", referenced from:
      _wdg_file_menu_destroy in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_destroy in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_destroy in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_set_elements in libec_interfaces.a(wdg_list.c.o)
  "_free_menu", referenced from:
      _wdg_file_menu_destroy in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_close in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_destroy in libec_interfaces.a(wdg_list.c.o)
  "_item_name", referenced from:
      _wdg_file_driver in libec_interfaces.a(wdg_file.c.o)
  "_item_opts", referenced from:
      _wdg_file_driver in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_driver in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_driver in libec_interfaces.a(wdg_list.c.o)
  "_item_opts_off", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_add in libec_interfaces.a(wdg_menu.c.o)
  "_item_userptr", referenced from:
      _wdg_menu_destroy in libec_interfaces.a(wdg_menu.c.o)
      _wdg_menu_get_msg in libec_interfaces.a(wdg_menu.c.o)
      _wdg_menu_driver in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_get_msg in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_driver in libec_interfaces.a(wdg_list.c.o)
  "_menu_driver", referenced from:
      _wdg_file_driver in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_driver in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_driver in libec_interfaces.a(wdg_list.c.o)
  "_new_item", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_add in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_set_elements in libec_interfaces.a(wdg_list.c.o)
  "_new_menu", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_post_menu", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_refresh in libec_interfaces.a(wdg_list.c.o)
  "_scale_menu", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_current_item", referenced from:
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_refresh in libec_interfaces.a(wdg_list.c.o)
  "_set_item_userptr", referenced from:
      _wdg_menu_add in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_set_elements in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_back", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_fore", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_format", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_grey", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_mark", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_spacing", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_sub", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_set_menu_win", referenced from:
      _wdg_file_menu_create in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_open in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_create in libec_interfaces.a(wdg_list.c.o)
  "_unpost_menu", referenced from:
      _wdg_file_menu_destroy in libec_interfaces.a(wdg_file.c.o)
      _wdg_menu_close in libec_interfaces.a(wdg_menu.c.o)
      _wdg_list_menu_destroy in libec_interfaces.a(wdg_list.c.o)
      _wdg_list_refresh in libec_interfaces.a(wdg_list.c.o)
ld: symbol(s) not found for architecture x86_64
```