### PR TITLE
binutils: make `keg_only`

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -4,6 +4,7 @@ class Binutils < Formula
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.gz"
   sha256 "e88f8d36bd0a75d3765a4ad088d819e35f8d7ac6288049780e2fefcad18dde88"
+  revision 1
 
   bottle do
     sha256 "92fdc2c6b6b95c3944156ad3da3b5c8a3118c245e088712df451237de67d6732" => :mojave
@@ -12,13 +13,13 @@ class Binutils < Formula
     sha256 "7c693e68ebfcd654fd781480e68469e8f5af93c7397754a8caae1937322feb8f" => :el_capitan
   end
 
-  # No --default-names option as it interferes with Homebrew builds.
+  keg_only :provided_by_macos,
+           "because Apple provides the same tools and binutils is poorly supported on macOS"
 
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--enable-deterministic-archives",
-                          "--program-prefix=g",
                           "--prefix=#{prefix}",
                           "--infodir=#{info}",
                           "--mandir=#{man}",
@@ -29,9 +30,12 @@ class Binutils < Formula
                           "--enable-targets=all"
     system "make"
     system "make", "install"
+    Dir["#{bin}/*"].each do |f|
+      bin.install_symlink f => "g" + File.basename(f)
+    end
   end
 
   test do
-    assert_match "main", shell_output("#{bin}/gnm #{bin}/gnm")
+    assert_match "Usage:", shell_output("#{bin}/strings #{bin}/strings")
   end
 end

--- a/Formula/pwntools.rb
+++ b/Formula/pwntools.rb
@@ -13,7 +13,6 @@ class Pwntools < Formula
     sha256 "3b4d273279f53627c5125be3bbb498d11339502565dc631e5dc6c7fe9badaf4f" => :sierra
   end
 
-  depends_on "binutils"
   depends_on "openssl"
   depends_on "python@2" # does not support Python 3
 


### PR DESCRIPTION
`gnm` is broken with macOS 10.14 Mojave/XCode 10. This breaks gcc when
binutils is linked.

Fixes: https://github.com/Homebrew/homebrew-core/issues/32516

See also: https://sourceware.org/bugzilla/show_bug.cgi?id=23728

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
