### PR TITLE
add --with-llvm option for PostgreSQL

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -12,6 +12,7 @@ class Postgresql < Formula
   end
 
   option "with-python", "Enable PL/Python3"
+  option "with-llvm", "Enable JIT support"
 
   deprecated_option "with-python3" => "with-python"
 
@@ -19,7 +20,9 @@ class Postgresql < Formula
   depends_on "icu4c"
   depends_on "openssl"
   depends_on "readline"
+  depends_on "perl"
   depends_on "python" => :optional
+  depends_on "llvm" => :optional
 
   conflicts_with "postgres-xc",
     :because => "postgresql and postgres-xc install the same binaries."
@@ -56,6 +59,10 @@ class Postgresql < Formula
       ENV["PYTHON"] = which("python3")
     end
 
+    if build.with? "llvm"
+      args << "--with-llvm"
+      ENV["LLVM_CONFIG"] = "#{Formula["llvm"].opt_bin}/llvm-config"
+    end
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
     # tclConfig.sh is not part of the SDK
     if MacOS.version >= :mavericks || MacOS::CLT.installed?


### PR DESCRIPTION
JIT is a new feature added in PostgreSQL 11.
This pull request adds `--with-llvm` option to enable the new feature.
https://www.postgresql.org/docs/11/jit.html

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`brew audit` doesn't work on my machine. It is similar to https://github.com/Homebrew/brew/issues/5372.
The output is
```
Error: Error running `rubocop --format json --force-exclusion --parallel --except NewFormulaAudit --config /usr/local/Homebrew/Library/.rubocop_audit.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/postgresql.rb`
Ignoring jaro_winkler-1.5.1 because its extensions are not built.  Try: gem pristine jaro_winkler --version 1.5.1
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- jaro_winkler (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.60.0/lib/rubocop/string_util.rb:3:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.60.0/lib/rubocop.rb:21:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.60.0/lib/rubocop.rb:21:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/rubocop-0.60.0/exe/rubocop:6:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `load'
	from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/bin/rubocop:22:in `<main>'
```

-----
