### PR TITLE
ccm: Allow cqlsh to be used against local Cassandra

### DIFF
--- a/Formula/ccm.rb
+++ b/Formula/ccm.rb
@@ -24,9 +24,14 @@ class Ccm < Formula
     sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
   end
 
+  resource "cassandra-driver" do
+    url "https://files.pythonhosted.org/packages/2d/77/2e344b58ffe8b11271735c1ee88fa668c897c5b72ed1913067dd86e1a966/cassandra-driver-3.13.0.tar.gz"
+    sha256 "61b670fb2ba95d51d91fa7b589aae3666df494713f5d1ed78bb5c510778d77f0"
+  end
+
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    %w[PyYAML six].each do |r|
+    %w[PyYAML six cassandra-driver].each do |r|
       resource(r).stage do
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Issue overview:

When connecting to local Cassandra instances via the cqlsh utility (among the most common Cassandra admin tools), `ccm` fails with a python missing-module error unless `pip install cassandra-driver` is run against  the Python being used.

This PR adds that dependency for CCM.

While CCM has other "plugin" or "as available" functionality that does not necessarily have all of its dependencies, I believe that `cqlsh` is a common/central enough administration tool that it  should be enabled out of the  box with this Formula.