### PR TITLE
git: add caveat explaining Net::SMTP::SSL module

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -152,6 +152,14 @@ class Git < Formula
     etc.install "gitconfig"
   end
 
+  def caveats; <<~EOS
+    Sending email via git send-email requires the Perl Net::SMTP::SSL module.
+    If your system Perl does not already have it, you can install it via:
+
+      sudo /usr/bin/cpan Net::SMTP::SSL
+  EOS
+  end
+
   test do
     system bin/"git", "init"
     %w[haunted house].each { |f| touch testpath/f }


### PR DESCRIPTION
Explain what needs to be done to have Git use the system Perl module necessary
for sending emails. This addresses #33524 (and partly #12870), as brew git
does not use modules from brewed Perl.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
