### PR TITLE
Restore HTTPS for SVN URLs

### DIFF
--- a/Formula/acme.rb
+++ b/Formula/acme.rb
@@ -1,7 +1,7 @@
 class Acme < Formula
   desc "Crossassembler for multiple environments"
   homepage "https://sourceforge.net/projects/acme-crossass/"
-  url "http://svn.code.sf.net/p/acme-crossass/code-0/trunk", :revision => "97"
+  url "https://svn.code.sf.net/p/acme-crossass/code-0/trunk", :revision => "97"
   version "0.96.4"
 
   bottle do

--- a/Formula/astyle.rb
+++ b/Formula/astyle.rb
@@ -3,7 +3,7 @@ class Astyle < Formula
   homepage "https://astyle.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_macos.tar.gz"
   sha256 "c4eebbe082eb2cb98f90aafcce3da2daeb774dd092e4cf8b728102fded8d1dcf"
-  head "http://svn.code.sf.net/p/astyle/code/trunk/AStyle"
+  head "https://svn.code.sf.net/p/astyle/code/trunk/AStyle"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -4,10 +4,10 @@ class ClangFormat < Formula
   version "2018-10-04"
 
   stable do
-    url "http://llvm.org/svn/llvm-project/llvm/tags/google/stable/2018-10-04/", :using => :svn
+    url "https://llvm.org/svn/llvm-project/llvm/tags/google/stable/2018-10-04/", :using => :svn
 
     resource "clang" do
-      url "http://llvm.org/svn/llvm-project/cfe/tags/google/stable/2018-10-04/", :using => :svn
+      url "https://llvm.org/svn/llvm-project/cfe/tags/google/stable/2018-10-04/", :using => :svn
     end
   end
 
@@ -19,10 +19,10 @@ class ClangFormat < Formula
   end
 
   head do
-    url "http://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
+    url "https://llvm.org/svn/llvm-project/llvm/trunk/", :using => :svn
 
     resource "clang" do
-      url "http://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
+      url "https://llvm.org/svn/llvm-project/cfe/trunk/", :using => :svn
     end
   end
 

--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -24,7 +24,7 @@ class Ctags < Formula
   end
 
   head do
-    url "http://svn.code.sf.net/p/ctags/code/trunk"
+    url "https://svn.code.sf.net/p/ctags/code/trunk"
     depends_on "autoconf" => :build
   end
 

--- a/Formula/dasm.rb
+++ b/Formula/dasm.rb
@@ -3,7 +3,7 @@ class Dasm < Formula
   homepage "https://dasm-dillon.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/dasm-dillon/dasm-dillon/2.20.11/dasm-2.20.11-2014.03.04-source.tar.gz"
   sha256 "a9330adae534aeffbfdb8b3ba838322b92e1e0bb24f24f05b0ffb0a656312f36"
-  head "http://svn.code.sf.net/p/dasm-dillon/code/trunk"
+  head "https://svn.code.sf.net/p/dasm-dillon/code/trunk"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -13,7 +13,7 @@ class Dosbox < Formula
   end
 
   head do
-    url "http://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk"
+    url "https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end

--- a/Formula/fuego.rb
+++ b/Formula/fuego.rb
@@ -1,10 +1,10 @@
 class Fuego < Formula
   desc "Collection of C++ libraries for the game of Go"
   homepage "https://fuego.sourceforge.io/"
-  url "http://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
+  url "https://svn.code.sf.net/p/fuego/code/trunk", :revision => 1981
   version "1.1.SVN"
   revision 2
-  head "http://svn.code.sf.net/p/fuego/code/trunk"
+  head "https://svn.code.sf.net/p/fuego/code/trunk"
 
   bottle do
     sha256 "2e8c65ddbcbb76158ab22805982c75940ed1a6eddc033cc157a03bee1364d502" => :mojave

--- a/Formula/fuse-emulator.rb
+++ b/Formula/fuse-emulator.rb
@@ -12,7 +12,7 @@ class FuseEmulator < Formula
   end
 
   head do
-    url "http://svn.code.sf.net/p/fuse-emulator/code/trunk/fuse"
+    url "https://svn.code.sf.net/p/fuse-emulator/code/trunk/fuse"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build

--- a/Formula/gmtl.rb
+++ b/Formula/gmtl.rb
@@ -1,7 +1,7 @@
 class Gmtl < Formula
   desc "Lightweight math library"
   homepage "https://ggt.sourceforge.io/"
-  head "http://svn.code.sf.net/p/ggt/code/trunk"
+  head "https://svn.code.sf.net/p/ggt/code/trunk"
 
   stable do
     url "https://downloads.sourceforge.net/project/ggt/Generic%20Math%20Template%20Library/0.6.1/gmtl-0.6.1.tar.gz"

