### PR TITLE
gcc: Remove D, which is not supported on macOS

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -53,9 +53,6 @@ class Gcc < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    # D will be included in GCC 9
-    languages << "d" if build.head?
-
     osmajor = `uname -r`.chomp
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 


### PR DESCRIPTION
When I tried building GDC two months ago, it failed. I doubt it works now, as there's no progress in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87788.