### PR TITLE
haproxy 1.8.17

### DIFF
--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -1,8 +1,8 @@
 class Haproxy < Formula
   desc "Reliable, high performance TCP/HTTP load balancer"
   homepage "https://www.haproxy.org/"
-  url "https://www.haproxy.org/download/1.8/src/haproxy-1.8.15.tar.gz"
-  sha256 "7113862f1146d7de8b8e64f45826ab3533c7f7f7b7767e24c08f7c762202a032"
+  url "https://www.haproxy.org/download/1.8/src/haproxy-1.8.17.tar.gz"
+  sha256 "7b789b177875afdd5ddeff058e7efde73aa895dc2dcf728b464358635ae3948e"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

There is a PR for 1.9.0 (#35421) but that is failing. This bumps to the latest 1.8.x version.