### PR TITLE
swiftgen: remove workaround needed for `rdar://40724445`

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -16,9 +16,6 @@ class Swiftgen < Formula
   depends_on :xcode => ["10.0", :build]
 
   def install
-    # Fix issue with libxml2, see https://github.com/Homebrew/brew/pull/4147
-    ENV["CC"] = Utils.popen_read("xcrun -find clang").chomp
-
     # Disable swiftlint build phase to avoid build errors if versions mismatch
     ENV["NO_CODE_LINT"] = "1"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