--- a/Formula/gpsim.rb
+++ b/Formula/gpsim.rb
@@ -3,7 +3,7 @@ class Gpsim < Formula
   homepage "https://gpsim.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gpsim/gpsim/0.30.0/gpsim-0.30.0.tar.gz"
   sha256 "e1927312c37119bc26d6abf2c250072a279a9c764c49ae9d71b4ccebb8154f86"
-  head "http://svn.code.sf.net/p/gpsim/code/trunk"
+  head "https://svn.code.sf.net/p/gpsim/code/trunk"
 
   bottle do
     cellar :any

--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -3,7 +3,7 @@ class Irrlicht < Formula
   homepage "https://irrlicht.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/irrlicht/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip"
   sha256 "f42b280bc608e545b820206fe2a999c55f290de5c7509a02bdbeeccc1bf9e433"
-  head "http://svn.code.sf.net/p/irrlicht/code/trunk"
+  head "https://svn.code.sf.net/p/irrlicht/code/trunk"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/lasi.rb
+++ b/Formula/lasi.rb
@@ -4,7 +4,7 @@ class Lasi < Formula
   url "https://downloads.sourceforge.net/project/lasi/lasi/1.1.2%20Source/libLASi-1.1.2.tar.gz"
   sha256 "448c6e52263a1e88ac2a157f775c393aa8b6cd3f17d81fc51e718f18fdff5121"
   revision 1
-  head "http://svn.code.sf.net/p/lasi/code/trunk"
+  head "https://svn.code.sf.net/p/lasi/code/trunk"
 
   bottle do
     cellar :any

--- a/Formula/lcs.rb
+++ b/Formula/lcs.rb
@@ -1,9 +1,9 @@
 class Lcs < Formula
   desc "Satirical console-based political role-playing/strategy game"
   homepage "https://sourceforge.net/projects/lcsgame/"
-  url "http://svn.code.sf.net/p/lcsgame/code/trunk", :revision => "738"
+  url "https://svn.code.sf.net/p/lcsgame/code/trunk", :revision => "738"
   version "4.07.4b"
-  head "http://svn.code.sf.net/p/lcsgame/code/trunk"
+  head "https://svn.code.sf.net/p/lcsgame/code/trunk"
 
   bottle do
     sha256 "91469578607a9f4d1ae989ee523f2b5dd97c976d32d9a822769129df828163e5" => :mojave

--- a/Formula/libspectrum.rb
+++ b/Formula/libspectrum.rb
@@ -13,7 +13,7 @@ class Libspectrum < Formula
   end
 
   head do
-    url "http://svn.code.sf.net/p/fuse-emulator/code/trunk/libspectrum"
+    url "https://svn.code.sf.net/p/fuse-emulator/code/trunk/libspectrum"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build

--- a/Formula/llnode.rb
+++ b/Formula/llnode.rb
@@ -36,7 +36,7 @@ class Llnode < Formula
       # It claims it to be lldb 350.0 for Xcode 7.3, but in fact it is based
       # of 34.
       # Xcode < 7.3 uses 340.4, so I assume we should be safe to go with this.
-      url "http://llvm.org/svn/llvm-project/lldb/tags/RELEASE_34/final/",
+      url "https://llvm.org/svn/llvm-project/lldb/tags/RELEASE_34/final/",
           :using => :svn
     end
   end

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -3,10 +3,10 @@ class Netpbm < Formula
   homepage "https://netpbm.sourceforge.io/"
   # Maintainers: Look at https://sourceforge.net/p/netpbm/code/HEAD/tree/
   # for stable versions and matching revisions.
-  url "http://svn.code.sf.net/p/netpbm/code/stable", :revision => 3413
+  url "https://svn.code.sf.net/p/netpbm/code/stable", :revision => 3413
   version "10.73.22"
   version_scheme 1
-  head "http://svn.code.sf.net/p/netpbm/code/trunk"
+  head "https://svn.code.sf.net/p/netpbm/code/trunk"
 
   bottle do
     cellar :any

--- a/Formula/np2.rb
+++ b/Formula/np2.rb
@@ -1,8 +1,8 @@
 class Np2 < Formula
   desc "Neko Project 2: PC-9801 emulator"
   homepage "https://www.yui.ne.jp/np2/"
