### PR TITLE
Vert.x 3.6.2

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.0-full.tar.gz"
-  sha256 "df2737aa6d5e5a921abec487263fa82354c22468677c61baafbfb05bcdbdcd79"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.2-full.tar.gz"
+  sha256 "0157c9ee2db462f83dbc1b7f56d89c6b9b88eff58da1d0406b4f38b44c7d3b71"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.6.2.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates the Vert.x version to 3.6.2. The homepage (https://vertx.io) is not yet updated as having the homebrew formula is part of the release process.
