### PR TITLE
gpgme: package python3 bindings as well - require python3 for build

### DIFF
--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -12,8 +12,8 @@ class Gpgme < Formula
     sha256 "bb4ac5c5bbc9f3f2c54febe2e872c780337d6c8612124778b76826371c673492" => :sierra
   end
 
+  depends_on "python" => :build
   depends_on "swig" => :build
-  depends_on "python3" => :build
   depends_on "gnupg"
   depends_on "libassuan"
   depends_on "libgpg-error"

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -13,6 +13,7 @@ class Gpgme < Formula
   end
 
   depends_on "swig" => :build
+  depends_on "python3" => :build
   depends_on "gnupg"
   depends_on "libassuan"
   depends_on "libgpg-error"
@@ -32,5 +33,6 @@ class Gpgme < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
     system "python2.7", "-c", "import gpg; print gpg.version.versionstr"
+    system "python3", "-c" "import gpg; print(gpg.version.versionstr)"
   end
 end

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -12,7 +12,7 @@ class Gpgme < Formula
     sha256 "bb4ac5c5bbc9f3f2c54febe2e872c780337d6c8612124778b76826371c673492" => :sierra
   end
 
-  depends_on "python" => :build
+  depends_on "python" => [:build, :test]
   depends_on "swig" => :build
   depends_on "gnupg"
   depends_on "libassuan"
@@ -33,6 +33,6 @@ class Gpgme < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
     system "python2.7", "-c", "import gpg; print gpg.version.versionstr"
-    system "python3", "-c" "import gpg; print(gpg.version.versionstr)"
+    system "python3", "-c", "import gpg; print(gpg.version.versionstr)"
   end
 end


### PR DESCRIPTION
Currently gpgme doesn't package the python3 bindings, only the python2.7 ones.  By adding a build dependency to python (== python 3) we ensure that the python3 bindings are also built and packaged.  

-----

- [/] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [/] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [/] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [/] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


----

A note on this PR;  during testing I discovered that if you have standard python.org python installed then it does't find the bindings.  I wonder if there is anything that could be easily done to make homebrew bindings automatically visible to python.org python.  The debian solution is to have a dist-packages directory which is supposed to be visible in all python versions but come _after_ the site-packages allowing packages there to be used but overridden as needed.  