### PR TITLE
LokiNetwork 0.3.1 (new formula)

### DIFF
--- a/Formula/loki-network.rb
+++ b/Formula/loki-network.rb
@@ -1,0 +1,61 @@
+class LokiNetwork < Formula
+  desc "Private, decentralized, and market-based overlay for the internet"
+  homepage "https://loki.network"
+  url "https://github.com/loki-project/loki-network/archive/v0.3.1.tar.gz"
+  sha256 "a745cd156fd08be575f0e9f2fd56f4d6cde896363103c6f49499c90451021b34"
+  head "https://github.com/loki-project/loki-network.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => [:build, :test]
+  depends_on "abyss"
+  depends_on "rapidjson"
+
+  def install
+    # set some build time options
+    ENV["USE_AVX2"] = "1"
+    ENV["USE_LIBABYSS"] = "1"
+    ENV["USE_JSONRPC"] = "1"
+    # make a subdirectory to store build outputs
+    mkdir "#{buildpath}/build"
+    # generate ninja build system files
+    system "cmake", "-GNinja", "-B", "#{buildpath}/build", "-S", buildpath.to_s, *std_cmake_args
+    # build everything
+    system "ninja", "-C", "#{buildpath}/build"
+    cd "#{buildpath}/build"
+    system "ninja"
+    # install binaries
+    libexec.install [
+      "#{buildpath}/build/lokinet",
+      "#{buildpath}/lokinet-bootstrap",
+      "#{buildpath}/build/dns",
+      "#{buildpath}/build/llarpc",
+      "#{buildpath}/build/rcutil",
+    ]
+    # symlink main binaries into #{prefix}/bin
+    link "#{libexec}/lokinet", "#{bin}/lokinet"
+    link "#{libexec}/lokinet-bootstrap", "#{bin}/lokinet-bootstrap"
+    # install library headers
+    include.install [
+      "#{buildpath}/include/llarp.h",
+      "#{buildpath}/include/llarp.hpp",
+      "#{buildpath}/include/tuntap.h",
+      "#{buildpath}/include/utp.h",
+      "#{buildpath}/include/utp_types.h",
+    ]
+    include.install Dir[
+      "#{buildpath}/include/llarp",
+      "#{buildpath}/include/tl",
+    ]
+    # install libraries
+    lib.install [
+      "#{buildpath}/build/liblokinet-cryptography.a",
+      "#{buildpath}/build/liblokinet-platform.a",
+      "#{buildpath}/build/liblokinet-static.a",
+    ]
+  end
+
+  test do
+    # run lokinet's self-test binary
+    system "#{buildpath}/build/testAll"
+  end
+end


### PR DESCRIPTION
Adds a formula for the loki-network software, a private,
decentralised, and market-based overlay for the internet.

This software serves a similar place to I2P and Tor.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note the output of `brew audit` is as follows
```
loki-network:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
  * Formulae should not have a `HEAD` spec
Error: 2 problems in 1 formula detected
```

For the lack of notability, see our other repositories, such as [this one](https://github.com/loki-project/loki) (1821 forks at time of writing).  Is the repository still not considered notable enough in this case?

For the not having a `HEAD` spec, I just wanted to seek clarification on this.  The project is under active development, what's the reasoning for not having `HEAD` specs?