### PR TITLE
libraw: Update to 0.19.2 and enable OpenMP

### DIFF
--- a/Formula/efl.rb
+++ b/Formula/efl.rb
@@ -3,7 +3,7 @@ class Efl < Formula
   homepage "https://www.enlightenment.org"
   url "https://download.enlightenment.org/rel/libs/efl/efl-1.21.0.tar.xz"
   sha256 "7e65be78a537aa67e447b945f01f4ecf9ddfa14d509bf6bbf53a60253ecbae4b"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "4eb301261e8368605e3f920168426ce51a989508b6992c85e136390d5ecf1d1e" => :mojave

--- a/Formula/libraw.rb
+++ b/Formula/libraw.rb
@@ -1,8 +1,8 @@
 class Libraw < Formula
   desc "Library for reading RAW files from digital photo cameras"
   homepage "https://www.libraw.org/"
-  url "https://www.libraw.org/data/LibRaw-0.19.0.tar.gz"
-  sha256 "e83f51e83b19f9ba6b8bd144475fc12edf2d7b3b930d8d280bdebd8a8f3ed259"
+  url "https://www.libraw.org/data/LibRaw-0.19.2.tar.gz"
+  sha256 "400d47969292291d297873a06fb0535ccce70728117463927ddd9452aa849644"
 
   bottle do
     cellar :any
@@ -15,6 +15,7 @@ class Libraw < Formula
   depends_on "pkg-config" => :build
   depends_on "jasper"
   depends_on "jpeg"
+  depends_on "libomp"
   depends_on "little-cms2"
 
   resource "librawtestfile" do
@@ -24,7 +25,10 @@ class Libraw < Formula
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking"
+                          "--disable-dependency-tracking",
+                          "ac_cv_prog_c_openmp=-Xpreprocessor -fopenmp",
+                          "ac_cv_prog_cxx_openmp=-Xpreprocessor -fopenmp",
+                          "LDFLAGS=-lomp"
     system "make"
     system "make", "install"
     doc.install Dir["doc/*"]

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -3,6 +3,7 @@ class Openimageio < Formula
   homepage "http://openimageio.org/"
   url "https://github.com/OpenImageIO/oiio/archive/Release-1.8.17.tar.gz"
   sha256 "a019086c05a6150d445a2240bab1723dff540dde5f5c327c36a97f0b5ae0e157"
+  revision 1
   head "https://github.com/OpenImageIO/oiio.git"
 
   bottle do

--- a/Formula/rawtoaces.rb
+++ b/Formula/rawtoaces.rb
@@ -3,7 +3,7 @@ class Rawtoaces < Formula
   homepage "https://github.com/ampas/rawtoaces"
   url "https://github.com/ampas/rawtoaces/archive/v1.0.tar.gz"
   sha256 "9d15e7e30c4fe97baedfdafb5fddf95534eee26392002b23e81649bbe6e501e9"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "35b1c3038fc3ac5f2afa237a02b0de3215fd0b5fd6ddc98e4efda984e2f8cf31" => :mojave

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -3,6 +3,7 @@ class Siril < Formula
   homepage "https://www.siril.org"
   url "https://free-astro.org/download/siril-0.9.10.tar.bz2"
   sha256 "caf9800a442bbe3991e820ffc66f41b453c6866f510e2934d236788c78f5be29"
+  revision 1
   head "https://gitlab.com/free-astro/siril.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've made a mistake when pull and push in vscode... So close #35997 and reopen one.

@fxcoudert I've changed `//` to `/` and yes single slash is okay. To OpenMP support, the docs of libraw ([link](https://www.libraw.org/docs/Install-LibRaw.html)) show that `--enable-openmp` is the default option if supported, and it's better to add it.
