### PR TITLE
gdal: use --with-proj instead of deprecated flag

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -79,7 +79,7 @@ class Gdal < Formula
       "--with-png=#{Formula["libpng"].opt_prefix}",
       "--with-spatialite=#{Formula["libspatialite"].opt_prefix}",
       "--with-sqlite3=#{Formula["sqlite"].opt_prefix}",
-      "--with-static-proj4=#{Formula["proj"].opt_prefix}",
+      "--with-proj=#{Formula["proj"].opt_prefix}",
       "--with-zstd=#{Formula["zstd"].opt_prefix}",
       "--with-liblzma=yes",
       "--with-cfitsio=/usr/local",


### PR DESCRIPTION
Fixes:
checking how to link PROJ library... configure: WARNING: --with-static-proj4 is deprecated. Please use --with-proj

On mac, it still finds proj, even with the wrong flag.
On Linux gdal fails to find proj, but that's a different topic that will
need to be fixed in Linuxbrew separately.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
