### PR TITLE
libnova 0.15 (new formula)

### DIFF
--- a/Formula/libnova.rb
+++ b/Formula/libnova.rb
@@ -1,0 +1,37 @@
+class Libnova < Formula
+  desc "Celestial mechanics, astrometry and astrodynamics library"
+  homepage "https://libnova.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/libnova/libnova/v%200.15.0/libnova-0.15.0.tar.gz"
+  sha256 "7c5aa33e45a3e7118d77df05af7341e61784284f1e8d0d965307f1663f415bb1"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  def install
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libnova/julian_day.h>
+
+      int main(void)
+      {
+        double JD;
+
+        JD = ln_get_julian_from_sys();
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnova", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Added libnova formula, a Celestial Mechanics, Astrometry and Astrodynamics library. (https://libnova.sourceforge.io/)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
