### PR TITLE
Added a dependency on X11.

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -49,6 +49,7 @@ class Ffmpeg < Formula
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
   depends_on "texi2html" => :build
+  depends_on :x11 => :build
 
   depends_on "lame" => :recommended
   depends_on "x264" => :recommended


### PR DESCRIPTION
ffmpeg failed to build on a clean system at "#include <xcb/xcb.h>". After installing the X11 cask this still failed. When I added a hard dependency on X11, the build was successful.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
