### PR TITLE
sng 1.1.0 (new formula)

### DIFF
--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -11,6 +11,7 @@ class Sng < Formula
   end
 
   test do
-    system "curl", "-o", "test.png", "https://upload.wikimedia.org/wikipedia/en/2/2c/WikiPNGRenderingTestB_Thumb_RGB.png", "&&", "sng", "test.png", "&&", "true"
+    system("curl -o $HOME/test.png 'https://upload.wikimedia.org/wikipedia/en/2/2c/WikiPNGRenderingTestB_Thumb_RGB.png'")
+    system("sng $HOME/test.png")
   end
 end

--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -12,6 +12,6 @@ class Sng < Formula
 
   test do
     system("curl -o $HOME/test.png 'https://upload.wikimedia.org/wikipedia/en/2/2c/WikiPNGRenderingTestB_Thumb_RGB.png'")
-    system("sng $HOME/test.png")
+    system("$bin/sng $HOME/test.png")
   end
 end

--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -1,0 +1,16 @@
+class Sng < Formula
+  desc "Enable lossless editing of PNGs via a textual representation"
+  homepage "https://sng.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/sng/sng-1.1.0.tar.gz"
+  sha256 "119c55870c1d1bdc65f7de9dbc62929ccb0c301c2fb79f77df63f5d477f34619"
+  depends_on "libpng"
+
+  def install
+    system "./configure", "--prefix=/usr/local/Cellar/sng/1.1.0"
+    system "make", "install"
+  end
+
+  test do
+    system "curl", "-o", "test.png", "https://upload.wikimedia.org/wikipedia/en/2/2c/WikiPNGRenderingTestB_Thumb_RGB.png", "&&", "sng", "test.png", "&&", "true"
+  end
+end


### PR DESCRIPTION
Adds a new formula for the Scriptable Network Graphics compiler/decompiler, `sng`

- [ √] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [√ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ √] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [√ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
