### PR TITLE
subversion:  Relax `--with-java`/JavaHL Java Version `Requirement`

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -39,7 +39,7 @@ class Subversion < Formula
   depends_on "utf8proc"
 
   # Other optional dependencies
-  depends_on :java => ["1.8", :optional]
+  depends_on :java => ["1.8+", :optional]
 
   # When building Perl or Ruby bindings, need to use a compiler that
   # recognizes GCC-style switches, since that's what the system languages


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?  
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?  
- [x] Have you built your formula locally with '`brew install --build-from-source <formula>`,' where '`<formula>`' is the name of the formula you're submitting?  
- [x] Have you successfully run '`brew test <formula>`,' where '`<formula>`' is the name of the formula you're submitting?  
- [x] Does your build pass '`brew audit --strict <formula>`' (after doing '`brew install <formula>`?')  

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Per [Subversion v1.11.0's release notes](https://subversion.apache.org/docs/release-notes/1.11):  

> ⋮
>
> ## Enhancements and Bugfixes
>
> ⋮
>
> ### API changes, improvements and language bindings (client and server)
>
> #### JavaHL Updates
>
> The JavaHL bindings have been updated to be compatible with Java 10.  Due to required build changes, JavaHL now requires at least Java 8 to compile.  
>
> ⋮

Java v11.x has also been tested and works identically.  