### PR TITLE
apache-arrow 0.12.0

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -1,0 +1,41 @@
+class ApacheArrow < Formula
+  desc "Columnar in-memory analytics layer designed to accelerate big data"
+  homepage "https://arrow.apache.org/"
+  url "https://archive.apache.org/dist/arrow/arrow-0.12.0/apache-arrow-0.12.0.tar.gz"
+  sha256 "34dae7e4dde9274e9a52610683e78a80f3ca312258ad9e9f2c0973cf44247a98"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "python" => :optional
+  depends_on "python@2" => :optional
+
+  def install
+    ENV.cxx11
+    args = []
+
+    if build.with?("python") && build.with?("python@2")
+      odie "Cannot provide both --with-python and --with-python@2"
+    end
+    Language::Python.each_python(build) do |python, _version|
+      args << "-DARROW_PYTHON=1" << "-DPYTHON_EXECUTABLE=#{which python}"
+    end
+
+    cd "cpp" do
+      system "cmake", ".", "-DARROW_JEMALLOC=FALSE", *std_cmake_args, *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include "arrow/api.h"
+      int main(void)
+      {
+        arrow::int64();
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
`apache-arrow` was removed; however, Apache Arrow 0.12 is now available so this formula can be fixed and added back. Related to https://github.com/Homebrew/homebrew-core/pull/36063.

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
