### PR TITLE
eiffelstudio: Restore ISE_PLATFORM env var

### DIFF
--- a/Formula/eiffelstudio.rb
+++ b/Formula/eiffelstudio.rb
@@ -3,7 +3,7 @@ class Eiffelstudio < Formula
   homepage "https://www.eiffel.com"
   url "https://ftp.eiffel.com/pub/download/17.01/eiffelstudio-17.01.9.9700.tar"
   sha256 "610344e8e4bbb4b8ccedc22e57b6ffa6b8fd7b9ffee05edad15fc1aa2b1259a1"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/eiffelstudio.rb
+++ b/Formula/eiffelstudio.rb
@@ -21,7 +21,7 @@ class Eiffelstudio < Formula
     system "./make_images", "macosx-x86-64"
     prefix.install Dir["Eiffel_17.01/*"]
     bin.mkpath
-    env = { :ISE_EIFFEL => prefix, :"macosx-x86-64" => "macosx-x86-64" }
+    env = { :ISE_EIFFEL => prefix, :ISE_PLATFORM => "macosx-x86-64" }
     (bin/"ec").write_env_script(prefix/"studio/spec/macosx-x86-64/bin/ec", env)
     (bin/"ecb").write_env_script(prefix/"studio/spec/macosx-x86-64/bin/ecb", env)
     (bin/"estudio").write_env_script(prefix/"studio/spec/macosx-x86-64/bin/estudio", env)
@@ -35,6 +35,6 @@ class Eiffelstudio < Formula
   test do
     # More extensive testing requires the full test suite
     # which is not part of this package.
-    system prefix/"studio/spec/macosx-x86-64/bin/ec", "-version"
+    system bin/"ec", "-version"
   end
 end


### PR DESCRIPTION
Per Eiffel Studio documentation, this environment variable should be set. Without it, running `brew test` throws a warning message. Also enhanced the formula test to run from bin/ instead of prefix/

Fixes #37077.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
