### PR TITLE
blast: remove mirror

### DIFF
--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -2,7 +2,6 @@ class Blast < Formula
   desc "Basic Local Alignment Search Tool"
   homepage "https://blast.ncbi.nlm.nih.gov/"
   url "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.7.1+-src.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/n/ncbi-blast+/ncbi-blast+_2.7.1.orig.tar.gz"
   version "2.7.1"
   sha256 "10a78d3007413a6d4c983d2acbf03ef84b622b82bd9a59c6bd9fbdde9d0298ca"
 


### PR DESCRIPTION
- previously added secure mirror had the same content
  but in a different tar.gz package
---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
