### PR TITLE
{open,libre}ssl*: provided by macOS.

### DIFF
--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -20,7 +20,8 @@ class Libressl < Formula
     depends_on "libtool" => :build
   end
 
-  keg_only "LibreSSL is not linked to prevent conflict with the system OpenSSL"
+  keg_only :provided_by_macos,
+    "LibreSSL is not linked to prevent conflict with the system OpenSSL"
 
   def install
     args = %W[

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -13,7 +13,8 @@ class OpensslAT11 < Formula
     sha256 "af76397790ce9cb571a8e0bd1014a90a47ed1c05b5ee6727a2f6796ebdb95365" => :sierra
   end
 
-  keg_only :versioned_formula
+  keg_only :provided_by_macos,
+    "openssl/libressl is provided by macOS so don't link an incompatible version"
 
   # Only needs 5.10 to run, but needs >5.13.4 to run the testsuite.
   # https://github.com/openssl/openssl/blob/4b16fa791d3ad8/README.PERL


### PR DESCRIPTION
This allows simplifying the OpenSSL link logic in Homebrew/brew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----