### PR TITLE
Update shairport-sync.rb to include service parameters

### DIFF
--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -48,4 +48,28 @@ class ShairportSync < Formula
     output = shell_output("#{bin}/shairport-sync -V", 1)
     assert_match "OpenSSL-ao-stdout-pipe-soxr-metadata", output
   end
+  
+  plist_options :manual => "shairport-sync"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+      <string>#{opt_bin}/shairport-sync</string>
+      <string>-d</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+    </dict>
+    </plist>
+  EOS
+  end
+
 end


### PR DESCRIPTION
Adding service parameters, so that Shairport-Sync automatically launches on every boot. 
Just type `brew services start shairport-sync` to enable.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
