### PR TITLE
sqlite3-pcre (new formula)

### DIFF
--- a/Formula/sqlite3-pcre.rb
+++ b/Formula/sqlite3-pcre.rb
@@ -1,0 +1,33 @@
+class Sqlite3Pcre < Formula
+  desc "SQLite3 extension using PCRE to provide the REGEXP function"
+  homepage "https://github.com/ralight/sqlite3-pcre"
+  head "https://github.com/ralight/sqlite3-pcre.git"
+
+  depends_on "coreutils" => :build
+  depends_on "pkg-config" => :build
+  depends_on "pcre"
+  depends_on "sqlite"
+
+  def install
+    system "make", "install", "prefix=#{prefix}", "INSTALL=ginstall"
+  end
+
+  def caveats; <<~EOS
+    sqlite3-pcre does not work with the macOS-provided sqlite3 because it does
+    not provide the `.load` meta-command. To invoke the Homebrew-supplied
+    keg-only sqlite3, run:
+      #{HOMEBREW_PREFIX}/opt/sqlite/bin/sqlite3
+
+    sqlite3 will not automatically load the pcre extension. To load it
+    interactively, use this .load command at the sqlite prompt or add it to
+    your ~/.sqliterc file:
+      .load #{lib}/sqlite3/pcre.so
+  EOS
+  end
+
+  test do
+    system "#{HOMEBREW_PREFIX}/opt/sqlite/bin/sqlite3",
+      "-cmd", ".load #{lib}/sqlite3/pcre.so\n",
+      "dummy.db", "SELECT 'abba' REGEXP 'ab*a';"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    - No, because it is a head-only formula. See below.

-----

This commit adds a new formula for sqlite3-pcre, an SQLite3 extension that uses
PCRE to provide an implementation of the SQL function REGEXP.

This formula attempts to address some of the concerns raised in
Homebrew/legacy-homebrew#26354. Rather than building the extension into sqlite
itself, it is provided as a separate formula that folks can install or not as
they please.

This package is a little unusual in that it installs a shared library (`.so`)
that can be dynamically loaded by SQLite in order to support the REGEXP
operator. This has to be done manually with the `.load` meta-command in SQLite,
and I note this in the caveats.

There are some issues with upstream that I'd like to acknowledge here, but I
hope that we can look past these since being able to help folks who need the
REGEXP operator is desirable and this seems to be the best way to do it.

   * Yes, this code is head-only. Upstream has never tagged a release. 🙄
   * Yes, it depends on a keg-only formula. The version of SQLite that ships
     with macOS doesn't support loading extensions, so it's necessary to install
     and use the Homebrew `sqlite` formula. This is mentioned in the caveats.
   * Yes, upstream is not very notable. I think in this case it's because the
     extension is basically done; there's no development happening because it's
     fairly simple and already just works.

The upstream Makefile assumes that `install` is GNU install, so I added a build
dependency on `coreutils` in order to provide that.
