### PR TITLE
opencv: fix Yosemite build by disabling AVX2

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -84,6 +84,14 @@ class Opencv < Formula
       -DPYTHON3_INCLUDE_DIR=#{py3_include}
     ]
 
+    # The compiler on older Mac OS cannot build some OpenCV files using AVX2
+    # extensions, failing with errors such as
+    # "error: use of undeclared identifier '_mm256_cvtps_ph'"
+    # Work around this by not trying to build AVX2 code.
+    if MacOS.version <= :yosemite
+      args << "-DCPU_DISPATCH=SSE4_1,SSE4_2,AVX"
+    end
+
     if build.bottle?
       args += %w[-DENABLE_SSE41=OFF -DENABLE_SSE42=OFF -DENABLE_AVX=OFF
                  -DENABLE_AVX2=OFF]


### PR DESCRIPTION
OpenCV adds runtime support for the AVX2 instruction set (amongst others) to accelerate some
algorithms on CPUs that support these instructions. However, the compiler in Mac OS 10.10 (Yosemite) or older does not fully support AVX2, so the build fails with errors such as "`error: use of undeclared identifier '_mm256_cvtps_ph'`"

Work around this by disabling AVX2 on older Mac OS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
