### PR TITLE
bower: revision after checksum fix

### DIFF
--- a/Formula/bower.rb
+++ b/Formula/bower.rb
@@ -6,10 +6,10 @@ class Bower < Formula
   # Use Github tarball to avoid bowers npm 4+ incompatible bundled dep usage
   url "https://github.com/bower/bower/archive/v1.8.4.tar.gz"
   sha256 "62a6f019638e2a1628d2434a3c62cb62f8d88528fee9abaf6199d203e68cffbc"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
-    rebuild 1
     sha256 "71091cd752679276938b3d522b3a3208028ac39d7567621c6be01d9ff8176208" => :mojave
     sha256 "055539589006d7eeb83b1ce11bf54e120660790c5795fc73acf5842691984e6e" => :high_sierra
     sha256 "aaaf74c6e92afb1cb2f2907a8e8380414915aac75a00e03c2356a6099b33520e" => :sierra


### PR DESCRIPTION
Bump revision to ensure non-bottled installations are rebuild
after the tarball was updated in #31767.