-  url "http://amethyst.yui.ne.jp/svn/pc98/np2/tags/VER_0_86/", :using => :svn, :revision => "2606"
-  head "http://amethyst.yui.ne.jp/svn/pc98/np2/trunk/", :using => :svn
+  url "https://amethyst.yui.ne.jp/svn/pc98/np2/tags/VER_0_86/", :using => :svn, :revision => "2606"
+  head "https://amethyst.yui.ne.jp/svn/pc98/np2/trunk/", :using => :svn
 
   bottle do
     cellar :any

--- a/Formula/npush.rb
+++ b/Formula/npush.rb
@@ -3,7 +3,7 @@ class Npush < Formula
   homepage "https://npush.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/npush/npush/0.7/npush-0.7.tgz"
   sha256 "f216d2b3279e8737784f77d4843c9e6f223fa131ce1ebddaf00ad802aba2bcd9"
-  head "http://svn.code.sf.net/p/npush/code/"
+  head "https://svn.code.sf.net/p/npush/code/"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pdfsandwich.rb
+++ b/Formula/pdfsandwich.rb
@@ -3,7 +3,7 @@ class Pdfsandwich < Formula
   homepage "http://www.tobias-elze.de/pdfsandwich/"
   url "https://downloads.sourceforge.net/project/pdfsandwich/pdfsandwich%200.1.7/pdfsandwich-0.1.7.tar.bz2"
   sha256 "9795ffea84b9b6b501f38d49a4620cf0469ddf15aac31bac6dbdc9ec1716fa39"
-  head "http://svn.code.sf.net/p/pdfsandwich/code/trunk/src"
+  head "https://svn.code.sf.net/p/pdfsandwich/code/trunk/src"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/qmmp.rb
+++ b/Formula/qmmp.rb
@@ -3,7 +3,7 @@ class Qmmp < Formula
   homepage "http://qmmp.ylsoftware.com/"
   url "http://qmmp.ylsoftware.com/files/qmmp-1.2.4.tar.bz2"
   sha256 "224904f073e3921a080dca008e6c99e3d606f5442d1df08835cba000a069ae66"
-  head "http://svn.code.sf.net/p/qmmp-dev/code/branches/qmmp-1.2/"
+  head "https://svn.code.sf.net/p/qmmp-dev/code/branches/qmmp-1.2/"
 
   bottle do
     sha256 "e8f99667d65835bdca131b967a1f49329431bc1665b92195349ece4938f8fdd4" => :mojave

--- a/Formula/quex.rb
+++ b/Formula/quex.rb
@@ -3,7 +3,7 @@ class Quex < Formula
   homepage "https://quex.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/quex/DOWNLOAD/quex-0.68.2.tar.gz"
   sha256 "b6a9325f92110c52126fec18432d0d6c9bd8a7593bde950db303881aac16a506"
-  head "http://svn.code.sf.net/p/quex/code/trunk"
+  head "https://svn.code.sf.net/p/quex/code/trunk"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/sdcc.rb
+++ b/Formula/sdcc.rb
@@ -3,7 +3,7 @@ class Sdcc < Formula
   homepage "https://sdcc.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sdcc/sdcc/3.8.0/sdcc-src-3.8.0.tar.bz2"
   sha256 "b331668deb7bd832efd112052e5b0ed2313db641a922bd39280ba6d47adbbb21"
-  head "http://svn.code.sf.net/p/sdcc/code/trunk/sdcc"
+  head "https://svn.code.sf.net/p/sdcc/code/trunk/sdcc"
 
   bottle do
     sha256 "f4ab0af5aedcbcc75312e82ac1bf771fb4a9b1763d5b591b390a7e1dec523f32" => :mojave

--- a/Formula/spim.rb
+++ b/Formula/spim.rb
@@ -2,9 +2,9 @@ class Spim < Formula
   desc "MIPS32 simulator"
   homepage "https://spimsimulator.sourceforge.io/"
   # No source code tarball exists
-  url "http://svn.code.sf.net/p/spimsimulator/code", :revision => 707
+  url "https://svn.code.sf.net/p/spimsimulator/code", :revision => 707
   version "9.1.19"
-  head "http://svn.code.sf.net/p/spimsimulator/code/"
+  head "https://svn.code.sf.net/p/spimsimulator/code/"
 
   bottle do
     sha256 "ed97fd8280e875fd1d20fe79ce6205dfdf9fb454c71b63f1f5b3849a24a4c7a2" => :mojave

--- a/Formula/supermodel.rb
+++ b/Formula/supermodel.rb
@@ -3,7 +3,7 @@ class Supermodel < Formula
   homepage "https://www.supermodel3.com/"
   url "https://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
   sha256 "ecaf3e7fc466593e02cbf824b722587d295a7189654acb8206ce433dcff5497b"
