### PR TITLE
unbound: Depend on OpenSSL 1.1

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -12,14 +12,14 @@ class Unbound < Formula
   end
 
   depends_on "libevent"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-libevent=#{Formula["libevent"].opt_prefix}
-      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     args << "--with-libexpat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed


### PR DESCRIPTION
Recent versions of unbound attempt to use OpenSSL 1.1 APIs to perform
hostname validation when using DNS over TLS.

When linked with OpenSSL 1.0, unbound now logs errors.  For example:

[1544059392] unbound[85070:0] error: no name verification functionality
in ssl library, ignored name for 1.1.1.1#cloudflare-dns.com

This patch updates the unbound formula to depend on OpenSSL 1.1 so
that unbound does not log errors.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
