### PR TITLE
elementary-wallpapers 5.3.0 (new formula)

### DIFF
--- a/Formula/elementary-wallpapers.rb
+++ b/Formula/elementary-wallpapers.rb
@@ -1,0 +1,19 @@
+class ElementaryWallpapers < Formula
+  desc "Collection of wallpapers for elementary OS"
+  homepage "https://elementary.io/"
+  url "https://github.com/elementary/wallpapers/archive/5.3.tar.gz"
+  sha256 "a8383821f2d3877ca172d49d711f90e7ddcf6f254469703cec90cb5bae70c383"
+  head "https://github.com/elementary/wallpapers.git"
+
+  bottle :unneeded
+
+  def install
+    Dir["*.jpg"].each do |bg|
+      (share/"backgrounds").install bg
+    end
+  end
+
+  test do
+    Dir["#{(share/"backgrounds")}/*.jpg"].any?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I really like [elementary OS's set of wallpapers](https://github.com/elementary/wallpapers), but use a Mac for work and wanted to keep them easily accessible. I don't know if a wallpaper package makes a huge amount of sense, though, so open to a ruling that it doesn't belong in Homebrew (I already have it in a personal tap). The formula chooses the installation directory based on where the compiled `deb` would install them.