### PR TITLE
opencoarrays: revision bump for open-mpi 3.1.3

### DIFF
--- a/Formula/opencoarrays.rb
+++ b/Formula/opencoarrays.rb
@@ -3,6 +3,7 @@ class Opencoarrays < Formula
   homepage "http://opencoarrays.org"
   url "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.3.1/OpenCoarrays-2.3.1.tar.gz"
   sha256 "2b87cc8c31874ecb01e0300bc99b30e4017714fc0d17690f637d8fa4d48560f3"
+  revision 1
   head "https://github.com/sourceryinstitute/opencoarrays.git"
 
   bottle do


### PR DESCRIPTION
 - Issue reported upstream at:
   https://github.com/sourceryinstitute/OpenCoarrays/issues/604
 - OpenCoarrays/CMake should follow links for MPI less agressively or be
   made aware of Homebrew installation locations/best practices

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
