### PR TITLE
Cleanup Requirements

### DIFF
--- a/Formula/apple-gcc42.rb
+++ b/Formula/apple-gcc42.rb
@@ -10,7 +10,7 @@ class AppleGcc42 < Formula
 
   option "with-gfortran-symlink", "Provide gfortran symlinks"
 
-  depends_on MaximumMacOSRequirement => :mavericks
+  depends_on :maximum_macos => :mavericks
 
   def install
     system "/bin/pax", "--insecure", "-rz", "-f", "usr.pkg/Payload", "-s", ",./usr,#{prefix},"

--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -14,17 +14,10 @@ class Camlp5 < Formula
     sha256 "f8561228e8b21eeaf36d56b56550c26cc8ddfe84b87489b5855f38d8902e3d08" => :el_capitan
   end
 
-  option "with-strict", "Compile in strict mode (not recommended)"
-
-  deprecated_option "strict" => "with-strict"
-
   depends_on "ocaml"
 
   def install
-    args = ["--prefix", prefix, "--mandir", man]
-    args << "--transitional" if build.without? "strict"
-
-    system "./configure", *args
+    system "./configure", "--prefix", prefix, "--mandir", man
     system "make", "world.opt"
     system "make", "install"
     (lib/"ocaml/camlp5").install "etc/META"
@@ -32,6 +25,7 @@ class Camlp5 < Formula
 
   test do
     (testpath/"hi.ml").write "print_endline \"Hi!\";;"
-    assert_equal "let _ = print_endline \"Hi!\"", shell_output("#{bin}/camlp5 #{lib}/ocaml/camlp5/pa_o.cmo #{lib}/ocaml/camlp5/pr_o.cmo hi.ml")
+    assert_equal "let _ = print_endline \"Hi!\"",
+      shell_output("#{bin}/camlp5 #{lib}/ocaml/camlp5/pa_o.cmo #{lib}/ocaml/camlp5/pr_o.cmo hi.ml")
   end
 end

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -1,15 +1,3 @@
-class Camlp5TransitionalModeRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) { !Tab.for_name("camlp5").with?("strict") }
-
-  def message; <<~EOS
-    camlp5 must be compiled in transitional mode (instead of --strict mode):
-      brew install camlp5
-  EOS
-  end
-end
-
 class Coq < Formula
   desc "Proof assistant for higher-order logic"
   homepage "https://coq.inria.fr/"
@@ -26,7 +14,6 @@ class Coq < Formula
 
   depends_on "ocaml-findlib" => :build
   depends_on "camlp5"
-  depends_on Camlp5TransitionalModeRequirement
   depends_on "ocaml"
   depends_on "ocaml-num"
 

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -45,7 +45,7 @@ class GccAT49 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
-  depends_on MaximumMacOSRequirement => :high_sierra
+  depends_on :maximum_macos => :high_sierra
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -45,7 +45,7 @@ class GccAT49 < Formula
   deprecated_option "enable-nls" => "with-nls"
   deprecated_option "enable-profiled-build" => "with-profiled-build"
 
-  depends_on :maximum_macos => :high_sierra
+  depends_on :maximum_macos => [:high_sierra, :build]
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -47,7 +47,7 @@ class GccAT5 < Formula
 
   depends_on "gmp"
   depends_on "libmpc"
-  depends_on MaximumMacOSRequirement => :high_sierra
+  depends_on :maximum_macos => :high_sierra
   depends_on "mpfr"
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -45,9 +45,10 @@ class GccAT5 < Formula
   option "with-jit", "Build the jit compiler"
   option "without-fortran", "Build without the gfortran compiler"
 
+  depends_on :maximum_macos => [:high_sierra, :build]
+
   depends_on "gmp"
   depends_on "libmpc"
-  depends_on :maximum_macos => :high_sierra
   depends_on "mpfr"
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib

--- a/Formula/ld64.rb
+++ b/Formula/ld64.rb
@@ -21,7 +21,7 @@ class Ld64 < Formula
   depends_on "cctools-headers" => :build
   depends_on "dyld-headers" => :build
   depends_on "libunwind-headers" => :build
-  depends_on MaximumMacOSRequirement => :snow_leopard
+  depends_on :maximum_macos => :snow_leopard
   depends_on "openssl"
 
   fails_with :gcc_4_0 do

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "llvm_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      lldb_codesign identity must be available to build with LLDB.
-      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
-    EOS
-  end
-end
-
 class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
@@ -145,7 +127,11 @@ class Llvm < Formula
 
   if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
-    depends_on CodesignRequirement
+    depends_on :codesign => [{
+      :identity => "lldb_codesign",
+      :with => "LLDB",
+      :url => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
+    }]
   end
 
   # According to the official llvm readme, GCC 4.7+ is required

--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "llvm_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      lldb_codesign identity must be available to build with LLDB.
-      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
-    EOS
-  end
-end
-
 class LlvmAT39 < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
@@ -51,7 +33,11 @@ class LlvmAT39 < Formula
 
   if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
-    depends_on CodesignRequirement
+    depends_on :codesign => [{
+      :identity => "lldb_codesign",
+      :with => "LLDB",
+      :url => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
+    }]
   end
 
   # According to the official llvm readme, GCC 4.7+ is required

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "llvm_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      lldb_codesign identity must be available to build with LLDB.
-      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
-    EOS
-  end
-end
-
 class LlvmAT4 < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
@@ -50,7 +32,11 @@ class LlvmAT4 < Formula
 
   if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
-    depends_on CodesignRequirement
+    depends_on :codesign => [{
+      :identity => "lldb_codesign",
+      :with => "LLDB",
+      :url => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
+    }]
   end
 
   # According to the official llvm readme, GCC 4.7+ is required

