### PR TITLE
mpd: test using TCPSocket

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -108,8 +108,14 @@ class Mpd < Formula
     sleep 2
 
     begin
-      assert_match "OK MPD", shell_output("curl localhost:6600")
-      assert_match "ACK", shell_output("(sleep 2; echo playid foo) | nc localhost 6600")
+      ohai "Connect to MPD command (localhost:6600)"
+      TCPSocket.open("localhost", 6600) do |sock|
+        assert_match "OK MPD", sock.gets
+        ohai "Ping server"
+        sock.puts("ping")
+        assert_match "OK", sock.gets
+        sock.close
+      end
     ensure
       Process.kill "SIGINT", pid
       Process.wait pid


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The netcat based tests of the `mpd` protocol are prone to race conditions and are artificially slowed by `sleep` calls. Resulting in [this build failure](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/35896/version=high_sierra/testReport/junit/brew-test-bot/high_sierra/test_mpd/) and https://github.com/Homebrew/homebrew-core/pull/34182#issuecomment-439492305. Also testing using the invalid command `playid foo` and `GET / HTTP/1.1` (curl) confuse the matter.