### PR TITLE
Remove x11 dependency

### DIFF
--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -3,7 +3,6 @@ class Pari < Formula
   homepage "https://pari.math.u-bordeaux.fr/"
   url "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.11.1.tar.gz"
   sha256 "24a9b324a6e9fb161f49dd93aa4dc3f8bb8996c96050ee0468b2f92b45eacac9"
-  revision 1
 
   bottle do
     sha256 "132614e46066837aa3d3a4661bbbcdc648dbb48ba1835873a58f54b8805d31f1" => :mojave

--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -1,8 +1,8 @@
 class Pari < Formula
   desc "Computer algebra system designed for fast computations in number theory"
   homepage "https://pari.math.u-bordeaux.fr/"
-  url "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.11.0.tar.gz"
-  sha256 "3835caccaa3e0c64764521032d89efeb8773cce841f6655fec6d58e790f4c9a1"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.11.1.tar.gz"
+  sha256 "24a9b324a6e9fb161f49dd93aa4dc3f8bb8996c96050ee0468b2f92b45eacac9"
   revision 1
 
   bottle do
@@ -13,7 +13,6 @@ class Pari < Formula
 
   depends_on "gmp"
   depends_on "readline"
-  depends_on :x11
 
   def install
     readline = Formula["readline"].opt_prefix


### PR DESCRIPTION
Pari/gp can be used on the command line without graphics. The x11
dependency results in error because homebrew does not automatically
install x11.

There is alternative graphics support through qt, but it needs to be
compiled with the "no-framework" flag (non default" and there is fltk,
which results in a compilation error.

I believe it is a good idea to just use it on the command line.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
