### PR TITLE
imagemagick: add OpenMP support

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -7,6 +7,7 @@ class Imagemagick < Formula
   url "https://dl.bintray.com/homebrew/mirror/ImageMagick-7.0.8-23.tar.xz"
   mirror "https://www.imagemagick.org/download/ImageMagick-7.0.8-23.tar.xz"
   sha256 "e535ef9c0e7e5961a9907a13475ffc4c0d7b84a2788484910337bcdb30498656"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git"
 
   bottle do
@@ -16,17 +17,16 @@ class Imagemagick < Formula
   end
 
   option "with-fftw", "Compile with FFTW support"
-  option "with-hdri", "Compile with HDRI support"
   option "with-libheif", "Compile with HEIF support"
   option "with-perl", "Compile with PerlMagick"
 
-  deprecated_option "enable-hdri" => "with-hdri"
   deprecated_option "with-libde265" => "with-libheif"
 
   depends_on "pkg-config" => :build
 
   depends_on "freetype"
   depends_on "jpeg"
+  depends_on "libomp"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
@@ -57,19 +57,21 @@ class Imagemagick < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --disable-opencl
-      --disable-openmp
       --enable-shared
       --enable-static
       --with-freetype=yes
       --with-modules
       --with-openjp2
       --with-webp=yes
+      --enable-openmp
+      ac_cv_prog_c_openmp=-Xpreprocessor\ -fopenmp
+      ac_cv_prog_cxx_openmp=-Xpreprocessor\ -fopenmp
+      LDFLAGS=-lomp
     ]
 
     args << "--without-gslib" if build.without? "ghostscript"
     args << "--with-perl" << "--with-perl-options='PREFIX=#{prefix}'" if build.with? "perl"
     args << "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts" if build.without? "ghostscript"
-    args << "--enable-hdri=yes" if build.with? "hdri"
     args << "--without-fftw" if build.without? "fftw"
     args << "--without-pango" if build.without? "pango"
     args << "--with-rsvg" if build.with? "librsvg"


### PR DESCRIPTION
_This PR needs https://github.com/Homebrew/brew/pull/5469 to be merged before it can actually work._

OpenMP support is added by:
- passing `-Xpreprocessor -fopenmp` to system clang
- linking against `libomp`

I'm also removing the HDRI option, because HDRI is enabled by default in ImageMagick 7 (which shows how well-tested our options are…)

---

With this PR (and the `brew` PR above), ImageMagick has OpenMP support:

```
$ magick --version                          
Version: ImageMagick 7.0.8-22 Q16 x86_64 2019-01-02 https://imagemagick.org
Copyright: © 1999-2019 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules OpenMP 
Delegates (built-in): bzlib freetype jng jp2 jpeg lcms ltdl lzma png tiff webp xml zlib
$ magick -bench 5 foo.png -sharpen 0x1 null:
Performance[1]: 5i 4.098ips 1.000000e 1.220000u 0:01.220
Performance[2]: 5i 7.353ips 0.642105e 1.350000u 0:00.680
Performance[3]: 5i 10.417ips 0.717647e 1.440000u 0:00.480
Performance[4]: 5i 11.364ips 0.734940e 1.770000u 0:00.440
Performance[5]: 5i 13.889ips 0.772152e 1.780000u 0:00.360
Performance[6]: 5i 14.286ips 0.777070e 2.040000u 0:00.350
Performance[7]: 5i 15.152ips 0.787097e 2.360000u 0:00.330
Performance[8]: 5i 15.152ips 0.787097e 2.570000u 0:00.330
Performance[9]: 5i 16.667ips 0.802631e 2.760000u 0:00.300
Performance[10]: 5i 17.241ips 0.807947e 2.890000u 0:00.290
Performance[11]: 5i 16.129ips 0.797386e 3.290000u 0:00.310
Performance[12]: 5i 17.857ips 0.813333e 3.230000u 0:00.280
```