### PR TITLE
proper 1.3 (new formula)

### DIFF
--- a/Formula/proper.rb
+++ b/Formula/proper.rb
@@ -1,0 +1,23 @@
+class Proper < Formula
+  desc "PropEr: a QuickCheck-inspired property-based testing tool for Erlang"
+  homepage "https://proper-testing.github.io"
+  url "https://github.com/proper-testing/proper/archive/v1.3.tar.gz"
+  sha256 "7e59eeaef12c07b1e42b0891238052cd05cbead58096efdffa3413b602cd8939"
+
+  depends_on "erlang"
+
+  def install
+    system "make"
+    prefix.install Dir["ebin", "include"]
+  end
+
+  def caveats; <<~EOS
+    Add the following line to your shell startup file (~/.bashrc in the case of the Bash shell):
+      export ERL_LIBS=#{opt_prefix}
+  EOS
+  end
+
+  test do
+    assert_equal "", shell_output("find #{opt_prefix}/{ebin,include} -prune -empty -type d")
+  end
+end

--- a/Formula/proper.rb
+++ b/Formula/proper.rb
@@ -11,12 +11,6 @@ class Proper < Formula
     prefix.install Dir["ebin", "include"]
   end
 
-  def caveats; <<~EOS
-    Add the following line to your shell startup file (~/.bashrc in the case of the Bash shell):
-      export ERL_LIBS=#{opt_prefix}
-  EOS
-  end
-
   test do
     assert_not_equal "non_existing", shell_output("erl -noshell -pa /usr/local/opt/proper/ebin -eval 'io:write(code:which(proper))' -s init stop")
   end

--- a/Formula/proper.rb
+++ b/Formula/proper.rb
@@ -18,6 +18,6 @@ class Proper < Formula
   end
 
   test do
-    assert_equal "", shell_output("find #{opt_prefix}/{ebin,include} -prune -empty -type d")
+    assert_not_equal "non_existing", shell_output("erl -noshell -pa /usr/local/opt/proper/ebin -eval 'io:write(code:which(proper))' -s init stop")
   end
 end

--- a/Formula/proper.rb
+++ b/Formula/proper.rb
@@ -1,5 +1,5 @@
 class Proper < Formula
-  desc "PropEr: a QuickCheck-inspired property-based testing tool for Erlang"
+  desc "QuickCheck-inspired property-based testing tool for Erlang"
   homepage "https://proper-testing.github.io"
   url "https://github.com/proper-testing/proper/archive/v1.3.tar.gz"
   sha256 "7e59eeaef12c07b1e42b0891238052cd05cbead58096efdffa3413b602cd8939"
@@ -12,6 +12,7 @@ class Proper < Formula
   end
 
   test do
-    assert_not_equal "non_existing", shell_output("erl -noshell -pa /usr/local/opt/proper/ebin -eval 'io:write(code:which(proper))' -s init stop")
+    output = shell_output("erl -noshell -pa #{opt_prefix}/ebin -eval 'io:write(code:which(proper))' -s init stop")
+    assert_not_equal "non_existing", output
   end
 end


### PR DESCRIPTION
This pull request introduces the [PropEr](https://proper-testing.github.io) formula to Homebrew. PropEr is a QuickCheck-inspired property-based testing tool for Erlang.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----