### PR TITLE
libtermkey: apply a patch to fix a buffer overflow issue

### DIFF
--- a/Formula/libtermkey.rb
+++ b/Formula/libtermkey.rb
@@ -3,6 +3,7 @@ class Libtermkey < Formula
   homepage "http://www.leonerd.org.uk/code/libtermkey/"
   url "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.21.tar.gz"
   sha256 "79ebd5cf965e7eb127bd33109d83d5b34226d5f0d039a505882d8d20f72deb3b"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,8 +15,27 @@ class Libtermkey < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
+  # Fix a buffer overflow issue.
+  # See https://github.com/neovim/neovim/issues/9630#issuecomment-465261774
+  patch :DATA
+
   def install
     system "make", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end
 end
+
+__END__
+diff --git a/driver-ti.c b/driver-ti.c
+index 981d420..3fe3c52 100644
+--- a/driver-ti.c
++++ b/driver-ti.c
+@@ -291,7 +291,7 @@ static int load_terminfo(TermKeyTI *ti)
+   /* First the regular key strings
+    */
+   for(i = 0; funcs[i].funcname; i++) {
+-    char name[MAX_FUNCNAME + 4 + 1];
++    char name[MAX_FUNCNAME + 5 + 1];
+ 
+     sprintf(name, "key_%s", funcs[i].funcname);
+     if(!try_load_terminfo_key(ti, name, &(struct keyinfo){


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
