### PR TITLE
git: add "--without-completion" option.

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -23,6 +23,7 @@ class Git < Formula
 
     option "with-openssl", "Build with Homebrew's OpenSSL instead of using CommonCrypto"
     option "with-curl", "Use Homebrew's version of cURL library"
+    option "without-completion", "Install without bash/zsh completion"
 
     depends_on "openssl" => :optional
     depends_on "curl" => :optional
@@ -114,10 +115,12 @@ class Git < Formula
     end
 
     # install the completion script first because it is inside "contrib"
-    bash_completion.install "contrib/completion/git-completion.bash"
-    bash_completion.install "contrib/completion/git-prompt.sh"
-    zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
-    cp "#{bash_completion}/git-completion.bash", zsh_completion
+    unless build.without?("completion")
+      bash_completion.install "contrib/completion/git-completion.bash"
+      bash_completion.install "contrib/completion/git-prompt.sh"
+      zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
+      cp "#{bash_completion}/git-completion.bash", zsh_completion
+    end
 
     elisp.install Dir["contrib/emacs/*.el"]
     (share/"git-core").install "contrib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I wanted to use [zsh's git completion][1] instead of [git official completion][2], so I made this option.

[1]:  https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_git
[2]: https://github.com/git/git/blob/master/contrib/completion/git-completion.zsh