### PR TITLE
boost@1.68 1.68.0 (new formula)

### DIFF
--- a/Aliases/boost-bcp@1.67
+++ b/Aliases/boost-bcp@1.67
@@ -1,0 +1,1 @@
+../Formula/boost-bcp.rb

--- a/Aliases/boost-build@1.67
+++ b/Aliases/boost-build@1.67
@@ -1,0 +1,1 @@
+../Formula/boost-build.rb

--- a/Aliases/boost-python3@1.67
+++ b/Aliases/boost-python3@1.67
@@ -1,0 +1,1 @@
+../Formula/boost-python3.rb

--- a/Formula/boost-bcp@1.68.rb
+++ b/Formula/boost-bcp@1.68.rb
@@ -1,0 +1,21 @@
+class BoostBcpAT168 < Formula
+  desc "Utility for extracting subsets of the Boost library"
+  homepage "https://www.boost.org/doc/tools/bcp/"
+  url "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2"
+  sha256 "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
+
+  keg_only :versioned_formula
+
+  depends_on "boost-build@1.68" => :build
+
+  def install
+    cd "tools/bcp" do
+      system "b2"
+      prefix.install "../../dist/bin"
+    end
+  end
+
+  test do
+    system bin/"bcp", "--help"
+  end
+end

--- a/Formula/boost-build@1.68.rb
+++ b/Formula/boost-build@1.68.rb
@@ -1,0 +1,27 @@
+class BoostBuildAT168 < Formula
+  desc "C++ build system"
+  homepage "https://www.boost.org/build/"
+  url "https://github.com/boostorg/build/archive/boost-1.68.0.tar.gz"
+  sha256 "0b8612f45c43da57f370234f52018d4a6a22e11e0fcd0dff4050a1650d82e294"
+
+  keg_only :versioned_formula
+
+  def install
+    system "./bootstrap.sh"
+    system "./b2", "--prefix=#{prefix}", "install"
+  end
+
+  test do
+    (testpath/"hello.cpp").write <<~EOS
+      #include <iostream>
+      int main (void) { std::cout << "Hello world"; }
+    EOS
+    (testpath/"Jamroot.jam").write("exe hello : hello.cpp ;")
+
+    system bin/"b2", "release"
+    out = Dir["bin/darwin-*/release/hello"]
+    assert out.length == 1
+    assert_predicate testpath/out[0], :exist?
+    assert_equal "Hello world", shell_output(out[0])
+  end
+end

--- a/Formula/boost-python3@1.68.rb
+++ b/Formula/boost-python3@1.68.rb
@@ -1,0 +1,98 @@
+class BoostPython3AT168 < Formula
+  desc "C++ library for C++/Python3 interoperability"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2"
+  sha256 "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
+
+  keg_only :versioned_formula
+
+  depends_on "boost@1.68"
+  depends_on "python"
+
+  resource "numpy" do
+    url "https://files.pythonhosted.org/packages/45/ba/2a781ebbb0cd7962cc1d12a6b65bd4eff57ffda449fdbbae4726dc05fbc3/numpy-1.15.2.zip"
+    sha256 "27a0d018f608a3fe34ac5e2b876f4c23c47e38295c47dd0775cc294cd2614bc1"
+  end
+
+  needs :cxx14
+
+  def install
+    # "layout" should be synchronized with boost
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "--user-config=user-config.jam",
+            "threading=multi,single",
+            "link=shared,static"]
+
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    # disable python detection in bootstrap.sh; it guesses the wrong include
+    # directory for Python 3 headers, so we configure python manually in
+    # user-config.jam below.
+    inreplace "bootstrap.sh", "using python", "#using python"
+
+    pyver = Language::Python.major_minor_version "python3"
+    py_prefix = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{pyver}"
+
+    numpy_site_packages = buildpath/"homebrew-numpy/lib/python#{pyver}/site-packages"
+    numpy_site_packages.mkpath
+    ENV["PYTHONPATH"] = numpy_site_packages
+    resource("numpy").stage do
+      system "python3", *Language::Python.setup_install_args(buildpath/"homebrew-numpy")
+    end
+
+    # Force boost to compile with the desired compiler
+    (buildpath/"user-config.jam").write <<~EOS
+      using darwin : : #{ENV.cxx} ;
+      using python : #{pyver}
+                   : python3
+                   : #{py_prefix}/include/python#{pyver}m
+                   : #{py_prefix}/lib ;
+    EOS
+
+    system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}",
+                             "--with-libraries=python", "--with-python=python3",
+                             "--with-python-root=#{py_prefix}"
+
+    system "./b2", "--build-dir=build-python3", "--stagedir=stage-python3",
+                   "python=#{pyver}", *args
+
+    lib.install Dir["stage-python3/lib/*py*"]
+    doc.install Dir["libs/python/doc/*"]
+  end
+
+  test do
+    (testpath/"hello.cpp").write <<~EOS
+      #include <boost/python.hpp>
+      char const* greet() {
+        return "Hello, world!";
+      }
+      BOOST_PYTHON_MODULE(hello)
+      {
+        boost::python::def("greet", greet);
+      }
+    EOS
+
+    pyincludes = Utils.popen_read("python3-config --includes").chomp.split(" ")
+    pylib = Utils.popen_read("python3-config --ldflags").chomp.split(" ")
+    pyver = Language::Python.major_minor_version("python3").to_s.delete(".")
+
+    system ENV.cxx, "-shared", "hello.cpp", "-std=c++14", "-stdlib=libc++",
+           "-I#{opt_include}", "-L#{opt_lib}", "-lboost_python#{pyver}", "-o",
+           "hello.so", *pyincludes, *pylib
+
+    output = <<~EOS
+      import hello
+      print(hello.greet())
+    EOS
+    assert_match "Hello, world!", pipe_output("python3", output, 0)
+  end
+end

