### PR TITLE
Remove old compilers' support

### DIFF
--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -15,8 +15,6 @@ class AmqpCpp < Formula
   depends_on "cmake" => :build
   depends_on "openssl"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/ape.rb
+++ b/Formula/ape.rb
@@ -14,11 +14,6 @@ class Ape < Formula
     sha256 "136d65f58cb956b95a6ccb9517a5affe69c3491d283478708ca88091abb3103f" => :mountain_lion
   end
 
-  fails_with :clang do
-    build 500
-    cause "multiple configure and compile errors"
-  end
-
   def install
     system "./build.sh"
     # The Makefile installs a configuration file in the bindir which our bot red-flags

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -16,17 +16,10 @@ class Arangodb < Formula
   depends_on :macos => :yosemite
   depends_on "openssl"
 
-  fails_with :clang do
-    build 600
-    cause "Fails with compile errors"
-  end
-
   fails_with :gcc do
     build 820
     cause "Generates incorrect code"
   end
-
-  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -16,8 +16,6 @@ class Aria2 < Formula
   depends_on "pkg-config" => :build
   depends_on "libssh2"
 
-  needs :cxx14
-
   def install
     # Fix "error: use of undeclared identifier 'make_unique'"
     # Reported upstream 15 May 2018 https://github.com/aria2/aria2/issues/1198

--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -18,8 +18,6 @@ class Asio < Formula
 
   depends_on "openssl"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/aspcud.rb
+++ b/Formula/aspcud.rb
@@ -17,8 +17,6 @@ class Aspcud < Formula
   depends_on "re2c" => :build
   depends_on "clingo"
 
-  needs :cxx14
-
   def install
     args = std_cmake_args
     args << "-DASPCUD_GRINGO_PATH=#{Formula["clingo"].opt_bin}/gringo"

--- a/Formula/atkmm.rb
+++ b/Formula/atkmm.rb
@@ -17,8 +17,6 @@ class Atkmm < Formula
   depends_on "atk"
   depends_on "glibmm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/bedops.rb
+++ b/Formula/bedops.rb
@@ -12,8 +12,6 @@ class Bedops < Formula
     sha256 "a860bbe9e2aa2d5289aa0d960bb01212841f71732eb1e913c8364de46f62708c" => :el_capitan
   end
 
-  needs :cxx11
-
   def install
     system "make"
     system "make", "install", "BINDIR=#{bin}"

--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -18,14 +18,6 @@ class Bigloo < Formula
   depends_on "gmp"
   depends_on "openssl"
 
