### PR TITLE
Asdf homeshick conflicts

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -16,6 +16,9 @@ class Asdf < Formula
   depends_on "readline"
   depends_on "unixodbc"
 
+  conflicts_with "homeshick",
+    :because => "asdf and homeshick both install files in lib/commands"
+
   def install
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"

--- a/Formula/homeshick.rb
+++ b/Formula/homeshick.rb
@@ -7,6 +7,9 @@ class Homeshick < Formula
 
   bottle :unneeded
 
+  conflicts_with "asdf",
+    :because => "asdf and homeshick both install files in lib/commands"
+
   def install
     inreplace "bin/homeshick", /^homeshick=.*/, "homeshick=#{opt_prefix}"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

asdf and homeshick conflict with each other because they both install generically-named files under `lib/commands`. This PR adds `conflicts_with` stanzas so users get better error messages when trying to install them both.

Addresses #35588.
