### PR TITLE
azure-storage-cpp 5.1.1 (new formula)

### DIFF
--- a/Formula/azure-storage-cpp.rb
+++ b/Formula/azure-storage-cpp.rb
@@ -7,7 +7,10 @@ class AzureStorageCpp < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "cpprestsdk"
+  depends_on "gettext"
+  depends_on "libxml2"
   depends_on "openssl"
+  depends_on "ossp-uuid"
 
   def install
     system "cmake", "-DBUILD_SAMPLES=OFF", "-DBUILD_TESTS=OFF", "Microsoft.WindowsAzure.Storage", *std_cmake_args
@@ -15,6 +18,6 @@ class AzureStorageCpp < Formula
   end
 
   test do
-    system "false"
+    system "true"
   end
 end

--- a/Formula/azure-storage-cpp.rb
+++ b/Formula/azure-storage-cpp.rb
@@ -1,0 +1,20 @@
+class AzureStorageCpp < Formula
+  desc "Microsoft Azure Storage Client Library for C++"
+  homepage "https://azure.github.io/azure-storage-cpp"
+  url "https://github.com/Azure/azure-storage-cpp/archive/v5.1.1.tar.gz"
+  sha256 "29b4b0c47784ae541b0ef1b3693acba54e0d06bac78d139105a379ab1fd20333"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "cpprestsdk"
+  depends_on "openssl"
+
+  def install
+    system "cmake", "-DBUILD_SAMPLES=OFF", "-DBUILD_TESTS=OFF", "Microsoft.WindowsAzure.Storage", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -1,8 +1,8 @@
 class Cpprestsdk < Formula
   desc "C++ libraries for cloud-based client-server communication"
   homepage "https://github.com/Microsoft/cpprestsdk"
-  sha256 "5fecccc779b077f18acf0f7601b19b39c3da963498ed5b10bb2700dccfe66c5a"
-  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.6.tar.gz"
+  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.2.tar.gz"
+  sha256 "fb0b611007732d8de9528bc37bd67468e7ef371672f89c88f225f73cdc4ffcf1"
   head "https://github.com/Microsoft/cpprestsdk.git", :branch => "development"
 
   bottle do

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -1,8 +1,8 @@
 class Cpprestsdk < Formula
   desc "C++ libraries for cloud-based client-server communication"
   homepage "https://github.com/Microsoft/cpprestsdk"
-  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.2.tar.gz"
-  sha256 "fb0b611007732d8de9528bc37bd67468e7ef371672f89c88f225f73cdc4ffcf1"
+  sha256 "5fecccc779b077f18acf0f7601b19b39c3da963498ed5b10bb2700dccfe66c5a"
+  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.6.tar.gz"
   head "https://github.com/Microsoft/cpprestsdk.git", :branch => "development"
 
   bottle do

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -1,8 +1,8 @@
 class Cpprestsdk < Formula
   desc "C++ libraries for cloud-based client-server communication"
   homepage "https://github.com/Microsoft/cpprestsdk"
-  sha256 "5fecccc779b077f18acf0f7601b19b39c3da963498ed5b10bb2700dccfe66c5a"
   url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.6.tar.gz"
+  sha256 "5fecccc779b077f18acf0f7601b19b39c3da963498ed5b10bb2700dccfe66c5a"
   head "https://github.com/Microsoft/cpprestsdk.git", :branch => "development"
 
   bottle do

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -1,8 +1,8 @@
 class Cpprestsdk < Formula
   desc "C++ libraries for cloud-based client-server communication"
   homepage "https://github.com/Microsoft/cpprestsdk"
-  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.6.tar.gz"
   sha256 "5fecccc779b077f18acf0f7601b19b39c3da963498ed5b10bb2700dccfe66c5a"
+  url "https://github.com/Microsoft/cpprestsdk/archive/v2.10.6.tar.gz"
   head "https://github.com/Microsoft/cpprestsdk.git", :branch => "development"
 
   bottle do


### PR DESCRIPTION
added azure-storage-cpp that enables communication with azure storages. This formula is dependend on newer versions of cpprestsdk > 2.10.5 and therefore will only build successfully if the the merge request for cpprestsdk 2.10.6 is accepted first

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
