### PR TITLE
pass: Set SYSTEM_EXTENSION_DIR to shared location

### DIFF
--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -19,6 +19,7 @@ class Pass < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "WITH_ALLCOMP=yes", "BASHCOMPDIR=#{bash_completion}", "ZSHCOMPDIR=#{zsh_completion}", "FISHCOMPDIR=#{fish_completion}", "install"
+    system "sed", "-e", "s:^SYSTEM_EXTENSION_DIR=.*:SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\":", "-i", "", "#{bin}/pass"
     elisp.install "contrib/emacs/password-store.el"
     pkgshare.install "contrib"
   end

--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -19,7 +19,7 @@ class Pass < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "WITH_ALLCOMP=yes", "BASHCOMPDIR=#{bash_completion}", "ZSHCOMPDIR=#{zsh_completion}", "FISHCOMPDIR=#{fish_completion}", "install"
-    system "sed", "-e", "s:^SYSTEM_EXTENSION_DIR=.*:SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\":", "-i", "", "#{bin}/pass"
+    inreplace "#{bin}/pass", /^SYSTEM_EXTENSION_DIR=.*$/, "SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\""
     elisp.install "contrib/emacs/password-store.el"
     pkgshare.install "contrib"
   end


### PR DESCRIPTION
After default build the variable is set to folder inside package cellar folder, which is very inconvenient for managing extensions. In this patch I setting the folder to some shared location under /usr/local/lib, so other extensions can link their own files there.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
