### PR TITLE
Istioctl 1.0.5 Update

### DIFF
--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -16,6 +16,7 @@ class Istioctl < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["TAG"] = version.to_s
+    ENV["ISTIO_VERSION"] = version.to_s
 
     srcpath = buildpath/"src/istio.io/istio"
     outpath = buildpath/"out/darwin_amd64/release"


### PR DESCRIPTION
Updated istioctl formula to take istio_version into account.

Helps in `istioctl version` command to see version of binary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
