### PR TITLE
vapoursynth: depend on ffmpeg and FFMS2

### DIFF
--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -5,6 +5,7 @@ class Vapoursynth < Formula
   homepage "http://www.vapoursynth.com"
   url "https://github.com/vapoursynth/vapoursynth/archive/R45.1.tar.gz"
   sha256 "4f43e5bb8c4817fdebe572d82febe4abac892918c54e1cb71aa6f6eb3677a877"
+  revision 1
   head "https://github.com/vapoursynth/vapoursynth.git"
 
   bottle do
@@ -19,6 +20,8 @@ class Vapoursynth < Formula
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
 
+  depends_on "ffmpeg"
+  depends_on "ffms2"
   depends_on "libass"
   depends_on :macos => :el_capitan # due to zimg dependency
   depends_on "python"
@@ -37,6 +40,10 @@ class Vapoursynth < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--with-cython=#{buildpath}/cython/bin/cython"
     system "make", "install"
+
+    # Add FFMS2 to system-wide autoload search path
+    ffms2 = Formula["ffms2"]
+    ln_s "#{ffms2.lib}/libffms2.dylib", "#{lib}/vapoursynth/libffms2.dylib"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Add _ffmpeg_ to the list of dependencies to re-enable _SubText_ plugin, used to be available in previous versions (and still is on other platforms).

Background: I have an old machine on Yosemite with two earlier versions (R43_2, R44) installed. I noticed only recently that the _SubText_ plugin (`core.sub`), which used to work on R43_2, is not available with R44 onwards. I confirmed this on another laptop running Mojave, with R45.1 installed both from source and from bottle. It seems that solely depending on _libass_ is not enough to enable subtitle support (any more?), as shown when configuring with `--enable-subtext`, which demands ffmpeg libraries.

Since something as heavy as ffmpeg is added, it seems reasonable to include the wrapper plugin FFMS2, enabling the popular video source plugin while adding no further dependencies. As options are now deprecated, it may be a reasonable choice to directly integrate FFMS2 as a symlink, as suggested in [this guide](http://www.l33tmeatwad.com/vapoursynth101/software-setup).