### PR TITLE
jinja2-cli 0.6.0 (new formula)

### DIFF
--- a/Formula/jinja2-cli.rb
+++ b/Formula/jinja2-cli.rb
@@ -1,0 +1,58 @@
+class Jinja2Cli < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI for the Jinja2 templating language"
+  homepage "https://github.com/mattrobenolt/jinja2-cli"
+  url "https://files.pythonhosted.org/packages/50/24/a774867a93c19d21f132154b509ad014ab22106e1927d0241b556cf8c836/jinja2-cli-0.6.0.tar.gz"
+  sha256 "4b1be17ce8a8f133df02205c3f0d3ebfc3a68e795d26987f846a2316636427b7"
+
+  depends_on "python"
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"
+    sha256 "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
+    sha256 "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("script -q /dev/null #{bin}/jinja2 --version")
+    expected_result = <<~EOS
+      The Beatles:
+      - Ringo Starr
+      - George Harrison
+      - Paul McCartney
+      - John Lennon
+    EOS
+    template_file = testpath/"my-template.tmpl"
+    template_file.write <<~EOS
+      {{ band.name }}:
+      {% for member in band.members -%}
+      - {{ member.first_name }} {{ member.last_name }}
+      {% endfor -%}
+    EOS
+    template_variables_file = testpath/"my-template-variables.json"
+    template_variables_file.write <<~EOS
+      {
+        "band": {
+          "name": "The Beatles",
+          "members": [
+            {"first_name": "Ringo",  "last_name": "Starr"},
+            {"first_name": "George", "last_name": "Harrison"},
+            {"first_name": "Paul",   "last_name": "McCartney"},
+            {"first_name": "John",   "last_name": "Lennon"}
+          ]
+        }
+      }
+    EOS
+    output = shell_output("#{bin}/jinja2 #{template_file} #{template_variables_file}")
+    assert_equal output, expected_result
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```bash
$ brew install --build-from-source jinja2-cli
==> Downloading https://files.pythonhosted.org/packages/50/24/a774867a93c19d21f132154b509ad014ab22106e1927d0241b556cf8c836/jinja2-cli-0.6.0.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/097aa9c2ac3a68108048a114787a6e799c1a1546ac6a4422972acc4993b920c3--jinja2-cli-0.6.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/8b/f4/360aa656ddb0f4168aeaa1057d8784b95d1ce12f34332c1cf52420b6db4e/virtualenv-16.3.0.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/890646fc981e3daeb6d7dff518b75d51b15047d63a145d58e0c73d0be724e358--virtualenv-16.3.0.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/jinja2-cli--homebrew-virtualenv-20190203-21995-1n7wb1n/target --install-scripts=/private/tmp/jinja2-cli--homebrew-virtua
==> python3 -s /private/tmp/jinja2-cli--homebrew-virtualenv-20190203-21995-1n7wb1n/target/bin/virtualenv -p python3 /usr/local/Cellar/jinja2-cli/0.6.0/libexec
==> Downloading https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/9c1a9f477c7fcc5026a536febac3cb5774febecd6fde81311142f0d682749f6f--Jinja2-2.10.tar.gz
==> /usr/local/Cellar/jinja2-cli/0.6.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/jinja2-cli--jinja2-20190203-21995-1fzvzbs/Jinja2-2.10
==> Downloading https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz
Already downloaded: /Users/christopherdcunha/Library/Caches/Homebrew/downloads/311d62bdf4f4a176670774758a0cb966479df4f7b18140e5b8ef83559b992c3f--MarkupSafe-1.1.0.tar.gz
==> /usr/local/Cellar/jinja2-cli/0.6.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/jinja2-cli--MarkupSafe-20190203-21995-94670g/MarkupSafe-1.1.0
==> /usr/local/Cellar/jinja2-cli/0.6.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/jinja2-cli-20190203-21995-c6y55n/jinja2-cli-0.6.0
🍺  /usr/local/Cellar/jinja2-cli/0.6.0: 1,045 files, 11.2MB, built in 15 seconds
$ echo $?
0
```
```bash
$ brew test jinja2-cli
Testing jinja2-cli
==> script -q /dev/null /usr/local/Cellar/jinja2-cli/0.6.0/bin/jinja2 --version
$ echo $?
0
```
```bash
$ brew audit --strict jinja2-cli
$ echo $?
0
```