### PR TITLE
dnscontrol 0.2.8

### DIFF
--- a/Formula/dnscontrol.rb
+++ b/Formula/dnscontrol.rb
@@ -1,8 +1,8 @@
 class Dnscontrol < Formula
   desc "It is system for maintaining DNS zones"
   homepage "https://github.com/StackExchange/dnscontrol"
-  url "https://github.com/StackExchange/dnscontrol/archive/v0.2.7.tar.gz"
-  sha256 "2889c6bec5c4b77a21bda82a1a3760ad64667f8a30ed009b4750f605c9827598"
+  url "https://github.com/StackExchange/dnscontrol/archive/v0.2.8.tar.gz"
+  sha256 "87018f5d05f407ab30db782f26d0b42cf80b340de1e695467c193ca9446d6c5e"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Version bump for dnscontrol. 

Release info can be found at: https://github.com/StackExchange/dnscontrol/releases

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
