### PR TITLE
protobuf: fix --with-python build with Python 3.7

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -28,6 +28,12 @@ class Protobuf < Formula
     sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
   end
 
+  # Upstream PR from 3 Jul 2018 "Add Python 3.7 compatibility"
+  patch do
+    url "https://github.com/protocolbuffers/protobuf/pull/4862.patch?full_index=1"
+    sha256 "4b1fe1893c40cdcef531c31746ddd18759c9ce3564c89ddcc0ec934ea5dbf377"
+  end
+
   needs :cxx11
 
   def install


### PR DESCRIPTION
If built using `--with-python`, compilation fails with Python 3.7 because the Python folks changed their C API such that `PyUnicode_AsUTF8AndSize()` now returns a `const char*` rather than a `char*`. Add a patch to work around.

This is the same patch that was applied for protobuf 3.6.1 in Homebrew/homebrew-core#29660. That patch was removed in the upgrade of the formula to protobuf 3.6.1.1 in Homebrew/homebrew-core@3a6b38b6, perhaps because it was incorrectly assumed the patch was incorporated upstream in the 3.6 branch.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
