### PR TITLE
ruby: make keg-only (as provided by macOS).

### DIFF
--- a/Formula/braid.rb
+++ b/Formula/braid.rb
@@ -26,6 +26,13 @@ class Braid < Formula
     sha256 "766f2fcce6ac3cc152249ed0f2b827770d3e517e2e87c5fba7ed74f4889d2dc3"
   end
 
+  if MacOS.version <= :sierra
+    resource "json" do
+      url "https://rubygems.org/gems/json-2.1.0.gem"
+      sha256 "b76fd09b881088c6c64a12721a1528f2f747a1c2ee52fab4c1f60db8af946607"
+    end
+  end
+
   resource "fattr" do
     url "https://rubygems.org/gems/fattr-2.3.0.gem"
     sha256 "0430a798270a7097c8c14b56387331808b8d9bb83904ba643b196c895bdf5993"

--- a/Formula/braid.rb
+++ b/Formula/braid.rb
@@ -4,6 +4,7 @@ class Braid < Formula
   url "https://github.com/cristibalan/braid.git",
       :tag      => "v1.1.2",
       :revision => "4a7eea721fd9c841e305b19ebd6e8c7006c52f53"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/haste-client.rb
+++ b/Formula/haste-client.rb
@@ -31,6 +31,13 @@ class HasteClient < Formula
     sha256 "6299046a78613ce330b67060e648a132ba7cca4f0ea769bc1d2bbcb22a23ec94"
   end
 
+  if MacOS.version <= :sierra
+    resource "json" do
+      url "https://rubygems.org/gems/json-2.1.0.gem"
+      sha256 "b76fd09b881088c6c64a12721a1528f2f747a1c2ee52fab4c1f60db8af946607"
+    end
+  end
+
   resource "multipart-post" do
     url "https://rubygems.org/gems/multipart-post-2.0.0.gem"
     sha256 "3dc44e50d3df3d42da2b86272c568fd7b75c928d8af3cc5f9834e2e5d9586026"

--- a/Formula/haste-client.rb
+++ b/Formula/haste-client.rb
@@ -1,7 +1,7 @@
 class HasteClient < Formula
   desc "CLI client for haste-server"
   homepage "https://hastebin.com/"
-  revision 3
+  revision 4
   head "https://github.com/seejohnrun/haste-client.git"
 
   stable do

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -16,7 +16,7 @@ class Mikutter < Formula
   depends_on "gobject-introspection"
   depends_on "gtk+"
   depends_on "libidn"
-  depends_on "ruby"
+  depends_on "ruby" if MacOS.version <= :high_sierra
   depends_on "terminal-notifier"
 
   resource "addressable" do

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -223,7 +223,7 @@ class Mikutter < Formula
       export GEM_HOME="#{HOMEBREW_PREFIX}/lib/mikutter/vendor"
       export GTK_PATH="#{HOMEBREW_PREFIX}/lib/gtk-2.0"
 
-      exec ruby "#{libexec}/mikutter.rb" "$@"
+      exec #{which("ruby")} "#{libexec}/mikutter.rb" "$@"
     EOS
   end
 

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -3,6 +3,7 @@ class Mikutter < Formula
   homepage "https://mikutter.hachune.net/"
   url "https://mikutter.hachune.net/bin/mikutter.3.7.4.tar.gz"
   sha256 "7695a76a809555b2688b56f5335834fd876f82ce1b645815ec2020aedbdff55c"
+  revision 1
   head "git://toshia.dip.jp/mikutter.git", :branch => "develop"
 
   bottle do

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -3,6 +3,7 @@ class Ruby < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.xz"
   sha256 "1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f"
+  revision 1
 
   bottle do
     sha256 "6c620464fee701978124bdb9ef12179fb55ba62e73222ed42d59e6c07d25a04a" => :mojave

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -15,6 +15,8 @@ class Ruby < Formula
     depends_on "autoconf" => :build
   end
 
+  keg_only :provided_by_macos
+
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl"
@@ -33,7 +35,7 @@ class Ruby < Formula
   end
 
   def rubygems_bindir
-    HOMEBREW_PREFIX/"bin"
+    HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/bin"
   end
 
   def install
@@ -181,6 +183,14 @@ class Ruby < Formula
         "#{opt_bin}/ruby"
       end
     end
+  EOS
+  end
+
+  def caveats; <<~EOS
+    By default, binaries installed by gem will be placed into:
+      #{rubygems_bindir}
+
+    You may want to add this to your PATH.
   EOS
   end
 

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -3,7 +3,7 @@ class Travis < Formula
   homepage "https://github.com/travis-ci/travis.rb/"
   url "https://github.com/travis-ci/travis.rb/archive/v1.8.9.tar.gz"
   sha256 "7a143bd0eb90e825370c808d38b70cca8c399c68bea8138442f40f09b6bbafc4"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -55,6 +55,13 @@ class Travis < Formula
     sha256 "1e147d5d20f1ad5b0e23357070d1e6d0904ae9f71c3c49e0234cf682ae3c2b06"
   end
 
+  if MacOS.version <= :sierra
+    resource "json" do
+      url "https://rubygems.org/gems/json-2.1.0.gem"
+      sha256 "b76fd09b881088c6c64a12721a1528f2f747a1c2ee52fab4c1f60db8af946607"
+    end
+  end
+
   resource "launchy" do
     url "https://rubygems.org/gems/launchy-2.4.3.gem"
     sha256 "42f52ce12c6fe079bac8a804c66522a0eefe176b845a62df829defe0e37214a4"


### PR DESCRIPTION
This makes it consistent with the other Ruby formulae and avoids weird PATH issues (exactly what keg-only is designed for).

Discussion in https://github.com/Homebrew/brew/issues/5155.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----