### PR TITLE
swig: fix test

### DIFF
--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -48,7 +48,7 @@ class Swig < Formula
     EOS
     system "#{bin}/swig", "-ruby", "test.i"
     system ENV.cc, "-c", "test.c"
-    system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
+    system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
     system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
     assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end

--- a/Formula/swig@3.04.rb
+++ b/Formula/swig@3.04.rb
@@ -42,7 +42,7 @@ class SwigAT304 < Formula
     EOS
     system "#{bin}/swig", "-ruby", "test.i"
     system ENV.cc, "-c", "test.c"
-    system ENV.cc, "-c", "test_wrap.c", "-I/System/Library/Frameworks/Ruby.framework/Headers/"
+    system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
     system ENV.cc, "-bundle", "-flat_namespace", "-undefined", "suppress", "test.o", "test_wrap.o", "-o", "test.bundle"
     assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
   end


### PR DESCRIPTION
`/System/Library/Frameworks/Ruby.framework/Headers` is no longer guaranteed to exist as of Xcode 10.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
