### PR TITLE
golang-migrate 4.0.0

### DIFF
--- a/Formula/golang-migrate.rb
+++ b/Formula/golang-migrate.rb
@@ -14,8 +14,7 @@ class GolangMigrate < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GO111MODULE"] = "on"
+    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
     (buildpath/"src/github.com/golang-migrate/migrate").install buildpath.children
 
     # Build and install CLI as "migrate"

--- a/Formula/golang-migrate.rb
+++ b/Formula/golang-migrate.rb
@@ -1,8 +1,8 @@
 class GolangMigrate < Formula
   desc "Database migrations CLI tool"
   homepage "https://github.com/golang-migrate/migrate"
-  url "https://github.com/golang-migrate/migrate/archive/v3.5.2.tar.gz"
-  sha256 "3c1d91648313d267136789214b0b2b4eb7adec21cd84e12d7f1cf978cd18b5b6"
+  url "https://github.com/golang-migrate/migrate/archive/v4.0.0.tar.gz"
+  sha256 "b6552d1450990fcbece1253b988e1a5ea8390d8686ce3bdfd52a0f7fbc1ad779"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,16 +11,15 @@ class GolangMigrate < Formula
     sha256 "ad5e40bbaa24391e1f05b8d81e923349f3d9681d8974ecda4422428ae9a065ec" => :sierra
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "on"
     (buildpath/"src/github.com/golang-migrate/migrate").install buildpath.children
 
     # Build and install CLI as "migrate"
     cd "src/github.com/golang-migrate/migrate" do
-      system "dep", "ensure", "-vendor-only"
       system "make", "build-cli", "VERSION=v#{version}"
       bin.install "cli/build/migrate.darwin-amd64" => "migrate"
       prefix.install_metafiles


### PR DESCRIPTION
v4.0.0 of golang-migrate use Go modules for dependency management instead of dep

**Note:** This change requires Go 1.11 (or 1.10.3+ or 1.9.7+). The `go` formula version is 1.11 in homebrew but I couldn't find a way to pin it. I think the previous versions of go were migrated to a different formula name (with `@[version number]`). Using `depends_on "go" => [:build, "1.11"]` gave me the following `brew audit --strict` error: `Dependency go does not define option "1.11"`

------

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?