### PR TITLE
sloc 0.2.1 (new formula)

### DIFF
--- a/Formula/sloc.rb
+++ b/Formula/sloc.rb
@@ -1,7 +1,7 @@
 require "language/node"
 
 class Sloc < Formula
-  desc "A simple tool to count source lines of code."
+  desc "Simple tool to count source lines of code"
   homepage "https://github.com/flosse/sloc#readme"
   url "https://registry.npmjs.org/sloc/-/sloc-0.2.1.tgz"
   sha256 "fb56f1763b7dadfd0566f819665efc0725ba8dfbec13c75da3839edf309596e6"

--- a/Formula/sloc.rb
+++ b/Formula/sloc.rb
@@ -1,10 +1,9 @@
 require "language/node"
 
 class Sloc < Formula
-  desc "sloc is a simple tool to count SLOC (source lines of code)"
+  desc "A simple tool to count source lines of code."
   homepage "https://github.com/flosse/sloc#readme"
   url "https://registry.npmjs.org/sloc/-/sloc-0.2.1.tgz"
-  version "0.2.1"
   sha256 "fb56f1763b7dadfd0566f819665efc0725ba8dfbec13c75da3839edf309596e6"
 
   depends_on "node"
@@ -23,8 +22,8 @@ class Sloc < Formula
     EOS
 
     std_output = <<~EOS
-    Path,Physical,Source,Comment,Single-line comment,Block comment,Mixed,Empty block comment,Empty,To Do
-    Total,4,4,0,0,0,0,0,0,0
+      Path,Physical,Source,Comment,Single-line comment,Block comment,Mixed,Empty block comment,Empty,To Do
+      Total,4,4,0,0,0,0,0,0,0
     EOS
 
     assert_match std_output, shell_output("#{bin}/sloc --format=csv .")

--- a/Formula/sloc.rb
+++ b/Formula/sloc.rb
@@ -1,0 +1,32 @@
+require "language/node"
+
+class Sloc < Formula
+  desc "sloc is a simple tool to count SLOC (source lines of code)"
+  homepage "https://github.com/flosse/sloc#readme"
+  url "https://registry.npmjs.org/sloc/-/sloc-0.2.1.tgz"
+  version "0.2.1"
+  sha256 "fb56f1763b7dadfd0566f819665efc0725ba8dfbec13c75da3839edf309596e6"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      int main(void) {
+        return 0;
+      }
+    EOS
+
+    std_output = <<~EOS
+    Path,Physical,Source,Comment,Single-line comment,Block comment,Mixed,Empty block comment,Empty,To Do
+    Total,4,4,0,0,0,0,0,0,0
+    EOS
+
+    assert_match std_output, shell_output("#{bin}/sloc --format=csv .")
+  end
+end


### PR DESCRIPTION
`sloc` is a simple tool to count SLOC (source lines of code) implemented in Node.js, which is kind of similar to `cloc` (another SLOC tool implemented in Perl).

- The main formula is generated using `noob`.
- The `test` part is inspired from the formula of `cloc`.
