### PR TITLE
libxslt: disable building Python2 bindings

### DIFF
--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -3,6 +3,7 @@ class Libxslt < Formula
   homepage "http://xmlsoft.org/XSLT/"
   url "http://xmlsoft.org/sources/libxslt-1.1.33.tar.gz"
   sha256 "8e36605144409df979cab43d835002f63988f3dc94d5d3537c12796db90e38c8"
+  revision 1
 
   bottle do
     cellar :any
@@ -26,12 +27,10 @@ class Libxslt < Formula
   def install
     system "autoreconf", "-fiv" if build.head?
 
-    # https://bugzilla.gnome.org/show_bug.cgi?id=762967
-    inreplace "configure", /PYTHON_LIBS=.*/, 'PYTHON_LIBS="-undefined dynamic_lookup"'
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
+                          "--without-python",
                           "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
The macOS version does not have Python2 bindings, so this aligns the
formula with what is provided by macOS.

This change removes the following files:
ls /usr/local/Cellar/libxslt/1.1.33/lib/python2.7/site-packages
libxslt.py    libxsltmod.a  libxsltmod.so

libxslt does not work with Python3
https://stackoverflow.com/a/43395461
and we want to be ready for the Python2 EOL.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is open for discussion. The real reason for this change is that I would like to have the same thing in Linuxbrew. There, I need to have `depends_on "python@2"`, which creates some mixed python2/python3 dependency tree. Removing that dependency would surely bring some clarity.

I am worried of are the analytics though:
```
==> Analytics
install: 5,721 (30 days), 13,966 (90 days), 47,786 (365 days)
install_on_request: 3,861 (30 days), 9,456 (90 days), 36,897 (365 days)
```

That seem to be a lot of install requests ... why would people need this if it is provided by macOS? For the bindings? Or because that version is too old?