### PR TITLE
cracklib: bump revision after checksum fix

### DIFF
--- a/Formula/cracklib.rb
+++ b/Formula/cracklib.rb
@@ -3,9 +3,9 @@ class Cracklib < Formula
   homepage "https://github.com/cracklib/cracklib"
   url "https://github.com/cracklib/cracklib/releases/download/cracklib-2.9.6/cracklib-2.9.6.tar.gz"
   sha256 "17cf76943de272fd579ed831a1fd85339b393f8d00bf9e0d17c91e972f583343"
+  revision 1
 
   bottle do
-    rebuild 1
     sha256 "a21962259717ab187dc477310b0e68b28449135839312f7c632f0e46414efcf1" => :mojave
     sha256 "52c1e0acde52e27553ca3884dba490596ebc4a45019181bbb355ed9bad50e778" => :high_sierra
     sha256 "e2cfe716fb290d4dd26558290707596146e15ca8da510b38897c128f961779b6" => :sierra


### PR DESCRIPTION
Bump revision to ensure non-bottled installations are rebuild
after the tarball was updated in #31948.