### PR TITLE
Update url, original site is dead (no 1.8.0 bottle on linuxbrew)

### DIFF
--- a/Formula/tree.rb
+++ b/Formula/tree.rb
@@ -1,7 +1,7 @@
 class Tree < Formula
   desc "Display directories as trees (with optional color/HTML output)"
   homepage "http://mama.indstate.edu/users/ice/tree/"
-  url "http://mama.indstate.edu/users/ice/tree/src/tree-1.8.0.tgz"
+  url "http://deb.debian.org/debian/pool/main/t/tree/tree_1.8.0.orig.tar.gz"
   sha256 "715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2"
 
   bottle do

--- a/Formula/tree.rb
+++ b/Formula/tree.rb
@@ -1,7 +1,7 @@
 class Tree < Formula
   desc "Display directories as trees (with optional color/HTML output)"
   homepage "http://mama.indstate.edu/users/ice/tree/"
-  url "http://deb.debian.org/debian/pool/main/t/tree/tree_1.8.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/t/tree/tree_1.8.0.orig.tar.gz"
   sha256 "715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2"
 
   bottle do


### PR DESCRIPTION
Creators original site is dead, web.archive - emtpy. There is Debians original.tar.gz.
[ ] no need to to test ```brew test …``` only url changed(point to Debian's tarball), SHA256 the same!
[ ] you should accept PR, because there is not ELF-bottle created at that moment, and Linux users need viable source to get tarball.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [NO NEED] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [NO NEED] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
