### PR TITLE
Remove options from versioned formulas

### DIFF
--- a/Formula/boost-python@1.59.rb
+++ b/Formula/boost-python@1.59.rb
@@ -15,21 +15,8 @@ class BoostPythonAT159 < Formula
 
   keg_only :versioned_formula
 
-  option :cxx11
-
-  option "without-python@2", "Build without python 2 support"
-
-  deprecated_option "with-python3" => "with-python"
-  deprecated_option "without-python" => "without-python@2"
-
-  depends_on "python@2" => :recommended
-  depends_on "python" => :optional
-
-  if build.cxx11?
-    depends_on "boost@1.59" => "c++11"
-  else
-    depends_on "boost@1.59"
-  end
+  depends_on "boost@1.59"
+  depends_on "python@2"
 
   def install
     # fix make_setter regression
@@ -47,18 +34,6 @@ class BoostPythonAT159 < Formula
             "--user-config=user-config.jam",
             "threading=multi,single",
             "link=shared,static"]
-
-    # Build in C++11 mode if boost was built in C++11 mode.
-    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
-    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
-    if build.cxx11?
-      args << "cxxflags=-std=c++11"
-      if ENV.compiler == :clang
-        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
-      end
-    elsif Tab.for_name("boost159").cxx11?
-      odie "boost159 was built in C++11 mode so boost-python159 must be built with --c++11."
-    end
 
     # disable python detection in bootstrap.sh; it guesses the wrong include directory
     # for Python 3 headers, so we configure python manually in user-config.jam below.
@@ -85,8 +60,7 @@ class BoostPythonAT159 < Formula
                      "python=#{version}", *args
     end
 
-    lib.install Dir["stage-python3/lib/*py*"] if build.with?("python")
-    lib.install Dir["stage-python2.7/lib/*py*"] if build.with?("python@2")
+    lib.install Dir["stage-python2.7/lib/*py*"]
     doc.install Dir["libs/python/doc/*"]
   end
 

--- a/Formula/boost@1.55.rb
+++ b/Formula/boost@1.55.rb
@@ -15,8 +15,6 @@ class BoostAT155 < Formula
 
   keg_only :versioned_formula
 
-  option :cxx11
-
   # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
   # https://github.com/Homebrew/homebrew/issues/27396
   # https://github.com/Homebrew/homebrew/pull/27436
@@ -74,15 +72,6 @@ class BoostAT155 < Formula
       threading=multi,single
       link=shared,static
     ]
-
-    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
-    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
-    if build.cxx11?
-      args << "cxxflags=-std=c++11"
-      if ENV.compiler == :clang
-        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
-      end
-    end
 
     system "./bootstrap.sh", *bargs
     system "./b2", *args

--- a/Formula/boost@1.57.rb
+++ b/Formula/boost@1.57.rb
@@ -15,19 +15,6 @@ class BoostAT157 < Formula
 
   keg_only :versioned_formula
 
-  option "with-icu4c", "Build regexp engine with icu support"
-  option "without-single", "Disable building single-threading variant"
-  option "without-static", "Disable building static library variant"
-  option :cxx11
-
-  if build.cxx11?
-    depends_on "icu4c" => [:optional, "c++11"]
-  else
-    depends_on "icu4c" => :optional
-  end
-
-  needs :cxx11 if build.cxx11?
-
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
@@ -35,14 +22,11 @@ class BoostAT157 < Formula
     end
 
     # libdir should be set by --prefix but isn't
-    bootstrap_args = ["--prefix=#{prefix}", "--libdir=#{lib}"]
-
-    if build.with? "icu4c"
-      icu4c_prefix = Formula["icu4c"].opt_prefix
-      bootstrap_args << "--with-icu=#{icu4c_prefix}"
-    else
-      bootstrap_args << "--without-icu"
-    end
+    bootstrap_args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}"
+      --without-icu
+    ]
 
     # Handle libraries that will not be built.
     without_libraries = ["python", "mpi"]
@@ -54,34 +38,17 @@ class BoostAT157 < Formula
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
 
     # layout should be synchronized with boost-python
