### PR TITLE
mage 1.8.0 (new formula)

### DIFF
--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -1,0 +1,25 @@
+class Mage < Formula
+  desc "Make/rake-like build tool using Go"
+  homepage "https://magefile.org"
+  url "https://github.com/magefile/mage.git",
+      :tag      => "v1.8.0",
+      :revision => "aedfce64c122eef47009b7f80c9771044753215d"
+  sha256 "e8fdfa30f68c8a90fcadd4e82f49c9136011accabff55e073ea26f5ee4280cf0"
+
+  depends_on "go"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/magefile/mage").install buildpath.children
+    cd "src/github.com/magefile/mage" do
+      system "go", "run", "bootstrap.go"
+      bin.install buildpath/"bin/mage"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_match "magefile.go created", shell_output("#{bin}/mage -init 2>&1")
+    assert_predicate testpath/"magefile.go", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The formula is using git instead of a zip archive because the project uses git commands to determine version tag and commit hash during the build process. This is later used to show version and hash when run with the version flag (`mage --version`).

I noticed there are also 2 closed pull requests for `mage` already, but they were flagged as outdated and closed with no further explanation (#31956, #31562).