### PR TITLE
FFmpeg 4.1 VMAF

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -19,6 +19,7 @@ class Ffmpeg < Formula
   option "with-libssh", "Enable SFTP protocol via libssh"
   option "with-tesseract", "Enable the tesseract OCR engine"
   option "with-libvidstab", "Enable vid.stab support for video stabilization"
+  option "with-libvmaf", "Enable VMAF perceptual video quality assessment library"
   option "with-opencore-amr", "Enable Opencore AMR NR/WB audio format"
   option "with-openh264", "Enable OpenH264 library"
   option "with-openjpeg", "Enable JPEG 2000 image format"
@@ -64,6 +65,7 @@ class Ffmpeg < Formula
   depends_on "libsoxr" => :optional
   depends_on "libssh" => :optional
   depends_on "libvidstab" => :optional
+  depends_on "libvmaf" => :optional
   depends_on "opencore-amr" => :optional
   depends_on "openh264" => :optional
   depends_on "openjpeg" => :optional
@@ -128,6 +130,7 @@ class Ffmpeg < Formula
     args << "--enable-libtesseract" if build.with? "tesseract"
     args << "--enable-libtwolame" if build.with? "two-lame"
     args << "--enable-libvidstab" if build.with? "libvidstab"
+    args << "--enable-libvmaf" if build.with? "libvmaf"
     args << "--enable-libwavpack" if build.with? "wavpack"
     args << "--enable-libwebp" if build.with? "webp"
     args << "--enable-libzimg" if build.with? "zimg"


### PR DESCRIPTION
##### References

https://github.com/Netflix/vmaf
https://github.com/Homebrew/homebrew-core/blob/master/Formula/libvmaf.rb
https://www.ffmpeg.org/ffmpeg-all.html#libvmaf

##### Test that the libvmap has installed correctly...

```
$ ffmpeg -hide_banner -filters | egrep "libvmaf" 
$ ffmpeg -hide_banner -help filter=libvmaf
```

##### Simple Usage
```
$ ffmpeg -hide_banner -report -i "variant.mp4" -i "reference.mp4" -filter_complex "libvmaf" -f "null" '/dev/null'
```

##### Advanced Usage
```
$ ffmpeg -hide_banner -report -i "variant.mp4" -i "reference.mp4" -filter_complex "libvmaf=model_path=/usr/local/share/model/vmaf_v0.6.1.pkl:log_path=./vmaf_log.xml:log_fmt=xml:psnr=true:ssim=true" -t "00:00:30.000" -f "null" 'dev/null'
```

```
$ cat ./vmaf_log.xml | xmllint --format -
```

```
$ ffmpeg -hide_banner -help filter=libvmaf

Filter libvmaf
  Calculate the VMAF between two video streams.
    Inputs:
       #0: main (video)
       #1: reference (video)
    Outputs:
       #0: default (video)
libvmaf AVOptions:
  model_path        <string>     ..FV..... Set the model to be used for computing vmaf. (default "/usr/local/share/model/vmaf_v0.6.1.pkl")
  log_path          <string>     ..FV..... Set the file path to be used to store logs.
  log_fmt           <string>     ..FV..... Set the format of the log (xml or json).
  enable_transform  <boolean>    ..FV..... Enables transform for computing vmaf. (default false)
  phone_model       <boolean>    ..FV..... Invokes the phone model that will generate higher VMAF scores. (default false)
  psnr              <boolean>    ..FV..... Enables computing psnr along with vmaf. (default false)
  ssim              <boolean>    ..FV..... Enables computing ssim along with vmaf. (default false)
  ms_ssim           <boolean>    ..FV..... Enables computing ms-ssim along with vmaf. (default false)
  pool              <string>     ..FV..... Set the pool method to be used for computing vmaf.
  n_threads         <int>        ..FV..... Set number of threads to be used when computing vmaf. (from 0 to UINT32_MAX) (default 0)
  n_subsample       <int>        ..FV..... Set interval for frame subsampling used when computing vmaf. (from 1 to UINT32_MAX) (default 1)
  enable_conf_interval <boolean>    ..FV..... Enables confidence interval. (default false)

framesync AVOptions:
  eof_action        <int>        ..FV..... Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)
     repeat                       ..FV..... Repeat the previous frame.
     endall                       ..FV..... End both streams.
     pass                         ..FV..... Pass through the main input.
  shortest          <boolean>    ..FV..... force termination when the shortest input terminates (default false)
  repeatlast        <boolean>    ..FV..... extend last frame of secondary streams beyond EOF (default true)
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
