### PR TITLE
bind: Fix issue with json include files

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -30,7 +30,7 @@ class Bind < Formula
                           "--enable-threads",
                           "--enable-ipv6",
                           "--with-openssl=#{Formula["openssl"].opt_prefix}",
-                          "--with-libjson=yes"
+                          "--with-libjson=#{Formula["json-c"].opt_prefix}"
 
     # From the bind9 README: "Do not use a parallel "make"
     ENV.deparallelize


### PR DESCRIPTION
When Homebrew is installed in a custom path, the json include files
won't be found. This fix follows how openssl include and library files
are found by setting the value to --with-libjson to the path of the
library.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes the following error:

```
==> Upgrading 1 outdated package, with result:
bind 9.12.1-P2 -> 9.12.2-P2_1
==> Upgrading bind
==> Downloading https://ftp.isc.org/isc/bind9/9.12.2-P2/bind-9.12.2-P2.tar.gz
Already downloaded: /Users/kevin/Library/Caches/Homebrew/downloads/263d3822678b81f143873118aa06e36ae78cc04efcbc69b159a6fb821a376b3d--bind-9.12.2-P2.tar.gz
==> ./configure --prefix=/Users/kevin/Homebrew/Cellar/bind/9.12.2-P2_1 --enable-
Last 15 lines from /Users/kevin/Library/Logs/Homebrew/bind/01.configure:
checking for DSA_get0_pqg... no
checking for OpenSSL ECDSA support... yes
checking for OpenSSL GOST support... yes
checking for OpenSSL Ed25519 support... no
checking for OpenSSL AES support... yes
checking for the algorithm for Client Cookie... aes
checking for using OpenSSL for hash functions... yes
checking for PKCS11 support... no
checking for PKCS11 tools... disabled
checking for native PKCS11... disabled
checking for clock_gettime... yes
checking for using the crypto library (vs. builtin) for random functions... "openssl"
checking for lmdb library... no
checking for libxml2 library... yes
checking for json library... configure: error: include/json{,-c}/json.h not found.
```