### PR TITLE
Elasticsearch formulae: make postinstall repeatable

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -1,9 +1,8 @@
 class Elasticsearch < Formula
   desc "Distributed search & analytics engine"
   homepage "https://www.elastic.co/products/elasticsearch"
-  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.6.0.tar.gz"
-  sha256 "5f302eecfa73c717401c016cb58bd1445b9b5b833724e0fbe627c515d54df0a4"
-  revision 1
+  url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.6.1.tar.gz"
+  sha256 "cdbc32ef68dcc89eb55dee757b52db6cbb579a136e5cf1df9ab5fb21b40a5242"
 
   head do
     url "https://github.com/elasticsearch/elasticsearch.git"

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -64,9 +64,9 @@ class Elasticsearch < Formula
     # Make sure runtime directories exist
     (var/"lib/elasticsearch/#{cluster_name}").mkpath
     (var/"log/elasticsearch").mkpath
-    ln_s etc/"elasticsearch", libexec/"config"
+    ln_s etc/"elasticsearch", libexec/"config" unless (libexec/"config").exist?
     (var/"elasticsearch/plugins").mkpath
-    ln_s var/"elasticsearch/plugins", libexec/"plugins"
+    ln_s var/"elasticsearch/plugins", libexec/"plugins" unless (libexec/"plugins").exist?
     # fix test not being able to create keystore because of sandbox permissions
     system bin/"elasticsearch-keystore", "create" unless (etc/"elasticsearch/elasticsearch.keystore").exist?
   end

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -59,8 +59,8 @@ class ElasticsearchAT24 < Formula
     # Make sure runtime directories exist
     (var/"elasticsearch/#{cluster_name}").mkpath
     (var/"log/elasticsearch").mkpath
-    ln_s etc/"elasticsearch", libexec/"config"
-    (libexec/"plugins").mkdir
+    ln_s etc/"elasticsearch", libexec/"config" unless (libexec/"config").exist?
+    (libexec/"plugins").mkpath
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew postinstall` is not repeatable for these formulae right now because they do a few things that aren't safe to do repeatedly:

* `ln_s` will raise if the target already exists.
* `mkdir` will raise if the target already exists.

I fixed the former by skipping the link when the target exists, and the latter by using `mkpath`.