### PR TITLE
yarn-completion fails to install without yarn installed

### DIFF
--- a/Formula/yarn-completion.rb
+++ b/Formula/yarn-completion.rb
@@ -6,6 +6,8 @@ class YarnCompletion < Formula
 
   bottle :unneeded
 
+  depends_on "yarn"
+
   def install
     bash_completion.install "yarn-completion.bash" => "yarn"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Attempting to install `yarn-completion` without having yarn installs yields the following:

```
blast$ brew install yarn-completion

/usr/local/Homebrew/Library/Homebrew/config.rb:39:in `initialize': no implicit conversion of nil into String (TypeError)
        from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `new'
        from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `<top (required)>'
        from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/Homebrew/Library/Homebrew/global.rb:25:in `<top (required)>'
        from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `require_relative'
        from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `<main>'
```

It's possible that we shouldn't explicitly depend on yarn being installed, as yarn can come from other sources, but a stacktrace is really not good for user experience.