### PR TITLE
evince: remove shared-mime-info dependency

### DIFF
--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -3,6 +3,7 @@ class Evince < Formula
   homepage "https://wiki.gnome.org/Apps/Evince"
   url "https://download.gnome.org/sources/evince/3.30/evince-3.30.1.tar.xz"
   sha256 "abc5516848e743bd79645e9693250974ffd5235617dd746c83b67c4c671ac0b7"
+  revision 1
 
   bottle do
     sha256 "c7bfedb128c67d2f8da4294250abefd6629c028a80cf5da57b84af8b3bd7a878" => :mojave
@@ -24,7 +25,6 @@ class Evince < Formula
   depends_on "libxml2"
   depends_on "poppler"
   depends_on "python@2"
-  depends_on "shared-mime-info"
 
   def install
     # Fix build failure "ar: illegal option -- D"
@@ -52,7 +52,6 @@ class Evince < Formula
   def post_install
     system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
     system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
-    system "#{Formula["shared-mime-info"].opt_bin}/update-mime-database", "#{HOMEBREW_PREFIX}/share/mime"
   end
 
   test do


### PR DESCRIPTION
It has been unused for a couple of releases and started creating problems on Jenkins