### PR TITLE
go 1.12beta1 (devel)

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -20,6 +20,15 @@ class Go < Formula
     sha256 "0732f59fc448ca5635aecab381b84f5527cc2fe32c30b211b79f9cffc1b03079" => :sierra
   end
 
+  devel do
+    url "https://dl.google.com/go/go1.12beta1.src.tar.gz"
+    sha256 "639585de6bfb67865a85cd750d41ecc39968039dafb9d1fdb15361eb118d150a"
+
+    resource "gotools" do
+      url "https://go.googlesource.com/tools.git"
+    end
+  end
+
   head do
     url "https://go.googlesource.com/go.git"
 


### PR DESCRIPTION
This doesn't pass `brew audit --strict` because it has a `devel` block, but...that's the point. I didn't realize these were no longer allowed?

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----