-    args = ["--prefix=#{prefix}",
-            "--libdir=#{lib}",
-            "-d2",
-            "-j#{ENV.make_jobs}",
-            "--layout=tagged",
-            "--user-config=user-config.jam",
-            "install"]
-
-    if build.with? "single"
-      args << "threading=multi,single"
-    else
-      args << "threading=multi"
-    end
-
-    if build.with? "static"
-      args << "link=shared,static"
-    else
-      args << "link=shared"
-    end
-
-    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
-    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
-    if build.cxx11?
-      args << "cxxflags=-std=c++11"
-      if ENV.compiler == :clang
-        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
-      end
-    end
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged
+      --user-config=user-config.jam
+      install
+      link=shared,static
+      threading=multi,single
+    ]
 
     system "./bootstrap.sh", *bootstrap_args
     system "./b2", "headers"

--- a/Formula/boost@1.59.rb
+++ b/Formula/boost@1.59.rb
@@ -15,17 +15,6 @@ class BoostAT159 < Formula
 
   keg_only :versioned_formula
 
-  option "with-icu4c", "Build regexp engine with icu support"
-  option "without-single", "Disable building single-threading variant"
-  option "without-static", "Disable building static library variant"
-  option :cxx11
-
-  if build.cxx11?
-    depends_on "icu4c" => [:optional, "c++11"]
-  else
-    depends_on "icu4c" => :optional
-  end
-
   # Fixed compilation of operator<< into a record ostream, when
   # the operator right hand argument is not directly supported by
   # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549
@@ -42,8 +31,6 @@ class BoostAT159 < Formula
     sha256 "2c3a3bae1691df5f8fce8fbd4e5727d57bd4dd813748b70d7471c855c4f19d1c"
   end
 
-  needs :cxx11 if build.cxx11?
-
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
@@ -51,14 +38,11 @@ class BoostAT159 < Formula
     end
 
     # libdir should be set by --prefix but isn't
-    bootstrap_args = ["--prefix=#{prefix}", "--libdir=#{lib}"]
-
-    if build.with? "icu4c"
-      icu4c_prefix = Formula["icu4c"].opt_prefix
-      bootstrap_args << "--with-icu=#{icu4c_prefix}"
-    else
-      bootstrap_args << "--without-icu"
-    end
+    bootstrap_args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --without-icu
+    ]
 
     # Handle libraries that will not be built.
     without_libraries = ["python", "mpi"]
@@ -70,34 +54,17 @@ class BoostAT159 < Formula
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
 
     # layout should be synchronized with boost-python
-    args = ["--prefix=#{prefix}",
-            "--libdir=#{lib}",
-            "-d2",
-            "-j#{ENV.make_jobs}",
-            "--layout=tagged",
-            "--user-config=user-config.jam",
-            "install"]
-
-    if build.with? "single"
-      args << "threading=multi,single"
-    else
-      args << "threading=multi"
-    end
-
-    if build.with? "static"
-      args << "link=shared,static"
-    else
-      args << "link=shared"
-    end
-
-    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
-    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
-    if build.cxx11?
-      args << "cxxflags=-std=c++11"
-      if ENV.compiler == :clang
-        args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
-      end
-    end
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged
+      --user-config=user-config.jam
+      install
+      threading=multi,single
+      link=shared,static
+    ]
 
     system "./bootstrap.sh", *bootstrap_args
     system "./b2", "headers"

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -13,18 +13,11 @@ class ErlangAT18 < Formula
 
   keg_only :versioned_formula
 
-  option "without-hipe", "Disable building hipe; fails on various macOS systems"
-  option "with-native-libs", "Enable native library compilation"
-  option "with-dirty-schedulers", "Enable experimental dirty schedulers"
-  option "with-java", "Build jinterface application"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "openssl"
-  depends_on "wxmac" => :recommended # for GUI apps like observer
-  depends_on "fop" => :optional # enables building PDF docs
-  depends_on :java => :optional
+  depends_on "wxmac"
 
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_18.3.tar.gz"
@@ -65,8 +58,6 @@ class ErlangAT18 < Formula
     # other modules doesn't fail with an unintelligable error.
     %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
 
-    ENV["FOP"] = "#{HOMEBREW_PREFIX}/bin/fop" if build.with? "fop"
-
     # Do this if building from a checkout to generate configure
     system "./otp_build", "autoconf" if File.exist? "otp_build"
 
@@ -81,28 +72,13 @@ class ErlangAT18 < Formula
       --with-ssl=#{Formula["openssl"].opt_prefix}
       --enable-shared-zlib
       --enable-smp-support
