### PR TITLE
cp2k: fix download URL

### DIFF
--- a/Formula/cp2k.rb
+++ b/Formula/cp2k.rb
@@ -1,7 +1,7 @@
 class Cp2k < Formula
   desc "Quantum chemistry and solid state physics software package"
   homepage "https://www.cp2k.org/"
-  url "https://downloads.sourceforge.net/project/cp2k/cp2k-5.1.tar.bz2"
+  url "https://github.com/cp2k/cp2k/releases/download/v5.1.0/cp2k-5.1.tar.bz2"
   sha256 "e23613b593354fa82e0b8410e17d94c607a0b8c6d9b5d843528403ab09904412"
   revision 2
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The old SourceForge download URL is 404. The cp2k home page now directs you to use the GitHub downloads.

No revision bump because the content has not changed.

Will partially fix the build error in #34973.