### PR TITLE
Use --lc-collate option for initdb

### DIFF
--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -63,7 +63,9 @@ begin
   end
 
   sql_for_lc_collate = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate';"
+  sql_for_lc_ctype = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_ctype';"
   lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).strip
+  lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_ctype).strip
 
   if quiet_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "status"
     system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "stop"
@@ -74,10 +76,10 @@ begin
   moved_data = true
 
   (var/"postgres").mkpath
-  if lc_collate.empty?
+  if lc_collate.empty? || lc_ctype.empty?
     system "#{bin}/initdb", "#{var}/postgres"
   else
-    system "#{bin}/initdb", "--lc-collate", lc_collate, "#{var}/postgres"
+    system "#{bin}/initdb", "--lc-collate", lc_collate, "--lc-ctype", lc_ctype, "#{var}/postgres"
   end
   initdb_run = true
 

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -53,7 +53,9 @@ begin
   unless system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "status", out: File::NULL
     safe_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "start", out: File::NULL
   end
-  lc_collate = `#{old_bin}/psql postgres -qtAc "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate'";`.strip
+
+  sql_for_lc_collate = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate';"
+  lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).strip
 
   if /#{name}\s+started/ =~ Utils.popen_read("brew", "services", "list")
     system "brew", "services", "stop", name

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -54,7 +54,6 @@ begin
     safe_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "start", out: File::NULL
   end
   lc_collate = `#{old_bin}/psql postgres -qtAc "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate'";`.strip
-  lc_collate = 'en_US.UTF-8' if lc_collate.empty?
 
   if /#{name}\s+started/ =~ Utils.popen_read("brew", "services", "list")
     system "brew", "services", "stop", name
@@ -69,7 +68,11 @@ begin
   moved_data = true
 
   (var/"postgres").mkpath
-  system "#{bin}/initdb", "--lc-collate", lc_collate, "#{var}/postgres"
+  if lc_collate.empty?
+    system "#{bin}/initdb", "#{var}/postgres"
+  else
+    system "#{bin}/initdb", "--lc-collate", lc_collate, "#{var}/postgres"
+  end
   initdb_run = true
 
   (var/"log").cd do

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -66,6 +66,9 @@ begin
   sql_for_lc_ctype = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_ctype';"
   lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).strip
   lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_ctype).strip
+  initdb_args = []
+  initdb_args += ["--lc-collate", lc_collate] unless lc_collate.empty?
+  initdb_args += ["--lc-ctype", lc_ctype] unless lc_ctype.empty?
 
   if quiet_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "status"
     system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "stop"
@@ -76,11 +79,7 @@ begin
   moved_data = true
 
   (var/"postgres").mkpath
-  if lc_collate.empty? || lc_ctype.empty?
-    system "#{bin}/initdb", "#{var}/postgres"
-  else
-    system "#{bin}/initdb", "--lc-collate", lc_collate, "--lc-ctype", lc_ctype, "#{var}/postgres"
-  end
+  system "#{bin}/initdb", *initdb_args, "#{var}/postgres"
   initdb_run = true
 
   (var/"log").cd do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I added `--lc-collate` option when initialize new database to avoid different locale error.

The script doesn't belong to a formula, so I don't know how to run the test.
I just run it in my environment to check the functionality.
Please tell me if there is a proper way to test it.

Related topic in discource: https://discourse.brew.sh/t/postgresql-upgrade-database-consistency-check-failure-was-my-data-migrated-or-not/2139