### PR TITLE
gcc@5: use DWARF-2 under pre-Mavericks.

### DIFF
--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -138,6 +138,11 @@ class GccAT5 < Formula
 
     args << "--disable-nls" if build.without? "nls"
 
+    # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
+    # format to avoid failure during the stage 3 comparison of object files.
+    # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version <= :mountain_lion
+
     if MacOS.prefer_64_bit?
       args << "--enable-multilib"
     else


### PR DESCRIPTION
The pre-Mavericks toolchain requires the older DWARF-2 debugging data
format to avoid failure during the stage 3 comparison of object files.

Re-apply of Homebrew/legacy-homebrew#46111

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This made it possible for me to compile gcc@5 under Snow Leopard 10.6.8 (with Homebrew gcc-4.9 - not sure if this matters at all). I can't truthfully check the lower two checkboxes as 1. I just used brew install with other flags (and the compilation takes around 4 hours so...) and 2. I don't have access to the machine at this moment so I can't check if the audit command passes but as I didn't change really anything about the packaging it should be fine.