### PR TITLE
opa: add more ldflags, and therefore change the used url scheme to git

### DIFF
--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -1,8 +1,11 @@
 class Opa < Formula
   desc "Open source, general-purpose policy engine"
   homepage "https://www.openpolicyagent.org"
-  url "https://github.com/open-policy-agent/opa/archive/v0.10.1.tar.gz"
-  sha256 "6b6121cbf7efc42b6ebc3f5ba6a2533e4e6eaf4b9eec446fb6f8fce4e6c02ae7"
+  url "https://github.com/open-policy-agent/opa.git",
+      :tag      => "v0.10.1",
+      :revision => "6c39555de1feda5b3650397b9a752bc59621c7ac"
+  revision 1
+  head "https://github.com/open-policy-agent/opa.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -18,9 +21,18 @@ class Opa < Formula
     (buildpath/"src/github.com/open-policy-agent/opa").install buildpath.children
 
     cd "src/github.com/open-policy-agent/opa" do
+      commit = Utils.popen_read("git rev-parse --short HEAD").chomp
+      timestamp = Utils.popen_read("date -u +\"%Y-%m-%dT%H:%M:%SZ\"").chomp
+      hostname = Utils.popen_read("hostname -f").chomp
+      ldflags = "-X github.com/open-policy-agent/opa/version.Version=#{version}"\
+                " -X github.com/open-policy-agent/opa/version.Vcs=#{commit}"\
+                " -X github.com/open-policy-agent/opa/version.Timestamp=#{timestamp}"\
+                " -X github.com/open-policy-agent/opa/version.Hostname=#{hostname}"
+
       system "go", "build", "-o", bin/"opa", "-installsuffix", "static",
                    "-ldflags",
-                   "-X github.com/open-policy-agent/opa/version.Version=#{version}"
+                   ldflags
+
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The brew audit gives this message:
```  
* stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
```
This is probably due to the fact that I changed the URL-scheme from HTTP to GIT, so no sha256 is specified anymore, but a git specific revision.