### PR TITLE
dosbox-x: remove unneeded `build.with`

### DIFF
--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -39,15 +39,11 @@ class DosboxX < Formula
                 "setCD(clientsocket > 0)", "setCD(clientsocket != 0)"
     end
 
-    args = %W[
-      --prefix=#{prefix}
-      --disable-dependency-tracking
-      --disable-sdltest
-      --enable-core-inline
-    ]
-    args << "--enable-debug" if build.with? "debugger"
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-sdltest",
+                          "--enable-core-inline"
 
-    system "./configure", *args
     chmod 0755, "install-sh"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
