### PR TITLE
gnumeric: remove vendored formulae resources.

### DIFF
--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -16,36 +16,11 @@ class Gnumeric < Formula
   depends_on "adwaita-icon-theme"
   depends_on "gettext"
   depends_on "goffice"
+  depends_on "itstool"
+  depends_on "libxml2"
   depends_on "rarian"
 
-  # Issue from 26 Nov 2017 "itstool-2.0.4: problem with gnumeric-1.12.35"
-  # See https://github.com/itstool/itstool/issues/22
-  resource "itstool" do
-    url "http://files.itstool.org/itstool/itstool-2.0.2.tar.bz2"
-    sha256 "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a"
-  end
-
-  # For itstool
-  resource "py_libxml2" do
-    url "http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz"
-    sha256 "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c"
-  end
-
   def install
-    resource("py_libxml2").stage do
-      cd "python" do
-        system "python", "setup.py", "install", "--prefix=#{buildpath}/vendor"
-      end
-    end
-
-    resource("itstool").stage do
-      ENV.append_path "PYTHONPATH", "#{buildpath}/vendor/lib/python2.7/site-packages"
-      system "./configure", "--prefix=#{buildpath}/vendor"
-      system "make", "install"
-    end
-
-    ENV.prepend_path "PATH", buildpath/"vendor/bin"
-
     # ensures that the files remain within the keg
     inreplace "component/Makefile.in",
               "GOFFICE_PLUGINS_DIR = @GOFFICE_PLUGINS_DIR@",

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -4,6 +4,7 @@ class Libxml2 < Formula
   url "http://xmlsoft.org/sources/libxml2-2.9.9.tar.gz"
   mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/libxml2/libxml2-2.9.9.tar.gz"
   sha256 "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871"
+  revision 1
 
   bottle do
     cellar :any
@@ -24,6 +25,15 @@ class Libxml2 < Formula
   keg_only :provided_by_macos
 
   depends_on "python"
+
+  # Fix crash when using Python 3 using Fedora's patch.
+  # Reported upstream:
+  # https://bugzilla.gnome.org/show_bug.cgi?id=789714
+  # https://gitlab.gnome.org/GNOME/libxml2/issues/12
+  patch do
+    url "https://bugzilla.opensuse.org/attachment.cgi?id=746044"
+    sha256 "37eb81a8ec6929eed1514e891bff2dd05b450bcf0c712153880c485b7366c17c"
+  end
 
   def install
     system "autoreconf", "-fiv" if build.head?


### PR DESCRIPTION
This looks from the linked issue like it should now be able to use a modern `itstool` and `libxml2`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----