### PR TITLE
tox: enhance post_install

### DIFF
--- a/Formula/tox.rb
+++ b/Formula/tox.rb
@@ -68,8 +68,9 @@ class Tox < Formula
       rm f
       ln_s realpath, f
     end
+    py = Formula["python"]
     inreplace lib_python_path/"orig-prefix.txt",
-              Formula["python"].opt_prefix, Formula["python"].prefix.realpath
+              py.opt_prefix, py.prefix(py.linked_version).realpath
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Attn @lembacon: this PR attempts to enhance #33042

If a user has an older version of Python linked, the `post_install` step silently breaks the installation.
This change gets the correct prefix for the currently linked version of the python formula.
