### PR TITLE
yaml-cpp: apply upstream patch to avoid installation of gtest

### DIFF
--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -3,6 +3,7 @@ class YamlCpp < Formula
   homepage "https://github.com/jbeder/yaml-cpp"
   url "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz"
   sha256 "e4d8560e163c3d875fd5d9e5542b5fd5bec810febdcba61481fe5fc4e6b1fd05"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,6 +14,14 @@ class YamlCpp < Formula
   end
 
   depends_on "cmake" => :build
+
+  # Upstream commit from Sep 3 2018 "Improvements to CMake buildsystem"
+  # which fixes the unexpected installation of Google Test.
+  # See https://github.com/jbeder/yaml-cpp/issues/539
+  patch do
+    url "https://github.com/jbeder/yaml-cpp/commit/5e79f5eed3d86125468681116e92814d2cf40067.patch?full_index=1"
+    sha256 "52da989f0dcaca68ae9ee6334155954639506e16cbe3b9bd007dace9e171e4bd"
+  end
 
   needs :cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Bottles of `yaml-cpp` currently contain a full installation of Google Test (gtest) which will be linked into the prefix, this is not expected.