### PR TITLE
libpulsar 2.2.1 (new formula)

### DIFF
--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -1,0 +1,40 @@
+class Libpulsar < Formula
+  desc "Apache Pulsar C++ library"
+  homepage "https://pulsar.apache.org"
+
+  url "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.2.1/apache-pulsar-2.2.1-src.tar.gz"
+  sha256 "3a365368f0d7beba091ba3a6d0f703dcc77545c8b454e5e33b72c1a29905232e"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "boost"
+  depends_on "jsoncpp"
+  depends_on "openssl"
+  depends_on "protobuf"
+
+  def install
+    cd "pulsar-client-cpp" do
+      system "cmake", ".", "-DBUILD_TESTS=OFF", "-DBUILD_PYTHON=OFF",
+          "-DBoost_INCLUDE_DIRS=#{Formula["boost"].include}",
+          "-DProtobuf_INCLUDE_DIR=#{Formula["protobuf"].include}",
+          "-DProtobuf_LIBRARIES=#{Formula["protobuf"].lib}/libprotobuf.dylib",
+          "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cc").write <<~EOS
+      #include <pulsar/Client.h>
+
+      int main (int argc, char **argv)
+      {
+          pulsar::Client client("pulsar://localhost:6650");
+          return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cc", "-I#{Formula["boost"].include}", "-L#{lib}", "-lpulsar", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -15,7 +15,7 @@ class Libpulsar < Formula
 
   def install
     cd "pulsar-client-cpp" do
-      system "cmake", ".", "-DBUILD_TESTS=OFF", "-DBUILD_PYTHON=OFF",
+      system "cmake", ".", "-DBUILD_TESTS=OFF", "-DBUILD_PYTHON_WRAPPER=OFF",
           "-DBoost_INCLUDE_DIRS=#{Formula["boost"].include}",
           "-DProtobuf_INCLUDE_DIR=#{Formula["protobuf"].include}",
           "-DProtobuf_LIBRARIES=#{Formula["protobuf"].lib}/libprotobuf.dylib",

--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -20,6 +20,7 @@ class Libpulsar < Formula
           "-DProtobuf_INCLUDE_DIR=#{Formula["protobuf"].include}",
           "-DProtobuf_LIBRARIES=#{Formula["protobuf"].lib}/libprotobuf.dylib",
           "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+      system "make", "pulsarShared", "pulsarStatic"
       system "make", "install"
     end
   end

--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -1,13 +1,11 @@
 class Libpulsar < Formula
   desc "Apache Pulsar C++ library"
-  homepage "https://pulsar.apache.org"
-
+  homepage "https://pulsar.apache.org/"
   url "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.2.1/apache-pulsar-2.2.1-src.tar.gz"
   sha256 "3a365368f0d7beba091ba3a6d0f703dcc77545c8b454e5e33b72c1a29905232e"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-
   depends_on "boost"
   depends_on "jsoncpp"
   depends_on "openssl"
@@ -15,11 +13,12 @@ class Libpulsar < Formula
 
   def install
     cd "pulsar-client-cpp" do
-      system "cmake", ".", "-DBUILD_TESTS=OFF", "-DBUILD_PYTHON_WRAPPER=OFF",
-          "-DBoost_INCLUDE_DIRS=#{Formula["boost"].include}",
-          "-DProtobuf_INCLUDE_DIR=#{Formula["protobuf"].include}",
-          "-DProtobuf_LIBRARIES=#{Formula["protobuf"].lib}/libprotobuf.dylib",
-          "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+      system "cmake", ".", *std_cmake_args,
+                      "-DBUILD_TESTS=OFF",
+                      "-DBUILD_PYTHON_WRAPPER=OFF",
+                      "-DBoost_INCLUDE_DIRS=#{Formula["boost"].include}",
+                      "-DProtobuf_INCLUDE_DIR=#{Formula["protobuf"].include}",
+                      "-DProtobuf_LIBRARIES=#{Formula["protobuf"].lib}/libprotobuf.dylib"
       system "make", "pulsarShared", "pulsarStatic"
       system "make", "install"
     end
@@ -29,10 +28,9 @@ class Libpulsar < Formula
     (testpath/"test.cc").write <<~EOS
       #include <pulsar/Client.h>
 
-      int main (int argc, char **argv)
-      {
-          pulsar::Client client("pulsar://localhost:6650");
-          return 0;
+      int main (int argc, char **argv) {
+        pulsar::Client client("pulsar://localhost:6650");
+        return 0;
       }
     EOS
     system ENV.cxx, "test.cc", "-I#{Formula["boost"].include}", "-L#{lib}", "-lpulsar", "-o", "test"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

@commitay @fxcoudert I have ported the formula from the closed PR #33584. This is targeting pulsar-2.2.1 which has fixed the python requirement for builds on MacOS.

-----
