### PR TITLE
pyenv: fix shell completions

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -30,8 +30,7 @@ class Pyenv < Formula
       bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"
     end
 
-    # Don't install shell completions here!!!
-    # See:
+    # Do not manually install shell completions. See:
     #   - https://github.com/pyenv/pyenv/issues/1056#issuecomment-356818337
     #   - https://github.com/Homebrew/homebrew-core/pull/22727
   end

--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -30,9 +30,10 @@ class Pyenv < Formula
       bin.install_symlink "#{prefix}/plugins/python-build/bin/#{cmd}"
     end
 
-    bash_completion.install "#{prefix}/completions/pyenv.bash"
-    zsh_completion.install "#{prefix}/completions/pyenv.zsh"
-    fish_completion.install "#{prefix}/completions/pyenv.fish"
+    # Don't install shell completions here!!!
+    # See:
+    #   - https://github.com/pyenv/pyenv/issues/1056#issuecomment-356818337
+    #   - https://github.com/Homebrew/homebrew-core/pull/22727
   end
 
   test do


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/34849 has broken https://github.com/pyenv/pyenv/blob/v1.2.8/libexec/pyenv-init#L98-L101

I fixed shell completions again.
Please see https://github.com/Homebrew/homebrew-core/pull/22727.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
