### PR TITLE
Add INSTALL_SYMLINKS flag to git

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -48,6 +48,7 @@ class Git < Formula
     ENV["PYTHON_PATH"] = which("python")
     ENV["PERL_PATH"] = which("perl")
     ENV["USE_LIBPCRE2"] = "1"
+    ENV["INSTALL_SYMLINKS"] = "1"
     ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
     ENV["V"] = "1" # build verbosely
 

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -3,7 +3,7 @@ class Git < Formula
   homepage "https://git-scm.com"
   url "https://www.kernel.org/pub/software/scm/git/git-2.19.0.tar.xz"
   sha256 "180feff58fc0d965d23ea010aa2c69ead92ec318eb9b09cf737529aec62f3ef4"
-  revision 1
+  revision 2
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
A patch created from the discussion in https://github.com/Homebrew/homebrew-core/issues/32131#issuecomment-421892882 by @georgexsh and https://github.com/Homebrew/brew/issues/4921.

Should reduce installation size of the git formula without requiring any changes to core Homebrew code (for now), nor user intervention by building git form source.
