### PR TITLE
Changing vsts-cli formula install directory

### DIFF
--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -197,13 +197,14 @@ class VstsCli < Formula
 
   def install
     virtualenv_install_with_resources
+    bin.install_symlink "#{libexec}/bin/vsts" => "vsts"
   end
 
   test do
-    system "#{libexec}/bin/vsts", "configure", "--help"
-    output = shell_output("#{libexec}/bin/vsts logout 2>&1", 1)
+    system "#{bin}/vsts", "configure", "--help"
+    output = shell_output("#{bin}/vsts logout 2>&1", 1)
     assert_equal "ERROR: The credential was not found", output.chomp
-    output = shell_output("#{libexec}/bin/vsts work 2>&1", 2)
+    output = shell_output("#{bin}/vsts work 2>&1", 2)
     assert_match "vsts work: error: the following arguments are required", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The formula is currently installed in the libexec path which is not accessible in the default path unless symlink is explicitly created to bin directory. So adding the symlink while installing.
