### PR TITLE
squashfs: Add support for zstd

### DIFF
--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -3,7 +3,8 @@ class Squashfs < Formula
   homepage "https://squashfs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
   sha256 "0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6"
-  revision 1
+  revision 2
+  head "https://github.com/plougher/squashfs-tools", :using => :git, :commit => "6e242dc95485ada8d1d0b3dd9346c5243d4a517f"
 
   bottle do
     cellar :any
@@ -13,16 +14,25 @@ class Squashfs < Formula
     sha256 "192a9b40b56ded7b5d97c1ae9a587173f4380e0a71ec8332dc475d9c5beeb5e1" => :el_capitan
   end
 
+  option "with-zstd", "Build with zstd support (currently only supported with --HEAD)"
   depends_on "lzo"
   depends_on "xz"
   depends_on "lz4" => :optional
+  depends_on "zstd" => :optional # Not in 4.3 release, only in HEAD
 
   # Patch necessary to emulate the sigtimedwait process otherwise we get build failures
   # Also clang fixes, extra endianness knowledge and a bundle of other macOS fixes.
   # Originally from https://github.com/plougher/squashfs-tools/pull/3
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/05ae0eb1/squashfs/squashfs-osx-bundle.diff"
-    sha256 "276763d01ec675793ddb0ae293fbe82cbf96235ade0258d767b6a225a84bc75f"
+  if build.head? # Updated patch for the HEAD commit (won't match otherwise)
+    patch do
+      url "https://gist.githubusercontent.com/blake-riley/b1d62c0c6eabe8209a77fbd4456124e7/raw/4ddeb316c1fd8808bdcc5cd6ad833d8db58ca07e/squashfs-osx-bundle.diff"
+      sha256 "61d1e8df8a79e542fcb470d75227e3661bd58a4816ea9d06b608b07292b13265"
+    end
+  else
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/05ae0eb1/squashfs/squashfs-osx-bundle.diff"
+      sha256 "276763d01ec675793ddb0ae293fbe82cbf96235ade0258d767b6a225a84bc75f"
+    end
   end
 
   def install
@@ -36,12 +46,24 @@ class Squashfs < Formula
       LZMA_XZ_SUPPORT=1
     ]
     args << "LZ4_SUPPORT=1" if build.with? "lz4"
+    if build.with? "zstd"
+      if build.head?
+        args << "ZSTD_SUPPORT=1"
+        args << "ZSTD_DIR=#{Formula["zstd"].opt_prefix}"
+      else
+        odie "Option --with-zstd is currently only supported with --HEAD."
+      end
+    end
 
     cd "squashfs-tools" do
       system "make", *args
       bin.install %w[mksquashfs unsquashfs]
     end
-    doc.install %w[ACKNOWLEDGEMENTS INSTALL OLD-READMEs PERFORMANCE.README README-4.3]
+    if build.head?
+      doc.install %w[ACKNOWLEDGEMENTS INSTALL RELEASE-README RELEASE-READMEs]
+    else
+      doc.install %w[ACKNOWLEDGEMENTS INSTALL OLD-READMEs PERFORMANCE.README README-4.3]
+    end
   end
 
   test do


### PR DESCRIPTION
1. Source has moved from SourceForge to GitHub (latest release on SourceForge is 4 years old), so add git HEAD. Despite lots of commits (and adding support for a new feature: zstd) there hasn't been a versioned release since.
2. Add patch to work with HEAD: the existing patch works with the SourceForge 4.3 release, but fails to match on the git repo HEAD.
3. Update doc.install targets (some of the old ones have disappeared).
4. Add make args for zstd, dependent on both --with-zstd and --HEAD. Die if user attempts --with-zstd without --HEAD.
5. Add custom message for zstd to make it clear for the user that --with-zstd requires --HEAD.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
