### PR TITLE
cloud-nuke 0.1.4 (new formula)

### DIFF
--- a/Formula/cloud-nuke.rb
+++ b/Formula/cloud-nuke.rb
@@ -1,0 +1,26 @@
+class CloudNuke < Formula
+  desc "Clean up your cloud accounts by nuking all resources in it"
+  homepage "https://gruntwork.io/"
+  url "https://github.com/gruntwork-io/cloud-nuke/archive/v0.1.4.tar.gz"
+  sha256 "ce2f5caff4db80accc9ceaeef859382135e772dfd08d1bf981e52098512c45f7"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    print buildpath
+    ENV["GOPATH"] = buildpath
+    cloud_nuke_path = buildpath/"src/github.com/gruntwork-io/cloud-nuke/"
+    cloud_nuke_path.install buildpath.children
+
+    cd cloud_nuke_path do
+      system "dep", "ensure", "-vendor-only"
+      system "go", "build", "-ldflags", "-X main.VERSION=#{version}"
+      bin.install "cloud-nuke"
+    end
+  end
+
+  test do
+    assert_match "cloud-nuke version 0.1.4", shell_output("#{bin}/cloud-nuke -v ")
+  end
+end


### PR DESCRIPTION
 cloud-nuke was created for situations when you might have an account
you use for testing and need to clean up left over resources so you're
not charged for them. Also great for cleaning out accounts with
redundant resources.

Signed-off-by: Thomas Nys <hello@thomasnys.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
