### PR TITLE
elasticsearch: fix postinstall

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -67,7 +67,7 @@ class Elasticsearch < Formula
     (var/"elasticsearch/plugins").mkpath
     ln_s var/"elasticsearch/plugins", libexec/"plugins"
     # fix test not being able to create keystore because of sandbox permissions
-    system bin/"elasticsearch-keystore", "create"
+    system bin/"elasticsearch-keystore", "create" unless (etc/"elasticsearch/elasticsearch.keystore").exist?
   end
 
   def caveats


### PR DESCRIPTION
only create new keystore if non already exists (fixing formula upgrades)

Fixes #32727

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
