### PR TITLE
ack: remove redundant version declaration

### DIFF
--- a/Formula/ack.rb
+++ b/Formula/ack.rb
@@ -2,7 +2,6 @@ class Ack < Formula
   desc "Search tool like grep, but optimized for programmers"
   homepage "https://beyondgrep.com/"
   url "https://beyondgrep.com/ack-2.24-single-file"
-  version "2.24"
   sha256 "8361e5a2654bc575db27bfa40470c4182d74d51098d390944d98fe7cd5b20d49"
   head "https://github.com/petdance/ack2.git", :branch => "dev"
 


### PR DESCRIPTION
The version for `ack` can be automatically detected from the URL, there is no need to set it explicitly. After removing it no errors are generated in `audit --strict` tests.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
