### PR TITLE
gloo-ctl 0.8.3 (new formula)

### DIFF
--- a/Formula/gloo-ctl.rb
+++ b/Formula/gloo-ctl.rb
@@ -29,6 +29,6 @@ class GlooCtl < Formula
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly
     status_output = shell_output("#{bin}/glooctl get proxy 2>&1", 1)
-    assert_match /failed to create proxy client/, status_output
+    assert_match "failed to create proxy client", status_output
   end
 end

--- a/Formula/gloo-ctl.rb
+++ b/Formula/gloo-ctl.rb
@@ -14,9 +14,8 @@ class GlooCtl < Formula
     dir.install buildpath.children - [buildpath/".brew_home"]
 
     cd dir do
-      # Make binary
       system "dep", "ensure", "-vendor-only"
-      system "make", "glooctl", "TAGGED_VERSION=v0.8.3", "RELEASE=false"
+      system "make", "glooctl", "TAGGED_VERSION=v#{version}", "RELEASE=false"
       bin.install "_output/glooctl"
     end
   end
@@ -26,7 +25,7 @@ class GlooCtl < Formula
     assert_match "glooctl is the unified CLI for Gloo.", run_output
 
     version_output = shell_output("#{bin}/glooctl --version 2>&1")
-    assert_match "glooctl version 0.8.3", version_output
+    assert_match "glooctl version #{version}", version_output
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly
     status_output = shell_output("#{bin}/glooctl get proxy 2>&1", 1)

--- a/Formula/gloo-ctl.rb
+++ b/Formula/gloo-ctl.rb
@@ -27,5 +27,9 @@ class GlooCtl < Formula
 
     version_output = shell_output("#{bin}/glooctl --version 2>&1")
     assert_match "glooctl version 0.8.3", version_output
+
+    # Should error out as it needs access to a Kubernetes cluster to operate correctly
+    status_output = shell_output("#{bin}/glooctl get proxy 2>&1", 1)
+    assert_match /failed to create proxy client/, status_output
   end
 end

--- a/Formula/gloo-ctl.rb
+++ b/Formula/gloo-ctl.rb
@@ -1,0 +1,31 @@
+class GlooCtl < Formula
+  desc "Envoy-Powered API Gateway"
+  homepage "https://gloo.solo.io"
+  url "https://github.com/solo-io/gloo.git",
+      :tag      => "v0.8.3",
+      :revision => "0e749d0fd9b41f8606dca85b70f0a9981cb0d5ca"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/solo-io/gloo"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      # Make binary
+      system "dep", "ensure", "-vendor-only"
+      system "make", "glooctl", "TAGGED_VERSION=v0.8.3", "RELEASE=false"
+      bin.install "_output/glooctl"
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/glooctl 2>&1")
+    assert_match "glooctl is the unified CLI for Gloo.", run_output
+
+    version_output = shell_output("#{bin}/glooctl --version 2>&1")
+    assert_match "glooctl version 0.8.3", version_output
+  end
+end


### PR DESCRIPTION
This is the command line tool for the [Gloo](https://github.com/solo-io/gloo) OSS project. This command line helps install and manage Gloo on Kubernetes based platforms.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
