### PR TITLE
libtiff: patch for CVE-2019-6128

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -4,6 +4,7 @@ class Libtiff < Formula
   url "https://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.10.tar.gz"
   sha256 "2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,8 +16,13 @@ class Libtiff < Formula
   depends_on "jpeg"
 
   # Patches are taken from latest Fedora package, which is currently
-  # libtiff-4.0.10-1.fc30.src.rpm and whose changelog is available at
+  # libtiff-4.0.10-2.fc30.src.rpm and whose changelog is available at
   # https://apps.fedoraproject.org/packages/libtiff/changelog/
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/d15e00544e7df009b5ad34f3b65351fc249092c0/libtiff/libtiff-CVE-2019-6128.patch"
+    sha256 "dbec51f5bec722905288871e3d8aa3c41059a1ba322c1ac42ddc8d62646abc66"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[Fedora commit](https://src.fedoraproject.org/rpms/libtiff/c/3e70d60fe1ebf2ab0584e1df22a1db8e84ac15f4)
Homebrew/formula-patches#265