### PR TITLE
cpansearch: secure test

### DIFF
--- a/Formula/cpansearch.rb
+++ b/Formula/cpansearch.rb
@@ -23,7 +23,7 @@ class Cpansearch < Formula
   end
 
   test do
-    output = shell_output("#{bin}/cpans -f http://cpan.nctu.edu.tw/")
+    output = shell_output("#{bin}/cpans --fetch https://cpan.metacpan.org/")
     assert_match "packages recorded", output
   end
 end


### PR DESCRIPTION
- swap CPAN mirror to a secure one (the one used in formulae)
- swap short option to the long form, because the former ignores
  any URL argument passed
---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
