### PR TITLE
cloud-nuke 0.1.4 (new formula)

### DIFF
--- a/Formula/cloud-nuke.rb
+++ b/Formula/cloud-nuke.rb
@@ -1,0 +1,16 @@
+class CloudNuke < Formula
+  desc "Cleaning up your cloud accounts by nuking all resources in it"
+  homepage "https://gruntwork.io/"
+  url "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.1.4/cloud-nuke_darwin_amd64"
+  version "0.1.4"
+  sha256 "eaf6cdc9d7590f1db4c3c266dd8ba29e04877082cfd06d372602045aafeee5a6"
+
+  def install
+    bin.install "cloud-nuke_darwin_amd64"
+    mv bin/"cloud-nuke_darwin_amd64", bin/"cloud-nuke"
+  end
+
+  test do
+    assert_match "cloud-nuke version v0.1.4", shell_output("#{bin}/cloud-nuke -v ")
+  end
+end


### PR DESCRIPTION
 cloud-nuke was created for situations when you might have an account
you use for testing and need to clean up left over resources so you're
not charged for them. Also great for cleaning out accounts with
redundant resources.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
