### PR TITLE
glooctl: renamed from gloo-ctl

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -1,4 +1,4 @@
-class GlooCtl < Formula
+class Glooctl < Formula
   desc "Envoy-Powered API Gateway"
   homepage "https://gloo.solo.io"
   url "https://github.com/solo-io/gloo.git",

--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -5,13 +5,6 @@ class Glooctl < Formula
       :tag      => "v0.8.6",
       :revision => "42a89574813b066fb096b289ebebbe412d9cf5a8"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "7583ecc0bd66af9e8e0305288a5f8573680ed3b347db18fa767f17605fdf638a" => :mojave
-    sha256 "9a5dc061fbfbc831d1b3b34ae2852ba32374b6995680d92d71da949412aae4bf" => :high_sierra
-    sha256 "5470c6c8c82fea7cbaa42ba05530d3f216ff1c3d9b760a33a9aba3c9d21ed246" => :sierra
-  end
-
   depends_on "dep" => :build
   depends_on "go" => :build
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -61,6 +61,7 @@
   "giflib@5": "giflib",
   "glfw2": "glfw@2",
   "glfw3": "glfw",
+  "gloo-ctl": "glooctl",
   "gmp4": "gmp@4",
   "gmt4": "gmt@4",
   "gnome-icon-theme": "adwaita-icon-theme",


### PR DESCRIPTION
Early feedback is that the name `glooctl` is how people refer to this component, and therefore it makes more sense to rename the Brew Formula to match how people call and refer to this component.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
