### PR TITLE
reprepro 5.3.0 (new formula)

### DIFF
--- a/Formula/reprepro.rb
+++ b/Formula/reprepro.rb
@@ -1,0 +1,37 @@
+class Reprepro < Formula
+  desc "Debian package repository manager"
+  homepage "https://salsa.debian.org/brlink/reprepro"
+  url "https://deb.debian.org/debian/pool/main/r/reprepro/reprepro_5.3.0.orig.tar.gz"
+  sha256 "5a5404114b43a2d4ca1f8960228b1db32c41fb55de1996f62bc1b36001f3fab4"
+
+  depends_on "berkeley-db@4"
+  depends_on "gcc"
+  depends_on "gpgme"
+  depends_on "libarchive"
+  depends_on "xz"
+
+  fails_with :clang do
+    cause "No support for GNU C nested functions"
+  end
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gpgme=#{Formula["gpgme"].opt_lib}",
+                          "--with-libarchive=#{Formula["libarchive"].opt_lib}",
+                          "--with-libbz2=yes",
+                          "--with-liblzma=#{Formula["xz"].opt_lib}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"conf"/"distributions").write <<~EOF
+      Codename: test_codename
+      Architectures: source
+      Components: main
+    EOF
+    system bin/"reprepro", "-b", testpath, "list", "test_codename"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[reprepro](https://wiki.debian.org/DebianRepository/SetupWithReprepro) is a management tool for Debian package repositories.

Two minor things to note when reviewing this formula:

* Homebrew's keg-only `libarchive` is required, because macOS's built-in `libarchive` does not include the requisite C header files needed to build this package.

* This package must be compiled by GCC, because [Clang does not support GNU C nested functions](http://clang.llvm.org/docs/UsersManual.html#gcc-extensions-not-implemented-yet) which are used in a few places in this package.