### PR TITLE
delete ENV.cxx11 from libcec.rb

### DIFF
--- a/Formula/libcec.rb
+++ b/Formula/libcec.rb
@@ -19,8 +19,6 @@ class Libcec < Formula
   end
 
   def install
-    ENV.cxx11
-
     resource("p8-platform").stage do
       mkdir "build" do
         system "cmake", "..", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I thought ENV.cxx11 was not necessary because of [the commit(cmake: remove checks for old compilers.) ](https://github.com/Homebrew/homebrew-core/commit/aa10a24bf061c712614d0fd3b09985e49dc0dbdd#diff-2520107225be308c9b77672fb2497213)