### PR TITLE
sox: build with libsndfile

### DIFF
--- a/Formula/sox.rb
+++ b/Formula/sox.rb
@@ -3,7 +3,7 @@ class Sox < Formula
   homepage "https://sox.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz"
   sha256 "b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -17,6 +17,7 @@ class Sox < Formula
   depends_on "flac"
   depends_on "lame"
   depends_on "libpng"
+  depends_on "libsndfile"
   depends_on "libvorbis"
   depends_on "mad"
   depends_on "opusfile"


### PR DESCRIPTION
Fixes #35810

`libsndfile` is not a heavy dependency, so including it as default sounds like a good choice.
