### PR TITLE
zsh: support keg-only ncurses.

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -4,6 +4,7 @@ class Zsh < Formula
   url "https://downloads.sourceforge.net/project/zsh/zsh/5.6.2/zsh-5.6.2.tar.xz"
   mirror "https://www.zsh.org/pub/zsh-5.6.2.tar.xz"
   sha256 "a50bd66c0557e8eca3b8fa24e85d0de533e775d7a22df042da90488623752e9e"
+  revision 1
 
   bottle do
     sha256 "443795937f11b04a0bff7047fb183c18f48dabff111d1b9f7f576a9881285f58" => :mojave
@@ -22,6 +23,7 @@ class Zsh < Formula
 
   deprecated_option "disable-etcdir" => "without-etcdir"
 
+  depends_on "ncurses"
   depends_on "gdbm" => :optional
   depends_on "pcre" => :optional
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The version of ncurses shipping in macOS Mojave is 10 years old. Building against Homebrew's ncurses gives zsh access to an updated terminfo database, e.g. allowing users to set `TERM=tmux`.

That's exactly my use case: I want to use the tmux terminfo entry with zsh. The easiest way to get highlight/italics right in tmux is to set the TERM appropriately. Ncurses has had `tmux` and `tmux-256color` entries in the terminfo database since 2015. The closest thing that the system ncurses has is `screen.xterm-new`, which is pretty good, but isn't 256color.

The stats on https://formulae.brew.sh/formula/zsh show that someone else has been doing `--with-ncurses`, so presumably there are other reasons to use a newer ncurses.

Ncurses is not that big of a package (14M). It might be worth it to use Homebrew's version by default.