### PR TITLE
libvirt: Add yajl as dependency

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -3,6 +3,7 @@ class Libvirt < Formula
   homepage "https://www.libvirt.org"
   url "https://libvirt.org/sources/libvirt-4.8.0.tar.xz"
   sha256 "c2fd7112d6689fbb4d700b31c01aadd8a0eb275e127dc959cdc166f5f60b3032"
+  revision 1
   head "https://github.com/libvirt/libvirt.git"
 
   bottle do
@@ -15,6 +16,7 @@ class Libvirt < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libgcrypt"
+  depends_on "yajl"
 
   if build.head?
     depends_on "autoconf" => :build


### PR DESCRIPTION
QEMU QMP probing doesn't work if libvirt was built without yajl. That breaks virsh capabilities.

The dependency slipped in #32820 because I had yajl installed locally and my tap somehow used it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----