### PR TITLE
dosbox-x 0.82.13

### DIFF
--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -1,9 +1,9 @@
 class DosboxX < Formula
   desc "DOSBox with accurate emulation and wide testing"
   homepage "http://dosbox-x.com/"
-  url "https://github.com/joncampbell123/dosbox-x/archive/v0.801.tar.gz"
-  sha256 "40f94cdcc5c9a374c522de7eb2c2288eaa8c6de85d0bd6a730f48bd5d84a89f9"
-  revision 1
+  url "https://github.com/joncampbell123/dosbox-x/archive/dosbox-x-v0.82.13.tar.gz"
+  sha256 "e2721125b650ef995fc66f95766a995844f52aab0cf4261ff7aa998eb60e6f4c"
+  version_scheme 1
   head "https://github.com/joncampbell123/dosbox-x.git"
 
   bottle do
@@ -15,13 +15,14 @@ class DosboxX < Formula
     sha256 "0b5098e3397a15804a300540be53c98f862c4f7276eb4c1de7966152421a9392" => :el_capitan
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "ffmpeg"
   depends_on "fluid-synth"
   depends_on "libpng"
   depends_on "sdl"
   depends_on "sdl_net"
   depends_on "sdl_sound"
-
-  conflicts_with "dosbox", :because => "both install `dosbox` binaries"
 
   # Otherwise build failure on Moutain Lion (#311)
   needs :cxx11
@@ -29,26 +30,21 @@ class DosboxX < Formula
   def install
     ENV.cxx11
 
-    # Fix build failure due to missing <remote-ext.h> included from pcap.h
-    # https://github.com/joncampbell123/dosbox-x/issues/275
-    inreplace "src/hardware/ne2000.cpp", "#define HAVE_REMOTE\n", ""
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-sdltest
+      --enable-core-inline
+    ]
 
-    # Fix compilation issue: https://github.com/joncampbell123/dosbox-x/pull/308
-    if DevelopmentTools.clang_build_version >= 900
-      inreplace "src/hardware/serialport/nullmodem.cpp",
-                "setCD(clientsocket > 0)", "setCD(clientsocket != 0)"
-    end
+    inreplace "vs2015/sdl/build-dosbox.sh",
+              "make -j || exit 1", "make || exit 1"
 
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
-                          "--disable-sdltest",
-                          "--enable-core-inline"
-
-    chmod 0755, "install-sh"
+    system "./build-macosx", *args
     system "make", "install"
   end
 
   test do
-    assert_match /DOSBox version #{version}/, shell_output("#{bin}/dosbox -version 2>&1", 1)
+    assert_match /DOSBox version #{version}/, shell_output("#{bin}/dosbox-x -version 2>&1", 1)
   end
 end

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -26,8 +26,6 @@ class Dosbox < Formula
   depends_on "sdl_net"
   depends_on "sdl_sound"
 
-  conflicts_with "dosbox-x", :because => "both install `dosbox` binaries"
-
   def install
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New version of `dosbox-x`:
* The binary is not called `dosbox-x` therefore removing the conflict with `dosbox`
* The patches in the Formula are fixed upstream
* Uses the projects own build script, `build-macosx`, as it depends on a patched version of SDL