### PR TITLE
Restore the --with-stoken build option

### DIFF
--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -21,7 +21,7 @@ class Openconnect < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "gnutls"
-  depends_on "stoken" => :optional
+  depends_on "stoken"
 
   resource "vpnc-script" do
     url "http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/6e04e0bbb66c0bf0ae055c0f4e58bea81dbb5c3c:/vpnc-script"

--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -4,6 +4,7 @@ class Openconnect < Formula
   url "ftp://ftp.infradead.org/pub/openconnect/openconnect-8.01.tar.gz"
   mirror "https://fossies.org/linux/privat/openconnect-8.01.tar.gz"
   sha256 "48868a4f99c81a7474d87fbabb41b8eaa7d32b54771c9f23a7aea72d9cd626fd"
+  revision 1
 
   bottle do
     sha256 "e9a11f88f2c226e6e5f9b2197e25f4f13b8c1dbdb237136de4cf1ea97cd19868" => :mojave

--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -21,6 +21,7 @@ class Openconnect < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "gnutls"
+  depends_on "stoken" => :optional
 
   resource "vpnc-script" do
     url "http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/6e04e0bbb66c0bf0ae055c0f4e58bea81dbb5c3c:/vpnc-script"


### PR DESCRIPTION
OpenConnect 8 still supports SecurID software tokens via libstoken.
Restore the `depends_on "stoken" => :optional` to allow that again.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
