### PR TITLE
libccd: use new option to enable double precision

### DIFF
--- a/Formula/libccd.rb
+++ b/Formula/libccd.rb
@@ -3,6 +3,7 @@ class Libccd < Formula
   homepage "http://libccd.danfis.cz/"
   url "https://github.com/danfis/libccd/archive/v2.1.tar.gz"
   sha256 "542b6c47f522d581fbf39e51df32c7d1256ac0c626e7c2b41f1040d4b9d50d1e"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,7 @@ class Libccd < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", "-DCCD_DOUBLE=ON", *std_cmake_args
+    system "cmake", ".", "-DENABLE_DOUBLE_PRECISION=ON", *std_cmake_args
     system "make", "install"
   end
 

--- a/Formula/libccd.rb
+++ b/Formula/libccd.rb
@@ -3,7 +3,6 @@ class Libccd < Formula
   homepage "http://libccd.danfis.cz/"
   url "https://github.com/danfis/libccd/archive/v2.1.tar.gz"
   sha256 "542b6c47f522d581fbf39e51df32c7d1256ac0c626e7c2b41f1040d4b9d50d1e"
-  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
The CMake mechanism for specifying double precision changed from the macro [`CCD_ENABLE` in 2.0](https://github.com/danfis/libccd/blob/v2.0/CMakeLists.txt#L20) to [`ENABLE_DOUBLE_PRECISION` in 2.1](https://github.com/danfis/libccd/blob/v2.1/CMakeLists.txt#L25). However, the formula still uses the [2.0 spelling](https://github.com/Homebrew/homebrew-core/blob/master/Formula/libccd.rb#L17).

Ref: https://github.com/flexible-collision-library/fcl/issues/291#issuecomment-467596314

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
