### PR TITLE
w3m 0.5.3-37 (new formula)

### DIFF
--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,7 +1,7 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "https://w3m.sourceforge.io/"
-  revision 5.5
+  revision 6
   head "https://github.com/tats/w3m.git"
 
   stable do

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -11,7 +11,7 @@ class W3m < Formula
     # Upstream is effectively Debian https://github.com/tats/w3m at this point.
     # The patches fix a pile of CVEs
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz"
+      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
       mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz"
       sha256 "e7f41ac222c55830ce121e1c50e67ab04b292837b9bb1ece2eae2689c82147ec"
       apply "patches/010_upstream.patch",

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -11,9 +11,9 @@ class W3m < Formula
     # Upstream is effectively Debian https://github.com/tats/w3m at this point.
     # The patches fix a pile of CVEs
     patch do
-      url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz"
-      sha256 "e7f41ac222c55830ce121e1c50e67ab04b292837b9bb1ece2eae2689c82147ec"
+      url "http://deb.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
+      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
+      sha256 "625f5b0cb71bf29b67ad3bb9c316420922877473a6e94e6c7bcc337cb22ce1eb"
       apply "patches/010_upstream.patch",
             "patches/020_debian.patch"
     end

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -12,7 +12,6 @@ class W3m < Formula
     # The patches fix a pile of CVEs
     patch do
       url "http://deb.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
-      mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz"
       sha256 "625f5b0cb71bf29b67ad3bb9c316420922877473a6e94e6c7bcc337cb22ce1eb"
       apply "patches/010_upstream.patch",
             "patches/020_debian.patch"

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,7 +1,7 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "https://w3m.sourceforge.io/"
-  revision 6
+  revision 5.5
   head "https://github.com/tats/w3m.git"
 
   stable do

--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -1,7 +1,7 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "https://w3m.sourceforge.io/"
-  revision 5
+  revision 6
   head "https://github.com/tats/w3m.git"
 
   stable do


### PR DESCRIPTION
patch 0.5.3-37 is not available anymore
```
➤ curl -I https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-36.debian.tar.xz                                                                                                                                     12:11:28
HTTP/1.1 404 Not Found
Date: Thu, 31 Jan 2019 11:11:29 GMT
Server: Apache/2.4
Content-Type: text/html; charset=iso-8859-1
```

