### PR TITLE
imagemagick: Enable OpenMP support on LLVM Clang.

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -15,6 +15,12 @@ class Imagemagick < Formula
     sha256 "fc2681e21a012516713f4b0bfd502aa2519642890e858b87f6482a67b687779f" => :sierra
   end
 
+  # Using LLVM with superenv would make the resulting binaries depend
+  # on /usr/local/opt/llvm/lib/libomp.dylib instead of the intended
+  # /usr/local/opt/libomp/lib/libomp.dylib, as superenv would add the
+  # LDFLAGS `-L/usr/local/opt/llvm/lib`.
+  env :std
+
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"
   option "with-libheif", "Compile with HEIF support"
@@ -23,10 +29,12 @@ class Imagemagick < Formula
   deprecated_option "enable-hdri" => "with-hdri"
   deprecated_option "with-libde265" => "with-libheif"
 
+  depends_on "llvm" => :build
   depends_on "pkg-config" => :build
 
   depends_on "freetype"
   depends_on "jpeg"
+  depends_on "libomp"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
@@ -57,7 +65,7 @@ class Imagemagick < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --disable-opencl
-      --disable-openmp
+      --enable-openmp
       --enable-shared
       --enable-static
       --with-freetype=yes
@@ -79,6 +87,14 @@ class Imagemagick < Formula
 
     # versioned stuff in main tree is pointless for us
     inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_VERSION}", "${PACKAGE_NAME}"
+
+    # Use LLVM Clang but do not depend on LLVM stuff (specifically, not the
+    # libomp from LLVM).
+    ENV["CC"] = "/usr/local/opt/llvm/bin/clang"
+    ENV["CXX"] = "/usr/local/opt/llvm/bin/clang++"
+    ENV["CPPFLAGS"] = ENV["CPPFLAGS"].split(" ").reject { |item| item =~ /llvm/ }.join(" ")
+    ENV["LDFLAGS"] = ENV["LDFLAGS"].split(" ").reject { |item| item =~ /llvm/ }.join(" ")
+
     system "./configure", *args
     system "make", "install"
   end


### PR DESCRIPTION
1. Re-enable OpenMP support (by default).
2. Use LLVM Clang to build (not GCC).
3. The resulting binaries depend only on libomp.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I have one remaining failure with `brew audit --strict imagemagick`. I used `env :std`, as I need to get rid of `-L/usr/local/opt/llvm/lib` so that the resulting binaries will not depend on `llvm`. If there is a better way, I will try it.