### PR TITLE
salt: fix build on Mojave

### DIFF
--- a/Formula/salt.rb
+++ b/Formula/salt.rb
@@ -130,6 +130,8 @@ class Salt < Formula
   end
 
   def install
+    ENV["SWIG_FEATURES"]="-I#{Formula["openssl"].opt_include}"
+
     virtualenv_install_with_resources
     prefix.install libexec/"share" # man pages
     (etc/"saltstack").install (buildpath/"conf").children # sample config files


### PR DESCRIPTION
Help swig find openssl during the M2Crypto compilation