### PR TITLE
nuttcp: revision after checksum fix

### DIFF
--- a/Formula/nuttcp.rb
+++ b/Formula/nuttcp.rb
@@ -3,10 +3,10 @@ class Nuttcp < Formula
   homepage "https://www.nuttcp.net/nuttcp"
   url "https://www.nuttcp.net/nuttcp/nuttcp-8.1.4.tar.bz2"
   sha256 "737f702ec931ec12fcf54e66c4c1d5af72bd3631439ffa724ed2ac40ab2de78d"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
-    rebuild 1
     sha256 "82951677c224a70e463033f266791122d7419dd5308bef61da5474738151497b" => :mojave
     sha256 "bb494c46c81a914bb8eb66ad4476c2503e0345fc8f9dcf82c5cd2576fe005869" => :high_sierra
     sha256 "9f4ca632e04e072eea5d17a54cd42e22d63ef7902e452d1133d42fea0ca2f829" => :sierra


### PR DESCRIPTION
Bump revision to ensure non-bottled installations are rebuild
after the tarball was updated in #32043.