### PR TITLE
resin-cli (7.10.6): new formula

### DIFF
--- a/Formula/resin-cli.rb
+++ b/Formula/resin-cli.rb
@@ -4,7 +4,6 @@ class ResinCli < Formula
   desc "The official resin.io CLI tool"
   homepage "https://docs.resin.io/reference/cli/"
   url "https://registry.npmjs.org/resin-cli/-/resin-cli-7.10.6.tgz"
-  version "7.10.6"
   sha256 "011f79bfb1a75ad077b82afdc42695ce6061a522ccb1671a4e6d47e3e39f0889"
 
   depends_on "node"

--- a/Formula/resin-cli.rb
+++ b/Formula/resin-cli.rb
@@ -3,8 +3,9 @@ require "language/node"
 class ResinCli < Formula
   desc "The official resin.io CLI tool"
   homepage "https://docs.resin.io/reference/cli/"
-  url "https://registry.npmjs.org/resin-cli/-/resin-cli-7.10.6.tgz"
-  sha256 "011f79bfb1a75ad077b82afdc42695ce6061a522ccb1671a4e6d47e3e39f0889"
+  # Frequent upstream releases, do not update more than once a week
+  url "https://registry.npmjs.org/resin-cli/-/resin-cli-8.0.2.tgz"
+  sha256 "4e1696d6b7f7724672ca11ee6d3d38d583869cc1ea3718fd1694bebc8d62aa3a"
 
   depends_on "node"
 
@@ -14,6 +15,6 @@ class ResinCli < Formula
   end
 
   test do
-    assert_match "Logging in to resin.io", pipe_output("#{bin}/resin login")
+    assert_match "Logging in to resin.io", shell_output("#{bin}/resin login --credentials --email johndoe@gmail.com --password secret", 1)
   end
 end

--- a/Formula/resin-cli.rb
+++ b/Formula/resin-cli.rb
@@ -1,0 +1,20 @@
+require "language/node"
+
+class ResinCli < Formula
+  desc "The official resin.io CLI tool"
+  homepage "https://docs.resin.io/reference/cli/"
+  url "https://registry.npmjs.org/resin-cli/-/resin-cli-7.10.6.tgz"
+  version "7.10.6"
+  sha256 "011f79bfb1a75ad077b82afdc42695ce6061a522ccb1671a4e6d47e3e39f0889"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "Logging in to resin.io", pipe_output("#{bin}/resin login")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a new formula to install the resin.io CLI, which can be used to manage resin.io deployed applications.