### PR TITLE
passenger: provide dynamic nginx module

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -18,9 +18,13 @@ class Nginx < Formula
   depends_on "pcre"
 
   def install
-    # keep clean copy of source for compiling dynamic modules
+    # keep clean copy of source for compiling dynamic modules e.g. passenger
     (share/"src").mkpath
-    (share/"src").install cached_download
+    mkdir "src_rebuild" do
+      system "tar", "-xf", cached_download, "--strip-components", "1", "--exclude='conf contrib LICENSE README html man CHANGES.ru CHANGES'"
+      system "tar", "-cJf", "src.txz", "--options", "compression-level=9", "--exclude", "src.txz", "."
+      (share/"src").install "src.txz"
+    end
 
     # Changes default port to 8080
     inreplace "conf/nginx.conf" do |s|
@@ -76,6 +80,8 @@ class Nginx < Formula
       --with-stream_ssl_module
       --with-stream_ssl_preread_module
     ]
+
+    File.write(share/"src/args.txt", args.join("\n"))
 
     if build.head?
       system "./auto/configure", *args

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -20,11 +20,7 @@ class Nginx < Formula
   def install
     # keep clean copy of source for compiling dynamic modules e.g. passenger
     (share/"src").mkpath
-    mkdir "src_rebuild" do
-      system "tar", "-xf", cached_download, "--strip-components", "1", "--exclude='conf contrib LICENSE README html man CHANGES.ru CHANGES'"
-      system "tar", "-cJf", "src.txz", "--options", "compression-level=9", "--exclude", "src.txz", "."
-      (share/"src").install "src.txz"
-    end
+    system "tar", "-cJf", (share/"src/src.tar.xz"), "--options", "compression-level=9", "."
 
     # Changes default port to 8080
     inreplace "conf/nginx.conf" do |s|
@@ -81,7 +77,7 @@ class Nginx < Formula
       --with-stream_ssl_preread_module
     ]
 
-    File.write(share/"src/args.txt", args.join("\n"))
+    (share/"src/configure_args.txt").write args.join("\n")
 
     if build.head?
       system "./auto/configure", *args

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -18,6 +18,10 @@ class Nginx < Formula
   depends_on "pcre"
 
   def install
+    # keep clean copy of source for compiling dynamic modules
+    (share/"src").mkpath
+    (share/"src").install cached_download
+
     # Changes default port to 8080
     inreplace "conf/nginx.conf" do |s|
       s.gsub! "listen       80;", "listen       8080;"

--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -16,12 +16,6 @@ class Passenger < Formula
   depends_on "openssl"
   depends_on "pcre"
 
-  # must match nginx formula
-  resource "nginx" do
-    url "https://nginx.org/download/nginx-1.15.8.tar.gz"
-    sha256 "a8bdafbca87eb99813ae4fcac1ad0875bf725ce19eb265d28268c309b2b40787"
-  end
-
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")
@@ -34,7 +28,9 @@ class Passenger < Formula
     system "rake", "apache2"
     system "rake", "nginx"
     nginx_addon_dir = `/usr/bin/ruby ./bin/passenger-config about nginx-addon-dir`.strip
-    resource("nginx").stage do
+
+    system "tar", "-xf", Dir["#{Formula["nginx"].opt_share}/src/*nginx*.tar.gz"].first
+    Dir.chdir("nginx-#{Formula["nginx"].installed_version}") do
       _, stderr, = Open3.capture3("nginx", "-V")
       args = stderr.split("configure arguments:").last.split(" --").reject(&:empty?).map { |s| "--#{s.strip}" }
       args << "--add-dynamic-module=#{nginx_addon_dir}"

--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -12,7 +12,8 @@ class Passenger < Formula
     sha256 "d094cecf62e66a527482b681bdfa01cc7fa956a16ad9e4d2fea520ffc63cac6f" => :sierra
   end
 
-  depends_on "nginx" => :build # for configure arguments
+  # to build nginx module
+  depends_on "nginx" => [:build, :test]
   depends_on "openssl"
   depends_on "pcre"
 
@@ -30,8 +31,8 @@ class Passenger < Formula
     nginx_addon_dir = `./bin/passenger-config about nginx-addon-dir`.strip
 
     mkdir "nginx" do
-      system "tar", "-xf", "#{Formula["nginx"].opt_share}/src/src.txz", "--strip-components", "1"
-      args = File.read("#{Formula["nginx"].opt_share}/src/args.txt").split("\n")
+      system "tar", "-xf", "#{Formula["nginx"].opt_share}/src/src.tar.xz", "--strip-components", "1"
+      args = (Formula["nginx"].opt_share/"src/configure_args.txt").read.split("\n")
       args << "--add-dynamic-module=#{nginx_addon_dir}"
 
       system "./configure", *args

--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -17,6 +17,11 @@ class Passenger < Formula
   depends_on "openssl"
   depends_on "pcre"
 
+  patch do
+    url "https://github.com/phusion/passenger/commit/20ca9e52.patch?full_index=1"
+    sha256 "e18966542571ce906b6fd9bdb7959418fba20da3669a2c7442a17f4e53179892"
+  end
+
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")
@@ -131,6 +136,6 @@ class Passenger < Formula
         }
       }
     EOS
-    system "nginx", "-t", "-c", testpath/"nginx.conf"
+    system "#{Formula["nginx"].opt_bin}/nginx", "-t", "-c", testpath/"nginx.conf"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I realize it's a bit weird to have nginx as a resource and build dependency, but this way there's less maintenance work keeping the nginx and passenger formulae in sync wrt the configuration flags passed to nginx. You just have to keep the resource version in sync for the dynamic module to work. And this way people can still use nginx with passenger without any options on the formula.