### PR TITLE
calcurse: Add building from HEAD

### DIFF
--- a/Formula/calcurse.rb
+++ b/Formula/calcurse.rb
@@ -3,6 +3,7 @@ class Calcurse < Formula
   homepage "https://calcurse.org/"
   url "https://calcurse.org/files/calcurse-4.3.0.tar.gz"
   sha256 "31ecc3dc09e1e561502b4c94f965ed6b167c03e9418438c4a7ad5bad2c785f9a"
+  head "git://git.calcurse.org/calcurse.git"
 
   bottle do
     sha256 "c3f0fc356930d24114a2ef1c16679f1184ba60a4f5bb888b822f6a343f7ae5b5" => :mojave
@@ -13,9 +14,27 @@ class Calcurse < Formula
 
   depends_on "gettext"
 
+  if build.head?
+    # For documentation
+    depends_on "asciidoc" => :build
+
+    # For general building
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
-    system "make"
+    if build.head?
+      system "./autogen.sh"
+    end
+
+    system "./configure",
+      "--disable-dependency-tracking",
+      "--prefix=#{prefix}"
+
+    # NOTE: Must specify the XML_CATALOG_FILES env so AsciiDoc files
+    #       being processed through an XML stage (via a2x) can work
+    system "make", "XML_CATALOG_FILES=/usr/local/etc/xml/catalog"
     system "make", "install"
   end
 

--- a/Formula/calcurse.rb
+++ b/Formula/calcurse.rb
@@ -15,25 +15,18 @@ class Calcurse < Formula
   depends_on "gettext"
 
   if build.head?
-    # For documentation
     depends_on "asciidoc" => :build
-
-    # For general building
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
 
   def install
-    if build.head?
-      system "./autogen.sh"
-    end
+    system "./autogen.sh" if build.head?
 
-    system "./configure",
-      "--disable-dependency-tracking",
-      "--prefix=#{prefix}"
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
 
-    # NOTE: Must specify the XML_CATALOG_FILES env so AsciiDoc files
-    #       being processed through an XML stage (via a2x) can work
+    # Specify XML_CATALOG_FILES for asciidoc
     system "make", "XML_CATALOG_FILES=/usr/local/etc/xml/catalog"
     system "make", "install"
   end


### PR DESCRIPTION
The last release of calcurse was a year ago and several changes have been made in the repository since then. This enables building from HEAD to receive those changes, some of which are necessary to get calcurse-caldav to work on Mac OS X.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
