### PR TITLE
Eclipse Vert.x 3.6.3

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.2-full.tar.gz"
-  sha256 "0157c9ee2db462f83dbc1b7f56d89c6b9b88eff58da1d0406b4f38b44c7d3b71"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.3-full.tar.gz"
+  sha256 "8025c994f1ef3b80ace23a9d92975abe3b3f41e75f6060127e3f95bc2ee8e9fd"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.6.3.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Eclipse Vert.x web site (https://vertx.io) is not publicizing the 3.6.3 release as updating the homebrew formula is part of the release process.