### PR TITLE
sqlite-regexp (0.1-alt1): new formula

### DIFF
--- a/Formula/sqlite-regexp.rb
+++ b/Formula/sqlite-regexp.rb
@@ -1,0 +1,41 @@
+class SqliteRegexp < Formula
+  desc "SQLite extension providing the REGEXP operator"
+  homepage "https://www.sqlite.org/src/file/ext/misc/regexp.c"
+  url "https://www.sqlite.org/2019/sqlite-src-3270200.zip"
+  version "3.27.2"
+  sha256 "15bd4286f2310f5fae085a1e03d9e6a5a0bb7373dcf8d4020868792e840fdf0a"
+
+  depends_on "sqlite"
+
+  def install
+    system "/usr/bin/install", "-d", "#{lib}/#{name}"
+    system ENV.cc, "-g", "-fPIC", "-dynamiclib", "ext/misc/regexp.c",
+      "-o", "#{lib}/#{name}/regexp.dylib"
+  end
+
+  def caveats; <<~EOS
+    sqlite-regexp does not work with the macOS-provided sqlite3. To invoke the
+    Homebrew-supplied keg-only sqlite3, run:
+
+      #{Formula["sqlite"].opt_bin}/sqlite3
+
+    SQLite does not automatically load extensions. To load the regexp extension,
+    run this command at the sqlite prompt:
+
+      .load #{HOMEBREW_PREFIX}/lib/#{name}/regexp
+
+    You can also add it to your ~/.sqliterc file to have it run automatically.
+
+    This implementation of the REGEXP operator supports a subset of PCRE syntax
+    documented in the regexp.c source file, which can be easily viewed here:
+
+      #{homepage}
+  EOS
+  end
+
+  test do
+    system "#{Formula["sqlite"].opt_bin}/sqlite3",
+      "-cmd", ".load #{HOMEBREW_PREFIX}/lib/#{name}/regexp",
+      ":memory:", "SELECT 'abba' REGEXP 'ab*a';"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This commit adds a new formula for the the SQLite REGEXP extension, which allows
users to use SQLite's non-standard REGEXP operator in SELECT statements.

I attempt to address the concerns raised in [Homebrew/legacy-homebrew#26354](https://github.com/Homebrew/legacy-homebrew/pull/26354) by
using the implementation that is included in the SQLite source code, rather than
[a third-party implementation](https://github.com/ralight/sqlite3-pcre/).

I added caveats describing how to load the extension and where to find docs on
the regular expression syntax that it supports (which is a subset of PCRE).

See also my previous attempts #37150, #37155.