### PR TITLE
tcc: Add MACOSX_DEPLOYMENT_TARGET in make for Mojave

### DIFF
--- a/Formula/tcc.rb
+++ b/Formula/tcc.rb
@@ -23,7 +23,7 @@ class Tcc < Formula
 
     ENV.deparallelize
     system "./configure", *args
-    system "make"
+    system "make", "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?