### PR TITLE
woboq_codebrowser: use llvm@6

### DIFF
--- a/Formula/woboq_codebrowser.rb
+++ b/Formula/woboq_codebrowser.rb
@@ -3,7 +3,7 @@ class WoboqCodebrowser < Formula
   homepage "https://code.woboq.org/"
   url "https://github.com/woboq/woboq_codebrowser/archive/2.1.tar.gz"
   sha256 "f7c803260a9a79405c4c2c561443c49702811f38dcf1081238ef024a6654caa0"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -14,11 +14,11 @@ class WoboqCodebrowser < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm"
+  depends_on "llvm@6"
 
   def install
     args = std_cmake_args + %W[
-      -DLLVM_CONFIG_EXECUTABLE=#{Formula["llvm"].opt_bin}/llvm-config
+      -DLLVM_CONFIG_EXECUTABLE=#{Formula["llvm@6"].opt_bin}/llvm-config
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     ]
     system "cmake", ".", *args
@@ -42,7 +42,6 @@ class WoboqCodebrowser < Formula
 
     assert_predicate testpath/"test/test.c.html", :exist?
     assert_predicate testpath/"refs/printf", :exist?
-    assert_predicate testpath/"include/sys/stdio.h.html", :exist?
     assert_predicate testpath/"fnSearch", :exist?
     assert_predicate testpath/"fileIndex", :exist?
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The latest release version of `woboq_codebrowser` does not support Clang 7 yet.