### PR TITLE
deno v0.5.0 (new formula)

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -8,7 +8,6 @@ class Deno < Formula
   depends_on "llvm" => :build
   depends_on "ninja" => :build
   depends_on "node" => :build
-  depends_on "python@2" => :build # GN require Python 2.7+
   depends_on "rust" => :build
 
   # https://bugs.chromium.org/p/chromium/issues/detail?id=620127

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -1,0 +1,56 @@
+class Deno < Formula
+  desc "Command-line JavaScript / TypeScript engine"
+  homepage "https://deno.land/"
+  url "https://github.com/denoland/deno.git",
+    :tag      => "v0.6.0",
+    :revision => "22feb74ba12215597416b5531f8a557302283e79"
+
+  depends_on "llvm" => :build
+  depends_on "ninja" => :build
+  depends_on "node" => :build
+  depends_on "python@2" => :build # GN require Python 2.7+
+  depends_on "rust" => :build
+
+  # https://bugs.chromium.org/p/chromium/issues/detail?id=620127
+  depends_on :macos => :el_capitan
+
+  resource "gn" do
+    url "https://gn.googlesource.com/gn.git",
+      :revision => "64b846c96daeb3eaf08e26d8a84d8451c6cb712b"
+  end
+
+  def install
+    # Build gn from source, move it to the expected location and add it to the PATH
+    (buildpath/"gn").install resource("gn")
+    cd "gn" do
+      system "python", "build/gen.py"
+      system "ninja", "-C", "out/", "gn"
+    end
+    (buildpath/"third_party/v8/buildtools/mac").install buildpath/"gn/out/gn"
+    ENV.prepend_path "PATH", buildpath/"third_party/v8/buildtools/mac"
+
+    # GN args for building a release build with homebrew clang / llvm
+    gn_args = {
+      :clang_base_path   => "\"#{Formula["llvm"].prefix}\"",
+      :is_debug          => false,
+      :is_official_build => true,
+      :symbol_level      => 0,
+    }
+    gn_args_string = gn_args.map { |k, v| "#{k}=#{v}" }.join(" ")
+    ENV["DENO_BUILD_MODE"] = "release"
+
+    # Build with the homebrew provided gn and ninja
+    system "gn", "gen", "--args=#{gn_args_string}", "target/release"
+    system "ninja", "-j", ENV.make_jobs, "-C", "target/release", "-v", "deno"
+
+    bin.install "target/release/deno"
+  end
+
+  test do
+    (testpath/"hello.ts").write <<~EOS
+      console.log("hello", "deno");
+    EOS
+    hello = shell_output("#{bin}/deno run hello.ts")
+    assert_includes hello, "hello deno"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

http://github.com/denoland/deno

A binary-only version of this PR was closed: #35590

Notes:
- It seems like git checkout, rather than zip, is required since deno uses submodules.
- ~There is a single test.py failure at the moment, hopefully we can debug this.~ It's a bug in that test, will be fixed soon (when testing in a directory not named "deno").
- ~There are some linker warnings, I'm not sure if these are a concern `ld: warning: object file ... was built for newer OSX version (10.14) than being linked (10.9)`.~ I'm told these are fine.
- ~Is there a way to specify the rust version? `depends_on "rust@1.30.0"` didn't work.~ I don't think rust version is important.