### PR TITLE
librealsense 2.16.1

### DIFF
--- a/Formula/librealsense.rb
+++ b/Formula/librealsense.rb
@@ -1,8 +1,8 @@
 class Librealsense < Formula
   desc "Intel RealSense D400 series and SR300 capture"
   homepage "https://github.com/IntelRealSense/librealsense"
-  url "https://github.com/IntelRealSense/librealsense/archive/v2.15.0.tar.gz"
-  sha256 "c855fcce74b686efb09caeb6b8d306d90027ded428f1434ed8ba982e36bcb98f"
+  url "https://github.com/IntelRealSense/librealsense/archive/v2.16.1.tar.gz"
+  sha256 "001787d51398160a4b9285ffa74df08e22615a8278a3c994fc55c1584644584a"
   head "https://github.com/IntelRealSense/librealsense.git"
 
   bottle do
@@ -13,18 +13,14 @@ class Librealsense < Formula
     sha256 "445caed7e761e5d5d03c76cb48820118021a4313db61cf5b2594a122c714ba7b" => :el_capitan
   end
 
-  option "with-glfw", "Build & install examples"
-
-  deprecated_option "with-examples" => "with-glfw"
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "glfw"
   depends_on "libusb"
-  depends_on "glfw" => :optional
 
   def install
     args = std_cmake_args
-    args << "-DBUILD_EXAMPLES=OFF" if build.without? "glfw"
+    args << "-DENABLE_CCACHE=OFF"
 
     system "cmake", ".", "-DBUILD_WITH_OPENMP=OFF", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR bumps librealsense version to `2.16.1`.

Note that has been introduced upstream default compilation with `ccache` that causes problems while compiling `librealsense` from source. As noted under `brew info ccache`
>ALSO NOTE: The brew command, by design, will never use ccache.

As a consequence, I forced `-DENABLE_CCACHE=OFF`.