### PR TITLE
chocolate-doom: fix hardcoded test

### DIFF
--- a/Formula/chocolate-doom.rb
+++ b/Formula/chocolate-doom.rb
@@ -48,6 +48,6 @@ class ChocolateDoom < Formula
   end
 
   test do
-    assert_match /Chocolate Doom 3.0.0/, shell_output("#{bin}/chocolate-doom -nogui", 255)
+    assert_match "Chocolate Doom #{version}", shell_output("#{bin}/chocolate-doom -nogui", 255)
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
version shouldn't be hardcoded in the test

cc @Moisan 