### PR TITLE
istioctl 1.0.5 (new formula)

### DIFF
--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -1,0 +1,14 @@
+class Istioctl < Formula
+  desc "Istio configuration command-line utility"
+  homepage "https://istio.io/"
+  url "https://github.com/istio/istio/releases/download/1.0.5/istio-1.0.5-osx.tar.gz"
+  sha256 "98043349092853796d2eb2709df0bfd029689ffcc70c451dce04ec45f5fabc83"
+
+  def install
+    bin.install "bin/istioctl"
+  end
+
+  test do
+    assert_match "Retrieve policies and rules", shell_output("#{bin}/istioctl get -h")
+  end
+end


### PR DESCRIPTION
This is related to  https://github.com/istio/istio/issues/10484.

Added command-line utility istioctl.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

