### PR TITLE
octave: remove unrecognized --without-osmesa configure arg

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -74,7 +74,6 @@ class Octave < Formula
                           "--enable-link-all-dependencies",
                           "--enable-shared",
                           "--disable-static",
-                          "--without-osmesa",
                           "--with-hdf5-includedir=#{Formula["hdf5"].opt_include}",
                           "--with-hdf5-libdir=#{Formula["hdf5"].opt_lib}",
                           "--with-x=no",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Octave no longer supports the `--without-osmesa` argument to `configure`. This PR removes it. This doesn't change any build behavior, but gets rid of an unnecessary warning in the `configure` output:

```
configure: WARNING: unrecognized options: --without-osmesa
```

No revision bump needed because the build artifacts are unchanged.