### PR TITLE
yara: add all buildable upstream modules

### DIFF
--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -3,7 +3,7 @@ class Yara < Formula
   homepage "https://github.com/VirusTotal/yara/"
   url "https://github.com/VirusTotal/yara/archive/v3.8.1.tar.gz"
   sha256 "283527711269354d3c60e2705f7f74b1f769d2d35ddba8f7f9ce97d0fd5cb1ca"
-  revision 1
+  revision 2
   head "https://github.com/VirusTotal/yara.git"
 
   bottle do

--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -15,7 +15,9 @@ class Yara < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "jansson" => :build
   depends_on "libtool" => :build
+  depends_on "libmagic"
   depends_on "openssl"
 
   def install
@@ -23,7 +25,12 @@ class Yara < Formula
     system "./configure", "--disable-silent-rules",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-dotnet"
+                          "--enable-dotnet",
+                          "--enable-cuckoo",
+                          "--enable-magic",
+                          "--enable-macho",
+                          "--enable-dex",
+                          "--with-crpyto"
     system "make", "install"
   end
 

--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -15,8 +15,8 @@ class Yara < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "jansson" => :build
   depends_on "libtool" => :build
+  depends_on "jansson"
   depends_on "libmagic"
   depends_on "openssl"
 


### PR DESCRIPTION
yara provides more modules than this formula currently builds.
With these changes yara will enable all buildable modules listed here:
https://yara.readthedocs.io/en/v3.8.1/modules.html

This makes the brew build comparable to other yara distributions and allows users to use these modules to enhance detection.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
