### PR TITLE
binutils: add patch for 10.14 compatibility

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -4,7 +4,7 @@ class Binutils < Formula
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.gz"
   sha256 "e88f8d36bd0a75d3765a4ad088d819e35f8d7ac6288049780e2fefcad18dde88"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "b4ed7c31d6738e2f084e801cb747f98cb63a4857ab5044c757ae361e3a68d32b" => :mojave
@@ -14,6 +14,14 @@ class Binutils < Formula
 
   keg_only :provided_by_macos,
            "because Apple provides the same tools and binutils is poorly supported on macOS"
+
+  # Adds support for macOS 10.14's new load commands.
+  # Will be in the next release.
+  # https://github.com/Homebrew/homebrew-core/issues/32516
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/91dc37fa4609cf1d040b5ede9f2eb971f3730597/binutils/add_mach_o_command.patch"
+    sha256 "abb053663a56c5caef35685ee60badf57e321b18f308e7cbd11626b48c876e8c"
+  end
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refs #32516 - this backports an upstream patch to add support for macOS 10.14's mach-o binaries.