### PR TITLE
gtk+3: Add upstream patch fixing mouse event handling

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -3,6 +3,7 @@ class Gtkx3 < Formula
   homepage "https://gtk.org/"
   url "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.2.tar.xz"
   sha256 "5b3b05e427cc928d103561ed2e91b2b2881fe88b1f167b0b1c9990da6aac8892"
+  revision 1
 
   bottle do
     rebuild 1
@@ -28,6 +29,12 @@ class Gtkx3 < Formula
   patch do
     url "https://gitlab.gnome.org/jralls/gtk/commit/efb3888af770937c6c2c184d9beea19fbc24bb4a.patch"
     sha256 "d847d1b4659153f0d815189039776054bccc73f85cfb967c5cc2cf0e0061d0d7"
+  end
+
+  # Follow-up of issue #1518
+  patch do
+    url "https://gitlab.gnome.org/GNOME/gtk/commit/e105fefc4923ebd035747daa7d453243eba4a836.patch"
+    sha256 "4efd9bc0c68942a8b4f3a39f683aa0d0ee5f6836012b004e9ea083894780ed91"
   end
 
   def install


### PR DESCRIPTION
Without this patch (already merged in the 3-24 branch) most mouse events are not
handled.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
