### PR TITLE
mosh: Added without-python@2 to protobuf dependency.

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -3,7 +3,7 @@ class Mosh < Formula
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.3.2.tar.gz"
   sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
-  revision 4
+  revision 5
 
   bottle do
     sha256 "5e05a95d972b509c0469ca933de7a522b74b049cc0dccfe5cb1aa6db34b54fc4" => :mojave
@@ -21,7 +21,7 @@ class Mosh < Formula
 
   depends_on "pkg-config" => :build
   depends_on "tmux" => :build if build.bottle?
-  depends_on "protobuf"
+  depends_on "protobuf" => ['without-python@2']
 
   needs :cxx11
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `protobuf` recipe lists `python` as `optional` and `python@2` as `recommended`, which
triggers `python@2` as a transient dependency of `mosh` via `protobuf`.  Neither protobuf
nor mosh require `python@2`, so it should be excluded from `mosh` dependencies.

Fixes #34345.