### PR TITLE
Dosbox: Strict check warning

### DIFF
--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -18,13 +18,10 @@ class Dosbox < Formula
     depends_on "automake" => :build
   end
 
-  option "with-debugger", "Enable internal debugger"
-
   depends_on "libpng"
   depends_on "sdl"
   depends_on "sdl_net"
   depends_on "sdl_sound"
-  depends_on "ncurses" => :optional
 
   def install
     args = %W[
@@ -33,7 +30,6 @@ class Dosbox < Formula
       --disable-sdltest
       --enable-core-inline
     ]
-    args << "--enable-debug" if build.with? "debugger"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args

--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -21,10 +21,10 @@ class Dosbox < Formula
   option "with-debugger", "Enable internal debugger"
 
   depends_on "libpng"
-  depends_on "ncurses" if build.with?("debugger")
   depends_on "sdl"
   depends_on "sdl_net"
   depends_on "sdl_sound"
+  depends_on "ncurses" => :optional
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Initially running `brew audit --strict dosbox` gave `Use :optional` or `:recommended` instead of `depends_on "ncurses" if build.with?("debugger")`

The same has been corrected. 