### PR TITLE
htop: enable mouse scroll on macOS

### DIFF
--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -3,6 +3,7 @@ class Htop < Formula
   homepage "https://hisham.hm/htop/"
   url "https://hisham.hm/htop/releases/2.2.0/htop-2.2.0.tar.gz"
   sha256 "d9d6826f10ce3887950d709b53ee1d8c1849a70fa38e91d5896ad8cbc6ba3c57"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,6 +21,7 @@ class Htop < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "ncurses" # enables mouse scroll
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-  [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Htop requires brew ncurses to enable mouse scroll function.

Previously, this was an option. Since option has been deprecated in
homebrew/core, let's enable it as default.
