### PR TITLE
add formula for fluxctl

### DIFF
--- a/Formula/fluxctl.rb
+++ b/Formula/fluxctl.rb
@@ -1,0 +1,48 @@
+class Fluxctl < Formula
+  desc "Command-line tool to access Weave Flux, the Kubernetes GitOps operator"
+  homepage "https://github.com/weaveworks/flux"
+  url "https://github.com/weaveworks/flux.git",
+      :tag => "1.8.0",
+      :revision => "9f2be4bf2d762034a5118a0a7e974bf91089afea"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/weaveworks/flux"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "dep", "ensure", "-vendor-only"
+      system "make", "release-bins"
+      bin.install "build/fluxctl_darwin_amd64" => "fluxctl"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/fluxctl 2>&1")
+    assert_match "fluxctl helps you deploy your code.", run_output
+
+    version_output = shell_output("#{bin}/fluxctl version 2>&1")
+    assert_match version.to_s, version_output
+
+    # As we can't bring up a Kubernetes cluster in this test, we simply
+    # run "fluxctl sync" and check that it 1) errors out, and 2) complains
+    # about a missing .kube/config file.
+    require "pty"
+    require "timeout"
+    r, _w, pid = PTY.spawn("#{bin}/fluxctl sync", :err=>:out)
+    begin
+      Timeout.timeout(5) do
+        assert r.gets.chomp =~ %r{Error: stat .*\/.kube\/config: no such file or directory}
+        Process.wait pid
+        assert_equal 1, $CHILD_STATUS.exitstatus
+      end
+    rescue Timeout::Error
+      puts "process not finished in time, killing it"
+      Process.kill("TERM", pid)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `fluxctl`, a command to control [Flux](https://github.com/weaveworks/flux), the GitOps operator for Kubernetes.

Signed-off-by: Daniel Holbach <daniel@weave.works>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
