### PR TITLE
re-enable ext-tidy for PHP

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -10,9 +10,6 @@ class Php < Formula
     sha256 "5c16b674951b548d1b11fe77d172b99bfca57ce90122c315e86ef53a0530ee9b" => :sierra
   end
 
-  option "with-tidy", "Compile tidy extension"
-  option "with-homebrew-tidy-html5", "Compile tidy extension with html5 support"
-
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -37,7 +34,7 @@ class Php < Formula
   depends_on "openssl"
   depends_on "pcre"
   depends_on "sqlite"
-  depends_on "tidy-html5" if build.with?("homebrew-tidy-html5")
+  depends_on "tidy-html5"
   depends_on "unixodbc"
   depends_on "webp"
 
@@ -155,6 +152,7 @@ class Php < Formula
       --with-pspell=#{Formula["aspell"].opt_prefix}
       --with-sodium=#{Formula["libsodium"].opt_prefix}
       --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
       --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
       --with-webp-dir=#{Formula["webp"].opt_prefix}
       --with-xmlrpc
@@ -176,12 +174,6 @@ class Php < Formula
 
     if MacOS.sdk_path_if_needed
       args << "--with-iconv=#{Formula["libiconv"].opt_prefix}"
-    end
-
-    if build.with?("homebrew-tidy-html5")
-      args << "--with-tidy=#{Formula["tidy-html5"].opt_prefix}"
-    elsif build.with?("tidy")
-      args << "--with-tidy"
     end
 
     system "./configure", *args

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -180,7 +180,7 @@ class Php < Formula
 
     if build.with?("homebrew-tidy-html5")
       args << "--with-tidy=#{Formula["tidy-html5"].opt_prefix}"
-    else if build.with?("tidy")
+    elsif build.with?("tidy")
       args << "--with-tidy"
     end
     

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -10,6 +10,9 @@ class Php < Formula
     sha256 "5c16b674951b548d1b11fe77d172b99bfca57ce90122c315e86ef53a0530ee9b" => :sierra
   end
 
+  option "with-tidy", "Compile tidy extension"
+  option "with-homebrew-tidy-html5", "Compile tidy extension with html5 support"
+  
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -34,6 +37,7 @@ class Php < Formula
   depends_on "openssl"
   depends_on "pcre"
   depends_on "sqlite"
+  depends_on "tidy-html5" if build.with?("homebrew-tidy-html5")
   depends_on "unixodbc"
   depends_on "webp"
 
@@ -174,6 +178,12 @@ class Php < Formula
       args << "--with-iconv=#{Formula["libiconv"].opt_prefix}"
     end
 
+    if build.with?("homebrew-tidy-html5")
+      args << "--with-tidy=#{Formula["tidy-html5"].opt_prefix}"
+    else if build.with?("tidy")
+      args << "--with-tidy"
+    end
+    
     system "./configure", *args
     system "make"
     system "make", "install"

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -12,7 +12,7 @@ class Php < Formula
 
   option "with-tidy", "Compile tidy extension"
   option "with-homebrew-tidy-html5", "Compile tidy extension with html5 support"
-  
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -183,7 +183,7 @@ class Php < Formula
     elsif build.with?("tidy")
       args << "--with-tidy"
     end
-    
+
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
Since the commit of https://github.com/Homebrew/homebrew-core/pull/25707 it's impossible to use PHP libraries that  depend on ext-tidy.

Based on https://github.com/JoyceBabu/homebrew-core/commit/a59963ccf51071cb33aec64108f9a95f47d343f8 this patch re-enables ext-tidy on demand. You have the choice to select the correct tidy library for your setup using one of these options:
- --with-tidy
- --with-homebrew-tidy-html5

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
