### PR TITLE
kommit: make `bottle :unneeded`

### DIFF
--- a/Formula/kommit.rb
+++ b/Formula/kommit.rb
@@ -4,15 +4,7 @@ class Kommit < Formula
   url "https://github.com/vigo/kommit/archive/v1.1.0.tar.gz"
   sha256 "c51e87c9719574feb9841fdcbd6d1a43b73a45afeca25e1312d2699fdf730161"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "a34a76453027a844fa47400df6a2599d93a4b0b63dd8098800b4cf0f54fd5345" => :mojave
-    sha256 "e56a06121acc174613b183d6d22ffe7c5d8b7af07dd8070324344753a5806111" => :high_sierra
-    sha256 "4c0ba086a72c5e3af247e6926d5374a193d64bfd3e7d8bc939f02ad965e16fe7" => :sierra
-    sha256 "2797509de1497eeae3a3cac0381822019e471e878f5082b1a79fa40bc2f6f768" => :el_capitan
-    sha256 "b15cf7fe56aceade3a06d52e467cdb08640f4d907d1a29dcef0e374815dee203" => :yosemite
-    sha256 "8f7d60cb1b837a3a1e1e7ae86d339c1a950ba3577e3053819ac9922144a6d0d3" => :mavericks
-  end
+  bottle :unneeded
 
   def install
     bin.install "bin/git-kommit"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/vigo/kommit/blob/v1.1.0/bin/git-kommit

bash script, doesn't need to be bottled.