+      --enable-hipe
+      --enable-wx
+      --without-javac
     ]
 
     args << "--enable-darwin-64bit" if MacOS.prefer_64_bit?
-    args << "--enable-native-libs" if build.with? "native-libs"
-    args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
-    args << "--enable-wx" if build.with? "wxmac"
     args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
-
-    if build.without? "hipe"
-      # HIPE doesn't strike me as that reliable on macOS
-      # https://syntatic.wordpress.com/2008/06/12/macports-erlang-bus-error-due-to-mac-os-x-1053-update/
-      # https://www.erlang.org/pipermail/erlang-patches/2008-September/000293.html
-      args << "--disable-hipe"
-    else
-      args << "--enable-hipe"
-    end
-
-    if build.with? "java"
-      args << "--with-javac"
-    else
-      args << "--without-javac"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/erlang@19.rb
+++ b/Formula/erlang@19.rb
@@ -14,20 +14,11 @@ class ErlangAT19 < Formula
 
   keg_only :versioned_formula
 
-  option "without-hipe", "Disable building hipe; fails on various macOS systems"
-  option "with-native-libs", "Enable native library compilation"
-  option "with-dirty-schedulers", "Enable experimental dirty schedulers"
-  option "with-java", "Build jinterface application"
-
-  deprecated_option "disable-hipe" => "without-hipe"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "openssl"
-  depends_on "wxmac" => :recommended # for GUI apps like observer
-  depends_on "fop" => :optional # enables building PDF docs
-  depends_on :java => :optional
+  depends_on "wxmac"
 
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_19.3.tar.gz"
@@ -62,8 +53,6 @@ class ErlangAT19 < Formula
     # other modules doesn't fail with an unintelligable error.
     %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
 
-    ENV["FOP"] = "#{HOMEBREW_PREFIX}/bin/fop" if build.with? "fop"
-
     # Do this if building from a checkout to generate configure
     system "./otp_build", "autoconf" if File.exist? "otp_build"
 
@@ -78,28 +67,13 @@ class ErlangAT19 < Formula
       --with-ssl=#{Formula["openssl"].opt_prefix}
       --enable-shared-zlib
       --enable-smp-support
+      --enable-wx
+      --enable-hipe
+      --without-javac
     ]
 
     args << "--enable-darwin-64bit" if MacOS.prefer_64_bit?
-    args << "--enable-native-libs" if build.with? "native-libs"
-    args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
-    args << "--enable-wx" if build.with? "wxmac"
     args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
-
-    if build.without? "hipe"
-      # HIPE doesn't strike me as that reliable on macOS
-      # https://syntatic.wordpress.com/2008/06/12/macports-erlang-bus-error-due-to-mac-os-x-1053-update/
-      # https://www.erlang.org/pipermail/erlang-patches/2008-September/000293.html
-      args << "--disable-hipe"
-    else
-      args << "--enable-hipe"
-    end
-
-    if build.with? "java"
-      args << "--with-javac"
-    else
-      args << "--without-javac"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -39,12 +39,6 @@ class GccAT49 < Formula
     satisfy { MacOS::CLT.installed? }
   end
 
-  option "with-nls", "Build with native language support (localization)"
-  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
-
-  deprecated_option "enable-nls" => "with-nls"
-  deprecated_option "enable-profiled-build" => "with-profiled-build"
-
   depends_on :maximum_macos => [:high_sierra, :build]
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
@@ -136,9 +130,8 @@ class GccAT49 < Formula
       # Even when suffixes are appended, the info pages conflict when
       # install-info is run.
       "MAKEINFO=missing",
+      "--disable-nls",
     ]
-
-    args << "--disable-nls" if build.without? "nls"
 
     if MacOS.prefer_64_bit?
       args << "--enable-multilib"
@@ -159,14 +152,7 @@ class GccAT49 < Formula
       end
 
       system "../configure", *args
-
-      if build.with? "profiled-build"
-        # Takes longer to build, may bug out. Provided for those who want to
-        # optimise all the way to 11.
-        system "make", "profiledbootstrap"
-      else
-        system "make", "bootstrap"
-      end
+      system "make", "bootstrap"
 
       # At this point `make check` could be invoked to run the testsuite. The
       # deja-gnu and autogen formulae must be installed in order to do this.

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -39,12 +39,6 @@ class GccAT5 < Formula
     satisfy { MacOS::CLT.installed? }
   end
 
