### PR TITLE
sphinx: make it possible to compile against versioned mysql

### DIFF
--- a/Formula/sphinx.rb
+++ b/Formula/sphinx.rb
@@ -15,13 +15,15 @@ class Sphinx < Formula
   end
 
   option "with-mysql", "Force compiling against MySQL"
+  option "with-mysql@5.7", "Force compiling against MySQL 5.7"
   option "with-postgresql", "Force compiling against PostgreSQL"
 
   deprecated_option "mysql" => "with-mysql"
   deprecated_option "pgsql" => "with-postgresql"
 
   depends_on "mysql" => :optional
-  depends_on "openssl" if build.with? "mysql"
+  depends_on "mysql@5.7" => :optional
+  depends_on "openssl" if build.with?("mysql") || build.with?("mysql@5.7")
   depends_on "postgresql" => :optional
 
   fails_with :clang do
@@ -47,7 +49,7 @@ class Sphinx < Formula
       --with-libstemmer
     ]
 
-    if build.with? "mysql"
+    if build.with?("mysql") || build.with?("mysql@5.7")
       args << "--with-mysql"
     else
       args << "--without-mysql"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    - I could not run `brew audit` because there was a problem installing the `rubocop` gem ([error gist](https://gist.github.com/sebroeder/8b5fb084e9f6565cd81e18f3bc3225c9)) I have to look into this.
-----

I have the versioned MySQL formula `mysql@5.7` installed and want to install `sphinx --with-mysql`. When I do this, the formula installs MySQL 8 and compiles against it. I added an option to force-compile against `mysql@5.7` to the sphinx formula and put it in a personal tap.

This works for me, but I since both the sphinx formula and a couple of versioned mysql formulas are ranking pretty high in the [installs on request list](https://formulae.brew.sh/analytics/install-on-request/365d/) I was wondering whether I could improve the formula enough to make this work for the general case (all versions of MySQL and Postgres in homebrew-core?) and push it upstream, so that all homebrew users can benefit from it.

My current solution to just add another option for a specific version of mysql does not scale very well in my opinion - it would be rather clunky to have 8-10 options to cover every version of MySQL and Postgres that is in homebrew-core, so I was hoping we might come up with a better abstraction for this kind of problem together. I have read https://docs.brew.sh/Versions.html and https://docs.brew.sh/Formula-Cookbook but could not find a good existing solution. The closest match may be a new kind of [Requirement](
https://www.rubydoc.info/github/Homebrew/brew/master/Requirement), that would allow us to write something like `depends_on :mysql => %w(mysql mysql@5.7 mysql@5.6 mysql@5.5)` or `depends_on :mysql => :allow_versions`.