### PR TITLE
IXWebSocket 1.1.0

### DIFF
--- a/Formula/ixwebsocket.rb
+++ b/Formula/ixwebsocket.rb
@@ -1,0 +1,20 @@
+class Ixwebsocket < Formula
+  desc "WebSocket client and server, and HTTP client command-line tool"
+  homepage "https://github.com/machinezone/IXWebSocket"
+  url "https://github.com/machinezone/IXWebSocket/archive/v1.1.0.tar.gz"
+  sha256 "52592ce3d0a67ad0f90ac9e8a458f61724175d95a01a38d1bad3fcdc5c7b6666"
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/ws", "--help"
+    system "#{bin}/ws", "send", "--help"
+    system "#{bin}/ws", "receive", "--help"
+    system "#{bin}/ws", "transfer", "--help"
+    system "#{bin}/ws", "curl", "--help"
+  end
+end


### PR DESCRIPTION
Add a formula for IXWebSocket, a WebSocket client and server, and HTTP
client. It comes with a command-line tool, ws, which is a simple
WebSocket toolkit. Tools include connect, chat, broadcast and echo
server, and send and receive tools to transfer files.  It also has a
curl like HTTP tool.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
