### PR TITLE
meson: Apply patch to fix regression in 0.49.0

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -3,6 +3,7 @@ class Meson < Formula
   homepage "https://mesonbuild.com/"
   url "https://github.com/mesonbuild/meson/releases/download/0.49.0/meson-0.49.0.tar.gz"
   sha256 "fb0395c4ac208eab381cd1a20571584bdbba176eb562a7efa9cb17cace0e1551"
+  revision 1
   head "https://github.com/mesonbuild/meson.git"
 
   bottle do
@@ -15,9 +16,10 @@ class Meson < Formula
   depends_on "ninja"
   depends_on "python"
 
-  # See https://github.com/mesonbuild/meson/pull/4652
+  # Fix issues with Qt, remove in 0.49.1
+  # https://github.com/mesonbuild/meson/pull/4652
   patch do
-    url "https://github.com/mesonbuild/meson/commit/c1e416ff619e59845c5272475f2e7c1f48f1d8db.patch?full_index=1"
+    url "https://github.com/mesonbuild/meson/commit/c1e416ff.patch?full_index=1"
     sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
   end
 

--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -15,6 +15,12 @@ class Meson < Formula
   depends_on "ninja"
   depends_on "python"
 
+  # See https://github.com/mesonbuild/meson/pull/4652
+  patch do
+    url "https://github.com/mesonbuild/meson/commit/c1e416ff619e59845c5272475f2e7c1f48f1d8db.patch?full_index=1"
+    sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
+  end
+
   def install
     version = Language::Python.major_minor_version("python3")
     ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/mesonbuild/meson/pull/4652 (for issue https://github.com/mesonbuild/meson/issues/4641)