### PR TITLE
Install drafter library and header

### DIFF
--- a/Formula/drafter.rb
+++ b/Formula/drafter.rb
@@ -13,8 +13,12 @@ class Drafter < Formula
   end
 
   def install
-    system "./configure"
-    system "make", "install", "DESTDIR=#{prefix}"
+    system "./configure", "--shared"
+    system "make", "drafter"
+
+    bin.install "bin/drafter"
+    (include + "drafter").install "src/drafter.h"
+    lib.install "build/out/Release/libdrafter.dylib"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Drafter formula in the Homebrew repository does not install the Drafter library unlike the official Drafter formula that used to be provided by Drafter (https://github.com/apiaryio/drafter/blob/db18d327f64f74f0f289383caba382f48336eac6/tools/homebrew/drafter.rb#L10) which means that certain tools that use Drafter will fail if they are trying to utilise Drafter as a library. https://github.com/kylef/draughtsman/issues/2#issuecomment-426591119 for example.

We've been wanting to make our installation command actually do this, but due to limitations by our build system (gyp) in Drafter, it has proven tricky to get this to work reliably in a cross platform manner and thus this hasn't happened. Drafter has been working towards moving to Cmake which resolves this problem which will make it to a future release. For now we have provided our official Drafter formula (https://github.com/apiaryio/drafter/blob/db18d327f64f74f0f289383caba382f48336eac6/tools/homebrew/drafter.rb which was installing drafter library). The other package for Drafter such as on [ArchLinux](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=drafter) behave similiar.