### PR TITLE
meson: scope the patch to fix HEAD builds

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -16,11 +16,13 @@ class Meson < Formula
   depends_on "ninja"
   depends_on "python"
 
-  # Fix issues with Qt, remove in 0.49.1
-  # https://github.com/mesonbuild/meson/pull/4652
-  patch do
-    url "https://github.com/mesonbuild/meson/commit/c1e416ff.patch?full_index=1"
-    sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
+  stable do
+    # Fix issues with Qt, remove in 0.49.1
+    # https://github.com/mesonbuild/meson/pull/4652
+    patch do
+      url "https://github.com/mesonbuild/meson/commit/c1e416ff.patch?full_index=1"
+      sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
+    end
   end
 
   def install

--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -1,10 +1,20 @@
 class Meson < Formula
   desc "Fast and user friendly build system"
   homepage "https://mesonbuild.com/"
-  url "https://github.com/mesonbuild/meson/releases/download/0.49.0/meson-0.49.0.tar.gz"
-  sha256 "fb0395c4ac208eab381cd1a20571584bdbba176eb562a7efa9cb17cace0e1551"
   revision 1
   head "https://github.com/mesonbuild/meson.git"
+
+  stable do
+    url "https://github.com/mesonbuild/meson/releases/download/0.49.0/meson-0.49.0.tar.gz"
+    sha256 "fb0395c4ac208eab381cd1a20571584bdbba176eb562a7efa9cb17cace0e1551"
+
+    # Fix issues with Qt, remove in 0.49.1
+    # https://github.com/mesonbuild/meson/pull/4652
+    patch do
+      url "https://github.com/mesonbuild/meson/commit/c1e416ff.patch?full_index=1"
+      sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -15,15 +25,6 @@ class Meson < Formula
 
   depends_on "ninja"
   depends_on "python"
-
-  stable do
-    # Fix issues with Qt, remove in 0.49.1
-    # https://github.com/mesonbuild/meson/pull/4652
-    patch do
-      url "https://github.com/mesonbuild/meson/commit/c1e416ff.patch?full_index=1"
-      sha256 "3be708cc65d2b6e54d01e64031c83b06abad2eca1c658b97b2230d1aa7d1062b"
-    end
-  end
 
   def install
     version = Language::Python.major_minor_version("python3")


### PR DESCRIPTION
Ref #35540

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The updated formula doesn't pass the audit with
```
meson:
  * C: 4: col 3: `url` should be put inside `stable` block
  * C: 5: col 3: `sha256` should be put inside `stable` block
  * C: 19: col 3: `stable` (line 19) should be put before `bottle` (line 9)
Error: 3 problems in 1 formula detected
```
but as far as I understand this, it wants basically everything to be put in the stable block - which will be removed again with 0.49.1 so moving everything seems a bit unnecessary?

I've also confirmed that building both "normal" and HEAD version works and the patch only gets applied for the "normal" version.