### PR TITLE
Remove postgresql options

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -13,32 +13,18 @@ class Postgresql < Formula
     sha256 "abd8104c82358d6067399b8001aec86738d2aced1a0c78cd1c9cb33b129098a5" => :el_capitan
   end
 
-  option "without-perl", "Build without Perl support"
-  option "without-tcl", "Build without Tcl support"
-  option "with-dtrace", "Build with DTrace support"
-  option "with-python", "Enable PL/Python3 (incompatible with --with-python@2)"
-  option "with-python@2", "Enable PL/Python2"
+  option "with-python", "Enable PL/Python3"
 
-  deprecated_option "no-perl" => "without-perl"
-  deprecated_option "no-tcl" => "without-tcl"
-  deprecated_option "enable-dtrace" => "with-dtrace"
   deprecated_option "with-python3" => "with-python"
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "openssl"
   depends_on "readline"
-
   depends_on "python" => :optional
-  depends_on "python@2" => :optional
 
   conflicts_with "postgres-xc",
     :because => "postgresql and postgres-xc install the same binaries."
-
-  fails_with :clang do
-    build 211
-    cause "Miscompilation resulting in segfault on queries"
-  end
 
   def install
     # avoid adding the SDK library directory to the linker search path
@@ -57,37 +43,29 @@ class Postgresql < Formula
       --enable-thread-safety
       --with-bonjour
       --with-gssapi
+      --with-icu
       --with-ldap
-      --with-openssl
-      --with-pam
       --with-libxml
       --with-libxslt
-      --with-icu
+      --with-openssl
+      --with-pam
+      --with-perl
+      --with-uuid=e2fs
     ]
 
-    args << "--with-perl" if build.with? "perl"
-
-    which_python = nil
-    if build.with?("python") && build.with?("python@2")
-      odie "Cannot provide both --with-python and --with-python@2"
-    elsif build.with?("python") || build.with?("python@2")
+    if build.with?("python")
       args << "--with-python"
-      which_python = which(build.with?("python") ? "python3" : "python2.7")
+      ENV["PYTHON"] = which("python3")
     end
-    ENV["PYTHON"] = which_python
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK
-    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
+    if MacOS.version >= :mavericks || MacOS::CLT.installed?
       args << "--with-tcl"
-
       if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
         args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
       end
     end
-
-    args << "--enable-dtrace" if build.with? "dtrace"
-    args << "--with-uuid=e2fs"
 
     # As of Xcode/CLT 10.x the Perl headers were moved from /System
     # to inside the SDK, so we need to use `-iwithsysroot` instead

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -14,20 +14,11 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  option "without-perl", "Build without Perl support"
-  option "without-tcl", "Build without Tcl support"
-  option "with-dtrace", "Build with DTrace support"
-
   deprecated_option "with-python" => "with-python@2"
 
   depends_on "openssl"
   depends_on "readline"
   depends_on "python@2" => :optional
-
-  fails_with :clang do
-    build 211
-    cause "Miscompilation resulting in segfault on queries"
-  end
 
   def install
     # Fix "configure: error: readline library not found"
@@ -52,22 +43,19 @@ class PostgresqlAT94 < Formula
       --with-pam
       --with-libxml
       --with-libxslt
+      --with-perl
+      --with-uuid=e2fs
     ]
 
-    args << "--with-perl" if build.with? "perl"
     args << "--with-python" if build.with? "python@2"
 
     # The CLT is required to build tcl support on 10.7 and 10.8 because tclConfig.sh is not part of the SDK
-    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
+    if MacOS.version >= :mavericks || MacOS::CLT.installed?
       args << "--with-tcl"
-
       if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
         args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
       end
     end
-
-    args << "--enable-dtrace" if build.with? "dtrace"
-    args << "--with-uuid=e2fs"
 
     # As of Xcode/CLT 10.x the Perl headers were moved from /System
     # to inside the SDK, so we need to use `-iwithsysroot` instead

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -14,23 +14,13 @@ class PostgresqlAT95 < Formula
 
   keg_only :versioned_formula
 
