### PR TITLE
xdot: Add dependency on adwaita-icon-theme

### DIFF
--- a/Formula/xdot.rb
+++ b/Formula/xdot.rb
@@ -13,6 +13,7 @@ class Xdot < Formula
     sha256 "d6712e41657d53116ad6eb9e18607e937372b2565259f4357d0ee302c9e535cc" => :sierra
   end
 
+  depends_on "adwaita-icon-theme"
   depends_on "gtk+3"
   depends_on "py3cairo"
   depends_on "pygobject3"


### PR DESCRIPTION
Without this dependency the icons in the toolbar are indistinguishable.
This fixes #19187.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I couldn't run `brew audit --strict <formula>` due to https://github.com/Homebrew/brew/issues/5561
