### PR TITLE
knot-resolver: Install icann-ca.pem to expected location

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -37,6 +37,7 @@ class KnotResolver < Formula
     (etc/"kresd").install "config"
 
     (etc/"kresd").install "etc/root.hints"
+    (etc/"kresd").install "etc/icann-ca.pem"
 
     (buildpath/"root.keys").write(root_keys)
     (var/"kresd").install "root.keys"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This PR installs the file icann-ca.pem from the knot-resolver source tarball to the expected location. This file is necessary for DNSSEC TA bootstrapping to work. It enables users to simply follow the [instructions](https://knot-resolver.readthedocs.io/en/stable/daemon.html#enabling-dnssec) from the knot-resolver documentation. This is related to my problem described in #32852.
