### PR TITLE
mps-youtube: youtube_dl 2019.1.17

### DIFF
--- a/Formula/mps-youtube.rb
+++ b/Formula/mps-youtube.rb
@@ -5,7 +5,7 @@ class MpsYoutube < Formula
   homepage "https://github.com/mps-youtube/mps-youtube"
   url "https://github.com/mps-youtube/mps-youtube/archive/v0.2.8.tar.gz"
   sha256 "d5f2c4bc1f57f0566242c4a0a721a5ceaa6d6d407f9d6dd29009a714a0abec74"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any_skip_relocation
@@ -23,14 +23,14 @@ class MpsYoutube < Formula
   end
 
   resource "youtube_dl" do
-    url "https://files.pythonhosted.org/packages/6a/e0/68e3701ca58ea54aab4abb018ab9fe76807598d45d46a787a3d3c986ec1c/youtube_dl-2018.11.7.tar.gz"
-    sha256 "f9b4a65e544b4a2b958ef693cd4b71ab5a5709ab1c7a9fc47c1a967dcca46f4a"
+    url "https://files.pythonhosted.org/packages/48/15/e73763a475242a480f9b547e1dc8f686a030c84d022f59f8b92bb1953584/youtube_dl-2019.1.17.tar.gz"
+    sha256 "864af477bd5eb683b9992270544d98ae865aedc32a04b103d6eaab2041242fb5"
   end
 
   def install
     venv = virtualenv_create(libexec, "python3")
 
-    ["youtube_dl", "pafy"].each do |r|
+    %w[youtube_dl pafy].each do |r|
       venv.pip_install resource(r)
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
20:58:03 <"ERROR: Signature extraction failed: Traceback (most recent call last):\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1225, in _decrypt_signature\n    video_id, player_url, s\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1133, in _extract_signature_function\n    res = self._parse_sig_js(code)\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1200, in _parse_sig_js\n    initial_function = jsi.extract_function(funcname)\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/jsinterp.py\", line 245, in extract_function\n    raise ExtractorError('Could not find JS function %r' % funcname)\nyoutube_dl.utils.ExtractorError: Could not find JS function 'encodeURIComponent'; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\n (caused by ExtractorError(\"Could not find JS function 'encodeURIComponent'; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\")); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\nERROR: Signature extraction failed: Traceback (most recent call last):\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1225, in _decrypt_signature\n    video_id, player_url, s\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1133, in _extract_signature_function\n    res = self._parse_sig_js(code)\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/extractor/youtube.py\", line 1200, in _parse_sig_js\n    initial_function = jsi.extract_function(funcname)\n  File \"/usr/local/Cellar/mps-youtube/0.2.8_5/libexec/lib/python3.7/site-packages/youtube_dl/jsinterp.py\", line 245, in extract_function\n    raise ExtractorError('Could not find JS function %r' % funcname)\nyoutube_dl.utils.ExtractorError: Could not find JS function 'encodeURIComponent'; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\n (caused by ExtractorError(\"Could not find JS function 'encodeURIComponent'; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\")); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\n"> expected to be empty.
```

Otherwise it would not work.