### PR TITLE
fix cassandra@2.2 plist_options

### DIFF
--- a/Formula/cassandra@2.2.rb
+++ b/Formula/cassandra@2.2.rb
@@ -96,7 +96,7 @@ class CassandraAT22 < Formula
     (bin/"cqlsh").write_env_script libexec/"bin/cqlsh", :PYTHONPATH => pypath
   end
 
-  plist_options :manual => "cassandra -f"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/cassandra@2.2/bin/cassandra -f"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
cassandra@2.2: add HOMEBREW_PREFIX/opt to plist_options like [solr@6.6](https://github.com/Homebrew/homebrew-core/blob/df2be4fabcb643c132527c8f2a9375b2dbdc1cbf/Formula/solr%406.6.rb#L35)