### PR TITLE
New formulae: kubernetes-helm@2.9 2.9.1 kubernetes-helm@2.10 2.10.0

### DIFF
--- a/Formula/kubernetes-helm@2.10.rb
+++ b/Formula/kubernetes-helm@2.10.rb
@@ -1,0 +1,57 @@
+class KubernetesHelmAT210 < Formula
+  desc "The Kubernetes package manager (v2.10)"
+  homepage "https://helm.sh/"
+
+  # Use git rather than tarball because the build tool
+  # updates the SemVer and revision information
+  url "https://github.com/helm/helm.git",
+      :tag      => "v2.10.0",
+      :revision => "9ad53aac42165a5fadc6c87be0dea6b115f93090"
+
+  bottle do
+    cellar :any_skip_relocation
+    rebuild 1
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+  depends_on "mercurial" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "bootstrap"
+      system "make", "build"
+
+      bin.install "bin/helm"
+      bin.install "bin/tiller"
+      man1.install Dir["docs/man/man1/*"]
+
+      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      (bash_completion/"helm").write output
+
+      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      (zsh_completion/"_helm").write output
+
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end

--- a/Formula/kubernetes-helm@2.9.rb
+++ b/Formula/kubernetes-helm@2.9.rb
@@ -1,0 +1,57 @@
+class KubernetesHelmAT29 < Formula
+  desc "The Kubernetes package manager (v2.9)"
+  homepage "https://helm.sh/"
+
+  # Use git rather than tarball because the build tool
+  # updates the SemVer and revision information
+  url "https://github.com/helm/helm.git",
+      :tag      => "v2.9.1",
+      :revision => "20adb27c7c5868466912eebdf6664e7390ebe710"
+
+  bottle do
+    cellar :any_skip_relocation
+    rebuild 1
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+  depends_on "mercurial" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    arch = MacOS.prefer_64_bit? ? "amd64" : "x86"
+    ENV["TARGETS"] = "darwin/#{arch}"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "bootstrap"
+      system "make", "build"
+
+      bin.install "bin/helm"
+      bin.install "bin/tiller"
+      man1.install Dir["docs/man/man1/*"]
+
+      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      (bash_completion/"helm").write output
+
+      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      (zsh_completion/"_helm").write output
+
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end


### PR DESCRIPTION
Helm does not support compatibility across minor versions between
client and server; therefore it is necessary to make past minor
versions available when running with Kubernetes clusters that have
not upgraded their Helm version (e.g. IBM Cloud Private).

I chose to use a keg-only approach because adjusting binary names
intoduces too many variables and users needing back versions can
adjust their PATHs when working with such clusters.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
