### PR TITLE
tomcat formulae: remove with-fulldocs option

### DIFF
--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -6,14 +6,7 @@ class Tomcat < Formula
 
   bottle :unneeded
 
-  option "with-fulldocs", "Install full documentation locally"
-
   depends_on :java => "1.8+"
-
-  resource "fulldocs" do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-9/v9.0.12/bin/apache-tomcat-9.0.12-fulldocs.tar.gz"
-    sha256 "3331252fefc6f768bdd0bd23d1e092d4f9883d4d8b01f3b15a8a873dd5821b83"
-  end
 
   def install
     # Remove Windows scripts
@@ -23,8 +16,6 @@ class Tomcat < Formula
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/catalina.sh" => "catalina"
-
-    (pkgshare/"fulldocs").install resource("fulldocs") if build.with? "fulldocs"
   end
 
   plist_options :manual => "catalina run"

--- a/Formula/tomcat@6.rb
+++ b/Formula/tomcat@6.rb
@@ -9,14 +9,7 @@ class TomcatAT6 < Formula
 
   keg_only :versioned_formula
 
-  option "with-fulldocs", "Install full documentation locally"
-
   depends_on :java
-
-  resource "fulldocs" do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-6/v6.0.53/bin/apache-tomcat-6.0.53-fulldocs.tar.gz"
-    sha256 "3465db40f8b6f048e0733444668e4a40e9814855e5112762f3bb14e45eb9724a"
-  end
 
   def install
     rm_rf Dir["bin/*.{cmd,bat]}"]
@@ -24,7 +17,6 @@ class TomcatAT6 < Formula
     (libexec+"logs").mkpath
     bin.mkpath
     Dir["#{libexec}/bin/*.sh"].each { |f| ln_s f, bin }
-    (share/"fulldocs").install resource("fulldocs") if build.with? "fulldocs"
   end
 
   def caveats; <<~EOS

--- a/Formula/tomcat@7.rb
+++ b/Formula/tomcat@7.rb
@@ -9,17 +9,10 @@ class TomcatAT7 < Formula
 
   keg_only :versioned_formula
 
-  option "with-fulldocs", "Install full documentation locally"
-
   depends_on :java
 
   # Keep log folders
   skip_clean "libexec"
-
-  resource "fulldocs" do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-7/v7.0.91/bin/apache-tomcat-7.0.91-fulldocs.tar.gz"
-    sha256 "0eadac93d16bd7512a64a84f29e631784d3e7c23287315d1fb166bd1ff44e418"
-  end
 
   def install
     # Remove Windows scripts
@@ -29,8 +22,6 @@ class TomcatAT7 < Formula
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/catalina.sh" => "catalina"
-
-    (pkgshare/"fulldocs").install resource("fulldocs") if build.with? "fulldocs"
   end
 
   test do

--- a/Formula/tomcat@8.rb
+++ b/Formula/tomcat@8.rb
@@ -9,15 +9,7 @@ class TomcatAT8 < Formula
 
   keg_only :versioned_formula
 
-  option "with-fulldocs", "Install full documentation locally"
-
   depends_on :java => "1.7+"
-
-  resource "fulldocs" do
-    url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34-fulldocs.tar.gz"
-    mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34-fulldocs.tar.gz"
-    sha256 "e3f188f3bf9980f766b0c8af3ccd999d060530e251073aeb25e00a0aecf08dec"
-  end
 
   def install
     # Remove Windows scripts
@@ -27,8 +19,6 @@ class TomcatAT8 < Formula
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/catalina.sh" => "catalina"
-
-    (pkgshare/"fulldocs").install resource("fulldocs") if build.with? "fulldocs"
   end
 
   plist_options :manual => "catalina run"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
==> Analytics
==> install (30 days)
Index | Name (with options)                                   | Count |  Percent
-----:|-------------------------------------------------------|------:|--------:
1     | tomcat                                                | 4,900 |   99.65%
2     | tomcat --with-fulldocs                                |    17 |    0.35%
Total |                                                       | 4,917 |  100.00%
==> install (90 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
1     | tomcat                                               | 17,128 |   99.45%
2     | tomcat --with-fulldocs                               |     95 |    0.55%
Total |                                                      | 17,223 |  100.00%
==> install (365 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
1     | tomcat                                               | 74,370 |   99.23%
2     | tomcat --with-fulldocs                               |    488 |    0.65%
3     | tomcat --devel                                       |     88 |    0.12%
Total |                                                      | 74,946 |  100.00%
==> install_on_request (30 days)
Index | Name (with options)                                   | Count |  Percent
-----:|-------------------------------------------------------|------:|--------:
1     | tomcat                                                | 4,254 |   99.74%
2     | tomcat --with-fulldocs                                |    11 |    0.26%
Total |                                                       | 4,265 |  100.00%
==> install_on_request (90 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
1     | tomcat                                               | 14,411 |   99.53%
2     | tomcat --with-fulldocs                               |     68 |    0.47%
Total |                                                      | 14,479 |  100.00%
==> install_on_request (365 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
1     | tomcat                                               | 59,044 |   99.33%
2     | tomcat --with-fulldocs                               |    320 |    0.54%
3     | tomcat --devel                                       |     81 |    0.14%
Total |                                                      | 59,445 |  100.00%
==> build_error (30 days)
Index | Name (with options)                                   | Count |  Percent
-----:|-------------------------------------------------------|------:|--------:
1     | tomcat                                                |     0 |    0.00%

```