### PR TITLE
fix: libetpan install through xcode

### DIFF
--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -3,24 +3,22 @@ class Libetpan < Formula
   homepage "https://www.etpan.org/libetpan.html"
   url "https://github.com/dinhviethoa/libetpan/archive/1.9.2.tar.gz"
   sha256 "45a3bef81ae1818b8feb67cd1f016e774247d7b03804d162196e5071c82304ab"
+  head "https://github.com/dinhviethoa/libetpan.git", :branch => "master"
 
-  bottle do
-    cellar :any
-    sha256 "dd099ac0345f5af0c75baa8203e7cbab1199e57e5db148094d8ab1e09a9cfe9a" => :mojave
-    sha256 "22bc38a732865ba07d68410ee7d99d237d1db87aceaecb084fb7cf6e46681ba8" => :high_sierra
-    sha256 "30eafeadf05274390a3416fe11d852410907b3d61c4d0fe171e03fa5f86df136" => :sierra
-  end
-
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
+  depends_on :xcode => :build
 
   def install
-    system "./autogen.sh", "--disable-debug",
-                           "--disable-dependency-tracking",
-                           "--disable-silent-rules",
-                           "--prefix=#{prefix}"
-    system "make", "install"
+    xcodebuild "-project", "build-mac/libetpan.xcodeproj",
+                       "-scheme", "static libetpan",
+                       "SYMROOT=build/libetpan",
+                       "build"
+    xcodebuild "-project", "build-mac/libetpan.xcodeproj",
+                       "-scheme", "libetpan",
+                       "SYMROOT=build/libetpan",
+                       "build"
+    lib.install Dir["build-mac/build/libetpan/Debug/{libetpan.a, libetpan.framework}"]
+    include.install Dir["build-mac/build/libetpan/Debug/include/**"]
+    bin.install "libetpan-config"
   end
 
   test do

--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -5,19 +5,31 @@ class Libetpan < Formula
   sha256 "45a3bef81ae1818b8feb67cd1f016e774247d7b03804d162196e5071c82304ab"
   head "https://github.com/dinhviethoa/libetpan.git", :branch => "master"
 
+  bottle do
+    cellar :any
+    sha256 "dd099ac0345f5af0c75baa8203e7cbab1199e57e5db148094d8ab1e09a9cfe9a" => :mojave
+    sha256 "22bc38a732865ba07d68410ee7d99d237d1db87aceaecb084fb7cf6e46681ba8" => :high_sierra
+    sha256 "30eafeadf05274390a3416fe11d852410907b3d61c4d0fe171e03fa5f86df136" => :sierra
+  end
+
   depends_on :xcode => :build
 
   def install
     xcodebuild "-project", "build-mac/libetpan.xcodeproj",
-                       "-scheme", "static libetpan",
-                       "SYMROOT=build/libetpan",
-                       "build"
+               "-scheme", "static libetpan",
+               "-configuration", "Release",
+               "SYMROOT=build/libetpan",
+               "build"
+
     xcodebuild "-project", "build-mac/libetpan.xcodeproj",
-                       "-scheme", "libetpan",
-                       "SYMROOT=build/libetpan",
-                       "build"
-    lib.install Dir["build-mac/build/libetpan/Debug/{libetpan.a, libetpan.framework}"]
-    include.install Dir["build-mac/build/libetpan/Debug/include/**"]
+               "-scheme", "libetpan",
+               "-configuration", "Release",
+               "SYMROOT=build/libetpan",
+               "build"
+
+    lib.install "build-mac/build/libetpan/Release/libetpan.a"
+    lib.install "build-mac/build/libetpan/Release/libetpan.framework"
+    include.install Dir["build-mac/build/libetpan/Release/include/**"]
     bin.install "libetpan-config"
   end
 

--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -3,6 +3,7 @@ class Libetpan < Formula
   homepage "https://www.etpan.org/libetpan.html"
   url "https://github.com/dinhviethoa/libetpan/archive/1.9.2.tar.gz"
   sha256 "45a3bef81ae1818b8feb67cd1f016e774247d7b03804d162196e5071c82304ab"
+  revision 1
   head "https://github.com/dinhviethoa/libetpan.git", :branch => "master"
 
   bottle do

--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -28,7 +28,7 @@ class Libetpan < Formula
                "build"
 
     lib.install "build-mac/build/libetpan/Release/libetpan.a"
-    lib.install "build-mac/build/libetpan/Release/libetpan.framework"
+    frameworks.install "build-mac/build/libetpan/Release/libetpan.framework"
     include.install Dir["build-mac/build/libetpan/Release/include/**"]
     bin.install "libetpan-config"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I have removed the bottles and build now using xcode, as the actual [instructions described here require](https://github.com/dinhviethoa/libetpan#mac--ios). This fixes an issue I have seen when building software using this version of libetpan. 

