### PR TITLE
gcc: remove options

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -28,9 +28,6 @@ class Gcc < Formula
     satisfy { MacOS::CLT.installed? }
   end
 
-  option "with-jit", "Build just-in-time compiler"
-  option "with-nls", "Build with native language support (localization)"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
@@ -57,30 +54,28 @@ class Gcc < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    # JIT compiler is off by default, enabling it has performance cost
-    languages << "jit" if build.with? "jit"
+    # D will be included in GCC 9
+    languages << "d" if build.head?
 
     osmajor = `uname -r`.chomp
+    pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 
-    args = [
-      "--build=x86_64-apple-darwin#{osmajor}",
-      "--prefix=#{prefix}",
-      "--libdir=#{lib}/gcc/#{version_suffix}",
-      "--enable-languages=#{languages.join(",")}",
-      # Make most executables versioned to avoid conflicts.
-      "--program-suffix=-#{version_suffix}",
-      "--with-gmp=#{Formula["gmp"].opt_prefix}",
-      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
-      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-      "--with-isl=#{Formula["isl"].opt_prefix}",
-      "--with-system-zlib",
-      "--enable-checking=release",
-      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
-      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+    args = %W[
+      --build=x86_64-apple-darwin#{osmajor}
+      --prefix=#{prefix}
+      --libdir=#{lib}/gcc/#{version_suffix}
+      --disable-nls
+      --enable-checking=release
+      --enable-languages=#{languages.join(",")}
+      --program-suffix=-#{version_suffix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-mpfr=#{Formula["mpfr"].opt_prefix}
+      --with-mpc=#{Formula["libmpc"].opt_prefix}
+      --with-isl=#{Formula["isl"].opt_prefix}
+      --with-system-zlib
+      --with-pkgversion=#{pkgversion}
+      --with-bugurl=https://github.com/Homebrew/homebrew-core/issues
     ]
-
-    args << "--disable-nls" if build.without? "nls"
-    args << "--enable-host-shared" if build.with?("jit")
 
     # Xcode 10 dropped 32-bit support
     args << "--disable-multilib" if DevelopmentTools.clang_build_version >= 1000

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -18,9 +18,6 @@ class GccAT6 < Formula
     satisfy { MacOS::CLT.installed? }
   end
 
-  option "with-nls", "Build with native language support (localization)"
-  option "with-jit", "Build the jit compiler"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
@@ -31,22 +28,12 @@ class GccAT6 < Formula
 
   fails_with :gcc_4_0
 
-  # Fix for libgccjit.so linkage on Darwin
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
-  # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225625332
-  # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225626490
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e9e0ee09389a54cc4c8fe1c24ebca3cd765ed0ba/gcc/6.1.0-jit.patch"
-    sha256 "863957f90a934ee8f89707980473769cff47ca0663c3906992da6afb242fb220"
-  end
-
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
     # C, C++, ObjC, Fortran compilers are always built
     languages = %w[c c++ objc obj-c++ fortran]
-    languages << "jit" if build.with? "jit"
 
     version_suffix = version.to_s.slice(/\d/)
 
@@ -78,15 +65,13 @@ class GccAT6 < Formula
       "--disable-werror",
       "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
       "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+      "--disable-nls",
     ]
 
     # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
     # format to avoid failure during the stage 3 comparison of object files.
     # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
     args << "--with-dwarf2" if MacOS.version <= :mountain_lion
-
-    args << "--disable-nls" if build.without? "nls"
-    args << "--enable-host-shared" if build.with?("jit")
 
     # Xcode 10 dropped 32-bit support
     args << "--disable-multilib" if DevelopmentTools.clang_build_version >= 1000


### PR DESCRIPTION
The NLS and JIT options are very seldom used:

```
==> install_on_request (30 days)
Index | Name (with options)                                  |  Count |  Percent
-----:|------------------------------------------------------|-------:|--------:
1     | gcc                                                  | 39,012 |   99.32%
2     | gcc --HEAD                                           |    199 |    0.51%
3     | gcc --with-jit --with-nls                            |     43 |    0.11%
4     | gcc --with-jit                                       |     17 |    0.04%
5     | gcc --with-nls                                       |      3 |    0.01%
6     | gcc --HEAD --with-nls                                |      2 |    0.01%
7     | gcc --HEAD --with-jit                                |      1 |    0.00%
8     | gcc --HEAD --with-jit --with-nls                     |      1 |    0.00%
9     | gcc --without-multilib                               |      1 |    0.00%
Total |                                                      | 39,279 |  100.00%
```

Adding support for D as language in HEAD (will be in GCC 9). 