### PR TITLE
ansible-lint: Update homepage URL to use new owner

### DIFF
--- a/Formula/ansible-lint.rb
+++ b/Formula/ansible-lint.rb
@@ -2,7 +2,7 @@ class AnsibleLint < Formula
   include Language::Python::Virtualenv
 
   desc "Checks ansible playbooks for practices and behaviour"
-  homepage "https://github.com/willthames/ansible-lint/"
+  homepage "https://github.com/ansible/ansible-lint/"
   url "https://files.pythonhosted.org/packages/e6/16/31f3244635b37474bbff4ac88afc916cfc24baf44766f8bcc8deeede187c/ansible-lint-4.1.0.tar.gz"
   sha256 "9430ea6e654ba4bf5b9c6921efc040f46cda9c4fd2896a99ff71d21037bcb123"
 


### PR DESCRIPTION
Evidently `ansible-lint` is now maintained by Ansible:

```sh-session
$ curl -IsS https://github.com/willthames/ansible-lint | grep 'Status\|Location'
Status: 301 Moved Permanently
Location: https://github.com/ansible/ansible-lint
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
