### PR TITLE
opa 0.10.1 (new formula)

### DIFF
--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -1,0 +1,26 @@
+class Opa < Formula
+  desc "Open source, general-purpose policy engine"
+  homepage "https://www.openpolicyagent.org"
+  url "https://github.com/open-policy-agent/opa/archive/v0.10.1.tar.gz"
+  sha256 "6b6121cbf7efc42b6ebc3f5ba6a2533e4e6eaf4b9eec446fb6f8fce4e6c02ae7"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/open-policy-agent/opa").install buildpath.children
+
+    cd "src/github.com/open-policy-agent/opa" do
+      system "go", "build", "-o", bin/"opa", "-installsuffix", "static",
+                   "-ldflags",
+                   "-X github.com/open-policy-agent/opa/version.Version=#{version}"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/opa 2>&1")
+    assert_match "An open source project to policy-enable your service.", output
+    assert_match "Version: #{version}", shell_output("#{bin}/opa version 2>&1")
+  end
+end

--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -19,8 +19,8 @@ class Opa < Formula
   end
 
   test do
-    output = shell_output("#{bin}/opa 2>&1")
-    assert_match "An open source project to policy-enable your service.", output
+    output = shell_output("#{bin}/opa eval -f pretty '[x, 2] = [1, y]' 2>&1")
+    assert_equal "+---+---+\n| x | y |\n+---+---+\n| 1 | 2 |\n+---+---+\n", output
     assert_match "Version: #{version}", shell_output("#{bin}/opa version 2>&1")
   end
 end


### PR DESCRIPTION
This formula adds the Open Policy Agent
(https://www.openpolicyagent.org) to homebrew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
