### PR TITLE
luarocks: Added option to install luarocks for luajit

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -12,13 +12,29 @@ class Luarocks < Formula
     sha256 "7a23c8cd3129369ae7502801765242e2e8a1f4afaf6c58d09b812654d5ba2dd3" => :el_capitan
   end
 
+  option "with-luajit", "Build for luajit"
+
+  if build.with?("luajit")
+    depends_on "luajit"
+  else
+    depends_on "lua"
+  end
+
   depends_on "lua@5.1" => :test
-  depends_on "lua"
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
-                          "--rocks-tree=#{HOMEBREW_PREFIX}"
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --rocks-tree=#{HOMEBREW_PREFIX}
+    ]
+
+    if build.with? "luajit"
+      args << "--with-lua=/usr/local/opt/luajit"
+      args << "--lua-suffix=jit"
+    end
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This PR adds the option `with-luajit` to the luarocks formula. This partly solves problems described in #32852. Now when running `luarocks install luasocket` etc. knot-resolver is able to locate and use these modules.
Since I am no ruby developer this is a best effort of me. If something is not as expected or uncanonical etc. please don't hesitate to tell me what needs to change.