### PR TITLE
GNU formulas: remove default-names option

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -71,18 +71,14 @@ class Coreutils < Formula
   end
 
   def caveats; <<~EOS
-    All commands have been installed with the prefix 'g'.
-
-    If you really need to use these commands with their normal names, you
+    All commands have been installed with the prefix "g".
+    If you need to use these commands with their normal names, you
     can add a "gnubin" directory to your PATH from your bashrc like:
-
-        PATH="#{opt_libexec}/gnubin:$PATH"
+      PATH="#{opt_libexec}/gnubin:$PATH"
 
     Additionally, you can access their man pages with normal names if you add
     the "gnuman" directory to your MANPATH from your bashrc as well:
-
-        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-
+      MANPATH="#{opt_libexec}/gnuman:$MANPATH"
   EOS
   end
 

--- a/Formula/findutils.rb
+++ b/Formula/findutils.rb
@@ -13,10 +13,6 @@ class Findutils < Formula
     sha256 "bc20b7e2a97c3277ea13fd91b44fbc0015628e8684a2bba203c38a4c7357f6c7" => :el_capitan
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
-  deprecated_option "default-names" => "with-default-names"
-
   def install
     # Work around unremovable, nested dirs bug that affects lots of
     # GNU projects. See:
@@ -31,29 +27,26 @@ class Findutils < Formula
       --localstatedir=#{var}/locate
       --disable-dependency-tracking
       --disable-debug
+      --program-prefix=g
     ]
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make", "install"
 
     # https://savannah.gnu.org/bugs/index.php?46846
     # https://github.com/Homebrew/homebrew/issues/47791
-    updatedb = (build.with?("default-names") ? "updatedb" : "gupdatedb")
-    (libexec/"bin").install bin/updatedb
-    (bin/updatedb).write <<~EOS
+    (libexec/"bin").install bin/"gupdatedb"
+    (bin/"gupdatedb").write <<~EOS
       #!/bin/sh
       export LC_ALL='C'
-      exec "#{libexec}/bin/#{updatedb}" "$@"
+      exec "#{libexec}/bin/gupdatedb" "$@"
     EOS
 
-    if build.without? "default-names"
-      [[prefix, bin], [share, man/"*"]].each do |base, path|
-        Dir[path/"g*"].each do |p|
-          f = Pathname.new(p)
-          gnupath = "gnu" + f.relative_path_from(base).dirname
-          (libexec/gnupath).install_symlink f => f.basename.sub(/^g/, "")
-        end
+    [[prefix, bin], [share, man/"*"]].each do |base, path|
+      Dir[path/"g*"].each do |p|
+        f = Pathname.new(p)
+        gnupath = "gnu" + f.relative_path_from(base).dirname
+        (libexec/gnupath).install_symlink f => f.basename.sub(/^g/, "")
       end
     end
   end
@@ -62,28 +55,21 @@ class Findutils < Formula
     (var/"locate").mkpath
   end
 
-  def caveats
-    if build.without? "default-names"
-      <<~EOS
-        All commands have been installed with the prefix 'g'.
-        If you do not want the prefix, install using the "with-default-names" option.
+  def caveats; <<~EOS
+    All commands have been installed with the prefix "g".
+    If you need to use these commands with their normal names, you
+    can add a "gnubin" directory to your PATH from your bashrc like:
+      PATH="#{opt_libexec}/gnubin:$PATH"
 
-        If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-
-            PATH="#{opt_libexec}/gnubin:$PATH"
-
-        Additionally, you can access their man pages with normal names if you add
-        the "gnuman" directory to your MANPATH from your bashrc as well:
-
-            MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-      EOS
-    end
+    Additionally, you can access their man pages with normal names if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
+      MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do
-    find = (build.with?("default-names") ? "find" : "gfind")
     touch "HOMEBREW"
-    assert_match "HOMEBREW", shell_output("#{bin}/#{find} .")
+    assert_match "HOMEBREW", shell_output("#{bin}/gfind .")
+    assert_match "HOMEBREW", shell_output("#{opt_libexec}/gnubin/find .")
   end
 end

