### PR TITLE
mongodb*: downgrade and comment on open source versions.

### DIFF
--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -1,8 +1,11 @@
 class Mongodb < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.com/"
-  url "https://fastdl.mongodb.org/src/mongodb-src-r4.0.5.tar.gz"
-  sha256 "d967098fc91d105cdb0f400c8b837e5c2795c3638d7720392bc47afb1efe1c10"
+  # do not upgrade to versions >4.0.3 as they are under the SSPL which is not
+  # an open-source license.
+  url "https://fastdl.mongodb.org/src/mongodb-src-r4.0.3.tar.gz"
+  sha256 "fbbe840e62376fe850775e98eb10fdf40594a023ecf308abec6dcec44d2bce0c"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -52,15 +55,18 @@ class Mongodb < Formula
 
     # New Go tools have their own build script but the server scons "install" target is still
     # responsible for installing them.
-
-    cd "src/mongo/gotools/src/github.com/mongodb/mongo-tools" do
+    cd "src/mongo/gotools" do
+      inreplace "build.sh" do |s|
+        s.gsub! "$(git describe)", version.to_s
+        s.gsub! "$(git rev-parse HEAD)", "homebrew"
+      end
       ENV["CPATH"] = Formula["openssl"].opt_include
       ENV["LIBRARY_PATH"] = Formula["openssl"].opt_lib
       ENV["GOROOT"] = Formula["go"].opt_libexec
       system "./build.sh", "ssl"
     end
 
-    (buildpath/"src/mongo-tools").install Dir["src/mongo/gotools/src/github.com/mongodb/mongo-tools/bin/*"]
+    (buildpath/"src/mongo-tools").install Dir["src/mongo/gotools/bin/*"]
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/mongodb@3.0.rb
+++ b/Formula/mongodb@3.0.rb
@@ -3,6 +3,8 @@ require "language/go"
 class MongodbAT30 < Formula
   desc "High-performance document-oriented database"
   homepage "https://www.mongodb.org/"
+  # do not upgrade to versions >3.0.15 as they are under the SSPL which is not
+  # an open-source license.
   url "https://fastdl.mongodb.org/src/mongodb-src-r3.0.15.tar.gz"
   sha256 "09ad76e06df007085520025c94a5e5840d65f37660c2b359f4962e135e4ae259"
 

--- a/Formula/mongodb@3.2.rb
+++ b/Formula/mongodb@3.2.rb
@@ -3,6 +3,8 @@ require "language/go"
 class MongodbAT32 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.org/"
+  # do not upgrade to versions >3.2.21 as they are under the SSPL which is not
+  # an open-source license.
   url "https://fastdl.mongodb.org/src/mongodb-src-r3.2.21.tar.gz"
   sha256 "8263befc10319809ea14e5cbf230c55113de7b38510b42a6ad27125dfa674371"
 

--- a/Formula/mongodb@3.4.rb
+++ b/Formula/mongodb@3.4.rb
@@ -1,6 +1,8 @@
 class MongodbAT34 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.org/"
+  # do not upgrade to versions >3.4.18 as they are under the SSPL which is not
+  # an open-source license.
   url "https://fastdl.mongodb.org/src/mongodb-src-r3.4.18.tar.gz"
   sha256 "a1c17e9977307752ddac4b06bcb65be177035057c21955df5a65e2db74a20856"
 

--- a/Formula/mongodb@3.6.rb
+++ b/Formula/mongodb@3.6.rb
@@ -1,8 +1,11 @@
 class MongodbAT36 < Formula
   desc "High-performance, schema-free, document-oriented database"
   homepage "https://www.mongodb.org/"
-  url "https://fastdl.mongodb.org/src/mongodb-src-r3.6.9.tar.gz"
-  sha256 "b5da7cf4323bd0958a38957e74107a149936d576db2a51fdabf2ea10a8f1eae4"
+  # do not upgrade to versions >3.6.8 as they are under the SSPL which is not
+  # an open-source license.
+  url "https://fastdl.mongodb.org/src/mongodb-src-r3.6.8.tar.gz"
+  sha256 "cbb6bedd8963db2abf87cdb6dcceffaa5ee86729d19f4dcbeefb6e0dba0a2d7d"
+  revision 1
 
   bottle do
     sha256 "0b494089cd797aabe923075ba00d32a0edf5d9d2e7b5473d49bd27336cefc993" => :mojave


### PR DESCRIPTION
The SSPL is not an OSI approved open source license. This is also agreed at this
point by Fedora and Debian.

See https://github.com/Homebrew/brew/pull/5406