### PR TITLE
Python 3 migration 9/n

### DIFF
--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -3,6 +3,7 @@ class Cassandra < Formula
   homepage "https://cassandra.apache.org"
   url "https://www.apache.org/dyn/closer.cgi?path=cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz"
   sha256 "d82e0670cb41b091e88fff55250ce945c4ea026c87a5517d3cf7b6b351d5e2ba"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Cassandra < Formula
   end
 
   depends_on "cython"
-  depends_on "python@2"
+  depends_on "python"
 
   # Only >=Yosemite has new enough setuptools for successful compile of the below deps.
   resource "setuptools" do
@@ -50,11 +51,12 @@ class Cassandra < Formula
     (var/"lib/cassandra").mkpath
     (var/"log/cassandra").mkpath
 
-    pypath = libexec/"vendor/lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    pypath = libexec/"vendor/lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", pypath
     resources.each do |r|
       r.stage do
-        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+        system "python3", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
 

--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -15,7 +15,7 @@ class CassandraAT21 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "python@2"
+  depends_on "python@2" # does not support Python 3
 
   # Only Yosemite has new enough setuptools for successful compile of the below deps.
   resource "setuptools" do

--- a/Formula/cassandra@2.2.rb
+++ b/Formula/cassandra@2.2.rb
@@ -16,7 +16,7 @@ class CassandraAT22 < Formula
   keg_only :versioned_formula
 
   depends_on "cython" => :build
-  depends_on "python@2"
+  depends_on "python@2" # does not support Python 3.7
 
   # Only >=Yosemite has new enough setuptools for successful compile of the below deps.
   resource "setuptools" do

--- a/Formula/ccm.rb
+++ b/Formula/ccm.rb
@@ -3,6 +3,7 @@ class Ccm < Formula
   homepage "https://github.com/pcmanus/ccm"
   url "https://files.pythonhosted.org/packages/fc/ab/b51afd466cc4acf2192e230ddb6fd3adb56066f05c7be1852af7bd655068/ccm-3.1.4.tar.gz"
   sha256 "a98268c2d8e5534d8d2d94267060e9ee9105b35e43d704bac0fa495a773acf7d"
+  revision 1
   head "https://github.com/pcmanus/ccm.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Ccm < Formula
     sha256 "8a240c8e92a87f5397614f79268c2802f2ddd22413f29213df1ac831a9a936b7" => :sierra
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   resource "PyYAML" do
     url "https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"
@@ -31,15 +32,16 @@ class Ccm < Formula
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
     %w[PyYAML six cassandra-driver].each do |r|
       resource(r).stage do
-        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+        system "python3", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
 
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    system "python", *Language::Python.setup_install_args(libexec)
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
+    system "python3", *Language::Python.setup_install_args(libexec)
 
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])

--- a/Formula/cython.rb
+++ b/Formula/cython.rb
@@ -1,8 +1,9 @@
 class Cython < Formula
   desc "Compiler for writing C extensions for the Python language"
-  homepage "http://cython.org"
+  homepage "https://cython.org/"
   url "https://files.pythonhosted.org/packages/21/89/ca320e5b45d381ae0df74c4b5694f1471c1b2453c5eb4bac3449f5970481/Cython-0.28.5.tar.gz"
   sha256 "b64575241f64f6ec005a4d4137339fb0ba5e156e826db2fdb5f458060d9979e0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -17,18 +18,20 @@ class Cython < Formula
     Users are advised to use `pip` to install cython
   EOS
 
-  depends_on "python@2"
+  depends_on "python"
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    system "python", *Language::Python.setup_install_args(libexec)
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
+    system "python3", *Language::Python.setup_install_args(libexec)
 
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
   test do
-    ENV.prepend_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
 
     phrase = "You are using Homebrew"
     (testpath/"package_manager.pyx").write "print '#{phrase}'"
@@ -40,7 +43,7 @@ class Cython < Formula
         ext_modules = cythonize("package_manager.pyx")
       )
     EOS
-    system "python", "setup.py", "build_ext", "--inplace"
-    assert_match phrase, shell_output("python -c 'import package_manager'")
+    system "python3", "setup.py", "build_ext", "--inplace"
+    assert_match phrase, shell_output("python3 -c 'import package_manager'")
   end
 end

