### PR TITLE
nexus 2.14.10-01

### DIFF
--- a/Formula/nexus.rb
+++ b/Formula/nexus.rb
@@ -1,9 +1,9 @@
 class Nexus < Formula
   desc "Repository manager for binary software components"
   homepage "https://www.sonatype.org/"
-  url "https://sonatype-download.global.ssl.fastly.net/nexus/oss/nexus-2.14.8-01-bundle.tar.gz"
-  version "2.14.8-01"
-  sha256 "dfe47d5e5b3c6667854d967eede2f778169c01c55ad930a17f79ee6a59c36903"
+  url "https://sonatype-download.global.ssl.fastly.net/repository/repositoryManager/oss/nexus-2.14.10-01-bundle.tar.gz"
+  version "2.14.10-01"
+  sha256 "d91fcc927ac90248d81ec741527668524388052abd7415548804dcb13a41e208"
 
   bottle :unneeded
 


### PR DESCRIPTION
Version bump.

I tried `brew bump-formula-pr` but was getting some error I didn't know how to diagnose.

```
$ brew bump-formula-pr \
    --url "https://sonatype-download.global.ssl.fastly.net/repository/repositor
yManager/oss/nexus-2.14.10-01-bundle.tar.gz" \
    --sha256 d91fcc927ac90248d81ec741527668524388052abd7415548804dcb13a41e208 \
    --version 2.14.10-01 \
    --verbose \
    --debug
/usr/bin/curl -q --show-error --user-agent Homebrew/1.7.7-10-gcf1c951\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.6\)\ curl/7.54.0 --fail --location --remote-time --continue-at 0 --output /Users/esamson/Library/Caches/Homebrew/Formula/nexus-2.14.10-01-bundle.tar.gz https://sonatype-download.global.ssl.fastly.net/repository/repositoryManager/oss/nexus-2.14.10-01-bundle.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 78.5M  100 78.5M    0     0  1028k      0  0:01:18  0:01:18 --:--:-- 2717k
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FromUrlLoader): loading /Users/esamson/Library/Caches/Homebrew/Formula/nexus-2.14.10-01-bundle.tar.gz
Error: nexus-2.14.10-01-bundle.tar.gz: /Users/esamson/Library/Caches/Homebrew/Formula/nexus-2.14.10-01-bundle.tar.gz:1: Invalid char `\x1F' in expression
/Users/esamson/Library/Caches/Homebrew/Formula/nexus-2.14.10-01-bundle.tar.gz:1: invalid multibyte char (UTF-8)
/usr/local/Homebrew/Library/Homebrew/formulary.rb:28:in `rescue in load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:25:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:46:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:128:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:201:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:118:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:114:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:309:in `factory'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:47:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:45:in `map'
/usr/local/Homebrew/Library/Homebrew/extend/ARGV.rb:45:in `formulae'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:120:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:89:in `<main>'
```