### PR TITLE
Remove build options from cmu-sphinxbase

### DIFF
--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -26,7 +26,7 @@ class CmuSphinxbase < Formula
   depends_on "pkg-config" => :build
   # If these are found, they will be linked against and there is no configure
   # switch to turn them off.
-  depends_on "libsamplerate" => "with-libsndfile"
+  depends_on "libsamplerate"
   depends_on "libsndfile"
 
   def install
@@ -38,5 +38,22 @@ class CmuSphinxbase < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include "cmd_ln.h"
+
+      int main(int argc, char **argv) {
+        cmd_ln_t *config = NULL;
+
+        config = cmd_ln_init(NULL, NULL, TRUE,
+          "-hello", "world", NULL);
+        cmd_ln_free_r(config);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-L#{lib}", "-lsphinxbase", "-I#{include}/sphinxbase", "test.cpp", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Reference: https://github.com/Homebrew/homebrew-core/issues/13133

The Formula cmu-pocketsphinx which depends on cmu-sphinxbase seems to still build fine after this changes.
