### PR TITLE
flamethrower 0.9 (new formula)

### DIFF
--- a/Formula/flamethrower.rb
+++ b/Formula/flamethrower.rb
@@ -1,0 +1,21 @@
+class Flamethrower < Formula
+  desc "DNS performance and functional testing utility"
+  homepage "https://github.com/DNS-OARC/flamethrower"
+  head "https://github.com/DNS-OARC/flamethrower.git"
+  depends_on "cmake" => :build
+  depends_on "ldns"
+  depends_on "libuv"
+  depends_on "openssl"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      bin.install "flame"
+    end
+  end
+
+  test do
+    system bin/"flame", "--version"
+  end
+end


### PR DESCRIPTION
New formula for [flamethrower](https://github.com/DNS-OARC/flamethrower).
Flamethrower is a DNS performance and functional testing utility (by @ns1).
Added only HEAD, as the upstream has no release tag yet.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
