### PR TITLE
EPUBCheck update 4.1.1

### DIFF
--- a/Formula/epubcheck.rb
+++ b/Formula/epubcheck.rb
@@ -1,8 +1,8 @@
 class Epubcheck < Formula
-  desc "Validate IDPF EPUB files, version 2.0 and later"
-  homepage "https://github.com/IDPF/epubcheck"
-  url "https://github.com/IDPF/epubcheck/releases/download/v4.1.0/epubcheck-4.1.0.zip"
-  sha256 "8be4f038326099ef95fcbd9dc02a36fb01373833f644573cb964a4442ae727ad"
+  desc "Validate EPUB files, version 2.0 and later"
+  homepage "https://github.com/w3c/epubcheck"
+  url "https://github.com/w3c/epubcheck/releases/download/v4.1.1/epubcheck-4.1.1.zip"
+  sha256 "0d07de09644d40a373bd7b6a35ab08bbf5537095c4f58a667ab98421e703b16a"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See release notes: https://github.com/w3c/epubcheck/releases/tag/v4.1.1

Note that the project moved from IDPF's organization over to the W3C org, thus the URL change.