### PR TITLE
cf-cli lives on cloudfoundry tap not pivotal tap

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -10,7 +10,7 @@
   "avidemux": "homebrew/cask",
   "awsenv": "Luzifer/tools",
   "chromedriver": "homebrew/cask",
-  "cloudfoundry-cli": "cloudfoundry/tap",
+  "cloudfoundry-cli": "cloudfoundry/tap/cf-cli",
   "cmucl": "homebrew/cask",
   "cockatrice": "homebrew/cask",
   "crystax-ndk": "homebrew/cask",

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -10,7 +10,7 @@
   "avidemux": "homebrew/cask",
   "awsenv": "Luzifer/tools",
   "chromedriver": "homebrew/cask",
-  "cloudfoundry-cli": "pivotal/tap",
+  "cloudfoundry-cli": "cloudfoundry/tap",
   "cmucl": "homebrew/cask",
   "cockatrice": "homebrew/cask",
   "crystax-ndk": "homebrew/cask",


### PR DESCRIPTION
Hi,

We are fixing an issue where homebrew reports the wrong tap for installing the Cloud Foundry CLI.
https://github.com/cloudfoundry/cli/issues/1455

FYI, a lot of your contributing docs and checklist seem to apply to PRs that changes formulae, but we are just updating the JSON.

Co-authored-by: Tom Viehman <tviehman@pivotal.io>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
