### PR TITLE
man-db 2.8.5 (new formula)

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -1,0 +1,72 @@
+class ManDb < Formula
+  desc "Unix documentation system"
+  homepage "http://man-db.nongnu.org/"
+  url "https://download.savannah.gnu.org/releases/man-db/man-db-2.8.5.tar.xz"
+  sha256 "b64d52747534f1fe873b2876eb7f01319985309d5d7da319d2bc52ba1e73f6c1"
+
+  depends_on "pkg-config" => :build
+
+  resource "libpipeline" do
+    url "https://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.5.1.tar.gz"
+    sha256 "d633706b7d845f08b42bc66ddbe845d57e726bf89298e2cee29f09577e2f902f"
+  end
+
+  def install
+    resource("libpipeline").stage do
+      system "./configure",
+        "--disable-dependency-tracking",
+        "--disable-silent-rules",
+        "--prefix=#{buildpath}/libpipeline",
+        "--enable-static",
+        "--disable-shared"
+      system "make"
+      system "make", "install"
+    end
+
+    ENV["libpipeline_CFLAGS"] = "-I#{buildpath}/libpipeline/include"
+    ENV["libpipeline_LIBS"] = "-L#{buildpath}/libpipeline/lib -lpipeline"
+
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --disable-cache-owner
+      --disable-setuid
+      --program-prefix=g
+    ]
+
+    # NB: Remove once man-db 2.8.6 is released
+    # https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=b74c839eaa5000a18d1c396e995eca85b0e9464b
+    args += %w[
+      --without-systemdtmpfilesdir
+      --without-systemdsystemunitdir
+    ]
+
+    system "./configure", *args
+
+    # NB: Remove once man-db 2.8.6 is released
+    # https://git.savannah.gnu.org/cgit/man-db.git/commit/?id=056e8c7c012b00261133259d6438ff8303a8c36c
+    ENV.append_to_cflags "-Wl,-flat_namespace,-undefined,suppress"
+
+    system "make", "CFLAGS=#{ENV.cflags}"
+    system "make", "install"
+
+    # Symlink non-conflicting binaries and man pages
+    %w[catman lexgrog mandb].each do |cmd|
+      bin.install_symlink "g#{cmd}" => cmd
+    end
+    sbin.install_symlink "gaccessdb" => "accessdb"
+
+    %w[accessdb catman mandb].each do |cmd|
+      man8.install_symlink "g#{cmd}.8" => "#{cmd}.8"
+    end
+    man1.install_symlink "glexgrog.1" => "lexgrog.1"
+  end
+
+  test do
+    ENV["PAGER"] = "cat"
+    output = shell_output("#{bin}/gman true")
+    assert_match "BSD General Commands Manual", output
+    assert_match "The true utility always returns with exit code zero", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New and improved `libpipeline` formula featuring
 - clean Ruby code
 - humble PR submitter

@sjackman, had to add `"-L#{opt_lib}"` to the test block
@iMichka ... 👋 

I'll submit a matching PR to remove it from linuxbrew/homebrew-extra repo.