### PR TITLE
kakoune: Add dependency on ncurses to fix mouse problems

### DIFF
--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -3,6 +3,7 @@ class Kakoune < Formula
   homepage "https://github.com/mawww/kakoune"
   url "https://github.com/mawww/kakoune/releases/download/v2018.10.27/kakoune-2018.10.27.tar.bz2"
   sha256 "687a173c8f94fb66aad899e7a3095fe8f08e1fdcab955dbc6785335427cc8a1d"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -13,6 +13,7 @@ class Kakoune < Formula
 
   depends_on "asciidoc" => :build
   depends_on "docbook-xsl" => :build
+  depends_on "ncurses"
 
   if MacOS.version <= :el_capitan
     depends_on "gcc"


### PR DESCRIPTION
When using OSX default ncurses (5.x) kakoune's mouse interactions are
broken, not allowing to scroll or click-drag.

Depending on the more up to date ncurses, like the linux versions do,
fixes the problems.

Fixes #35514

Related issues:
* https://github.com/mawww/kakoune/issues/2651
* https://github.com/Homebrew/homebrew-core/issues/35514

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I also tested the mouse behaviour and it works great when building with the ncurses formula as a dependency 👍 