### PR TITLE
camlp5: improve camlp5 formula test

### DIFF
--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -21,9 +21,11 @@ class Camlp5 < Formula
     (lib/"ocaml/camlp5").install "etc/META"
   end
 
+  ocaml = Formula["ocaml"]
+
   test do
     (testpath/"hi.ml").write "print_endline \"Hi!\";;"
     assert_equal "let _ = print_endline \"Hi!\"",
-      shell_output("#{bin}/camlp5 #{lib}/ocaml/camlp5/pa_o.cmo #{lib}/ocaml/camlp5/pr_o.cmo hi.ml")
+      shell_output("#{bin}/camlp5 #{lib}/ocaml/camlp5/pa_o.cmo #{lib}/ocaml/camlp5/pr_o.cmo #{ocaml.opt_lib}/ocaml/bigarray.cma hi.ml")
   end
 end

--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -4,6 +4,7 @@ class Camlp5 < Formula
   url "https://github.com/camlp5/camlp5/archive/rel707.tar.gz"
   version "7.07"
   sha256 "a2c493b833b217adf94d2000eb19015b990c4e441beb35cf36b1d33ed2351991"
+  revision 1
   head "https://gforge.inria.fr/anonscm/git/camlp5/camlp5.git"
 
   bottle do
@@ -21,11 +22,14 @@ class Camlp5 < Formula
     (lib/"ocaml/camlp5").install "etc/META"
   end
 
-  ocaml = Formula["ocaml"]
-
   test do
+    ocaml = Formula["ocaml"]
     (testpath/"hi.ml").write "print_endline \"Hi!\";;"
     assert_equal "let _ = print_endline \"Hi!\"",
       shell_output("#{bin}/camlp5 #{lib}/ocaml/camlp5/pa_o.cmo #{lib}/ocaml/camlp5/pr_o.cmo #{ocaml.opt_lib}/ocaml/bigarray.cma hi.ml")
+    # The purpose of linking with the file "bigarray.cma" is to ensure that the
+    # ocaml files are in sync with the camlp5 files.  If camlp5 has been
+    # compiled with an older version of the ocaml compiler, then an error
+    # "interface mismatch" will occur.
   end
 end


### PR DESCRIPTION
... by ensuring that the ocaml compiler provided by the package ocaml is up to
date enough.  We do that by adding a random compiled file from the ocaml
package ( bigarray.cma ) to the command line of the current test,
so camlp5 will try to link it in with the others.  If that compiled file is too
old, then the magic number stored in it will be smaller than the magic number
in the compiled files used by camlp5.

There is a discussion about this issue here:

  https://discourse.brew.sh/t/prebuilt-bottle-dependencies/3853

In addition to the tests below, I have verified that `brew test camlp5` will now fail if the current
pre-built camlp5 bottle is installed.

- [ yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [yes ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ yes] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
