### PR TITLE
php,php@7.1,php@7.2: Use built-in pcre library

### DIFF
--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -33,7 +33,6 @@ class PhpAT71 < Formula
   depends_on "mcrypt"
   depends_on "openldap"
   depends_on "openssl"
-  depends_on "pcre"
   depends_on "sqlite"
   depends_on "tidy-html5"
   depends_on "unixodbc"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -33,7 +33,6 @@ class PhpAT72 < Formula
   depends_on "libzip"
   depends_on "openldap"
   depends_on "openssl"
-  depends_on "pcre"
   depends_on "sqlite"
   depends_on "tidy-html5"
   depends_on "unixodbc"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove the pcre dependency since the code required for the extension is shipped with PHP. The latest version had this change made already but wasn't revision bumped so I included that here as well.