### PR TITLE
generate-json-schema: fix test flakiness

### DIFF
--- a/Formula/generate-json-schema.rb
+++ b/Formula/generate-json-schema.rb
@@ -23,7 +23,7 @@ class GenerateJsonSchema < Formula
   end
 
   test do
-    input = <<~EOS
+    (testpath/"test.json").write <<~EOS
       {
           "id": 2,
           "name": "An ice sculpture",
@@ -40,6 +40,6 @@ class GenerateJsonSchema < Formula
           }
       }
     EOS
-    assert_match "schema.org", pipe_output("#{bin}/generate-schema", input, 0)
+    assert_match "schema.org", shell_output("#{bin}/generate-schema test.json", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refs: #34899, #33690 (and others), https://github.com/nijikokun/generate-schema/issues/44

Works around the `generate-json-schema` test flakiness observed in the latest node upgrade PRs by moving the test from *piping the test data in* to *writing the test data to a file* [as documented](https://www.npmjs.com/package/generate-schema#cli). This  basically avoids their buggy command line arguments parsing code triggering the observed issues.
