### PR TITLE
fpc 3.0.4_1: Fix for macOS Mojave

### DIFF
--- a/Formula/fpc.rb
+++ b/Formula/fpc.rb
@@ -3,6 +3,7 @@ class Fpc < Formula
   homepage "https://www.freepascal.org/"
   url "https://downloads.sourceforge.net/project/freepascal/Source/3.0.4/fpc-3.0.4.source.tar.gz"
   sha256 "69b3b7667b72b6759cf27226df5eb54112ce3515ff5efb79d95ac14bac742845"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,12 +17,15 @@ class Fpc < Formula
     sha256 "a67ef5def356d122a4692e21b209c328f6d46deef4539f4d4506c3dc1eecb4b0"
   end
 
+  patch :DATA
+
   def install
     fpc_bootstrap = buildpath/"bootstrap"
     resource("bootstrap").stage { fpc_bootstrap.install Dir["*"] }
 
     fpc_compiler = fpc_bootstrap/"ppcx64"
-    system "make", "build", "PP=#{fpc_compiler}"
+    args = (MacOS.version >= :mojave) ? ['OPT="-XR/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"'] : []
+    system "make", "build", "PP=#{fpc_compiler}", *args
     system "make", "install", "PP=#{fpc_compiler}", "PREFIX=#{prefix}"
 
     bin.install_symlink lib/"#{name}/#{version}/ppcx64"
@@ -46,3 +50,21 @@ class Fpc < Formula
     assert_equal "Hello Homebrew", `./hello`.strip
   end
 end
+
+__END__
+diff --git a/compiler/systems/t_bsd.pas b/compiler/systems/t_bsd.pas
+index b35a78ae..61d0817d 100644
+--- a/compiler/systems/t_bsd.pas
++++ b/compiler/systems/t_bsd.pas
+@@ -310,7 +310,10 @@ begin
+   if startupfile<>'' then
+     begin
+      if not librarysearchpath.FindFile(startupfile,false,result) then
+-       result:='/usr/lib/'+startupfile
++       if sysutils.fileexists('/usr/lib/'+startupfile) then
++         result:='/usr/lib/'+startupfile
++       else if sysutils.fileexists('/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/') then
++         result:='/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/'+startupfile
+     end
+   else
+     result:='';


### PR DESCRIPTION
This PR fixes build issue on macOS Mojave, which removed `crt1.10.5.o` from `/usr/lib`.
I added a patch for `fpc` and changed a `make` argument to fix the bootstrap compiler.

The relevant discussion can be found [here](https://www.mail-archive.com/fpc-devel@lists.freepascal.org/msg36278.html).