### PR TITLE
Add gost-proxy: 2.6.1

### DIFF
--- a/Formula/gost-proxy.rb
+++ b/Formula/gost-proxy.rb
@@ -1,0 +1,42 @@
+class GostProxy < Formula
+  desc "GO Simple Tunnel - a simple tunnel written in golang"
+  homepage "https://github.com/ginuerzh/gost"
+  url "https://github.com/ginuerzh/gost/archive/v2.6.1.tar.gz"
+  sha256 "d8231f5869e54066e0f1ba333d0209727bfe14998d296ebdf7b423d0c33209c6"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    (buildpath/"src/github.com/ginuerzh/gost").install buildpath.children
+    cd "src/github.com/ginuerzh/gost" do
+      system "go", "build", "-o", bin/"gost-proxy", "./cmd/gost"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    (testpath/"index.html").write("Gost Proxy Test")
+
+    pid_gost = fork do
+      exec "#{bin}/gost-proxy -D -L=http://localhost:8080"
+    end
+
+    pid_http = fork do
+      exec "python -m SimpleHTTPServer 8000"
+    end
+
+    sleep 2
+
+    begin
+      output = shell_output("curl -x http://localhost:8080 http://localhost:8000/index.html")
+      assert_match "Gost Proxy Test", output, "Gost proxy server did not start!"
+    ensure
+      Process.kill("SIGINT", pid_gost)
+      Process.kill("SIGKILL", pid_http)
+      Process.wait(pid_gost)
+      Process.wait(pid_http)
+    end
+  end
+end


### PR DESCRIPTION
GOST is a powerful proxy tool
homepage: [ginuerzh/gost](/ginuerzh/gost)

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----