### PR TITLE
atomist-cli 1.1.0 (new formula)

### DIFF
--- a/Formula/atomist-cli.rb
+++ b/Formula/atomist-cli.rb
@@ -1,0 +1,36 @@
+require "language/node"
+
+class AtomistCli < Formula
+  desc "The Atomist CLI"
+  homepage "https://github.com/atomist/cli#readme"
+  url "https://registry.npmjs.org/@atomist/cli/-/@atomist/cli-1.1.0.tgz"
+  sha256 "bdc37fc2216745b1156f7038de66f755a355fc9328ee72ec53630d95c1b22be9"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bash_completion.install "#{libexec}/lib/node_modules/@atomist/cli/assets/bash_completion/atomist"
+  end
+
+  test do
+    assert_predicate bin/"atomist", :exist?
+    assert_predicate bin/"atomist", :executable?
+    assert_predicate bin/"@atomist", :exist?
+    assert_predicate bin/"@atomist", :executable?
+
+    run_output = shell_output("#{bin}/atomist 2>&1")
+    assert_match "Not enough non-option arguments", run_output
+    assert_match "Specify --help for available options", run_output
+
+    version_output = shell_output("#{bin}/atomist --version")
+    assert_match "@atomist/cli", version_output
+    assert_match "@atomist/sdm ", version_output
+    assert_match "@atomist/sdm-core", version_output
+    assert_match "@atomist/sdm-local", version_output
+
+    skill_output = shell_output("#{bin}/atomist show skills")
+    assert_match(/\d+ commands are available from \d+ connected SDMs/, skill_output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds the formula for the [Atomist CLI](https://github.com/atomist/cli), which is currently provided via a dedicated [tap](https://github.com/atomist/homebrew-tap). See the [Atomist](https://atomist.com) website for more information.
