### PR TITLE
erlang formulae: remove without-docs option 

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -17,10 +17,8 @@ class Erlang < Formula
   option "with-native-libs", "Enable native library compilation"
   option "with-dirty-schedulers", "Enable experimental dirty schedulers"
   option "with-java", "Build jinterface application"
-  option "without-docs", "Do not install documentation"
 
   deprecated_option "disable-hipe" => "without-hipe"
-  deprecated_option "no-docs" => "without-docs"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -90,10 +88,8 @@ class Erlang < Formula
     system "make"
     system "make", "install"
 
-    if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
-      doc.install resource("html")
-    end
+    (lib/"erlang").install resource("man").files("man")
+    doc.install resource("html")
   end
 
   def caveats; <<~EOS

--- a/Formula/erlang@17.rb
+++ b/Formula/erlang@17.rb
@@ -16,7 +16,6 @@ class ErlangAT17 < Formula
   option "without-hipe", "Disable building hipe; fails on various macOS systems"
   option "with-native-libs", "Enable native library compilation"
   option "with-dirty-schedulers", "Enable experimental dirty schedulers"
-  option "without-docs", "Do not install documentation"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -96,10 +95,8 @@ class ErlangAT17 < Formula
     ENV.deparallelize # Install is not thread-safe; can try to create folder twice and fail
     system "make", "install"
 
-    if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
-      doc.install resource("html")
-    end
+    (lib/"erlang").install resource("man").files("man")
+    doc.install resource("html")
   end
 
   def caveats; <<~EOS

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -18,7 +18,6 @@ class ErlangAT18 < Formula
   option "with-native-libs", "Enable native library compilation"
   option "with-dirty-schedulers", "Enable experimental dirty schedulers"
   option "with-java", "Build jinterface application"
-  option "without-docs", "Do not install documentation"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -111,10 +110,8 @@ class ErlangAT18 < Formula
     ENV.deparallelize # Install is not thread-safe; can try to create folder twice and fail
     system "make", "install"
 
-    if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
-      doc.install resource("html")
-    end
+    (lib/"erlang").install resource("man").files("man")
+    doc.install resource("html")
   end
 
   def caveats; <<~EOS

--- a/Formula/erlang@19.rb
+++ b/Formula/erlang@19.rb
@@ -18,10 +18,8 @@ class ErlangAT19 < Formula
   option "with-native-libs", "Enable native library compilation"
   option "with-dirty-schedulers", "Enable experimental dirty schedulers"
   option "with-java", "Build jinterface application"
-  option "without-docs", "Do not install documentation"
 
   deprecated_option "disable-hipe" => "without-hipe"
-  deprecated_option "no-docs" => "without-docs"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -107,10 +105,8 @@ class ErlangAT19 < Formula
     system "make"
     system "make", "install"
 
-    if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
-      doc.install resource("html")
-    end
+    (lib/"erlang").install resource("man").files("man")
+    doc.install resource("html")
   end
 
   def caveats; <<~EOS

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -18,10 +18,8 @@ class ErlangAT20 < Formula
   option "with-native-libs", "Enable native library compilation"
   option "with-dirty-schedulers", "Enable experimental dirty schedulers"
   option "with-java", "Build jinterface application"
-  option "without-docs", "Do not install documentation"
 
   deprecated_option "disable-hipe" => "without-hipe"
-  deprecated_option "no-docs" => "without-docs"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -91,10 +89,8 @@ class ErlangAT20 < Formula
     system "make"
     system "make", "install"
 
