### PR TITLE
Libfreefare endian patch

### DIFF
--- a/Formula/libfreefare.rb
+++ b/Formula/libfreefare.rb
@@ -33,4 +33,16 @@ class Libfreefare < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
   end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <freefare.h>
+      int main() {
+        mifare_desfire_aid_new(0);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lfreefare", "-o", "test"
+    system "./test"
+  end
 end

--- a/Formula/libfreefare.rb
+++ b/Formula/libfreefare.rb
@@ -20,6 +20,13 @@ class Libfreefare < Formula
   depends_on "libnfc"
   depends_on "openssl"
 
+  # Upstream commit for endianness-related functions, fixes
+  # https://github.com/nfc-tools/libfreefare/issues/55
+  patch do
+    url "https://github.com/nfc-tools/libfreefare/commit/358df775.diff?full_index=1"
+    sha256 "54cace0b9f7be073ba96ba1ae04fba8882a5ce99100a7b707498b9d2bfb0a660"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a patch to resolve an upstream issue that can cause linking errors/crashes (https://github.com/nfc-tools/libfreefare/issues/55) and adds a simple test to the formula. The patch can be removed when libfreefare releases a new version with the associated pull request included.