### PR TITLE
circleci cli: install packr as a homebrew resource

### DIFF
--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -15,10 +15,9 @@ class Circleci < Formula
 
   depends_on "go" => :build
 
-  resource "packr2" do
-    "https://github.com/gobuffalo/packr/releases/download/v2.0.1/packr_2.0.1_darwin_amd64.tar.gz"
-    # Source: https://github.com/gobuffalo/packr/releases/download/v2.0.1/checksums.txt
-    "0347a77997471535ea5cddaabc962aba16a374582ec75af7c901c8d0877aef69"
+  resource "packr" do
+    url "https://github.com/gobuffalo/packr/archive/v2.0.1.tar.gz"
+    sha256 "cc0488e99faeda4cf56631666175335e1cce021746972ce84b8a3083aa88622f"
   end
 
   def install
@@ -29,8 +28,11 @@ class Circleci < Formula
     dir.install buildpath.children
 
     cd dir do
-      resource("packr2").stage buildpath/"bin"/resource.name
-      system "make", "pack"
+      resource("packr").stage do
+        system "go", "install", "./packr"
+      end
+      # Refer to packr by its absolute path, in case GOPATH isn't in the user's path
+      system buildpath/"bin/packr build"
       commit = Utils.popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[
         -s -w

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -3,8 +3,8 @@ class Circleci < Formula
   homepage "https://circleci.com/docs/2.0/local-cli/"
   # Updates should be pushed no more frequently than once per week.
   url "https://github.com/CircleCI-Public/circleci-cli.git",
-      :tag      => "v0.1.4786",
-      :revision => "bad101fb126ffbb15669b67f441d9848a6798b4f"
+      :tag      => "v0.1.5389",
+      :revision => "4379bab5169f609898214b717c313f9943fdbe41"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,6 +15,12 @@ class Circleci < Formula
 
   depends_on "go" => :build
 
+  resource "packr" do
+    "https://github.com/gobuffalo/packr/releases/download/v2.0.1/packr_2.0.1_darwin_amd64.tar.gz"
+    # Source: https://github.com/gobuffalo/packr/releases/download/v2.0.1/checksums.txt
+    "0347a77997471535ea5cddaabc962aba16a374582ec75af7c901c8d0877aef69"
+  end
+
   def install
     ENV["GOPATH"] = buildpath
     ENV["GO111MODULE"] = "on"
@@ -23,6 +29,9 @@ class Circleci < Formula
     dir.install buildpath.children
 
     cd dir do
+      # TODO: figure out the right syntax for this (change pycrypto to packr)
+      # resource("pycrypto").stage { system "python", *Language::Python.setup_install_args(libexec/"vendor") }
+      system "make", "pack"
       commit = Utils.popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[
         -s -w

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -15,7 +15,7 @@ class Circleci < Formula
 
   depends_on "go" => :build
 
-  resource "packr" do
+  resource "packr2" do
     "https://github.com/gobuffalo/packr/releases/download/v2.0.1/packr_2.0.1_darwin_amd64.tar.gz"
     # Source: https://github.com/gobuffalo/packr/releases/download/v2.0.1/checksums.txt
     "0347a77997471535ea5cddaabc962aba16a374582ec75af7c901c8d0877aef69"
@@ -29,8 +29,7 @@ class Circleci < Formula
     dir.install buildpath.children
 
     cd dir do
-      # TODO: figure out the right syntax for this (change pycrypto to packr)
-      # resource("pycrypto").stage { system "python", *Language::Python.setup_install_args(libexec/"vendor") }
+      resource("packr2").stage buildpath/"bin"/resource.name
       system "make", "pack"
       commit = Utils.popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've been unable to run the brew testing commands locally due to `brew audit` and `brew test` having some issues installing the `json` gem. I'm hoping that opening this PR might trigger the test suite to run on CI.

I've collaborated with @zzak to take a different approach from [this PR](https://github.com/Homebrew/homebrew-core/pull/36546), but towards the same goal.

I'll try to get this tested locally in the next week.