### PR TITLE
Crystal: always install pkg-config

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -27,7 +27,7 @@ class Crystal < Formula
   end
 
   depends_on "libatomic_ops" => :build # for building bdw-gc
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config"
   depends_on "bdw-gc"
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

pkg-config seems to always be required to compile Crystal programs,
see https://github.com/crystal-lang/crystal/issues/6875