### PR TITLE
vtk 8.1.2

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -1,8 +1,8 @@
 class Vtk < Formula
   desc "Toolkit for 3D computer graphics, image processing, and visualization"
   homepage "https://www.vtk.org/"
-  url "https://www.vtk.org/files/release/8.1/VTK-8.1.1.tar.gz"
-  sha256 "71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324"
+  url "https://www.vtk.org/files/release/8.1/VTK-8.1.2.tar.gz"
+  sha256 "0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db"
   revision 2
   head "https://github.com/Kitware/VTK.git"
 

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -3,7 +3,6 @@ class Vtk < Formula
   homepage "https://www.vtk.org/"
   url "https://www.vtk.org/files/release/8.1/VTK-8.1.2.tar.gz"
   sha256 "0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db"
-  revision 2
   head "https://github.com/Kitware/VTK.git"
 
   bottle do

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -5,12 +5,6 @@ class Vtk < Formula
   sha256 "0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db"
   head "https://github.com/Kitware/VTK.git"
 
-  bottle do
-    sha256 "9ebecbab78563a12b4a55f62d7c15afeab7b288891ba2b71d8f461b1d77b8b33" => :mojave
-    sha256 "f17ccc19e0183f06c07e6d7b2ac23f21a5056bb8b8bcb57f5411f656639d168a" => :high_sierra
-    sha256 "b0cce7d37ebea9901e98519412b7d8078499ca03ee4cc6ec283525ba9dd2f121" => :sierra
-  end
-
   option "without-python@2", "Build without python2 support"
 
   deprecated_option "without-python" => "without-python@2"


### PR DESCRIPTION
8.1.1 has some problem when
```
brew install vtk --with-python --without-python@2
```
[https://gitlab.kitware.com/vtk/vtk/issues/17350](https://gitlab.kitware.com/vtk/vtk/issues/17350)

So vtk should be updated to 8.1.2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----