### PR TITLE
makensis: remove zlib DLL

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -1,3 +1,4 @@
+
 class Makensis < Formula
   desc "System to create Windows installers"
   homepage "https://nsis.sourceforge.io/"
@@ -20,18 +21,7 @@ class Makensis < Formula
     sha256 "b53a79078f2c6abf21f11d9fe68807f35b228393eb17a0cd3873614190116ba7"
   end
 
-  # v1.2.8 is outdated, but the last version available as compiled DLL
-  resource "zlib-win32" do
-    url "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip"
-    sha256 "a03fd15af45e91964fb980a30422073bc3f3f58683e9fdafadad3f7db10762b1"
-  end
-
   def install
-    # requires zlib (win32) to build utils
-    resource("zlib-win32").stage do
-      @zlib_path = Dir.pwd
-    end
-
     args = [
       "CC=#{ENV.cc}",
       "CXX=#{ENV.cxx}",
@@ -40,7 +30,6 @@ class Makensis < Formula
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
       "STRIP=0",
       "VERSION=#{version}",
-      "ZLIB_W32=#{@zlib_path}",
     ]
     scons "makensis", *args
     bin.install "build/urelease/makensis/makensis"

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -1,4 +1,3 @@
-
 class Makensis < Formula
   desc "System to create Windows installers"
   homepage "https://nsis.sourceforge.io/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since this formula is no longer building some of the Win32 tools, we no longer need the zlib DLL. `SetCompressor zlib` works without it! 🙌🏼