### PR TITLE
libxml2: fix build on pre-clang systems

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -26,8 +26,11 @@ class Libxml2 < Formula
   depends_on "python@2"
 
   def install
-    inreplace "configure", "-Wno-array-bounds", "" if ENV.compiler == :gcc_4_2
     system "autoreconf", "-fiv" if build.head?
+
+    # Fix build on OS X 10.5 and 10.6 with Xcode 3.2.6
+    inreplace "configure", "-Wno-array-bounds", "" if ENV.compiler == :gcc_4_2
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--without-python",

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -26,6 +26,7 @@ class Libxml2 < Formula
   depends_on "python@2"
 
   def install
+    inreplace "configure", "-Wno-array-bounds", "" if ENV.compiler == :gcc_4_2
     system "autoreconf", "-fiv" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove a flag not added until GCC 4.6 if being installed on a system that doesn't include clang. Being a git dependency, this fix allows Homebrew to install without interruption on OS X 10.5 & 10.6 w/ Xcode 3.2.6.
