### PR TITLE
imagemagick: add rsvg support

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -23,6 +23,7 @@ class Imagemagick < Formula
   depends_on "libheif"
   depends_on "libomp"
   depends_on "libpng"
+  depends_on "librsvg"
   depends_on "libtiff"
   depends_on "libtool"
   depends_on "little-cms2"
@@ -50,6 +51,7 @@ class Imagemagick < Formula
       --with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts
       --without-fftw
       --without-pango
+      --with-rsvg
       --without-x
       --without-wmf
       --enable-openmp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I would like to add rsvg to imagemagic as without is svg->png conversions don't work. It was pretty popular (similar to HEIF I think which was accepted).

https://formulae.brew.sh/formula/imagemagick