### PR TITLE
pyside 5.12.1

### DIFF
--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -1,8 +1,8 @@
 class Pyside < Formula
   desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
-  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.12.0-src/pyside-setup-everywhere-src-5.12.0.tar.xz"
-  sha256 "890149628a6c722343d6498a9f7e1906ce3c10edcaef0cc53cd682c1798bef51"
+  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.12.1-src/pyside-setup-everywhere-src-5.12.1.tar.xz"
+  sha256 "6e26b6240b97558b8bf3c97810e950ef4121a03a1ebdecfb649992a505f18059"
 
   bottle do
     sha256 "054b6d47901926ccdcc7e536f64b4fe5940a4a3cc66eb9cd8fa79dfa1c2b2ffc" => :mojave
@@ -62,8 +62,8 @@ class Pyside < Formula
       ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
     end
     ["python", "python@2"].each do |python|
-      if python == "python"
-        ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
+      if python == "python@2"
+        ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"
       end
       system "cmake", "-H#{pkgshare}/samplebinding",
                       "-B.",
@@ -72,6 +72,7 @@ class Pyside < Formula
                       "-DCMAKE_BUILD_TYPE=Release"
       system "make"
       system "make", "clean"
+      rm "CMakeCache.txt"
     end
   end
 end


### PR DESCRIPTION
Bumps to the latest version of pyside.
Includes a small change in the test block to ensure that the tests are fully evaluated on both versions of python.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
