### PR TITLE
cmake: support building html docs

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -12,6 +12,8 @@ class Cmake < Formula
     sha256 "d13ad4c2b41c027d9b06154ef40ff2cd1fbff8f6595a6712a88b4e0edfc81c1b" => :sierra
   end
 
+  option "with-html-docs", "build HTML help in addition to the man pages"
+
   depends_on "sphinx-doc" => :build
 
   # The completions were removed because of problems with system bash
@@ -42,6 +44,7 @@ class Cmake < Formula
       --system-bzip2
       --system-curl
     ]
+    args << "--sphinx-html" if build.with? "html-docs"
 
     # There is an existing issue around macOS & Python locale setting
     # See https://bugs.python.org/issue18378#msg215215 for explanation

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -12,8 +12,6 @@ class Cmake < Formula
     sha256 "d13ad4c2b41c027d9b06154ef40ff2cd1fbff8f6595a6712a88b4e0edfc81c1b" => :sierra
   end
 
-  option "with-html-docs", "build HTML help in addition to the man pages"
-
   depends_on "sphinx-doc" => :build
 
   # The completions were removed because of problems with system bash
@@ -39,12 +37,12 @@ class Cmake < Formula
       --docdir=/share/doc/cmake
       --mandir=/share/man
       --sphinx-build=#{Formula["sphinx-doc"].opt_bin}/sphinx-build
+      --sphinx-html
       --sphinx-man
       --system-zlib
       --system-bzip2
       --system-curl
     ]
-    args << "--sphinx-html" if build.with? "html-docs"
 
     # There is an existing issue around macOS & Python locale setting
     # See https://bugs.python.org/issue18378#msg215215 for explanation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I vastly prefer reading the HTML docs versus the man pages, and suspect I'm not alone in that. I actually prefer the `singlehtml` sphinx build target over html, but they don't appear to readily support that (one can use `--init` but yikes what a lot of code just to get a new doc flavor)

I did see the "We frown upon `option`s in core" sentence, but I felt this was safe because it only adds another documentation target, rather than altering cmake functionality