### PR TITLE
bash: add sh and rbash symlinks.

### DIFF
--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -28,11 +28,18 @@ class Bash < Formula
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+
+    (libexec/"bin").install_symlink (bin/"bash").realpath => "sh"
+    (libexec/"bin").install_symlink (bin/"bash").realpath => "rbash"
   end
 
   def caveats; <<~EOS
     In order to use this build of bash as your login shell,
     it must be added to /etc/shells.
+
+    Alternate invocation names `sh` and `rbash` both symlinked to
+    `bash`, have been installed into
+      #{opt_libexec}/bin
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From bash's man page:
>If **bash** is invoked with the name **sh**, it tries to mimic the startup behavior of historical versions of **sh** as closely as  possible, while conforming to the POSIX standard as well.
>
>If **bash** is started with the name **rbash**, the shell becomes restricted. A restricted shell is used
to set up an environment more controlled than the standard shell.