### PR TITLE
ttfautohint: restore --with-qt option and fix building ttfautohintGUI

### DIFF
--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -41,6 +41,7 @@ class Ttfautohint < Formula
 
     args << "--without-qt" if build.without? "qt"
 
+    ENV["QMAKESPEC"] = "macx-clang"
     system "./bootstrap" if build.head?
     system "./configure", *args
     system "make", "install"

--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -21,22 +21,36 @@ class Ttfautohint < Formula
     depends_on "pkg-config" => :build
   end
 
+  option "with-qt", "Build ttfautohintGUI also"
+
+  deprecated_option "with-qt5" => "with-qt"
+
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "harfbuzz"
   depends_on "libpng"
+  depends_on "qt" => :optional
 
   def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --without-doc
+    ]
+
+    args << "--without-qt" if build.without? "qt"
+
     system "./bootstrap" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--without-doc",
-                          "--without-qt"
+    system "./configure", *args
     system "make", "install"
   end
 
   test do
-    system "#{bin}/ttfautohint", "-V"
+    if build.with? "qt"
+      system "#{bin}/ttfautohintGUI", "-V"
+    else
+      system "#{bin}/ttfautohint", "-V"
+    end
   end
 end


### PR DESCRIPTION
follow up from https://github.com/Homebrew/homebrew-core/issues/34257#issuecomment-448945115

this PR reverts https://github.com/Homebrew/homebrew-core/pull/34410 and exports QMAKESPEC=" macx-clang" environment variable before building ttfautohint.

I verified that it builds locally on my MacOS Mojave 10.14.2.

/cc @lemzwerg @MikeMcQuaid @SMillerDev  
