### PR TITLE
carthage 0.31.0

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -15,12 +15,11 @@ class Carthage < Formula
 
   depends_on :xcode => ["9.4", :build]
 
-  patch do
-    url "https://gist.githubusercontent.com/jdhealy/8db93b4e3791fa3715554b01e55d366d/raw/88d2913bd9cc0408a11a75715c593789ebcfb068/patch.diff"
-    sha256 "47a9b2c48373d4eacc54d684f0d55597b07464e1d2bcbde3384cbc61467a96e4"
-  end
-
   def install
+    match = "XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage' DSTROOT=$(CARTHAGE_TEMPORARY_FOLDER)"
+    inreplace "Makefile" do |s|
+      s.sub!(match, match + " OTHER_LDFLAGS=-Wl,-headerpad_max_install_names")
+    end
     system "make", "prefix_install", "PREFIX=#{prefix}"
     bash_completion.install "Source/Scripts/carthage-bash-completion" => "carthage"
     zsh_completion.install "Source/Scripts/carthage-zsh-completion" => "_carthage"

--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -2,8 +2,8 @@ class Carthage < Formula
   desc "Decentralized dependency manager for Cocoa"
   homepage "https://github.com/Carthage/Carthage"
   url "https://github.com/Carthage/Carthage.git",
-      :tag => "0.30.1",
-      :revision => "49c7901f851384a358bac2e5d2333cabc4f91900",
+      :tag => "0.31.0",
+      :revision => "04994e9e844d53220d8796a648a7dad12a5808c9",
       :shallow => false
   head "https://github.com/Carthage/Carthage.git", :shallow => false
 
@@ -13,7 +13,12 @@ class Carthage < Formula
     sha256 "1d7ffb4d63ad048712d6b81f7e26fa4c5613d5dd6d34c3e5c46a086854d3a59e" => :sierra
   end
 
-  depends_on :xcode => ["9.0", :build]
+  depends_on :xcode => ["9.4", :build]
+
+  patch do
+    url "https://gist.githubusercontent.com/jdhealy/8db93b4e3791fa3715554b01e55d366d/raw/88d2913bd9cc0408a11a75715c593789ebcfb068/patch.diff"
+    sha256 "47a9b2c48373d4eacc54d684f0d55597b07464e1d2bcbde3384cbc61467a96e4"
+  end
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  - Not quite the same, see patch — didn’t want to force push over @blender
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update Carthage to 0.31.0 · Supersedes homebrew/homebrew-core#32403

Patches `OTHER_LDFLAGS` `headerpad_max_install_names` to avoid:

```
Changing dylib ID of /usr/local/Cellar/carthage/0.30.1/Frameworks/CarthageKit.framework/Versions/A/Frameworks/Tentacle.framework/Versions/A/Tentacle
  from @rpath/Tentacle.framework/Versions/A/Tentacle
    to /usr/local/opt/carthage/Frameworks/CarthageKit.framework/Versions/A/Frameworks/Tentacle.framework/Versions/A/Tentacle
Error: Failed changing dylib ID of /usr/local/Cellar/carthage/0.30.1/Frameworks/CarthageKit.framework/Versions/A/Frameworks/Tentacle.framework/Versions/A/Tentacle
  from @rpath/Tentacle.framework/Versions/A/Tentacle
    to /usr/local/opt/carthage/Frameworks/CarthageKit.framework/Versions/A/Frameworks/Tentacle.framework/Versions/A/Tentacle
Error: Failed to fix install linkage
```

/cc @woodruffw 

