### PR TITLE
swift: fix SourceKit compilation

### DIFF
--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -68,7 +68,7 @@ class Swift < Formula
         compiler clang-resource-dir-symlink
         clang-builtin-headers-in-clang-resource-dir stdlib sdk-overlay tools
         editor-integration testsuite-tools toolchain-dev-tools license
-        sourcekit-inproc sourcekit-xpc-service swift-remote-mirror
+        sourcekit-xpc-service swift-remote-mirror
         swift-remote-mirror-headers
       ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes #33960.

In-process SourceKit is not present in Apple's toolchains on macOS.
Since Swift build script can only build one version (either XPC or in-proc) at a time, we need to only build the XPC version which is required on macOS.