### PR TITLE
Add a readline formula pinned to readline v7.

### DIFF
--- a/Formula/readline@7.rb
+++ b/Formula/readline@7.rb
@@ -1,0 +1,51 @@
+class ReadlineAT7 < Formula
+  desc "Library for command-line editing"
+  homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
+  url "https://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz"
+  mirror "https://ftpmirror.gnu.org/readline/readline-7.0.tar.gz"
+  version "7.0.5"
+  sha256 "750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334"
+
+  keg_only :shadowed_by_macos, <<~EOS
+    macOS provides the BSD libedit library, which shadows libreadline.
+    In order to prevent conflicts when programs look for libreadline we are
+    defaulting this GNU Readline installation to keg-only.
+    This is also an alternate version of another formula
+  EOS
+
+  %w[
+    001 9ac1b3ac2ec7b1bf0709af047f2d7d2a34ccde353684e57c6b47ebca77d7a376
+    002 8747c92c35d5db32eae99af66f17b384abaca961653e185677f9c9a571ed2d58
+    003 9e43aa93378c7e9f7001d8174b1beb948deefa6799b6f581673f465b7d9d4780
+    004 f925683429f20973c552bff6702c74c58c2a38ff6e5cf305a8e847119c5a6b64
+    005 ca159c83706541c6bbe39129a33d63bbd76ac594303f67e4d35678711c51b753
+  ].each_slice(2) do |p, checksum|
+    patch :p0 do
+      url "https://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-#{p}"
+      mirror "https://ftpmirror.gnu.org/readline/readline-7.0-patches/readline70-#{p}"
+      sha256 checksum
+    end
+  end
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <readline/readline.h>
+
+      int main()
+      {
+        printf("%s\\n", readline("test> "));
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-L", lib, "test.c", "-L#{lib}", "-lreadline", "-o", "test"
+    assert_equal "test> Hello, World!\nHello, World!",
+      pipe_output("./test", "Hello, World!\n").strip
+  end
+end

--- a/Formula/readline@7.rb
+++ b/Formula/readline@7.rb
@@ -6,12 +6,7 @@ class ReadlineAT7 < Formula
   version "7.0.5"
   sha256 "750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334"
 
-  keg_only :shadowed_by_macos, <<~EOS
-    macOS provides the BSD libedit library, which shadows libreadline.
-    In order to prevent conflicts when programs look for libreadline we are
-    defaulting this GNU Readline installation to keg-only.
-    This is also an alternate version of another formula
-  EOS
+  keg_only :versioned_formula
 
   %w[
     001 9ac1b3ac2ec7b1bf0709af047f2d7d2a34ccde353684e57c6b47ebca77d7a376


### PR DESCRIPTION
On stable systems, it is undesirable to update linked libraries out from
under compiled programs. A large number of binary executables may link
to a specific major version of readline and expect it to not disappear.

I have no idea what I'm doing here, so feel free to suggest changes.