### PR TITLE
uriparser 0.9.0

### DIFF
--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,8 +1,8 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
-  url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.8.6/uriparser-0.8.6.tar.bz2"
-  sha256 "0709a7e572417db763f0356250d91686c19a64ab48e9da9f5a1e8055dc2a4a54"
+  url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.0/uriparser-0.9.0.tar.bz2"
+  sha256 "ec67eb34feda8eac166f281799f03ed48387694fca44f6f5852f61f8fb535e2c"
 
   bottle do
     cellar :any
@@ -20,12 +20,24 @@ class Uriparser < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "cpptest"
 
   conflicts_with "libkml", :because => "both install `liburiparser.dylib`"
 
+  resource "gtest" do
+    url "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
+    sha256 "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
+  end
+
   def install
+    (buildpath/"gtest").install resource("gtest")
+    (buildpath/"gtest/googletest").cd do
+      system "cmake", "."
+      system "make"
+    end
+    ENV["GTEST_CFLAGS"] = "-I./gtest/googletest/include"
+    ENV["GTEST_LIBS"] = "-L./gtest/googletest/ -lgtest"
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? *Supercedes #33452*
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Bumps uriparser to 0.9.0 and vendors gtest in.

Closes https://github.com/Homebrew/homebrew-core/pull/33452.
