### PR TITLE
apache-arrow 0.11.0, apache-arrow-glib 0.11.0

### DIFF
--- a/Formula/apache-arrow-glib.rb
+++ b/Formula/apache-arrow-glib.rb
@@ -1,8 +1,8 @@
 class ApacheArrowGlib < Formula
   desc "GObject Introspection files of Apache Arrow"
   homepage "https://arrow.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz"
-  sha256 "943207a2fcc7ba8de0e50bdb6c6ea4e9ed7f7e7bf55f6b426d7f867f559e842d"
+  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.11.0/apache-arrow-0.11.0.tar.gz"
+  sha256 "1838faa3775e082062ad832942ebc03aaf95386c0284288346ddae0632be855d"
   head "https://github.com/apache/arrow.git"
 
   bottle do

--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -1,8 +1,8 @@
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"
   homepage "https://arrow.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz"
-  sha256 "943207a2fcc7ba8de0e50bdb6c6ea4e9ed7f7e7bf55f6b426d7f867f559e842d"
+  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.11.0/apache-arrow-0.11.0.tar.gz"
+  sha256 "1838faa3775e082062ad832942ebc03aaf95386c0284288346ddae0632be855d"
   head "https://github.com/apache/arrow.git"
 
   bottle do
@@ -18,14 +18,6 @@ class ApacheArrow < Formula
   depends_on "jemalloc"
   depends_on "python" => :optional
   depends_on "python@2" => :optional
-
-  # Fix "Invalid character ('{') in a variable name: 'ENV'"
-  # Upstream PR 08 Aug 2018 "[C++] Fix a typo in `FindClangTools.cmake`."
-  # See https://github.com/apache/arrow/pull/2404
-  patch do
-    url "https://github.com/apache/arrow/pull/2404.patch?full_index=1"
-    sha256 "77a03e841186e132b44d8a6212c7ca6934b1b9bd77173f91cff53507b0906f3e"
-  end
 
   needs :cxx11
 


### PR DESCRIPTION
This PR update apache-arrow to latest version. It also removes the patches required for previous version. In addition, I changed the source URL from the official one to the one on GitHub. One issue I have found with apache-arrow is that their official URL often become invalid especially after new versions being releases. I haven't updated the bottle SHA256 sums, I don't have the required machine to build it and not sure how to test and update it properly.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
