### PR TITLE
unicorn: add option install python bindings

### DIFF
--- a/Formula/unicorn.rb
+++ b/Formula/unicorn.rb
@@ -23,6 +23,10 @@ class Unicorn < Formula
     ENV["UNICORN_DEBUG"] = "no"
     system "make"
     system "make", "install"
+
+    cd "bindings/python" do
+      system "python", *Language::Python.setup_install_args(prefix)
+    end
   end
 
   test do
@@ -72,5 +76,7 @@ class Unicorn < Formula
     system ENV.cc, "-o", testpath/"test1", testpath/"test1.c",
       "-lpthread", "-lm", "-L#{lib}", "-lunicorn"
     system testpath/"test1"
+
+    system "python", "-c", "import unicorn; print(unicorn.__version__)"
   end
 end


### PR DESCRIPTION
The unicorn emulator provides bindings to several languages. I've added an option to installing the python bindings.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
