### PR TITLE
kustomize: Fix kustomize version

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -36,7 +36,7 @@ class Kustomize < Formula
   end
 
   test do
-    assert_match "KustomizeVersion:", shell_output("#{bin}/kustomize version")
+    assert_match "KustomizeVersion:v#{version}", shell_output("#{bin}/kustomize version")
 
     (testpath/"kustomization.yaml").write <<~EOS
       resources:

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -25,8 +25,9 @@ class Kustomize < Formula
     dir.install buildpath.children - [buildpath/".brew_home"]
     cd dir do
       ldflags = %W[
-        -s -X sigs.k8s.io/kustomize/pkg/commands.kustomizeVersion=#{tag}
-        -X sigs.k8s.io/kustomize/pkg/commands.gitCommit=#{revision}
+        -s -X sigs.k8s.io/kustomize/pkg/commands/misc.kustomizeVersion=#{tag}
+        -X sigs.k8s.io/kustomize/pkg/commands/misc.gitCommit=#{revision}
+        -X sigs.k8s.io/kustomize/pkg/commands/misc.buildDate=#{Time.now.iso8601}
       ]
       system "go", "install", "-ldflags", ldflags.join(" ")
       bin.install buildpath/"bin/kustomize"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`kustomize version` show `unknown` because using incorrect ldflags.

```
 % kustomize version
Version: {KustomizeVersion:unknown GitCommit:$Format:%H$ BuildDate:1970-01-01T00:00:00Z GoOs:unknown GoArch:unknown}
```

So, refer to [this](https://github.com/kubernetes-sigs/kustomize/blob/5c918dc56a664492c3526fa047b74e7204e2a460/build/goreleaser.yaml#L7), fix ldflags.

```
% kustomize version
Version: {KustomizeVersion:v2.0.1 GitCommit:ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3 BuildDate:2019-02-14T11:38:59+09:00 GoOs:unknown GoArch:unknown}
```