### PR TITLE
Update desc of binutils to note missing tools

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -1,5 +1,5 @@
 class Binutils < Formula
-  desc "Most GNU utilies for native development, notably missing ld, as, and gdb."
+  desc "GNU binary tools for native development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.gz"

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -1,5 +1,5 @@
 class Binutils < Formula
-  desc "FSF/GNU ld, ar, readelf, etc. for native development"
+  desc "Most GNU utilies for native development, notably missing ld, as, and gdb."
   homepage "https://www.gnu.org/software/binutils/binutils.html"
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.31.1.tar.gz"


### PR DESCRIPTION
The binutils configure script excludes some tools for Darwin on purpose.
Previously the description mentioned providing `ld` which is specifically excluded.

See #29177.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ]  Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

Skipping the build steps because this is a doc change.
