### PR TITLE
crosstool-ng: Add support for --HEAD version

### DIFF
--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -3,7 +3,8 @@ class CrosstoolNg < Formula
   homepage "https://crosstool-ng.github.io/"
   url "http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.23.0.tar.xz"
   sha256 "68a43ea98ccf9cb345cb6eec494a497b224fee24c882e8c14c6713afbbe79196"
-  revision 2
+  revision 3
+  head "https://github.com/crosstool-ng/crosstool-ng.git"
 
   bottle do
     cellar :any
@@ -23,12 +24,25 @@ class CrosstoolNg < Formula
   depends_on "grep"
   depends_on "libtool"
   depends_on "m4"
+  depends_on "make"
   depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
   depends_on "xz"
 
+  if build.head?
+    depends_on "bash"
+    depends_on "bison"
+    depends_on "gettext"
+  end
+
   def install
+    if build.head?
+      system "./bootstrap"
+      ENV["BISON"] = "#{Formula["bison"].opt_bin}/bison"
+      ENV.append "LDFLAGS", "-lintl"
+    end
+
     ENV["M4"] = "#{Formula["m4"].opt_bin}/m4"
-    ENV["MAKE"] = "/usr/bin/make" # prevent hardcoding make path from superenv
+    ENV["MAKE"] = "#{Formula["make"].opt_bin}/gmake"
 
     system "./configure", "--prefix=#{prefix}"
 


### PR DESCRIPTION
It's been a while since crosstool-ng had a realease. Nonetheless the tool is actively developed and quite usable. A toolchain can be generated on mac without any workaround/quirks in ~50 minutes. I've managed to build two toolchains for the platforms of my interest so far:
 
- powerpc64le-unknown-linux-gnu
- x86_64-unknown-linux-gnu

Caveats:
* leftover from non-keg-only binutils can mess with crosstool-ng.
  Reinstallation of binutils should help, but make sure ar points to
  system ar.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
