### PR TITLE
Imagemagick: remove some options

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -7,6 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick--7.0.8-12.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-7.0.8-12.tar.xz"
   sha256 "48df5877fe85603940310fe5c811a89af416882b60379918a95dcd4de6582b55"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git"
 
   bottle do
@@ -18,13 +19,9 @@ class Imagemagick < Formula
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
   option "with-libheif", "Compile with HEIF support"
-  option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
-  option "with-zero-configuration", "Disables depending on XML configuration files"
 
   deprecated_option "enable-hdri" => "with-hdri"
-  deprecated_option "with-gcc" => "with-openmp"
-  deprecated_option "with-jp2" => "with-openjpeg"
   deprecated_option "with-libde265" => "with-libheif"
 
   depends_on "pkg-config" => :build
@@ -34,6 +31,9 @@ class Imagemagick < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
+  depends_on "little-cms2"
+  depends_on "openjpeg"
+  depends_on "webp"
   depends_on "xz"
 
   depends_on "fftw" => :optional
@@ -44,18 +44,10 @@ class Imagemagick < Formula
   depends_on "librsvg" => :optional
   depends_on "libwmf" => :optional
   depends_on "little-cms" => :optional
-  depends_on "little-cms2" => :optional
   depends_on "openexr" => :optional
-  depends_on "openjpeg" => :optional
   depends_on "pango" => :optional
   depends_on "perl" => :optional
-  depends_on "webp" => :optional
   depends_on :x11 => :optional
-
-  if build.with? "openmp"
-    depends_on "gcc"
-    fails_with :clang
-  end
 
   skip_clean :la
 
@@ -66,29 +58,14 @@ class Imagemagick < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --disable-opencl
+      --disable-openmp
       --enable-shared
       --enable-static
       --with-freetype=yes
       --with-modules
+      --with-openjp2
+      --with-webp=yes
     ]
-
-    if build.with? "openmp"
-      args << "--enable-openmp"
-    else
-      args << "--disable-openmp"
-    end
-
-    if build.with? "webp"
-      args << "--with-webp=yes"
-    else
-      args << "--without-webp"
-    end
-
-    if build.with? "openjpeg"
-      args << "--with-openjp2"
-    else
-      args << "--without-openjp2"
-    end
 
     args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
@@ -99,7 +76,6 @@ class Imagemagick < Formula
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-x" if build.without? "x11"
     args << "--with-fontconfig=yes" if build.with? "fontconfig"
-    args << "--enable-zero-configuration" if build.with? "zero-configuration"
     args << "--without-wmf" if build.without? "libwmf"
 
     # versioned stuff in main tree is pointless for us

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -7,6 +7,7 @@ class ImagemagickAT6 < Formula
   url "https://dl.bintray.com/homebrew/mirror/imagemagick%406--6.9.10-12.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.10-12.tar.xz"
   sha256 "54549fe394598f6a7cec8cb5adc45d5d65b8b4f043745c6610693618b1372966"
+  revision 1
   head "https://github.com/imagemagick/imagemagick6.git"
 
   bottle do
@@ -19,13 +20,9 @@ class ImagemagickAT6 < Formula
 
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
-  option "with-openmp", "Compile with OpenMP support"
   option "with-perl", "Compile with PerlMagick"
-  option "with-zero-configuration", "Disables depending on XML configuration files"
 
   deprecated_option "enable-hdri" => "with-hdri"
-  deprecated_option "with-gcc" => "with-openmp"
-  deprecated_option "with-jp2" => "with-openjpeg"
 
   depends_on "pkg-config" => :build
 
@@ -34,6 +31,9 @@ class ImagemagickAT6 < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
+  depends_on "little-cms2"
+  depends_on "openjpeg"
+  depends_on "webp"
   depends_on "xz"
 
   depends_on "fftw" => :optional
@@ -43,17 +43,9 @@ class ImagemagickAT6 < Formula
   depends_on "librsvg" => :optional
   depends_on "libwmf" => :optional
   depends_on "little-cms" => :optional
-  depends_on "little-cms2" => :optional
   depends_on "openexr" => :optional
-  depends_on "openjpeg" => :optional
   depends_on "pango" => :optional
   depends_on "perl" => :optional
-  depends_on "webp" => :optional
-
-  if build.with? "openmp"
-    depends_on "gcc"
-    fails_with :clang
-  end
 
   skip_clean :la
 
@@ -64,29 +56,14 @@ class ImagemagickAT6 < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --disable-opencl
+      --disable-openmp
       --enable-shared
       --enable-static
       --with-freetype=yes
       --with-modules
+      --with-webp=yes
+      --with-openjp2
     ]
-
-    if build.with? "openmp"
-      args << "--enable-openmp"
-    else
-      args << "--disable-openmp"
-    end
-
-    if build.with? "webp"
-      args << "--with-webp=yes"
-    else
-      args << "--without-webp"
-    end
-
-    if build.with? "openjpeg"
-      args << "--with-openjp2"
-    else
-      args << "--without-openjp2"
-    end
 
     args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
@@ -97,7 +74,6 @@ class ImagemagickAT6 < Formula
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-x" if build.without? "x11"
     args << "--with-fontconfig=yes" if build.with? "fontconfig"
-    args << "--enable-zero-configuration" if build.with? "zero-configuration"
     args << "--without-wmf" if build.without? "libwmf"
 
     # versioned stuff in main tree is pointless for us


### PR DESCRIPTION
- OpenMP is broken (https://github.com/Homebrew/homebrew-core/issues/32673), and so is zero-configuration (analytics show it has 96% build errors)
- Webp is the most used option, and is a cheap dependency. So is openjpeg.