### PR TITLE
ivy: update to 2.5.0-rc1, make ant depend on it

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -7,12 +7,8 @@ class Ant < Formula
 
   bottle :unneeded
 
+  depends_on "ivy"
   depends_on :java => "1.8+"
-
-  resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-    sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
-  end
 
   resource "bcel" do
     url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3-bin.tar.gz"
@@ -28,10 +24,6 @@ class Ant < Formula
       #!/bin/sh
       #{libexec}/bin/ant -lib #{HOMEBREW_PREFIX}/share/ant "$@"
     EOS
-
-    resource("ivy").stage do
-      (libexec/"lib").install Dir["ivy-*.jar"]
-    end
 
     resource("bcel").stage do
       (libexec/"lib").install "bcel-#{resource("bcel").version}.jar"

--- a/Formula/ivy.rb
+++ b/Formula/ivy.rb
@@ -1,8 +1,8 @@
 class Ivy < Formula
   desc "Agile dependency manager"
   homepage "https://ant.apache.org/ivy/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-  sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
+  url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.5.0-rc1/apache-ivy-2.5.0-rc1-bin.tar.gz"
+  sha256 "7fe2a21c5208c8db23698eb06bd5c681e7c0f208d96879df2317e94262931362"
 
   bottle :unneeded
 


### PR DESCRIPTION


- [/] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [/] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [/] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [/] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [/] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
