### PR TITLE
pilosa: remove unused dependency on dep

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -11,7 +11,6 @@ class Pilosa < Formula
     sha256 "ae71b47cc9f21ffbfd250cd40dcad8f312200dfa44852e54b9b517778d1e2de2" => :sierra
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The pilosa formula doesn't actually use dep during the build process anymore (since https://github.com/pilosa/pilosa/pull/1616) so it can be removed.