### PR TITLE
bumpversion 0.5.3 (new formula)

### DIFF
--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -1,0 +1,26 @@
+class Bumpversion < Formula
+  include Language::Python::Virtualenv
+
+  desc "Increase version numbers with SemVer terms"
+  homepage "https://pypi.python.org/pypi/bumpversion"
+  url "https://github.com/peritus/bumpversion/archive/v0.5.3.tar.gz"
+  sha256 "97ac6efca7544853309b68efe92f113ab6bddb77ecbaefa5702a6183a30bcb33"
+
+  depends_on "python"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_includes shell_output("script -q /dev/null #{bin}/bumpversion --help"), "bumpversion: v#{version}"
+    version_file = testpath/"VERSION"
+    version_file.write "0.0.0"
+    system bin/"bumpversion", "--current-version", "0.0.0", "minor", version_file
+    assert_match "0.1.0", version_file.read
+    system bin/"bumpversion", "--current-version", "0.1.0", "patch", version_file
+    assert_match "0.1.1", version_file.read
+    system bin/"bumpversion", "--current-version", "0.1.1", "major", version_file
+    assert_match "1.0.0", version_file.read
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


-----

```bash
$ brew install --build-from-source bumpversion
==> Downloading https://github.com/peritus/bumpversion/archive/v0.5.3.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/1fd5cb602da7c64b40ac511e97216eeb7a4706cf17684ded6580b7ea014e23b4--bumpversion-0.5.3.tar.gz
==> Downloading https://files.pythonhosted.org/packages/8b/f4/360aa656ddb0f4168aeaa1057d8784b95d1ce12f34332c1cf52420b6db4e/virtualenv-16.3.0.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/890646fc981e3daeb6d7dff518b75d51b15047d63a145d58e0c73d0be724e358--virtualenv-16.3.0.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/bumpversion--homebrew-virtualenv-20190203-15457-1a9kfzy/target --install-scripts=/private/tmp/bumpversion--homebrew-virt
==> python3 -s /private/tmp/bumpversion--homebrew-virtualenv-20190203-15457-1a9kfzy/target/bin/virtualenv -p python3 /usr/local/Cellar/bumpversion/0.5.3/libexec
==> /usr/local/Cellar/bumpversion/0.5.3/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/bumpversion-20190203-15457-1b81jme/bumpversion-0.5.3
🍺  /usr/local/Cellar/bumpversion/0.5.3: 960 files, 10.4MB, built in 12 seconds
$ echo $?
0
```
```bash
$ brew test bumpversion
Testing bumpversion
==> script -q /dev/null /usr/local/Cellar/bumpversion/0.5.3/bin/bumpversion --help
$ echo $?
0
```
```bash
$ brew audit --strict bumpversion
$ echo $?
0
```