### PR TITLE
makensis: skip building Win32 tools, modify test

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -36,7 +36,7 @@ class Makensis < Formula
       "CC=#{ENV.cc}",
       "CXX=#{ENV.cxx}",
       "PREFIX_DOC=#{share}/nsis/Docs",
-      "SKIPUTILS=NSIS Menu",
+      "SKIPUTILS=Makensisw,NSIS Menu,zip2exe",
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
       "STRIP=0",
       "VERSION=#{version}",

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -49,14 +49,6 @@ class Makensis < Formula
 
   test do
     system "#{bin}/makensis", "-VERSION"
-    (testpath/"test.nsi").write <<~EOS
-      # name the installer
-      OutFile "test.exe"
-      # default section start; every NSIS script has at least one section.
-      Section
-      # default section end
-      SectionEnd
-    EOS
-    system "#{bin}/makensis", "#{testpath}/test.nsi"
+    system "#{bin}/makensis", "#{share}/nsis/Examples/bigtest.nsi", "-XOutfile /dev/null"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR incorporates two changes:

1. the build parameters skip building Win32 GUI apps, which should result in shorter build times

2. the test compiles the bundled [`bigtest.nsi`](https://github.com/kichik/nsis/blob/master/Examples/bigtest.nsi), which “attempts to test most of the functionality of the NSIS exehead”