### PR TITLE
expect: revision after checksum fix

### DIFF
--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -3,9 +3,9 @@ class Expect < Formula
   homepage "https://expect.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/expect/Expect/5.45.4/expect5.45.4.tar.gz"
   sha256 "49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34"
+  revision 1
 
   bottle do
-    rebuild 1
     sha256 "668b4fb12eed5bbf783e8b4ec52dad24b88f38af5577ba1e45ed9947e50e50ef" => :mojave
     sha256 "a0c6ffe797dc0bbe512b628819acee67a7a9b00573b6433fe0672285d41a9df1" => :high_sierra
     sha256 "fc9ad781caaf8d45f47a87d4303645faa2e600852c73fd5432f0be2e588e95f2" => :sierra


### PR DESCRIPTION
Bump revision to ensure non-bottled installations are rebuild
after the tarball was updated in #23852.