### PR TITLE
fish: use sphinx-doc in HEAD builds

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -14,7 +14,7 @@ class Fish < Formula
   head do
     url "https://github.com/fish-shell/fish-shell.git", :shallow => false
 
-    depends_on "doxygen" => :build
+    depends_on "sphinx-doc" => :build
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
fish has switched to a new documentation system which requires sphinx-doc, not doxygen.

The release tarballs will continue to ship with the documentation already compiled, so this remains only needed for HEAD builds.