### PR TITLE
Include 'emacs-module.h' header when option is enabled

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -108,6 +108,10 @@ class Emacs < Formula
       (bin/"ctags").unlink
       (man1/"ctags.1.gz").unlink
     end
+
+    if build.with? "modules"
+      include.install "src/emacs-module.h"
+    end
   end
 
   def caveats


### PR DESCRIPTION
- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
