### PR TITLE
wxmac 3.1.1

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -16,6 +16,12 @@ class Wxmac < Formula
 
   option "with-stl", "use standard C++ classes for everything"
   option "with-static", "build static libraries"
+  option "with-v3.1.1", "use WxWidgets Release 3.1.1"
+
+  if build.with? "v3.1.1"
+    url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.1/wxWidgets-3.1.1.tar.bz2"
+    sha256 "c925dfe17e8f8b09eb7ea9bfdcfcc13696a3e14e92750effd839f5e10726159e"
+  end
 
   depends_on "jpeg"
   depends_on "libpng"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source wxmac`?
- [x] Does your build pass `brew audit --strict wxmac` (after doing `brew install wxmac`)?

-----

Release 3.1.1 was available through `--devel` option, but it has been removed in #33202.

This PR adds option `--with-v3.1.1` in order to recover this version.

As mentioned in [WxWidgets site](https://www.wxwidgets.org), `3.1.1` is not fully compatible with the “stable” `3.0.x` so just updating the formula version is not a valid option, although version `3.1.1` is a stable release.