### PR TITLE
mpv 0.29.1

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -51,13 +51,10 @@ class Mpv < Formula
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
 
-    # Prevents a conflict between python2 and python3 when
-    # gobject-introspection is using brewed python.
-    ENV.delete("PYTHONPATH") if MacOS.version <= :mavericks
-
-    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
     resource("docutils").stage do
-      system "python2.7", *Language::Python.setup_install_args(buildpath/"vendor")
+      system "python3", *Language::Python.setup_install_args(buildpath/"vendor")
     end
     ENV.prepend_path "PATH", buildpath/"vendor/bin"
 

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -1,8 +1,8 @@
 class Mpv < Formula
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io"
-  url "https://github.com/mpv-player/mpv/archive/v0.28.2.tar.gz"
-  sha256 "aada14e025317b5b3e8e58ffaf7902e8b6e4ec347a93d25a7c10d3579426d795"
+  url "https://github.com/mpv-player/mpv/archive/v0.29.1.tar.gz"
+  sha256 "f9f9d461d1990f9728660b4ccb0e8cb5dce29ccaa6af567bec481b79291ca623"
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
@@ -16,7 +16,7 @@ class Mpv < Formula
   option "with-lgpl", "Build with LGPLv2.1 or later license"
 
   depends_on "pkg-config" => :build
-  depends_on "python@2" => :build
+  depends_on "python" => :build
 
   depends_on "ffmpeg"
   depends_on "jpeg"
@@ -86,11 +86,11 @@ class Mpv < Formula
     end
 
     system "./bootstrap.py"
-    system "python", "waf", "configure", *args
-    system "python", "waf", "install"
+    system "python3", "waf", "configure", *args
+    system "python3", "waf", "install"
 
     if build.with? "bundle"
-      system "python", "TOOLS/osxbundle.py", "build/mpv"
+      system "python3", "TOOLS/osxbundle.py", "build/mpv"
       prefix.install "build/mpv.app"
     end
   end

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -41,8 +41,8 @@ class Mpv < Formula
   depends_on :x11 => :optional
 
   resource "docutils" do
-    url "https://files.pythonhosted.org/packages/05/25/7b5484aca5d46915493f1fd4ecb63c38c333bd32aa9ad6e19da8d08895ae/docutils-0.13.1.tar.gz"
-    sha256 "718c0f5fb677be0f34b781e04241c4067cbd9327b66bdd8e763201130f5175be"
+    url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
+    sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
   end
 
   def install


### PR DESCRIPTION
Includes fixes for macOS Mojave issues.

Again compatible with Python 3, so reverted commit b314a662626e0a7fd61fb8f2a5e12fbbb04651e6.