### PR TITLE
upx: Patch to fix Go bug with 3.95 release

### DIFF
--- a/Formula/upx.rb
+++ b/Formula/upx.rb
@@ -1,6 +1,7 @@
 class Upx < Formula
   desc "Compress/expand executable files"
   homepage "https://upx.github.io/"
+  revision 1
   head "https://github.com/upx/upx.git", :branch => "devel"
 
   stable do
@@ -26,6 +27,18 @@ class Upx < Formula
     patch do
       url "https://github.com/upx/upx/commit/9bb6854e642a2505102b9d3f9ec8535ec8ab6d9c.patch?full_index=1"
       sha256 "f525a574b65e6484f0eb29e2a37d5df58da85b121adec06271b19ed5f4cc49b4"
+    end
+
+    # The following two patches fix an issue where UPX 3.95 produces broken go binaries - will be fixed in 3.96
+    # See https://github.com/upx/upx/issues/222 for details
+    patch do
+      url "https://github.com/upx/upx/commit/4d1c754af943f4640062884f38742fd97a6bda0d.patch?full_index=1"
+      sha256 "64c1cbfd2127172bab973be5cdfba3ad05b0ee506c9076eb6bf0e2d8b4d205b0"
+    end
+
+    patch do
+      url "https://github.com/upx/upx/commit/bb1f9cdecd02130e468b9bed680a9bb6122f8a0c.patch?full_index=1"
+      sha256 "2712240751a0b5c6cb3e4d562fc79b125d612f1f185cd84766fcee12900dea61"
     end
   end
 


### PR DESCRIPTION
This is a patch to address #32422, and to allow me to get past the failures in #32405. I've tested out gomplate's full suite of integration tests with the compressed binary, and it all seems to work correctly with these two patches.

See also https://github.com/upx/upx/issues/222 for details. There's also some hint that Rust binaries might have a further issue (fixed upstream), though I feel that should be addressed in a separate PR if that's relevant.

/cc @fxcoudert 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
