### PR TITLE
octave: fix for Qt 5.12 compatibility

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -65,7 +65,13 @@ class Octave < Formula
     inreplace "src/mkoctfile.in.cc", /%OCTAVE_CONF_OCT(AVE)?_LINK_(DEPS|OPTS)%/, '""'
 
     args = []
-    args << "--without-qt" if build.without? "qt"
+    if build.with? "qt"
+      # Stuff for Qt 5.12 compatibility
+      # https://savannah.gnu.org/bugs/?55187
+      ENV["QCOLLECTIONGENERATOR"]="qhelpgenerator"
+    else
+      args << "--without-qt"
+    end
 
     system "./bootstrap" if build.head?
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #35903.

This PR hacks in Qt 5.12 support to Octave 4.4.1's build process, restoring `octave --gui` functionality.

No revision bump needed because this only affects an optional build path.