--- a/Formula/gnu-indent.rb
+++ b/Formula/gnu-indent.rb
@@ -13,10 +13,6 @@ class GnuIndent < Formula
     sha256 "d31ad8b842092150f18dd706d369a0fa6db7fbb41302247eac601c97785218af" => :el_capitan
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
-  deprecated_option "default-names" => "with-default-names"
-
   depends_on "gettext"
 
   def install
@@ -25,17 +21,28 @@ class GnuIndent < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --mandir=#{man}
+      --program-prefix=g
     ]
-
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"gindent" => "indent"
-      (libexec/"gnuman/man1").install_symlink man1/"gindent.1" => "indent.1"
-    end
+    (libexec/"gnubin").install_symlink bin/"gindent" => "indent"
+    (libexec/"gnuman/man1").install_symlink man1/"gindent.1" => "indent.1"
+  end
+
+  def caveats; <<~EOS
+    GNU "indent" has been installed as "gindent".
+    If you need to use it as "indent", you can add a "gnubin" directory
+    to your PATH from your bashrc like:
+
+        PATH="#{opt_libexec}/gnubin:$PATH"
+
+    Additionally, you can access its man page with normal name if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
+
+        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do

--- a/Formula/gnu-time.rb
+++ b/Formula/gnu-time.rb
@@ -14,26 +14,30 @@ class GnuTime < Formula
     sha256 "a6ae05233326897ed622ab5c6ee63081e1c445b5e7496c68efa00dd5718b589c" => :el_capitan
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
   def install
-    args = [
-      "--prefix=#{prefix}",
-      "--mandir=#{man}",
-      "--info=#{info}",
+    args = %W[
+      --prefix=#{prefix}
+      --info=#{info}
+      --program-prefix=g
     ]
-
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"gtime" => "time"
-    end
+    (libexec/"gnubin").install_symlink bin/"gtime" => "time"
+  end
+
+  def caveats; <<~EOS
+    GNU "time" has been installed as "gtime".
+    If you need to use it as "time", you can add a "gnubin" directory
+    to your PATH from your bashrc like:
+
+        PATH="#{opt_libexec}/gnubin:$PATH"
+  EOS
   end
 
   test do
     system bin/"gtime", "ruby", "--version"
+    system opt_libexec/"gnubin/time", "ruby", "--version"
   end
 end

--- a/Formula/gnu-units.rb
+++ b/Formula/gnu-units.rb
@@ -11,27 +11,37 @@ class GnuUnits < Formula
     sha256 "3ed2c600cbc2af885b6c3d660b2a707e74cec265d94e141a62e40bb9517348c6" => :sierra
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
-  deprecated_option "default-names" => "with-default-names"
-
   depends_on "readline"
 
   def install
-    args = ["--prefix=#{prefix}", "--with-installed-readline"]
-    args << "--program-prefix=g" if build.without? "default-names"
+    args = %W[
+      --prefix=#{prefix}
+      --with-installed-readline
+      --program-prefix=g
+    ]
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"gunits" => "units"
-      (libexec/"gnubin").install_symlink bin/"gunits_cur" => "units_cur"
-      (libexec/"gnuman/man1").install_symlink man1/"gunits.1" => "units.1"
-    end
+    (libexec/"gnubin").install_symlink bin/"gunits" => "units"
+    (libexec/"gnubin").install_symlink bin/"gunits_cur" => "units_cur"
+    (libexec/"gnuman/man1").install_symlink man1/"gunits.1" => "units.1"
+  end
+
+  def caveats; <<~EOS
+    All commands have been installed with the prefix "g".
+    If you need to use these commands with their normal names, you
+    can add a "gnubin" directory to your PATH from your bashrc like:
+      PATH="#{opt_libexec}/gnubin:$PATH"
+
+    Additionally, you can access their man pages with normal names if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
+      MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do
     assert_equal "* 18288", shell_output("#{bin}/gunits '600 feet' 'cm' -1").strip
+    assert_equal "* 18288", shell_output("#{opt_libexec}/gnubin/units '600 feet' 'cm' -1").strip
   end
 end

--- a/Formula/gnu-which.rb
+++ b/Formula/gnu-which.rb
@@ -15,24 +15,36 @@ class GnuWhich < Formula
     sha256 "e6b1179b99922a7d49b3dee829c1d31c3fa7269b000799f862361637594d34e1" => :el_capitan
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
-  deprecated_option "default-names" => "with-default-names"
-
   def install
-    args = ["--prefix=#{prefix}", "--disable-dependency-tracking"]
-    args << "--program-prefix=g" if build.without? "default-names"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --program-prefix=g
+    ]
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"gwhich" => "which"
-      (libexec/"gnuman/man1").install_symlink man1/"gwhich.1" => "which.1"
-    end
+    (libexec/"gnubin").install_symlink bin/"gwhich" => "which"
+    (libexec/"gnuman/man1").install_symlink man1/"gwhich.1" => "which.1"
+  end
+
+  def caveats; <<~EOS
+    GNU "which" has been installed as "gwhich".
+    If you need to use it as "which", you can add a "gnubin" directory
+    to your PATH from your bashrc like:
+
+        PATH="#{opt_libexec}/gnubin:$PATH"
+
+    Additionally, you can access its man page with normal name if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
+
+        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do
     system "#{bin}/gwhich", "gcc"