--- a/Formula/gandi.cli.rb
+++ b/Formula/gandi.cli.rb
@@ -5,6 +5,7 @@ class GandiCli < Formula
   homepage "https://cli.gandi.net/"
   url "https://files.pythonhosted.org/packages/68/fd/1e2d6711a2cb3293288caa732057f97e9e5e529bebcb2692d7e3bb50d7f3/gandi.cli-1.2.tar.gz"
   sha256 "51b5287a285bf665446d7ff47ed9cb447caa79ab8504d29e4212ae825e27086e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class GandiCli < Formula
     sha256 "6adbf5ec8e25c411e3f9514600de37d679083e19b0eed789a6f24775f87ac22e" => :el_capitan
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/4d/9c/46e950a6f4d6b4be571ddcae21e7bc846fcbb88f1de3eff0f6dd0a6be55d/certifi-2018.4.16.tar.gz"

--- a/Formula/libplist.rb
+++ b/Formula/libplist.rb
@@ -3,6 +3,7 @@ class Libplist < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2"
   sha256 "3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,7 +22,6 @@ class Libplist < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "cython" => :build
   depends_on "pkg-config" => :build
 
   def install
@@ -31,6 +31,7 @@ class Libplist < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
+      --without-cython
     ]
 
     system "./autogen.sh" if build.head?

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -3,7 +3,7 @@ class Portmidi < Formula
   homepage "https://sourceforge.net/projects/portmedia/"
   url "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
   sha256 "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,8 +15,6 @@ class Portmidi < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "cython" => :build
-  depends_on "python@2"
 
   def install
     if MacOS.version == :sierra || MacOS.version == :el_capitan
@@ -37,19 +35,5 @@ class Portmidi < Formula
 
     system "make", "-f", "pm_mac/Makefile.osx"
     system "make", "-f", "pm_mac/Makefile.osx", "install"
-
-    cd "pm_python" do
-      # There is no longer a CHANGES.txt or TODO.txt.
-      inreplace "setup.py" do |s|
-        s.gsub! "CHANGES = open('CHANGES.txt').read()", 'CHANGES = ""'
-        s.gsub! "TODO = open('TODO.txt').read()", 'TODO = ""'
-      end
-      # Provide correct dirs (that point into the Cellar)
-      ENV.append "CFLAGS", "-I#{include}"
-      ENV.append "LDFLAGS", "-L#{lib}"
-
-      ENV.prepend_path "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python2.7/site-packages"
-      system "python", *Language::Python.setup_install_args(prefix)
-    end
   end
 end

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -5,6 +5,7 @@ class Pyinvoke < Formula
   homepage "https://www.pyinvoke.org/"
   url "https://github.com/pyinvoke/invoke/archive/1.2.0.tar.gz"
   sha256 "266003d33a8b3a565268e33aa0f9767b9441cf1476a20258f929768ee5acd390"
+  revision 1
   head "https://github.com/pyinvoke/invoke.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Pyinvoke < Formula
     sha256 "b5f66b9b794c89e86c1b860ea840d4ffe663fdbe7badd3d65c252db3a5a16141" => :sierra
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -4,6 +4,7 @@ class Spades < Formula
   url "http://cab.spbu.ru/files/release3.12.0/SPAdes-3.12.0.tar.gz"
   mirror "https://github.com/ablab/spades/releases/download/v3.12.0/SPAdes-3.12.0.tar.gz"
   sha256 "15b48a3bcbbe6a8ad58fd04ba5d3f1015990fbfd9bdf4913042803b171853ac7"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,6 @@ class Spades < Formula
 
   depends_on "cmake" => :build
   depends_on "gcc"
-  depends_on "python@2"
 
   fails_with :clang # no OpenMP support
 

--- a/Formula/yasm.rb
+++ b/Formula/yasm.rb
@@ -4,7 +4,7 @@ class Yasm < Formula
   url "https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz"
   mirror "https://ftp.openbsd.org/pub/OpenBSD/distfiles/yasm-1.3.0.tar.gz"
   sha256 "3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -23,17 +23,12 @@ class Yasm < Formula
     depends_on "gettext"
   end
 
-  depends_on "cython" => :build
-
   def install
     args = %W[
       --disable-debug
       --prefix=#{prefix}
+      --disable-python
     ]
-
-    ENV.prepend_path "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python2.7/site-packages"
-    args << "--enable-python"
-    args << "--enable-python-bindings"
 
     # https://github.com/Homebrew/legacy-homebrew/pull/19593
     ENV.deparallelize


### PR DESCRIPTION
- Dealing in particular with Cython-related formulas.
- libplist, yasm and portmidi Python bindings do not support Python 3. As they are not used by other Homebrew formulas, removing them seems the best option going forward.
- Another option could be to create a `cython-python2` formula (or a better name), but that does not appear like a long-term choice.