### PR TITLE
octave-4.4.1: partially fix build octave with --with-qt

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -65,7 +65,25 @@ class Octave < Formula
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
 
     args = []
-    args << "--without-qt" if build.without? "qt"
+    if build.with? "qt"
+      args << "--with-qt"
+      qcollection = "#{Formula["qt"].bin}/qcollectiongenerator"
+      unless File.exist?(qcollection)
+        odie "octave configure script checks for qcollectiongenerator " \
+        "bin to use qt gui feature, but it is not bundled with qt5 formula, " \
+        "so we can fake it by make a symbol link for it, for example, " \
+        "ln -s {Cellar}/qt/5.12.0/bin/qhelpgenerator {Cellar}/qt/5.12.0/bin/qcollectiongenerator"
+      end
+
+      # to fix by making a symbol link is prohibited by macOS (https://github.com/Homebrew/brew/issues/3002)
+      # qhelp = "#{Formula["qt"].bin}/qhelpgenerator"
+      # if File.exist?(qhelp)
+      #   qcollection = "#{Formula["qt"].bin}/qcollectiongenerator"
+      #   if not File.exist?(qcollection)
+      #     ln_s "#{qhelp}","#{qcollection}", :force=>true
+      #   end
+      # end
+    end
 
     system "./bootstrap" if build.head?
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Current octave formula cannot get built with --with-qt flag for 2 reasons:

1. in formula it is not correct to use build.without? to detect qt flag
2. the octave configure script checks for qcollectiongenerator binary, but it is bundled with qt formula

1: is fixed
2: I don't know there should be a qcollectiongenerator with qt, so I just want to make a symbol link for it. However it seems the system does not allow it to create a symbol link in bin dir, so I only check for existence of qcollectiongenerator and report error (odie) if not existed.