### PR TITLE
gnuplot: remove unnecessary dependency pango

### DIFF
--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -3,6 +3,7 @@ class Gnuplot < Formula
   homepage "http://www.gnuplot.info/"
   url "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.2.5/gnuplot-5.2.5.tar.gz"
   sha256 "039db2cce62ddcfd31a6696fe576f4224b3bc3f919e66191dfe2cdb058475caa"
+  revision 1
 
   bottle do
     sha256 "eaf80b9ce3cf64e57e005af62067e526d57755ef26b3ee0596581f2caf070692" => :mojave
@@ -29,10 +30,10 @@ class Gnuplot < Formula
   depends_on "pkg-config" => :build
   depends_on "gd"
   depends_on "lua"
-  depends_on "pango"
   depends_on "readline"
   depends_on "qt" => :optional
   depends_on "wxmac" => :optional
+  depends_on "pango" if build.with?("wxmac")
   depends_on :x11 => :optional
 
   needs :cxx11 if build.with? "qt"


### PR DESCRIPTION
In #32840, pango was accidentally added as a required dependency to the
gnuplot. However, it is only needed when building with wxmac. Therefore,
it introduces several unnecessary dependencies (e.g. pango, cario, glib,
etc.) to the users who use default options or bottles.

This commit corrects the logic of the dependency handling.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
