### PR TITLE
Remove some python options

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -3,7 +3,7 @@ class Collectd < Formula
   homepage "https://collectd.org/"
   url "https://collectd.org/files/collectd-5.8.0.tar.bz2"
   sha256 "b06ff476bbf05533cb97ae6749262cc3c76c9969f032bd8496690084ddeb15c9"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "cc40ab3b126a55310a7e0687be7ce458a5203578015f287377e6a52cbf1d2903" => :mojave
@@ -19,20 +19,11 @@ class Collectd < Formula
     depends_on "automake" => :build
   end
 
-  option "with-java", "Enable Java support"
-  option "with-python", "Enable Python support"
-  option "with-riemann-client", "Enable write_riemann support"
-
-  deprecated_option "java" => "with-java"
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "libgcrypt"
   depends_on "libtool"
   depends_on "net-snmp"
-  depends_on :java => :optional
-  depends_on "python@2" => :optional
-  depends_on "riemann-client" => :optional
+  depends_on "riemann-client"
 
   fails_with :clang do
     build 318
@@ -48,11 +39,9 @@ class Collectd < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --localstatedir=#{var}
+      --disable-java
+      --enable-write_riemann
     ]
-
-    args << "--disable-java" if build.without? "java"
-    args << "--enable-python" if build.with? "python@2"
-    args << "--enable-write_riemann" if build.with? "riemann-client"
 
     system "./build.sh" if build.head?
     system "./configure", *args

--- a/Formula/enchant.rb
+++ b/Formula/enchant.rb
@@ -11,18 +11,9 @@ class Enchant < Formula
     sha256 "4240a9afdab529f1349963fd7d0e90725365fcd8fa27a937d5fc115abad50a65" => :el_capitan
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "aspell"
   depends_on "glib"
-  depends_on "python@2" => :optional
-
-  # https://pythonhosted.org/pyenchant/
-  resource "pyenchant" do
-    url "https://files.pythonhosted.org/packages/9e/54/04d88a59efa33fefb88133ceb638cdf754319030c28aadc5a379d82140ed/pyenchant-2.0.0.tar.gz"
-    sha256 "fc31cda72ace001da8fe5d42f11c26e514a91fa8c70468739216ddd8de64e2a0"
-  end
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -30,19 +21,7 @@ class Enchant < Formula
                           "--enable-relocatable"
 
     system "make", "install"
-
     ln_s "enchant-2.pc", lib/"pkgconfig/enchant.pc"
-
-    if build.with? "python@2"
-      resource("pyenchant").stage do
-        # Don't download and install distribute now
-        inreplace "setup.py", "ez_setup.use_setuptools()", ""
-        ENV["PYENCHANT_LIBRARY_PATH"] = lib/"libenchant-2.dylib"
-        system "python", "setup.py", "install", "--prefix=#{prefix}",
-                              "--single-version-externally-managed",
-                              "--record=installed.txt"
-      end
-    end
   end
 
   test do

--- a/Formula/gwyddion.rb
+++ b/Formula/gwyddion.rb
@@ -3,6 +3,7 @@ class Gwyddion < Formula
   homepage "http://gwyddion.net/"
   url "http://gwyddion.net/download/2.51/gwyddion-2.51.tar.gz"
   sha256 "67c1319b3a3e5682a37390b34d2580208a624c7d56dae8b5a3389fa5856508ee"
+  revision 1
 
   bottle do
     sha256 "fdf2a687132e224d1107e749bd627f3a257750760e606a7048eacb0f4fe31c09" => :mojave
@@ -11,19 +12,16 @@ class Gwyddion < Formula
     sha256 "09c1f364d6942d1fe8b2a88f99340437005b3fc84a7b0ee0e359fcf4a8b0ed5b" => :el_capitan
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "fftw"
   depends_on "gtk+"
   depends_on "gtk-mac-integration"
   depends_on "gtkglext"
+  depends_on "gtksourceview"
   depends_on "libxml2"
   depends_on "minizip"
