### PR TITLE
openssl: Add newline to the last line of cert.pem

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -109,7 +109,7 @@ class Openssl < Formula
         openssldir.install "cacert-#{resource("ca-bundle").version}.pem" => "cert.pem"
       end
     else
-      (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+      (openssldir/"cert.pem").atomic_write(valid_certs.join("\n") << "\n")
     end
   end
 

--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -82,7 +82,7 @@ class OpensslAT11 < Formula
     end
 
     openssldir.mkpath
-    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n") << "\n")
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
Ensure that that the last line of `cert.pem` contains a newline.  This
allows additional certificates to be concatenated with `cert.pem` using
standard Unix text processing utilities.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
