### PR TITLE
ffmpeg: --enable-fdk-aac

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -4,6 +4,7 @@ class Ffmpeg < Formula
   url "https://ffmpeg.org/releases/ffmpeg-4.1.1.tar.xz"
   sha256 "373749824dfd334d84e55dff406729edfd1606575ee44dd485d97d45ea4d2d86"
   head "https://github.com/FFmpeg/FFmpeg.git"
+  revision 1
 
   bottle do
     sha256 "468153bac4b90b445fa5c6adfb70ec3213ebc0f63c7a97a6b2a1649d9c32a786" => :mojave
@@ -16,6 +17,7 @@ class Ffmpeg < Formula
   depends_on "texi2html" => :build
 
   depends_on "aom"
+  depends_on "fdk-aac"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "frei0r"
@@ -83,6 +85,9 @@ class Ffmpeg < Formula
       --disable-indev=jack
       --enable-libaom
       --enable-libsoxr
+
+      --enable-nonfree
+      --enable-libfdk-aac
     ]
 
     system "./configure", *args


### PR DESCRIPTION
ffmpeg's native AAC encoder "... quality is on par or better than libfdk_aac at the default bitrate of 128kbps."[1] However, the ffmpeg native AAC encoder does not support the HE-AAC and HE-AACv2 profiles, so libfdk_aac is still required to use those codecs.

1. https://www.ffmpeg.org/ffmpeg-codecs.html#aac
2. https://www.ffmpeg.org/ffmpeg-codecs.html#libfdk_005faac

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
Brew audit is not working for me, seems unrelated to this change.

```
$ brew audit --strict ffmpeg
==> Installing 'bundler' gem
ERROR:  While executing gem ... (TypeError)
    incompatible marshal file format (can't be read)
	format version 4.8 required; 60.33 given
Error: failed to install the 'bundler' gem.
```
-----
