### PR TITLE
vtk: disable deprecated Tcl wrappers

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -51,15 +51,7 @@ class Vtk < Formula
       -DVTK_USE_SYSTEM_PNG=ON
       -DVTK_USE_SYSTEM_TIFF=ON
       -DVTK_USE_SYSTEM_ZLIB=ON
-      -DVTK_WRAP_TCL=ON
     ]
-
-    unless MacOS::CLT.installed?
-      # We are facing an Xcode-only installation, and we have to keep
-      # vtk from using its internal Tk headers (that differ from OSX's).
-      args << "-DTK_INCLUDE_PATH:PATH=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Headers"
-      args << "-DTK_INTERNAL_PATH:PATH=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Headers/tk-private"
-    end
 
     mkdir "build" do
       if build.with?("python") && build.with?("python@2")
@@ -120,7 +112,7 @@ class Vtk < Formula
   def caveats; <<~EOS
     Even without the --with-qt option, you can display native VTK render windows
     from python. Alternatively, you can integrate the RenderWindowInteractor
-    in PyQt5, Tk or Wx at runtime. Read more:
+    in PyQt5 or Wx at runtime. Read more:
       import vtk.qt5; help(vtk.qt5) or import vtk.wx; help(vtk.wx)
   EOS
   end


### PR DESCRIPTION
This allows to restore build on Mojave (and possibly High Sierra with Xcode 10). See 
https://github.com/Homebrew/homebrew-core/issues/31400#issuecomment-430607903 for details.