### PR TITLE
batik 1.11

### DIFF
--- a/Formula/batik.rb
+++ b/Formula/batik.rb
@@ -1,8 +1,8 @@
 class Batik < Formula
   desc "Java-based toolkit for SVG images"
   homepage "https://xmlgraphics.apache.org/batik/"
-  url "https://www.apache.org/dist/xmlgraphics/batik/binaries/batik-bin-1.10.tar.gz"
-  sha256 "226b3910a8bdc642c8e3a512f34a9b19bf942c17fef3ad7dc901ac34a2714322"
+  url "https://www.apache.org/dist/xmlgraphics/batik/binaries/batik-bin-1.11.tar.gz"
+  sha256 "ba84f10c52e5471ddde1a1db8b2af9a056b31fd600dea803150fe9567b7426d1"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This update also fixes the `batik-rasterizer` command which was broken in the 1.10 upstream release, see also https://github.com/Homebrew/homebrew-core/issues/28591