### PR TITLE
make boost as an option for nghttp2 formula

### DIFF
--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -20,6 +20,7 @@ class Nghttp2 < Formula
   end
 
   option "with-python", "Build python3 bindings"
+  option "with-boost", "Build high level api with boost"
 
   deprecated_option "with-python3" => "with-python"
 
@@ -33,6 +34,7 @@ class Nghttp2 < Formula
   depends_on "libevent"
   depends_on "libxml2" if MacOS.version <= :lion
   depends_on "openssl"
+  depends_on "boost" => :optional
   depends_on "python" => :optional
 
   resource "Cython" do
@@ -58,6 +60,11 @@ class Nghttp2 < Formula
     # requires thread-local storage features only available in 10.11+
     args << "--disable-threads" if MacOS.version < :el_capitan
     args << "--with-xml-prefix=/usr" if MacOS.version > :lion
+
+    if build.with? "boost"
+      args << "--with-boost=#{Formula["boost"].opt_prefix}"
+      args << "--enable-asio-lib"
+    end
 
     system "autoreconf", "-ivf" if build.head?
     system "./configure", *args


### PR DESCRIPTION
- [yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [yes] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#34441 remove boost from nghttp2 formula

I think it is better to make boost as an option.
I have using the high level api of nghttp2 with boost, after #34441 it takes a lot of time to make my project run properly.
