### PR TITLE
[haskell-stack] Remove now-redundant build flags

### DIFF
--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -33,8 +33,7 @@ class HaskellStack < Formula
     cabal_sandbox do
       cabal_install "happy"
 
-      # The flag works around https://github.com/commercialhaskell/stack/issues/4363
-      cabal_install "--flags=disable-git-info"
+      cabal_install
 
       # Let `stack` handle its own parallelization
       # Prevents "install: mkdir ... ghc-7.10.3/lib: File exists"
@@ -45,7 +44,7 @@ class HaskellStack < Formula
              "--system-ghc", "--no-install-ghc", "setup"
       system "stack", "-j#{jobs}", "--stack-yaml=stack-lts-12.yaml",
              "--system-ghc", "--no-install-ghc", "--local-bin-path=#{bin}",
-             "install", "--flag", "stack:disable-git-info"
+             "install"
     end
   end
 


### PR DESCRIPTION
These flags were added (by me) in #33855, but as of #34714 they are redundant because the underlying issue has been fixed upstream.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
