### PR TITLE
time-machine-cleanup 2.0.0 (new formula)

### DIFF
--- a/Formula/time-machine-cleanup.rb
+++ b/Formula/time-machine-cleanup.rb
@@ -1,0 +1,18 @@
+class TimeMachineCleanup < Formula
+  desc "Clean up Time Machine backups and reduce its size"
+  homepage "https://github.com/emcrisostomo/Time-Machine-Cleanup"
+  url "https://github.com/emcrisostomo/Time-Machine-Cleanup/releases/download/2.0.0/tm-cleanup-2.0.0.tar.gz"
+  sha256 "e2beac0ef924e1b12df453205767147ef54eb0518507558222df8688b8e8adc2"
+
+  depends_on "dialog"
+
+  def install
+    system "./configure", "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/tm-cleanup.sh", "-h"
+  end
+end


### PR DESCRIPTION
Zsh script to clean up Time Machine backups and reduce its size.
The name of the script is tm-cleanup.sh.

https://github.com/emcrisostomo/Time-Machine-Cleanup

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
