### PR TITLE
Fix newt python detection on mojave

### DIFF
--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -3,6 +3,7 @@ class Newt < Formula
   homepage "https://pagure.io/newt"
   url "https://pagure.io/releases/newt/newt-0.52.20.tar.gz"
   sha256 "8d66ba6beffc3f786d4ccfee9d2b43d93484680ef8db9397a4fb70b5adbb6dbc"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -20,6 +20,8 @@ class Newt < Formula
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]
 
+    inreplace "configure", "ls /usr/include/python*/Python.h", "find /System/Library/Frameworks/Python.framework/Versions/ -name 'Python.h'"
+
     inreplace "Makefile.in" do |s|
       # name libraries correctly
       # https://bugzilla.redhat.com/show_bug.cgi?id=1192285


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes #35291 