### PR TITLE
pulumi: build from git checkout so version is correct

### DIFF
--- a/Formula/pulumi.rb
+++ b/Formula/pulumi.rb
@@ -1,9 +1,10 @@
 class Pulumi < Formula
   desc "Cloud native development platform"
   homepage "https://pulumi.io/"
-  url "https://github.com/pulumi/pulumi/archive/v0.16.11.tar.gz"
-  sha256 "98c0bcc8bedc90a6ad55de0d70a8dfbdbe0f14a5cfb4998fb055d965ddab8257"
-  head "https://github.com/pulumi/pulumi.git"
+  url "https://github.com/pulumi/pulumi.git",
+      :tag      => "v0.16.11",
+      :revision => "378bae27d83e649e482beed8fe33be20bd3c7805"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi!  When built using the source provided tarballs from upstream, the embedded version number in the binary is incorrect, since it based on git tags, which are not present in the source tarball, leading to `pulumi version` to report 0.0.0 instead of `0.16.11`.