### PR TITLE
Eclipse Vert.x 3.6.0

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.5.4-full.tar.gz"
-  sha256 "9a23895f45c5951c53368d3b5b511d760183617aff76e1693d359a5e928220a2"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.0-full.tar.gz"
+  sha256 "df2737aa6d5e5a921abec487263fa82354c22468677c61baafbfb05bcdbdcd79"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.6.0

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As the homebrew update is part of the Vert.x release process, the homepage (https://vertx.io) is not yet updated, but the artifacts are already deployed publicly. 
