### PR TITLE
redis 4.0.12

### DIFF
--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -1,0 +1,79 @@
+class RedisAT40 < Formula
+  desc "Persistent key-value database, with built-in net interface"
+  homepage "https://redis.io/"
+  url "http://download.redis.io/releases/redis-4.0.11.tar.gz"
+  sha256 "fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "3fe9646ce3289742cea430d232d119e5379cddf046a87fc6e241399958e906db" => :high_sierra
+    sha256 "87ef8c6f7b036f61d2c65b6e9304c9dadff608d956aa132816832e8a760f60c3" => :sierra
+    sha256 "20f218187739eab0d8fe48ba38ed3cf496abd03ae4e9664a90923d78f26e7d3a" => :el_capitan
+  end
+
+  keg_only :versioned_formula
+
+  option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"
+
+  def install
+    # Architecture isn't detected correctly on 32bit Snow Leopard without help
+    ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
+
+    args = %W[
+      PREFIX=#{prefix}
+      CC=#{ENV.cc}
+    ]
+    args << "MALLOC=jemalloc" if build.with? "jemalloc"
+    system "make", "install", *args
+
+    %w[run db/redis log].each { |p| (var/p).mkpath }
+
+    # Fix up default conf file to match our paths
+    inreplace "redis.conf" do |s|
+      s.gsub! "/var/run/redis.pid", var/"run/redis.pid"
+      s.gsub! "dir ./", "dir #{var}/db/redis/"
+      s.sub!  /^bind .*$/, "bind 127.0.0.1 ::1"
+    end
+
+    etc.install "redis.conf"
+    etc.install "sentinel.conf" => "redis-sentinel.conf"
+  end
+
+  plist_options :manual => "redis-server #{HOMEBREW_PREFIX}/etc/redis.conf"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/redis-server</string>
+          <string>#{etc}/redis.conf</string>
+          <string>--daemonize no</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/redis.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/redis.log</string>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    system bin/"redis-server", "--test-memory", "2"
+    %w[run db/redis log].each { |p| assert_predicate var/p, :exist?, "#{var/p} doesn't exist!" }
+  end
+end

--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -4,13 +4,6 @@ class RedisAT40 < Formula
   url "http://download.redis.io/releases/redis-4.0.11.tar.gz"
   sha256 "fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "3fe9646ce3289742cea430d232d119e5379cddf046a87fc6e241399958e906db" => :high_sierra
-    sha256 "87ef8c6f7b036f61d2c65b6e9304c9dadff608d956aa132816832e8a760f60c3" => :sierra
-    sha256 "20f218187739eab0d8fe48ba38ed3cf496abd03ae4e9664a90923d78f26e7d3a" => :el_capitan
-  end
-
   keg_only :versioned_formula
 
   option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"

--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -1,23 +1,16 @@
 class RedisAT40 < Formula
   desc "Persistent key-value database, with built-in net interface"
   homepage "https://redis.io/"
-  url "http://download.redis.io/releases/redis-4.0.11.tar.gz"
-  sha256 "fc53e73ae7586bcdacb4b63875d1ff04f68c5474c1ddeda78f00e5ae2eed1bbb"
+  url "https://github.com/antirez/redis/archive/4.0.12.tar.gz"
+  sha256 "d11767986ba90b7bad6cc8bc67419a3900d86c047a453fab1deedb71875ff65c"
 
   keg_only :versioned_formula
-
-  option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"
 
   def install
     # Architecture isn't detected correctly on 32bit Snow Leopard without help
     ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
 
-    args = %W[
-      PREFIX=#{prefix}
-      CC=#{ENV.cc}
-    ]
-    args << "MALLOC=jemalloc" if build.with? "jemalloc"
-    system "make", "install", *args
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}"
 
     %w[run db/redis log].each { |p| (var/p).mkpath }
 
@@ -32,7 +25,7 @@ class RedisAT40 < Formula
     etc.install "sentinel.conf" => "redis-sentinel.conf"
   end
 
-  plist_options :manual => "redis-server #{HOMEBREW_PREFIX}/etc/redis.conf"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/redis@4.0/bin/redis-server"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>

--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -25,7 +25,7 @@ class RedisAT40 < Formula
     etc.install "sentinel.conf" => "redis-sentinel.conf"
   end
 
-  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/redis@4.0/bin/redis-server"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/redis@4.0/bin/redis-server #{HOMEBREW_PREFIX}/etc/redis.conf"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Now(October 23th, 2018), we can install redis@5 and redis@3 by `brew install`, 
but we cannot do redis@4. 
So, I add a new formula for redis4.
