### PR TITLE
Create and read the db from the same place

### DIFF
--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -85,8 +85,8 @@ class PostgresqlAT10 < Formula
 
   def post_install
     (var/"log").mkpath
-    (var/"postgres").mkpath
-    unless File.exist? "#{var}/postgres/PG_VERSION"
+    (var/"#{name}").mkpath
+    unless File.exist? "#{var}/#{name}/PG_VERSION"
       system "#{bin}/initdb", "#{var}/#{name}"
     end
   end

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -87,7 +87,7 @@ class PostgresqlAT10 < Formula
     (var/"log").mkpath
     (var/"postgres").mkpath
     unless File.exist? "#{var}/postgres/PG_VERSION"
-      system "#{bin}/initdb", "#{var}/postgres"
+      system "#{bin}/initdb", "#{var}/#{name}"
     end
   end
 

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -85,7 +85,7 @@ class PostgresqlAT10 < Formula
 
   def post_install
     (var/"log").mkpath
-    (var/"#{name}").mkpath
+    (var/name).mkpath
     unless File.exist? "#{var}/#{name}/PG_VERSION"
       system "#{bin}/initdb", "#{var}/#{name}"
     end


### PR DESCRIPTION
I was trying to do a brand new install of postgresql 10. At the end of the install, the server does not work.

What I think is happening is that the postgresql@10 formula runs `initdb` in `"#{var}/postgres"` as seen [L90](https://github.com/Homebrew/homebrew-core/blob/master/Formula/postgresql@10.rb#L90) but is configured to read the db from `#{var}/#{name}` i.e. `/usr/local/var/postgresql@10` in its plist file as seen [there](https://github.com/Homebrew/homebrew-core/blob/master/Formula/postgresql@10.rb#L115)

I'm not doing a PR because I'm not quite sure how it's supposed to work so I'll let someone knowledgeable check.
