### PR TITLE
dash: Fix shell quoting

### DIFF
--- a/Formula/dash.rb
+++ b/Formula/dash.rb
@@ -4,6 +4,7 @@ class Dash < Formula
   url "http://gondor.apana.org.au/~herbert/dash/files/dash-0.5.10.2.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/dash-0.5.10.2.tar.gz"
   sha256 "3c663919dc5c66ec991da14c7cf7e0be8ad00f3db73986a987c118862b5f6071"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -24,9 +25,7 @@ class Dash < Formula
 
     system "./configure", "--prefix=#{prefix}",
                           "--with-libedit",
-                          "--disable-dependency-tracking",
-                          "--enable-fnmatch",
-                          "--enable-glob"
+                          "--disable-dependency-tracking"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Dash's shell quoting previously was horribly broken (try running
just `sed "s///"`; this fails because extra backslashes are inserted
into the argument).

This occurs because dash 0.5.10 introduced a work-around for a broken
glob() in glibc, which it applied to Mac OS even though Mac OS doesn't
have the broken glibc.  This fix tells dash to use its internal glob()
and fnmatch(), correcting the problem.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----