### PR TITLE
asciidoc: add source-highlight dependency

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -4,7 +4,7 @@ class Asciidoc < Formula
   # This release is listed as final on GitHub, but not listed on asciidoc.org.
   url "https://github.com/asciidoc/asciidoc/archive/8.6.10.tar.gz"
   sha256 "9e52f8578d891beaef25730a92a6e723596ddbd07bfe0d2a56486fcf63a0b983"
-  revision 1
+  revision 2
   head "https://github.com/asciidoc/asciidoc.git"
 
   bottle do
@@ -18,6 +18,7 @@ class Asciidoc < Formula
   depends_on "autoconf" => :build
   depends_on "docbook-xsl" => :build
   depends_on "docbook"
+  depends_on "source-highlight"
 
   def install
     ENV.prepend_path "PATH", "/System/Library/Frameworks/Python.framework/Versions/2.7/bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without `source-highlight`, `asciidoc` cannot render source code:

```
▶ cat foo.adoc
= Hello, AsciiDoc!
Doc Writer <doc@example.com>

An introduction to http://asciidoc.org[AsciiDoc].

== First Section

* item 1
* item 2

[source,ruby]
puts "Hello, World!"
```

```
▶ asciidoc foo.adoc
/bin/sh: source-highlight: command not found
asciidoc: WARNING: foo.adoc: line 12: filter non-zero exit code: source-highlight --gen-version -f xhtml -s ruby: returned 127
asciidoc: WARNING: foo.adoc: line 12: no output from filter: source-highlight --gen-version -f xhtml -s ruby
```