### PR TITLE
Update caveat text to point to correct folder to source

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -40,7 +40,7 @@ class BashCompletion < Formula
 
   def caveats; <<~EOS
     Add the following line to your ~/.bash_profile:
-      [ -f #{etc}/bash_completion ] && . #{etc}/bash_completion
+      [ -d #{etc}/bash_completion.d ] && . #{etc}/bash_completion.d/*
   EOS
   end
 


### PR DESCRIPTION
See https://discourse.brew.sh/t/bash-completion-and-brew-instructions-for-setting-up-completions/3808

On both my Ubuntu and macOS brew installs, bash completions are found in `[brew --prefix]/etc/bash_completion.d` yet the caveat instructions considers `brew_completion` as a file to source, rather than source all files within the `bash_completion.d` folder. Is `bash_completion.d` where everyone else finds their completions?

Also update the main documentation @ https://github.com/Homebrew/brew/pull/5511

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
