### PR TITLE
graph-tool 2.27: upstream fix and with-expat option added

### DIFF
--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -92,7 +92,7 @@ class GraphTool < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       PYTHON=python3
-      PYTHON_LIBS=-undefined dynamic_lookup
+      PYTHON_LIBS=-undefined\ dynamic_lookup
       --with-python-module-path=#{lib}/python#{xy}/site-packages
       --with-boost-python=boost_python#{xy.to_s.delete(".")}-mt
     ]

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -92,7 +92,8 @@ class GraphTool < Formula
                           "PYTHON=python3",
                           "PYTHON_LIBS=-undefined dynamic_lookup",
                           "--with-python-module-path=#{lib}/python#{xy}/site-packages",
-                          "--with-boost-python=boost_python#{xy.to_s.delete(".")}-mt"
+                          "--with-boost-python=boost_python#{xy.to_s.delete(".")}-mt",
+                          "--with-expat=/usr/local/opt/expat"
     system "make", "install"
 
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -71,6 +71,7 @@ class GraphTool < Formula
     sha256 "94559544ad95753a13ee701c02af706c8b296c54af2c1706520ec96e24aa6d39"
   end
 
+  # Remove for > 2.27
   # Upstream commit from 3 Oct 2018 "Fix compilation with CGAL 4.13"
   patch do
     url "https://git.skewed.de/count0/graph-tool/commit/aa39e4a6.diff"
@@ -86,14 +87,18 @@ class GraphTool < Formula
       venv.pip_install_and_link r
     end
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "PYTHON=python3",
-                          "PYTHON_LIBS=-undefined dynamic_lookup",
-                          "--with-python-module-path=#{lib}/python#{xy}/site-packages",
-                          "--with-boost-python=boost_python#{xy.to_s.delete(".")}-mt",
-                          "--with-expat=/usr/local/opt/expat"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      PYTHON=python3
+      PYTHON_LIBS=-undefined dynamic_lookup
+      --with-python-module-path=#{lib}/python#{xy}/site-packages
+      --with-boost-python=boost_python#{xy.to_s.delete(".")}-mt
+    ]
+    args << "--with-libexpat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
+
+    system "./configure", *args
     system "make", "install"
 
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -71,6 +71,12 @@ class GraphTool < Formula
     sha256 "94559544ad95753a13ee701c02af706c8b296c54af2c1706520ec96e24aa6d39"
   end
 
+  # Upstream commit from 3 Oct 2018 "Fix compilation with CGAL 4.13"
+  patch do
+    url "https://git.skewed.de/count0/graph-tool/commit/aa39e4a6.diff"
+    sha256 "5a4ea386342c2de9422da5b07dd4272d47d2cdbba99d9b258bff65a69da562c1"
+  end
+
   def install
     xy = Language::Python.major_minor_version "python3"
 

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -96,7 +96,7 @@ class GraphTool < Formula
       --with-python-module-path=#{lib}/python#{xy}/site-packages
       --with-boost-python=boost_python#{xy.to_s.delete(".")}-mt
     ]
-    args << "--with-libexpat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
+    args << "--with-expat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -80,7 +80,7 @@ class GraphTool < Formula
 
   def install
     # Work around "error: no member named 'signbit' in the global namespace"
-    ENV.delete("SDKROOT")
+    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :high_sierra
 
     xy = Language::Python.major_minor_version "python3"
     venv = virtualenv_create(libexec, "python3")

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -79,8 +79,10 @@ class GraphTool < Formula
   end
 
   def install
-    xy = Language::Python.major_minor_version "python3"
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete("SDKROOT")
 
+    xy = Language::Python.major_minor_version "python3"
     venv = virtualenv_create(libexec, "python3")
 
     resources.each do |r|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream fix solves [issue](https://git.skewed.de/count0/graph-tool/commit/aa39e4a6b42d43fac30c841d176c75aff92cc01a) with graph-tool compilation with CGAL 4.13

Adding --with-expat option solves problem with using expat from brew.