### PR TITLE
circleci: Use compiler hook to disable update feature

### DIFF
--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -24,6 +24,7 @@ class Circleci < Formula
       commit = Utils.popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[
         -s -w
+        -X github.com/CircleCI-Public/circleci-cli/cmd.AutoUpdate=false
         -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
         -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{commit}
       ]
@@ -40,5 +41,7 @@ class Circleci < Formula
     (testpath/".circleci.yml").write("{version: 2.1}")
     output = shell_output("#{bin}/circleci build -c #{testpath}/.circleci.yml 2>&1", 255)
     assert_match "Local builds do not support that version at this time", output
+    # assert update is not included in output of help meaning it was not included in the build
+    assert_no_match /update      Update the tool to the latest version/, shell_output("#{bin}/circleci help")
   end
 end

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -25,6 +25,7 @@ class Circleci < Formula
       ldflags = %W[
         -s -w
         -X github.com/CircleCI-Public/circleci-cli/cmd.AutoUpdate=false
+        -X github.com/CircleCI-Public/circleci-cli/cmd.PackageManager=homebrew
         -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
         -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{commit}
       ]
@@ -42,6 +43,7 @@ class Circleci < Formula
     output = shell_output("#{bin}/circleci build -c #{testpath}/.circleci.yml 2>&1", 255)
     assert_match "Local builds do not support that version at this time", output
     # assert update is not included in output of help meaning it was not included in the build
-    assert_no_match /update      Update the tool to the latest version/, shell_output("#{bin}/circleci help")
+    assert_match "update      This command is unavailable on your platform", shell_output("#{bin}/circleci help")
+    assert_match "`update` is not available because this tool was installed using `homebrew`.", shell_output("#{bin}/circleci update")
   end
 end


### PR DESCRIPTION
This should be merged once CircleCI-Public/circleci-cli#171 is shipped.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
