### PR TITLE
docker-machine-driver-xhyve: remove qcow2 support to restore build

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -4,6 +4,7 @@ class DockerMachineDriverXhyve < Formula
   url "https://github.com/zchee/docker-machine-driver-xhyve.git",
       :tag => "v0.3.3",
       :revision => "7d92f74a8b9825e55ee5088b8bfa93b042badc47"
+  revision 1
   head "https://github.com/zchee/docker-machine-driver-xhyve.git"
 
   bottle do
@@ -15,16 +16,9 @@ class DockerMachineDriverXhyve < Formula
     sha256 "10bc22b8ece5f7ae8fa190d3c95b6f0f4825a5d1adcb941500c993f4b9ddf2a9" => :yosemite
   end
 
-  option "without-qcow2", "Do not support qcow2 disk image format"
-
   depends_on "go" => :build
   depends_on :macos => :yosemite
   depends_on "docker-machine" => :recommended
-  if build.with? "qcow2"
-    depends_on "ocaml" => :build
-    depends_on "opam" => :build
-    depends_on "libev"
-  end
 
   def install
     (buildpath/"gopath/src/github.com/zchee/docker-machine-driver-xhyve").install Dir["{*,.git,.gitignore,.gitmodules}"]
@@ -40,33 +34,8 @@ class DockerMachineDriverXhyve < Formula
       go_ldflags = "-w -s -X 'github.com/zchee/docker-machine-driver-xhyve/xhyve.GitCommit=Homebrew#{git_hash}'"
       ENV["GO_LDFLAGS"] = go_ldflags
       ENV["GO_BUILD_TAGS"] = build_tags
-      ENV["LIBEV_FILE"] = "#{Formula["libev"].opt_lib}/libev.a"
 
-      if build.with? "qcow2"
-        build_tags << " qcow2"
-        system "opam", "init", "--no-setup"
-        opam_dir = "#{buildpath}/.brew_home/.opam"
-        ENV["CAML_LD_LIBRARY_PATH"] = "#{opam_dir}/system/lib/stublibs:/usr/local/lib/ocaml/stublibs"
-        ENV["OPAMUTF8MSGS"] = "1"
-        ENV["PERL5LIB"] = "#{opam_dir}/system/lib/perl5"
-        ENV["OCAML_TOPLEVEL_PATH"] = "#{opam_dir}/system/lib/toplevel"
-        ENV.prepend_path "PATH", "#{opam_dir}/system/bin"
-
-        inreplace "#{opam_dir}/compilers/4.05.0/4.05.0/4.05.0.comp",
-          '["./configure"', '["./configure" "-no-graph"' # Avoid X11
-
-        ENV.deparallelize { system "opam", "switch", "4.05.0" }
-
-        system "opam", "config", "exec", "--",
-               "opam", "install", "-y", "uri", "qcow-format", "io-page.1.6.1",
-               "conf-libev", "mirage-block-unix>2.3.0", "lwt<3.1.0"
-
-        system "opam", "config", "exec", "--", "make", "lib9p"
-        system "opam", "config", "exec", "--", "make", "build"
-      else
-        system "make", "lib9p"
-        system "make", "build"
-      end
+      system "make", "build", "CC=#{ENV.cc}"
 
       bin.install "bin/docker-machine-driver-xhyve"
       prefix.install_metafiles


### PR DESCRIPTION
`docker-machine-driver-xhyve` is our most-downloaded formula that still doesn't build on Mojave. In fact, it doesn't build from source at all since we have updated to opam 2. That formula thus fails to install for 25% of users (1,233 installs out of 5,320).

Given there is no movement on the upstream bug report I filed at https://github.com/machine-drivers/docker-machine-driver-xhyve/issues/210, I think the best approach right now is to disable qcow2 support (which was the case of this formula before), and provide a working formula for most users.

To anyone who comes here and needs qcow2 support: we welcome a pull request to bring it back!

Maintainers, what say you?
