### PR TITLE
Use libfontconfig in FFmpeg by default

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,7 +3,7 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.1.tar.xz"
   sha256 "a38ec4d026efb58506a99ad5cd23d5a9793b4bf415f2c4c2e9c1bb444acd1994"
-  revision 2
+  revision 3
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -16,6 +16,7 @@ class Ffmpeg < Formula
   depends_on "pkg-config" => :build
   depends_on "texi2html" => :build
 
+  depends_on "fontconfig"
   depends_on "freetype"
   depends_on "frei0r"
   depends_on "lame"
@@ -57,6 +58,7 @@ class Ffmpeg < Formula
       --enable-libx265
       --enable-libxvid
       --enable-lzma
+      --enable-libfontconfig
       --enable-libfreetype
       --enable-frei0r
       --enable-libass

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -3,7 +3,7 @@ class FfmpegAT28 < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-2.8.15.tar.bz2"
   sha256 "35647f6c1f6d4a1719bc20b76bf4c26e4ccd665f46b5676c0e91c5a04622ee21"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "5dc8f7042e9a58edb6a8f046f1dfa461fb1cab0f586f57128a748dd4b2428e6d" => :mojave

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -17,6 +17,7 @@ class FfmpegAT28 < Formula
   depends_on "texi2html" => :build
   depends_on "yasm" => :build
 
+  depends_on "fontconfig"
   depends_on "freetype"
   depends_on "frei0r"
   depends_on "lame"
@@ -64,6 +65,7 @@ class FfmpegAT28 < Formula
       --enable-libx264
       --enable-libx265
       --enable-libxvid
+      --enable-libfontconfig
       --enable-libfreetype
       --enable-frei0r
       --enable-libass


### PR DESCRIPTION
Due to Homebrew/homebrew-core#31510, several options were removed from
the FFmpeg formula in f75cb0920. However, removing "fontconfig" while
leaving "freetype" in seems illogical since they are complementary. For
example, the "drawtext" filter depends on libfreetype, and the "font"
option for the "drawtext" filter depends on libfontconfig.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
