### PR TITLE
ppl: fix build with Xcode 10

### DIFF
--- a/Formula/ppl.rb
+++ b/Formula/ppl.rb
@@ -15,9 +15,15 @@ class Ppl < Formula
 
   depends_on "gmp"
 
+  # Fix compilation with Xcode 10
+  # Upstream commit, remove for next version
+  patch do
+    url "http://www.cs.unipr.it/git/gitweb.cgi?p=ppl/ppl.git;a=commitdiff_plain;h=c39f6a07b51f89e365b05ba4147aa2aa448febd7"
+    sha256 "6786f432784b74b81805b1d97e97cd1cc9f68653077681bb4f531466cbf8dc99"
+  end
+
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--with-gmp=#{Formula["gmp"].opt_prefix}",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Otherwise fails to compile with:

```
In file included from Box.cc:25:
In file included from ./Box_defs.hh:2286:
In file included from ./Box_templates.hh:38:
In file included from ./BD_Shape_defs.hh:2371:
In file included from ./BD_Shape_inlines.hh:31:
In file included from ./Octagonal_Shape_defs.hh:36:
In file included from ./OR_Matrix_defs.hh:607:
./OR_Matrix_inlines.hh:100:8: error: missing 'typename' prior to dependent type template name 'OR_Matrix<T>::Pseudo_Row'
inline OR_Matrix<T>::Pseudo_Row<U>&
       ^
1 error generated.
```