### PR TITLE
Add antlr@3 formula

### DIFF
--- a/Formula/antlr@3.rb
+++ b/Formula/antlr@3.rb
@@ -1,0 +1,26 @@
+class AntlrAT3 < Formula
+  desc "ANother Tool for Language Recognition"
+  homepage "https://www.antlr3.org/"
+  url "https://www.antlr3.org/download/antlr-3.5.2-complete.jar"
+  sha256 "26ca659f47d77384f518cf2b6463892fcd4f0b0d4d8c0de2addf697e63e7326b"
+
+  keg_only :versioned_formula
+  depends_on :java => "1.5+"
+
+  def install
+    share.install "antlr-3.5.2-complete.jar"
+    (share+"java").install_symlink "#{share}/antlr-3.5.2-complete.jar" => "antlr-3.jar"
+
+    (bin+"antlr-3.5.2").write <<~EOS
+      #!/bin/sh
+      java -jar #{share}/java/antlr-3.jar "$@"
+    EOS
+
+    bin.install_symlink bin/"antlr-3.5.2" => "antlr3"
+  end
+
+  test do
+    assert_match "ANTLR Parser Generator  Version #{version}",
+      shell_output("#{bin}/antlr3 -version 2>&1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds the `antlr@3` formula that uses the pre-built Antlr 3.5.2 JAR from the official repo. Building the sources for Antlr 3 is a big pain as it requires having Java 5 or 6 installed and it would have a large impact on users' systems as nobody should still have nor use those unsupported Java versions anymore.

_Why would we still need Antlr3?_ Because [Groovy](https://github.com/groovy/groovy-core/blob/master/src/main/org/codehaus/groovy/antlr/groovy.g), for one. And, we have `antlr@2`, and `antlr` (4.x), but we're missing 3.x.