### PR TITLE
grv: fix build on Mojave

### DIFF
--- a/Formula/grv.rb
+++ b/Formula/grv.rb
@@ -15,6 +15,7 @@ class Grv < Formula
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build
+  depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
   depends_on "readline"
 
   def install


### PR DESCRIPTION
Without this, on Mojave the necessary symbols are not found in the system curses library:

```
# github.com/rgburke/grv/cmd/grv/vendor/github.com/rgburke/goncurses
Undefined symbols for architecture x86_64:
  "_current_item", referenced from:
      __cgo_eed8f6ed3399_Cfunc_current_item in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_current_item, __cgo_eed8f6ed3399_Cfunc_set_current_item )
  "_free_item", referenced from:
      __cgo_eed8f6ed3399_Cfunc_free_item in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_free_item)
  "_free_menu", referenced from:
      __cgo_eed8f6ed3399_Cfunc_free_menu in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_free_menu)
  "_item_count", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_count in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_count)
  "_item_description", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_description in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_description)
  "_item_index", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_index in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_index)
  "_item_name", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_name in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_name)
  "_item_opts_off", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_opts_off in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_opts_off)
  "_item_opts_on", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_opts_on in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_opts_on)
  "_item_value", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_value in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_value, __cgo_eed8f6ed3399_Cfunc_set_item_value )
  "_item_visible", referenced from:
      __cgo_eed8f6ed3399_Cfunc_item_visible in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_item_visible)
  "_menu_back", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_back in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_back, __cgo_eed8f6ed3399_Cfunc_menu_back )
  "_menu_driver", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_driver in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_driver)
  "_menu_fore", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_fore in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_fore, __cgo_eed8f6ed3399_Cfunc_menu_fore )
  "_menu_items", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_items in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_items, __cgo_eed8f6ed3399_Cfunc_menu_items )
  "_menu_opts_off", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_opts_off in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_opts_off)
  "_menu_opts_on", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_opts_on in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_opts_on)
  "_menu_pad", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_pad in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_pad, __cgo_eed8f6ed3399_Cfunc_set_menu_pad )
  "_menu_pattern", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_pattern in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_pattern, __cgo_eed8f6ed3399_Cfunc_set_menu_pattern )
  "_menu_request_by_name", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_request_by_name in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_request_by_name)
  "_menu_request_name", referenced from:
      __cgo_eed8f6ed3399_C2func_menu_request_name in _x006.o
      __cgo_eed8f6ed3399_Cfunc_menu_request_name in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_menu_request_name, __cgo_eed8f6ed3399_C2func_menu_request_name )
  "_menu_spacing", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_spacing in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_spacing, __cgo_eed8f6ed3399_Cfunc_menu_spacing )
  "_menu_win", referenced from:
      __cgo_eed8f6ed3399_Cfunc_menu_win in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_win, __cgo_eed8f6ed3399_Cfunc_menu_win )
  "_new_item", referenced from:
      __cgo_eed8f6ed3399_C2func_new_item in _x006.o
      __cgo_eed8f6ed3399_Cfunc_new_item in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_new_item, __cgo_eed8f6ed3399_C2func_new_item )
  "_new_menu", referenced from:
      __cgo_eed8f6ed3399_C2func_new_menu in _x006.o
      __cgo_eed8f6ed3399_Cfunc_new_menu in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_new_menu, __cgo_eed8f6ed3399_C2func_new_menu )
  "_pos_menu_cursor", referenced from:
      __cgo_eed8f6ed3399_Cfunc_pos_menu_cursor in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_pos_menu_cursor)
  "_post_menu", referenced from:
      __cgo_eed8f6ed3399_Cfunc_post_menu in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_post_menu)
  "_scale_menu", referenced from:
      __cgo_eed8f6ed3399_Cfunc_scale_menu in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_scale_menu)
  "_set_current_item", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_current_item in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_current_item)
  "_set_item_value", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_item_value in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_item_value)
  "_set_menu_back", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_back in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_back)
  "_set_menu_fore", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_fore in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_fore)
  "_set_menu_format", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_format in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_format)
  "_set_menu_grey", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_grey in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_grey)
  "_set_menu_items", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_items in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_items)
  "_set_menu_mark", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_mark in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_mark)
  "_set_menu_pad", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_pad in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_pad)
  "_set_menu_pattern", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_pattern in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_pattern)
  "_set_menu_spacing", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_spacing in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_spacing)
  "_set_menu_sub", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_sub in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_sub)
  "_set_menu_win", referenced from:
      __cgo_eed8f6ed3399_Cfunc_set_menu_win in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_set_menu_win)
  "_unpost_menu", referenced from:
      __cgo_eed8f6ed3399_Cfunc_unpost_menu in _x006.o
     (maybe you meant: __cgo_eed8f6ed3399_Cfunc_unpost_menu)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [build-only] Error 2
```