### PR TITLE
open-babel: fix python2 path reference

### DIFF
--- a/Formula/open-babel.rb
+++ b/Formula/open-babel.rb
@@ -37,7 +37,7 @@ class OpenBabel < Formula
 
     # Point cmake towards correct python
     if build.with? "python@2"
-      ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+      ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"
       pypref = `python -c 'import sys;print(sys.prefix)'`.strip
       pyinc = `python -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'`.strip
       args << "-DPYTHON_BINDINGS=ON"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this change, building open-babel fails to build from source if `--with-python@2` is specified:

```
make[2]: *** Waiting for unfinished jobs....
[100%] Building CXX object scripts/CMakeFiles/bindings_python.dir/python/openbabel-python.cpp.o
cd /tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/build/scripts && /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++  -DHAVE_EIGEN -DHAVE_EIGEN3 -DHAVE_LIBZ -DHAVE_SHARED_POINTER -DHAVE_WXWIDGETS -DUSING_DYNAMIC_LIBS -DWXUSINGDLL -D_FILE_OFFSET_BITS=64 -D__WXMAC__ -D__WXOSX_COCOA__ -D__WXOSX__ -Dbindings_python_EXPORTS -I/tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/build/include -I/tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/data -I/tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/include -I/usr/local/include/eigen3 -I/usr/local/Cellar/python/3.7.1/Frameworks/Python.framework/Versions/3.7/include/python3.7m -isystem /usr/local/lib/wx/include/osx_cocoa-unicode-3.0 -isystem /usr/local/include/wx-3.0  -DNDEBUG -fPIC   -DOB_MODULE_PATH="\"/usr/local/Cellar/open-babel/2.4.1/lib/openbabel/2.4.1\"" -o CMakeFiles/bindings_python.dir/python/openbabel-python.cpp.o -c /tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/scripts/python/openbabel-python.cpp
/tmp/open-babel-20181110-58122-15qkb4/openbabel-openbabel-2-4-1/scripts/python/openbabel-python.cpp:177:11: fatal error: 'Python.h' file not found
# include <Python.h>
          ^~~~~~~~~~
1 error generated.
```

however, about that `brew audit` step, it does not pass with the following failure, which I can't say whether that audit failure was _introduced_ by my change or it was always there and was only _surfaced_ by this PR process:

```
open-babel:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/opt/open-babel/lib/python2.7/site-packages/_openbabel.so
Error: 1 problem in 1 formula detected
```

I guess with enough time and energy I could find a way to pass the necessary compilation flags through `cmake` down to `swig` but I'd only want to bother if you genuinely feel that audit failure was introduced by this change