### PR TITLE
kustomize: add head

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -4,6 +4,7 @@ class Kustomize < Formula
   url "https://github.com/kubernetes-sigs/kustomize.git",
       :tag      => "v1.0.11",
       :revision => "8f701a00417a812558a7b785e8354957afa469ae"
+  head "https://github.com/kubernetes-sigs/kustomize.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When using `HEAD`, the test has warnings due to changes with the `kustomize` spec:

    $ brew test kustomize
    Testing kustomize
    ==> /usr/local/Cellar/kustomize/HEAD-2c1be17/bin/kustomize version
    ==> /usr/local/Cellar/kustomize/HEAD-2c1be17/bin/kustomize build /private/tmp/kustomize-test-20190123-10434-14tq0hn
    2019/01/23 17:07:51 apiVersion is not defined. This will not be allowed in the next release.
    Please run `kustomize edit fix`
    kind is not defined. This will not be allowed in the next release.
    Please run `kustomize edit fix`

I left the test as-is, since I didn't see any docs/guidelines about updating tests to pass using the `HEAD` version of a formula.