### PR TITLE
Don't advise users to upgrade pip, setuptools or wheel.

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -350,9 +350,6 @@ class Python < Formula
       If you need Homebrew's Python 2.7 run
         brew install python@2
 
-      Pip, setuptools, and wheel have been installed. To update them run
-        pip3 install --upgrade pip setuptools wheel
-
       You can install Python packages with
         pip3 install <package>
       They will install into the site-package directory


### PR DESCRIPTION
Upgrading pip, setuptools or wheel causes the installer to overwrite
the python2 versions of pip, easy_install and wheel with python3
versions. This is a cause for confusion for users. The pip,
setuptools and wheel modules should only be upgraded when upgrading
python using brew.