### PR TITLE
crystal 0.27.0

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -44,6 +44,10 @@ class Crystal < Formula
   def install
     (buildpath/"boot").install resource("boot")
 
+    if build.head?
+      ENV["CRYSTAL_CONFIG_BUILD_COMMIT"] = Utils.popen_read("git rev-parse --short HEAD").strip
+    end
+
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
     ENV.append_path "PATH", "boot/bin"
 

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,11 +1,10 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
-  revision 1
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.26.1.tar.gz"
-    sha256 "b7c755a7d0f49f572ae5c08b8b0139fcb1c6862c9479dfae74f00e2c8424fcb0"
+    url "https://github.com/crystal-lang/crystal/archive/0.27.0.tar.gz"
+    sha256 "43c8ac1b5c59ccea3cd58c9bd2a7af07a56f96cf1eff1e54d93f648b5340e83a"
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz"
@@ -37,19 +36,13 @@ class Crystal < Formula
   depends_on "pcre"
 
   resource "boot" do
-    url "https://github.com/crystal-lang/crystal/releases/download/0.26.0/crystal-0.26.0-1-darwin-x86_64.tar.gz"
-    version "0.26.0-1"
-    sha256 "13ccd6425593f33f7423423553bc5c2fdcf5d76b6b97b82bf4204bc55831ec43"
+    url "https://github.com/crystal-lang/crystal/releases/download/0.26.1/crystal-0.26.1-1-darwin-x86_64.tar.gz"
+    version "0.26.1-1"
+    sha256 "3ad9616204d36ee4171e15892ee32216eab06f87f1f6cf5e32b45196dd4231d7"
   end
 
   def install
     (buildpath/"boot").install resource("boot")
-
-    if build.head?
-      ENV["CRYSTAL_CONFIG_VERSION"] = Utils.popen_read("git rev-parse --short HEAD").strip
-    else
-      ENV["CRYSTAL_CONFIG_VERSION"] = version
-    end
 
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
     ENV.append_path "PATH", "boot/bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Crystal 0.27.0 has been released.
The `CRYSTAL_CONFIG_VERSION` is no longer used.
It still requires llvm@6.

~~I am not sure if the `revision` should be changed or not.~~