### PR TITLE
tesseract-lang 4.0.0 (new formula)

### DIFF
--- a/Formula/tesseract-lang.rb
+++ b/Formula/tesseract-lang.rb
@@ -1,0 +1,26 @@
+class TesseractLang < Formula
+  desc "Enables extra languages support for Tesseract"
+  homepage "https://github.com/tesseract-ocr/tessdata_fast/"
+  url "https://github.com/tesseract-ocr/tessdata_fast/archive/4.0.0.tar.gz"
+  sha256 "f1b71e97f27bafffb6a730ee66fd9dc021afc38f318fdc80a464a84a519227fe"
+
+  depends_on "tesseract"
+
+  resource "testfile" do
+    url "https://raw.githubusercontent.com/tesseract-ocr/test/6dd816cdaf3e76153271daf773e562e24c928bf5/testing/eurotext.tif"
+    sha256 "7b9bd14aba7d5e30df686fbb6f71782a97f48f81b32dc201a1b75afe6de747d6"
+  end
+
+  def install
+    rm "eng.traineddata"
+    rm "osd.traineddata"
+    (share/"tessdata").install Dir["*"]
+  end
+
+  test do
+    resource("testfile").stage do
+      system "#{Formula["tesseract"].bin}/tesseract", "./eurotext.tif", "./output", "-l", "eng+deu"
+      assert_match "über den faulen Hund. Le renard brun\n", shell_output("cat ./output.txt")
+    end
+  end
+end

--- a/Formula/tesseract-lang.rb
+++ b/Formula/tesseract-lang.rb
@@ -20,7 +20,7 @@ class TesseractLang < Formula
   test do
     resource("testfile").stage do
       system "#{Formula["tesseract"].bin}/tesseract", "./eurotext.tif", "./output", "-l", "eng+deu"
-      assert_match "über den faulen Hund. Le renard brun\n", shell_output("cat ./output.txt")
+      assert_match "über den faulen Hund. Le renard brun\n", File.read("output.txt")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

Following the indications in PR #36786, this PR includes a new `tesseract-lang` formula that depends on `tesseract` and installs all the language data files (besides English and osd, needed to run the software) in its `share` folder. 

The original `tesseract` formula is also updated to embed only the essential data files, and amended to search for language data files in `#{HOMEBREW_PREFIX}/share`. Symlinks do the rest of the trick.

In this way, the installed size of `tesseract` drops to 30 MB, while the size of `tesseract-lang`is about 650 MB. 

The `test` block of both formulas has also been updated to perform an actual OCR task on an example taken from the upstream test repository. The test is made using only English in `tesseract`and using also German in `tesseract-lang`.