brew install
```
➤ brew install --build-from-source w3m                                                                     12:16:43
==> Downloading https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz
Already downloaded: /Users/napcae/Library/Caches/Homebrew/downloads/0b6dc0b08a1ffe2ad74625da9e77941ab1dfb05696e7c4f4367b145f06f08f94--w3m-0.5.3.tar.gz
==> Downloading https://mirrors.ocf.berkeley.edu/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz
Already downloaded: /Users/napcae/Library/Caches/Homebrew/downloads/a3c4199059919cad021ea025c765332352244eb495c5c02036c91ac17a4a8be9--w3m_0.5.3-37.debian.tar.xz
==> Patching
==> Applying patches/010_upstream.patch
patching file ChangeLog
patching file Makefile.in
patching file doc/STORY.html
patching file doc/w3m.1
patching file doc-jp/STORY.html
patching file file.c
patching file html.c
patching file version.c.in
==> Applying patches/020_debian.patch
patching file Bonus/goodict.cgi
patching file ChangeLog
patching file Makefile.in
patching file NEWS
patching file README
patching file Str.c
patching file Str.h
patching file acinclude.m4
patching file alloc.h
patching file anchor.c
patching file buffer.c
patching file config.guess
patching file config.h.dist
patching file config.h.in
patching file config.sub
patching file configure
patching file configure.ac
patching file cookie.c
patching file display.c
patching file doc-de/FAQ.html
patching file doc-de/MANUAL.html
patching file doc-de/README.func
patching file doc-de/w3m.1
patching file doc-jp/FAQ.html
patching file doc-jp/MANUAL.html
patching file doc-jp/README
patching file doc-jp/README.SSL
patching file doc-jp/README.func
patching file doc-jp/README.siteconf
patching file doc-jp/README.tab
patching file doc-jp/keymap.lynx
patching file doc-jp/w3m.1
patching file doc/FAQ.html
patching file doc/HISTORY
patching file doc/MANUAL.html
patching file doc/README
patching file doc/README.cookie
patching file doc/README.dict
patching file doc/README.func
patching file doc/README.img
patching file doc/README.m17n
patching file doc/README.pre_form
patching file doc/README.siteconf
patching file doc/README.sixel
patching file doc/README.tab
patching file doc/keymap.lynx
patching file doc/menu.submenu
patching file doc/w3m.1
patching file entity.c
patching file etc.c
patching file file.c
patching file fm.h
patching file form.c
patching file frame.c
patching file ftp.c
patching file func.c
patching file history.c
patching file html.c
patching file html.h
patching file image.c
patching file indep.c
patching file indep.h
patching file istream.c
patching file istream.h
patching file keybind.c
patching file keybind_lynx.c
patching file libwc/ambwidth_map.awk
patching file libwc/charset.c
patching file libwc/gb18030.c
patching file libwc/iso2022.c
patching file libwc/johab.c
patching file libwc/map/big5_ucs.map
patching file libwc/map/cns11643_ucs.map
patching file libwc/map/gb12345_ucs.map
patching file libwc/map/gb2312_ucs.map
patching file libwc/map/gbk_ucs.map
patching file libwc/map/hkscs_ucs.map
patching file libwc/map/jisx0208x0212x0213_ucs.map
patching file libwc/map/ksx1001_ucs.map
patching file libwc/map/sjis_ext_ucs.map
patching file libwc/map/ucs_ambwidth.map
patching file libwc/map/uhc_ucs.map
patching file libwc/status.c
patching file libwc/ucs.c
patching file libwc/ucs.map
patching file libwc/wtf.c
patching file libwc/wtf.h
patching file linein.c
patching file local.c
patching file mailcap.c
patching file main.c
patching file map.c
patching file matrix.c
patching file menu.c
patching file mimehead.c
patching file news.c
patching file parsetagx.c
patching file po/LINGUAS
patching file po/Makefile.in.in
patching file po/Makevars
patching file po/de.po
patching file po/ja.po
patching file po/w3m.pot
patching file po/zh_CN.po
patching file po/zh_TW.po
patching file proto.h
patching file rc.c
patching file regex.c
patching file scripts/Makefile.in
patching file scripts/w3mdict.cgi
patching file scripts/w3mhelp-funcdesc.de.pl.in
patching file scripts/w3mhelp-funcdesc.en.pl.in
patching file scripts/w3mhelp-funcdesc.ja.pl.in
patching file scripts/w3mhelp.cgi.in
patching file scripts/w3mman/Makefile.in
patching file scripts/w3mman/w3mman.1.in
patching file scripts/w3mman/w3mman.de.1.in
patching file scripts/w3mman/w3mman.in
patching file scripts/w3mman/w3mman2html.cgi.in
patching file symbol.c
patching file table.c
patching file table.h
patching file tagtable.tab
patching file terms.c
patching file url.c
patching file version.c.in
patching file w3m-doc/install.html.in
patching file w3m-doc/outline.html.in
patching file w3m-doc/sample/keymap.cgi
patching file w3mbookmark.c
patching file w3mhelp-lynx_en.html.in
patching file w3mhelp-lynx_ja.html.in
patching file w3mhelp-w3m_en.html.in
patching file w3mhelp-w3m_ja.html.in
patching file w3mhelperpanel.c
patching file w3mimg/Makefile.in
patching file w3mimg/fb/fb.c
patching file w3mimg/fb/fb.h
patching file w3mimg/fb/fb_gdkpixbuf.c
patching file w3mimg/fb/fb_imlib2.c
patching file w3mimg/fb/fb_w3mimg.c
patching file w3mimg/x11/x11_w3mimg.c
patching file w3mimgdisplay.c
==> ./configure --prefix=/usr/local/Cellar/w3m/0.5.3_5 --disable-image --with-ssl=/usr/local/opt/openssl
==> make install
🍺  /usr/local/Cellar/w3m/0.5.3_5: 28 files, 1.8MB, built in 30 seconds
Removing: /Users/napcae/Library/Caches/Homebrew/w3m--patch--e7f41ac222c55830ce121e1c50e67ab04b292837b9bb1ece2eae2689c82147ec.tar.xz... (193.6KB)
```

brew test
```
➤ brew test w3m                                                                                            12:15:41
Testing w3m
==> /usr/local/Cellar/w3m/0.5.3_5/bin/w3m -dump https://duckduckgo.com
```

brew audit
```
➤ brew audit --strict w3m                                                                                 12:32:45
w3m:
  * C: 15: col 7: Please use https://deb.debian.org/debian/ for https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/w3m/w3m_0.5.3-37.debian.tar.xz
Error: 1 problem in 1 formula detected
```

Updating it with the new url

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