--- a/Formula/boost-python@1.68.rb
+++ b/Formula/boost-python@1.68.rb
@@ -1,0 +1,68 @@
+class BoostPythonAT168 < Formula
+  desc "C++ library for C++/Python2 interoperability"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2"
+  sha256 "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
+
+  keg_only :versioned_formula
+
+  depends_on "boost@1.68"
+
+  needs :cxx14
+
+  def install
+    # "layout" should be synchronized with boost
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "threading=multi,single",
+            "link=shared,static"]
+
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    pyver = Language::Python.major_minor_version "python"
+
+    system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}",
+                             "--with-libraries=python", "--with-python=python"
+
+    system "./b2", "--build-dir=build-python", "--stagedir=stage-python",
+                   "python=#{pyver}", *args
+
+    lib.install Dir["stage-python/lib/*py*"]
+    doc.install Dir["libs/python/doc/*"]
+  end
+
+  test do
+    (testpath/"hello.cpp").write <<~EOS
+      #include <boost/python.hpp>
+      char const* greet() {
+        return "Hello, world!";
+      }
+      BOOST_PYTHON_MODULE(hello)
+      {
+        boost::python::def("greet", greet);
+      }
+    EOS
+
+    pyincludes = Utils.popen_read("python-config --includes").chomp.split(" ")
+    pylib = Utils.popen_read("python-config --ldflags").chomp.split(" ")
+
+    system ENV.cxx, "-shared", "hello.cpp", "-std=c++14", "-stdlib=libc++",
+           "-I#{opt_include}", "-L#{opt_lib}", "-lboost_python27", "-o",
+           "hello.so", *pyincludes, *pylib
+
+    output = <<~EOS
+      from __future__ import print_function
+      import hello
+      print(hello.greet())
+    EOS
+    assert_match "Hello, world!", pipe_output("python", output, 0)
+  end
+end

--- a/Formula/boost@1.68.rb
+++ b/Formula/boost@1.68.rb
@@ -1,0 +1,111 @@
+class BoostAT168 < Formula
+  desc "Collection of portable C++ source libraries"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2"
+  sha256 "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
+
+  option "with-icu4c", "Build regexp engine with icu support"
+  option "without-single", "Disable building single-threading variant"
+  option "without-static", "Disable building static library variant"
+
+  depends_on "icu4c" => :optional
+
+  needs :cxx14
+
+  def install
+    # Force boost to compile with the desired compiler
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+    end
+
+    # libdir should be set by --prefix but isn't
+    bootstrap_args = ["--prefix=#{prefix}", "--libdir=#{lib}"]
+
+    if build.with? "icu4c"
+      icu4c_prefix = Formula["icu4c"].opt_prefix
+      bootstrap_args << "--with-icu=#{icu4c_prefix}"
+    else
+      bootstrap_args << "--without-icu"
+    end
+
+    # Handle libraries that will not be built.
+    without_libraries = ["python", "mpi"]
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc
+
+    bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
+
+    # layout should be synchronized with boost-python and boost-mpi
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "--user-config=user-config.jam",
+            "-sNO_LZMA=1",
+            "install"]
+
+    if build.with? "single"
+      args << "threading=multi,single"
+    else
+      args << "threading=multi"
+    end
+
+    if build.with? "static"
+      args << "link=shared,static"
+    else
+      args << "link=shared"
+    end
+
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    system "./bootstrap.sh", *bootstrap_args
+    system "./b2", "headers"
+    system "./b2", *args
+  end
+
+  def caveats
+    s = ""
+    # ENV.compiler doesn't exist in caveats. Check library availability
+    # instead.
+    if Dir["#{lib}/libboost_log*"].empty?
+      s += <<~EOS
+        Building of Boost.Log is disabled because it requires newer GCC or Clang.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <boost/algorithm/string.hpp>
+      #include <string>
+      #include <vector>
+      #include <assert.h>
+      using namespace boost::algorithm;
+      using namespace std;
+
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++14", "-stdlib=libc++",
+           "-I#{opt_include}", "-L#{opt_lib}", "-lboost_system", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This will add Boost 1.68 as a versioned formula. It turns out that a lot of formulae will fail to build against Boost 1.68, see #30914 and #31193. By adding Boost 1.68 as a versioned formula, we can slowly move formulae that can successfully build against Boost 1.68 depend on it afterwards, and eventually remove Boost 1.67 and make Boost 1.68 the default.

The rationale that I think this approach is actually worth to consider is that, we can meanwhile bump the C++ standard to C++14, as some formulae now require C++14, e.g. Folly.

This pull request does not include `boost-mpi@1.68` as `openmpi` still compiles under C++11.