### PR TITLE
weechat: Link against Homebrew ncurses

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -21,6 +21,7 @@ class Weechat < Formula
   depends_on "gettext"
   depends_on "gnutls"
   depends_on "libgcrypt"
+  depends_on "ncurses"
   depends_on "aspell" => :optional
   depends_on "curl" => :optional
   depends_on "lua" => :optional

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -3,6 +3,7 @@ class Weechat < Formula
   homepage "https://www.weechat.org"
   url "https://weechat.org/files/src/weechat-2.3.tar.xz"
   sha256 "ef8654313bfb0ca92e27cf579efb2d9b17e53505e615bf3d71a51aef44e56a5f"
+  revision 1
   head "https://github.com/weechat/weechat.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The current system ncurses library (ncurses 5.4.0 on Mojave 10.14.2) is a little old and some WeeChat features aren't supported (in this case *italics*). Depending on ncurses supplied by Homebrew (6.0.0) fixes the current issue and will avoid any similar incompatibilities in the future.

Relevant discourse discussion:
https://discourse.brew.sh/t/link-weechat-against-homebrew-ncurses-v6/3702/2