### PR TITLE
pass-otp 1.2.0

### DIFF
--- a/Formula/pass-otp.rb
+++ b/Formula/pass-otp.rb
@@ -1,8 +1,8 @@
 class PassOtp < Formula
   desc "The Pass extension for managing one-time-password (OTP) tokens"
   homepage "https://github.com/tadfisher/pass-otp#readme"
-  url "https://github.com/tadfisher/pass-otp/releases/download/v1.1.1/pass-otp-1.1.1.tar.gz"
-  sha256 "edb3142ab81d70af4e6d1c7f13abebd7c349be474a3f9293d9648ee91b75b458"
+  url "https://github.com/tadfisher/pass-otp/releases/download/v1.2.0/pass-otp-1.2.0.tar.gz"
+  sha256 "5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New upstream version:

*  New: Bash completion is now supported. (thanks Zoltan Kertesz)
* Fix getopt parsing; passing `--issuer` and `--account` should no longer hang.
  (thanks @xPMo)
