### PR TITLE
skinny 3.0.1

### DIFF
--- a/Formula/skinny.rb
+++ b/Formula/skinny.rb
@@ -1,8 +1,8 @@
 class Skinny < Formula
   desc "Full-stack web app framework in Scala"
   homepage "http://skinny-framework.org/"
-  url "https://github.com/skinny-framework/skinny-framework/releases/download/3.0.0/skinny-3.0.0-1.tar.gz"
-  sha256 "f5861281ff34153ffd2052ed2335ad18d7887eaa0545638c36a56ccb5a167337"
+  url "https://github.com/skinny-framework/skinny-framework/releases/download/3.0.1/skinny-3.0.1.tar.gz"
+  sha256 "e81578959b8edf715a407aaf17d339ff5223d9c3654f308cd5bcee553e95eef8"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Skinny Framework 3.0.1 is out. Could you merge this update on `skinny` formula?

https://github.com/skinny-framework/skinny-framework/releases/tag/3.0.1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew install --build-from-source Formula/skinny.rb 
==> Downloading https://github.com/skinny-framework/skinny-framework/releases/download/3.0.1/skinny-3.0.1.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/13057782/0103ff00-fe09-11e8-9a12-541cf969316d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20181212%2Fus-east-1%2Fs3%2Fa
######################################################################## 100.0%
🍺  /usr/local/Cellar/skinny/3.0.1: 666 files, 71.0MB, built in 10 minutes 22 seconds
$ 
```

```
$ brew audit --strict Formula/skinny.rb 
==> Installing or updating 'rubocop' gem
Fetching: jaro_winkler-1.5.1.gem (100%)
Building native extensions.  This could take a while...
Successfully installed jaro_winkler-1.5.1
Fetching: parallel-1.12.1.gem (100%)
Successfully installed parallel-1.12.1
Fetching: ast-2.4.0.gem (100%)
Successfully installed ast-2.4.0
Fetching: parser-2.5.3.0.gem (100%)
Successfully installed parser-2.5.3.0
Fetching: powerpack-0.1.2.gem (100%)
Successfully installed powerpack-0.1.2
Fetching: rainbow-3.0.0.gem (100%)
Successfully installed rainbow-3.0.0
Fetching: ruby-progressbar-1.10.0.gem (100%)
Successfully installed ruby-progressbar-1.10.0
Fetching: unicode-display_width-1.4.0.gem (100%)
Successfully installed unicode-display_width-1.4.0
Fetching: rubocop-0.61.1.gem (100%)
Successfully installed rubocop-0.61.1
9 gems installed
==> Installing or updating 'rubocop-rspec' gem
Fetching: rubocop-rspec-1.30.1.gem (100%)
Successfully installed rubocop-rspec-1.30.1
1 gem installed
$ 
```