-  option "without-perl", "Build without Perl support"
-  option "without-tcl", "Build without Tcl support"
-  option "with-dtrace", "Build with DTrace support"
-  option "with-python", "Build with Python3 (incompatible with --with-python@2)"
-  option "with-python@2", "Build with Python2 (incompatible with --with-python)"
+  option "with-python", "Build with Python3"
 
   deprecated_option "with-python3" => "with-python"
 
   depends_on "openssl"
   depends_on "readline"
   depends_on "python" => :optional
-  depends_on "python@2" => :optional
-
-  fails_with :clang do
-    build 211
-    cause "Miscompilation resulting in segfault on queries"
-  end
 
   def install
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
@@ -50,35 +40,27 @@ class PostgresqlAT95 < Formula
       --with-bonjour
       --with-gssapi
       --with-ldap
-      --with-openssl
-      --with-pam
       --with-libxml
       --with-libxslt
+      --with-openssl
+      --with-pam
+      --with-perl
+      --with-uuid=e2fs
     ]
 
-    args << "--with-perl" if build.with? "perl"
-
-    which_python = nil
-    if build.with?("python") && build.with?("python@2")
-      odie "Cannot provide both --with-python and --with-python@2"
-    elsif build.with?("python") || build.with?("python@2")
+    if build.with?("python")
       args << "--with-python"
-      which_python = which(build.with?("python") ? "python3" : "python2.7")
+      ENV["PYTHON"] = which("python3")
     end
-    ENV["PYTHON"] = which_python
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK
-    if build.with?("tcl") && (MacOS.version >= :mavericks || MacOS::CLT.installed?)
+    if MacOS.version >= :mavericks || MacOS::CLT.installed?
       args << "--with-tcl"
-
       if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
         args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
       end
     end
-
-    args << "--enable-dtrace" if build.with? "dtrace"
-    args << "--with-uuid=e2fs"
 
     # As of Xcode/CLT 10.x the Perl headers were moved from /System
     # to inside the SDK, so we need to use `-iwithsysroot` instead


### PR DESCRIPTION
Python is the only option with significant usage, keeping it.

```
==> install_on_request (90 days)
Index | Name (with options)                                 |   Count |  Percent
-----:|-----------------------------------------------------|--------:|--------:
01    | postgresql                                          | 144,883 |   99.27%
02    | postgresql --with-python                            |     593 |    0.41%
03    | postgresql --with-dtrace --with-python              |     156 |    0.11%
04    | postgresql --without-perl                           |      46 |    0.03%
05    | postgresql --with-python@2                          |      45 |    0.03%
06    | postgresql --without-tcl                            |      40 |    0.03%
07    | postgresql --without-perl --without-tcl             |      35 |    0.02%
08    | postgresql --without-perl --without-tcl --with-pyth |      26 |    0.02%
09    | postgresql --HEAD                                   |      20 |    0.01%
10    | postgresql --with-python --with-python@2            |      17 |    0.01%
11    | postgresql --with-dtrace                            |      16 |    0.01%
12    | postgresql --HEAD --with-python                     |      11 |    0.01%
13    | postgresql --HEAD --with-dtrace --with-python       |       9 |    0.01%
14    | postgresql --with-dtrace --with-python@2            |       9 |    0.01%
15    | postgresql --HEAD --without-perl --with-python@2    |       8 |    0.01%
16    | postgresql --HEAD --without-perl --with-python      |       7 |    0.00%
17    | postgresql --HEAD --without-perl --with-python --wi |       7 |    0.00%
18    | postgresql --without-tcl --with-python              |       7 |    0.00%
19    | postgreSQL                                          |       4 |    0.00%
20    | postgresql --without-perl --with-dtrace --with-pyth |       4 |    0.00%
21    | postgresql --without-perl --without-tcl --with-dtra |       4 |    0.00%
22    | postgresql --without-perl --with-python             |       3 |    0.00%
23    | postgresql --without-perl --without-tcl --with-dtra |       3 |    0.00%
Total |                                                     | 145,953 |  100.00%
```