### PR TITLE
Tile38: remove unused godep dependency

### DIFF
--- a/Formula/tile38.rb
+++ b/Formula/tile38.rb
@@ -13,7 +13,6 @@ class Tile38 < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
 
   def datadir
     var/"tile38/data"
@@ -70,6 +69,16 @@ class Tile38 < Formula
   end
 
   test do
-    system bin/"tile38-cli", "-h"
+    begin
+      pid = fork do
+        exec "#{bin}/tile38-server", "-q"
+      end
+      sleep 2
+      json_output = shell_output("#{bin}/tile38-cli server")
+      tile38_server = JSON.parse(json_output)
+      assert_equal tile38_server["ok"], true
+    ensure
+      Process.kill("HUP", pid)
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Similar PR to https://github.com/Homebrew/homebrew-core/pull/37426, the Tile38 formula doesn't actually use godep during the build process so it can be removed.