### PR TITLE
freeradius-server: secure URL

### DIFF
--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -1,8 +1,8 @@
 class FreeradiusServer < Formula
   desc "High-performance and highly configurable RADIUS server"
   homepage "https://freeradius.org/"
-  url "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.17.tar.bz2"
-  sha256 "3f03404b6e4a4f410e1f15ea2ababfec7f8a7ae8a49836d8a0c137436d913b96"
+  url "https://github.com/FreeRADIUS/freeradius-server/archive/release_3_0_17.tar.gz"
+  sha256 "5b2382f08c0d9d064298281c1fb8348fc13df76550ce7a5cfc47ea91361fad91"
   head "https://github.com/FreeRADIUS/freeradius-server.git"
 
   bottle do


### PR DESCRIPTION
by switching to the official release tarball published via GitHub. This has the same content as the existing `.bz2` file, but using `.gz` compression and they are using a differently named topmost directory; hence the different checksums.

.gz file listed here: https://freeradius.org/releases/

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Script to prove that the old and new tarballs are identical:
```shell
#!/bin/sh

curl "ftp://ftp.freeradius.org/pub/freeradius/freeradius-server-3.0.17.tar.bz2"         | tar -xvf -
curl "https://github.com/FreeRADIUS/freeradius-server/archive/release_3_0_17.tar.gz" -L | tar -xvf -

( cd freeradius-server-3.0.17         && shasum -a 256 $(find . -name '*' -type f) | sort -k 2 ) > old.sum
( cd freeradius-server-release_3_0_17 && shasum -a 256 $(find . -name '*' -type f) | sort -k 2 ) > new.sum

rm -rf ./freeradius-server-3.0.17        
rm -rf ./freeradius-server-release_3_0_17

diff -u old.sum new.sum
```
