### PR TITLE
exploitdb 2018-11-06

### DIFF
--- a/Formula/exploitdb.rb
+++ b/Formula/exploitdb.rb
@@ -2,9 +2,9 @@ class Exploitdb < Formula
   desc "The official Exploit Database"
   homepage "https://www.exploit-db.com/"
   url "https://github.com/offensive-security/exploit-database.git",
-      :tag      => "2018-08-18",
-      :revision => "16744756bc5f01071041e2a03a30732cde65efc4"
-  version "2018-08-18"
+      :tag      => "2018-11-06",
+      :revision => "363500a603389fc5ebfca441e328229a12700ca7"
+  version "2018-11-06"
   head "https://github.com/offensive-security/exploit-database.git"
 
   bottle :unneeded
@@ -13,16 +13,16 @@ class Exploitdb < Formula
     inreplace "searchsploit",
               "rc_file=\"\"", "rc_file=\"#{etc}/searchsploit_rc\""
 
-    optpath = opt_share/"exploit-database"
+    optpath = opt_share/"exploitdb"
     inreplace ".searchsploit_rc" do |s|
-      s.gsub! "\"/opt/exploit-database\"", optpath
-      s.gsub! "\"/opt/exploit-database-papers\"", "#{optpath}-papers"
+      s.gsub! "\"/opt/exploitdb\"", optpath
+      s.gsub! "\"/opt/exploitdb-papers\"", "#{optpath}-papers"
     end
 
     bin.install "searchsploit"
     etc.install ".searchsploit_rc" => "searchsploit_rc"
 
-    upshare = share/"exploit-database"
+    upshare = pkgshare
     upshare.install %w[.git exploits files_exploits.csv files_shellcodes.csv
                        shellcodes]
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? *#33822, but it's buggy; this fixes it*
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? *No, but I think it's a false positive?*

-----

Closes https://github.com/Homebrew/homebrew-core/pull/33822 and supersedes it.

Failed audit:

```
$ brew audit --strict exploitdb
exploitdb:
  * Use pkgshare instead of (share/"exploitdb")
Error: 1 problem in 1 formula detected
```

I suspect that's mistakenly matching the `opt_share/"exploitdb"` in `optpath = opt_share/"exploitdb"` using a too-loose regex.