### PR TITLE
libopenmpt 0.4.3 (new formula)

### DIFF
--- a/Formula/libopenmpt.rb
+++ b/Formula/libopenmpt.rb
@@ -1,0 +1,38 @@
+class Libopenmpt < Formula
+  desc "Software library to decode tracked music files"
+  homepage "https://lib.openmpt.org/libopenmpt/"
+  url "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.4.3+release.autotools.tar.gz"
+  version "0.4.3"
+  sha256 "d77443a279003921d6f0c4edb30d1e9dda387983f44113a6d58f623c1e6942ae"
+
+  depends_on "pkg-config" => :build
+
+  depends_on "flac"
+  depends_on "libogg"
+  depends_on "libsndfile"
+  depends_on "libvorbis"
+  depends_on "mpg123"
+  depends_on "portaudio"
+
+  resource "mystique.s3m" do
+    url "https://api.modarchive.org/downloads.php?moduleid=54144#mystique.s3m"
+    sha256 "e9a3a679e1c513e1d661b3093350ae3e35b065530d6ececc0a96e98d3ffffaf4"
+  end
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--without-vorbisfile"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    resource("mystique.s3m").stage do
+      system "#{bin}/openmpt123", "--probe", "mystique.s3m"
+    end
+  end
+end

--- a/Formula/libopenmpt.rb
+++ b/Formula/libopenmpt.rb
@@ -32,7 +32,8 @@ class Libopenmpt < Formula
 
   test do
     resource("mystique.s3m").stage do
-      system "#{bin}/openmpt123", "--probe", "mystique.s3m"
+      output = shell_output("#{bin}/openmpt123 --probe mystique.s3m")
+      assert_match "Success", output
     end
   end
 end


### PR DESCRIPTION
Add new formula with libopenmpt, along with small utility openmpt123. 

libopenmpt is a library to play to play tracker music files (XM, MOD, etc.).

openmpt123 is a small player based on libopenmpt to demonstrate libopenmpt.

Based on #33005

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Only the last requirement (`audit`) left unchecked because `audit` asks to remove `:optional` and `:recommended` (`Formulae should not have optional or recommended dependencies`) but I am not quite sure how to allow build with SDL or SDL2 without specifying dependency scope. 
