### PR TITLE
wine: Add Debian mirror for libtiff

### DIFF
--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -88,9 +88,7 @@ class Wine < Formula
     # All of these have been reported upstream & should
     # be fixed in the next release, but please check.
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
-      mirror "https://snapshot.debian.org/archive/debian/20180702T023653Z/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
+      url "https://snapshot.debian.org/archive/debian/20180702T023653Z/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
       sha256 "4e145dcde596e0c406a9f482680f9ddd09bed61a0dc6d3ac7e4c77c8ae2dd383"
       apply "patches/CVE-2017-9935.patch",
             "patches/CVE-2017-18013.patch",
@@ -106,7 +104,7 @@ class Wine < Formula
 
   resource "little-cms2" do
     url "https://downloads.sourceforge.net/project/lcms/lcms/2.9/lcms2-2.9.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/l/lcms2/lcms2_2.9.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/l/lcms2/lcms2_2.9.orig.tar.gz"
     sha256 "48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20"
   end
 
@@ -156,7 +154,7 @@ class Wine < Formula
   end
 
   resource "sane-backends" do
-    url "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+    url "https://deb.debian.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
     mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
     sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   end

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -90,6 +90,7 @@ class Wine < Formula
     patch do
       url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
       mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
+      mirror "https://snapshot.debian.org/archive/debian/20180702T023653Z/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz"
       sha256 "4e145dcde596e0c406a9f482680f9ddd09bed61a0dc6d3ac7e4c77c8ae2dd383"
       apply "patches/CVE-2017-9935.patch",
             "patches/CVE-2017-18013.patch",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? **Yes**
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **Yes, no `wine` PRs are open**
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Yes**
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **Yes**

-----

Debian recently (Sun, 28 Oct 2018) updated its `tiff` package: [tiff_4.0.9+git181026-1_changelog](https://metadata.ftp-master.debian.org/changelogs//main/t/tiff/tiff_4.0.9+git181026-1_changelog)

This made the old version (`tiff_4.0.9-6.debian.tar.xz`) disappear from the two listed Debian mirror URLs. Since [snapshot.debian.org](https://snapshot.debian.org/) keeps track of old files, we can continue using the existing file, just via a different mirror URL.

However, since the original URLs are 404'ing, I could also remove the two URLs and just replace them with a single snapshot.debian.org URL.