--- a/Formula/llvm@5.rb
+++ b/Formula/llvm@5.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "llvm_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      lldb_codesign identity must be available to build with LLDB.
-      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
-    EOS
-  end
-end
-
 class LlvmAT5 < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
@@ -49,7 +31,11 @@ class LlvmAT5 < Formula
 
   if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
-    depends_on CodesignRequirement
+    depends_on :codesign => [{
+      :identity => "lldb_codesign",
+      :with => "LLDB",
+      :url => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
+    }]
   end
 
   # According to the official llvm readme, GCC 4.7+ is required

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "llvm_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      lldb_codesign identity must be available to build with LLDB.
-      See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
-    EOS
-  end
-end
-
 class LlvmAT6 < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
@@ -57,7 +39,11 @@ class LlvmAT6 < Formula
 
   if build.with? "lldb"
     depends_on "swig" if MacOS.version >= :lion
-    depends_on CodesignRequirement
+    depends_on :codesign => [{
+      :identity => "lldb_codesign",
+      :with => "LLDB",
+      :url => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
+    }]
   end
 
   # According to the official llvm readme, GCC 4.7+ is required

--- a/Formula/pngpaste.rb
+++ b/Formula/pngpaste.rb
@@ -13,7 +13,7 @@ class Pngpaste < Formula
   end
 
   # Sierra's CLT is sufficient, but El Capitain's isn't
-  depends_on :xcode => [:build, "8.0"] if MacOS.version < :sierra
+  depends_on :xcode => ["8.0", :build] if MacOS.version < :sierra
 
   depends_on :macos => :el_capitan # needs NSBitmapImageFileTypePNG, etc.
 

--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -1,21 +1,3 @@
-class CodesignRequirement < Requirement
-  fatal true
-
-  satisfy(:build_env => false) do
-    mktemp do
-      FileUtils.cp "/usr/bin/false", "radare2_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", "org.radare.radare2", "--dryrun", "radare2_check"
-    end
-  end
-
-  def message
-    <<~EOS
-      org.radare.radare2 identity must be available to build with automated signing.
-      See: https://github.com/radare/radare2/blob/master/doc/macos.md
-    EOS
-  end
-end
-
 class Radare2 < Formula
   desc "Reverse engineering framework"
   homepage "https://radare.org"
@@ -60,7 +42,14 @@ class Radare2 < Formula
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
   depends_on "valabind" => :build
-  depends_on CodesignRequirement if build.with? "code-signing"
+
+  if build.with? "code-signing"
+    depends_on :codesign => [{
+      :identity => "org.radare.radare2",
+      :url => "https://github.com/radare/radare2/blob/master/doc/macos.md",
+    }]
+  end
+
   depends_on "gmp"
   depends_on "jansson"
   depends_on "libewf"

--- a/Formula/smlnj.rb
+++ b/Formula/smlnj.rb
@@ -10,7 +10,7 @@ class Smlnj < Formula
 
   # Mojave doesn't support 32-bit builds, and thus smlnj fails to compile.
   # This will only be safe to remove when upstream support 64-bit builds.
-  depends_on :maximum_macos => :high_sierra
+  depends_on :maximum_macos => [:high_sierra, :build]
 
   resource "cm" do
     url "https://www.smlnj.org/dist/working/110.84/cm.tgz"

--- a/Formula/smlnj.rb
+++ b/Formula/smlnj.rb
@@ -10,7 +10,7 @@ class Smlnj < Formula
 
   # Mojave doesn't support 32-bit builds, and thus smlnj fails to compile.
   # This will only be safe to remove when upstream support 64-bit builds.
-  depends_on MaximumMacOSRequirement => :high_sierra
+  depends_on :maximum_macos => :high_sierra
 
   resource "cm" do
     url "https://www.smlnj.org/dist/working/110.84/cm.tgz"

--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -18,7 +18,7 @@ class Treefrog < Formula
 
   deprecated_option "with-qt5" => "with-qt"
 
-  depends_on :xcode => [:build, "8.0"]
+  depends_on :xcode => ["8.0", :build]
   depends_on :macos => :el_capitan
 
   qt_build_options = []

--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -7,7 +7,7 @@ class Valgrind < Formula
     mirror "https://dl.bintray.com/homebrew/mirror/valgrind-3.14.0.tar.bz2"
     sha256 "037c11bfefd477cc6e9ebe8f193bb237fe397f7ce791b4a4ce3fa1c6a520baa5"
 
-    depends_on MaximumMacOSRequirement => :high_sierra
+    depends_on :maximum_macos => :high_sierra
   end
 
   bottle do

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -39,7 +39,7 @@ class Wine < Formula
     end
 
     # Does not build with Xcode 10, used on High Sierra and Mojave
-    depends_on MaximumMacOSRequirement => :sierra
+    depends_on :maximum_macos => :sierra
   end
 
   depends_on "cmake" => :build

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -44,6 +44,11 @@ class Wine < Formula
 
   depends_on "cmake" => :build
   depends_on "makedepend" => :build
+
+  # High Sierra doesn't support 32-bit builds, and thus wine fails to compile.
+  # This will only be safe to remove when upstream support 64-bit builds.
+  depends_on :maximum_macos => [:sierra, :build]
+
   depends_on "pkg-config" => :build
   depends_on :macos => :el_capitan
 


### PR DESCRIPTION
- Move CodeSignRequirement to Homebrew/brew and use new `:codesign` requirement symbol.
- remove barely used `camlp5` `--with-strict` option to avoid need for `coq` requirement.
- Use new `:maximum_macos` requirement symbol.

Shouldn't be merged until https://github.com/Homebrew/brew/pull/5101 is in a stable tag.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----