### PR TITLE
mu: remove dependency on emacs

### DIFF
--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -23,10 +23,10 @@ class Mu < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "emacs" => :build
   depends_on "libgpg-error" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "emacs"
   depends_on "gettext"
   depends_on "glib"
   depends_on "xapian"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`brew audit --strict` failed installing required dependencies (building native extensions for `json (2.1.0)`).

-----



* mu can be used without Emacs
* Emacs may be installed through other means (e.g. Cask)