### PR TITLE
openssl*: remove without-test option.

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -20,10 +20,6 @@ class Openssl < Formula
   keg_only :provided_by_macos,
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
 
-  option "without-test", "Skip build-time tests (not recommended)"
-
-  deprecated_option "without-check" => "without-test"
-
   depends_on "makedepend" => :build
 
   def arch_args
@@ -61,7 +57,7 @@ class Openssl < Formula
     system "perl", "./Configure", *(configure_args + arch_args[arch])
     system "make", "depend"
     system "make"
-    system "make", "test" if build.with?("test")
+    system "make", "test"
 
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
   end

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -16,12 +16,10 @@ class OpensslAT11 < Formula
 
   keg_only :versioned_formula
 
-  option "without-test", "Skip build-time tests (not recommended)"
-
   # Only needs 5.10 to run, but needs >5.13.4 to run the testsuite.
   # https://github.com/openssl/openssl/blob/4b16fa791d3ad8/README.PERL
   # The MacOS ML tag is same hack as the way we handle most :python deps.
-  depends_on "perl" if build.with?("test") && MacOS.version <= :mountain_lion
+  depends_on "perl" if MacOS.version <= :mountain_lion
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
   # SSLv3 & zlib are off by default with 1.1.0 but this may not
@@ -56,7 +54,7 @@ class OpensslAT11 < Formula
     ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
-    system "make", "test" if build.with?("test")
+    system "make", "test"
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
   end
 


### PR DESCRIPTION
This is based on their `brew info --analytics` usage and build errors. Additionally, we already recommend not using this option.

Part of https://github.com/Homebrew/homebrew-core/issues/31510.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----