### PR TITLE
man-db 2.8.5 & libpipeline 1.5.1 (new formulae)

### DIFF
--- a/Formula/libpipeline.rb
+++ b/Formula/libpipeline.rb
@@ -1,0 +1,30 @@
+class Libpipeline < Formula
+  desc "C library for manipulating pipelines of subprocesses"
+  homepage "http://libpipeline.nongnu.org/"
+  url "https://download.savannah.nongnu.org/releases/libpipeline/libpipeline-1.5.1.tar.gz"
+  sha256 "d633706b7d845f08b42bc66ddbe845d57e726bf89298e2cee29f09577e2f902f"
+
+  depends_on "pkg-config"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdint.h>
+      #include <pipeline.h>
+      int main(void)
+      {
+        pipeline *p = pipeline_new_command_args("true", NULL);
+        int status = pipeline_run(p);
+        return status;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lpipeline", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -1,0 +1,28 @@
+class ManDb < Formula
+  desc "Modern, featureful implementation of the Unix man page system"
+  homepage "https://nongnu.org/man-db/"
+  url "https://download.savannah.nongnu.org/releases/man-db/man-db-2.8.5.tar.xz"
+  sha256 "b64d52747534f1fe873b2876eb7f01319985309d5d7da319d2bc52ba1e73f6c1"
+  keg_only :provided_by_macos
+  
+  depends_on "libpipeline"
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-systemdtmpfilesdir=no",
+                          "--with-systemdsystemunitdir=no",
+                          "--disable-cache-owner",
+                          "--disable-setuid"
+    # NB: These CFLAGS can be dropped once man-db 2.8.6 is released
+    ENV.append_to_cflags "-Wl,-flat_namespace,-undefined,suppress"
+    system "make", "CFLAGS=#{ENV.cflags}"
+    system "make", "install"
+  end
+
+  test do
+    ENV["PAGER"] = "cat"
+    output = shell_output("#{bin}/man true")
+    assert_match "BSD General Commands Manual", output
+    assert_match "The true utility always returns with exit code zero", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See #25376. This PR uses @ylluminarious's earlier work, which was originally rejected because of an upstream/patch issue. This was [recently fixed](https://github.com/ylluminarious/homebrew-man-db/issues/1) by the maintainer after I brought it up on [Groff's mailing list](https://www.mail-archive.com/groff@gnu.org/msg12489.html). It now builds and runs perfectly on macOS.

/cc @cjwatson