### PR TITLE
gdal: add a dependency on expat

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -3,6 +3,7 @@ class Gdal < Formula
   homepage "https://www.gdal.org/"
   url "https://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.xz"
   sha256 "3f6d78fe8807d1d6afb7bed27394f19467840a82bc36d65e66316fa0aa9d32a4"
+  revision 1
 
   bottle do
     sha256 "97c2b47f65141cc67949dc49fc7fdd0972e34d9ac9b21b7c14b27816220facc3" => :mojave

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -18,6 +18,7 @@ class Gdal < Formula
 
   deprecated_option "complete" => "with-complete"
 
+  depends_on "expat"
   depends_on "freexl"
   depends_on "geos"
   depends_on "giflib"
@@ -72,6 +73,7 @@ class Gdal < Formula
 
       # Homebrew backends
       "--with-curl=/usr/bin/curl-config",
+      "--with-expat=#{Formula["expat"].prefix}",
       "--with-freexl=#{Formula["freexl"].opt_prefix}",
       "--with-geos=#{Formula["geos"].opt_prefix}/bin/geos-config",
       "--with-geotiff=#{Formula["libgeotiff"].opt_prefix}",


### PR DESCRIPTION
The expat xml library is used in the processing of GPX files.  Without
it, the GPX file handling is essentially nonfunctional.  Add it as a
required dependency.

Signed-off-by: Jonah Petri <jonah@petri.us>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
