### PR TITLE
Update kustomize.rb to allow installing from HEAD

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -4,6 +4,8 @@ class Kustomize < Formula
   url "https://github.com/kubernetes-sigs/kustomize.git",
       :tag      => "v1.0.11",
       :revision => "8f701a00417a812558a7b785e8354957afa469ae"
+  
+  head "https://github.com/kubernetes-sigs/kustomize.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
