### PR TITLE
ruby@2.4: bump revision to eliminate rogue gmp dependency

### DIFF
--- a/Formula/ruby@2.4.rb
+++ b/Formula/ruby@2.4.rb
@@ -3,7 +3,7 @@ class RubyAT24 < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.xz"
   sha256 "2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "f12140e2606482d2484a76dce1e9e2eea5a3adf8e0b94b8f181d2101af8c5c73" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes #36612