### PR TITLE
pypy: fix build for Xcode 10

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -16,6 +16,9 @@ class Pypy < Formula
   depends_on "pkg-config" => :build
   depends_on :arch => :x86_64
   depends_on "gdbm"
+  # pypy does not find system libffi, and its location cannot be given
+  # as a build option
+  depends_on "libffi" if DevelopmentTools.clang_build_version >= 1000
   depends_on "openssl"
   depends_on "sqlite"
 

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -15,6 +15,9 @@ class Pypy3 < Formula
   depends_on "pypy" => :build
   depends_on :arch => :x86_64
   depends_on "gdbm"
+  # pypy does not find system libffi, and its location cannot be given
+  # as a build option
+  depends_on "libffi" if DevelopmentTools.clang_build_version >= 1000
   depends_on "openssl"
   depends_on "sqlite"
   depends_on "xz"


### PR DESCRIPTION
This is a workaround, because pypy does not find the libffi headers with recent SDKs. It expects the libffi headers to be either:
- discoverable by `pkg-config`, which is not true of macOS system libffi
- in `/usr/include`, which is not true anymore since Xcode 10

All this is hardcoded inside the pypy build system and I have found no way to configure it otherwise. Thus, I am proposing this workaround.