### PR TITLE
cafeobj 1.5.9 (new formula)

### DIFF
--- a/Formula/cafeobj.rb
+++ b/Formula/cafeobj.rb
@@ -1,0 +1,18 @@
+class Cafeobj < Formula
+  desc "New generation algebraic specification and programming language"
+  homepage "https://cafeobj.org/"
+  url "http://cafeobj.org/files/1.5.9/cafeobj-1.5.9.tar.gz"
+  sha256 "a4085e9ee060a8a0a22cb7c522c17aa1ccadb5bdce8f90085e08ded3794498d4"
+  revision 1
+
+  depends_on "sbcl"
+
+  def install
+    system "./configure", "--with-lisp=sbcl", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "cafeobj", "-batch"
+  end
+end

--- a/Formula/cafeobj.rb
+++ b/Formula/cafeobj.rb
@@ -3,7 +3,6 @@ class Cafeobj < Formula
   homepage "https://cafeobj.org/"
   url "http://cafeobj.org/files/1.5.9/cafeobj-1.5.9.tar.gz"
   sha256 "a4085e9ee060a8a0a22cb7c522c17aa1ccadb5bdce8f90085e08ded3794498d4"
-  revision 1
 
   depends_on "sbcl"
 

--- a/Formula/cafeobj.rb
+++ b/Formula/cafeobj.rb
@@ -7,7 +7,7 @@ class Cafeobj < Formula
   depends_on "sbcl"
 
   def install
-    system "./configure", "--with-lisp=sbcl", "--prefix=#{prefix}", "--with-lispdir=#{prefix}/share/emacs/site-lisp/cafeobj'"
+    system "./configure", "--with-lisp=sbcl", "--prefix=#{prefix}", "--with-lispdir=#{share}/emacs/site-lisp/cafeobj"
     system "make", "install"
   end
 

--- a/Formula/cafeobj.rb
+++ b/Formula/cafeobj.rb
@@ -7,7 +7,7 @@ class Cafeobj < Formula
   depends_on "sbcl"
 
   def install
-    system "./configure", "--with-lisp=sbcl", "--prefix=#{prefix}"
+    system "./configure", "--with-lisp=sbcl", "--prefix=#{prefix}", "--with-lispdir=#{prefix}/share/emacs/site-lisp/cafeobj'"
     system "make", "install"
   end
 

--- a/Formula/cafeobj.rb
+++ b/Formula/cafeobj.rb
@@ -1,7 +1,7 @@
 class Cafeobj < Formula
   desc "New generation algebraic specification and programming language"
   homepage "https://cafeobj.org/"
-  url "http://cafeobj.org/files/1.5.9/cafeobj-1.5.9.tar.gz"
+  url "https://cafeobj.org/files/1.5.9/cafeobj-1.5.9.tar.gz"
   sha256 "a4085e9ee060a8a0a22cb7c522c17aa1ccadb5bdce8f90085e08ded3794498d4"
 
   depends_on "sbcl"
@@ -12,6 +12,6 @@ class Cafeobj < Formula
   end
 
   test do
-    system "cafeobj", "-batch"
+    system "#{bin}/cafeobj", "-batch"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
I have tried to run this on my Linuxbrew but without success:
```
$ brew audit --strict Formula/cafeobj.rb 
==> Installing or updating 'bundler' gem
Error: Unable to resolve dependency: user requested 'did_you_mean (= 1.2.1)'
```

-----

CafeOBJ has been installed via a third party tap maintained by me in several computers already, now I would like to include it into the main Brew repository. As I am maintaining CafeOBJ and have provided (mac)ports installation options as well as Debian packages, I would like to see a brew formula, too.

I would also like to add bottles, but without a Mac computer I *think* I cannot do this.

Thanks

Norbert