### PR TITLE
euler-py: fix formula

### DIFF
--- a/Formula/euler-py.rb
+++ b/Formula/euler-py.rb
@@ -30,7 +30,7 @@ class EulerPy < Formula
     end
 
     ENV.prepend_create_path "PYTHONPATH", "#{lib}/python#{xy}/site-packages"
-    system "python", "setup.py", "install", "--prefix=#{prefix}",
+    system "python3", "setup.py", "install", "--prefix=#{prefix}",
                      "--single-version-externally-managed",
                      "--record=installed.txt"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I decided to try installing EulerPy on a new development machine and ran into the following issue with the current version of the formula after `brew install`-ing:

```
$ euler
Traceback (most recent call last):
  File "/usr/local/Cellar/euler-py/1.3.0_1/libexec/bin/euler", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 3095, in <module>
    @_call_aside
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 3081, in _call_aside
    f(*args, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 3108, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 658, in _build_master
    ws.require(__requires__)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 959, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/pkg_resources/__init__.py", line 846, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'EulerPy==1.3.0' distribution was not found and is required by the application
```

The change to this PR appears to fix the issue (something related to mixing up Python 2 and 3?), but I'm not sure if it's the desired fix to this problem (the formula has changed quite a bit since I originally added it to Homebrew!). Interestingly, `brew test` still seemed to work prior to making this change as well.