### PR TITLE
traefik: Add plist for traefik service.

### DIFF
--- a/Formula/traefik.rb
+++ b/Formula/traefik.rb
@@ -36,6 +36,39 @@ class Traefik < Formula
     end
   end
 
+  plist_options :manual => "traefik"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <false/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/traefik</string>
+            <string>--configfile=#{etc/"traefik/traefik.toml"}</string>
+          </array>
+          <key>EnvironmentVariables</key>
+          <dict>
+          </dict>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/traefik.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/traefik.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
   test do
     require "socket"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a plist entry (akin to the one for [elasticsearch](https://github.com/Homebrew/homebrew-core/blob/master/Formula/elasticsearch.rb#L86)) so traefik can be picked up as a service ran through Homebrew.

I'm unable to build from source due to problems with installing the `node-sass` during build. Installing node-sass works completely fine globally and in other projects where I use it, but in the brew build env it fails. Since I'm not changing the build itself, simply adding a plist file, it should not be related. Installing the bottle works just fine, and installs the plist as expected.

I also added a `revision` as I saw that in another commit which simply changes the formulae but doesn't update the bottle. If that's wrong, I'll revert it.

If I should change something, hit me up 👍 