### PR TITLE
topgrade 0.19.0

### DIFF
--- a/Formula/topgrade.rb
+++ b/Formula/topgrade.rb
@@ -1,8 +1,8 @@
 class Topgrade < Formula
   desc "Upgrade all the things"
   homepage "https://github.com/r-darwish/topgrade"
-  url "https://github.com/r-darwish/topgrade/archive/v0.18.0.tar.gz"
-  sha256 "c72cefd01d2bad53ba48fabef8c0920813bac810920426f3de08d776dfbd7dbe"
+  url "https://github.com/r-darwish/topgrade/archive/v0.19.0.tar.gz"
+  sha256 "0b2ebb65f3fe4884186d2a47811b7036937a0e197de34786fc99c77ce4563f0f"
 
   bottle do
     sha256 "b7087d33d3b2fec5fbd2b61d684f2dac4fa6957a0508682de22db38a212d3297" => :mojave
@@ -19,5 +19,6 @@ class Topgrade < Formula
   test do
     output = shell_output("#{bin}/topgrade -n")
     assert_match "Dry running: #{HOMEBREW_PREFIX}/bin/brew upgrade", output
+    assert_not_match /\sSelf update\s/, output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The latest upstream release has **introduced a self-upgrade feature**, which runs automatically. The feature is opt-in at build time so there’s nothing to do in the formula right now to prevent the self-upgrade from running.

As a fail safe, however, this commit adds an assertion to the test block. The test will now fail if the feature is present.
