### PR TITLE
v8 7.0.276.38

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -3,8 +3,8 @@ class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
   url "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-      :revision => "74b702466046e0a59366cea26290af6590007675"
-  version "7.0.276.28" # the version of the v8 checkout, not a depot_tools version
+      :revision => "e28390cc438f6206082894048801aea07964f603"
+  version "7.0.276.38" # the version of the v8 checkout, not a depot_tools version
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR upgrades `v8` to version 7.0.276.38 following today's mid release cycle Chrome update.
