### PR TITLE
xhyve: Fix install --HEAD failing with "No such file or directory - xhyverun.sh"

### DIFF
--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -23,7 +23,7 @@ class Xhyve < Formula
     system "make", *args
     bin.install "build/xhyve"
     pkgshare.install "test/"
-    pkgshare.install "xhyverun.sh"
+    pkgshare.install Dir["xhyverun*.sh"]
     man1.install "xhyve.1" if build.head?
   end
 


### PR DESCRIPTION
`xhyve` 0.2.0 ships `xhyverun.sh`.  More recent versions, after commit 97c6be2b19aebdc3c5d969e03fbee89acb19f891 , ship `xhyverun-{freebsd,tinycorelinux,windows}.sh`.

Currently, `--HEAD` builds are necessary for running recent Linux kernels; so, use a wildcard to support both 0.2.0 and `--HEAD` from the same formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  (both with 0.2.0 and `--HEAD`)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
  (both with 0.2.0 and `--HEAD`)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