-  fails_with :clang do
-    build 500
-    cause <<~EOS
-      objs/obj_u/Ieee/dtoa.c:262:79504: fatal error: parser
-      recursion limit reached, program too complex
-    EOS
-  end
-
   def install
     args = %W[
       --disable-debug

--- a/Formula/binaryen.rb
+++ b/Formula/binaryen.rb
@@ -15,8 +15,6 @@ class Binaryen < Formula
   depends_on "cmake" => :build
   depends_on :macos => :el_capitan # needs thread-local storage
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -27,8 +27,6 @@ class Bitcoin < Formula
   depends_on "openssl"
   depends_on "zeromq"
 
-  needs :cxx11
-
   def install
     if MacOS.version == :el_capitan && MacOS::Xcode.installed? &&
        MacOS::Xcode.version >= "8.0"

--- a/Formula/blahtexml.rb
+++ b/Formula/blahtexml.rb
@@ -26,8 +26,6 @@ class Blahtexml < Formula
     sha256 "d696d10931f2c2ded1cef50842b78887dba36679fbb2e0abc373e7b6405b8468"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -14,8 +14,6 @@ class BoostMpi < Formula
   depends_on "boost"
   depends_on "open-mpi"
 
-  needs :cxx11
-
   def install
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -14,8 +14,6 @@ class BoostPython < Formula
 
   depends_on "boost"
 
-  needs :cxx11
-
   def install
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -19,8 +19,6 @@ class BoostPython3 < Formula
     sha256 "a4a433b3a264dbc9aa9c7c241e87c0358a503ea6394f8737df1683c7c9a102ac"
   end
 
-  needs :cxx11
-
   def install
     # "layout" should be synchronized with boost
     args = ["--prefix=#{prefix}",

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -15,8 +15,6 @@ class Boost < Formula
 
   depends_on "icu4c"
 
-  needs :cxx14
-
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|

--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -14,8 +14,6 @@ class Botan < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -15,8 +15,6 @@ class Caf < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     system "./configure", "--prefix=#{prefix}", "--no-examples",
                           "--build-static", "--no-opencl"

--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -36,8 +36,6 @@ class Caffe < Formula
     sha256 "6a6368d715284fabfa96660b6d24d1f4f419f3e6cdddab9a7293954fee4ec2bc"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/cairomm.rb
+++ b/Formula/cairomm.rb
@@ -18,8 +18,6 @@ class Cairomm < Formula
   depends_on "libpng"
   depends_on "libsigc++"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/capnp.rb
+++ b/Formula/capnp.rb
@@ -15,8 +15,6 @@ class Capnp < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx14
-
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -25,8 +25,6 @@ class Cataclysm < Formula
   depends_on "sdl2_mixer"
   depends_on "sdl2_ttf"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/ccrypt.rb
+++ b/Formula/ccrypt.rb
@@ -13,11 +13,6 @@ class Ccrypt < Formula
 
   conflicts_with "ccat", :because => "both install `ccat` binaries"
 
-  fails_with :clang do
-    build 318
-    cause "Tests fail when optimizations are enabled"
-  end
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/clingo.rb
+++ b/Formula/clingo.rb
@@ -24,8 +24,6 @@ class Clingo < Formula
   link_overwrite "bin/lpconvert"
   link_overwrite "bin/reify"
 
-  needs :cxx14
-
   def install
     system "cmake", ".", "-DCLINGO_BUILD_WITH_PYTHON=ON",
                          "-DCLINGO_BUILD_PY_SHARED=ON",

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -20,8 +20,6 @@ class Cmake < Formula
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
   # For the GUI application please instead use `brew cask install cmake`.
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -23,14 +23,6 @@ class Collectd < Formula
   depends_on "net-snmp"
   depends_on "riemann-client"
 
-  fails_with :clang do
-    build 318
-    cause <<~EOS
-      Clang interacts poorly with the collectd-bundled libltdl,
-      causing configure to fail.
-    EOS
-  end
-
   def install
     args = %W[
       --disable-debug

--- a/Formula/console_bridge.rb
+++ b/Formula/console_bridge.rb
@@ -13,8 +13,6 @@ class ConsoleBridge < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/cppcheck.rb
+++ b/Formula/cppcheck.rb
@@ -13,8 +13,6 @@ class Cppcheck < Formula
 
   depends_on "pcre"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/cppcms.rb
+++ b/Formula/cppcms.rb
@@ -16,8 +16,6 @@ class Cppcms < Formula
   depends_on "openssl"
   depends_on "pcre"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", *std_cmake_args

--- a/Formula/cquery.rb
+++ b/Formula/cquery.rb
@@ -19,8 +19,6 @@ class Cquery < Formula
   # error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12
   depends_on :macos => :sierra
 
-  needs :cxx14
-
   def install
     system "cmake", ".", "-DSYSTEM_CLANG=ON", *std_cmake_args
     system "make", "install"

--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -23,8 +23,6 @@ class Cryfs < Formula
   depends_on "openssl"
   depends_on :osxfuse
 
-  needs :cxx11
-
   def install
     configure_args = [
       "-DBUILD_TESTING=off",

--- a/Formula/csv-fix.rb
+++ b/Formula/csv-fix.rb
@@ -14,8 +14,6 @@ class CsvFix < Formula
     sha256 "0b86933c8e32830d5abd0f26ef83b1a60e0254da67542b695fd50ab1e3ba2e68" => :mavericks
   end
 
-  needs :cxx11
-
   def install
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x

--- a/Formula/curlpp.rb
+++ b/Formula/curlpp.rb
@@ -15,8 +15,6 @@ class Curlpp < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/dar.rb
+++ b/Formula/dar.rb
@@ -17,8 +17,6 @@ class Dar < Formula
   depends_on "lzo"
   depends_on :macos => :el_capitan # needs thread-local storage
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -25,8 +25,6 @@ class Dartsim < Formula
   depends_on "tinyxml2"
   depends_on "urdfdom"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -22,8 +22,6 @@ class Dbxml < Formula
     sha256 "98d518934072d86c15780f10ceee493ca34bba5bc788fd9db1981a78234b0dc4"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dlib.rb
+++ b/Formula/dlib.rb
@@ -19,8 +19,6 @@ class Dlib < Formula
   depends_on :macos => :el_capitan # needs thread-local storage
   depends_on "openblas"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -23,8 +23,6 @@ class DosboxX < Formula
   depends_on "sdl_net"
   depends_on "sdl_sound"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dspdfviewer.rb
+++ b/Formula/dspdfviewer.rb
@@ -38,8 +38,6 @@ class Dspdfviewer < Formula
     sha256 "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -38,8 +38,6 @@ class Dynare < Formula
     sha256 "fa80f7c75dab6bfaca93c3b374c774fd87876f34fba969af9133eeaea5f39a3d"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/efl.rb
+++ b/Formula/efl.rb
@@ -34,8 +34,6 @@ class Efl < Formula
   depends_on "pulseaudio"
   depends_on "shared-mime-info"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -41,8 +41,6 @@ class Emscripten < Formula
   depends_on "python@2"
   depends_on "yuicompressor"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     # rewrite hardcoded paths from system python to homebrew python

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -19,8 +19,6 @@ class Encfs < Formula
   depends_on "openssl"
   depends_on :osxfuse
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/enigma.rb
+++ b/Formula/enigma.rb
@@ -37,8 +37,6 @@ class Enigma < Formula
     sha256 "5870bb761dbba508e998fc653b7b05a130f9afe84180fa21667e7c2271ccb677"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/fastbit.rb
+++ b/Formula/fastbit.rb
@@ -22,8 +22,6 @@ class Fastbit < Formula
     sha256 "e1198caf262a125d2216d70cfec80ebe98d122760ffa5d99d34fc33646445390"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-debug",

--- a/Formula/fcl.rb
+++ b/Formula/fcl.rb
@@ -18,8 +18,6 @@ class Fcl < Formula
   depends_on "libccd"
   depends_on "octomap"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -25,11 +25,6 @@ class Flac < Formula
   depends_on "pkg-config" => :build
   depends_on "libogg"
 
-  fails_with :clang do
-    build 500
-    cause "Undefined symbols ___cpuid and ___cpuid_count"
-  end
-
   def install
     args = %W[
       --disable-dependency-tracking

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -34,8 +34,6 @@ class Folly < Formula
   # https://github.com/facebook/folly/pull/445
   fails_with :gcc => "6"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -30,7 +30,6 @@ class Freeswitch < Formula
   depends_on "sqlite"
 
   # https://github.com/Homebrew/homebrew/issues/42865
-  fails_with :gcc_4_2
 
   #----------------------- Begin sound file resources -------------------------
   sounds_url_base = "https://files.freeswitch.org/releases/sounds"

--- a/Formula/fswatch.rb
+++ b/Formula/fswatch.rb
@@ -11,8 +11,6 @@ class Fswatch < Formula
     sha256 "9362bc3b3321bf0238fa70d2f2825e4118e18deb2207af3a2633b6772bb33666" => :sierra
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/gammaray.rb
+++ b/Formula/gammaray.rb
@@ -16,8 +16,6 @@ class Gammaray < Formula
   depends_on "graphviz"
   depends_on "qt"
 
-  needs :cxx11
-
   def install
     # For Mountain Lion
     ENV.libcxx

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -18,8 +18,6 @@ class Gdcm < Formula
   depends_on "openssl"
   depends_on "python"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/gjs.rb
+++ b/Formula/gjs.rb
@@ -23,8 +23,6 @@ class Gjs < Formula
     sha256 "a4e7bb80e7ebab19769b2b8940966349136a99aabd497034662cffa54ea30e40"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["_MACOSX_DEPLOYMENT_TARGET"] = ENV["MACOSX_DEPLOYMENT_TARGET"]

--- a/Formula/glbinding.rb
+++ b/Formula/glbinding.rb
@@ -14,8 +14,6 @@ class Glbinding < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args, "-DGLFW_LIBRARY_RELEASE="

--- a/Formula/glibmm.rb
+++ b/Formula/glibmm.rb
@@ -15,8 +15,6 @@ class Glibmm < Formula
   depends_on "glib"
   depends_on "libsigc++"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/globjects.rb
+++ b/Formula/globjects.rb
@@ -16,8 +16,6 @@ class Globjects < Formula
   depends_on "glbinding"
   depends_on "glm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", "-Dglbinding_DIR=#{Formula["glbinding"].opt_prefix}", *std_cmake_args

--- a/Formula/gnome-builder.rb
+++ b/Formula/gnome-builder.rb
@@ -34,8 +34,6 @@ class GnomeBuilder < Formula
   # fix sandbox violation and remove unavailable linker option
   patch :DATA
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["DESTDIR"] = ""

--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -28,8 +28,6 @@ class Gnuplot < Formula
   depends_on "qt"
   depends_on "readline"
 
-  needs :cxx11
-
   def install
     # Qt5 requires c++11 (and the other backends do not care)
     ENV.cxx11

--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -31,8 +31,6 @@ class Gobby < Formula
   # and all traces of ige-mac-integration have been removed from the code
   patch :DATA
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/google-benchmark.rb
+++ b/Formula/google-benchmark.rb
@@ -15,8 +15,6 @@ class GoogleBenchmark < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", "-DBENCHMARK_ENABLE_GTEST_TESTS=OFF", *std_cmake_args

--- a/Formula/gource.rb
+++ b/Formula/gource.rb
@@ -29,8 +29,6 @@ class Gource < Formula
   depends_on "sdl2"
   depends_on "sdl2_image"
 
-  needs :cxx11
-
   def install
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x

--- a/Formula/graphite2.rb
+++ b/Formula/graphite2.rb
@@ -19,8 +19,6 @@ class Graphite2 < Formula
     sha256 "7e573896bbb40088b3a8490f83d6828fb0fd0920ac4ccdfdd7edb804e852186a"
   end
 
-  needs :cxx11
-
   def install
     system "cmake", *std_cmake_args
     system "make", "install"

--- a/Formula/gsmartcontrol.rb
+++ b/Formula/gsmartcontrol.rb
@@ -17,8 +17,6 @@ class Gsmartcontrol < Formula
   depends_on "pcre"
   depends_on "smartmontools"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/gstreamermm.rb
+++ b/Formula/gstreamermm.rb
@@ -17,8 +17,6 @@ class Gstreamermm < Formula
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -21,8 +21,6 @@ class Gtkmm < Formula
   depends_on "libsigc++"
   depends_on "pangomm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/gtkmm3.rb
+++ b/Formula/gtkmm3.rb
@@ -16,8 +16,6 @@ class Gtkmm3 < Formula
   depends_on "gtk+3"
   depends_on "pangomm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/gtksourceviewmm.rb
+++ b/Formula/gtksourceviewmm.rb
@@ -17,8 +17,6 @@ class Gtksourceviewmm < Formula
   depends_on "gtkmm"
   depends_on "gtksourceview"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/gtksourceviewmm3.rb
+++ b/Formula/gtksourceviewmm3.rb
@@ -17,8 +17,6 @@ class Gtksourceviewmm3 < Formula
   depends_on "gtkmm3"
   depends_on "gtksourceview3"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -29,11 +29,6 @@ class Guile < Formula
   depends_on "pkg-config" # guile-config is a wrapper around pkg-config.
   depends_on "readline"
 
-  fails_with :clang do
-    build 211
-    cause "Segfaults during compilation"
-  end
-
   def install
     system "./autogen.sh" unless build.stable?
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/guile@2.0.rb
+++ b/Formula/guile@2.0.rb
@@ -22,11 +22,6 @@ class GuileAT20 < Formula
   depends_on "pkg-config" # guile-config is a wrapper around pkg-config.
   depends_on "readline"
 
-  fails_with :clang do
-    build 211
-    cause "Segfaults during compilation"
-  end
-
   if MacOS.version >= :sierra
     # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23870
     # https://git.net/ml/bug-guile-gnu/2016-06/msg00180.html

--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -25,8 +25,6 @@ class Hfstospell < Formula
     sha256 "0a3146e871ac0e3c71248b8671d09f6d8a8a69713b6f4857eab7bdb684709083"
   end
 
-  needs :cxx11
-
   def install
     # icu4c 61.1 compatability
     ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"

--- a/Formula/howard-hinnant-date.rb
+++ b/Formula/howard-hinnant-date.rb
@@ -14,8 +14,6 @@ class HowardHinnantDate < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     system "cmake", ".", *std_cmake_args,
                          "-DENABLE_DATE_TESTING=OFF",

--- a/Formula/i2pd.rb
+++ b/Formula/i2pd.rb
@@ -15,8 +15,6 @@ class I2pd < Formula
   depends_on "miniupnpc"
   depends_on "openssl@1.1"
 
-  needs :cxx11
-
   def install
     system "make", "install", "DEBUG=no", "HOMEBREW=1", "USE_UPNP=yes", "USE_AENSI=no", "USE_AVX=no", "PREFIX=#{prefix}"
 

--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -16,8 +16,6 @@ class Ibex < Formula
   depends_on "flex" => :build
   depends_on "pkg-config" => [:build, :test]
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/json11.rb
+++ b/Formula/json11.rb
@@ -14,8 +14,6 @@ class Json11 < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/jsoncpp.rb
+++ b/Formula/jsoncpp.rb
@@ -15,8 +15,6 @@ class Jsoncpp < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/jsonnet.rb
+++ b/Formula/jsonnet.rb
@@ -14,8 +14,6 @@ class Jsonnet < Formula
 
   depends_on :macos => :mavericks
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "make"

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -16,8 +16,6 @@ class KitchenSync < Formula
   depends_on "libpq"
   depends_on "mysql-client"
 
-  needs :cxx14
-
   def install
     system "cmake", ".",
                     "-DMySQL_INCLUDE_DIR=#{Formula["mysql-client"].opt_include}/mysql",

--- a/Formula/kyoto-cabinet.rb
+++ b/Formula/kyoto-cabinet.rb
@@ -13,14 +13,6 @@ class KyotoCabinet < Formula
     sha256 "bfed1b4b4aa5e742c89f9aa0ba83375ad4ff1d5daaf0e060260d16df4024582d" => :mavericks
   end
 
-  fails_with :clang do
-    build 421
-    cause <<~EOS
-      Kyoto-cabinet relies on GCC atomic intrinsics, but Clang does not
-      implement them for non-integer types.
-    EOS
-  end
-
   patch :DATA if MacOS.version >= :mavericks
 
   def install

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -21,8 +21,6 @@ class Ldc < Formula
     sha256 "a946e658aaff1eed80bffeb4d69b572f259368fac44673731781f6d487dea3cd"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     (buildpath/"ldc-bootstrap").install resource("ldc-bootstrap")

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -25,8 +25,6 @@ class Ledger < Formula
     sha256 "2e652fc4b247b9c7cd482bd07aa57a66fc86597d7a564e6ccf93232700a6c8d8"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/libcec.rb
+++ b/Formula/libcec.rb
@@ -18,8 +18,6 @@ class Libcec < Formula
     sha256 "064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/libchaos.rb
+++ b/Formula/libchaos.rb
@@ -14,7 +14,6 @@ class Libchaos < Formula
   end
 
   depends_on "cmake" => :build
-  needs :cxx11
 
   def install
     mkdir "build" do

--- a/Formula/libdap.rb
+++ b/Formula/libdap.rb
@@ -24,8 +24,6 @@ class Libdap < Formula
   depends_on "libxml2"
   depends_on "openssl"
 
-  needs :cxx11 if MacOS.version < :mavericks
-
   def install
     # Otherwise, "make check" fails
     ENV.cxx11 if MacOS.version < :mavericks

--- a/Formula/libglademm.rb
+++ b/Formula/libglademm.rb
@@ -17,8 +17,6 @@ class Libglademm < Formula
   depends_on "gtkmm"
   depends_on "libglade"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libgnomecanvasmm.rb
+++ b/Formula/libgnomecanvasmm.rb
@@ -17,8 +17,6 @@ class Libgnomecanvasmm < Formula
   depends_on "gtkmm"
   depends_on "libgnomecanvas"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/liblas.rb
+++ b/Formula/liblas.rb
@@ -32,8 +32,6 @@ class Liblas < Formula
     sha256 "3f5cc283d3e908d991b05b4dcf5cc0440824441ec270396e11738f96a0a23a9f"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/libphonenumber.rb
+++ b/Formula/libphonenumber.rb
@@ -23,8 +23,6 @@ class Libphonenumber < Formula
     sha256 "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     (buildpath/"gtest").install resource("gtest")

--- a/Formula/libpointing.rb
+++ b/Formula/libpointing.rb
@@ -13,8 +13,6 @@ class Libpointing < Formula
     sha256 "7120c106e54576154687dd63cdedb72633644e27213c7dbc1aa515a1227a8f3c" => :yosemite
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "make"

--- a/Formula/libsass.rb
+++ b/Formula/libsass.rb
@@ -16,7 +16,6 @@ class Libsass < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/libsigc++.rb
+++ b/Formula/libsigc++.rb
@@ -11,8 +11,6 @@ class Libsigcxx < Formula
     sha256 "c0183cda1eafe9542d87a47e986c1efb02b82c747e5f466a4ddd5cff9ac4c6a1" => :sierra
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"

--- a/Formula/libvoikko.rb
+++ b/Formula/libvoikko.rb
@@ -21,8 +21,6 @@ class Libvoikko < Formula
     sha256 "71a823120a35ade6f20eaa7d00db27ec7355aa46a45a5b1a4a1f687a42134496"
   end
 
-  needs :cxx11
-
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -17,8 +17,6 @@ class Libxmlxx < Formula
   depends_on "pkg-config" => :build
   depends_on "glibmm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -16,8 +16,6 @@ class Libxmlxx3 < Formula
   depends_on "pkg-config" => :build
   depends_on "glibmm"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -28,9 +28,6 @@ class Libxml2 < Formula
   def install
     system "autoreconf", "-fiv" if build.head?
 
-    # Fix build on OS X 10.5 and 10.6 with Xcode 3.2.6
-    inreplace "configure", "-Wno-array-bounds", "" if ENV.compiler == :gcc_4_2
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--without-python",

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -105,12 +105,6 @@ class Llvm < Formula
 
   depends_on "python@2" if MacOS.version <= :snow_leopard
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   def install
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang

--- a/Formula/llvm@3.9.rb
+++ b/Formula/llvm@3.9.rb
@@ -18,12 +18,6 @@ class LlvmAT39 < Formula
   depends_on "libffi"
   depends_on "python@2" if MacOS.version <= :snow_leopard
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "clang" do
     url "https://releases.llvm.org/3.9.1/cfe-3.9.1.src.tar.xz"
     sha256 "e6c4cebb96dee827fa0470af313dff265af391cb6da8d429842ef208c8f25e63"

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -18,12 +18,6 @@ class LlvmAT4 < Formula
   depends_on "libffi"
   depends_on "python@2" if MacOS.version <= :snow_leopard
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "clang" do
     url "https://releases.llvm.org/4.0.1/cfe-4.0.1.src.tar.xz"
     sha256 "61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b"

--- a/Formula/llvm@5.rb
+++ b/Formula/llvm@5.rb
@@ -18,12 +18,6 @@ class LlvmAT5 < Formula
   depends_on "libffi"
   depends_on "python@2" if MacOS.version <= :snow_leopard
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "clang" do
     url "https://releases.llvm.org/5.0.2/cfe-5.0.2.src.tar.xz"
     sha256 "fa9ce9724abdb68f166deea0af1f71ca0dfa9af8f7e1261f2cae63c280282800"

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -25,12 +25,6 @@ class LlvmAT6 < Formula
   depends_on "libffi"
   depends_on "python@2" if MacOS.version <= :snow_leopard
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "clang" do
     url "https://releases.llvm.org/6.0.1/cfe-6.0.1.src.tar.xz"
     sha256 "7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667"

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -12,8 +12,6 @@ class Log4cplus < Formula
     sha256 "3a3f4952bf0064e0cd81b0e8c538ca7f49434cfb387a4f9e8441f7dbddeb6d33" => :el_capitan
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/logstalgia.rb
+++ b/Formula/logstalgia.rb
@@ -29,8 +29,6 @@ class Logstalgia < Formula
   depends_on "sdl2"
   depends_on "sdl2_image"
 
-  needs :cxx11
-
   def install
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x

--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -26,7 +26,6 @@ class Mame < Formula
   depends_on "utf8proc"
 
   # Need C++ compiler and standard library support C++14.
-  needs :cxx14
 
   def install
     inreplace "scripts/src/osd/sdl.lua", "--static", ""

--- a/Formula/mapcrafter.rb
+++ b/Formula/mapcrafter.rb
@@ -18,8 +18,6 @@ class Mapcrafter < Formula
   depends_on "jpeg-turbo"
   depends_on "libpng"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -30,8 +30,6 @@ class Mapnik < Formula
     sha256 "e00e8475f04e9010dbb1724e5ae10403d2e7f1da8a83e67dfb54a7a969d81669"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/mdds.rb
+++ b/Formula/mdds.rb
@@ -14,7 +14,6 @@ class Mdds < Formula
 
   depends_on "autoconf" => :build
   depends_on "boost"
-  needs :cxx11
 
   def install
     # Gets it to work when the CLT is installed

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -67,8 +67,6 @@ class Mesos < Formula
     sha256 "47959d0651c32102c10ad919b8a0ffe0ae85f44b8457ddcf2bdc0358fb03dc29"
   end
 
-  needs :cxx11
-
   def install
     # Disable optimizing as libc++ does not play well with optimized clang
     # builds (see https://llvm.org/bugs/show_bug.cgi?id=28469 and

--- a/Formula/metashell.rb
+++ b/Formula/metashell.rb
@@ -14,8 +14,6 @@ class Metashell < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -32,8 +32,6 @@ class Mkvtoolnix < Formula
   depends_on "libogg"
   depends_on "libvorbis"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/mongo-cxx-driver.rb
+++ b/Formula/mongo-cxx-driver.rb
@@ -15,8 +15,6 @@ class MongoCxxDriver < Formula
   depends_on "cmake" => :build
   depends_on "mongo-c-driver"
 
-  needs :cxx11
-
   def install
     mongo_c_prefix = Formula["mongo-c-driver"].opt_prefix
     system "cmake", ".", *std_cmake_args,

--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -37,8 +37,6 @@ class Mongodb < Formula
     sha256 "4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/mongodb@3.0.rb
+++ b/Formula/mongodb@3.0.rb
@@ -28,8 +28,6 @@ class MongodbAT30 < Formula
       :revision => "86d15daf966ce58f5ce01985db07a7a5a3641ecb"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/mongodb@3.2.rb
+++ b/Formula/mongodb@3.2.rb
@@ -30,8 +30,6 @@ class MongodbAT32 < Formula
         :shallow  => false
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/mongodb@3.4.rb
+++ b/Formula/mongodb@3.4.rb
@@ -22,8 +22,6 @@ class MongodbAT34 < Formula
   depends_on :macos => :mountain_lion
   depends_on "openssl"
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/mongodb@3.6.rb
+++ b/Formula/mongodb@3.6.rb
@@ -39,8 +39,6 @@ class MongodbAT36 < Formula
     sha256 "4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -23,8 +23,6 @@ class Mosh < Formula
   depends_on "tmux" => :build if build.bottle?
   depends_on "protobuf"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -34,8 +34,6 @@ class Mpd < Formula
   depends_on "opus"
   depends_on "sqlite"
 
-  needs :cxx11
-
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
     # that against libstdc++ anyway, which won't work.

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -23,11 +23,6 @@ class MysqlCluster < Formula
   conflicts_with "mysql-connector-c",
     :because => "both install `bin/my_print_defaults`"
 
-  fails_with :clang do
-    build 500
-    cause "https://article.gmane.org/gmane.comp.db.mysql.cluster/2085"
-  end
-
   resource "boost" do
     url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
     sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"

--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -28,8 +28,6 @@ class Ncmpcpp < Formula
   depends_on "readline"
   depends_on "taglib"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV.append "LDFLAGS", "-liconv"

--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -19,8 +19,6 @@ class Newsboat < Formula
   depends_on "json-c"
   depends_on "libstfl"
 
-  needs :cxx11
-
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
     system "make", "install", "prefix=#{prefix}"

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -34,11 +34,6 @@ class Nghttp2 < Formula
     sha256 "18ab7646985a97e02cee72e1ddba2e732d4931d4e1732494ff30c5aa084bfb97"
   end
 
-  # https://github.com/tatsuhiro-t/nghttp2/issues/125
-  # Upstream requested the issue closed and for users to use gcc instead.
-  # Given this will actually build with Clang with cxx11, just use that.
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -16,13 +16,6 @@ class Node < Formula
   depends_on "python@2" => :build
   depends_on "icu4c"
 
-  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
-  fails_with :clang if MacOS.version <= :snow_leopard
-  fails_with :gcc_4_2
-  ("4.3".."4.7").each do |n|
-    fails_with :gcc => n
-  end
-
   # We track major/minor from upstream Node releases.
   # We will accept *important* npm patch releases when necessary.
   resource "npm" do

--- a/Formula/node@10.rb
+++ b/Formula/node@10.rb
@@ -17,13 +17,6 @@ class NodeAT10 < Formula
   depends_on "python@2" => :build
   depends_on "icu4c"
 
-  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
-  fails_with :clang if MacOS.version <= :snow_leopard
-  fails_with :gcc_4_2
-  ("4.3".."4.7").each do |n|
-    fails_with :gcc => n
-  end
-
   def install
     system "./configure", "--prefix=#{prefix}", "--with-intl=system-icu"
     system "make", "install"

--- a/Formula/node@6.rb
+++ b/Formula/node@6.rb
@@ -16,13 +16,6 @@ class NodeAT6 < Formula
   depends_on "pkg-config" => :build
   depends_on "python@2" => :build
 
-  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
-  fails_with :clang if MacOS.version <= :snow_leopard
-  fails_with :gcc_4_2
-  ("4.3".."4.7").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "icu4c" do
     url "https://ssl.icu-project.org/files/icu4c/58.2/icu4c-58_2-src.tgz"
     version "58.2"

--- a/Formula/node@8.rb
+++ b/Formula/node@8.rb
@@ -17,13 +17,6 @@ class NodeAT8 < Formula
   depends_on "python@2" => :build
   depends_on "icu4c"
 
-  # Per upstream - "Need g++ 4.8 or clang++ 3.4".
-  fails_with :clang if MacOS.version <= :snow_leopard
-  fails_with :gcc_4_2
-  ("4.3".."4.7").each do |n|
-    fails_with :gcc => n
-  end
-
   def install
     system "./configure", "--prefix=#{prefix}", "--with-intl=system-icu"
     system "make", "install"

--- a/Formula/nordugrid-arc.rb
+++ b/Formula/nordugrid-arc.rb
@@ -24,18 +24,11 @@ class NordugridArc < Formula
   # libc++ and libstdc++
   depends_on :macos => :yosemite
 
-  fails_with :clang do
-    build 500
-    cause "Fails with 'template specialization requires \"template<>\"'"
-  end
-
   # bug filed upstream at https://bugzilla.nordugrid.org/show_bug.cgi?id=3514
   patch do
     url "https://gist.githubusercontent.com/tschoonj/065dabc33be5ec636058/raw/beee466cdf5fe56f93af0b07022532b1945e9d2e/nordugrid-arc.diff"
     sha256 "5561ea013ddd03ee4f72437f2e01f22b2c0cac2806bf837402724be281ac2b6d"
   end
-
-  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -16,21 +16,6 @@ class Nzbget < Formula
   depends_on "gcc" if MacOS.version <= :mavericks
   depends_on "openssl"
 
-  fails_with :clang do
-    build 600
-    cause "No compiler with C++14 support was found"
-  end
-
-  fails_with :clang do
-    build 500
-    cause <<~EOS
-      Clang older than 5.1 requires flexible array members to be POD types.
-      More recent versions require only that they be trivially destructible.
-    EOS
-  end
-
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/ompl.rb
+++ b/Formula/ompl.rb
@@ -15,8 +15,6 @@ class Ompl < Formula
   depends_on "boost"
   depends_on "eigen"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -23,8 +23,6 @@ class OpenMpi < Formula
 
   conflicts_with "mpich", :because => "both install MPI compiler wrappers"
 
-  needs :cxx11
-
   def install
     # otherwise libmpi_usempi_ignore_tkr gets built as a static library
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version

--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -18,9 +18,6 @@ class OpenalSoft < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
 
-  # clang 4.2's support for alignas is incomplete
-  fails_with(:clang) { build 425 }
-
   def install
     # Please don't reenable example building. See:
     # https://github.com/Homebrew/homebrew/issues/38274

--- a/Formula/opencc.rb
+++ b/Formula/opencc.rb
@@ -15,8 +15,6 @@ class Opencc < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", "-DBUILD_DOCUMENTATION:BOOL=OFF", *std_cmake_args

--- a/Formula/openclonk.rb
+++ b/Formula/openclonk.rb
@@ -27,8 +27,6 @@ class Openclonk < Formula
   # Requires some C++14 features missing in Mavericks
   depends_on :macos => :yosemite
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -28,8 +28,6 @@ class Opencv < Formula
     sha256 "0d8acbad4b7074cfaafd906a7419c23629179d5e98894714402090b192ef8237"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"

--- a/Formula/opencv@3.rb
+++ b/Formula/opencv@3.rb
@@ -30,8 +30,6 @@ class OpencvAT3 < Formula
     sha256 "8f73d029887c726fed89c69a2b0fcb1d098099fcd81c1070e1af3b452669fbe2"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"

--- a/Formula/opensaml.rb
+++ b/Formula/opensaml.rb
@@ -19,8 +19,6 @@ class Opensaml < Formula
   depends_on "xml-security-c"
   depends_on "xml-tooling-c"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/openvdb.rb
+++ b/Formula/openvdb.rb
@@ -25,8 +25,6 @@ class Openvdb < Formula
     sha256 "05476e84e91c0214ad7593850e6e7c28f777aa4ff0a1d88d91168a7dd050f922"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     # Adjust hard coded paths in Makefile

--- a/Formula/osm-pbf.rb
+++ b/Formula/osm-pbf.rb
@@ -15,8 +15,6 @@ class OsmPbf < Formula
 
   depends_on "protobuf"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/pacvim.rb
+++ b/Formula/pacvim.rb
@@ -15,8 +15,6 @@ class Pacvim < Formula
     sha256 "13f43d00b08183febdc7afcba0553cd512dd9ae23a7fd770b09e3eedb4f8ea37" => :mountain_lion
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/pagmo.rb
+++ b/Formula/pagmo.rb
@@ -16,8 +16,6 @@ class Pagmo < Formula
   depends_on "eigen"
   depends_on "nlopt"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", "-DPAGMO_WITH_EIGEN3=ON", "-DPAGMO_WITH_NLOPT=ON",

--- a/Formula/pangomm.rb
+++ b/Formula/pangomm.rb
@@ -16,8 +16,6 @@ class Pangomm < Formula
   depends_on "glibmm"
   depends_on "pango"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/pdfgrep.rb
+++ b/Formula/pdfgrep.rb
@@ -24,8 +24,6 @@ class Pdfgrep < Formula
   depends_on "pcre"
   depends_on "poppler"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./autogen.sh" if build.head?

--- a/Formula/pdftoedn.rb
+++ b/Formula/pdftoedn.rb
@@ -22,8 +22,6 @@ class Pdftoedn < Formula
   depends_on "poppler"
   depends_on "rapidjson"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/pdftoipe.rb
+++ b/Formula/pdftoipe.rb
@@ -14,8 +14,6 @@ class Pdftoipe < Formula
   depends_on "pkg-config" => :build
   depends_on "poppler"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -13,7 +13,7 @@ class Pdnsrec < Formula
 
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "gcc" if DevelopmentTools.clang_build_version <= 600
+  depends_on "gcc" if DevelopmentTools.clang_build_version == 600
   depends_on "lua"
   depends_on "openssl"
 
@@ -21,8 +21,6 @@ class Pdnsrec < Formula
     build 600
     cause "incomplete C++11 support"
   end
-
-  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -41,8 +41,6 @@ class Php < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -43,8 +43,6 @@ class PhpAT71 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -43,8 +43,6 @@ class PhpAT72 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra

--- a/Formula/pioneer.rb
+++ b/Formula/pioneer.rb
@@ -23,8 +23,6 @@ class Pioneer < Formula
   depends_on "sdl2"
   depends_on "sdl2_image"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["PIONEER_DATA_DIR"] = "#{pkgshare}/data"

--- a/Formula/pioneers.rb
+++ b/Formula/pioneers.rb
@@ -18,11 +18,6 @@ class Pioneers < Formula
   depends_on "gtk+3"
   depends_on "librsvg" # svg images for gdk-pixbuf
 
-  fails_with :clang do
-    build 318
-    cause "'#line directive requires a positive integer' argument in generated file"
-  end
-
   def install
     # fix usage of echo options not supported by sh
     inreplace "Makefile.in", /\becho/, "/bin/echo"

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -26,8 +26,6 @@ class Ponyc < Formula
   depends_on :macos => :yosemite
   depends_on "pcre2"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["LLVM_CONFIG"] = "#{Formula["llvm@3.9"].opt_bin}/llvm-config"

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -36,8 +36,6 @@ class Poppler < Formula
     sha256 "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/postgres-xc.rb
+++ b/Formula/postgres-xc.rb
@@ -18,11 +18,6 @@ class PostgresXc < Formula
   conflicts_with "postgresql",
     :because => "postgres-xc and postgresql install the same binaries."
 
-  fails_with :clang do
-    build 211
-    cause "Miscompilation resulting in segfault on queries"
-  end
-
   # Fix PL/Python build: https://github.com/Homebrew/homebrew/issues/11162
   patch :DATA
 

--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -22,8 +22,6 @@ class Povray < Formula
   depends_on :macos => :lion
   depends_on "openexr"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/prefixsuffix.rb
+++ b/Formula/prefixsuffix.rb
@@ -16,8 +16,6 @@ class Prefixsuffix < Formula
   depends_on "pkg-config" => :build
   depends_on "gtkmm3"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/protobuf-c.rb
+++ b/Formula/protobuf-c.rb
@@ -16,8 +16,6 @@ class ProtobufC < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -19,8 +19,6 @@ class ProtobufSwift < Formula
   conflicts_with "swift-protobuf",
     :because => "both install `protoc-gen-swift` binaries"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -25,8 +25,6 @@ class Protobuf < Formula
     sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
   end
 
-  needs :cxx11
-
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -28,11 +28,6 @@ class Pulseaudio < Formula
   depends_on "openssl"
   depends_on "speexdsp"
 
-  fails_with :clang do
-    build 421
-    cause "error: thread-local storage is unsupported for the current target"
-  end
-
   def install
     args = %W[
       --disable-dependency-tracking

--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -22,9 +22,6 @@ class Pypy < Formula
   depends_on "openssl"
   depends_on "sqlite"
 
-  # https://bugs.launchpad.net/ubuntu/+source/gcc-4.2/+bug/187391
-  fails_with :gcc_4_2
-
   resource "bootstrap" do
     url "https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2"
     version "6.0.0"

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -23,9 +23,6 @@ class Pypy3 < Formula
   depends_on "sqlite"
   depends_on "xz"
 
-  # https://bugs.launchpad.net/ubuntu/+source/gcc-4.2/+bug/187391
-  fails_with :gcc_4_2
-
   # packaging depends on pyparsing
   resource "pyparsing" do
     url "https://files.pythonhosted.org/packages/3c/ec/a94f8cf7274ea60b5413df054f82a8980523efd712ec55a59e7c3357cf7c/pyparsing-2.2.0.tar.gz"

--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -34,11 +34,6 @@ class Python < Formula
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5", "bin/pip-3.6", "bin/pip-3.7"
   skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5", "bin/easy_install-3.6", "bin/easy_install-3.7"
 
-  fails_with :clang do
-    build 425
-    cause "https://bugs.python.org/issue24844"
-  end
-
   resource "setuptools" do
     url "https://files.pythonhosted.org/packages/37/1b/b25507861991beeade31473868463dad0e58b1978c209de27384ae541b0b/setuptools-40.6.3.zip"
     sha256 "3b474dad69c49f0d2d86696b68105f3a6f195f7ab655af12ef9a9c326d2b08f8"

--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -25,10 +25,6 @@ class Qemu < Formula
   depends_on "pixman"
   depends_on "vde"
 
-  fails_with :gcc do
-    cause "qemu requires a compiler with support for the __thread specifier"
-  end
-
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
     url "https://dl.bintray.com/homebrew/mirror/FD12FLOPPY.zip"

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -16,8 +16,6 @@ class Qjackctl < Formula
   depends_on "jack"
   depends_on "qt"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "./configure", "--disable-debug",

--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -13,8 +13,6 @@ class Re2 < Formula
     sha256 "06a90d1d8bfcab9a86323fc00034057cef39c66077f06664009f6eeb57cef44c" => :sierra
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -17,11 +17,6 @@ class Rethinkdb < Formula
   depends_on :macos => :lion
   depends_on "openssl"
 
-  fails_with :gcc do
-    build 5666 # GCC 4.2.1
-    cause "RethinkDB uses C++0x"
-  end
-
   # Fix error with Xcode 9, patch merged upstream:
   # https://github.com/rethinkdb/rethinkdb/pull/6450
   if DevelopmentTools.clang_build_version >= 900

--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -16,8 +16,6 @@ class Rocksdb < Formula
   depends_on "lz4"
   depends_on "snappy"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["PORTABLE"] = "1" if build.bottle?

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -44,8 +44,6 @@ class Root < Formula
 
   skip_clean "bin"
 
-  needs :cxx11
-
   def install
     # Work around "error: no member named 'signbit' in the global namespace"
     ENV.delete("SDKROOT") if DevelopmentTools.clang_build_version >= 900

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -44,12 +44,6 @@ class Rust < Formula
   depends_on "openssl"
   depends_on "pkg-config"
 
-  # According to the official readme, GCC 4.7+ is required
-  fails_with :gcc_4_2
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   resource "cargobootstrap" do
     # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.txt
     url "https://static.rust-lang.org/dist/2018-12-20/cargo-0.32.0-x86_64-apple-darwin.tar.gz"

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -22,10 +22,6 @@ class Scipy < Formula
 
   cxxstdlib_check :skip
 
-  # https://github.com/Homebrew/homebrew-python/issues/110
-  # There are ongoing problems with gcc+accelerate.
-  fails_with :gcc_4_2
-
   def install
     openblas = Formula["openblas"].opt_prefix
     ENV["ATLAS"] = "None" # avoid linking against Accelerate.framework

--- a/Formula/sdcv.rb
+++ b/Formula/sdcv.rb
@@ -19,9 +19,6 @@ class Sdcv < Formula
   depends_on "glib"
   depends_on "readline"
 
-  # see: https://github.com/Homebrew/homebrew/issues/26321
-  needs :cxx11
-
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args

--- a/Formula/sdf.rb
+++ b/Formula/sdf.rb
@@ -18,14 +18,6 @@ class Sdf < Formula
   depends_on "pkg-config" => :build
   depends_on "aterm"
 
-  fails_with :clang do
-    build 425
-    cause <<~EOS
-      ParsedError.c:15434:611: fatal error: parser recursion
-      limit reached, program too complex
-    EOS
-  end
-
   resource "c-library" do
     url "http://www.meta-environment.org/releases/c-library-1.2.tar.gz"
     sha256 "08fdec0faf3c941203ff3decaf518117f49f62a42b111bac39d88e62c453b066"

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -45,10 +45,6 @@ class Sdl < Formula
 
     args = %W[--prefix=#{prefix} --without-x]
     args << "--disable-nasm" unless MacOS.version >= :mountain_lion # might work with earlier, might only work with new clang
-    # LLVM-based compilers choke on the assembly code packaged with SDL.
-    if ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421
-      args << "--disable-assembly"
-    end
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -45,9 +45,6 @@ class Sdl2 < Formula
     args = %W[--prefix=#{prefix} --without-x]
 
     # LLVM-based compilers choke on the assembly code packaged with SDL.
-    if ENV.compiler == :clang && DevelopmentTools.clang_build_version < 421
-      args << "--disable-assembly"
-    end
     args << "--disable-haptic" << "--disable-joystick" if MacOS.version <= :snow_leopard
 
     system "./configure", *args

--- a/Formula/shibboleth-sp.rb
+++ b/Formula/shibboleth-sp.rb
@@ -25,8 +25,6 @@ class ShibbolethSp < Formula
   depends_on "xml-security-c"
   depends_on "xml-tooling-c"
 
-  needs :cxx11
-
   def install
     ENV.O2 # Os breaks the build
     ENV.cxx11

--- a/Formula/shogun.rb
+++ b/Formula/shogun.rb
@@ -62,8 +62,6 @@ class Shogun < Formula
     sha256 "0a1c3e2e16b2ce70855c1f15876bddd5e5de35ab29290afceacdf7179c4558cb"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/simh.rb
+++ b/Formula/simh.rb
@@ -16,15 +16,6 @@ class Simh < Formula
     sha256 "e9043ec0dc68a5660a20fe270488dbfbf8741a77aae8dace61441fc348e74234" => :mavericks
   end
 
-  # After 3.9-0 the project moves to https://github.com/simh/simh
-  # It doesn't actually fail, but the makefile queries llvm-gcc -v --help a lot
-  # to determine what flags to throw.  It is simply not designed for clang.
-  # Remove at the next revision that will support clang (see github site).
-  fails_with :clang do
-    build 421
-    cause "The program is closely tied to gcc & llvm-gcc in this revision."
-  end
-
   def install
     ENV.deparallelize unless build.head?
     inreplace "makefile", "GCC = gcc", "GCC = #{ENV.cc}"

--- a/Formula/simple-mtpfs.rb
+++ b/Formula/simple-mtpfs.rb
@@ -19,8 +19,6 @@ class SimpleMtpfs < Formula
   depends_on "libmtp"
   depends_on :osxfuse
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -40,8 +40,6 @@ class Siril < Formula
     sha256 "22e179e832c7f6a28d5f2bfb3953be477b15450df41ceeb353b77376bec7e048"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/sl.rb
+++ b/Formula/sl.rb
@@ -15,10 +15,6 @@ class Sl < Formula
     sha256 "c7d4432bfc169f7338eeb0c8300a975495b229d6e85bfff4fdd6bbd11eb8da17" => :mavericks
   end
 
-  fails_with :clang do
-    build 318
-  end
-
   def install
     system "make", "-e"
     bin.install "sl"

--- a/Formula/soci.rb
+++ b/Formula/soci.rb
@@ -14,11 +14,6 @@ class Soci < Formula
   depends_on "cmake" => :build
   depends_on "sqlite" if MacOS.version <= :snow_leopard
 
-  fails_with :clang do
-    build 421
-    cause "Template oddities"
-  end
-
   def install
     args = std_cmake_args + %w[
       -DWITH_SQLITE3:BOOL=ON

--- a/Formula/source-highlight.rb
+++ b/Formula/source-highlight.rb
@@ -15,8 +15,6 @@ class SourceHighlight < Formula
 
   depends_on "boost"
 
-  needs :cxx11
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -14,8 +14,6 @@ class Spdlog < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/sphinx.rb
+++ b/Formula/sphinx.rb
@@ -15,11 +15,6 @@ class Sphinx < Formula
   depends_on "mysql"
   depends_on "openssl"
 
-  fails_with :clang do
-    build 421
-    cause "sphinxexpr.cpp:1802:11: error: use of undeclared identifier 'ExprEval'"
-  end
-
   resource "stemmer" do
     url "https://github.com/snowballstem/snowball.git",
         :revision => "9b58e92c965cd7e3208247ace3cc00d173397f3c"

--- a/Formula/stk.rb
+++ b/Formula/stk.rb
@@ -15,11 +15,6 @@ class Stk < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  fails_with :clang do
-    build 421
-    cause "due to configure file this application will not properly compile with clang"
-  end
-
   def install
     system "autoreconf", "-fiv"
     system "./configure", "--prefix=#{prefix}", "--disable-debug"

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -14,8 +14,6 @@ class StoneSoup < Formula
   depends_on "lua@5.1"
   depends_on "pcre"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -34,14 +34,6 @@ class Subversion < Formula
   depends_on "sqlite"
   depends_on "utf8proc"
 
-  # When building Perl or Ruby bindings, need to use a compiler that
-  # recognizes GCC-style switches, since that's what the system languages
-  # were compiled against.
-  fails_with :clang do
-    build 318
-    cause "core.c:1: error: bad value (native) for -march= switch"
-  end
-
   resource "serf" do
     url "https://www.apache.org/dyn/closer.cgi?path=serf/serf-1.3.9.tar.bz2"
     mirror "https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2"

--- a/Formula/supersonic.rb
+++ b/Formula/supersonic.rb
@@ -19,8 +19,6 @@ class Supersonic < Formula
   depends_on "glog"
   depends_on "protobuf"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/supertux.rb
+++ b/Formula/supertux.rb
@@ -41,8 +41,6 @@ class Supertux < Formula
     sha256 "1830dcb88f635f611aa3236abdaee75b53293df407ebc8214f31635a75876831"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/synfig.rb
+++ b/Formula/synfig.rb
@@ -33,8 +33,6 @@ class Synfig < Formula
     sha256 "0ac5b757ba3dda6a863a79e717fc239648c490eac1e643ff275b8ac232a466a3"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     boost = Formula["boost"]

--- a/Formula/task.rb
+++ b/Formula/task.rb
@@ -17,8 +17,6 @@ class Task < Formula
   depends_on "cmake" => :build
   depends_on "gnutls"
 
-  needs :cxx11
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -41,8 +41,6 @@ class Tesseract < Formula
     sha256 "36f772980ff17c66a767f584a0d80bf2302a1afa585c01a226c1863afcea1392"
   end
 
-  needs :cxx11
-
   def install
     # explicitly state leptonica header location, as the makefile defaults to /usr/local/include,
     # which doesn't work for non-default homebrew location

--- a/Formula/thors-serializer.rb
+++ b/Formula/thors-serializer.rb
@@ -14,8 +14,6 @@ class ThorsSerializer < Formula
 
   depends_on "libyaml"
 
-  needs :cxx14
-
   def install
     ENV["COV"] = "gcov"
 

--- a/Formula/tmux-mem-cpu-load.rb
+++ b/Formula/tmux-mem-cpu-load.rb
@@ -17,8 +17,6 @@ class TmuxMemCpuLoad < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/tracebox.rb
+++ b/Formula/tracebox.rb
@@ -21,8 +21,6 @@ class Tracebox < Formula
   depends_on "json-c"
   depends_on "lua"
 
-  needs :cxx11
-
   def install
     ENV.libcxx
     system "autoreconf", "--install"

--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -5,8 +5,6 @@ class Trafficserver < Formula
   stable do
     url "https://www.apache.org/dyn/closer.cgi?path=trafficserver/trafficserver-7.1.4.tar.bz2"
     sha256 "1c5213f8565574ec8a66e08529fd20060c1b9a6cd9b803ba9bbb3b9847651b53"
-
-    needs :cxx11
   end
 
   bottle do

--- a/Formula/upscaledb.rb
+++ b/Formula/upscaledb.rb
@@ -37,11 +37,6 @@ class Upscaledb < Formula
   depends_on "openssl"
   depends_on "protobuf"
 
-  fails_with :clang do
-    build 503
-    cause "error: member access into incomplete type 'const std::type_info"
-  end
-
   resource "libuv" do
     url "https://github.com/libuv/libuv/archive/v0.10.37.tar.gz"
     sha256 "4c12bed4936dc16a20117adfc5bc18889fa73be8b6b083993862628469a1e931"

--- a/Formula/urdfdom.rb
+++ b/Formula/urdfdom.rb
@@ -18,8 +18,6 @@ class Urdfdom < Formula
   depends_on "tinyxml"
   depends_on "urdfdom_headers"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/urdfdom_headers.rb
+++ b/Formula/urdfdom_headers.rb
@@ -13,8 +13,6 @@ class UrdfdomHeaders < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args

--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -19,8 +19,6 @@ class V8 < Formula
   # https://bugs.chromium.org/p/chromium/issues/detail?id=620127
   depends_on :macos => :el_capitan
 
-  needs :cxx11
-
   def install
     # Add depot_tools in PATH
     ENV.prepend_path "PATH", buildpath

--- a/Formula/vc4asm.rb
+++ b/Formula/vc4asm.rb
@@ -20,8 +20,6 @@ class Vc4asm < Formula
     sha256 "2ea9a9e660e85dace2e9b1c9be17a57c8a91e89259d477f9f63820aee102a2d3"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/visp.rb
+++ b/Formula/visp.rb
@@ -25,8 +25,6 @@ class Visp < Formula
   # https://github.com/lagadic/visp/commit/547041b8
   patch :DATA
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/vowpal-wabbit.rb
+++ b/Formula/vowpal-wabbit.rb
@@ -17,8 +17,6 @@ class VowpalWabbit < Formula
   depends_on "libtool" => :build
   depends_on "boost"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV["AC_PATH"] = "#{HOMEBREW_PREFIX}/share"

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -24,8 +24,6 @@ class Vtk < Formula
   depends_on "python"
   depends_on "qt"
 
-  needs :cxx11
-
   def install
     python_executable = `which python3`.strip
     python_prefix = `#{python_executable} -c 'import sys;print(sys.prefix)'`.chomp

--- a/Formula/wellington.rb
+++ b/Formula/wellington.rb
@@ -23,8 +23,6 @@ class Wellington < Formula
         :revision => "f09c4662a0bd6bd8943ac7b4931e185df9471da4"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11 if MacOS.version < :mavericks
 

--- a/Formula/widelands.rb
+++ b/Formula/widelands.rb
@@ -25,8 +25,6 @@ class Widelands < Formula
   depends_on "sdl2_net"
   depends_on "sdl2_ttf"
 
-  needs :cxx11
-
   def install
     # icu4c 61.1 compatability
     ENV.append "CXXFLAGS", "-DU_USING_ICU_NAMESPACE=1"

--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -27,8 +27,6 @@ class XalanC < Formula
     sha256 "7c317c6b99cb5fb44da700e954e6b3e8c5eda07bef667f74a42b0099d038d767"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     ENV.deparallelize # See https://issues.apache.org/jira/browse/XALANC-696

--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -14,8 +14,6 @@ class XercesC < Formula
 
   depends_on "cmake" => :build
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/xml-security-c.rb
+++ b/Formula/xml-security-c.rb
@@ -16,8 +16,6 @@ class XmlSecurityC < Formula
   depends_on "openssl"
   depends_on "xerces-c"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/xml-tooling-c.rb
+++ b/Formula/xml-tooling-c.rb
@@ -24,8 +24,6 @@ class XmlToolingC < Formula
     sha256 "7802c54076500be500b171fde786258579d60547a3a35b8c5a23d8c88e8f9620"
   end
 
-  needs :cxx11
-
   def install
     ENV.O2 # Os breaks the build
     ENV.cxx11

--- a/Formula/xqilla.rb
+++ b/Formula/xqilla.rb
@@ -17,8 +17,6 @@ class Xqilla < Formula
 
   conflicts_with "zorba", :because => "Both supply xqc.h"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/xsd.rb
+++ b/Formula/xsd.rb
@@ -30,8 +30,6 @@ class Xsd < Formula
   #    received no response (yet).
   patch :DATA
 
-  needs :cxx11
-
   def install
     ENV.append "LDFLAGS", `pkg-config --libs --static xerces-c`.chomp
     ENV.cxx11

--- a/Formula/xtensor.rb
+++ b/Formula/xtensor.rb
@@ -18,8 +18,6 @@ class Xtensor < Formula
     sha256 "6f9d2f849e4dd8a36db1e62648ed1855a691991739119b0a73cd55084c6d28b2"
   end
 
-  needs :cxx14
-
   def install
     resource("xtl").stage do
       system "cmake", ".", *std_cmake_args

--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -22,8 +22,6 @@ class YamlCpp < Formula
     sha256 "52da989f0dcaca68ae9ee6334155954639506e16cbe3b9bd007dace9e171e4bd"
   end
 
-  needs :cxx11
-
   def install
     system "cmake", ".", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
     system "make", "install"

--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -30,8 +30,6 @@ class Zbackup < Formula
     sha256 "060491c216a145d34a8fd3385b138630718579404e1a2ec2adea284a52699672"
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -17,10 +17,6 @@ class Zile < Formula
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
 
-  fails_with :gcc do
-    cause "src/funcs.c:1128: error: #pragma GCC diagnostic not allowed inside functions"
-  end
-
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/zmqpp.rb
+++ b/Formula/zmqpp.rb
@@ -15,8 +15,6 @@ class Zmqpp < Formula
   depends_on "doxygen" => :build
   depends_on "zeromq"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/znc.rb
+++ b/Formula/znc.rb
@@ -24,8 +24,6 @@ class Znc < Formula
   depends_on "openssl"
   depends_on "python"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     # These need to be set in CXXFLAGS, because ZNC will embed them in its

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -19,8 +19,6 @@ class Zorba < Formula
 
   conflicts_with "xqilla", :because => "Both supply xqc.h"
 
-  needs :cxx11
-
   def install
     # icu4c 61.1 compatability
     ENV.append "CXXFLAGS", "-DU_USING_ICU_NAMESPACE=1"


### PR DESCRIPTION
We will no longer support versions before Mavericks in 2.0.0 (or, more specifically, after https://github.com/Homebrew/brew/pull/5599 is merged)

As a result, remove checks for old compilers that never shipped on Mavericks
(Apple GCC 4.0, Apple GCC 4.2, Clang < 6.0.0). Additionally, remove checks for
C++11 and C++14 that are supported by all the compilers that are supported on
Homebrew.

I will immediately cancel CI because this will be a long, pointless job
otherwise.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----