### PR TITLE
fltkwithcairo 1.4.0-r13071 (devel)

### DIFF
--- a/Formula/fltkwithcairo.rb
+++ b/Formula/fltkwithcairo.rb
@@ -1,0 +1,32 @@
+class Fltkwithcairo < Formula
+  desc "Latest non-stable branch of FLTK *with* Cairo support enabled"
+  homepage "http://www.fltk.org/"
+  url "http://fltk.org/pub/fltk/snapshots/fltk-1.4.x-r13071.tar.gz"
+  version "1.4.x-r13071"
+  sha256 "09ea8ae57aa5a5c0e017607d69e4beba0227181e431a9cbb54c1dfa5d082e3b3"
+
+  depends_on "cairo"
+  depends_on "jpeg"
+  depends_on "libpng"
+
+  def install
+    archcmd = "uname -m"
+    sysarch = `#{archcmd}`.tr("\n", "")
+    compiler_flags = " -g -DBUILD_SHARED_LIBS -D__APPLE__"
+    include_flags = " -I /usr/local/opt/cairo/include/cairo"
+    config_args = [
+      "--prefix=#{prefix}",
+      "--enable-cairo",
+      "--enable-threads",
+      "CC=clang" + compiler_flags + " -arch " + sysarch + include_flags,
+      "CXX=clang++" + compiler_flags + " -arch " + sysarch + include_flags,
+    ]
+    system "make", "clean"
+    system "./configure", *config_args
+    system "make", "install"
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
# Addressing prerequisites: 

- Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? :white_check_mark:
- Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? :white_check_mark:
- Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? :white_check_mark:
- Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? :white_check_mark:
-----

# Summary of the pull request

We have a new application which requires the FLTK library (on Mac OSX) built with the most recent *development* branch 1.4.x, which is currently not available with the existing [fltk formula](https://formulae.brew.sh/formula/fltk), **AND** which is built with the configure options ``--enable-cairo --enable-threads``. Note that based on my experimentation building *FLTK* (both revisons 1.3.x and 1.4.x) on the most recent versions of *Mojave*, adding in the ``--enable-cairo`` support -- *AND* -- getting the end application to correctly link with it are seemingly daunting tasks. I have created from-source build instructions [here](https://github.com/gtDMMB/RNAStructViz/tree/with-cairo#building-fltk-13x-from-source) which summarize the following necessary configure flags to get this support completely up and running off the ground:
```
$ ./configure --enable-cairo --enable-threads --with-archflags="-arch $(uname -m)" CC="clang -g -DBUILD_SHARED_LIBS -D__APPLE__ -arch $(uname -m)" CXX="clang++ -g -DBUILD_SHARED_LIBS -D__APPLE__ -arch $(uname -m)"
$ make 
$ sudo make install
```
Given the new complexities that enabling [cairo support](https://formulae.brew.sh/formula/cairo) with FLTK involves, we feel it is warranted that a separate brew formula should be created to handle this option. This is not unlike Debian's ``apt`` which also offers a separate *with-cairo* package for FLTK. 

Please include our new formula in the default repository so we can have users install the prerequisites for our application using ``brew`` and non-sudo permissions on OSX. Thank you for the great program! Keep up the good work!
