### PR TITLE
zeromq: disable libunwind to fix pkg-config

### DIFF
--- a/Formula/zeromq.rb
+++ b/Formula/zeromq.rb
@@ -3,6 +3,7 @@ class Zeromq < Formula
   homepage "http://www.zeromq.org/"
   url "https://github.com/zeromq/libzmq/releases/download/v4.3.1/zeromq-4.3.1.tar.gz"
   sha256 "bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,7 +21,7 @@ class Zeromq < Formula
   end
 
   depends_on "asciidoc" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config" => [:build, :test]
   depends_on "xmlto" => :build
 
   def install
@@ -32,9 +33,11 @@ class Zeromq < Formula
 
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
-    ENV["LIBUNWIND_LIBS"] = "-framework System"
-    sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
-    ENV["LIBUNWIND_CFLAGS"] = "-I#{sdk}/usr/include"
+    # Disable libunwind support due to pkg-config problem
+    # https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454177261
+    # ENV["LIBUNWIND_LIBS"] = "-framework System"
+    # sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
+    # ENV["LIBUNWIND_CFLAGS"] = "-I#{sdk}/usr/include"
 
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
@@ -56,5 +59,7 @@ class Zeromq < Formula
     EOS
     system ENV.cc, "test.c", "-L#{lib}", "-lzmq", "-o", "test"
     system "./test"
+    system "pkg-config", "libzmq", "--cflags"
+    system "pkg-config", "libzmq", "--libs"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

ZeroMQ uses `libunwind` by manually specifying its build flags since macOS provides `libunwind` but without a pkg-config file. That wasn't a problem until the recent zeromq 4.3.1 release changed its `libzmq.pc` pkg-config file to require `libunwind.pc` ( https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454177261 ). I first noticed this in downstream software outside of homebrew-core, but it has also caused a [build failure of libbitcoin-protocol](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/36348/version=mojave/consoleFull) in the boost 1.69 pull request ( https://github.com/Homebrew/homebrew-core/pull/35030 ).

I submitted a pull request to add `libunwind.pc` to brew in https://github.com/Homebrew/brew/pull/5539 but that won't be accepted as long as https://github.com/Homebrew/brew/issues/5068 is outstanding. So as suggested by a zeromq developer ( https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454319617 ), this pull request will disable `libunwind` support until we can resolve the `pkg-config` issue.

I've also added a test for the `pkg-config` file to the formula so we can catch this in the future.