### PR TITLE
Corrected sha256 sum for jq sources

### DIFF
--- a/Formula/jq.rb
+++ b/Formula/jq.rb
@@ -2,7 +2,7 @@ class Jq < Formula
   desc "Lightweight and flexible command-line JSON processor"
   homepage "https://stedolan.github.io/jq/"
   url "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz"
-  sha256 "9625784cf2e4fd9842f1d407681ce4878b5b0dcddbcd31c6135114a30c71e6a8"
+  sha256 "5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Seems, that during upgrade somebody forgot about it.

Now:

```
[art@osx:~]% curl -s -L 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz' | shasum -a 256
5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72  -
```

Without it, I get checksum mismatch when trying to upgrade jq on El Captain OSX.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
