### PR TITLE
tcl-tk add critcl support.

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -79,13 +79,14 @@ class TclTk < Formula
     end
 
     resource("critcl").stage do
-      system "SDKROOT=#{MacOS.sdk_path} #{prefix}/bin/tclsh build.tcl install"
+      system bin/"tclsh", "build.tcl", "install"
     end
 
     resource("tcllib").stage do
       system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
       system "make", "install"
-      system "SDKROOT=#{MacOS.sdk_path} make critcl"
+      ENV["SDKROOT"] = MacOS.sdk_path
+      system "make", "critcl"
       cp_r "modules/tcllibc", "#{lib}/"
       ln_s "#{lib}/tcllibc/macosx-x86_64-clang", "#{lib}/tcllibc/macosx-x86_64"
     end

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -79,15 +79,13 @@ class TclTk < Formula
     end
 
     resource("critcl").stage do
-      sdk_root = `xcrun --sdk macosx --show-sdk-path`.strip
-      system "SDKROOT=#{sdk_root} #{prefix}/bin/tclsh build.tcl install"
+      system "SDKROOT=#{MacOS.sdk_path} #{prefix}/bin/tclsh build.tcl install"
     end
 
     resource("tcllib").stage do
       system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
       system "make", "install"
-      sdk_root = `xcrun --sdk macosx --show-sdk-path`.strip
-      system "SDKROOT=#{sdk_root} make critcl"
+      system "SDKROOT=#{MacOS.sdk_path} make critcl"
       cp_r "modules/tcllibc", "#{lib}/"
       ln_s "#{lib}/tcllibc/macosx-x86_64-clang", "#{lib}/tcllibc/macosx-x86_64"
     end

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -17,6 +17,11 @@ class TclTk < Formula
 
   depends_on "openssl"
 
+  resource "critcl" do
+    url "https://github.com/andreas-kupries/critcl/archive/3.1.17.tar.gz"
+    sha256 "fff83b341fc07b8ff23bf1f645133bb4bffe4741da2e6f31155e522a74c228e4"
+  end
+
   resource "tcllib" do
     url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.19/tcllib-1.19.tar.gz"
     sha256 "01fe87cf1855b96866cf5394b6a786fd40b314022714b34110aeb6af545f6a9c"
@@ -73,9 +78,18 @@ class TclTk < Formula
       end
     end
 
+    resource("critcl").stage do
+      sdk_root = `xcrun --sdk macosx --show-sdk-path`.strip
+      system "SDKROOT=#{sdk_root} #{prefix}/bin/tclsh build.tcl install"
+    end
+
     resource("tcllib").stage do
       system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
       system "make", "install"
+      sdk_root = `xcrun --sdk macosx --show-sdk-path`.strip
+      system "SDKROOT=#{sdk_root} make critcl"
+      cp_r "modules/tcllibc", "#{lib}/"
+      ln_s "#{lib}/tcllibc/macosx-x86_64-clang", "#{lib}/tcllibc/macosx-x86_64"
     end
 
     resource("tcltls").stage do


### PR DESCRIPTION
tcl-tk already installs Tcllib. Tcllib has a number of modules, such as json, that are Tcl-only implementations and are slow compared to their C variants. Critcl provides C implementations of these modules. Tcllib already has support for Critcl and this change adds Critcl to the build.

A question on the PR: An environment variable is needed to tell Critcl where the macOS SDK is. Not sure whether the method used is the idiomatic way to do this. Please advise.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [?] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? Please see environment variable question above.

-----