### PR TITLE
folly: depend on zstd

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -3,7 +3,7 @@ class Folly < Formula
   homepage "https://github.com/facebook/folly"
   url "https://github.com/facebook/folly/archive/v2018.09.24.00.tar.gz"
   sha256 "99b6ddb92ee9cf3db262b372ee7dc6a29fe3e2de14511ecc50458bf77fc29c6e"
-  revision 1
+  revision 2
   head "https://github.com/facebook/folly.git"
 
   bottle do
@@ -28,6 +28,7 @@ class Folly < Formula
   depends_on "openssl"
   depends_on "snappy"
   depends_on "xz"
+  depends_on "zstd"
 
   # Known issue upstream. They're working on it:
   # https://github.com/facebook/folly/pull/445


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Current bottles of `folly` have opportunistic linkage against `zstd`, it seems that there is no trivial way to disable [zstd](https://github.com/facebook/folly/blob/v2018.09.24.00/CMake/folly-deps.cmake#L112-L117), let's make `folly` depend on `zstd` since it a fairly small dependency.

The opportunistic linkage was spotted in #34008.