### PR TITLE
vips: build with ImageMagick

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -3,6 +3,7 @@ class Vips < Formula
   homepage "https://github.com/libvips/libvips"
   url "https://github.com/libvips/libvips/releases/download/v8.7.4/vips-8.7.4.tar.gz"
   sha256 "ce7518a8f31b1d29a09b3d7c88e9852a5a2dcb3ee1501524ab477e433383f205"
+  revision 1
 
   bottle do
     sha256 "b0f5e9de2c412d6f188fe36371d7c828c735f8b873bc68d9058a0d6145751476" => :mojave
@@ -17,7 +18,7 @@ class Vips < Formula
   depends_on "gettext"
   depends_on "giflib"
   depends_on "glib"
-  depends_on "graphicsmagick"
+  depends_on "imagemagick"
   depends_on "jpeg"
   depends_on "libexif"
   depends_on "libgsf"
@@ -37,7 +38,6 @@ class Vips < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --with-magick
-      --with-magickpackage=GraphicsMagick
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, brew builds vips with GraphicsMagick support, while it would better to build it with ImageMagick since it's better supported. For example, it adds support of `vips_magicksave`, that I actively use in imgproxy.

Couldn't run `brew audit --strict <formula>` due to Homebrew/brew#5561