### PR TITLE
git: remove broken send-email script

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -137,6 +137,11 @@ class Git < Formula
       rm "#{libexec}/git-core/git-imap-send"
     end
 
+    # git-send-email is broken without either linking to a user-installed
+    # perl at compile-time or installing modules to system perl, neither of
+    # which is supported.
+    rm "#{libexec}/git-core/git-send-email"
+
     # This is only created when building against system Perl, but it isn't
     # purged by Homebrew's post-install cleaner because that doesn't check
     # "Library" directories. It is however pointless to keep around as it


### PR DESCRIPTION
git-send-email works only with user-installed perl (no longer supported)
or by installing modules on system perl (discouraged). Better to not
ship a script that we know will break: indeed, git.rb already removes
git-imap-send if openssl is not going to be present. Now do the same,
unconditionally, for git-send-email.

Fixes #33524.

- [ X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
