### PR TITLE
watch: support build with ncurses

### DIFF
--- a/Formula/watch.rb
+++ b/Formula/watch.rb
@@ -18,12 +18,16 @@ class Watch < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "ncurses" => :build
 
   depends_on "gettext"
 
   conflicts_with "visionmedia-watch"
 
   def install
+    ENV["NCURSESW_CFLAGS"] = "#{Formula["ncurses"].include} #{Formula["ncurses"].include}/ncursesw"
+    ENV["NCURSESW_LIBS"] = "#{Formula["ncurses"].lib} -lncursesw"
+
     system "autoreconf", "-fiv"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

watch: support build with ncurses.
Basically, avoid not supported(in other words, not included Apple's terminfo) terminfo such as following error.

```console
Error opening terminal: xterm-direct.
```

```console
$ otool -L $(brew --prefix watch)/bin/watch
/usr/local/opt/watch/bin/watch:
        /usr/local/opt/ncurses/lib/libncursesw.6.dylib (compatibility version 6.0.0, current version 6.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
```