### PR TITLE
Deny software requests in Bugreport template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Reproducible-Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Reproducible-Bug-Report.md
@@ -6,7 +6,7 @@ about: Submit an issue so we can investigate
 
 **Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
 
-- [ ] are reporting a bug others will be able to reproduce and not asking a question. If you're not sure or want to ask a question do so on our Discourse: https://discourse.brew.sh
+- [ ] are reporting a bug others will be able to reproduce and not asking a question or requesting software. If you're not sure or want to ask a question do so on our Discourse: https://discourse.brew.sh. To get software added or changed in Homebrew please file a [Pull Request](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)
 - [ ] have a problem with `brew install` (or `upgrade`, `reinstall`) a single, official formula (not cask)? If it's a general `brew` problem please file this issue at Homebrew/brew: https://github.com/Homebrew/brew/issues/new/choose. If it's a `brew cask` problem please file this issue at https://github.com/Homebrew/homebrew-cask/issues/new/choose. If it's a tap (e.g. Homebrew/homebrew-php) problem please file this issue at the tap.
 - [ ] ran `brew update` and can still reproduce the problem?
 - [ ] ran `brew doctor`, fixed all issues and can still reproduce the problem?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is only specified in the generic template that rarely anyone ever sees. This should make it clearer for people unfamiliar with the process how to request software changes.