### PR TITLE
cmake: remove completions

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -12,9 +12,9 @@ class Cmake < Formula
     sha256 "a940f8d8e9818512c466ffd205612cb1b477d936e87ab3d6c7dac888f6d03b92" => :sierra
   end
 
-  option "with-completion", "Install Bash completion (Has potential problems with system bash)"
-
   depends_on "sphinx-doc" => :build
+
+  # The completions were removed becuase of problems with system bash
 
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
@@ -50,12 +50,6 @@ class Cmake < Formula
     system "./bootstrap", *args, "--", "-DCMAKE_BUILD_TYPE=Release"
     system "make"
     system "make", "install"
-
-    if build.with? "completion"
-      cd "Auxiliary/bash-completion/" do
-        bash_completion.install "ctest", "cmake", "cpack"
-      end
-    end
 
     elisp.install "Auxiliary/cmake-mode.el"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
We don't want to enable these by default if they have potential problems with system bash and it doesn't look like there has been any upstream changes to the completions since it was made optional.
