### PR TITLE
Remove unnecessary Xcode.installed? checks.

### DIFF
--- a/Formula/anttweakbar.rb
+++ b/Formula/anttweakbar.rb
@@ -29,8 +29,7 @@ class Anttweakbar < Formula
     # namespace" and Xcode 8 issue on El Capitan "error: missing ',' between
     # enumerators"
     if DevelopmentTools.clang_build_version >= 900 ||
-       (MacOS.version == :el_capitan && MacOS::Xcode.installed? &&
-       MacOS::Xcode.version >= "8.0")
+       (MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0")
       ENV.delete("SDKROOT")
     end
 

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -23,7 +23,7 @@ class ArgyllCms < Formula
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # Reported 20 Aug 2017 to graeme AT argyllcms DOT com
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "numlib/numsup.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH"
     end
 

--- a/Formula/baresip.rb
+++ b/Formula/baresip.rb
@@ -16,7 +16,7 @@ class Baresip < Formula
 
   def install
     # baresip doesn't like the 10.11 SDK when on Yosemite
-    if MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7
+    if MacOS::Xcode.version.to_i >= 7
       ENV.delete("SDKROOT")
       ENV.delete("HOMEBREW_SDKROOT") if MacOS::Xcode.without_clt?
     end

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -30,8 +30,7 @@ class Bitcoin < Formula
   needs :cxx11
 
   def install
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? &&
-       MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       ENV.delete("SDKROOT")
     end
 

--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -16,7 +16,7 @@ class Chezscheme < Formula
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # Reported 20 Feb 2017 https://github.com/cisco/ChezScheme/issues/146
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       inreplace "c/stats.c" do |s|
         s.gsub! "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH"
         s.gsub! "CLOCK_PROCESS_CPUTIME_ID", "UNDEFINED_GIBBERISH"

--- a/Formula/cmocka.rb
+++ b/Formula/cmocka.rb
@@ -17,7 +17,7 @@ class Cmocka < Formula
   def install
     args = std_cmake_args
     args << "-DWITH_STATIC_LIB=ON" << "-DWITH_CMOCKERY_SUPPORT=ON" << "-DUNIT_TESTING=ON"
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0"
     end
 

--- a/Formula/erlang@18.rb
+++ b/Formula/erlang@18.rb
@@ -48,7 +48,7 @@ class ErlangAT18 < Formula
   def install
     # Fixes "dyld: Symbol not found: _clock_gettime"
     # Reported 17 Sep 2016 https://bugs.erlang.org/browse/ERL-256
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       ENV["erl_cv_clock_gettime_monotonic_default_resolution"] = "no"
       ENV["erl_cv_clock_gettime_monotonic_try_find_pthread_compatible"] = "no"
       ENV["erl_cv_clock_gettime_wall_default_resolution"] = "no"

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -38,7 +38,7 @@ class FfmpegAT28 < Formula
 
   def install
     # Fixes "dyld: lazy symbol binding failed: Symbol not found: _clock_gettime"
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       inreplace %w[libavdevice/v4l2.c libavutil/time.c], "HAVE_CLOCK_GETTIME",
                                                          "UNDEFINED_GIBBERISH"
     end

--- a/Formula/gnu-smalltalk.rb
+++ b/Formula/gnu-smalltalk.rb
@@ -26,7 +26,7 @@ class GnuSmalltalk < Formula
 
   def install
     # Fix build failure "Symbol not found: _clock_gettime"
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       ENV["ac_cv_search_clock_gettime"] = "no"
     end
 

--- a/Formula/gtk-gnutella.rb
+++ b/Formula/gtk-gnutella.rb
@@ -18,7 +18,7 @@ class GtkGnutella < Formula
   def install
     ENV.deparallelize
 
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "Configure", "ret = clock_gettime(CLOCK_REALTIME, &tp);",
                              "ret = undefinedgibberish(CLOCK_REALTIME, &tp);"
     end

--- a/Formula/libcddb.rb
+++ b/Formula/libcddb.rb
@@ -17,7 +17,7 @@ class Libcddb < Formula
   depends_on "libcdio"
 
   def install
-    if MacOS.version == :yosemite && MacOS::Xcode.installed? && MacOS::Xcode.version >= "7.0"
+    if MacOS.version == :yosemite && MacOS::Xcode.version >= "7.0"
       ENV.delete("SDKROOT")
     end
 

--- a/Formula/masscan.rb
+++ b/Formula/masscan.rb
@@ -16,7 +16,7 @@ class Masscan < Formula
   def install
     # Fix `dyld: lazy symbol binding failed: Symbol not found: _clock_gettime`
     # Reported 8 July 2017: https://github.com/robertdavidgraham/masscan/issues/284
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "src/pixie-timer.c", "#elif defined(CLOCK_MONOTONIC)", "#elif defined(NOT_A_MACRO)"
     end
 

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -81,7 +81,7 @@ class Mesos < Formula
     ENV.O0 unless DevelopmentTools.clang_build_version >= 900
 
     # work around to avoid `_clock_gettime` symbol not found error.
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       ENV["ac_have_clock_syscall"] = "no"
     end
 

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -38,7 +38,7 @@ class MysqlCluster < Formula
     (var/"mysql-cluster").mkpath
 
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       inreplace "configure.cmake", "(clock_gettime", "(everything_is_terrible"
     end
 

--- a/Formula/pigz.rb
+++ b/Formula/pigz.rb
@@ -15,7 +15,7 @@ class Pigz < Formula
   def install
     # Fix dyld: lazy symbol binding failed: Symbol not found: _deflatePending
     # Reported 8 Dec 2016 to madler at alumni.caltech.edu
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "pigz.c", "ZLIB_VERNUM >= 0x1260", "ZLIB_VERNUM >= 0x9999"
     end
 

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -62,7 +62,7 @@ class Pypy3 < Formula
 
   def install
     # Work around "dyld: Symbol not found: _utimensat"
-    if MacOS.version == :sierra && MacOS::Xcode.installed? && MacOS::Xcode.version >= "9.0"
+    if MacOS.version == :sierra && MacOS::Xcode.version >= "9.0"
       ENV.delete("SDKROOT")
     end
 

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -23,7 +23,7 @@ class Rtags < Formula
 
     args = std_cmake_args << "-DRTAGS_NO_BUILD_CLANG=ON"
 
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       args << "-DHAVE_CLOCK_MONOTONIC_RAW:INTERNAL=0"
       args << "-DHAVE_CLOCK_MONOTONIC:INTERNAL=0"
     end

--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -23,7 +23,7 @@ class Spdylay < Formula
   depends_on "openssl"
 
   def install
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       ENV["ac_cv_search_clock_gettime"] = "no"
     end
 

--- a/Formula/tarsnap.rb
+++ b/Formula/tarsnap.rb
@@ -23,7 +23,7 @@ class Tarsnap < Formula
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # Reported 20 Aug 2017 https://github.com/Tarsnap/tarsnap/issues/286
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "libcperciva/util/monoclock.c", "CLOCK_MONOTONIC",
                                                 "UNDEFINED_GIBBERISH"
     end

--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -20,8 +20,7 @@ class Xdotool < Formula
   def install
     # Work around an issue with Xcode 8 on El Capitan, which
     # errors out with `typedef redefinition with different types`
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? &&
-       MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       ENV.delete("SDKROOT")
     end
 

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -32,7 +32,7 @@ class Zabbix < Formula
       --with-openssl=#{Formula["openssl"].opt_prefix}
     ]
 
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       inreplace "configure", "clock_gettime(CLOCK_REALTIME, &tp);",
                              "undefinedgibberish(CLOCK_REALTIME, &tp);"
     end

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -31,7 +31,7 @@ class Zorba < Formula
 
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # usual superenv fix doesn't work since zorba doesn't use HAVE_CLOCK_GETTIME
-    if MacOS.version == :el_capitan && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"
       args << "-DZORBA_HAVE_CLOCKGETTIME=OFF"
     end
 


### PR DESCRIPTION
The version comparisons are sufficient now since `Version::NULL`.

Will kill the CI build as there's no output changes.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----