### PR TITLE
doxygen: add patch to fix build breakage with CMake 3.13

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -30,8 +30,8 @@ class Doxygen < Formula
   # Fix build breakage for 1.8.15 and CMake 3.13
   # https://github.com/Homebrew/homebrew-core/issues/35815
   patch do
-    url "https://github.com/doxygen/doxygen/commit/889eab308b564c4deba4ef58a3f134a309e3e9d1.patch?full_index=1"
-    sha256 "0a5bc1c52972c65d0e61009b356d23e0f4780c76ef9aa4c71ff3e786bc7540e7"
+    url "https://github.com/doxygen/doxygen/commit/889eab308b564c4deba4ef58a3f134a309e3e9d1.diff?full_index=1"
+    sha256 "ba4f9251e2057aa4da3ae025f8c5f97ea11bf26065a3f0e3b313b9acdad0b938"
   end
 
   def install

--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -27,6 +27,13 @@ class Doxygen < Formula
   depends_on "llvm" => :optional
   depends_on "qt" => :optional
 
+  # Fix build breakage for 1.8.15 and CMake 3.13
+  # https://github.com/Homebrew/homebrew-core/issues/35815
+  patch do
+    url "https://github.com/doxygen/doxygen/commit/889eab308b564c4deba4ef58a3f134a309e3e9d1.patch?full_index=1"
+    sha256 "0a5bc1c52972c65d0e61009b356d23e0f4780c76ef9aa4c71ff3e786bc7540e7"
+  end
+
   def install
     args = std_cmake_args << "-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=#{MacOS.version}"
     args << "-Dbuild_wizard=ON" if build.with? "qt"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #35815

Pulls in a patch that has been merged upstream in https://github.com/doxygen/doxygen/pull/6750.
