### PR TITLE
tika 1.19.1

### DIFF
--- a/Formula/tika.rb
+++ b/Formula/tika.rb
@@ -1,16 +1,16 @@
 class Tika < Formula
   desc "Content analysis toolkit"
   homepage "https://tika.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.18.jar"
-  sha256 "edf6e18c805113385deeb1e7ede482d53e83d37c819f9697a43b73734f60ec21"
+  url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-app-1.19.1.jar"
+  sha256 "7b2c6a8baf14e4974b4ba26c01e162ec78fb9fea1fc625ee4d7ca054d9778c89"
 
   bottle :unneeded
 
   depends_on :java => "1.7+"
 
   resource "server" do
-    url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-server-1.17.jar"
-    sha256 "286c693134a115ac2bf452e5f1569dfa9eb928b9658c22a147f56cf01bfb4639"
+    url "https://www.apache.org/dyn/closer.cgi?path=tika/tika-server-1.19.1.jar"
+    sha256 "76d607df16cd85af35d40d6a2098ed1523b6c0b9f7dad885e289121e6207c11b"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Use latest stable versions of tika. This formula no longer works without this change as the mirrors do not have the old versions tika-app-1.18.jar or tika-server-1.17.jar. To repo this failure, you can run 'brew install tika' which cannot download these versions and the install fails. This is why I am fixing the tika formula.