### PR TITLE
curl-openssl: add dependencies.

### DIFF
--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -14,9 +14,15 @@ class CurlOpenssl < Formula
 
   depends_on "pkg-config" => :build
   depends_on "brotli"
+  depends_on "c-ares"
+  depends_on "libidn"
+  depends_on "libmetalink"
+  depends_on "libssh2"
+  depends_on "nghttp2"
   depends_on "nghttp2"
   depends_on "openldap"
   depends_on "openssl"
+  depends_on "rtmpdump"
 
   def install
     # Allow to build on Lion, lowering from the upstream setting of 10.8
@@ -27,15 +33,17 @@ class CurlOpenssl < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --disable-ares
+      --enable-ares=#{Formula["c-ares"].opt_prefix}
       --with-ca-bundle=#{etc}/openssl/cert.pem
       --with-ca-path=#{etc}/openssl/certs
       --with-gssapi
-      --without-libidn2
-      --without-libmetalink
-      --without-librtmp
-      --without-libssh2
+      --with-libidn2
+      --with-libmetalink
+      --with-librtmp
+      --with-libssh2
       --with-ssl=#{Formula["openssl"].opt_prefix}
+      --with-libmetalink
+      --with-libssh2
     ]
 
     system "./configure", *args

--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -3,6 +3,7 @@ class CurlOpenssl < Formula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.63.0.tar.bz2"
   sha256 "9bab7ed4ecff77020a312d84cc5fb7eb02d58419d218f267477a724a17fd8dd8"
+  revision 1
 
   bottle do
     sha256 "84c070944750b1ab555478769569326a5af985de9242b64a4f59041cd51b4a3b" => :mojave

--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -19,7 +19,6 @@ class CurlOpenssl < Formula
   depends_on "libmetalink"
   depends_on "libssh2"
   depends_on "nghttp2"
-  depends_on "nghttp2"
   depends_on "openldap"
   depends_on "openssl"
   depends_on "rtmpdump"
@@ -42,8 +41,6 @@ class CurlOpenssl < Formula
       --with-librtmp
       --with-libssh2
       --with-ssl=#{Formula["openssl"].opt_prefix}
-      --with-libmetalink
-      --with-libssh2
     ]
 
     system "./configure", *args


### PR DESCRIPTION
As `curl` is more minimal we can add more things here.

See https://github.com/Homebrew/homebrew-core/issues/31510.