-  head "http://svn.code.sf.net/p/model3emu/code/trunk"
+  head "https://svn.code.sf.net/p/model3emu/code/trunk"
 
   bottle do
     rebuild 1

--- a/Formula/synfig.rb
+++ b/Formula/synfig.rb
@@ -4,7 +4,7 @@ class Synfig < Formula
   url "https://downloads.sourceforge.net/project/synfig/releases/1.0.2/source/synfig-1.0.2.tar.gz"
   sha256 "34cdf9eac90aadea29fb2997e82da1c32713ab02940f7c8873330f894e167fb4"
   revision 5
-  head "http://svn.code.sf.net/p/synfig/code/"
+  head "https://svn.code.sf.net/p/synfig/code/"
 
   bottle do
     sha256 "7051446f2836f7de2f71508639cd7e82de5b71013e55801124f6e5ecf426cca4" => :mojave

--- a/Formula/sz81.rb
+++ b/Formula/sz81.rb
@@ -3,7 +3,7 @@ class Sz81 < Formula
   homepage "https://sz81.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sz81/sz81/2.1.7/sz81-2.1.7-source.tar.gz"
   sha256 "4ad530435e37c2cf7261155ec43f1fc9922e00d481cc901b4273f970754144e1"
-  head "http://svn.code.sf.net/p/sz81/code/sz81"
+  head "https://svn.code.sf.net/p/sz81/code/sz81"
 
   bottle do
     sha256 "b90dc9986a1f3f6fa93967745f331d55d4e8837e05e47b9b28d3ee9245e561d3" => :mojave

--- a/Formula/teem.rb
+++ b/Formula/teem.rb
@@ -3,7 +3,7 @@ class Teem < Formula
   homepage "https://teem.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
   sha256 "a01386021dfa802b3e7b4defced2f3c8235860d500c1fa2f347483775d4c8def"
-  head "http://svn.code.sf.net/p/teem/code/teem/trunk"
+  head "https://svn.code.sf.net/p/teem/code/teem/trunk"
 
   bottle do
     sha256 "439d02dd7f54d7f307b5984d00448a4e77309660e8f1c52e998ef9ea40fdcaa1" => :mojave

--- a/Formula/ucon64.rb
+++ b/Formula/ucon64.rb
@@ -3,7 +3,7 @@ class Ucon64 < Formula
   homepage "https://ucon64.sourceforge.io/"
   url "https://downloads.sourceforge.net/ucon64/ucon64-2.1.0-src.tar.gz"
   sha256 "c99964060a5337cea811b27c4103e186a14ba1f04b19cff08bac0260271bc872"
-  head "http://svn.code.sf.net/p/ucon64/svn/trunk/ucon64"
+  head "https://svn.code.sf.net/p/ucon64/svn/trunk/ucon64"
 
   bottle do
     sha256 "84609c8e92dae09a76f12eebe5c19d1769eb22d28029db5d15c14949800c358f" => :mojave

--- a/Formula/xu4.rb
+++ b/Formula/xu4.rb
@@ -1,9 +1,9 @@
 class Xu4 < Formula
   desc "Remake of Ultima IV"
   homepage "https://xu4.sourceforge.io/"
-  url "http://svn.code.sf.net/p/xu4/code/trunk/u4", :revision => "3088"
+  url "https://svn.code.sf.net/p/xu4/code/trunk/u4", :revision => "3088"
   version "1.0beta4+r3088"
-  head "http://svn.code.sf.net/p/xu4/code/trunk/u4"
+  head "https://svn.code.sf.net/p/xu4/code/trunk/u4"
 
   bottle do
     cellar :any

--- a/Formula/zboy.rb
+++ b/Formula/zboy.rb
@@ -3,7 +3,7 @@ class Zboy < Formula
   homepage "https://zboy.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/zboy/zBoy%20v0.60/zboy-0.60.tar.gz"
   sha256 "f81e61433a5b74c61ab84cac33da598deb03e49699f3d65dcb983151a6f1c749"
-  head "http://svn.code.sf.net/p/zboy/code/trunk"
+  head "https://svn.code.sf.net/p/zboy/code/trunk"
 
   bottle do
     cellar :any


### PR DESCRIPTION
macOS Mojave 10.14.2 fixed the issue that resulted in a certificate prompt when accessing any Subversion repository URLs via HTTPS protocol in previous Mojave revisions. On 10.14.2 and later, HTTPS URLs work the same as they did in Sierra and High Sierra.

Ref: https://github.com/Homebrew/brew/issues/4870#issuecomment-444637222
Ref: https://github.com/Homebrew/homebrew-core/pull/32010

/cc @fxcoudert 