### PR TITLE
knot-resolver: fix cannot be started by `brew services restart knot-r…

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -67,6 +67,8 @@ class KnotResolver < Formula
         <string>#{sbin}/kresd</string>
         <string>-c</string>
         <string>#{etc}/kresd/config</string>
+        <string>-f</string>
+        <string>1</string>
       </array>
       <key>StandardInPath</key>
       <string>/dev/null</string>


### PR DESCRIPTION
knot-resolver: fix cannot be started by `brew services restart knot-resolver`.