### PR TITLE
Switch to Debian.org from a Hard Coded mirror

### DIFF
--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -18,7 +18,7 @@ class Cloog < Formula
 
   resource "isl" do
     url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
+    mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
     sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
   end
 


### PR DESCRIPTION
This pull request switches the mirror from berkeley.edu (a hard coded mirror) to Debian.org, strict audits complain.

Also a quick question for the maintainers, quite a few packages complain about this. Should I make a bunch of small pull requests or one large one updating mirrors in mass? If there are pull request and commit naming guidelines could you make me aware of them?