### PR TITLE
subversion: replace deprecated scons call (follow-up to 4fc4bf16)

### DIFF
--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -41,7 +41,7 @@ class Libswiften < Formula
       #{prefix}
     ]
 
-    scons *args
+    system "scons", *args
   end
 
   test do

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -4,7 +4,6 @@ class Subversion < Formula
   url "https://www.apache.org/dyn/closer.cgi?path=subversion/subversion-1.11.1.tar.bz2"
   mirror "https://archive.apache.org/dist/subversion/subversion-1.11.1.tar.bz2"
   sha256 "9efd2750ca4d72ec903431a24b9c732b6cbb84aad9b7563f59dd96dea5be60bb"
-  revision 1
 
   bottle do
     sha256 "1d0858de6bed79c12fa438af3bf072a5634af792f8e56504df662ec26ce9c7a9" => :mojave

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -4,6 +4,7 @@ class Subversion < Formula
   url "https://www.apache.org/dyn/closer.cgi?path=subversion/subversion-1.11.1.tar.bz2"
   mirror "https://archive.apache.org/dist/subversion/subversion-1.11.1.tar.bz2"
   sha256 "9efd2750ca4d72ec903431a24b9c732b6cbb84aad9b7563f59dd96dea5be60bb"
+  revision 1
 
   bottle do
     sha256 "1d0858de6bed79c12fa438af3bf072a5634af792f8e56504df662ec26ce9c7a9" => :mojave
@@ -76,7 +77,7 @@ class Subversion < Formula
         APR=#{Formula["apr"].opt_prefix}
         APU=#{Formula["apr-util"].opt_prefix}
       ]
-      scons(*args)
+      system "scons", *args
       system "scons", "install"
     end
 

--- a/Formula/subversion@1.8.rb
+++ b/Formula/subversion@1.8.rb
@@ -56,7 +56,7 @@ class SubversionAT18 < Formula
         args << "APU=#{Formula["apr-util"].opt_prefix}"
       end
 
-      scons(*args)
+      system "scons", *args
       system "scons", "install"
     end
 

--- a/Formula/wesnoth.rb
+++ b/Formula/wesnoth.rb
@@ -37,7 +37,7 @@ class Wesnoth < Formula
     args << "wesnothd"
     args << "-j#{ENV.make_jobs}"
 
-    scons *args
+    system "scons", *args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There was still one build warning remaining:
> Warning: Calling scons is deprecated! Use system "scons" instead.