+    system "#{opt_libexec}/gnubin/which", "gcc"
   end
 end

--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -12,9 +12,6 @@ class Grep < Formula
     sha256 "ccae999dfa982fcafd94f710c62887ee402fb7e45b422242c7f2b6d9ba4c8f4c" => :sierra
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-  deprecated_option "default-names" => "with-default-names"
-
   depends_on "pkg-config" => :build
   depends_on "pcre"
 
@@ -26,47 +23,39 @@ class Grep < Formula
       --infodir=#{info}
       --mandir=#{man}
       --with-packager=Homebrew
+      --program-prefix=g
     ]
-
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make"
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"ggrep" => "grep"
-      (libexec/"gnubin").install_symlink bin/"gegrep" => "egrep"
-      (libexec/"gnubin").install_symlink bin/"gfgrep" => "fgrep"
-
-      (libexec/"gnuman/man1").install_symlink man1/"ggrep.1" => "grep.1"
-      (libexec/"gnuman/man1").install_symlink man1/"gegrep.1" => "egrep.1"
-      (libexec/"gnuman/man1").install_symlink man1/"gfgrep.1" => "fgrep.1"
+    %w[grep egrep fgrep].each do |prog|
+      (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
+      (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
     end
   end
 
-  def caveats
-    if build.without? "default-names" then <<~EOS
-      The command has been installed with the prefix "g".
-      If you do not want the prefix, install using the "with-default-names"
-      option.
+  def caveats; <<~EOS
+    All commands have been installed with the prefix "g".
+    If you need to use these commands with their normal names, you
+    can add a "gnubin" directory to your PATH from your bashrc like:
+      PATH="#{opt_libexec}/gnubin:$PATH"
 
-      If you need to use these commands with their normal names, you
-      can add a "gnubin" directory to your PATH from your bashrc like:
-        PATH="#{opt_libexec}/gnubin:$PATH"
-
-      Additionally, you can access their man pages with normal names if you add
-      the "gnuman" directory to your MANPATH from your bashrc as well:
-        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-    EOS
-    end
+    Additionally, you can access their man pages with normal names if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
+      MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do
     text_file = testpath/"file.txt"
     text_file.write "This line should be matched"
-    cmd = build.with?("default-names") ? "grep" : "ggrep"
-    grepped = shell_output("#{bin}/#{cmd} match #{text_file}")
+
+    grepped = shell_output("#{bin}/ggrep match #{text_file}")
+    assert_match "should be matched", grepped
+
+    grepped = shell_output("#{opt_libexec}/gnubin/grep match #{text_file}")
     assert_match "should be matched", grepped
   end
 end

--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -13,8 +13,6 @@ class Inetutils < Formula
     sha256 "08419e32bd90cdc6c6b4715e64b2facae634a3cd45ecc7e54da87cab7b112458" => :el_capitan
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
   depends_on "libidn"
 
   def noshadow
@@ -29,48 +27,44 @@ class Inetutils < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
+      --program-prefix=g
       --with-idn
     ]
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      # Binaries not shadowing macOS utils symlinked without 'g' prefix
-      noshadow.each do |cmd|
-        bin.install_symlink "g#{cmd}" => cmd
-        man1.install_symlink "g#{cmd}.1" => "#{cmd}.1"
-      end
+    # Binaries not shadowing macOS utils symlinked without 'g' prefix
+    noshadow.each do |cmd|
+      bin.install_symlink "g#{cmd}" => cmd
+      man1.install_symlink "g#{cmd}.1" => "#{cmd}.1"
+    end
 
-      # Symlink commands without 'g' prefix into libexec/gnubin and
-      # man pages into libexec/gnuman
-      bin.find.each do |path|
-        next unless File.executable?(path) && !File.directory?(path)
-        cmd = path.basename.to_s.sub(/^g/, "")
-        (libexec/"gnubin").install_symlink bin/"g#{cmd}" => cmd
-        (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}" => cmd
-      end
+    # Symlink commands without 'g' prefix into libexec/gnubin and
+    # man pages into libexec/gnuman
+    bin.find.each do |path|
+      next unless File.executable?(path) && !File.directory?(path)
+      cmd = path.basename.to_s.sub(/^g/, "")
+      (libexec/"gnubin").install_symlink bin/"g#{cmd}" => cmd
+      (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}" => cmd
     end
   end
 
-  def caveats
-    if build.without? "default-names" then <<~EOS
-      The following commands have been installed with the prefix 'g'.
+  def caveats; <<~EOS
+    The following commands have been installed with the prefix 'g'.
 
-          #{noshadow.sort.join("\n    ")}
+        #{noshadow.sort.join("\n    ")}
 
-      If you really need to use these commands with their normal names, you
-      can add a "gnubin" directory to your PATH from your bashrc like:
+    If you really need to use these commands with their normal names, you
+    can add a "gnubin" directory to your PATH from your bashrc like:
 
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        PATH="#{opt_libexec}/gnubin:$PATH"
 
-      Additionally, you can access their man pages with normal names if you add
-      the "gnuman" directory to your MANPATH from your bashrc as well:
+    Additionally, you can access their man pages with normal names if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
 
-          MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-    EOS
-    end
+        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do

--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -13,42 +13,32 @@ class Make < Formula
     sha256 "98d5e65561d42e737713bd745110bf808800819a393e2ddb7743896203f92b56" => :sierra
   end
 
-  option "with-default-names", "Do not prepend 'g' to the binary"
-
   def install
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
+      --program-prefix=g
     ]
