### PR TITLE
bash-completion: instruct users to source proper file

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -40,7 +40,7 @@ class BashCompletion < Formula
 
   def caveats; <<~EOS
     Add the following line to your ~/.bash_profile:
-      [ -d #{etc}/bash_completion.d ] && . #{etc}/bash_completion.d/*
+      [ -r #{etc}/profile.d/bash_completion.sh ] && . #{etc}/profile.d/bash_completion.sh
   EOS
   end
 

--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -40,7 +40,7 @@ class BashCompletion < Formula
 
   def caveats; <<~EOS
     Add the following line to your ~/.bash_profile:
-      [ -r #{etc}/profile.d/bash_completion.sh ] && . #{etc}/profile.d/bash_completion.sh
+      [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Currently, instructions in `bash-completion` (shouldn't it be `bash-completions` ???) formula are "unsafe". The right file to source is `#{etc}/profile.d/bash_completion.sh`. And here is why:

`#{etc}/profile.d/bash_completion.sh` file checks that:
- it is sourced from an interactive shell
- it has not been sourced already,
- Bash has the right version
- programmable completions are turned on
- `#{etc}/bash_completion` is readable
and only then sources `#{etc}/bash_completion`

`#{etc}/bash_completion`, in turn, sources files `#{etc}/bash_completion.d/*` as necessary.

No changes to bottles are required.