### PR TITLE
balena-cli: renamed from resin-cli

### DIFF
--- a/Formula/balena-cli.rb
+++ b/Formula/balena-cli.rb
@@ -1,11 +1,11 @@
 require "language/node"
 
-class ResinCli < Formula
-  desc "The official resin.io CLI tool"
-  homepage "https://docs.resin.io/reference/cli/"
+class BalenaCli < Formula
+  desc "The official balena CLI tool"
+  homepage "https://www.balena.io/docs/reference/cli/"
   # Frequent upstream releases, do not update more than once a week
-  url "https://registry.npmjs.org/resin-cli/-/resin-cli-8.0.2.tgz"
-  sha256 "4e1696d6b7f7724672ca11ee6d3d38d583869cc1ea3718fd1694bebc8d62aa3a"
+  url "https://registry.npmjs.org/balena-cli/-/balena-cli-9.12.1.tgz"
+  sha256 "19244422731ac93f1f8b5a673936f54cfab80b1ee30eb9c7b1d63d6c9e215b7e"
 
   bottle do
     sha256 "1e11dca0cab1b9760c80c23f160477df9fe3b86b75928fd4d4d33d03dabdadf8" => :mojave
@@ -21,7 +21,7 @@ class ResinCli < Formula
   end
 
   test do
-    output = shell_output("#{bin}/resin login --credentials --email johndoe@gmail.com --password secret", 1)
-    assert_match "Logging in to resin.io", output
+    output = shell_output("#{bin}/balena login --credentials --email johndoe@gmail.com --password secret 2>/dev/null", 1)
+    assert_match "Logging in to balena-cloud.com", output
   end
 end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -157,6 +157,7 @@
   "racket": "minimal-racket",
   "rebar@3": "rebar3",
   "recipes": "gnome-recipes",
+  "resin-cli": "balena-cli",
   "root6": "root",
   "ruby187": "ruby@1.8",
   "ruby20": "ruby@2.0",


### PR DESCRIPTION
Renamed from resin-cli to balena-cli as [resin.io changed it's name to balena](https://www.balena.io/blog/resin-io-changes-name-to-balena-releases-open-source-edition/) in October 2018.

Also update to current version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
