### PR TITLE
re-flex 1.0.12 stable release - new formula

### DIFF
--- a/Formula/re-flex.rb
+++ b/Formula/re-flex.rb
@@ -1,0 +1,29 @@
+class ReFlex < Formula
+  desc "The regex-centric, fast and flexible scanner generator for C++"
+  homepage "https://www.genivia.com/doc/reflex/html"
+  url "https://github.com/Genivia/RE-flex/archive/reflex-1.0.12.tar.gz"
+  sha256 "75a1761d9a6fd3fee6454e3b6ec954efbad76ece9b68633a07ada977af4cd300"
+
+  depends_on "boost"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"echo.l").write <<~'EOS'
+      %{
+      #include <stdio.h>
+      %}
+      %option noyywrap main
+      %%
+      .+  ECHO;
+      %%
+    EOS
+    system "#{bin}/reflex", "--flex", "echo.l"
+    assert_predicate testpath/"lex.yy.cpp", :exist?
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? Yes, but I had trouble with this command that installs 'gem native extension' which failed. This was the error I received that suggest I report this to Homebrew:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.1.0/ext/json/ext/generator
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -r
./siteconf20190202-23963-122ogem.rb extconf.rb
creating Makefile

current directory:
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.1.0/ext/json/ext/generator
make "DESTDIR=" clean

current directory:
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.1.0/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:
In file included from ./../fbuffer/fbuffer.h:5:
In file included from
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/include/ruby-2.3.0/ruby.h:33:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/include/ruby-2.3.0/ruby/ruby.h:24:10:
fatal error: 'ruby/config.h' file not found
#include "ruby/config.h"
         ^~~~~~~~~~~~~~~
1 error generated.
make: *** [generator.o] Error 1

make failed, exit code 2

...

An error occurred while installing json (2.1.0), and Bundler cannot
continue.
Make sure that `gem install json -v '2.1.0' --source 'https://rubygems.org/'`
succeeds before bundling.

In Gemfile:
  coveralls was resolved to 0.8.22, which depends on
    simplecov was resolved to 0.16.1, which depends on
      json
Error: cannot load such file -- rubocop
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/style.rb:21:in `check_style_impl'
/usr/local/Homebrew/Library/Homebrew/style.rb:14:in `check_style_json'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:115:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
```

-----