### PR TITLE
gst-plugins-*: remove options

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -20,23 +20,23 @@ class GstPluginsBad < Formula
   depends_on "gobject-introspection" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "faac"
+  depends_on "faad2"
   depends_on "gettext"
   depends_on "gst-plugins-base"
+  depends_on "jpeg"
+  depends_on "libmms"
   depends_on "openssl"
-  depends_on "jpeg" => :recommended
-  depends_on "orc" => :recommended
+  depends_on "opus"
+  depends_on "orc"
   depends_on "dirac" => :optional
-  depends_on "faac" => :optional
-  depends_on "faad2" => :optional
   depends_on "fdk-aac" => :optional
   depends_on "gnutls" => :optional
   depends_on "libdvdread" => :optional
   depends_on "libexif" => :optional
-  depends_on "libmms" => :optional
   depends_on "libnice" => :optional
   depends_on "libvo-aacenc" => :optional
   depends_on "opencv@2" => :optional
-  depends_on "opus" => :optional
   depends_on "rtmpdump" => :optional
   depends_on "schroedinger" => :optional
   depends_on "sound-touch" => :optional

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -22,16 +22,12 @@ class GstPluginsBase < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "gstreamer"
-
-  # The set of optional dependencies is based on the intersection of
-  # https://cgit.freedesktop.org/gstreamer/gst-plugins-base/tree/REQUIREMENTS
-  # and Homebrew formulae
-  depends_on "orc" => :recommended
-  depends_on "pango" => :recommended
-  depends_on "libogg" => :optional
-  depends_on "libvorbis" => :optional
-  depends_on "opus" => :optional
-  depends_on "theora" => :optional
+  depends_on "libogg"
+  depends_on "libvorbis"
+  depends_on "opus"
+  depends_on "orc"
+  depends_on "pango"
+  depends_on "theora"
 
   def install
     # gnome-vfs turned off due to lack of formula for it.

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -1,6 +1,7 @@
 class GstPluginsGood < Formula
   desc "GStreamer plugins (well-supported, under the LGPL)"
   homepage "https://gstreamer.freedesktop.org/"
+  revision 1
 
   stable do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.14.4.tar.xz"
@@ -25,29 +26,29 @@ class GstPluginsGood < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "flac"
   depends_on "gettext"
   depends_on "gst-plugins-base"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libshout"
   depends_on "libsoup"
+  depends_on "libvpx"
+  depends_on "orc"
+  depends_on "speex"
+  depends_on "taglib"
 
   # Dependencies based on the intersection of
   # https://cgit.freedesktop.org/gstreamer/gst-plugins-good/tree/REQUIREMENTS
   # and Homebrew formulae.
-  depends_on "jpeg" => :recommended
-  depends_on "orc" => :recommended
   depends_on "aalib" => :optional
-  depends_on "cairo" => :optional
-  depends_on "flac" => :optional
   depends_on "gdk-pixbuf" => :optional
   depends_on "gtk+3" => :optional
   depends_on "jack" => :optional
   depends_on "libcaca" => :optional
   depends_on "libdv" => :optional
-  depends_on "libpng" => :optional
-  depends_on "libshout" => :optional
-  depends_on "libvpx" => :optional
   depends_on "pulseaudio" => :optional
-  depends_on "speex" => :optional
-  depends_on "taglib" => :optional
   depends_on :x11 => :optional
 
   def install

--- a/Formula/gst-plugins-ugly.rb
+++ b/Formula/gst-plugins-ugly.rb
@@ -3,6 +3,7 @@ class GstPluginsUgly < Formula
   homepage "https://gstreamer.freedesktop.org/"
   url "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.14.4.tar.xz"
   sha256 "ac02d837f166c35ff6ce0738e281680d0b90052cfb1f0255dcf6aaca5f0f6d23"
+  revision 1
 
   bottle do
     sha256 "f2a66569b4d7a6a5ca09c025b58bb18023d7867617c6c9a4bc8e39f042df92e1" => :mojave
@@ -19,32 +20,32 @@ class GstPluginsUgly < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "flac"
   depends_on "gettext"
   depends_on "gst-plugins-base"
+  depends_on "jpeg"
+  depends_on "lame"
+  depends_on "libmms"
+  depends_on "libshout"
+  depends_on "libvorbis"
+  depends_on "pango"
+  depends_on "theora"
+  depends_on "x264"
 
   # The set of optional dependencies is based on the intersection of
   # gst-plugins-ugly-0.10.17/REQUIREMENTS and Homebrew formulae
-  depends_on "jpeg" => :recommended
   depends_on "a52dec" => :optional
   depends_on "aalib" => :optional
   depends_on "cdparanoia" => :optional
   depends_on "dirac" => :optional
-  depends_on "flac" => :optional
   depends_on "gtk+" => :optional
-  depends_on "lame" => :optional
   depends_on "libcaca" => :optional
   depends_on "libdvdread" => :optional
-  depends_on "libmms" => :optional
   depends_on "libmpeg2" => :optional
   depends_on "liboil" => :optional
-  depends_on "libshout" => :optional
-  depends_on "libvorbis" => :optional
   depends_on "mad" => :optional
   depends_on "opencore-amr" => :optional
-  depends_on "pango" => :optional
-  depends_on "theora" => :optional
   depends_on "two-lame" => :optional
-  depends_on "x264" => :optional
   # Does not work with libcdio 0.9
 
   def install


### PR DESCRIPTION
Trying to reduce source builds for these `gst-plugins-*` options, based on analytics (what options are used) and dep trees (what options come at low cost).

cc @tschoonj 