### PR TITLE
sourcedocs 0.5.1 (new formula)

### DIFF
--- a/Formula/sourcedocs.rb
+++ b/Formula/sourcedocs.rb
@@ -1,0 +1,30 @@
+class Sourcedocs < Formula
+  desc "Generate Markdown files from inline source code documentation"
+  homepage "https://github.com/eneko/SourceDocs"
+  url "https://github.com/eneko/SourceDocs/archive/0.5.1.tar.gz"
+  sha256 "3c2e2de695d49dbdd5acb49f8876042bdc97e8d6b95584d3ef6b592b8f10affc"
+
+  depends_on :xcode => ["9.3", :build, :test]
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc", "-static-stdlib"
+    bin.install ".build/release/sourcedocs"
+  end
+
+  test do
+    assert_equal `#{bin}/sourcedocs version`.strip, "SourceDocs v0.5.1"
+
+    # There are some issues with SourceKitten running in sandbox mode in Mojave
+    # The following test has been disabled on Mojave until that issue is resolved
+    # - https://github.com/Homebrew/homebrew/pull/50211
+    # - https://github.com/Homebrew/homebrew-core/pull/32548
+    if MacOS.version < "10.14"
+      mkdir "foo" do
+        system "swift", "package", "init"
+        system "swift", "build", "--disable-sandbox"
+        system "#{bin}/sourcedocs", "generate", "--spm-module", "foo"
+        assert_true File.file?("Documentation/Reference/README.md")
+      end
+    end
+  end
+end

--- a/Formula/sourcedocs.rb
+++ b/Formula/sourcedocs.rb
@@ -12,7 +12,7 @@ class Sourcedocs < Formula
   end
 
   test do
-    assert_equal `#{bin}/sourcedocs version`.strip, "SourceDocs v0.5.1"
+    assert_match "SourceDocs v#{version}", shell_output("#{bin}/sourcedocs version")
 
     # There are some issues with SourceKitten running in sandbox mode in Mojave
     # The following test has been disabled on Mojave until that issue is resolved
@@ -22,8 +22,10 @@ class Sourcedocs < Formula
       mkdir "foo" do
         system "swift", "package", "init"
         system "swift", "build", "--disable-sandbox"
-        system "#{bin}/sourcedocs", "generate", "--spm-module", "foo"
-        assert_true File.file?("Documentation/Reference/README.md")
+        system "#{bin}/sourcedocs", "generate",
+               "--spm-module", "foo",
+               "--output-folder", testpath/"Documentation/Reference"
+        assert_predicate testpath/"Documentation/Reference/README.md", :exist?
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add [`sourcedocs`](https://github.com/eneko/SourceDocs) formula.
