### PR TITLE
tinyproxy: fix binary location in the plist file

### DIFF
--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -54,7 +54,7 @@ class Tinyproxy < Formula
         <false/>
         <key>ProgramArguments</key>
         <array>
-            <string>#{opt_sbin}/tinyproxy</string>
+            <string>#{bin}/tinyproxy</string>
             <string>-d</string>
         </array>
         <key>WorkingDirectory</key>

--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -54,7 +54,7 @@ class Tinyproxy < Formula
         <false/>
         <key>ProgramArguments</key>
         <array>
-            <string>#{bin}/tinyproxy</string>
+            <string>#{opt_bin}/tinyproxy</string>
             <string>-d</string>
         </array>
         <key>WorkingDirectory</key>


### PR DESCRIPTION
Using ${bin} according to the docs at https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md

This fixes issue #35040 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
