### PR TITLE
source-highlight: Use Formula["boost"].prefix

### DIFF
--- a/Formula/source-highlight.rb
+++ b/Formula/source-highlight.rb
@@ -21,7 +21,7 @@ class SourceHighlight < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-boost=#{HOMEBREW_PREFIX}"
+                          "--with-boost=#{Formula["boost"].opt_prefix}"
     system "make", "install"
 
     bash_completion.install "completion/source-highlight"


### PR DESCRIPTION
Use Formula["boost"].prefix rather than HOMEBREW_PREFIX.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

No need to update the bottle afte this change. This PR can be squash-merged.