### PR TITLE
sphinx-doc: move to Python 3

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -38,11 +38,6 @@ class Notmuch < Formula
   patch :DATA
 
   def install
-    # configure runs `python -m sphinx.writers.manpage` to detect if
-    # `sphinx-build` will work
-    ENV.prepend_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"vendor/lib/python2.7/site-packages"
-    ENV.prepend_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"lib/python2.7/site-packages"
-
     args = %W[--prefix=#{prefix} --mandir=#{man}]
 
     if build.with? "emacs"

--- a/Formula/sphinx-doc.rb
+++ b/Formula/sphinx-doc.rb
@@ -1,8 +1,11 @@
 class SphinxDoc < Formula
+  include Language::Python::Virtualenv
+
   desc "Tool to create intelligent and beautiful documentation"
   homepage "https://www.sphinx-doc.org/"
   url "https://files.pythonhosted.org/packages/4d/ed/4595274b5c9ce53a768cc0804ef65fd6282c956b93919a969e98d53894e4/Sphinx-1.8.3.tar.gz"
   sha256 "c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,14 +19,9 @@ class SphinxDoc < Formula
     Users are advised to use `pip` to install sphinx-doc
   EOS
 
-  depends_on "python@2" if MacOS.version <= :snow_leopard
+  depends_on "python"
 
-  # generated from sphinx, setuptools, numpydoc and python-docs-theme
-  resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/37/1b/b25507861991beeade31473868463dad0e58b1978c209de27384ae541b0b/setuptools-40.6.3.zip"
-    sha256 "3b474dad69c49f0d2d86696b68105f3a6f195f7ab655af12ef9a9c326d2b08f8"
-  end
-
+  # generated from sphinx, numpydoc and python-docs-theme
   resource "alabaster" do
     url "https://files.pythonhosted.org/packages/cc/b4/ed8dcb0d67d5cfb7f83c4d5463a7614cb1d078ad7ae890c9143edebbf072/alabaster-0.7.12.tar.gz"
     sha256 "a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
@@ -130,24 +128,12 @@ class SphinxDoc < Formula
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
-    resources.each do |r|
-      r.stage do
-        system "python", *Language::Python.setup_install_args(libexec/"vendor")
-      end
-    end
-
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    system "python", *Language::Python.setup_install_args(libexec)
-
-    bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    virtualenv_install_with_resources
   end
 
   test do
     system bin/"sphinx-quickstart", "-pPorject", "-aAuthor", "-v1.0", "-q", testpath
     system bin/"sphinx-build", testpath, testpath/"build"
     assert_predicate testpath/"build/index.html", :exist?
-    assert_predicate libexec/"vendor/lib/python2.7/site-packages/python_docs_theme", :exist?
   end
 end

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -16,10 +16,7 @@ class Xapian < Formula
   option "with-ruby", "Ruby bindings"
 
   deprecated_option "ruby" => "with-ruby"
-  deprecated_option "with-python" => "with-python@2"
 
-  depends_on "python@2" => :optional
-  depends_on "sphinx-doc" => :build if build.with? "python@2"
   depends_on "ruby" => :optional if MacOS.version <= :sierra
 
   skip_clean :la
@@ -35,7 +32,7 @@ class Xapian < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
 
-    if build.with?("ruby") || build.with?("python@2")
+    if build.with?("ruby")
       resource("bindings").stage do
         ENV["XAPIAN_CONFIG"] = bin/"xapian-config"
 
@@ -48,21 +45,6 @@ class Xapian < Formula
           ruby_site = lib/"ruby/site_ruby"
           ENV["RUBY_LIB"] = ENV["RUBY_LIB_ARCH"] = ruby_site
           args << "--with-ruby"
-        end
-
-        if build.with? "python@2"
-          # https://github.com/Homebrew/homebrew-core/issues/2422
-          ENV.delete("PYTHONDONTWRITEBYTECODE")
-
-          (lib/"python2.7/site-packages").mkpath
-          ENV["PYTHON_LIB"] = lib/"python2.7/site-packages"
-
-          ENV.append_path "PYTHONPATH",
-                          Formula["sphinx-doc"].opt_libexec/"lib/python2.7/site-packages"
-          ENV.append_path "PYTHONPATH",
-                          Formula["sphinx-doc"].opt_libexec/"vendor/lib/python2.7/site-packages"
-
-          args << "--with-python"
         end
 
         system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sphinx was originally developed to generate documentation for CPython. Say whatever you want about Apple's inertia to move to Python 3, from my perspective when the Sphinx we ship cannot build CPython documentation (#33224), something is just wrong. Python 2.7 EOL is less than a year from now, the py27-based version cannot be shipped forever, so now is as good a time as any for switching. It's kinda ironic that `python@2` has its documentation built but the default `python` does not, due to `sphinx-doc` stuck with, guess what, python@2. (Edit: To be clear, I'm not proposing this change in order to bring docs to the `python` formula; I'm aware of the circular dependency. This PR is about pushing the ecosystem forward.)

Certain formulae that depends on `"sphinx-doc" => :build` might break if their Sphinx conf is still incompatible with Python 3 (shouldn't be hard to fix at all), or they insist on tapping into Sphinx from a python2.7 executable instead of just calling `sphinx-build`. But they really should up their game. Alternatively, a `sphinx-doc-python2` formula may be provided to keep those who are stuck in the past happy, but that's a really bad idea.