-  option "with-all-languages", "Enable all compilers and languages, except Ada"
-  option "with-nls", "Build with native language support (localization)"
-  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
-  option "with-jit", "Build the jit compiler"
-  option "without-fortran", "Build without the gfortran compiler"
-
   depends_on :maximum_macos => [:high_sierra, :build]
 
   depends_on "gmp"
@@ -58,13 +52,6 @@ class GccAT5 < Formula
     url "https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.14.tar.bz2"
     mirror "https://mirrorservice.org/sites/distfiles.macports.org/isl/isl-0.14.tar.bz2"
     sha256 "7e3c02ff52f8540f6a85534f54158968417fd676001651c8289c705bd0228f36"
-  end
-
-  # Fix for libgccjit.so linkage on Darwin.
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/64fd2d52/gcc%405/5.4.0.patch"
-    sha256 "1e126048d9a6b29b0da04595ffba09c184d338fe963cf9db8d81b47222716bc4"
   end
 
   # Fix build with Xcode 9
@@ -93,18 +80,8 @@ class GccAT5 < Formula
     # Build ISL 0.14 from source during bootstrap
     resource("isl").stage buildpath/"isl"
 
-    if build.with? "all-languages"
-      # Everything but Ada, which requires a pre-existing GCC Ada compiler
-      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
-      # currently only compilable on Linux.
-      languages = %w[c c++ fortran objc obj-c++ jit]
-    else
-      # C, C++, ObjC compilers are always built
-      languages = %w[c c++ objc obj-c++]
-
-      languages << "fortran" if build.with? "fortran"
-      languages << "jit" if build.with? "jit"
-    end
+    # C, C++, ObjC and Fortran compilers are always built
+    languages = %w[c c++ fortran objc obj-c++]
 
     version_suffix = version.to_s.slice(/\d/)
 
@@ -132,11 +109,10 @@ class GccAT5 < Formula
       # A no-op unless --HEAD is built because in head warnings will
       # raise errors. But still a good idea to include.
       "--disable-werror",
+      "--disable-nls",
       "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
       "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
     ]
-
-    args << "--disable-nls" if build.without? "nls"
 
     # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
     # format to avoid failure during the stage 3 comparison of object files.
@@ -148,8 +124,6 @@ class GccAT5 < Formula
     else
       args << "--disable-multilib"
     end
-
-    args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
 
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303
@@ -164,14 +138,7 @@ class GccAT5 < Formula
       end
 
       system "../configure", *args
-
-      if build.with? "profiled-build"
-        # Takes longer to build, may bug out. Provided for those who want to
-        # optimise all the way to 11.
-        system "make", "profiledbootstrap"
-      else
-        system "make", "bootstrap"
-      end
+      system "make", "bootstrap"
 
       # At this point `make check` could be invoked to run the testsuite. The
       # deja-gnu and autogen formulae must be installed in order to do this.

--- a/Formula/gnupg@1.4.rb
+++ b/Formula/gnupg@1.4.rb
@@ -14,7 +14,6 @@ class GnupgAT14 < Formula
   end
 
   depends_on "curl" if MacOS.version <= :mavericks
-  depends_on "libusb-compat" => :optional
 
   def install
     args = %W[
@@ -23,8 +22,8 @@ class GnupgAT14 < Formula
       --prefix=#{prefix}
       --disable-asm
       --program-suffix=1
+      --with-libusb=no
     ]
-    args << "--with-libusb=no" if build.without? "libusb-compat"
 
     system "./configure", *args
     system "make"

--- a/Formula/go@1.4.rb
+++ b/Formula/go@1.4.rb
@@ -14,9 +14,6 @@ class GoAT14 < Formula
 
   keg_only :versioned_formula
 
-  option "with-cc-all", "Build with cross-compilers and runtime support for all supported platforms"
-  option "with-cc-common", "Build with cross-compilers and runtime support for darwin, linux and windows"
-
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
         :branch => "release-branch.go1.4"
@@ -25,40 +22,11 @@ class GoAT14 < Formula
   def install
     ENV.refurbish_args
 
