### PR TITLE
google-java-format 1.7

### DIFF
--- a/Formula/google-java-format.rb
+++ b/Formula/google-java-format.rb
@@ -1,8 +1,8 @@
 class GoogleJavaFormat < Formula
   desc "Reformats Java source code to comply with Google Java Style"
   homepage "https://github.com/google/google-java-format"
-  url "https://github.com/google/google-java-format/archive/google-java-format-1.6.tar.gz"
-  sha256 "d471a84c49ef33e1ab5059f7a04f5e1ac127ccf05db1c2d69d4c1733a256a15f"
+  url "https://github.com/google/google-java-format/archive/google-java-format-1.7.tar.gz"
+  sha256 "199c70851146bc15c8e828f5ca78d6c2d7b338def9cc70786ac3ef5967796399"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,6 +15,7 @@ class GoogleJavaFormat < Formula
   depends_on "maven" => :build
 
   def install
+    system "mvn", "versions:set", "-DnewVersion=#{version}"
     system "mvn", "install", "-DskipTests=true", "-Dmaven.javadoc.skip=true", "-B"
     libexec.install "core/target/google-java-format-#{version}-all-deps.jar"
 


### PR DESCRIPTION
The pom.xml in the source archive for release 1.7 has the version set
to 1.7-SNAPSHOT which causes the build to fail, therefore include a
call to mvn versions:set to force it to the correct version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
