### PR TITLE
joplin: update to 1.0.120

### DIFF
--- a/Formula/joplin.rb
+++ b/Formula/joplin.rb
@@ -5,7 +5,6 @@ class Joplin < Formula
   homepage "https://joplin.cozic.net/"
   url "https://registry.npmjs.org/joplin/-/joplin-1.0.120.tgz"
   sha256 "80a96934f099ef45a35389184de718d683aabdd9b3371c179c0ae6fee5db9ab2"
-  revision 1
 
   bottle do
     sha256 "d9b4ce17add87eab53f2068a9dbad86cd502f30860b4212d59b2c348e99fd861" => :mojave

--- a/Formula/joplin.rb
+++ b/Formula/joplin.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Joplin < Formula
   desc "Note taking and to-do application with synchronisation capabilities"
   homepage "https://joplin.cozic.net/"
-  url "https://registry.npmjs.org/joplin/-/joplin-1.0.116.tgz"
-  sha256 "ddb4cd6246c5396064506cc23ab5773ec6d8c6075bba3ff338f68797ea2665e6"
+  url "https://registry.npmjs.org/joplin/-/joplin-1.0.120.tgz"
+  sha256 "80a96934f099ef45a35389184de718d683aabdd9b3371c179c0ae6fee5db9ab2"
   revision 1
 
   bottle do


### PR DESCRIPTION
I am not using brew, thus I couldn't run any of the commands below.

However, I only updated the url and the sha256 hash.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----