-    # host platform (darwin) must come last in the targets list
-    if build.with? "cc-all"
-      targets = [
-        ["linux",   ["386", "amd64", "arm"]],
-        ["freebsd", ["386", "amd64", "arm"]],
-        ["netbsd",  ["386", "amd64", "arm"]],
-        ["openbsd", ["386", "amd64"]],
-        ["windows", ["386", "amd64"]],
-        ["dragonfly", ["386", "amd64"]],
-        ["plan9",   ["386", "amd64"]],
-        ["solaris", ["amd64"]],
-        ["darwin",  ["386", "amd64"]],
-      ]
-    elsif build.with? "cc-common"
-      targets = [
-        ["linux",   ["386", "amd64", "arm"]],
-        ["windows", ["386", "amd64"]],
-        ["darwin",  ["386", "amd64"]],
-      ]
-    else
-      targets = [["darwin", [""]]]
-    end
-
     cd "src" do
-      targets.each do |os, archs|
-        archs.each do |arch|
-          ENV["GOROOT_FINAL"] = libexec
-          ENV["GOOS"]         = os
-          ENV["GOARCH"]       = arch
-          ENV["CGO_ENABLED"]  = "0"
-          ohai "Building go for #{arch}-#{os}"
-          system "./make.bash", "--no-clean"
-        end
-      end
+      ENV["GOROOT_FINAL"] = libexec
+      ENV["GOOS"]         = "darwin"
+      ENV["CGO_ENABLED"]  = "0"
+      system "./make.bash", "--no-clean"
     end
 
     (buildpath/"pkg/obj").rmtree

--- a/Formula/hdf5@1.8.rb
+++ b/Formula/hdf5@1.8.rb
@@ -12,21 +12,13 @@ class Hdf5AT18 < Formula
 
   keg_only :versioned_formula
 
-  option "with-mpi", "Enable parallel support"
-  option :cxx11
-
-  deprecated_option "enable-parallel" => "with-mpi"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "gcc" # for gfortran
-  depends_on "open-mpi" if build.with? "mpi"
   depends_on "szip"
 
   def install
-    ENV.cxx11 if build.cxx11?
-
     inreplace %w[c++/src/h5c++.in fortran/src/h5fc.in tools/misc/h5cc.in],
       "${libdir}/libhdf5.settings", "#{pkgshare}/libhdf5.settings"
 
@@ -41,21 +33,8 @@ class Hdf5AT18 < Formula
       --with-szlib=#{Formula["szip"].opt_prefix}
       --enable-build-mode=production
       --enable-fortran
+      --disable-cxx
     ]
-
-    if build.without?("mpi")
-      args << "--enable-cxx"
-    else
-      args << "--disable-cxx"
-    end
-
-    if build.with? "mpi"
-      ENV["CC"] = "mpicc"
-      ENV["CXX"] = "mpicxx"
-      ENV["FC"] = "mpif90"
-
-      args << "--enable-parallel"
-    end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -3,7 +3,7 @@ class LuaAT51 < Formula
   desc "Powerful, lightweight programming language (v5.1.5)"
   homepage "https://www.lua.org/"
   url "https://www.lua.org/ftp/lua-5.1.5.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/l/lua5.1/lua5.1_5.1.5.orig.tar.gz"
   sha256 "2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333"
   revision 8
 
@@ -15,30 +15,9 @@ class LuaAT51 < Formula
     sha256 "e43d1c75fe4462c5dca2d95ebee9b0e4897c872f03c4331d5898a06a408cbcb3" => :el_capitan
   end
 
-  option "with-completion", "Enables advanced readline support"
-  option "without-sigaction", "Revert to ANSI signal instead of improved POSIX sigaction"
-
   # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
   # See: https://github.com/Homebrew/homebrew/pull/5043
   patch :DATA
-
-  # sigaction provided by posix signalling power patch from
-  # http://lua-users.org/wiki/LuaPowerPatches
-  if build.with? "completion"
-    patch do
-      url "http://lua-users.org/files/wiki_insecure/power_patches/5.1/sig_catch.patch"
-      sha256 "221435dedd84a386e2d40454e6260a678286bfb7128afa18a4339e5fdda9c8f2"
-    end
-  end
-
-  # completion provided by advanced readline power patch from
-  # http://lua-users.org/wiki/LuaPowerPatches
-  if build.with? "completion"
-    patch do
-      url "https://luajit.org/patches/lua-5.1.4-advanced_readline.patch"
-      sha256 "dfd17e720d1079dcb64529af3e4fea4a4abc0115c934f365282a489d134cceb4"
-    end
-  end
 
   def install
     # Use our CC/CFLAGS to compile.

