### PR TITLE
fatsort 1.5.0

### DIFF
--- a/Formula/fatsort.rb
+++ b/Formula/fatsort.rb
@@ -1,9 +1,9 @@
 class Fatsort < Formula
   desc "Sorts FAT16 and FAT32 partitions"
   homepage "https://fatsort.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/fatsort/fatsort-1.4.2.439.tar.xz"
-  version "1.4.2"
-  sha256 "bdbcf99307baef3e76d99700691ac525c9a9cf96d8433b45c89314940cc6a1e0"
+  url "https://downloads.sourceforge.net/project/fatsort/fatsort-1.5.0.456.tar.xz"
+  version "1.5.0"
+  sha256 "a835b47814fd30d5bad464b839e9fc404bc1a6f5a5b1f6ed760ce9744915de95"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
fatsort 1.5.0 released 08-09-2019

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----