### PR TITLE
dmg2img 1.6.7 (new formula)

### DIFF
--- a/Formula/dmg2img.rb
+++ b/Formula/dmg2img.rb
@@ -1,0 +1,21 @@
+class Dmg2img < Formula
+  desc "Utilities for converting macOS DMG images"
+  homepage "http://vu1tur.eu.org/tools/"
+  url "http://vu1tur.eu.org/tools/dmg2img-1.6.7.tar.gz"
+  sha256 "02aea6d05c5b810074913b954296ddffaa43497ed720ac0a671da4791ec4d018"
+  depends_on "openssl"
+
+  def install
+    ENV["CFLAGS"]=ENV["CXXFLAGS"]="-L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include"
+    ENV["DESTDIR"]=bin.to_s
+    system "make"
+    bin.install "dmg2img"
+    bin.install "vfdecrypt"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/dmg2img")
+    output = shell_output("#{bin}/vfdecrypt 2>&1", 1)
+    assert_match "No Passphrase given.", output
+  end
+end


### PR DESCRIPTION
This adds a formula for dmg2img and vfdecrypt.  dmg2img is a CLI tool used to convert macOS DMG files to raw image files, and is used by some Linux scripts when dealing with DMG files.  vfdecrypt is a utility to decrypt encrypted DMG files if given the correct decryption key.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
