### PR TITLE
openssl: fix compilation on older systems

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -24,7 +24,16 @@ class Openssl < Formula
 
   deprecated_option "without-check" => "without-test"
 
-  depends_on "makedepend" => :build
+  # An updated list of CA certificates for use by Leopard, whose built-in certificates
+  # are outdated, and Snow Leopard, whose `security` command returns no output.
+  resource "ca-bundle" do
+    url "https://curl.haxx.se/ca/cacert-2018-10-17.pem"
+    mirror "http://gitcdn.xyz/cdn/paragonie/certainty/d3e2777e1ca2b1401329a49c7d56d112e6414f23/data/cacert-2018-10-17.pem"
+    sha256 "86695b1be9225c3cf882d283f05c944e3aabbc1df6428a4424269a93e997dc65"
+  end
+
+  # Use standard env on Snow Leopard to allow compilation fix below to work.
+  env :std if MacOS.version == :snow_leopard
 
   def arch_args
     {
@@ -57,10 +66,19 @@ class Openssl < Formula
       arch = Hardware::CPU.arch_32_bit
     end
 
+    # Keep Leopard/Snow Leopard support alive for things like building portable Ruby by
+    # avoiding a makedepend issue introduced in recent versions of OpenSSL 1.0.2.
+    # https://github.com/Homebrew/homebrew-core/pull/34326
+    depend_args = (MacOS.version <= :snow_leopard) ? ["MAKEDEPPROG=cc"] : []
+
+    # Build with GCC on Snow Leopard, which errors during tests if built with its clang.
+    # https://github.com/Homebrew/homebrew-core/issues/2766
+    args = (MacOS.version == :snow_leopard) ? ["CC=cc"] : []
+
     ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args[arch])
-    system "make", "depend"
-    system "make"
+    system "make", "depend", *depend_args
+    system "make", *args
     system "make", "test" if build.with?("test")
 
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
@@ -90,7 +108,13 @@ class Openssl < Formula
     end
 
     openssldir.mkpath
-    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+    if MacOS.version <= :snow_leopard
+      resource("ca-bundle").stage do
+        openssldir.install "cacert-#{resource("ca-bundle").version}.pem" => "cert.pem"
+      end
+    else
+      (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+    end
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
Fixes #2766.
Also removes unused makedepend dependency.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Turns out that OpenSSL 1.0.2 does not actually use makedepend on macOS. Checking the sources, its [Configure](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/Configure#L1676-L1679) script sets `MAKEDEPPROG` in the Makefile to the compiler on systems where `__clang__` is defined, i.e. OS X 10.7 and later. (See what is defined for your compiler with `cc -dM -E -x c /dev/null 2>&1`.)

In fact, if after running Configure manually you edit the Makefile to `MAKEDEPPROG= makedepend` and then run `make depend`, you'll find it doesn't work for recent version of OpenSSL 1.0.2. For some reason, its `util/domd` script now [strips out](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/util/domd#L7-L14) the `--` arguments that separate compiler flags from makedepend's own flags, causing errors like `makedepend: error:  "no-common" is not present`. This is fixed by setting `MAKEDEPPROG` for OS X 10.5 & 10.6.

The newest compiler on OS X 10.5 is GCC 4.2, which works fine. On 10.6, `make test` will fail (#2766) because superenv is redirecting all compilation to `clang`, even though the output of `brew --env` suggests that it would use `gcc-4.2` (LLVM-GCC). The simplest fix is to use the standard env and specify the compiler for `make` only for 10.6, which avoids another issue where the compiler doesn't understand `-march=native`, even though this offends`brew audit --strict`. 

This continues work to get Homebrew working on older systems (Homebrew/install#154, Homebrew/brew#5238). CC @MikeMcQuaid as requested.