### PR TITLE
dita-ot 3.3

### DIFF
--- a/Formula/dita-ot.rb
+++ b/Formula/dita-ot.rb
@@ -1,8 +1,8 @@
 class DitaOt < Formula
   desc "DITA Open Toolkit is an implementation of the OASIS DITA specification"
   homepage "https://www.dita-ot.org/"
-  url "https://github.com/dita-ot/dita-ot/releases/download/3.3/dita-ot-3.3.0.zip"
-  sha256 "889c5ce4c3b245a02a3da0545a29ac285bc1f5f673cf2c52b305e20f5aaa32cf"
+  url "https://github.com/dita-ot/dita-ot/releases/download/3.3/dita-ot-3.3.zip"
+  sha256 "1b6cc040bdc11a2eb4c8b0b0243d58fb6981c060686d1d4e95cfcd42a79eaa5d"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

No:

```
dita-ot:
  * stable: sha256 changed without the version also changing; 
    please create an issue upstream to rule out malicious circumstances 
    and to find out why the file changed.
```
-----

## ⚠️ Hotfix for a previously merged formula with the same version

This PR supersedes the previously merged PR https://github.com/Homebrew/homebrew-core/pull/37439, which was based on an incorrectly named `3.3.0` version of the distribution package that contained errors and was later pulled & replaced by the project maintainers, so the current formula on `master` fails to install:

```console
$ brew upgrade dita-ot
==> Upgrading 1 outdated package:
dita-ot 3.2.1 -> 3.3.0
==> Upgrading dita-ot 
==> Downloading https://github.com/dita-ot/dita-ot/releases/download/3.3/dita-ot-3.3.0.zip

curl: (22) The requested URL returned error: 404 Not Found
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "dita-ot"
Download failed: https://github.com/dita-ot/dita-ot/releases/download/3.3/dita-ot-3.3.0.zip
```

The changes here replace the retracted `3.3.0` package with the correct `3.3` version as provided on the project website at https://www.dita-ot.org/download and the GitHub release tag page at https://github.com/dita-ot/dita-ot/releases/tag/3.3.