### PR TITLE
bash-completion@2: fix installation and caveats

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -27,16 +27,14 @@ class BashCompletionAT2 < Formula
     inreplace "bash_completion", "readlink -f", "readlink"
 
     system "autoreconf", "-i" if build.head?
-    system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
+    system "./configure", "--prefix=#{prefix}"
     ENV.deparallelize
     system "make", "install"
   end
 
   def caveats; <<~EOS
     Add the following to your ~/.bash_profile:
-      if [ -f #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion ]; then
-        . #{HOMEBREW_PREFIX}/share/bash-completion/bash_completion
-      fi
+      [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- ` "--sysconfdir=#{etc}"` forces `bash_completion.sh` **file** to be installed in `#{etc}/profile.d/` directory and, as a result, not be deleted upon formula removal. As a result, it prevents clean installation of `bash-completion` ("conflicting" formula) after  removal of `bash-completion@2`
- In caveats section, instruct users to source the right file that checks for a number of things that ensure that these completions are sourced only when necessary and in the right Bash session (interactive Bash 4.1+ session that has not sourced this file already).