### PR TITLE
Adding dhall formula

### DIFF
--- a/Formula/dhall.rb
+++ b/Formula/dhall.rb
@@ -1,0 +1,23 @@
+require "language/haskell"
+
+class Dhall < Formula
+  include Language::Haskell::Cabal
+
+  desc "Interpreter for the Dhall language"
+  homepage "https://dhall-lang.org/"
+  url "https://hackage.haskell.org/package/dhall-1.20.0/dhall-1.20.0.tar.gz"
+  sha256 "662862e65e73de18c01001e0ab43af155d111631ad12d14d89ec37d1397ccf43"
+
+  depends_on "cabal-install" => :build
+  depends_on "ghc" => :build
+
+  def install
+    install_cabal_package
+  end
+
+  test do
+    assert_match "{=}", pipe_output("#{bin}/dhall format", "{ = }", 0)
+    assert_match "8", pipe_output("#{bin}/dhall normalize", "(\\(x : Natural) -> x + 3) 5", 0)
+    assert_match "∀(x : Natural) → Natural", pipe_output("#{bin}/dhall type", "\\(x: Natural) -> x + 3", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Adds the command `dhall`, which offers infrastructure for dealing with dhall files themselves (distinct from `dhall-json`):
```
brick:dhall-haskell blast$ dhall --help
Usage: dhall ([version] | [resolve] | [type] | [normalize] | [repl] | [diff] |
             [hash] | [lint] | [format] | [freeze]) [--explain] [--plain]
  Interpreter for the Dhall language

Available options:
  -h,--help                Show this help text
  --explain                Explain error messages in more detail
  --plain                  Disable syntax highlighting

Available commands:
  version                  Display version
  resolve                  Resolve an expression's imports
  type                     Infer an expression's type
  normalize                Normalize an expression
  repl                     Interpret expressions in a REPL
  diff                     Render the difference between the normal form of two
                           expressions
  hash                     Compute semantic hashes for Dhall expressions
  lint                     Improve Dhall code
  format                   Formatter for the Dhall language
  freeze                   Add hashes to all import statements of an expression
```

Specifically, the commands I'm looking for are:
- `dhall repl`
- `dhall diff`
- `dhall lint`
- `dhall format`