--- a/Formula/mongodb@3.6.rb
+++ b/Formula/mongodb@3.6.rb
@@ -12,17 +12,13 @@ class MongodbAT36 < Formula
 
   keg_only :versioned_formula
 
-  option "with-boost", "Compile using installed boost, not the version shipped with mongodb"
-  option "with-sasl", "Compile with SASL support"
-
   depends_on "go" => :build
   depends_on "pkg-config" => :build
   depends_on "scons" => :build
   depends_on :xcode => ["8.3.2", :build]
   depends_on :macos => :mountain_lion
+  depends_on "openssl"
   depends_on "python@2"
-  depends_on "openssl" => :recommended
-  depends_on "boost" => :optional
 
   resource "Cheetah" do
     url "https://files.pythonhosted.org/packages/cd/b0/c2d700252fc251e91c08639ff41a8a5203b627f4e0a2ae18a6b662ab32ea/Cheetah-2.4.4.tar.gz"
@@ -55,8 +51,8 @@ class MongodbAT36 < Formula
       import site; site.addsitedir("#{buildpath}/vendor/lib/python2.7/site-packages")
     EOS
 
-    # New Go tools have their own build script but the server scons "install" target is still
-    # responsible for installing them.
+    # New Go tools have their own build script but the server scons "install"
+    # target is still responsible for installing them.
 
     cd "src/mongo/gotools" do
       inreplace "build.sh" do |s|
@@ -64,44 +60,29 @@ class MongodbAT36 < Formula
         s.gsub! "$(git rev-parse HEAD)", "homebrew"
       end
 
-      args = %w[]
+      ENV["LIBRARY_PATH"] = Formula["openssl"].opt_lib
+      ENV["CPATH"] = Formula["openssl"].opt_include
 
-      if build.with? "openssl"
-        args << "ssl"
-        ENV["LIBRARY_PATH"] = Formula["openssl"].opt_lib
-        ENV["CPATH"] = Formula["openssl"].opt_include
-      end
-
-      args << "sasl" if build.with? "sasl"
-
-      system "./build.sh", *args
+      system "./build.sh", "ssl"
     end
 
     (buildpath/"src/mongo-tools").install Dir["src/mongo/gotools/bin/*"]
 
     args = %W[
-      --prefix=#{prefix}
       -j#{ENV.make_jobs}
+      --build-mongoreplay=true
+      --prefix=#{prefix}
+      --ssl
+      --use-new-tools
+      CC=#{ENV.cc}
+      CXX=#{ENV.cxx}
+      CCFLAGS=-mmacosx-version-min=#{MacOS.version}
+      LINKFLAGS=-mmacosx-version-min=#{MacOS.version}
+      CCFLAGS=-I#{Formula["openssl"].opt_include}
+      LINKFLAGS=-L#{Formula["openssl"].opt_lib}
     ]
 
-    args << "CC=#{ENV.cc}"
-    args << "CXX=#{ENV.cxx}"
-
-    args << "CCFLAGS=-mmacosx-version-min=#{MacOS.version}"
-    args << "LINKFLAGS=-mmacosx-version-min=#{MacOS.version}"
-
-    args << "--use-sasl-client" if build.with? "sasl"
-    args << "--use-system-boost" if build.with? "boost"
-    args << "--use-new-tools"
-    args << "--build-mongoreplay=true"
     args << "--disable-warnings-as-errors" if MacOS.version >= :yosemite
-
-    if build.with? "openssl"
-      args << "--ssl"
-
-      args << "CCFLAGS=-I#{Formula["openssl"].opt_include}"
-      args << "LINKFLAGS=-L#{Formula["openssl"].opt_lib}"
-    end
 
     scons "install", *args
 

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -13,10 +13,6 @@ class OpencvAT2 < Formula
 
   keg_only :versioned_formula
 
-  option "without-python@2", "Build without python2 support"
-
-  deprecated_option "without-python" => "without-python@2"
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "eigen"
@@ -24,9 +20,9 @@ class OpencvAT2 < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "numpy"
   depends_on "openexr"
-  depends_on "python@2" => :recommended
-  depends_on "numpy" if build.with? "python@2"
+  depends_on "python@2"
 
   def install
     jpeg = Formula["jpeg"]
@@ -42,6 +38,7 @@ class OpencvAT2 < Formula
       -DBUILD_TIFF=OFF
       -DBUILD_ZLIB=OFF
       -DBUILD_opencv_java=OFF
