### PR TITLE
bazel: revision to add bottle

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -3,6 +3,7 @@ class Bazel < Formula
   homepage "https://bazel.build/"
   url "https://github.com/bazelbuild/bazel/releases/download/0.18.1/bazel-0.18.1-dist.zip"
   sha256 "baed9f28c317000a4ec1ad2571b3939356d22746ca945ac2109148d7abb860d4"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Not applicable**
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upgrading `bazel` currently fails because no bottle has been published for 0.18.1 after d5c2df4f50:

```
==> Upgrading bazel 
==> Downloading https://homebrew.bintray.com/bottles/bazel-0.18.1.mojave.bottle.tar.gz

curl: (22) The requested URL returned error: 401 Unauthorized
Error: Failed to download resource "bazel"
Download failed: https://homebrew.bintray.com/bottles/bazel-0.18.1.mojave.bottle.tar.gz
```
