### PR TITLE
gtranslator 3.30.1 (new formula)

### DIFF
--- a/Formula/gspell.rb
+++ b/Formula/gspell.rb
@@ -3,6 +3,7 @@ class Gspell < Formula
   homepage "https://wiki.gnome.org/Projects/gspell"
   url "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.1.tar.xz"
   sha256 "819a1d23c7603000e73f5e738bdd284342e0cd345fb0c7650999c31ec741bbe5"
+  revision 1
 
   bottle do
     rebuild 1
@@ -100,7 +101,8 @@ class Gspell < Formula
       -lpangocairo-1.0
     ]
     system ENV.cc, "test.c", "-o", "test", *flags
-    system "./test"
+    ENV["G_DEBUG"] = "fatal-warnings"
+    system "./test" # This test will fail intentionally when iso-codes gets updated. Resolve by revbumping this formula.
   end
 end
 

--- a/Formula/gtranslator.rb
+++ b/Formula/gtranslator.rb
@@ -1,0 +1,38 @@
+class Gtranslator < Formula
+  desc "GNOME gettext PO file editor"
+  homepage "https://wiki.gnome.org/Design/Apps/Translator"
+  url "https://download.gnome.org/sources/gtranslator/3.30/gtranslator-3.30.1.tar.xz"
+  sha256 "c77afffa588c453fcf2241acc6d68a636975b69cc4aab8057a3382cb218cf42c"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python" => :build
+  depends_on "adwaita-icon-theme"
+  depends_on "glib"
+  depends_on "gspell"
+  depends_on "gtk+3"
+  depends_on "gtksourceview4"
+  depends_on "iso-codes"
+  depends_on "itstool"
+  depends_on "libgda"
+
+  def install
+    # stop meson_post_install.py from doing what needs to be done in the post_install step
+    ENV["DESTDIR"] = "/"
+    mkdir "build" do
+      system "meson", "--prefix=#{prefix}", ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+  end
+
+  def post_install
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+  end
+
+  test do
+    system "#{bin}/gtranslator", "-h"
+  end
+end

--- a/Formula/iso-codes.rb
+++ b/Formula/iso-codes.rb
@@ -3,6 +3,7 @@ class IsoCodes < Formula
   homepage "https://salsa.debian.org/iso-codes-team/iso-codes"
   url "https://deb.debian.org/debian/pool/main/i/iso-codes/iso-codes_4.2.orig.tar.xz"
   sha256 "2b7f66c81808ac52e1ed0efe4ce8ae8e43309eedcc411f94f71a3f603cc21f42"
+  revision 1
   head "https://salsa.debian.org/iso-codes-team/iso-codes.git"
 
   bottle do
@@ -13,8 +14,8 @@ class IsoCodes < Formula
   end
 
   depends_on "gettext" => :build
-  depends_on "pkg-config"
-  depends_on "python"
+  depends_on "pkg-config" => :build
+  depends_on "python" => :build
 
   def install
     system "./configure", "--prefix=#{prefix}"
@@ -24,8 +25,7 @@ class IsoCodes < Formula
   end
 
   test do
-    pkg_config = Formula["pkg-config"].opt_bin/"pkg-config"
-    output = shell_output("#{pkg_config} --variable=domains iso-codes")
+    output = shell_output("grep domains #{share}/pkgconfig/iso-codes.pc")
     assert_match "iso_639-2 iso_639-3 iso_639-5 iso_3166-1", output
   end
 end

--- a/Formula/libgda.rb
+++ b/Formula/libgda.rb
@@ -3,7 +3,7 @@ class Libgda < Formula
   homepage "http://www.gnome-db.org/"
   url "https://download.gnome.org/sources/libgda/5.2/libgda-5.2.8.tar.xz"
   sha256 "e2876d987c00783ac3c1358e9da52794ac26f557e262194fcba60ac88bafa445"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "31bc1f2cecf14e6a2d751f257a09426d5f00ef0c46910154fe2ec1180dbe059e" => :mojave
@@ -21,7 +21,15 @@ class Libgda < Formula
   depends_on "libgee"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "sqlite"
+
+  # this build uses the sqlite source code that comes with libgda,
+  # as opposed to using the system or brewed sqlite3, which is not supported on macOS,
+  # as mentioned in https://github.com/GNOME/libgda/blob/95eeca4b0470f347c645a27f714c62aa6e59f820/libgda/sqlite/README#L31
+  # The following patch ensures that libgda's sqlite3.h header will get used instead of the system one.
+  patch :p0 do
+    url "https://raw.githubusercontent.com/macports/macports-ports/8c93c519f7b234af318cc21e93a1b8164622e530/databases/libgda5/files/patch-use-embedded-sqlite3.diff?full_index=1"
+    sha256 "140742f6214f6f6ea495a9854eef99fa06141157a15556ebdf7be55794267a0f"
+  end
 
   def install
     system "./configure", "--disable-debug",
@@ -31,7 +39,8 @@ class Libgda < Formula
                           "--disable-binreloc",
                           "--disable-gtk-doc",
                           "--without-java",
-                          "--enable-introspection"
+                          "--enable-introspection",
+                          "--enable-system-sqlite=no"
     system "make"
     system "make", "install"
   end

--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -3,6 +3,7 @@ class SharedMimeInfo < Formula
   homepage "https://wiki.freedesktop.org/www/Software/shared-mime-info"
   url "https://freedesktop.org/~hadess/shared-mime-info-1.10.tar.xz"
   sha256 "c625a83b4838befc8cafcd54e3619946515d9e44d63d61c4adf7f5513ddfbebf"
+  revision 1
 
   bottle do
     cellar :any
@@ -42,9 +43,12 @@ class SharedMimeInfo < Formula
   end
 
   def post_install
-    ln_sf HOMEBREW_PREFIX/"share/mime", share/"mime"
-    (HOMEBREW_PREFIX/"share/mime/packages").mkpath
-    cp (pkgshare/"packages").children, HOMEBREW_PREFIX/"share/mime/packages"
+    #(HOMEBREW_PREFIX/"share/mime/packages").mkpath
+    system "mkdir", "-p", HOMEBREW_PREFIX/"share/mime/packages"
+    #ln_sf HOMEBREW_PREFIX/"share/mime", share/"mime"
+    system "ln", "-sf", HOMEBREW_PREFIX/"share/mime", share/"mime"
+    #cp (pkgshare/"packages").children, HOMEBREW_PREFIX/"share/mime/packages"
+    system "cp", pkgshare/"packages/freedesktop.org.xml", HOMEBREW_PREFIX/"share/mime/packages/"
     system bin/"update-mime-database", HOMEBREW_PREFIX/"share/mime"
   end
 


### PR DESCRIPTION
Also fixes in its dependencies:
* iso-codes: fix dependencies and test
* libgda: apply macports patches
* gspell: rebuild for latest iso-codes