+      -DBUILD_opencv_python=ON
       -DWITH_CUDA=OFF
       -DWITH_EIGEN=ON
       -DWITH_FFMPEG=ON
@@ -54,18 +51,14 @@ class OpencvAT2 < Formula
       -DJPEG_LIBRARY=#{jpeg.opt_lib}/libjpeg.dylib
     ]
 
-    args << "-DBUILD_opencv_python=" + (build.with?("python@2") ? "ON" : "OFF")
+    py_prefix = `python-config --prefix`.chomp
+    py_lib = "#{py_prefix}/lib"
+    args << "-DPYTHON_LIBRARY=#{py_lib}/libpython2.7.dylib"
+    args << "-DPYTHON_INCLUDE_DIR=#{py_prefix}/include/python2.7"
 
-    if build.with? "python@2"
-      py_prefix = `python-config --prefix`.chomp
-      py_lib = "#{py_prefix}/lib"
-      args << "-DPYTHON_LIBRARY=#{py_lib}/libpython2.7.dylib"
-      args << "-DPYTHON_INCLUDE_DIR=#{py_prefix}/include/python2.7"
-
-      # Make sure find_program locates system Python
-      # https://github.com/Homebrew/homebrew-science/issues/2302
-      args << "-DCMAKE_PREFIX_PATH=#{py_prefix}"
-    end
+    # Make sure find_program locates system Python
+    # https://github.com/Homebrew/homebrew-science/issues/2302
+    args << "-DCMAKE_PREFIX_PATH=#{py_prefix}"
 
     if ENV.compiler == :clang && !build.bottle?
       args << "-DENABLE_SSSE3=ON" if Hardware::CPU.ssse3?
@@ -94,7 +87,7 @@ class OpencvAT2 < Formula
     assert_equal version.to_s, shell_output("./test").strip
 
     ENV["PYTHONPATH"] = lib/"python2.7/site-packages"
-    assert_match version.to_s,
-                 shell_output("python2.7 -c 'import cv2; print(cv2.__version__)'")
+    output = shell_output("python2.7 -c 'import cv2; print(cv2.__version__)'")
+    assert_match version.to_s, output
   end
 end

--- a/Formula/perl@5.18.rb
+++ b/Formula/perl@5.18.rb
@@ -12,12 +12,6 @@ class PerlAT518 < Formula
 
   keg_only :versioned_formula
 
-  option "with-dtrace", "Build with DTrace probes"
-  option "with-test", "Build and run the test suite"
-
-  deprecated_option "use-dtrace" => "with-dtrace"
-  deprecated_option "with-tests" => "with-test"
-
   def install
     args = [
       "-des",
@@ -29,11 +23,8 @@ class PerlAT518 < Formula
       "-Dusethreads",
     ]
 
-    args << "-Dusedtrace" if build.with? "dtrace"
-
     system "./Configure", *args
     system "make"
-    system "make", "test" if build.with? "tests"
     system "make", "install"
   end
 

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -12,15 +12,10 @@ class PostgresqlAT10 < Formula
 
   keg_only :versioned_formula
 
-  option "with-python", "Enable PL/Python3"
-
-  deprecated_option "with-python3" => "with-python"
-
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "python" => :optional
 
   def install
     # avoid adding the SDK library directory to the linker search path
@@ -48,11 +43,6 @@ class PostgresqlAT10 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-
-    if build.with?("python")
-      args << "--with-python"
-      ENV["PYTHON"] = which("python3")
-    end
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -14,11 +14,8 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  deprecated_option "with-python" => "with-python@2"
-
   depends_on "openssl"
   depends_on "readline"
-  depends_on "python@2" => :optional
 
   def install
     # Fix "configure: error: readline library not found"
@@ -46,8 +43,6 @@ class PostgresqlAT94 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-
-    args << "--with-python" if build.with? "python@2"
 
     # The CLT is required to build tcl support on 10.7 and 10.8 because tclConfig.sh is not part of the SDK
     if MacOS.version >= :mavericks || MacOS::CLT.installed?

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -14,13 +14,8 @@ class PostgresqlAT95 < Formula
 
   keg_only :versioned_formula
 
-  option "with-python", "Build with Python3"
-
-  deprecated_option "with-python3" => "with-python"
-
   depends_on "openssl"
   depends_on "readline"
