### PR TITLE
Migrate `safe` back to its original tap

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -35,6 +35,7 @@
   "pebble-sdk": "pebble/pebble-sdk",
   "phantomjs": "homebrew/cask",
   "quassel": "homebrew/cask",
+  "safe": "starkandwayne/cf",
   "transmission-remote-gtk": "homebrew/cask/transmission-remote-gui",
   "tuntap": "homebrew/cask"
 }


### PR DESCRIPTION
The safe project (https://github.com/starkandwayne/safe) has
maintained a working version in its tap, starkandwayne/cf
(https://github.com/starkandwayne/homebrew-cf), since before the
appearance of the `safe` Formula in homebrew-core.

The version in homebrew-core is not being reliably updated in a timely
fashion, and we would like to remove it from core.  The starkandwayne/cf
tap version has CI/CD behind it that runs tests and cuts releases.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
