### PR TITLE
ttfautohint: remove with-qt option.

### DIFF
--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -21,36 +21,22 @@ class Ttfautohint < Formula
     depends_on "pkg-config" => :build
   end
 
-  option "with-qt", "Build ttfautohintGUI also"
-
-  deprecated_option "with-qt5" => "with-qt"
-
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "harfbuzz"
   depends_on "libpng"
-  depends_on "qt" => :optional
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --prefix=#{prefix}
-      --without-doc
-    ]
-
-    args << "--without-qt" if build.without? "qt"
-
     system "./bootstrap" if build.head?
-    system "./configure", *args
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--without-doc",
+                          "--without-qt"
     system "make", "install"
   end
 
   test do
-    if build.with? "qt"
-      system "#{bin}/ttfautohintGUI", "-V"
-    else
-      system "#{bin}/ttfautohint", "-V"
-    end
+    system "#{bin}/ttfautohint", "-V"
   end
 end


### PR DESCRIPTION
Used by ~10% of installs (https://formulae.brew.sh/formula/ttfautohint) and reported broken in #34257.

If this fails CI this PR will be changed to remove this option.

Fixes #34257.
Part of #31510.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?