### PR TITLE
Zig 0.3.0

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,8 +1,8 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://github.com/ziglang/zig/archive/0.2.0.tar.gz"
-  sha256 "09843a3748bf8a5f1742fe93dbf45699f92051ecf479b23272b067dfc3837cc7"
+  url "https://github.com/ziglang/zig/archive/0.3.0.tar.gz"
+  sha256 "23ebb962823b2c78fd7bb16dd033b189c3050eee9991070debbd79c9b8648772"
   head "https://github.com/ziglang/zig.git"
 
   bottle do


### PR DESCRIPTION
Here you go!

Here's my periodic request to use `llvm@7` instead of the current `llvm` alias, since Zig 0.2.0 will not build with 7 and whenever 0.4.0 comes out it will likely not build with 7 either. Whattaya say? :) 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
