### PR TITLE
libopenmpt 0.3.12 (new formula)

### DIFF
--- a/Formula/libopenmpt.rb
+++ b/Formula/libopenmpt.rb
@@ -24,6 +24,8 @@ class Libopenmpt < Formula
   end
 
   test do
-    system "#{bin}/openmpt123", "--version"
+    system "curl", "-o", "mystique.s3m", "https://api.modarchive.org/downloads.php?moduleid=54144#mystique.s3m"
+    system "openmpt123", "--probe", "mystique.s3m"
+    $?.success? or raise "Probing a known-good file failed"
   end
 end

--- a/Formula/libopenmpt.rb
+++ b/Formula/libopenmpt.rb
@@ -1,0 +1,29 @@
+class Libopenmpt < Formula
+  desc "Software library to decode tracked music files"
+  homepage "https://lib.openmpt.org/libopenmpt/"
+  url "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.3.12+release.autotools.tar.gz"
+  sha256 "7134db999d33b96dc2db13dbaf29b7beeb4c58f62e57fd3caf36bb8428aa4b42"
+
+  depends_on "pkg-config" => :build
+
+  depends_on "flac"
+  depends_on "libogg"
+  depends_on "libsndfile"
+  depends_on "libvorbis"
+  depends_on "portaudio"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--without-mpg123",
+                          "--without-vorbisfile"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/openmpt123", "--version"
+  end
+end


### PR DESCRIPTION
Created "Formula/libopenmpt.rb", which compiles libopenmpt version 0.3.12, ignoring dependencies that don't already exist as Homebrew packages.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