-    if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
-      doc.install resource("html")
-    end
+    (lib/"erlang").install resource("man").files("man")
+    doc.install resource("html")
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
==> Analytics
==> install (30 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
01    | erlang                                               | 33,190 |   99.40%
02    | erlang --without-wxmac                               |     37 |    0.11%
03    | erlang --with-native-libs --with-java --with-fop     |     30 |    0.09%
04    | erlang --with-native-libs --with-dirty-schedulers -- |     22 |    0.07%
05    | erlang --with-java                                   |     18 |    0.05%
06    | erlang --with-native-libs --with-dirty-schedulers    |     12 |    0.04%
07    | erlang --without-docs                                |     12 |    0.04%
08    | erlang --with-fop                                    |     11 |    0.03%
09    | erlang --with-dirty-schedulers                       |      9 |    0.03%
10    | erlang --with-native-libs                            |      9 |    0.03%
11    | erlang --with-odbc                                   |      7 |    0.02%
12    | erlang --with-native-libs --with-dirty-schedulers -- |      4 |    0.01%
13    | erlang --with-native-libs --with-fop                 |      4 |    0.01%
14    | erlang --with-odbc --without-docs                    |      4 |    0.01%
15    | erlang --without-docs --without-wxmac                |      4 |    0.01%
16    | erlang --HEAD --with-native-libs --with-dirty-schedu |      3 |    0.01%
17    | erlang --with-dirty-schedulers --with-fop            |      2 |    0.01%
18    | erlang --with-native-libs --with-java --without-docs |      2 |    0.01%
19    | erlang --with-native-libs --with-java --without-docs |      2 |    0.01%
20    | erlang --without-hipe                                |      2 |    0.01%
21    | erlang --HEAD                                        |      1 |    0.00%
22    | erlang --HEAD --with-native-libs --with-java --with- |      1 |    0.00%
23    | erlang --with-java --without-wxmac                   |      1 |    0.00%
24    | erlang --with-native-libs --with-java                |      1 |    0.00%
25    | erlang --with-native-libs --without-wxmac            |      1 |    0.00%
26    | erlang --without-docs --with-odbc                    |      1 |    0.00%
27    | erlang --without-hipe --with-native-libs --without-d |      1 |    0.00%
28    | erlang --without-hipe --without-docs                 |      1 |    0.00%
Total |                                                      | 33,392 |  100.00%
==> install (90 days)
Index | Name (with options)                                 |   Count |  Percent
-----:|-----------------------------------------------------|--------:|--------:
01    | erlang                                              | 106,988 |   99.35%
02    | erlang --without-wxmac                              |     134 |    0.12%
03    | erlang --with-native-libs --with-java --with-fop    |      94 |    0.09%
04    | erlang --with-native-libs --with-dirty-schedulers - |      80 |    0.07%
05    | erlang --with-native-libs --with-dirty-schedulers   |      56 |    0.05%
06    | erlang --with-java                                  |      55 |    0.05%
07    | erlang --with-dirty-schedulers                      |      49 |    0.05%
08    | erlang --without-docs                               |      49 |    0.05%
09    | erlang --with-native-libs                           |      41 |    0.04%
10    | erlang --with-fop                                   |      39 |    0.04%
11    | erlang --with-native-libs --with-fop                |      18 |    0.02%
12    | erlang --with-native-libs --with-dirty-schedulers - |      13 |    0.01%
13    | erlang --with-dirty-schedulers --with-fop           |      11 |    0.01%
14    | erlang --without-docs --without-wxmac               |      10 |    0.01%
15    | erlang --with-odbc                                  |       7 |    0.01%
16    | erlang --with-native-libs --with-java               |       6 |    0.01%
17    | erlang --with-native-libs --with-java --without-doc |       6 |    0.01%
18    | erlang --HEAD                                       |       5 |    0.00%
19    | erlang --with-java --with-fop                       |       5 |    0.00%
20    | erlang --with-native-libs --with-java --without-doc |       5 |    0.00%
21    | erlang --without-hipe                               |       5 |    0.00%
22    | erlang --with-odbc --without-docs                   |       4 |    0.00%
23    | erlang --HEAD --with-native-libs --with-dirty-sched |       3 |    0.00%
24    | erlang --with-native-libs --with-java --without-doc |       3 |    0.00%
Total |                                                     | 107,686 |  100.00%
==> install (365 days)
Index | Name (with options)                                 |   Count |  Percent
-----:|-----------------------------------------------------|--------:|--------:
01    | erlang                                              | 412,867 |   99.32%
02    | erlang --without-wxmac                              |     663 |    0.16%
03    | erlang --with-native-libs --with-java --with-fop    |     336 |    0.08%
04    | erlang --with-native-libs --with-dirty-schedulers - |     269 |    0.06%
05    | erlang --with-dirty-schedulers                      |     212 |    0.05%
06    | erlang --without-docs                               |     206 |    0.05%
07    | erlang --with-native-libs                           |     172 |    0.04%
08    | erlang --with-java                                  |     162 |    0.04%
09    | erlang --with-fop                                   |     157 |    0.04%
10    | erlang --with-native-libs --with-java               |     140 |    0.03%
11    | erlang --with-native-libs --with-dirty-schedulers   |     136 |    0.03%
12    | erlang --with-native-libs --with-fop                |      96 |    0.02%
13    | erlang --with-dirty-schedulers --with-fop           |      38 |    0.01%
14    | erlang --with-native-libs --with-dirty-schedulers - |      38 |    0.01%
15    | erlang --HEAD                                       |      34 |    0.01%
16    | erlang --without-hipe                               |      31 |    0.01%
17    | erlang --with-java --with-fop                       |      29 |    0.01%
18    | erlang --with-native-libs --with-java --without-doc |      28 |    0.01%
19    | erlang --without-docs --without-wxmac               |      25 |    0.01%
20    | erlang --with-native-libs --with-java --without-doc |      23 |    0.01%
21    | erlang --with-dirty-schedulers --with-java --with-f |      18 |    0.00%
22    | erlang --without-hipe --with-native-libs            |      17 |    0.00%
23    | erlang --HEAD --with-native-libs --with-dirty-sched |      15 |    0.00%
Total |                                                     | 415,712 |  100.00%
==> install_on_request (30 days)
Index | Name (with options)                                   | Count |  Percent
-----:|-------------------------------------------------------|------:|--------:
01    | erlang                                                | 7,055 |   97.85%
02    | erlang --with-native-libs --with-java --with-fop      |    28 |    0.39%
03    | erlang --with-native-libs --with-dirty-schedulers --w |    18 |    0.25%
04    | erlang --with-java                                    |    15 |    0.21%
05    | erlang --without-wxmac                                |    13 |    0.18%
06    | erlang --with-native-libs --with-dirty-schedulers     |    12 |    0.17%
07    | erlang --without-docs                                 |    11 |    0.15%
08    | erlang --with-dirty-schedulers                        |     9 |    0.12%
09    | erlang --with-native-libs                             |     7 |    0.10%
10    | erlang --with-odbc                                    |     7 |    0.10%
11    | erlang --with-fop                                     |     5 |    0.07%
12    | erlang --with-native-libs --with-dirty-schedulers --w |     4 |    0.06%
13    | erlang --with-odbc --without-docs                     |     4 |    0.06%
14    | erlang --HEAD --with-native-libs --with-dirty-schedul |     3 |    0.04%
15    | erlang --without-docs --without-wxmac                 |     3 |    0.04%
16    | erlang --with-dirty-schedulers --with-fop             |     2 |    0.03%
17    | erlang --with-native-libs --with-fop                  |     2 |    0.03%
18    | erlang --with-native-libs --with-java --without-docs  |     2 |    0.03%
19    | erlang --without-hipe                                 |     2 |    0.03%
20    | erlang --HEAD                                         |     1 |    0.01%
21    | erlang --HEAD --with-native-libs --with-java --with-f |     1 |    0.01%
22    | erlang --with-java --without-wxmac                    |     1 |    0.01%
23    | erlang --with-native-libs --with-java --without-docs  |     1 |    0.01%
24    | erlang --with-native-libs --without-wxmac             |     1 |    0.01%
25    | erlang --without-docs --with-odbc                     |     1 |    0.01%
26    | erlang --without-hipe --with-native-libs --without-do |     1 |    0.01%
27    | erlang --without-hipe --without-docs                  |     1 |    0.01%
Total |                                                       | 7,210 |  100.00%
==> install_on_request (90 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
01    | erlang                                               | 22,136 |   97.78%
02    | erlang --with-native-libs --with-java --with-fop     |     87 |    0.38%
03    | erlang --with-native-libs --with-dirty-schedulers -- |     67 |    0.30%
04    | erlang --with-native-libs --with-dirty-schedulers    |     56 |    0.25%
05    | erlang --with-dirty-schedulers                       |     47 |    0.21%
06    | erlang --with-java                                   |     45 |    0.20%
07    | erlang --without-docs                                |     45 |    0.20%
08    | erlang --with-native-libs                            |     32 |    0.14%
09    | erlang --without-wxmac                               |     29 |    0.13%
10    | erlang --with-fop                                    |     19 |    0.08%
11    | erlang --with-native-libs --with-dirty-schedulers -- |     13 |    0.06%
12    | erlang --with-dirty-schedulers --with-fop            |     10 |    0.04%
13    | erlang --with-native-libs --with-fop                 |     10 |    0.04%
14    | erlang --with-odbc                                   |      7 |    0.03%
15    | erlang --with-native-libs --with-java --without-docs |      6 |    0.03%
16    | erlang --HEAD                                        |      5 |    0.02%
17    | erlang --with-java --with-fop                        |      5 |    0.02%
18    | erlang --without-hipe                                |      5 |    0.02%
19    | erlang --with-odbc --without-docs                    |      4 |    0.02%
20    | erlang --without-docs --without-wxmac                |      4 |    0.02%
21    | erlang --HEAD --with-native-libs --with-dirty-schedu |      3 |    0.01%
22    | erlang --with-native-libs --with-java --without-docs |      3 |    0.01%
Total |                                                      | 22,638 |  100.00%
==> install_on_request (365 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
01    | erlang                                               | 76,250 |   97.71%
02    | erlang --with-native-libs --with-java --with-fop     |    287 |    0.37%
03    | erlang --with-native-libs --with-dirty-schedulers -- |    226 |    0.29%
04    | erlang --without-wxmac                               |    205 |    0.26%
05    | erlang --with-dirty-schedulers                       |    148 |    0.19%
06    | erlang --with-native-libs --with-dirty-schedulers    |    131 |    0.17%
07    | erlang --with-native-libs                            |    126 |    0.16%
08    | erlang --with-native-libs --with-java                |    125 |    0.16%
09    | erlang --without-docs                                |    124 |    0.16%
10    | erlang --with-java                                   |    107 |    0.14%
11    | erlang --with-fop                                    |     70 |    0.09%
12    | erlang --with-native-libs --with-fop                 |     59 |    0.08%
13    | erlang --with-dirty-schedulers --with-fop            |     34 |    0.04%
14    | erlang --HEAD                                        |     33 |    0.04%
15    | erlang --with-native-libs --with-dirty-schedulers -- |     33 |    0.04%
16    | erlang --with-native-libs --with-java --without-docs |     22 |    0.03%
17    | erlang --without-hipe                                |     22 |    0.03%
18    | erlang --with-dirty-schedulers --with-java --with-fo |     18 |    0.02%
19    | erlang --with-java --with-fop                        |     15 |    0.02%
Total |                                                      | 78,035 |  100.00%
==> build_error (30 days)
Index | Name (with options)                                   | Count |  Percent
-----:|-------------------------------------------------------|------:|--------:
1     | erlang                                                |     0 |    0.00%
```