### PR TITLE
Intltool: Set explicit path for xgettext in intltool-update

### DIFF
--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -3,6 +3,7 @@ class Intltool < Formula
   homepage "https://wiki.freedesktop.org/www/Software/intltool"
   url "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz"
   sha256 "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,6 +17,8 @@ class Intltool < Formula
   end
 
   def install
+    # give explicit path to brew'd xgettext as it is a GNU gettext creation
+    inreplace "intltool-update.in", "|| \"xgettext\"", "|| \"#{Formula["gettext"].opt_bin}/xgettext\""
     system "./configure", "--prefix=#{prefix}",
                           "--disable-silent-rules"
     system "make", "install"


### PR DESCRIPTION
As xgettext is a GNU gettext creation it is not included in the version of gettext that comes with macOS, and GNU gettext is not linked due to the version of gettext included with macOS therefore change intltool-update from relying on xgettext being in $PATH to an explicit path, while keeping the ability to override using XGETTEXT environment variable.

As this seems to be primarily a homebrew installation heirachy thing and due to the environment variable that exists this has not been submitted upstream

issue #32874

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
