### PR TITLE
libcaption 0.7 (new formula)

### DIFF
--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -3,7 +3,6 @@ class Libcaption < Formula
   homepage "https://github.com/szatmary/libcaption"
 
   url "https://github.com/szatmary/libcaption/archive/0.7.tar.gz"
-  # version "0.7"
   sha256 "125c9c55e1d5f0dc37ef151fa9583dd2fcfaefe7699d348c7292e634859e527e"
 
   depends_on "cmake" => :build

--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -1,0 +1,41 @@
+class Libcaption < Formula
+  desc "Library for the creation and parsing of closed caption data"
+  homepage "https://github.com/szatmary/libcaption"
+
+  url "https://github.com/szatmary/libcaption/archive/0.7.tar.gz"
+  # version "0.7"
+  sha256 "125c9c55e1d5f0dc37ef151fa9583dd2fcfaefe7699d348c7292e634859e527e"
+  revision 0
+
+  # --HEAD version
+  head "https://github.com/szatmary/libcaption.git"
+
+  depends_on "cmake" => :build
+  depends_on "ffmpeg" => :build
+  depends_on "re2c" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    # Create an FLV video file
+    INPUT_VIDEO = testpath/"input_video.flv"
+    system "ffmpeg", "-report", "-hide_banner",
+    "-f", "lavfi", "-i", "smptebars=duration=2:size=640x360:rate=30",
+    "-c:v", "libx264", "-crf", "23", "-preset", "ultrafast",
+    "-f", "flv", INPUT_VIDEO
+    # system "ffprobe", "-i", INPUT_VIDEO
+
+    INPUT_CAPTION_FILE = testpath/"input_caption.srt"
+    INPUT_CAPTION_FILE.write <<~EOS
+      1
+      00:00:00,000 --> 00:00:02,000
+      Caption Text
+    EOS
+    OUTPUT_FILE = testpath/"output.flv"
+    system bin/"flv+srt", INPUT_VIDEO, INPUT_CAPTION_FILE, OUTPUT_FILE
+    assert_predicate OUTPUT_FILE, :exist?
+  end
+end

--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -26,7 +26,6 @@ class Libcaption < Formula
     "-f", "lavfi", "-i", "smptebars=duration=2:size=640x360:rate=30",
     "-c:v", "libx264", "-crf", "23", "-preset", "ultrafast",
     "-f", "flv", INPUT_VIDEO
-    # system "ffprobe", "-i", INPUT_VIDEO
 
     INPUT_CAPTION_FILE = testpath/"input_caption.srt"
     INPUT_CAPTION_FILE.write <<~EOS

--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -10,7 +10,7 @@ class Libcaption < Formula
   head "https://github.com/szatmary/libcaption.git"
 
   depends_on "cmake" => :build
-  depends_on "ffmpeg" => :build
+  depends_on "ffmpeg" => [:build, :test]
   depends_on "re2c" => :build
 
   def install

--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -5,7 +5,6 @@ class Libcaption < Formula
   url "https://github.com/szatmary/libcaption/archive/0.7.tar.gz"
   # version "0.7"
   sha256 "125c9c55e1d5f0dc37ef151fa9583dd2fcfaefe7699d348c7292e634859e527e"
-  revision 0
 
   # --HEAD version
   head "https://github.com/szatmary/libcaption.git"

--- a/Formula/libcaption.rb
+++ b/Formula/libcaption.rb
@@ -6,9 +6,6 @@ class Libcaption < Formula
   # version "0.7"
   sha256 "125c9c55e1d5f0dc37ef151fa9583dd2fcfaefe7699d348c7292e634859e527e"
 
-  # --HEAD version
-  head "https://github.com/szatmary/libcaption.git"
-
   depends_on "cmake" => :build
   depends_on "ffmpeg" => [:build, :test]
   depends_on "re2c" => :build


### PR DESCRIPTION
Added a formula for libcaption https://github.com/szatmary/libcaption, an open source, cross platform library for the creation and parsing of EIA608, CEA708 closed caption data in video files.

##### Strict Audit
```
$ brew install libcaption
/usr/local/Cellar/libcaption/0.7: 24 files, 618.7KB, built in 17 seconds
$ brew audit --strict libcaption
```

##### Build from Source
```
$ brew install --build-from-source libcaption
/usr/local/Cellar/libcaption/0.7: 24 files, 618.7KB, built in 17 seconds
```

##### Test
```
$ brew test libcaption
```

##### Dry Run
```
$ brew install --dry-run libcaption
```

##### Info
```
$ brew info libcaption
libcaption: stable 0.7, HEAD
Library for the creation and parsing of closed caption data
https://github.com/szatmary/libcaption
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----