### PR TITLE
Poppler 0.70.1

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/archive/v0.2.tar.gz"
   sha256 "cb90f2e0fd4bc3fe235111f982bc20455a1d6bc13f4219babcba6bd60c1fe466"
-  revision 34
+  revision 35
 
   bottle do
     cellar :any

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -1,9 +1,8 @@
 class Pdftoedn < Formula
   desc "Extract PDF document data and save the output in EDN format"
   homepage "https://github.com/edporras/pdftoedn"
-  url "https://github.com/edporras/pdftoedn/archive/v0.35.3.tar.gz"
-  sha256 "b73c0f95b79882dad639828629c9e66455899edb5d601d4f1daef78844dacebf"
-  revision 1
+  url "https://github.com/edporras/pdftoedn/archive/v0.36.0.tar.gz"
+  sha256 "3a397b7ee9dbc26b29dbd16dc48c1704006bf10be6138c54529ea1df1810df86"
 
   bottle do
     cellar :any

--- a/Formula/pdftoipe.rb
+++ b/Formula/pdftoipe.rb
@@ -3,6 +3,7 @@ class Pdftoipe < Formula
   homepage "https://github.com/otfried/ipe-tools"
   url "https://github.com/otfried/ipe-tools/archive/v7.2.7.1.tar.gz"
   sha256 "b45a7d6bec339e878717bd273c32c7957e2d4d87c57e117e772ee3dd3231d7aa"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,6 +14,13 @@ class Pdftoipe < Formula
 
   depends_on "pkg-config" => :build
   depends_on "poppler"
+
+  # https://github.com/otfried/ipe-tools/pull/30
+  # Should be safe to remove on next release but check if merged.
+  patch do
+    url "https://github.com/otfried/ipe-tools/pull/30.patch?full_index=1"
+    sha256 "ac7f9945f12ff11a3ae41e368cb439aeac1e9ff3e81907568b39c3752959288c"
+  end
 
   needs :cxx11
 

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -1,9 +1,8 @@
 class Poppler < Formula
   desc "PDF rendering library (based on the xpdf-3.0 code base)"
   homepage "https://poppler.freedesktop.org/"
-  url "https://poppler.freedesktop.org/poppler-0.69.0.tar.xz"
-  sha256 "637ff943f805f304ff1da77ba2e7f1cbd675f474941fd8ae1e0fc01a5b45a3f9"
-  revision 1
+  url "https://poppler.freedesktop.org/poppler-0.70.1.tar.xz"
+  sha256 "66972047d9ef8162cc8c389d7e7698291dfc9f2b3e4ea9a9f08ae604107451bd"
   head "https://anongit.freedesktop.org/git/poppler/poppler.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`pdftoipe` won't compile due to the API changes in poppler-0.70.x. I've submitted [PR #30](https://github.com/otfried/ipe-tools/pull/30) with a fix.