### PR TITLE
Add formula for 'Open-In' Chrome/FireFox extension's native-client

### DIFF
--- a/Formula/open-in.rb
+++ b/Formula/open-in.rb
@@ -1,0 +1,15 @@
+class OpenIn < Formula
+  desc "The native client for the 'Open-In' Chrome & FireFox browser extensions"
+  homepage "https://add0n.com/open-in.html"
+  url "https://github.com/andy-portmen/native-client/releases/download/0.7.0/mac.zip"
+  sha256 "e45e84f6876b6886f401f7660376140db53a7ee5fda962d5395161dcf148cb1e"
+
+  def install
+    system "./install.sh", "--custom-dir=#{prefix}"
+  end
+
+  test do
+    Dir.chdir prefix
+    system "node", "-e", "require('./com.add0n.node/host.js') && process.exit(0)"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula does not, unfortunately, pass `brew audit --online`; for reasons I can't discern, the actual, definitely-correct website for this project reports a 404 to Curl, but loads fine in every actual browser I've tried. Go figure.

That said: otherwise, I hope I've followed the process to a `T`! I got sick of manually installing this native client, time, and time, and time again on every new machine; I also see a lot of GitHub Issues on the project in question for package-manager entries. Please add this; it's a fairly popular set of projects, all supported by this one tiny command-line package! Thanks!