### PR TITLE
Update apache-drill.rb to 1.15.0

### DIFF
--- a/Formula/apache-drill.rb
+++ b/Formula/apache-drill.rb
@@ -1,9 +1,9 @@
 class ApacheDrill < Formula
   desc "Schema-free SQL Query Engine for Hadoop, NoSQL and Cloud Storage"
   homepage "https://drill.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=drill/drill-1.14.0/apache-drill-1.14.0.tar.gz"
-  mirror "https://archive.apache.org/dist/drill/drill-1.14.0/apache-drill-1.14.0.tar.gz"
-  sha256 "1145bdbb723119f271d32daf4cdd77cdeebe88ddcb7d04facd585b715bb5723b"
+  url "http://apache.mirrors.ionfish.org/drill/drill-1.15.0/apache-drill-1.15.0.tar.gz"
+  mirror "http://www.gtlib.gatech.edu/pub/apache/drill/drill-1.15.0/apache-drill-1.15.0.tar.gz"
+  sha256 "188c1d0df28e50f0265f4bc3c5871b4e7abc9450a4e5a7dbe7f0b23146bec76b"
 
   bottle :unneeded
 


### PR DESCRIPTION
New Apache Drill released on 29 Dec 2018. 

I tried brew bump-formula-pr but could not get that to work. I edited my local formula and everything works fine.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
