### PR TITLE
physfs 2.0.3 (new formula)

### DIFF
--- a/Formula/physfs@2.rb
+++ b/Formula/physfs@2.rb
@@ -1,0 +1,28 @@
+class PhysfsAT2 < Formula
+    desc "Library to provide abstract access to various archives"
+    homepage "https://icculus.org/physfs/"
+    url "https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
+    sha256 "ca862097c0fb451f2cacd286194d071289342c107b6fe69079c079883ff66b69"
+  
+    depends_on "cmake" => :build
+  
+    def install
+      mkdir "macbuild" do
+        args = std_cmake_args
+        args << "-DPHYSFS_BUILD_TEST=TRUE"
+        args << "-DPHYSFS_BUILD_WX_TEST=FALSE"
+        system "cmake", "..", *args
+        system "make", "install"
+      end
+    end
+  
+    test do
+      (testpath/"test.txt").write "homebrew"
+      system "zip", "test.zip", "test.txt"
+      (testpath/"test").write <<~EOS
+        addarchive test.zip 1
+        cat test.txt
+      EOS
+      assert_match /Successful\.\nhomebrew/, shell_output("#{bin}/test_physfs < test 2>&1")
+    end
+  end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

2.0.3 is still the highest version available for Ubuntu LTS and Debian Stable, not having it available in Brew makes cross-platform development a pain.