### PR TITLE
macvim: allow disabling core interpreters

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -14,6 +14,7 @@ class Macvim < Formula
     sha256 "029365cfcc11097d216e12e431cc779c805bff5592a35bc337144e72c093e02f" => :el_capitan
   end
 
+  option "without-interpreters", "Build without embedded perl, ruby, tcl interpreters"
   option "with-override-system-vim", "Override system vim"
 
   deprecated_option "override-system-vim" => "with-override-system-vim"
@@ -37,13 +38,19 @@ class Macvim < Formula
     # If building for OS X 10.7 or up, make sure that CC is set to "clang"
     ENV.clang if MacOS.version >= :lion
 
+    if build.without? "interpreters"
+      want_interp = "disable"
+    else
+      want_interp = "enable"
+    end
+
     args = %W[
       --with-features=huge
       --enable-multibyte
       --with-macarchs=#{MacOS.preferred_arch}
-      --enable-perlinterp
-      --enable-rubyinterp
-      --enable-tclinterp
+      --#{want_interp}-perlinterp
+      --#{want_interp}-rubyinterp
+      --#{want_interp}-tclinterp
       --enable-terminal
       --with-tlib=ncurses
       --with-compiledby=Homebrew
@@ -109,7 +116,11 @@ class Macvim < Formula
 
   test do
     output = shell_output("#{bin}/mvim --version")
-    assert_match "+ruby", output
+    if build.without? "interpreters"
+      assert_match "-ruby", output
+    else
+      assert_match "+ruby", output
+    end
 
     # Simple test to check if MacVim was linked to Homebrew's Python 3
     if build.with? "python"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I think #10951 and this are in the same spirit, but in the opposite direction. It makes me sad when my MacVim stops working due to a change in the system ruby against which MacVim is linked, because I don't use the embedded perl(!), ruby, or tcl interpreters. Since those 3 currently have hard-coded `--enable` lines, it felt reasonable to allow similarly vanilla-minded folks to toggle them off.

I did see the "Brew frowns upon `option`s in core formula" line, and so I'm prepared for this to be closed wontmerge, but thought I'd take my chances