### PR TITLE
Buildifier 0.19.2.1

### DIFF
--- a/Formula/buildifier.rb
+++ b/Formula/buildifier.rb
@@ -2,8 +2,8 @@ class Buildifier < Formula
   desc "Format bazel BUILD files with a standard convention"
   homepage "https://github.com/bazelbuild/buildtools"
   url "https://github.com/bazelbuild/buildtools.git",
-      :tag      => "0.17.2",
-      :revision => "7926f6cd8f2568556b0efc23530743df4278e0fe"
+      :tag      => "0.19.2.1",
+      :revision => "3f6a2256863cb60d56b63b883dc797225b888e15"
 
   bottle do
     cellar :any_skip_relocation
@@ -21,10 +21,11 @@ class Buildifier < Formula
 
     commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
     inreplace "buildifier/buildifier.go" do |s|
-      s.gsub! /^(var buildifierVersion = ")redacted/, "\\1#{version}"
+      s.gsub! /^(var buildVersion = ")redacted/, "\\1#{version}"
       s.gsub! /^(var buildScmRevision = ")redacted/, "\\1#{commit}"
     end
 
+    system "go", "get", "github.com/golang/protobuf/proto"
     system "go", "build", "-o", bin/"buildifier", "buildifier/buildifier.go"
   end
 


### PR DESCRIPTION
- Upgrade buildifier to 0.19.2.1
- Change the replace pattern to replace 'buildVersion' rather than 'buildifierVersion'
- Fetch the protobuf dependency prior to building


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
