### PR TITLE
scrcpy 1.5-fixversion

### DIFF
--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -1,8 +1,8 @@
 class Scrcpy < Formula
   desc "Display and control your Android device"
   homepage "https://github.com/Genymobile/scrcpy"
-  url "https://github.com/Genymobile/scrcpy/archive/v1.5.tar.gz"
-  sha256 "9eef28d352d064320b8a2b9cc1000d478fb617a99807f2456a54af855b39ecf9"
+  url "https://github.com/Genymobile/scrcpy/archive/v1.5-fixversion.tar.gz"
+  sha256 "79249fb0881c8de6af23ed58e2b31dc6738174d7e49c490ae6e7992f7b3ec2cd"
 
   bottle do
     sha256 "3f1fc3cb5964c4f94383531dca5a548e24680fc3698d33bf65a90c1edf4a9346" => :mojave
@@ -17,8 +17,8 @@ class Scrcpy < Formula
   depends_on "sdl2"
 
   resource "prebuilt-server" do
-    url "https://github.com/Genymobile/scrcpy/releases/download/v1.5/scrcpy-server-v1.5.jar"
-    sha256 "c827f566172a5c5946e63b8378ac93d374dff9e229083e5cd9980df57536947b"
+    url "https://github.com/Genymobile/scrcpy/releases/download/v1.5-fixversion/scrcpy-server-v1.5.jar"
+    sha256 "d97aab6f60294e33e7ff79c2856ad3e01f912892395131f4f337e9ece03c24de"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[1.5](https://github.com/Homebrew/homebrew-core/pull/33996) has been merged.

But after the release, we discovered the version string was not updated (https://github.com/Genymobile/scrcpy/pull/332). As a consequence, `scrcpy --version` still printed `scrcpy v1.4`, which is very confusing.  #epicfail

To avoid further confusion, I didn't want to push-force the same tag/release, so I published a new release [`v1.5-fixversion`](https://github.com/Genymobile/scrcpy/releases/tag/v1.5-fixversion).

Please double-check that everything works fine in Homebrew before merging :wink:

Thank you and sorry for the inconvenience.