### PR TITLE
docker-machine-driver-xhyve: update to opam 2.x

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb~
+++ b/Formula/docker-machine-driver-xhyve.rb~
@@ -44,17 +44,18 @@ class DockerMachineDriverXhyve < Formula
 
       if build.with? "qcow2"
         build_tags << " qcow2"
-        system "opam", "init", "--no-setup", "--disable-sandboxing"
+        system "opam", "init", "--no-setup"
         opam_dir = "#{buildpath}/.brew_home/.opam"
-        opam_compiler = "4.05.0"
-        ENV["CAML_LD_LIBRARY_PATH"] = "#{opam_dir}/#{opam_compiler}/lib/stublibs:/usr/local/lib/ocaml/stublibs"
+        ENV["CAML_LD_LIBRARY_PATH"] = "#{opam_dir}/system/lib/stublibs:/usr/local/lib/ocaml/stublibs"
         ENV["OPAMUTF8MSGS"] = "1"
-        ENV["OCAML_TOPLEVEL_PATH"] = "#{opam_dir}/#{opam_compiler}/lib/toplevel"
-        ENV.prepend_path "PATH", "#{opam_dir}/#{opam_compiler}/bin"
+        ENV["PERL5LIB"] = "#{opam_dir}/system/lib/perl5"
+        ENV["OCAML_TOPLEVEL_PATH"] = "#{opam_dir}/system/lib/toplevel"
+        ENV.prepend_path "PATH", "#{opam_dir}/system/bin"
 
-        ENV.deparallelize { system "opam", "switch", "create", opam_compiler }
+        inreplace "#{opam_dir}/compilers/4.05.0/4.05.0/4.05.0.comp",
+          '["./configure"', '["./configure" "-no-graph"' # Avoid X11
 
-        system "opam", "switch", opam_compiler
+        ENV.deparallelize { system "opam", "switch", "4.05.0" }
 
         system "opam", "config", "exec", "--",
                "opam", "install", "-y", "uri", "qcow-format", "io-page.1.6.1",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates docker-machine-driver-xhyve to compile with opam 2.x on Mojave.
Fixes #31740.