### PR TITLE
docker-machine-driver-vultr: remove unused godep dependency

### DIFF
--- a/Formula/docker-machine-driver-vultr.rb
+++ b/Formula/docker-machine-driver-vultr.rb
@@ -15,7 +15,6 @@ class DockerMachineDriverVultr < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
   depends_on "docker-machine"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Similar PR to #37426 and #37467, the docker-machine-driver-vultr formula doesn't actually use godep during the build process so it can be removed.