### PR TITLE
glances: add Docker plugin

### DIFF
--- a/Formula/glances.rb
+++ b/Formula/glances.rb
@@ -3,7 +3,7 @@ class Glances < Formula
   homepage "https://nicolargo.github.io/glances/"
   url "https://github.com/nicolargo/glances/archive/v3.0.2.tar.gz"
   sha256 "76a793a8e0fbdce11ad7fb35000695fdb70750f937db41f820881692d5b0a29c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -42,6 +42,11 @@ class Glances < Formula
   resource "CouchDB" do
     url "https://files.pythonhosted.org/packages/7c/c8/f94a107eca0c178e5d74c705dad1a5205c0f580840bd1b155cd8a258cb7c/CouchDB-1.2.tar.gz"
     sha256 "1386a1a43f25bed3667e3b805222054940d674fa1967fa48e9d2012a18630ab7"
+  end
+
+  resource "docker" do
+    url "https://files.pythonhosted.org/packages/42/e1/784ec7b36b9b1592055b4c6f36f9cebfc320427cf56b8a9051f613d343f7/docker-3.7.0.tar.gz"
+    sha256 "2840ffb9dc3ef6d00876bde476690278ab13fa1f8ba9127ef855ac33d00c3152"
   end
 
   resource "elasticsearch" do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I missed the Docker plugin in #35900 because it was incorrectly labeled as Linux-only. Seems to work fine on macOS; I tested it locally with a fresh Docker install and docker info appeared.

Fixes https://github.com/Homebrew/homebrew-core/pull/35900#issuecomment-453486025