-
-  depends_on "python@2" => :optional
-  depends_on "pygtk" if build.with? "python@2"
-  depends_on "gtksourceview" if build.with? "python@2"
+  depends_on "pygtk"
+  depends_on "python@2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/lcm.rb
+++ b/Formula/lcm.rb
@@ -22,13 +22,9 @@ class Lcm < Formula
     depends_on "xz" => :build
   end
 
-  deprecated_option "with-python3" => "with-python"
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on :java => "1.8"
-  depends_on "python" => :optional
-  depends_on "python@2" => :optional
 
   def install
     if build.head?

--- a/Formula/libpeas.rb
+++ b/Formula/libpeas.rb
@@ -12,22 +12,14 @@ class Libpeas < Formula
     sha256 "e564ba0cc81e732fdd1e5632d5628ab1ac9c9a45d094b17e22d01dde345f3946" => :el_capitan
   end
 
-  option "with-python@2", "Build with support for python2 plugins"
-
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
+  depends_on "pygobject3"
   depends_on "python"
-  depends_on "python@2" => :optional
-
-  if build.with? "python@2"
-    depends_on "pygobject3" => "with-python@2"
-  else
-    depends_on "pygobject3"
-  end
 
   def install
     args = %W[
@@ -36,19 +28,12 @@ class Libpeas < Formula
       --prefix=#{prefix}
       --enable-gtk
       --enable-python3
+      --disable-python2
     ]
 
     xy = Language::Python.major_minor_version "python3"
     py3_lib = Formula["python"].opt_frameworks/"Python.framework/Versions/#{xy}/lib"
     ENV.append "LDFLAGS", "-L#{py3_lib}"
-
-    if build.with? "python@2"
-      py2_lib = Formula["python@2"].opt_frameworks/"Python.framework/Versions/2.7/lib"
-      ENV.append "LDFLAGS", "-L#{py2_lib}"
-      args << "--enable-python2"
-    else
-      args << "--disable-python2"
-    end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/libpst.rb
+++ b/Formula/libpst.rb
@@ -3,6 +3,7 @@ class Libpst < Formula
   homepage "http://www.five-ten-sg.com/libpst/"
   url "http://www.five-ten-sg.com/libpst/packages/libpst-0.6.72.tar.gz"
   sha256 "8a19d891eb077091c507d98ed8e2d24b7f48b3e82743bcce2b00a12040f5d507"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,32 +13,20 @@ class Libpst < Formula
     sha256 "154c2402a1949c8bcd7b784181b9f1d47705b035ea996506f6d142c3c92e2423" => :el_capitan
   end
 
-  option "with-pst2dii", "Build pst2dii using gd"
-
-  deprecated_option "pst2dii" => "with-pst2dii"
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "gd" if build.with? "pst2dii"
+  depends_on "boost-python"
   depends_on "gettext"
   depends_on "libgsf"
-  depends_on "python@2" => :optional
-  depends_on "boost-python" if build.with? "python@2"
+  depends_on "python@2"
 
   def install
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
+      --enable-python
+      --with-boost-python=mt
     ]
-
-    args << "--disable-dii" if build.with? "pst2dii"
-
-    if build.with? "python@2"
-      args << "--enable-python" << "--with-boost-python=mt"
-    else
-      args << "--disable-python"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -3,6 +3,7 @@ class LibtorrentRasterbar < Formula
   homepage "https://www.libtorrent.org/"
   url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1_8/libtorrent-rasterbar-1.1.8.tar.gz"
   sha256 "6bbf8fd0430e27037b09a870c89cfc330ea41816102fe1d1d16cc7428df08d5d"
+  revision 1
 
   bottle do
     cellar :any
@@ -19,28 +20,25 @@ class LibtorrentRasterbar < Formula
     depends_on "libtool" => :build
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "boost"
+  depends_on "boost-python"
   depends_on "openssl"
-  depends_on "python@2" => :optional
-  depends_on "boost-python" if build.with? "python@2"
+  depends_on "python@2"
 
   def install
     ENV.cxx11
