### PR TITLE
lastpass-cli: Use homebrew's libcurl on Mojave to avoid crashes

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -3,6 +3,7 @@ class LastpassCli < Formula
   homepage "https://github.com/lastpass/lastpass-cli"
   url "https://github.com/lastpass/lastpass-cli/archive/v1.3.1.tar.gz"
   sha256 "25dc9a0c99a10ee70b5b3991d525448c25f312cc69fa0216d7ac70c4ae384b1b"
+  revision 1
   head "https://github.com/lastpass/lastpass-cli.git"
 
   bottle do
@@ -18,13 +19,22 @@ class LastpassCli < Formula
   depends_on "cmake" => :build
   depends_on "docbook-xsl" => :build
   depends_on "pkg-config" => :build
+  # Avoid crashes on Mojave's version of libcurl (https://github.com/lastpass/lastpass-cli/issues/427)
+  depends_on "curl" if MacOS.version >= :mojave
   depends_on "openssl"
   depends_on "pinentry" => :optional
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
-    system "make", "PREFIX=#{prefix}", "install"
-    system "make", "MANDIR=#{man}", "install-doc"
+
+    args = std_cmake_args + %W[
+      -DCMAKE_INSTALL_MANDIR:PATH=#{man}
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "all", "lpass-test", "test", "install", "install-doc"
+    end
 
     bash_completion.install "contrib/lpass_bash_completion"
     zsh_completion.install "contrib/lpass_zsh_completion" => "_lpass"

--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -22,17 +22,13 @@ class LastpassCli < Formula
   # Avoid crashes on Mojave's version of libcurl (https://github.com/lastpass/lastpass-cli/issues/427)
   depends_on "curl" if MacOS.version >= :mojave
   depends_on "openssl"
-  depends_on "pinentry" => :optional
+  depends_on "pinentry"
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
 
-    args = std_cmake_args + %W[
-      -DCMAKE_INSTALL_MANDIR:PATH=#{man}
-    ]
-
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_MANDIR:PATH=#{man}"
       system "make", "all", "lpass-test", "test", "install", "install-doc"
     end
 


### PR DESCRIPTION
- See https://github.com/lastpass/lastpass-cli/issues/427

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
