### PR TITLE
ffmpeg: enable OpenJPEG, Rubberband & Tesseract

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,7 +3,7 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.1.tar.xz"
   sha256 "a38ec4d026efb58506a99ad5cd23d5a9793b4bf415f2c4c2e9c1bb444acd1994"
-  revision 3
+  revision 4
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
@@ -28,9 +28,11 @@ class Ffmpeg < Formula
   depends_on "opencore-amr"
   depends_on "opus"
   depends_on "rtmpdump"
+  depends_on "rubberband"
   depends_on "sdl2"
   depends_on "snappy"
   depends_on "speex"
+  depends_on "tesseract"
   depends_on "theora"
   depends_on "x264"
   depends_on "x265"
@@ -73,6 +75,11 @@ class Ffmpeg < Formula
       --disable-libjack
       --disable-indev=jack
     ]
+
+    # Force the use of OpenJPEG
+    args << "--enable-libopenjpeg"
+    args << "--disable-decoder=jpeg2000"
+    args << "--extra-cflags=" + `pkg-config --cflags libopenjp2`.chomp
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -69,17 +69,14 @@ class Ffmpeg < Formula
       --enable-libass
       --enable-libopencore-amrnb
       --enable-libopencore-amrwb
+      --enable-libopenjpeg
       --enable-librtmp
       --enable-libspeex
       --enable-videotoolbox
+      --disable-decoder=jpeg2000
       --disable-libjack
       --disable-indev=jack
     ]
-
-    # Force the use of OpenJPEG
-    args << "--enable-libopenjpeg"
-    args << "--disable-decoder=jpeg2000"
-    args << "--extra-cflags=" + `pkg-config --cflags libopenjp2`.chomp
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -74,7 +74,6 @@ class Ffmpeg < Formula
       --enable-librtmp
       --enable-libspeex
       --enable-videotoolbox
-      --disable-decoder=jpeg2000
       --disable-libjack
       --disable-indev=jack
     ]

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -26,6 +26,7 @@ class Ffmpeg < Formula
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "opencore-amr"
+  depends_on "openjpeg"
   depends_on "opus"
   depends_on "rtmpdump"
   depends_on "rubberband"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Commit https://github.com/Homebrew/homebrew-core/commit/f75cb092032c2eb921ba0bcdcf6a45af5cf86714 has removed these options. For use of FFmpeg in the archive community the following options are important:

- the OpenJPEG offers much more possibilities than FFmpeg’s own JPEG 2000 encoder/decoder
- the Rubberband audio filter allows time-stretching and pitch-shifting
- the Tesseract filter for optical character recognition, e.g. for extracting intertitles or subtitles