### PR TITLE
[gnutls] `--with-guile`:  Change to `--with-guile@2.0`

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -12,13 +12,15 @@ class Gnutls < Formula
     sha256 "e7e08cf6a0cb9a3ccb14442eb47e63de97c55aa36971c05707a0c96a38bb6b70" => :sierra
   end
 
+  deprecated_option "with-guile" => "with-guile@2.0"
+
   depends_on "pkg-config" => :build
   depends_on "gmp"
   depends_on "libtasn1"
   depends_on "libunistring"
   depends_on "nettle"
   depends_on "p11-kit" => :recommended
-  depends_on "guile" => :optional
+  depends_on "guile@2.0" => :optional
   depends_on "unbound" => :optional
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?  
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?  
- [x] Have you built your formula locally with '`brew install --build-from-source <formula>`,' where `<formula>` is the name of the formula you're submitting?  
- [x] Did you successfully run '`brew test <formula>`,' where `<formula>` is the name of the formula you're submitting?  
- [x] Does your build pass '`brew audit --strict <formula>`' (after doing '`brew install <formula>`?')  

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;As stated in my commit message:  

> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Building the formula's associated package for installation fails otherwise.  (Also add a `deprecated_option` specification to enable smooth migration.)  

I can amend this PR to remove the latter change if desired, though that might cause user confusion over the resulting behavior.  This change can also be revisited once [upstream issue #199](https://gitlab.com/gnutls/gnutls/issues/199) on GUILE v2.2.x compatibility gets fixed.  