### PR TITLE
fb-client: update resources, depend on curl-openssl

### DIFF
--- a/Formula/fb-client.rb
+++ b/Formula/fb-client.rb
@@ -3,7 +3,7 @@ class FbClient < Formula
   homepage "https://paste.xinu.at"
   url "https://paste.xinu.at/data/client/fb-2.0.3.tar.gz"
   sha256 "dd318de67c1581e6dfa6b6c84e8c8e995b27d115fed86d81d5579aa9a2358114"
-  revision 4
+  revision 5
   head "https://git.server-speed.net/users/flo/fb", :using => :git
 
   bottle do
@@ -16,18 +16,19 @@ class FbClient < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "curl-openssl"
   depends_on "python"
 
   conflicts_with "findbugs", :because => "findbugs and fb-client both install a `fb` binary"
 
   resource "pycurl" do
-    url "https://files.pythonhosted.org/packages/12/3f/557356b60d8e59a1cce62ffc07ecc03e4f8a202c86adae34d895826281fb/pycurl-7.43.0.tar.gz"
-    sha256 "aa975c19b79b6aa6c0518c0cc2ae33528900478f0b500531dbcdbf05beec584c"
+    url "https://files.pythonhosted.org/packages/e8/e4/0dbb8735407189f00b33d84122b9be52c790c7c3b25286826f4e1bdb7bde/pycurl-7.43.0.2.tar.gz"
+    sha256 "0f0cdfc7a92d4f2a5c44226162434e34f7d6967d3af416a6f1448649c09a25a4"
   end
 
   resource "pyxdg" do
-    url "https://files.pythonhosted.org/packages/26/28/ee953bd2c030ae5a9e9a0ff68e5912bd90ee50ae766871151cd2572ca570/pyxdg-0.25.tar.gz"
-    sha256 "81e883e0b9517d624e8b0499eb267b82a815c0b7146d5269f364988ae031279d"
+    url "https://files.pythonhosted.org/packages/47/6e/311d5f22e2b76381719b5d0c6e9dc39cd33999adae67db71d7279a6d70f4/pyxdg-0.26.tar.gz"
+    sha256 "fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06"
   end
 
   def install
@@ -39,13 +40,8 @@ class FbClient < Formula
 
     # avoid error about libcurl link-time and compile-time ssl backend mismatch
     resource("pycurl").stage do
-      args = Language::Python.setup_install_args(libexec/"vendor")
-
-      if MacOS.version >= :high_sierra
-        args << "--libcurl-dll=/usr/lib/libcurl.dylib"
-      end
-
-      system "python3", *args
+      system "python3", *Language::Python.setup_install_args(libexec/"vendor"),
+                        "--curl-config=#{Formula["curl-openssl"].opt_bin}/curl-config"
     end
 
     resource("pyxdg").stage do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
01:46:38 ==> brew test --verbose fb-client
01:46:41 ==> FAILED
01:46:41 Testing fb-client
01:46:41 […]
01:46:41 ==> /usr/local/Cellar/fb-client/2.0.3_4/bin/fb -h
01:46:41 Traceback (most recent call last):
01:46:41   File "/usr/local/Cellar/fb-client/2.0.3_4/libexec/bin/fb", line 15, in <module>
01:46:41     import pycurl
01:46:41 ImportError: dlopen(/usr/local/Cellar/fb-client/2.0.3_4/libexec/vendor/lib/python3.7/site-packages/pycurl.cpython-37m-darwin.so, 2): Library not loaded: @@HOMEBREW_PREFIX@@/opt/openssl/lib/libcrypto.1.0.0.dylib
01:46:41   Referenced from: /usr/local/Cellar/fb-client/2.0.3_4/libexec/vendor/lib/python3.7/site-packages/pycurl.cpython-37m-darwin.so
01:46:41   Reason: image not found
01:46:41 Error: fb-client: failed
```

Attempting to fix another long-standing issue.

As of macOS Mojave, the system cURL depends on the LibreSSL shipped by Apple, however `pycurl` is having some troubles while determining this.

Let's switch to our cURL, which, by default, does not depend on OpenSSL at all.