### PR TITLE
dar: build with some previously removed options

### DIFF
--- a/Formula/dar.rb
+++ b/Formula/dar.rb
@@ -11,6 +11,9 @@ class Dar < Formula
     sha256 "0f3d68d33877c3d98b9d8fbacdbd52c54569ccc1a46130ecec244415c58c5c73" => :el_capitan
   end
 
+  depends_on "upx" => :build
+  depends_on "libgcrypt"
+  depends_on "lzo"
   depends_on :macos => :el_capitan # needs thread-local storage
 
   needs :cxx11
@@ -23,10 +26,7 @@ class Dar < Formula
                           "--disable-dar-static",
                           "--disable-debug",
                           "--disable-dependency-tracking",
-                          "--disable-libgcrypt-linking",
-                          "--disable-liblzo2-linking",
                           "--disable-libxz-linking",
-                          "--disable-upx",
                           "--enable-mode=64"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds build dependencies to `dar` that were previously optional and then recently removed as part of the #31510 options purge. As there is a fraction of reported users using the previously optional dependencies libgcrypt, lzo, and upx including myself I have returned these select options and turned them into required dependencies. I left out libxz since it appears nobody was using it.

Please note that `dar` is useful for backups and restorations between platforms so there's a need for interoperability of build options between package managers. As an example, Fedora's package builds with libgcrypt, lzo, upx, and libxz. Also note that the existing formula disables build options that would otherwise be enabled by default.

>  $ dar -V
>  dar version 2.5.16, Copyright (C) 2002-2052 Denis Corbin
>    Long options support       : YES
> 
>  Using libdar 5.12.3 built with compilation time options:
>    Libz compression (gzip)      : YES
>    Libbz2 compression (bzip2)   : YES
>    Liblzo2 compression (lzo)    : YES
>    Liblzma compression (xz)     : NO
>    Strong encryption (libgcrypt): YES
>    Public key ciphers (gpgme)   : NO
>    Extended Attributes support  : YES
>    Large files support (> 2GB)  : YES
>    ext2fs NODUMP flag support   : NO
>    Special allocation scheme    : NO
>    Integer size used            : 64 bits
>    Thread safe support          : YES
>    Furtive read mode support    : NO
>    Linux ext2/3/4 FSA support   : NO
>    Mac OS X HFS+ FSA support    : YES
>    Detected system/CPU endian   : little
>    Posix fadvise support        : NO
>    Large dir. speed optimi.     : YES
>    Timestamp read accuracy      : 1 s
>    Timestamp write accuracy     : 1 microsecond
>    Restores dates of symlinks   : YES