### PR TITLE
wget2 1.99.1 (new formula)

### DIFF
--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -1,0 +1,24 @@
+class Wget2 < Formula
+  desc "Multithreaded metalink/file/website downloader"
+  homepage "https://gitlab.com/gnuwget/wget2/"
+  url "https://alpha.gnu.org/gnu/wget/wget2-1.99.1.tar.gz"
+  sha256 "8d9b0b0897ff9623169db47c656d09007677f8d51de5f5cd3652258aab8b4dde"
+
+  depends_on "gettext"
+  depends_on "gnutls"
+  depends_on "gpgme"
+  depends_on "libpsl"
+  depends_on "nghttp2"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"wget2", "-O", "/dev/null", "https://www.example.org/"
+  end
+end


### PR DESCRIPTION
GNU Wget2 is the successor of GNU Wget, a file and recursive website downloader.

Designed and written from scratch it wraps around libwget, that provides the basic functions needed by a web client.

Wget2 works multi-threaded and uses many features to allow fast operation.

In many cases Wget2 downloads much faster than Wget1.x due to HTTP zlib compression, parallel connections and use of If-Modified-Since HTTP header.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
