### PR TITLE
man-db: symlink commands without 'g' prefix into libexec/bin

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -3,6 +3,7 @@ class ManDb < Formula
   homepage "http://man-db.nongnu.org/"
   url "https://download.savannah.gnu.org/releases/man-db/man-db-2.8.5.tar.xz"
   sha256 "b64d52747534f1fe873b2876eb7f01319985309d5d7da319d2bc52ba1e73f6c1"
+  revision 1
 
   bottle do
     sha256 "4d1631d07729c3bc4187b3cdd2d617719dc1c50dfb8b54c4327b31e4634064d0" => :mojave
@@ -57,6 +58,20 @@ class ManDb < Formula
     system "make", "CFLAGS=#{ENV.cflags}"
     system "make", "install"
 
+    # Symlink commands without 'g' prefix into libexec/bin and
+    # man pages into libexec/man
+    %w[apropos catman lexgrog man mandb manpath whatis].each do |cmd|
+      (libexec/"bin").install_symlink bin/"g#{cmd}" => cmd
+    end
+    (libexec/"sbin").install_symlink sbin/"gaccessdb" => "accessdb"
+    %w[apropos lexgrog man manconv manpath whatis zsoelim].each do |cmd|
+      (libexec/"man"/"man1").install_symlink man1/"g#{cmd}.1" => "#{cmd}.1"
+    end
+    (libexec/"man"/"man5").install_symlink man5/"gmanpath.5" => "manpath.5"
+    %w[accessdb catman mandb].each do |cmd|
+      (libexec/"man"/"man8").install_symlink man8/"g#{cmd}.8" => "#{cmd}.8"
+    end
+
     # Symlink non-conflicting binaries and man pages
     %w[catman lexgrog mandb].each do |cmd|
       bin.install_symlink "g#{cmd}" => cmd
@@ -67,6 +82,14 @@ class ManDb < Formula
       man8.install_symlink "g#{cmd}.8" => "#{cmd}.8"
     end
     man1.install_symlink "glexgrog.1" => "lexgrog.1"
+  end
+
+  def caveats; <<~EOS
+    Commands also provided by macOS have been installed with the prefix "g".
+    If you need to use these commands with their normal names, you
+    can add a "bin" directory to your PATH from your bashrc like:
+      PATH="#{opt_libexec}/bin:$PATH"
+  EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Make `man-db` consistent with other formulae prefixed by `g`.