### PR TITLE
bash-completion@2: add info on how to support existing v1 completions

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -35,6 +35,9 @@ class BashCompletionAT2 < Formula
   def caveats; <<~EOS
     Add the following to your ~/.bash_profile:
       [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
+
+    If you'd like to use existing homebrew v1 completions, add the following before the previous line:
+      export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

After trying out `bash-completion@2` and finding that other Homebrew completions were lost (on a Mac) I poked around the internet and found https://discourse.brew.sh/t/bash-completion-2-vs-brews-auto-installed-bash-completions/2391 which lead me to the `BASH_COMPLETION_COMPAT_DIR` environment variable.

I'm not sure who this negatively impacts, but felt that adding more info to the caveats section could be helpful to other users.

I tried to run `brew audit --strict <formula>` locally, but I don't think it plays nice with Ruby managed by `asdf`.