### PR TITLE
alacritty 0.2.1 (new formula)

### DIFF
--- a/Formula/alacritty.rb
+++ b/Formula/alacritty.rb
@@ -1,0 +1,16 @@
+class Alacritty < Formula
+  desc "Cross-platform, GPU-accelerated terminal emulator"
+  homepage "https://github.com/jwilm/alacritty"
+  url "https://github.com/jwilm/alacritty/archive/v0.2.1.tar.gz"
+  sha256 "d335f09ba914faf8d8b2ba91a67672aab3acd1a3bb1528ec3d9339381697f6a1"
+  depends_on "rust" => :build
+
+  def install
+    system "make", "app"
+    bin.install "target/release/osx/Alacritty.app/Contents/MacOS/alacritty"
+  end
+
+  test do
+    system "#{bin}/alacritty", "-V"
+  end
+end


### PR DESCRIPTION
No `.app`, just builds the binary.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

(#8727 was an attempt a year and a half ago, before alacritty had stable releases)

- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
