### PR TITLE
fix: disable bottle for luit 20180628

### DIFF
--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -12,6 +12,6 @@ class Luit < Formula
   end
 
   test do
-    system "#{bin}/luit", "-encoding GBK ls"
+    system "#{bin}/luit", "-encoding", "GBK", "ls"
   end
 end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -10,10 +10,14 @@ class Luit < Formula
   end
 
   test do
-    require "pty"
-    (testpath/"input").write("#end {bye}\n")
-    PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
-      assert_match "foobar", r.read
-    end
+    #require "pty"
+    #(testpath/"input").write("#end {bye}\n")
+    #PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
+      #assert_match "foobar", r.read
+    #end
+    ENV["TERM"] = "xterm"
+    system "#{bin}/luit", "-encoding", "GBK", "echo", "foobar"
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    system bin/"luit", "-encoding", "GBK", "echo", "foobar"
   end
 end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -10,11 +10,6 @@ class Luit < Formula
   end
 
   test do
-    #require "pty"
-    #(testpath/"input").write("#end {bye}\n")
-    #PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
-      #assert_match "foobar", r.read
-    #end
     ENV["TERM"] = "xterm"
     system "#{bin}/luit", "-encoding", "GBK", "echo", "foobar"
     ENV["LC_ALL"] = "en_US.UTF-8"

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -12,7 +12,7 @@ class Luit < Formula
   test do
     require "pty"
     (testpath/"input").write("#end {bye}\n")
-    PTY.spawn(bin/"luit", "-encoding", "GBK", "echo" "foobar") do |r, _w, _pid|
+    PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
       assert_match "foobar", r.read
     end
   end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -4,10 +4,8 @@ class Luit < Formula
   url "https://invisible-mirror.net/archives/luit/luit-20180628.tgz"
   sha256 "7b84f63072589e9b03bb3e99e01ef344bb37793b76ad1cbb7b11f05000d64844"
 
-  bottle :disable, "Library and clients must be built on the same microarchitecture"
-
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--without-x"
     system "make", "install"
   end
 

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -10,6 +10,10 @@ class Luit < Formula
   end
 
   test do
-    system "#{bin}/luit", "-encoding", "GBK", "ls"
+    require "pty"
+    (testpath/"input").write("#end {bye}\n")
+    PTY.spawn(bin/"luit", "-encoding", "GBK", "echo" "foobar") do |r, _w, _pid|
+      assert_match "foobar", r.read
+    end
   end
 end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -4,13 +4,7 @@ class Luit < Formula
   url "https://invisible-mirror.net/archives/luit/luit-20180628.tgz"
   sha256 "7b84f63072589e9b03bb3e99e01ef344bb37793b76ad1cbb7b11f05000d64844"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "1c3dacfce73760ac50146bee7befa165a4ddf7f6bddae148777dfd9425f6cc9e" => :mojave
-    sha256 "e2b66941a0cf7dfb7fe0b1c15917ca1586ccc77999a4f9e9a150fc08e4fd6f7c" => :high_sierra
-    sha256 "a365a4654be845ee683827113bff9efa96832fbbd248234f3a785fd4d1ebb2ba" => :sierra
-    sha256 "323633917450a82e0f86958f77be43d6fbfba4e262d8ea393473f72b0db9d304" => :el_capitan
-  end
+  bottle :disable, "Library and clients must be built on the same microarchitecture"
 
   def install
     system "./configure", "--prefix=#{prefix}"
@@ -18,6 +12,6 @@ class Luit < Formula
   end
 
   test do
-    system "#{bin}/luit", "-list"
+    system "#{bin}/luit", "-encoding GBK ls"
   end
 end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -4,6 +4,14 @@ class Luit < Formula
   url "https://invisible-mirror.net/archives/luit/luit-20180628.tgz"
   sha256 "7b84f63072589e9b03bb3e99e01ef344bb37793b76ad1cbb7b11f05000d64844"
 
+  bottle do
+     cellar :any_skip_relocation
+     sha256 "1c3dacfce73760ac50146bee7befa165a4ddf7f6bddae148777dfd9425f6cc9e" => :mojave
+     sha256 "e2b66941a0cf7dfb7fe0b1c15917ca1586ccc77999a4f9e9a150fc08e4fd6f7c" => :high_sierra
+     sha256 "a365a4654be845ee683827113bff9efa96832fbbd248234f3a785fd4d1ebb2ba" => :sierra
+     sha256 "323633917450a82e0f86958f77be43d6fbfba4e262d8ea393473f72b0db9d304" => :el_capitan
+   end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--without-x"
     system "make", "install"

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -10,14 +10,10 @@ class Luit < Formula
   end
 
   test do
-    #require "pty"
-    #(testpath/"input").write("#end {bye}\n")
-    #PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
-      #assert_match "foobar", r.read
-    #end
-    ENV["TERM"] = "xterm"
-    system "#{bin}/luit", "-encoding", "GBK", "echo", "foobar"
-    ENV["LC_ALL"] = "en_US.UTF-8"
-    system bin/"luit", "-encoding", "GBK", "echo", "foobar"
+    require "pty"
+    (testpath/"input").write("#end {bye}\n")
+    PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
+      assert_match "foobar", r.read
+    end
   end
 end

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -10,6 +10,11 @@ class Luit < Formula
   end
 
   test do
+    #require "pty"
+    #(testpath/"input").write("#end {bye}\n")
+    #PTY.spawn(bin/"luit", "-encoding", "GBK", "echo", "foobar") do |r, _w, _pid|
+      #assert_match "foobar", r.read
+    #end
     ENV["TERM"] = "xterm"
     system "#{bin}/luit", "-encoding", "GBK", "echo", "foobar"
     ENV["LC_ALL"] = "en_US.UTF-8"

--- a/Formula/luit.rb
+++ b/Formula/luit.rb
@@ -5,12 +5,12 @@ class Luit < Formula
   sha256 "7b84f63072589e9b03bb3e99e01ef344bb37793b76ad1cbb7b11f05000d64844"
 
   bottle do
-     cellar :any_skip_relocation
-     sha256 "1c3dacfce73760ac50146bee7befa165a4ddf7f6bddae148777dfd9425f6cc9e" => :mojave
-     sha256 "e2b66941a0cf7dfb7fe0b1c15917ca1586ccc77999a4f9e9a150fc08e4fd6f7c" => :high_sierra
-     sha256 "a365a4654be845ee683827113bff9efa96832fbbd248234f3a785fd4d1ebb2ba" => :sierra
-     sha256 "323633917450a82e0f86958f77be43d6fbfba4e262d8ea393473f72b0db9d304" => :el_capitan
-   end
+    cellar :any_skip_relocation
+    sha256 "1c3dacfce73760ac50146bee7befa165a4ddf7f6bddae148777dfd9425f6cc9e" => :mojave
+    sha256 "e2b66941a0cf7dfb7fe0b1c15917ca1586ccc77999a4f9e9a150fc08e4fd6f7c" => :high_sierra
+    sha256 "a365a4654be845ee683827113bff9efa96832fbbd248234f3a785fd4d1ebb2ba" => :sierra
+    sha256 "323633917450a82e0f86958f77be43d6fbfba4e262d8ea393473f72b0db9d304" => :el_capitan
+  end
 
   def install
     system "./configure", "--prefix=#{prefix}", "--without-x"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
luit:
  * Formulae should not use `bottle :disabled`
Error: 1 problem in 1 formula detected
```

If luit build on Jenkins server, it will failed on my macOS.


-----
