### PR TITLE
Update advancecomp url to an actual release

### DIFF
--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -31,6 +31,6 @@ class Advancecomp < Formula
     system bin/"advpng", "--recompress", "--shrink-fast", "test.png"
 
     version_string = shell_output("#{bin}/advpng --version")
-    assert_includes version_string, "advancecomp v2.1"
+    assert_includes version_string, "advancecomp v#{version}"
   end
 end

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -26,9 +26,11 @@ class Advancecomp < Formula
 
   test do
     system bin/"advdef", "--version"
-    system bin/"advpng", "--version"
 
     cp test_fixtures("test.png"), "test.png"
     system bin/"advpng", "--recompress", "--shrink-fast", "test.png"
+
+    version_string = shell_output("#{bin}/advpng --version")
+    assert_includes version_string, "advancecomp v2.1"
   end
 end

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -27,5 +27,8 @@ class Advancecomp < Formula
   test do
     system bin/"advdef", "--version"
     system bin/"advpng", "--version"
+
+    cp test_fixtures("test.png"), "test.png"
+    system bin/"advpng", "--recompress", "--shrink-fast", "test.png"
   end
 end

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -3,6 +3,7 @@ class Advancecomp < Formula
   homepage "https://www.advancemame.it/comp-readme.html"
   url "https://github.com/amadvance/advancecomp/releases/download/v2.1/advancecomp-2.1.tar.gz"
   sha256 "3ac0875e86a8517011976f04107186d5c60d434954078bc502ee731480933eb8"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -1,8 +1,8 @@
 class Advancecomp < Formula
   desc "Recompression utilities for .PNG, .MNG, .ZIP, and .GZ files"
   homepage "https://www.advancemame.it/comp-readme.html"
-  url "https://github.com/amadvance/advancecomp/archive/v2.1.tar.gz"
-  sha256 "6113c2b6272334af710ba486e8312faa3cee5bd6dc8ca422d00437725e2b602a"
+  url "https://github.com/amadvance/advancecomp/releases/download/v2.1/advancecomp-2.1.tar.gz"
+  sha256 "3ac0875e86a8517011976f04107186d5c60d434954078bc502ee731480933eb8"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It does not pass `brew audit` because the SHA256 is different:

```
advancecomp:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 1 problem in 1 formula detected
```

-----

# What this change does

We noticed here:  https://github.com/toy/image_optim/issues/165 that `advpng` distributed through Homebrew did not include a version, so when the documented arguments (`--version` or `-V`) were used, the program didn't write any version:

```bash
$ advpng -V
advancecomp vnone by Andrea Mazzoleni, http://www.advancemame.it
```

So we found out that Advancecomp uses a script called `autover.sh` defined here: https://github.com/amadvance/advancecomp/blob/master/autover.sh The script set a tag when building the application, it will set a tag depending on a git-tag or by reading a `.version`-file.

The source where Homebrew download the source from does not contain the `.version`-file, but the Github release page does, so when my version has been installed we get the correct output:

```bash
$ advpng -V
advancecomp v2.1 by Andrea Mazzoleni, http://www.advancemame.it
```