### PR TITLE
circleci v0.1.4005

### DIFF
--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -3,8 +3,8 @@ class Circleci < Formula
   homepage "https://circleci.com/docs/2.0/local-cli/"
   # Updates should be pushed no more frequently than once per week.
   url "https://github.com/CircleCI-Public/circleci-cli.git",
-      :tag      => "v0.1.3923",
-      :revision => "6fecf9d611e14f99bdf7fb668ddc87bab190ea25"
+      :tag      => "v0.1.4005",
+      :revision => "6011639b61b5434a12ba87e18e09708ba9356303"
 
   bottle do
     cellar :any_skip_relocation
@@ -24,7 +24,6 @@ class Circleci < Formula
       commit = Utils.popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[
         -s -w
-        -X github.com/CircleCI-Public/circleci-cli/cmd.AutoUpdate=false
         -X github.com/CircleCI-Public/circleci-cli/cmd.PackageManager=homebrew
         -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
         -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{commit}


### PR DESCRIPTION
This release removes the need for an AutoUpdate flag, as we assume the
PackageManager (in this case "homebrew") with the same behavior.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