-    args = ["--disable-debug",
-            "--disable-dependency-tracking",
-            "--disable-silent-rules",
-            "--enable-encryption",
-            "--prefix=#{prefix}",
-            "--with-boost=#{Formula["boost"].opt_prefix}"]
 
-    # Build python bindings requires forcing usage of the mt version of boost_python.
-    if build.with? "python@2"
-      args << "--enable-python-binding"
-      args << "--with-boost-python=boost_python27-mt"
-    end
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-encryption
+      --enable-python-binding
+      --with-boost=#{Formula["boost"].opt_prefix}
+      --with-boost-python=boost_python27-mt
+    ]
 
     if build.head?
       system "./bootstrap.sh", *args

--- a/Formula/mat.rb
+++ b/Formula/mat.rb
@@ -13,16 +13,12 @@ class Mat < Formula
     sha256 "be9d42344640bddc264ccefc4d11e569187aa109b99e052d0d068cc8046bb2f8" => :el_capitan
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "coreutils"
   depends_on "poppler"
   depends_on "py2cairo"
   depends_on "pygobject3" => "with-python@2"
-  depends_on "exiftool" => :optional
-  depends_on "python@2" => :optional
 
   resource "hachoir-core" do
     url "https://files.pythonhosted.org/packages/source/h/hachoir-core/hachoir-core-1.3.3.tar.gz"

--- a/Formula/pacparser.rb
+++ b/Formula/pacparser.rb
@@ -14,22 +14,13 @@ class Pacparser < Formula
     sha256 "3d2092ad71629a2c71d5b88138d0ea7443247d7cd89414ef46a9cab7898b250c" => :yosemite
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
-  depends_on "python@2" => :optional
-
   def install
     # Disable parallel build due to upstream concurrency issue.
     # https://github.com/pacparser/pacparser/issues/27
     ENV.deparallelize
     ENV["VERSION"] = version
     Dir.chdir "src"
-    system "make", "install",
-           "PREFIX=#{prefix}"
-    if build.with? "python@2"
-      system "make", "install-pymod",
-             "EXTRA_ARGS=\"--prefix=#{prefix}\""
-    end
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/silk.rb
+++ b/Formula/silk.rb
@@ -11,15 +11,10 @@ class Silk < Formula
     sha256 "d90ea3352ba364ec403c56712b0503fe2c4e67e678d4a5147868eb1c233926ff" => :el_capitan
   end
 
-  option "with-python@2", "Build with the PySiLK python interface"
-
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "libfixbuf"
   depends_on "yaf"
-  depends_on "python@2" => :optional
 
   def install
     args = %W[
@@ -30,14 +25,11 @@ class Silk < Formula
       --enable-data-rootdir=#{var}/silk
     ]
 
-    if build.with? "python@2"
-      args << "--with-python" << "--with-python-prefix=#{prefix}"
-    end
     system "./configure", *args
     system "make"
     system "make", "install"
 
-    (var+"silk").mkpath
+    (var/"silk").mkpath
   end
 
   test do

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -13,12 +13,8 @@ class Unbound < Formula
     sha256 "457aefbc06c993b8c8712d7686f8542b59fc993d49f2efe4493543404be95ace" => :el_capitan
   end
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "libevent"
   depends_on "openssl"
-  depends_on "python@2" => :optional
-  depends_on "swig" if build.with? "python@2"
 
   def install
     args = %W[
@@ -27,15 +23,6 @@ class Unbound < Formula
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-ssl=#{Formula["openssl"].opt_prefix}
     ]
-
-    if build.with? "python@2"
-      ENV.prepend "LDFLAGS", `python-config --ldflags`.chomp
-      ENV.prepend "PYTHON_VERSION", "2.7"
-
-      args << "--with-pyunbound"
-      args << "--with-pythonmodule"
-      args << "PYTHON_SITE_PKG=#{lib}/python2.7/site-packages"
-    end
 
     args << "--with-libexpat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
     system "./configure", *args


### PR DESCRIPTION
Following #31510 and the upcoming Python migration, make our life easier by removing python options that are unused (as shown by analytics). Also take care of other options in those formulas, either removing them or integrating them.