### PR TITLE
trace2html 2019-01-26

### DIFF
--- a/Formula/trace2html.rb
+++ b/Formula/trace2html.rb
@@ -1,16 +1,15 @@
 class Trace2html < Formula
   desc "Utility from Google Trace Viewer to convert JSON traces to HTML"
-  homepage "https://github.com/google/trace-viewer"
-  url "https://github.com/google/trace-viewer/archive/2015-07-07.tar.gz"
-  version "2015-07-07"
-  sha256 "6125826d07869fbd634ef898a45df3cabf45e6bcf951f2c63e49f87ce6a0442a"
-  revision 1
+  homepage "https://github.com/catapult-project/catapult/tree/master/tracing"
+  url "https://github.com/catapult-project/catapult/archive/93d499d2f97f3c298a77dff1a55befdf7e97d2a4.tar.gz"
+  version "2019-01-26"
+  sha256 "1779b759d08c5b75ac9a59b3065ac5aa5531e33337b418d1a124bda3d06d173f"
 
   bottle :unneeded
 
   def install
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"tracing/trace2html"
+    bin.install_symlink libexec/"tracing/bin/trace2html"
   end
 
   test do


### PR DESCRIPTION
This patch updates trace2html to a recent HEAD. We also update the
upstream which has moved to a different location some time ago.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
