### PR TITLE
djbdns: change test to check example.com

### DIFF
--- a/Formula/djbdns.rb
+++ b/Formula/djbdns.rb
@@ -36,6 +36,7 @@ class Djbdns < Formula
   end
 
   test do
-    assert_match "localhost", shell_output("#{bin}/dnsname 127.0.0.1").chomp
+    # Use example.com instead of localhost, because localhost does not resolve in all cases
+    assert_match /\d+\.\d+\.\d+\.\d+/, shell_output("#{bin}/dnsip example.com").chomp
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Lets https://github.com/Homebrew/homebrew-core/pull/33890 proceed.

The current test for `djbdns` fails in some cases. This may be dependent on your DNS server situation. It's currently breaking for me locally, and on the CI machines (per https://github.com/Homebrew/homebrew-core/pull/33890's [test output](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/33145/version=high_sierra/testReport/junit/brew-test-bot/high_sierra/test_djbdns/)).

```
$ brew test djbdns                                                                                                   master
Testing djbdns
==> /usr/local/Cellar/djbdns/1.05/bin/dnsname 127.0.0.1
Error: djbdns: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: </localhost/> expected to be =~
<"">.
```

This PR replaces the test with a lookup of `example.com`, which is a well-known name that should resolve under any sane DNS setup. This means the test will fail when offline, but I don't think that's a big deal for a DNS tool. (For that matter, the current test may fail when offline, because I believe the reverse lookup of 127.0.0.1 actually depends on DNS servers and is not special-cased by the djbdns lookup mechanism unless you're using its cache server.)