### PR TITLE
Add new formula for bs1770gain utility

### DIFF
--- a/Formula/bs1770gain.rb
+++ b/Formula/bs1770gain.rb
@@ -1,0 +1,21 @@
+class Bs1770gain < Formula
+  desc "Loudness scanner compliant with ITU-R BS.1770 and ReplayGain 2.0"
+  homepage "https://bs1770gain.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/bs1770gain/bs1770gain/0.5.1/bs1770gain-0.5.1.tar.gz"
+  sha256 "06749f866417e6bcdb9fb24883cb08ae54248333a532380c7ddc56f7a45a8e64"
+
+  depends_on "ffmpeg"
+  depends_on "sox"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/bs1770gain", "-h"
+  end
+end


### PR DESCRIPTION
New formula for bs1770fain, loudness scanner compliant with ITU-R BS.1770 and its flavors EBU R128, ATSC A/85, and ReplayGain 2.0
Test is very basic, but it's the only test I can think of right now

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
