### PR TITLE
tesseract: switch to only including eng, osd, and snum tessdata

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -54,7 +54,8 @@ class Tesseract < Formula
     system "make", "install"
 
     resource("snum").stage { mv "snum.traineddata", share/"tessdata" }
-    resource("tessdata").stage { mv Dir["*"], share/"tessdata" }
+    resource("eng").stage { mv "eng.traineddata", share/"tessdata" }
+    resource("osd").stage { mv "osd.traineddata", share/"tessdata" }
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This reduces tesseract's installed size from 680MB to 30MB. A [a change from two weeks ago](https://github.com/Homebrew/homebrew-core/pull/36293/files) made tesseract include data for 162 languages and scripts.  See #36760 for context and more details. 

It's possible that other solutions could be better (like including data for the top 10 most popular languages?).  If so probably better to just close this and have a discussion on #36760.

