### PR TITLE
Publish Needle version v0.8.5

### DIFF
--- a/Formula/needle.rb
+++ b/Formula/needle.rb
@@ -1,0 +1,18 @@
+class Needle < Formula
+  desc "Compile-time safe Swift dependency injection framework with real code"
+  homepage "https://github.com/uber/needle"
+  url "https://github.com/uber/needle.git",
+      :tag      => "v0.8.5",
+      :revision => "e08b1ad4948f8bab44d1898b8707fffc2de0a690"
+
+  depends_on :xcode => ["10.0", :build]
+  depends_on :xcode => "6.0"
+
+  def install
+    system "make", "install", "BINARY_FOLDER_PREFIX=#{prefix}"
+  end
+
+  test do
+    assert_match "0.8.5", shell_output("#{bin}/needle version")
+  end
+end


### PR DESCRIPTION
First publish of Needle (https://github.com/uber/needle), a compile-time safe dependency injection system for Swift. This publishes the generator executable to Homebrew.

- [✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/uber/needle/issues/197