### PR TITLE
v8 7.2.502.25

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -3,8 +3,8 @@ class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
   url "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-      :revision => "b69515579db8fb53d13c0d7acf4b5fc6ac4e2b5e"
-  version "7.2.502.24" # the version of the v8 checkout, not a depot_tools version
+      :revision => "aec259ea62328ce39916607876956239fbce29b8"
+  version "7.2.502.25" # the version of the v8 checkout, not a depot_tools version
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR upgrades `v8` to version 7.2.502.25, which includes the [fix for CVE-2019-5784](https://chromereleases.googleblog.com/2019/02/stable-channel-update-for-desktop.html).
