### PR TITLE
signify-osx: update to 1.4

### DIFF
--- a/Formula/signify-osx.rb
+++ b/Formula/signify-osx.rb
@@ -1,8 +1,8 @@
 class SignifyOsx < Formula
   desc "Cryptographically sign and verify files"
-  homepage "https://man.openbsd.org/OpenBSD-current/man1/signify.1"
-  url "https://github.com/jpouellet/signify-osx/archive/1.3.tar.gz"
-  sha256 "c67090135a55478a6a6c11d507d9c3865a11de665c010a8a5f2457737f277f89"
+  homepage "https://man.openbsd.org/signify.1"
+  url "https://github.com/jpouellet/signify-osx/archive/1.4.tar.gz"
+  sha256 "5aa954fe6c54f2fc939771779e5bb64298e46d0a4ae3d08637df44c7ed8d2897"
   head "https://github.com/jpouellet/signify-osx.git"
 
   bottle do
@@ -21,6 +21,6 @@ class SignifyOsx < Formula
   end
 
   test do
-    system "#{bin}/signify", "-G", "-n", "-p", "pubkey", "-s", "seckey"
+    system "#{bin}/signify", "-G", "-n", "-p", "test.pub", "-s", "test.sec"
   end
 end


### PR DESCRIPTION
Also:
- Update homepage to short man.openbsd.org url scheme.
- Fix tests to pass new filename validation.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
