### PR TITLE
fix percona-server@5.6 plist option

### DIFF
--- a/Formula/percona-server@5.6.rb
+++ b/Formula/percona-server@5.6.rb
@@ -121,7 +121,7 @@ class PerconaServerAT56 < Formula
   EOS
   end
 
-  plist_options :manual => "mysql.server start"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/percona-server@5.6/bin/mysql.server start"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I fixed percona-server@5.6 plist_option like [solr@6.6](https://github.com/Homebrew/homebrew-core/blob/df2be4fabcb643c132527c8f2a9375b2dbdc1cbf/Formula/solr%406.6.rb#L35)