### PR TITLE
weboob: Update URLs

### DIFF
--- a/Formula/weboob.rb
+++ b/Formula/weboob.rb
@@ -3,7 +3,7 @@ class Weboob < Formula
 
   desc "Web Outside of Browsers"
   homepage "https://weboob.org/"
-  url "https://symlink.me/attachments/download/356/weboob-1.3.tar.gz"
+  url "https://git.weboob.org/weboob/weboob/uploads/e8c77b143e84c97fca354579575d18e9/weboob-1.3.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/w/weboob/weboob_1.3.orig.tar.gz"
   sha256 "c991785c889877c76f18d19e372ed4ae0c3f8b819fd1e8da296bd34b1381be54"
   revision 2
@@ -126,6 +126,5 @@ class Weboob < Formula
 
   test do
     system bin/"weboob-config", "update"
-    system bin/"weboob-config", "applications"
   end
 end


### PR DESCRIPTION
symlink.me does not have weboob anymore, everything has been moved to
git.weboob.org.
It is the same tarball, so the hash has not changed.

Also removing the "applications" tests as it is being phased out:
https://git.weboob.org/weboob/weboob/commit/d2988f65b22153838fcc3d16f6ebf0409c0d9faa

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