-  depends_on "python" => :optional
 
   def install
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
@@ -47,11 +42,6 @@ class PostgresqlAT95 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-
-    if build.with?("python")
-      args << "--with-python"
-      ENV["PYTHON"] = which("python3")
-    end
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -14,13 +14,8 @@ class PostgresqlAT96 < Formula
 
   keg_only :versioned_formula
 
-  option "with-python", "Enable PL/Python3"
-
-  deprecated_option "with-python3" => "with-python"
-
   depends_on "openssl"
   depends_on "readline"
-  depends_on "python" => :optional
 
   def install
     # avoid adding the SDK library directory to the linker search path
@@ -47,11 +42,6 @@ class PostgresqlAT96 < Formula
       --with-perl
       --with-uuid=e2fs
     ]
-
-    if build.with?("python")
-      args << "--with-python"
-      ENV["PYTHON"] = which("python3")
-    end
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK

--- a/Formula/protobuf@2.5.rb
+++ b/Formula/protobuf@2.5.rb
@@ -15,17 +15,10 @@ class ProtobufAT25 < Formula
 
   keg_only :versioned_formula
 
-  option :cxx11
-
-  deprecated_option "with-python" => "with-python@2"
-
-  depends_on "python@2" => :optional
-
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
     ENV.prepend "CXXFLAGS", "-DNDEBUG"
-    ENV.cxx11 if build.cxx11?
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -37,19 +30,6 @@ class ProtobufAT25 < Formula
 
     # Install editor support and examples
     doc.install "editors", "examples"
-
-    if build.with? "python@2"
-      chdir "python" do
-        ENV["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "cpp"
-        ENV.append_to_cflags "-I#{include}"
-        ENV.append_to_cflags "-L#{lib}"
-        args = Language::Python.setup_install_args libexec
-        system "python", *args
-      end
-      site_packages = "lib/python2.7/site-packages"
-      pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-      (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
-    end
   end
 
   def caveats; <<~EOS
@@ -69,10 +49,5 @@ class ProtobufAT25 < Formula
       }
     EOS
     system bin/"protoc", "test.proto", "--cpp_out=."
-    if build.with? "python@2"
-      protobuf_pth = lib/"python2.7/site-packages/homebrew-protobuf.pth"
-      (testpath.realpath/"Library/Python/2.7/lib/python/site-packages").install_symlink protobuf_pth
-      system "python", "-c", "import google.protobuf"
-    end
   end
 end

--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -14,18 +14,11 @@ class RedisAT32 < Formula
 
   keg_only :versioned_formula
 
-  option "with-jemalloc", "Select jemalloc as memory allocator when building Redis"
-
   def install
     # Architecture isn't detected correctly on 32bit Snow Leopard without help
     ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"
 
-    args = %W[
-      PREFIX=#{prefix}
-      CC=#{ENV.cc}
-    ]
-    args << "MALLOC=jemalloc" if build.with? "jemalloc"
-    system "make", "install", *args
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}"
 
     %w[run db/redis log].each { |p| (var/p).mkpath }
 

--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -14,8 +14,6 @@ class ThriftAT09 < Formula
 
   keg_only :versioned_formula
 
-  option "with-java", "Install Java binding"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "bison" => :build
@@ -24,15 +22,11 @@ class ThriftAT09 < Formula
   depends_on "boost"
   depends_on "openssl"
 
-  if build.with? "java"
-    depends_on "ant" => :build
-    depends_on :java => "1.8"
-  end
-
   def install
     args = %w[
       --without-erlang
       --without-haskell
+      --without-java
       --without-perl
       --without-php
       --without-php_extension
@@ -41,16 +35,10 @@ class ThriftAT09 < Formula
       --without-tests
     ]
 
-    args << "--without-java" if build.without? "java"
-
     ENV.cxx11 if MacOS.version >= :mavericks && ENV.compiler == :clang
 
     # Don't install extensions to /usr
     ENV["JAVA_PREFIX"] = pkgshare/"java"
-
-    # configure's version check breaks on ant >1.10 so just override it. This
-    # doesn't need guarding because of the --without-java flag used above.
-    inreplace "configure", 'ANT=""', "ANT=\"#{Formula["ant"].opt_bin}/ant\""
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
After that pull request, the only versioned formulas that will retain options are `imagemagick@6` (14 options) and `ffmpeg@2.8` (35 options).