### PR TITLE
sqlcipher: option to statically link OpenSSL

### DIFF
--- a/Formula/sqlcipher.rb
+++ b/Formula/sqlcipher.rb
@@ -14,6 +14,7 @@ class Sqlcipher < Formula
   end
 
   option "with-fts", "Build with full-text search enabled"
+  option "with-static-linking", "Build SQLCipher with OpenSSL statically linked instead of dynamically linked"
 
   depends_on "openssl"
 
@@ -21,10 +22,18 @@ class Sqlcipher < Formula
     args = %W[
       --prefix=#{prefix}
       --enable-tempstore=yes
-      --with-crypto-lib=#{Formula["openssl"].opt_prefix}
+      --with-crypto-lib=openssl
       --enable-load-extension
       --disable-tcl
     ]
+
+    # Static vs. dynamic linking of libcrypto is documented here:
+    # https://www.zetetic.net/sqlcipher/introduction/
+    if build.with?("static-linking")
+      args << %Q(LDFLAGS=#{Formula["openssl"].opt_prefix}/lib/libcrypto.a)
+    else
+      args << %Q(LDFLAGS=-L#{Formula["openssl"].opt_prefix}/lib -lcrypto)
+    end
 
     if build.with?("fts")
       args << "CFLAGS=-DSQLITE_HAS_CODEC -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS5"


### PR DESCRIPTION
I'm building a desktop app that uses SQLCipher (i.e.
libsqlcipher.a). My app crashed when it was deployed to macOS
computers that *don't* have OpenSSL installed via Homebrew (i.e. most
non-developers). This was because I was using Homebrew for development
and by default, SQLCipher installed via Homebrew *dynamically* links
OpenSSL (i.e. /usr/local/opt/openssl/lib/libcrypto.dylib), causing
crashes on computers that don't have that file (i.e. computers without
OpenSSL installed via Homebrew)

This change allows a `--with-static-linking` option that builds
SQLCipher with the OpenSSL crypto lib *statically* linked.

It took me a week to track the root cause of this down because it was
so low level in relation to my app. I was following the instructions
on the README of node-sqlite3, which give examples of building native
modules against SQLCipher from Homebrew.

Resources:
* https://www.zetetic.net/sqlcipher/introduction/ (builidng SQLCipher
  with static linking)
* https://github.com/mapbox/node-sqlite3#building-for-sqlcipher (if
  you follow the current instructions for Electron+SQLCipher, you're
  left with an app that is undeployable to machines without OpenSSL
  installed via Homebrew).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
