### PR TITLE
mpv: use `docutils` as a build time dependency

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -12,6 +12,7 @@ class Mpv < Formula
     sha256 "697fdbdb8313c795528cc7b161fc1b65c15799cdbbca5b3e972fb52f41374458" => :sierra
   end
 
+  depends_on "docutils" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => :build
 
@@ -25,23 +26,11 @@ class Mpv < Formula
   depends_on "vapoursynth"
   depends_on "youtube-dl"
 
-  resource "docutils" do
-    url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
-    sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
-  end
-
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since
     # that's good enough for building the manpage.
     ENV["LC_ALL"] = "C"
-
-    xy = Language::Python.major_minor_version "python3"
-    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
-    resource("docutils").stage do
-      system "python3", *Language::Python.setup_install_args(buildpath/"vendor")
-    end
-    ENV.prepend_path "PATH", buildpath/"vendor/bin"
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Both `mpv` and `docutils` depend on `python` now, so we can get rid of the `docutils` resource block.