### PR TITLE
x11 is an optional dependancy

### DIFF
--- a/Formula/mscgen.rb
+++ b/Formula/mscgen.rb
@@ -3,7 +3,7 @@ class Mscgen < Formula
   homepage "http://www.mcternan.me.uk/mscgen/"
   url "http://www.mcternan.me.uk/mscgen/software/mscgen-src-0.20.tar.gz"
   sha256 "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/mscgen.rb
+++ b/Formula/mscgen.rb
@@ -17,7 +17,7 @@ class Mscgen < Formula
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "gd"
-  depends_on :x11
+  depends_on :x11 => :optional
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
mscgen does not require x11. Some functionality may work better with it, but similar to graphviz, it can work wholly from the command line without x11.