-
-    args << "--program-prefix=g" if build.without? "default-names"
 
     system "./configure", *args
     system "make", "install"
 
-    if build.without? "default-names"
-      (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
-      (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
-    end
+    (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
+    (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
   end
 
-  def caveats
-    if build.without? "default-names"
-      <<~EOS
-        All commands have been installed with the prefix 'g'.
-        If you do not want the prefix, install using the "with-default-names" option.
+  def caveats; <<~EOS
+    GNU "make" has been installed as "gmake".
+    If you need to use it as "make", you can add a "gnubin" directory
+    to your PATH from your bashrc like:
 
-        If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
+        PATH="#{opt_libexec}/gnubin:$PATH"
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+    Additionally, you can access its man page with normal name if you add
+    the "gnuman" directory to your MANPATH from your bashrc as well:
 
-        Additionally, you can access their man pages with normal names if you add
-        the "gnuman" directory to your MANPATH from your bashrc as well:
-
-            MANPATH="#{opt_libexec}/gnuman:$MANPATH"
-      EOS
-    end
+        MANPATH="#{opt_libexec}/gnuman:$MANPATH"
+  EOS
   end
 
   test do
@@ -57,9 +47,7 @@ class Make < Formula
       \t@echo Homebrew
     EOS
 
-    cmd = build.with?("default-names") ? "make" : "gmake"
-
-    assert_equal "Homebrew\n",
-      shell_output("#{bin}/#{cmd}")
+    assert_equal "Homebrew\n", shell_output("#{bin}/gmake")
+    assert_equal "Homebrew\n", shell_output("#{opt_libexec}/gnubin/make")
   end
 end


### PR DESCRIPTION
Provide consistent handling of GNU software that would shadow system binaries. Remove the `with-default-names` option, which required recompilation, and make use of `libexec/gnu{bin,man}` allowing users to put the “default names” in their PATH after installation.

poke @MikeMcQuaid for review