### PR TITLE
add x86_64-elf-binutils 2.31.1

### DIFF
--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -4,11 +4,6 @@ class X8664ElfBinutils < Formula
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.xz"
   sha256 "5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86"
 
-  bottle do
-    sha256 "89312270dc465d7d2c622d7253acfecc7e8b0d5a5cc7688822c1dbb10ee7166e" => :mojave
-    sha256 "1f7b4aa5dd270750954ef0a177223843affc45214cb7f19fc5e85743608fc8a6" => :high_sierra
-    sha256 "7ca42ad9603b7e336f029ae87407c789f1533af638daa54d3db3f2bde2afbf0c" => :sierra
-  end
 
   def install
     system "./configure", "--target=x86_64-elf",

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -1,0 +1,26 @@
+class X8664ElfBinutils < Formula
+  desc "FSF Binutils for x86_64-elf cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.31.1.tar.xz"
+  sha256 "5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86"
+
+  bottle do
+    sha256 "89312270dc465d7d2c622d7253acfecc7e8b0d5a5cc7688822c1dbb10ee7166e" => :mojave
+    sha256 "1f7b4aa5dd270750954ef0a177223843affc45214cb7f19fc5e85743608fc8a6" => :high_sierra
+    sha256 "7ca42ad9603b7e336f029ae87407c789f1533af638daa54d3db3f2bde2afbf0c" => :sierra
+  end
+
+  def install
+    system "./configure", "--target=x86_64-elf",
+                          "--disable-multilib",
+                          "--disable-nls",
+                          "--disable-werror",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "f()", shell_output("#{bin}/x86_64-elf-c++filt _Z1fv")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add x86_64-elf-binutils for ld, as, etc for cross compiling. Similar to the formula i386-elf-binutils/
Found #35914 but that is for updating the desc of the original binutils formula where ld, as is not installed.
This formula is for the missing binaries prefixed, so that we can use the original linker provided by Darwin.