### PR TITLE
Hugo 0.51

### DIFF
--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -1,8 +1,8 @@
 class Hugo < Formula
   desc "Configurable static site generator"
   homepage "https://gohugo.io/"
-  url "https://github.com/gohugoio/hugo/archive/v0.50.tar.gz"
-  sha256 "4dade11c38aace73877750ea8d67ab2ccccf643751754d5a4afdd8d62e655012"
+  url "https://github.com/gohugoio/hugo/archive/v0.51.tar.gz"
+  sha256 "5433920c3830df4217c2e6b4e80958543b00c36a890fe4b3c990cfcf5fa46e33"
   head "https://github.com/gohugoio/hugo.git"
 
   bottle do


### PR DESCRIPTION
- [x] run `brew bump-formula-pr --strict hugo --url=https://github.com/gohugoio/hugo/archive/v0.51.tar.gz`
- [x] run `shasum -a 256 -c hugo-0.51.tar.gz`: `5433920c3830df4217c2e6b4e80958543b00c36a890fe4b3c990cfcf5fa46e33  hugo-0.51.tar.gz`
- [x]  Have you built your formula locally with `brew install --HEAD -s hugo`?
- [x] Does your build pass `brew audit --strict hugo` (after doing `brew install hugo`)?
