### PR TITLE
php: depend on openldap and resource curl

### DIFF
--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -1,0 +1,52 @@
+class CurlOpenssl < Formula
+  desc "Get a file from an HTTP, HTTPS or FTP server"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.62.0.tar.bz2"
+  mirror "http://curl.mirror.anstey.ca/curl-7.62.0.tar.bz2"
+  sha256 "7802c54076500be500b171fde786258579d60547a3a35b8c5a23d8c88e8f9620"
+
+  keg_only :provided_by_macos
+
+  depends_on "pkg-config" => :build
+  depends_on "brotli"
+  depends_on "nghttp2"
+  depends_on "openldap"
+  depends_on "openssl"
+
+  def install
+    # Allow to build on Lion, lowering from the upstream setting of 10.8
+    ENV.append_to_cflags "-mmacosx-version-min=10.7" if MacOS.version <= :lion
+
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --disable-ares
+      --with-ca-bundle=#{etc}/openssl/cert.pem
+      --with-ca-path=#{etc}/openssl/certs
+      --with-gssapi
+      --without-libidn2
+      --without-libmetalink
+      --without-librtmp
+      --without-libssh2
+      --with-ssl=#{Formula["openssl"].opt_prefix}
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+    libexec.install "lib/mk-ca-bundle.pl"
+  end
+
+  test do
+    # Fetch the curl tarball and see that the checksum matches.
+    # This requires a network connection, but so does Homebrew in general.
+    filename = (testpath/"test.tar.gz")
+    system "#{bin}/curl", "-L", stable.url, "-o", filename
+    filename.verify_checksum stable.checksum
+
+    system libexec/"mk-ca-bundle.pl", "test.pem"
+    assert_predicate testpath/"test.pem", :exist?
+    assert_predicate testpath/"certdata.txt", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #32916. This ensures we don't have crashes related to mixed crypto or ldap libs. 

While it does bring in a large dependency, it better than trying to work around the problems created by trying to mix system and homebrew libs. curl is built in a manner that would make the features match what the system lib provides.

The patch to `PHP_ADD_INCLUDE`, should have been in the original patch. This was mentioned on the existing [upstream PR](https://github.com/php/php-src/pull/3472#issuecomment-436854897). We just got lucky that macOS's system headers files were compatible with the homebrew library includes.

The patch to `PHP_SETUP_ICONV` is to support the system iconv, by means of searching for `.tbd`. This has been [reported upstream ](https://github.com/php/php-src/pull/3616)in a more generic manner.