### PR TITLE
tintin 2.01.6

### DIFF
--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -1,9 +1,8 @@
 class Tintin < Formula
   desc "MUD client"
   homepage "https://tintin.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/tintin/TinTin%2B%2B%20Source%20Code/2.01.4/tintin-2.01.4.tar.gz"
-  sha256 "dd22afbff45a93ec399065bae385489131af7e1b6ae8abb28f80d6a03b82ebbc"
-  revision 2
+  url "http://downloads.sourceforge.net/tintin/tintin-2.01.6.tar.gz"
+  sha256 "522b3ca3ef2aadc0c3c3fd4a2cb9b779c977c9db5ea5e18309bf120cd11d153e"
 
   bottle do
     cellar :any

--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -1,7 +1,7 @@
 class Tintin < Formula
   desc "MUD client"
   homepage "https://tintin.sourceforge.io/"
-  url "http://downloads.sourceforge.net/tintin/tintin-2.01.6.tar.gz"
+  url "https://downloads.sourceforge.net/tintin/tintin-2.01.6.tar.gz"
   sha256 "522b3ca3ef2aadc0c3c3fd4a2cb9b779c977c9db5ea5e18309bf120cd11d153e"
 
   bottle do


### PR DESCRIPTION
Upgrading the package to 2.01.6
Use the URL recommended by install documentation https://tintin.sourceforge.io/install.php#OSX

Signed-off-by: Amelia Aronsohn <WagThatTail@Me.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
