### PR TITLE
go@1.10: add 1.10.8 bottle

### DIFF
--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -1,9 +1,9 @@
 class GoAT110 < Formula
   desc "Go programming environment (1.10)"
   homepage "https://golang.org"
-  url "https://dl.google.com/go/go1.10.7.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.10.7.src.tar.gz"
-  sha256 "b84a0d7c90789f3a2ec5349dbe7419efb81f1fac9289b6f60df86bd919bd4447"
+  url "https://dl.google.com/go/go1.10.8.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.10.8.src.tar.gz"
+  sha256 "6faf74046b5e24c2c0b46e78571cca4d65e1b89819da1089e53ea57539c63491"
 
   bottle do
     sha256 "69e7e40e04726319c86533c8b4f40ddd5b0936289a7afe9904e0e624db34596e" => :mojave
@@ -29,24 +29,24 @@ class GoAT110 < Formula
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 
-    cd "src" do
+    cd "go/src" do
       ENV["GOROOT_FINAL"] = libexec
       ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    (buildpath/"go/pkg/obj").rmtree
     rm_rf "gobootstrap" # Bootstrap not required beyond compile.
     libexec.install Dir["*"]
-    bin.install_symlink Dir[libexec/"bin/go*"]
+    bin.install_symlink Dir[libexec/"go/bin/go*"]
 
     system bin/"go", "install", "-race", "std"
 
     # Build and install godoc
     ENV.prepend_path "PATH", bin
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/golang.org/x/tools").install resource("gotools")
-    cd "src/golang.org/x/tools/cmd/godoc/" do
+    ENV["GOPATH"] = buildpath/"go"
+    (buildpath/"go/src/golang.org/x/tools").install resource("gotools")
+    cd "go/src/golang.org/x/tools/cmd/godoc/" do
       system "go", "build"
       (libexec/"bin").install "godoc"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, I would like to update `go@1.10` formula with Go 1.10.8.

This is my first contribution to Homebrew, so, I might have done it in a wrong way.
I changed `url` and `sha256` (as I can see this is very minimum required). For example it was also done on [updating to Go 1.10.7](https://github.com/Homebrew/homebrew-core/commit/c343f126d6b3d135f6761ff666a1d658c2e12593).

But somehow it was required to change paths. I am not sure why it was required and what is a better way for doing it. Without these changes command `brew install --debug --build-from-source go@1.10` fails. And after changes it passes, `brew test go@1.10` and `brew audit --strict go@1.10` passes too.

Thank you.