### PR TITLE
grc: install zsh completion

### DIFF
--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -24,6 +24,7 @@ class Grc < Formula
     etc.install "grc.bashrc"
     etc.install "grc.zsh"
     etc.install "grc.fish"
+    zsh_completion.install "_grc"
   end
 
   # Apply the upstream fix from garabik/grc@ddc789bf to preexisting config files


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/garabik/grc/blob/v1.11.3/install.sh#L29-L33

Upstream installation script will not install the zsh completion unless the installation prefix is `/usr/local`.