### PR TITLE
dosbox-x: Added build dependencies for HEAD

### DIFF
--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -4,7 +4,6 @@ class DosboxX < Formula
   url "https://github.com/joncampbell123/dosbox-x/archive/v0.801.tar.gz"
   sha256 "40f94cdcc5c9a374c522de7eb2c2288eaa8c6de85d0bd6a730f48bd5d84a89f9"
   revision 1
-  head "https://github.com/joncampbell123/dosbox-x.git"
 
   bottle do
     cellar :any
@@ -13,6 +12,13 @@ class DosboxX < Formula
     sha256 "8cbaa0cf9658118b4b4ba32f4d1718f9bf49d0aec71cc7846463f37966559656" => :high_sierra
     sha256 "d3fc4b2bd340ed6f7d2624b8daf95397891f8e142d6219437f2cae215f538216" => :sierra
     sha256 "0b5098e3397a15804a300540be53c98f862c4f7276eb4c1de7966152421a9392" => :el_capitan
+  end
+
+  head do
+    url "https://github.com/joncampbell123/dosbox-x.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
   end
 
   depends_on "fluid-synth"
@@ -29,20 +35,28 @@ class DosboxX < Formula
   def install
     ENV.cxx11
 
-    # Fix build failure due to missing <remote-ext.h> included from pcap.h
-    # https://github.com/joncampbell123/dosbox-x/issues/275
-    inreplace "src/hardware/ne2000.cpp", "#define HAVE_REMOTE\n", ""
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-sdltest
+      --enable-core-inline
+    ]
 
-    # Fix compilation issue: https://github.com/joncampbell123/dosbox-x/pull/308
-    if DevelopmentTools.clang_build_version >= 900
-      inreplace "src/hardware/serialport/nullmodem.cpp",
-                "setCD(clientsocket > 0)", "setCD(clientsocket != 0)"
+    if build.head?
+      system "./build-macosx", *args
+    else
+      # Fix build failure due to missing <remote-ext.h> included from pcap.h
+      # https://github.com/joncampbell123/dosbox-x/issues/275
+      inreplace "src/hardware/ne2000.cpp", "#define HAVE_REMOTE\n", ""
+
+      # Fix compilation issue: https://github.com/joncampbell123/dosbox-x/pull/308
+      if DevelopmentTools.clang_build_version >= 900
+        inreplace "src/hardware/serialport/nullmodem.cpp",
+                  "setCD(clientsocket > 0)", "setCD(clientsocket != 0)"
+      end
+
+      system "./configure", *args
     end
-
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
-                          "--disable-sdltest",
-                          "--enable-core-inline"
 
     chmod 0755, "install-sh"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

HEAD uses the projects `build-macosx` script, this could be used for the stable build on next release.