### PR TITLE
go: Add devel version 1.12rc1.

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -20,6 +20,16 @@ class Go < Formula
     sha256 "6b3c580ad568f04cbaf3eb2dca9f4ce3bb11e071f7340b172a8a2ade2555ded4" => :sierra
   end
 
+  devel do
+    url "https://dl.google.com/go/go1.12rc1.src.tar.gz"
+    sha256 "ed1d4f8e8a33f0d4a59a2f642584c7c6375fce2f8a4edaece73309cf2c89b8ee"
+
+    resource "gotools" do
+      url "https://go.googlesource.com/tools.git",
+          :branch => "release-branch.go1.12"
+    end
+  end
+
   head do
     url "https://go.googlesource.com/go.git"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I don't quite grasp why `brew audit` fails with

```
* Formulae should not have a `devel` spec
```

I didn't find any hints as to why this wouldn't be allowed in this case. Any pointers greatly appreciated 🙂.