### PR TITLE
kotlin-native 1.3.0 (new formula)

### DIFF
--- a/Formula/kotlin-native.rb
+++ b/Formula/kotlin-native.rb
@@ -1,8 +1,8 @@
 class KotlinNative < Formula
   desc "Technology for compiling Kotlin code to native binaries"
   homepage "https://kotlinlang.org/docs/reference/native-overview.html"
-  url "https://github.com/JetBrains/kotlin/releases/download/v1.3.0/kotlin-native-macos-1.3.0.tar.gz"
-  sha256 "0621a7c32db37b695b95f75c9085f2d20ba46c74934973cc47fbf09b7e265401"
+  url "https://github.com/JetBrains/kotlin/releases/download/v1.3.11/kotlin-native-macos-1.3.11.tar.gz"
+  sha256 "0813985e9cabf2393cf3396e5eb08a4b4bb21ed14e838a8b9e56b2809e89d284"
 
   bottle :unneeded
 

--- a/Formula/kotlin-native.rb
+++ b/Formula/kotlin-native.rb
@@ -1,0 +1,23 @@
+class KotlinNative < Formula
+  desc "Technology for compiling Kotlin code to native binaries"
+  homepage "https://kotlinlang.org/docs/reference/native-overview.html"
+  url "https://github.com/JetBrains/kotlin/releases/download/v1.3.0/kotlin-native-macos-1.3.0.tar.gz"
+  sha256 "0621a7c32db37b695b95f75c9085f2d20ba46c74934973cc47fbf09b7e265401"
+
+  bottle :unneeded
+
+  def install
+    libexec.install "bin", "klib", "konan", "tools"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    prefix.install "README.md"
+  end
+
+  test do
+    (testpath/"test.kt").write <<~EOS
+      fun main(args: Array<String>) {
+        println("Hello World!")
+      }
+    EOS
+    system "#{bin}/kotlinc-native", "test.kt", "-o", "test.kexe"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a re-opening of #33989 as the former cannot be commented on anymore. IMO it is not feasible that this formula will build from source and pre-built binaries should be used instead.

According to Kotlin Native's [README.md](https://github.com/JetBrains/kotlin-native/blob/d74384db189a70318bd187d7c43d57040bf50467/README.md):
>The build can take about an hour on a Macbook Pro

Not to mention that the prerequisites are to have the following installed:

>install JDK for your platform, instead of JRE. The build requires tools.jar, which is not included in JRE;
>on macOS install Xcode 10.1


BTW: I noticed that the already existing [Kotlin formula](https://github.com/Homebrew/homebrew-core/blob/a506f8508e40d47040698349ba95d7df06f34d75/Formula/kotlin.rb) also downloads a pre-built binary. (Just saying)


