### PR TITLE
postgresql@10 10.6

### DIFF
--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -1,0 +1,139 @@
+class PostgresqlAT10 < Formula
+  desc "Object-relational database system"
+  homepage "https://www.postgresql.org/"
+  url "https://ftp.postgresql.org/pub/source/v10.6/postgresql-10.6.tar.bz2"
+  sha256 "68a8276f08bda8fbefe562faaf8831cb20664a7a1d3ffdbbcc5b83e08637624b"
+
+  keg_only :versioned_formula
+
+  option "with-python", "Enable PL/Python3"
+
+  deprecated_option "with-python3" => "with-python"
+
+  depends_on "pkg-config" => :build
+  depends_on "icu4c"
+  depends_on "openssl"
+  depends_on "readline"
+  depends_on "python" => :optional
+
+  def install
+    # avoid adding the SDK library directory to the linker search path
+    ENV["XML2_CONFIG"] = "xml2-config --exec-prefix=/usr"
+
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --datadir=#{pkgshare}
+      --libdir=#{lib}
+      --sysconfdir=#{etc}
+      --docdir=#{doc}
+      --enable-thread-safety
+      --with-bonjour
+      --with-gssapi
+      --with-icu
+      --with-ldap
+      --with-libxml
+      --with-libxslt
+      --with-openssl
+      --with-pam
+      --with-perl
+      --with-uuid=e2fs
+    ]
+
+    if build.with?("python")
+      args << "--with-python"
+      ENV["PYTHON"] = which("python3")
+    end
+
+    # The CLT is required to build Tcl support on 10.7 and 10.8 because
+    # tclConfig.sh is not part of the SDK
+    if MacOS.version >= :mavericks || MacOS::CLT.installed?
+      args << "--with-tcl"
+      if File.exist?("#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh")
+        args << "--with-tclconfig=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework"
+      end
+    end
+
+    # As of Xcode/CLT 10.x the Perl headers were moved from /System
+    # to inside the SDK, so we need to use `-iwithsysroot` instead
+    # of `-I` to point to the correct location.
+    # https://www.postgresql.org/message-id/153558865647.1483.573481613491501077%40wrigleys.postgresql.org
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib} -R#{lib}/postgresql"
+
+    system "./configure", *args
+    system "make"
+
+    #  pkglibdir=#{lib}/postgresql
+    dirs = %W[datadir=#{pkgshare} libdir=#{lib} pkglibdir=#{lib}]
+
+    # Temporarily disable building/installing the documentation.
+    # Postgresql seems to "know" the build system has been altered and
+    # tries to regenerate the documentation when using `install-world`.
+    # This results in the build failing:
+    #  `ERROR: `osx' is missing on your system.`
+    # Attempting to fix that by adding a dependency on `open-sp` doesn't
+    # work and the build errors out on generating the documentation, so
+    # for now let's simply omit it so we can package Postgresql for Mojave.
+    if DevelopmentTools.clang_build_version >= 1000
+      system "make", "all"
+      system "make", "-C", "contrib", "install", "all", *dirs
+      system "make", "install", "all", *dirs
+    else
+      system "make", "install-world", *dirs
+    end
+  end
+
+  def post_install
+    (var/"log").mkpath
+    (var/"postgres").mkpath
+    unless File.exist? "#{var}/postgres/PG_VERSION"
+      system "#{bin}/initdb", "#{var}/postgres"
+    end
+  end
+
+  def caveats; <<~EOS
+    To migrate existing data from a previous major version of PostgreSQL run:
+      brew postgresql-upgrade-database
+  EOS
+  end
+
+  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres@10 start"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/postgres</string>
+        <string>-D</string>
+        <string>#{var}/postgres</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{HOMEBREW_PREFIX}</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/log/postgres.log</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/log/postgres.log</string>
+    </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    system "#{bin}/initdb", testpath/"test"
+    assert_equal pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
+    assert_equal lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
+    assert_equal lib.to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Some folks, myself included, may perform PostgreSQL upgrade from 10 to 11 a bit to hastily without reading the upgrade output instructing to perform schema upgrade before running `brew cleanup`.
This build gives them an option to install keg-only build of PostgreSQL 10 which can coexist with version 11 allowing upgrade with pg_upgrade:

```
brew update
brew upgrade # or brew upgrade postgresql
brew cleanup # oops - version 10 binaries removed
# 
# ensure no postgres processes are running
ps -ef |grep postgres
# initialize empty db v. 11
initdb /usr/local/var/postgres-11 -E utf-8
brew install postgresql@10.6
# perform upgrade
pg_upgrade -v \
  -d /usr/local/var/postgres -D /usr/local/var/postgres-11 \
  -b /usr/local/Cellar/postgresql@10.6/10.6/bin -B /usr/local/Cellar/postgresql/11.1/bin
# ensure no postgres processes are running
mv /usr/local/var/postgres /usr/local/var/postgres-10.6
mv /usr/local/var/postgres-11  /usr/local/var/postgres
# start postgres whichever way you fancy
launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
# ymmv - run analyze_new_cluster.sh or vacuumdb --all --analyze-only
./analyze_new_cluster.sh
# profit
```

Fixes https://github.com/Homebrew/homebrew-core/issues/34879