### PR TITLE
libpulsar 2.3.0

### DIFF
--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -1,8 +1,8 @@
 class Libpulsar < Formula
   desc "Apache Pulsar C++ library"
   homepage "https://pulsar.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=pulsar/pulsar-2.2.1/apache-pulsar-2.2.1-src.tar.gz"
-  sha256 "3a365368f0d7beba091ba3a6d0f703dcc77545c8b454e5e33b72c1a29905232e"
+  url "https://www.apache.org/dyn/closer.cgi?path=pulsar/pulsar-2.3.0/apache-pulsar-2.3.0-src.tar.gz"
+  sha256 "ac182c83f2fff03e8242cb9f9540d5ae2a32e3b9b382a2340f139dfa0bfb0a28"
 
   bottle do
     cellar :any
@@ -14,9 +14,9 @@ class Libpulsar < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "jsoncpp"
   depends_on "openssl"
   depends_on "protobuf"
+  depends_on "zstd"
 
   def install
     cd "pulsar-client-cpp" do
@@ -40,7 +40,7 @@ class Libpulsar < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cc", "-I#{Formula["boost"].include}", "-L#{lib}", "-lpulsar", "-o", "test"
+    system ENV.cxx, "test.cc", "-L#{lib}", "-lpulsar", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Notes: 
 * Removed jsoncpp since it's not used anymore 
 * Added zstd dep since it's a new feature
 * Remove boost include dir from test compilation, since we don't need boost headers anymore.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
