### PR TITLE
llvm: build with Ninja instead of GNU Make

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -111,6 +111,7 @@ class Llvm < Formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
+  depends_on "ninja" => :build
   depends_on "libffi"
 
   depends_on "python@2" if MacOS.version <= :snow_leopard
@@ -186,10 +187,10 @@ class Llvm < Formula
     ]
 
     mkdir "build" do
-      system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
-      system "make"
-      system "make", "install"
-      system "make", "install-xcode-toolchain"
+      system "cmake", "-G", "Ninja", "..", *(std_cmake_args + args)
+      system "ninja"
+      system "ninja", "install"
+      system "ninja", "install-xcode-toolchain"
     end
 
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]


### PR DESCRIPTION
Fixes #35513. This commit adds Ninja as a build dependency, and
replaces the CMake Unix Makefiles generator/GNU Make build toolchain
with a CMake Ninja generator/Ninja toolchain.

An alternative fix proposed by @fxcoudert and tested by @ducky427
involves leaving the build toolchain as-is and setting the
`HOMEBREW_MAKE_JOBS` shell environment variable to `1`. This approach
does not introduce an additional build dependency, but is likely to
slow down a build from source significantly compared to the approach
implemented in this commit (all other things equal) because Ninja is
generally a faster build system, and the Ninja-based build system can
use all system cores versus using a single core in the Make-based
approach.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The build does not yet pass `brew audit --strict llvm`; the error message follows below. My impression from the diff in this PR is that the current LLVM formula version in `master` would also exhibit this failure, if it were to build via `brew install llvm --with-lldb` on macOS 10.14.2 (and possibly other macOS versions).

```console
Error: 1 problem in 1 formula detected
llvm:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/opt/llvm/lib/python2.7/site-packages/lldb/_lldb.so
```