### PR TITLE
Bash completions: resolve the conflict

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -16,8 +16,6 @@ class BashCompletion < Formula
     sha256 "58be92ef01d5068f37b1c00af8e9b202bdb409c93121bb0e07dcbb5e55dc3be2" => :yosemite
   end
 
-  conflicts_with "bash-completion@2", :because => "Differing version of same formula"
-
   # Backports the following upstream patch from 2.x:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740971
   patch do

--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -21,8 +21,6 @@ class BashCompletionAT2 < Formula
 
   depends_on "bash"
 
-  conflicts_with "bash-completion", :because => "Differing version of same formula"
-
   def install
     inreplace "bash_completion", "readlink -f", "readlink"
 
@@ -30,11 +28,12 @@ class BashCompletionAT2 < Formula
     system "./configure", "--prefix=#{prefix}"
     ENV.deparallelize
     system "make", "install"
+    mv prefix/"etc/profile.d/bash_completion.sh", prefix/"etc/profile.d/bash_completion@2.sh"
   end
 
   def caveats; <<~EOS
     Add the following to your ~/.bash_profile:
-      [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
+      [[ -r "#{etc}/profile.d/bash_completion@2.sh" ]] && . "#{etc}/profile.d/bash_completion@2.sh"
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Here is an attempt to resolve the conflict between two formulae that provide Bash completion functionality for different Bash versions.