### PR TITLE
zsh: Add support for PCRE

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -4,7 +4,7 @@ class Zsh < Formula
   url "https://downloads.sourceforge.net/project/zsh/zsh/5.7/zsh-5.7.tar.xz"
   mirror "https://www.zsh.org/pub/zsh-5.7.tar.xz"
   sha256 "7807b290b361d9fa1e4c2dfafc78cb7e976e7015652e235889c6eff7468bd613"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "704757d9e92b55847dfc1442461121ff03efeeeb80a1ac3e81ed60cf04a20444" => :mojave
@@ -18,6 +18,7 @@ class Zsh < Formula
   end
 
   depends_on "ncurses"
+  depends_on "pcre"
 
   resource "htmldoc" do
     url "https://downloads.sourceforge.net/project/zsh/zsh-doc/5.7/zsh-5.7-doc.tar.xz"
@@ -44,6 +45,7 @@ class Zsh < Formula
                           "--enable-cap",
                           "--enable-maildir-support",
                           "--enable-multibyte",
+                          "--enable-pcre",
                           "--enable-zsh-secure-free",
                           "--enable-unicode9",
                           "--enable-etcdir=/etc",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I was surprised that zsh/pcre is not included by default. I saw the option to add PCRE support was removed in e19ac9d73151cd7d3d9b56726db694cd0fef9dd5, most likely because bd51456cd0c1029a2313da283a866138e3b9c249 made it optional.

Having looked at the related PR (#22535), I'd like to add support for PCRE again.

I don't believe there's any significant downside for people who don't use PCRE since the extension won't be loaded if they don't use it. However, people who do use PCRE, particularly when sharing scripts between Linux and macOS, will be surprised: [Debian](https://salsa.debian.org/debian/zsh/blob/14d262602341f1a2d69aa9149a331d047851ef55/debian/rules#L30) for instance compiles zsh with `--enable-pcre` and so does [Arch Linux](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/zsh). Adding PCRE support back would help provide the same environment on both Linux and macOS.

Pinging both @ilovezfs and @zmwangx as they discussed this before: folks, do you feel strongly about this?