### PR TITLE
Use fails_with :gcc_4_2 rather than :gcc

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -35,7 +35,7 @@ class Freeswitch < Formula
   depends_on "sqlite"
 
   # https://github.com/Homebrew/homebrew/issues/42865
-  fails_with :gcc
+  fails_with :gcc_4_2
 
   #----------------------- Begin sound file resources -------------------------
   sounds_url_base = "https://files.freeswitch.org/releases/sounds"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -150,7 +150,7 @@ class Llvm < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -56,7 +56,7 @@ class LlvmAT39 < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -55,7 +55,7 @@ class LlvmAT4 < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/llvm@5.rb
+++ b/Formula/llvm@5.rb
@@ -54,7 +54,7 @@ class LlvmAT5 < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -62,7 +62,7 @@ class LlvmAT6 < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -26,7 +26,7 @@ class Node < Formula
   # Per upstream - "Need g++ 4.8 or clang++ 3.4".
   fails_with :clang if MacOS.version <= :snow_leopard
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.7").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/node@6.rb
+++ b/Formula/node@6.rb
@@ -25,7 +25,7 @@ class NodeAT6 < Formula
   # Per upstream - "Need g++ 4.8 or clang++ 3.4".
   fails_with :clang if MacOS.version <= :snow_leopard
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.7").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/node@8.rb
+++ b/Formula/node@8.rb
@@ -27,7 +27,7 @@ class NodeAT8 < Formula
   # Per upstream - "Need g++ 4.8 or clang++ 3.4".
   fails_with :clang if MacOS.version <= :snow_leopard
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.7").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -20,7 +20,7 @@ class Pypy < Formula
   depends_on "sqlite"
 
   # https://bugs.launchpad.net/ubuntu/+source/gcc-4.2/+bug/187391
-  fails_with :gcc
+  fails_with :gcc_4_2
 
   resource "bootstrap" do
     url "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2"

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -20,7 +20,7 @@ class Pypy3 < Formula
   depends_on "xz"
 
   # https://bugs.launchpad.net/ubuntu/+source/gcc-4.2/+bug/187391
-  fails_with :gcc
+  fails_with :gcc_4_2
 
   # packaging depends on pyparsing
   resource "pyparsing" do

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -48,7 +48,7 @@ class Rust < Formula
 
   # According to the official readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -25,7 +25,7 @@ class Scipy < Formula
 
   # https://github.com/Homebrew/homebrew-python/issues/110
   # There are ongoing problems with gcc+accelerate.
-  fails_with :gcc
+  fails_with :gcc_4_2
 
   def install
     config = <<~EOS

--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -20,7 +20,7 @@ class Swift < Formula
 
   # According to the official llvm readme, GCC 4.7+ is required
   fails_with :gcc_4_0
-  fails_with :gcc
+  fails_with :gcc_4_2
   ("4.3".."4.6").each do |n|
     fails_with :gcc => n
   end


### PR DESCRIPTION
`fails_with :gcc` was renamed to `fails_with :gcc_4_2`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?