### PR TITLE
ffmpeg: enable libbluray

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -23,6 +23,7 @@ class Ffmpeg < Formula
   depends_on "frei0r"
   depends_on "lame"
   depends_on "libass"
+  depends_on "libbluray"
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "opencore-amr"
@@ -51,6 +52,7 @@ class Ffmpeg < Formula
       --enable-ffplay
       --enable-gpl
       --enable-libaom
+      --enable-libbluray
       --enable-libmp3lame
       --enable-libopus
       --enable-libsnappy


### PR DESCRIPTION
Commit f75cb09 removed support for
libbluray, which is needed in order for the ffmpeg formula's `ffprobe`
binary to be able to read information from Blu-ray data.

From looking at the ffmpeg formula's
30 day install history (https://formulae.brew.sh/formula/ffmpeg)
I calculated that about 30,000 installs were attempted with the
`--with-libbluray` switch, and that's with the option having been
missing for the past 17 days.

libbluray (https://www.videolan.org/developers/libbluray.html) is
pretty handy to have, and does not attempt any DRM circumvention, so
it is perfectly safe to include.