### PR TITLE
arcade-learning-environment: fix dylib install name

### DIFF
--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -3,7 +3,7 @@ class ArcadeLearningEnvironment < Formula
   homepage "https://github.com/mgbellemare/Arcade-Learning-Environment"
   url "https://github.com/mgbellemare/Arcade-Learning-Environment/archive/v0.6.0.tar.gz"
   sha256 "da4597edf8ebef99961394daca44fa30148c778adff59ee5aec073ea94dcc175"
-  revision 2
+  revision 3
   head "https://github.com/mgbellemare/Arcade-Learning-Environment.git"
 
   bottle do
@@ -19,7 +19,11 @@ class ArcadeLearningEnvironment < Formula
   depends_on "sdl"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    args = std_cmake_args + %W[
+      -DCMAKE_INSTALL_NAME_DIR=#{opt_lib}
+      -DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON
+    ]
+    system "cmake", ".", *args
     system "make", "install"
     system "python3", *Language::Python.setup_install_args(prefix)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
01:17:03 ==> brew linkage --test arcade-learning-environment
01:17:04 ==> FAILED
01:17:04 Missing libraries:
01:17:04   /tmp/arcade-learning-environment-20181206-96897-1pd16gs/Arcade-Learning-Environment-0.6.0/ale_python_interface/libale_c.so
```

Attempting to fix this long-standing issue.