### PR TITLE
apt-dater: don't install global config

### DIFF
--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -23,7 +23,10 @@ class AptDater < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make", "AM_LDFLAGS=", "install"
+    system "make", "install"
+    # Global config overrides local config, so delete global config to prioritize the
+    # config in $HOME/.config/apt-dater
+    (prefix/"etc").rmtree
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This seems to fix the issues raised in #37208 and #5762 regarding config file precedence. Ideally upstream should provide a way to handle this but until they do, this should fix things.

Not sure if a `revision` bump would be needed here, please advise.