### PR TITLE
Specify explicit --smbd= path when building QEMU

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -63,6 +63,14 @@ class Qemu < Formula
       args << "--enable-cocoa"
     end
 
+    # Samba can be used to share directories with the guest in QEMU user-mode (SLIRP) networking
+    # with the `-net user,id=net0,smb=/share/this/with/guest` option. However, it requires the
+    # samba.org smbd which is incompatible with the one in /usr/sbin. The QEMU configure script
+    # will default to --smbd=/usr/sbin/smbd which causes silent runtime failures if the smb=
+    # option is used. By setting it to <prefix>/sbin/samba-dot-org-smbd, QEMU will print a
+    # sensible runtime error. Users that need the option can then install samba from a tap.
+    args << "--smbd=#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
+
     args << (build.with?("vde") ? "--enable-vde" : "--disable-vde")
     args << (build.with?("sdl2") ? "--enable-sdl" : "--disable-sdl")
     args << (build.with?("gtk+3") ? "--enable-gtk" : "--disable-gtk")


### PR DESCRIPTION
Samba can be used to share directories with the guest in QEMU user-mode
(SLIRP) networking with the `-net user,id=net0,smb=/share/this/with/guest`
option. Sharing directories using SMB is very useful when running guests
that have support for smbfs, but not for the QEMU 9p VirtFS (such as e.g.
FreeBSD). However, by default QEMU will attempt use the system
/usr/sbin/smbd which does not understand the options and config file
generated by QEMU. Unfortunately QEMU doesn't give any indication of this
incompatibility and just silently fails to setup the share.

By passing "--smbd=$(brew --prefix)/sbin/samba-dot-org-smbd" to the
configure script QEMU will no longer attempt to start the incompatible
smbd whenever the `-net user,smb=...` option is used.
Before this change QEMU starts fine if `-net user,smb=...` is set but
attempting to mount the share from the host fails with a permission denied
error (without any indication from QEMU that something went wrong starting
smbd). With this patch QEMU prints an error message and refuses to start:
`qemu-system-mips64: Could not find '/usr/local/sbin/samba-dot-org-smbd', please install it`

Due to Samba not being well supported on MacOS there is no formula for it
in homebrew-core, but if this situation changes it could be added in the
future. For now a QEMU-compatible smbd can built from source using
`brew install arichardson/cheri/samba`.

See also #32031 and https://bugs.launchpad.net/qemu/+bug/1779447

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
