### PR TITLE
libvirt: Enable QEMU driver

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -37,7 +37,7 @@ class Libvirt < Formula
       --with-test
       --with-vbox
       --with-vmware
-      --without-qemu
+      --with-qemu
     ]
 
     args << "ac_cv_path_RPCGEN=#{Formula["rpcgen"].opt_prefix}/bin/rpcgen" if build.head?

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -63,6 +63,34 @@ class Libvirt < Formula
     end
   end
 
+  unless build.without? "libvirtd"
+    plist_options :manual => "libvirtd"
+
+    def plist; <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>PATH</key>
+            <string>#{HOMEBREW_PREFIX}/bin</string>
+          </dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{sbin}/libvirtd</string>
+          </array>
+          <key>KeepAlive</key>
+          <true/>
+          <key>RunAtLoad</key>
+          <true/>
+        </dict>
+      </plist>
+    EOS
+    end
+  end
   test do
     if build.head?
       output = shell_output("#{bin}/virsh -V")


### PR DESCRIPTION
The driver has been fixed on macOS by the two commits:
libvirt/libvirt@171aa72baaee3bf3d827a9e7ed98ac7d184e4cfb
and
libvirt/libvirt@0041eda1e498976bcbde26de6df7366d26862162

The fixes are available since v4.7.0-rc1

The PR also adds a service plist for libvirtd.

libvirtd can be started as launchd agent to run and manage local QEMU VMs. All virsh command are redirected to the local daemon URI by default.

`virsh define FILE` will define a local VM from an XML file.
`virsh start DOMAIN` will spin up a VM named DOMAIN locally.
It's no different from libvirt on Linux except less features built-in.
Available features can be listed with:
```
virsh domcapabilities
```

Note, that only qemu domain type is suppored on macOS. kvm domain type is not available on macOS, and there's no hvf domain type yet. That essentially means, that QEMU VMs will be emulated by TCG backend and won't be accelerated by Hypervisor.framework.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----