### PR TITLE
A few more Python 3 migrations

### DIFF
--- a/Formula/bzt.rb
+++ b/Formula/bzt.rb
@@ -5,6 +5,7 @@ class Bzt < Formula
   homepage "https://gettaurus.org"
   url "https://files.pythonhosted.org/packages/source/b/bzt/bzt-1.13.2.tar.gz"
   sha256 "939d8c51f9eeffe35813f3370e2a88b06fdfa0238b3201c43fbe178d444e1504"
+  revision 1
   head "https://github.com/greyfenrir/taurus.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Bzt < Formula
     sha256 "666543689012d3c0875d31942818ae36e3bce7b1a2e59aa5c1530021568ba1d2" => :sierra
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   resource "apiritif" do
     url "https://files.pythonhosted.org/packages/3e/4d/cc49edec3128c558e6476da68d165f1614b9250bca538aa86af2476d842e/apiritif-0.6.7.tar.gz"
@@ -82,8 +83,8 @@ class Bzt < Formula
   end
 
   resource "fuzzyset" do
-    url "https://files.pythonhosted.org/packages/92/21/4939957d219ff9f88b3b120061282199eda0ddd7393732a8c15cfcf51253/fuzzyset-0.0.15.tar.gz"
-    sha256 "861f156d69bfe22096047b8c07c8cbc78291022f4dabe55b81d2bd8235eb4402"
+    url "https://files.pythonhosted.org/packages/80/b4/c202f15029f497539bfb57f641acba5ca63a81d77e69afa767a0111483e5/fuzzyset-0.0.16.tar.gz"
+    sha256 "dce505e52dfd6a791214728b9b6b43f8f58e8f88fcf783c80d759d1c4349a160"
   end
 
   resource "gevent" do

--- a/Formula/libpst.rb
+++ b/Formula/libpst.rb
@@ -3,7 +3,7 @@ class Libpst < Formula
   homepage "https://www.five-ten-sg.com/libpst/"
   url "https://www.five-ten-sg.com/libpst/packages/libpst-0.6.72.tar.gz"
   sha256 "8a19d891eb077091c507d98ed8e2d24b7f48b3e82743bcce2b00a12040f5d507"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -14,17 +14,14 @@ class Libpst < Formula
 
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "boost-python"
   depends_on "gettext"
   depends_on "libgsf"
-  depends_on "python@2"
 
   def install
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --enable-python
-      --with-boost-python=mt
+      --disable-python
     ]
 
     system "./configure", *args

--- a/Formula/mitie.rb
+++ b/Formula/mitie.rb
@@ -3,6 +3,7 @@ class Mitie < Formula
   homepage "https://github.com/mit-nlp/MITIE/"
   url "https://github.com/mit-nlp/MITIE/archive/v0.6.tar.gz"
   sha256 "bcfa6aab057206a2f5eeacbefa27a3205fe3bd906a54e0e790df3448b1c73243"
+  revision 1
   head "https://github.com/mit-nlp/MITIE.git"
 
   bottle do
@@ -12,7 +13,7 @@ class Mitie < Formula
     sha256 "b2813c1046c67800ff73f187d22c1d7d63aa9d6c8736606e69f2be5d3102ccee" => :sierra
   end
 
-  depends_on "python@2"
+  depends_on "python"
 
   resource "models-english" do
     url "https://downloads.sourceforge.net/project/mitie/binaries/MITIE-models-v0.2.tar.bz2"
@@ -28,9 +29,12 @@ class Mitie < Formula
 
     include.install Dir["mitielib/include/*"]
     lib.install "mitielib/libmitie.dylib", "mitielib/libmitie.a"
-    (lib/"python2.7/site-packages").install "mitielib/mitie.py"
+
+    xy = Language::Python.major_minor_version "python3"
+    (lib/"python#{xy}/site-packages").install "mitielib/mitie.py"
     pkgshare.install "examples", "sample_text.txt",
-      "sample_text.reference-output", "sample_text.reference-output-relations"
+                     "sample_text.reference-output",
+                     "sample_text.reference-output-relations"
     bin.install "ner_example", "ner_stream", "relation_extraction_example"
   end
 

--- a/Formula/trace2html.rb
+++ b/Formula/trace2html.rb
@@ -4,10 +4,9 @@ class Trace2html < Formula
   url "https://github.com/google/trace-viewer/archive/2015-07-07.tar.gz"
   version "2015-07-07"
   sha256 "6125826d07869fbd634ef898a45df3cabf45e6bcf951f2c63e49f87ce6a0442a"
+  revision 1
 
   bottle :unneeded
-
-  depends_on "python@2"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
`libpst` build system does not fully work with Python 3, and it is not core to the formula. Removing it for now.