### PR TITLE
hazelcast-member 3.11.0

### DIFF
--- a/Formula/hazelcast-member.rb
+++ b/Formula/hazelcast-member.rb
@@ -1,0 +1,46 @@
+class HazelcastMember < Formula
+  desc "Command-line tool for running Hazelcast member instance(s)"
+  homepage "https://github.com/hazelcast/hazelcast"
+  url "https://github.com/hazelcast/hazelcast-member-tool/releases/download/v3.11.0/hazelcast-member-3.11.0.tar.gz"
+  sha256 "13d9d8f9c608ea8f672e58dba87500ff38c2c70d1f69e1f3cf30532a9be67056"
+
+  bottle :unneeded
+
+  depends_on "coreutils"
+  depends_on :java => "1.7+"
+
+  def install
+    mkpath "#{etc}/hazelcast"
+    libexec.install Dir["*"]
+    etc.install_symlink "#{libexec}/etc/hazelcast/hazelcast.xml" => "hazelcast/hazelcast.xml"
+    bin.install_symlink Dir["#{libexec}/bin/hazelcast-member"]
+    var.mkpath
+    inreplace "#{libexec}/bin/utils.sh", "${var}", var.to_s
+    inreplace "#{libexec}/bin/utils.sh", "${etc}", etc.to_s
+    prefix.install_metafiles
+    bash_completion.install "#{libexec}/bin/hazelcast-member-completion.sh" => "hazelcast-member"
+  end
+
+  def caveats
+    <<~EOS
+      To enable tab completion add to your profile:
+        if which hazelcast-member > /dev/null; then eval "$(hazelcast-member init -)"; fi
+    EOS
+  end
+
+  test do
+    begin
+      output = shell_output("#{bin}/hazelcast-member start --verbose -J -Dhazelcast.http.healthcheck.enabled=true")
+      assert_match /ID:/, output
+      sleep 5
+      output = shell_output("#{bin}/hazelcast-member status")
+      assert_match /Running/, output
+
+      assert_match /Hazelcast::NodeState=ACTIVE/, shell_output("curl -s http://127.0.0.1:5701/hazelcast/health")
+      output = shell_output("#{bin}/hazelcast-member stop")
+      assert_match /shut down/, output
+    ensure
+      quiet_system "pkill", "-9", "-f", "hazelcast"
+    end
+  end
+end

--- a/Formula/hazelcast-member.rb
+++ b/Formula/hazelcast-member.rb
@@ -1,6 +1,6 @@
 class HazelcastMember < Formula
-  desc "Command-line tool for running Hazelcast member instance(s)"
-  homepage "https://github.com/hazelcast/hazelcast"
+  desc "Command-line tool to run and control Hazelcast member instances"
+  homepage "https://github.com/hazelcast/hazelcast-member-tool"
   url "https://github.com/hazelcast/hazelcast-member-tool/releases/download/v3.11.0/hazelcast-member-3.11.0.tar.gz"
   sha256 "13d9d8f9c608ea8f672e58dba87500ff38c2c70d1f69e1f3cf30532a9be67056"
 
@@ -10,22 +10,14 @@ class HazelcastMember < Formula
   depends_on :java => "1.7+"
 
   def install
-    mkpath "#{etc}/hazelcast"
     libexec.install Dir["*"]
-    etc.install_symlink "#{libexec}/etc/hazelcast/hazelcast.xml" => "hazelcast/hazelcast.xml"
+    (etc/"hazelcast").install_symlink "#{libexec}/etc/hazelcast/hazelcast.xml"
     bin.install_symlink Dir["#{libexec}/bin/hazelcast-member"]
     var.mkpath
     inreplace "#{libexec}/bin/utils.sh", "${var}", var.to_s
     inreplace "#{libexec}/bin/utils.sh", "${etc}", etc.to_s
     prefix.install_metafiles
     bash_completion.install "#{libexec}/bin/hazelcast-member-completion.sh" => "hazelcast-member"
-  end
-
-  def caveats
-    <<~EOS
-      To enable tab completion add to your profile:
-        if which hazelcast-member > /dev/null; then eval "$(hazelcast-member init -)"; fi
-    EOS
   end
 
   test do

--- a/Formula/hazelcast-member.rb
+++ b/Formula/hazelcast-member.rb
@@ -1,5 +1,5 @@
 class HazelcastMember < Formula
-  desc "Command-line tool to run and control Hazelcast member instances"
+  desc "Tool to run Hazelcast IMDG member instances locally"
   homepage "https://github.com/hazelcast/hazelcast-member-tool"
   url "https://github.com/hazelcast/hazelcast-member-tool/releases/download/v3.11.0/hazelcast-member-3.11.0.tar.gz"
   sha256 "13d9d8f9c608ea8f672e58dba87500ff38c2c70d1f69e1f3cf30532a9be67056"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`hazelcast-member` is a command line tool that is able to run one or more [Hazelcast IMDG](https://hazelcast.org) member
instance(s) on the local machine.

Hazelcast is an open source In-Memory Data Grid (IMDG) that provides elastically scalable distributed In-Memory computing.

Distributed applications can use Hazelcast for distributed caching, synchronization, clustering, processing, pub/sub messaging, etc.

Hazelcast is implemented in Java and has clients for Java, C/C++, .NET, REST, Python, Go and Node.js. Hazelcast also speaks Memcached protocol. It plugs into Hibernate and can easily be used with any existing database system.
