### PR TITLE
Update jsonnet homepage

### DIFF
--- a/Formula/jsonnet.rb
+++ b/Formula/jsonnet.rb
@@ -1,6 +1,6 @@
 class Jsonnet < Formula
   desc "Domain specific configuration language for defining JSON data"
-  homepage "https://google.github.io/jsonnet/doc/"
+  homepage "https://jsonnet.org/"
   url "https://github.com/google/jsonnet/archive/v0.11.2.tar.gz"
   sha256 "c7c33f159a9391e90ab646b3b5fd671dab356d8563dc447ee824ecd77f4609f8"
 


### PR DESCRIPTION
The old url redirects to http://jsonnet.org/doc/ which is a 404 page.

Thanks!