### PR TITLE
tass64 1.53.1515 (new formula)

### DIFF
--- a/Aliases/64tass
+++ b/Aliases/64tass
@@ -1,0 +1,1 @@
+../Formula/tass64.rb

--- a/Formula/tass64.rb
+++ b/Formula/tass64.rb
@@ -1,15 +1,13 @@
 class Tass64 < Formula
   desc "Multi pass optimizing macro assembler for the 65xx series of processors"
-  homepage "https://tass64.sourceforge.io"
+  homepage "https://tass64.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/tass64/source/64tass-1.53.1515-src.zip"
   sha256 "f18e5d3f7f27231c1f8ce781eee8b585fe5aaec186eccdbdb820c1b8c323eb6c"
 
   def install
     system "make", "install", "CPPFLAGS=-D_XOPEN_SOURCE", "prefix=#{prefix}"
 
-    # `make install` doesn't install the bundled syntax highlighting
-    # defintions. $prefix/share/tass64/syntax seems a reasonable place to put
-    # them
+    # `make install` does not install syntax highlighting defintions
     pkgshare.install "syntax"
   end
 
@@ -32,6 +30,6 @@ class Tass64 < Formula
     EOS
 
     system "#{bin}/64tass", "-a", "hello.asm", "-o", "hello.prg"
-    File.exist?("hello.prg")
+    assert_predicate testpath/"hello.prg", :exist?
   end
 end

--- a/Formula/tass64.rb
+++ b/Formula/tass64.rb
@@ -1,0 +1,37 @@
+class Tass64 < Formula
+  desc "Multi pass optimizing macro assembler for the 65xx series of processors"
+  homepage "https://tass64.sourceforge.io"
+  url "https://downloads.sourceforge.net/project/tass64/source/64tass-1.53.1515-src.zip"
+  sha256 "f18e5d3f7f27231c1f8ce781eee8b585fe5aaec186eccdbdb820c1b8c323eb6c"
+
+  def install
+    system "make", "install", "CPPFLAGS=-D_XOPEN_SOURCE", "prefix=#{prefix}"
+
+    # `make install` doesn't install the bundled syntax highlighting
+    # defintions. $prefix/share/tass64/syntax seems a reasonable place to put
+    # them
+    pkgshare.install "syntax"
+  end
+
+  test do
+    (testpath/"hello.asm").write <<~'EOS'
+      ;; Simple "Hello World" program for C64
+      *=$c000
+      	LDY #$00
+      L0
+      	LDA L1,Y
+      	CMP #0
+      	BEQ L2
+      	JSR $FFD2
+      	INY
+      	JMP L0
+      L1
+      	.text "HELLO WORLD",0
+      L2
+      	RTS
+    EOS
+
+    system "#{bin}/64tass", "-a", "hello.asm", "-o", "hello.prg"
+    File.exist?("hello.prg")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`64tass` is a popular assembler for the 65xx series of microprocessors found in many early home computers.

Project's real name is `64tass`, which is not a valid formula name. Add an alias to work around this.