### PR TITLE
Temporary disable installing fish completions for bat

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -19,7 +19,9 @@ class Bat < Formula
     system "cargo", "install", "--root", prefix, "--path", "."
     man1.install "doc/bat.1"
     bash_completion.install "bat.bash"
-    fish_completion.install "bat.fish"
+    # Temporary disable fish completions due to upstream issues. The completions might not work on
+    # some systems. See https://github.com/sharkdp/bat/issues/372
+    # fish_completion.install "bat.fish"
     zsh_completion.install "_bat"
   end
 


### PR DESCRIPTION
Disabling the completions will not disable path name completions. In
fact not installing them fixes path name completion on most systems. Fixes #36116 

Completion of bat's command line arguments which are not broken will be
disabled however. One might optionally source those completions from
`$(brew --cellar)/bat/x.x.x/share/fish/vendor_completions.d/bat.fish`
or extract the cli arguments only but as long as the complete set of
completions is not reliably working they shouldn't be installed by
default.

This might be re-enabled or removed entirely as soon as upstream decides
what happens with the completions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
