### PR TITLE
ry: install Bash completion script in the right place

### DIFF
--- a/Formula/ry.rb
+++ b/Formula/ry.rb
@@ -20,10 +20,8 @@ class Ry < Formula
   depends_on "ruby-build"
 
   def install
-    ENV["PREFIX"] = prefix
-    ENV["BASH_COMPLETIONS_DIR"] = etc/"bash_completion.d"
-    ENV["ZSH_COMPLETIONS_DIR"] = share/"zsh/site-functions"
-    system "make", "install"
+    ENV["BASH_COMPLETIONS_DIR"] = prefix/"etc/bash_completion.d"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

At the moment,  formula sets `BASH_COMPLETIONS_DIR` env variable to `etc/"bash_completion.d"`, so `ry` creates a _file_, not a symbolic link, in that location. This file is not deleted when we remove the formula.
No need to set `ZSH_COMPLETIONS_DIR` to `share/"zsh/site-functions"` because this is the default (it is set in the Makefile)