### PR TITLE
psfex 3.21.1 (new formula)

### DIFF
--- a/Formula/psfex.rb
+++ b/Formula/psfex.rb
@@ -1,0 +1,22 @@
+class Psfex < Formula
+  desc "Extracts precise models of the PSFs from images processed by SExtractor"
+  homepage "https://www.astromatic.net/software/psfex"
+  url "https://github.com/astromatic/psfex/archive/3.21.1.zip"
+  sha256 "0716e6be8d701ada0500c3e5e40091d4ac15f85ebd670dc4f937f92812b26b70"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "fftw"
+  depends_on "openblas"
+  depends_on "plplot"
+
+  def install
+    openblas = Formula["openblas"].opt_prefix
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}", "--enable-openblas", "--with-openblas-libdir=#{openblas}/lib", "--with-openblas-incdir=#{openblas}/include"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Adds PSFex software recipe. PSFEx (“PSF Extractor”) extracts models of the Point Spread Function (PSF) from FITS images processed with SExtractor and measures the quality of images.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
