### PR TITLE
Healpix 3.40 (new formula)

### DIFF
--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -22,7 +22,6 @@ class Healpix < Formula
       system "make", "install"
     end
 
-    ENV.append_to_cflags "-DENABLE_FITSIO"
     cd "src/cxx/autotools" do
       system "autoreconf", "--install"
       system "./configure", *configure_args

--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -24,7 +24,6 @@ class Healpix < Formula
 
     ENV.append_to_cflags "-DENABLE_FITSIO"
     cd "src/cxx/autotools" do
-      system "echo", "\"AUTOMAKE_OPTIONS = subdir-objects\" >> Makefile.am"
       system "autoreconf", "--install"
       system "./configure", *configure_args
       system "make", "install"
@@ -46,7 +45,7 @@ class Healpix < Formula
         }
       };
     EOS
-    # Build step
+
     system ENV.cxx, "-o", "test", "test.cxx", "-L#{lib}", "-lchealpix"
     system "./test"
   end

--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -12,9 +12,11 @@ class Healpix < Formula
   depends_on "cfitsio"
 
   def install
-    configure_args = %W[  --disable-dependency-tracking
-                          --disable-silent-rules
-                          --prefix=#{prefix}  ]
+    configure_args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
 
     cd "src/C/autotools" do
       system "autoreconf", "--install"
@@ -35,7 +37,7 @@ class Healpix < Formula
       #include <stdio.h>
       #include "chealpix.h"
       int main(void) {
-        long   nside, npix, pp, ns1;
+        long nside, npix, pp, ns1;
         nside = 1024;
         for (pp = 0; pp < 14; pp++) {
           nside = pow(2, pp);

--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -1,0 +1,53 @@
+class Healpix < Formula
+  desc "Hierarchical Equal Area isoLatitude Pixelization of a sphere"
+  homepage "https://healpix.jpl.nasa.gov"
+  url "https://downloads.sourceforge.net/project/healpix/Healpix_3.40/Healpix_3.40_2018Jun22.tar.gz"
+  version "3.40"
+  sha256 "f10ce170a10a2f37830c65616554c39005442021741ed19c1efa998994d8a069"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "cfitsio"
+
+  def install
+    configure_args = %W[  --disable-dependency-tracking
+                          --disable-silent-rules
+                          --prefix=#{prefix}  ]
+
+    cd "src/C/autotools" do
+      system "autoreconf", "--install"
+      system "./configure", *configure_args
+      system "make", "install"
+    end
+
+    ENV.append_to_cflags "-DENABLE_FITSIO"
+    cd "src/cxx/autotools" do
+      system "echo", "\"AUTOMAKE_OPTIONS = subdir-objects\" >> Makefile.am"
+      system "autoreconf", "--install"
+      system "./configure", *configure_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cxx").write <<-EOS
+      #include <math.h>
+      #include <stdio.h>
+      #include "chealpix.h"
+      int main(void) {
+        long   nside, npix, pp, ns1;
+        nside = 1024;
+        for (pp = 0; pp < 14; pp++) {
+          nside = pow(2, pp);
+          npix = nside2npix(nside);
+          ns1  = npix2nside(npix);
+        }
+      };
+    EOS
+    # Build step
+    system ENV.cxx, "-o", "test", "test.cxx", "-L#{lib}", "-lchealpix"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This package was in homebrew-science but was never moved to
homebrew-core. This formula is basically an updated version of
what was in homebrew-science. Previous versions of this software had
a problem on macos because it used an acient autotools macro.
That macro was removed in version 3.40.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
