### PR TITLE
Remove unused dependencies in ipfs formula

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -14,9 +14,6 @@ class Ipfs < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
-  depends_on "gx"
-  depends_on "gx-go"
 
   def install
     ENV["GOPATH"] = buildpath
@@ -47,6 +44,6 @@ class Ipfs < Formula
   end
 
   test do
-    system bin/"ipfs", "version"
+    assert_match "initializing IPFS node", shell_output(bin/"ipfs init")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Turns out that ipfs bootstraps it's own copy of gx and gx-go during the build, so it never actually uses the dependencies declared in the formula, and I'm pretty sure it never used godep for anything either.