### PR TITLE
gdb: patch 8.2 for build failure `--with-all-targets`

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -41,6 +41,8 @@ class Gdb < Formula
     EOS
   end
 
+  patch :p0, :DATA
+
   def install
     args = [
       "--prefix=#{prefix}",
@@ -92,3 +94,19 @@ class Gdb < Formula
     system bin/"gdb", bin/"gdb", "-configuration"
   end
 end
+
+__END__
+
+diff -Naru /tmp/aarch64-linux-tdep.c gdb/aarch64-linux-tdep.c.new
+--- gdb/aarch64-linux-tdep.c	2018-09-27 21:05:15.000000000 -0700
++++ gdb/aarch64-linux-tdep.c.new	2018-09-27 21:05:47.000000000 -0700
+@@ -315,7 +315,7 @@
+      passed in SVE regset or a NEON fpregset.  */
+
+   /* Extract required fields from the header.  */
+-  uint64_t vl = extract_unsigned_integer (header + SVE_HEADER_VL_OFFSET,
++  ULONGEST vl = extract_unsigned_integer (header + SVE_HEADER_VL_OFFSET,
+ 					  SVE_HEADER_VL_LENGTH, byte_order);
+   uint16_t flags = extract_unsigned_integer (header + SVE_HEADER_FLAGS_OFFSET,
+ 					     SVE_HEADER_FLAGS_LENGTH,
+


### PR DESCRIPTION
- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This update adds a temporary upstream patch to the gdb build which will otherwise fail when specifying the formula's `--with-all-targets` option. The patch already appears in the upstream source as can be seen here:

[git://sourceware.org/binutils-gdb.git/commitdiff](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=0c0a40e0abb9f1a584330a1911ad06b3686e5361)

Adding the patch will resolve the issue until the next release of gdb becomes available.
