### PR TITLE
Update mirrors to https://deb.debian.org/debian/ in formulas where ap…

### DIFF
--- a/Formula/bzrtools.rb
+++ b/Formula/bzrtools.rb
@@ -2,7 +2,7 @@ class Bzrtools < Formula
   desc "Bazaar plugin that supplies useful additional utilities"
   homepage "http://wiki.bazaar.canonical.com/BzrTools"
   url "https://launchpad.net/bzrtools/stable/2.6.0/+download/bzrtools-2.6.0.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/b/bzrtools/bzrtools_2.6.0.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/b/bzrtools/bzrtools_2.6.0.orig.tar.gz"
   sha256 "8b17fbba61dafc8dbefe1917a2ce084a8adc7650dee60add340615270dfb7f58"
 
   bottle :unneeded

--- a/Formula/dns2tcp.rb
+++ b/Formula/dns2tcp.rb
@@ -2,7 +2,6 @@ class Dns2tcp < Formula
   desc "TCP over DNS tunnel"
   homepage "https://packages.debian.org/sid/dns2tcp"
   url "https://deb.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
   sha256 "ea9ef59002b86519a43fca320982ae971e2df54cdc54cdb35562c751704278d9"
 
   bottle do

--- a/Formula/dns2tcp.rb
+++ b/Formula/dns2tcp.rb
@@ -1,8 +1,8 @@
 class Dns2tcp < Formula
   desc "TCP over DNS tunnel"
   homepage "https://packages.debian.org/sid/dns2tcp"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
   sha256 "ea9ef59002b86519a43fca320982ae971e2df54cdc54cdb35562c751704278d9"
 
   bottle do

--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -2,7 +2,6 @@ class Fakeroot < Formula
   desc "Provide a fake root environment"
   homepage "https://tracker.debian.org/pkg/fakeroot"
   url "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
-  mirror "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
   sha256 "009cd6696a931562cf1c212bb57ca441a4a2d45cd32c3190a35c7ae98506f4f6"
 
   bottle do

--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -1,8 +1,8 @@
 class Fakeroot < Formula
   desc "Provide a fake root environment"
   homepage "https://tracker.debian.org/pkg/fakeroot"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.23.orig.tar.xz"
   sha256 "009cd6696a931562cf1c212bb57ca441a4a2d45cd32c3190a35c7ae98506f4f6"
 
   bottle do

--- a/Formula/freealut.rb
+++ b/Formula/freealut.rb
@@ -2,7 +2,6 @@ class Freealut < Formula
   desc "Implementation of OpenAL's ALUT standard"
   homepage "https://github.com/vancegroup/freealut"
   url "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   sha256 "60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
 
   bottle do

--- a/Formula/freealut.rb
+++ b/Formula/freealut.rb
@@ -1,8 +1,8 @@
 class Freealut < Formula
   desc "Implementation of OpenAL's ALUT standard"
   homepage "https://github.com/vancegroup/freealut"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   sha256 "60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
 
   bottle do

--- a/Formula/geomview.rb
+++ b/Formula/geomview.rb
@@ -1,7 +1,7 @@
 class Geomview < Formula
   desc "Interactive 3D viewing program"
   homepage "http://www.geomview.org"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/geomview/geomview_1.9.5.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/g/geomview/geomview_1.9.5.orig.tar.gz"
   mirror "https://downloads.sourceforge.net/project/geomview/geomview/1.9.5/geomview-1.9.5.tar.gz"
   sha256 "67edb3005a22ed2bf06f0790303ee3f523011ba069c10db8aef263ac1a1b02c0"
   revision 1

--- a/Formula/giflib.rb
+++ b/Formula/giflib.rb
@@ -18,7 +18,6 @@ class Giflib < Formula
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=820526
   patch do
     url "https://deb.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
-    mirror "https://deb.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
     sha256 "767ea03c1948fa203626107ead3d8b08687a3478d6fbe4690986d545fb1d60bf"
     apply "patches/CVE-2016-3977.patch"
   end

--- a/Formula/giflib.rb
+++ b/Formula/giflib.rb
@@ -17,8 +17,8 @@ class Giflib < Formula
   # https://sourceforge.net/p/giflib/bugs/102/
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=820526
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
+    mirror "https://deb.debian.org/debian/pool/main/g/giflib/giflib_5.1.4-3.debian.tar.xz"
     sha256 "767ea03c1948fa203626107ead3d8b08687a3478d6fbe4690986d545fb1d60bf"
     apply "patches/CVE-2016-3977.patch"
   end

--- a/Formula/grace.rb
+++ b/Formula/grace.rb
@@ -1,7 +1,7 @@
 class Grace < Formula
   desc "WYSIWYG 2D plotting tool for X11"
   homepage "http://plasma-gate.weizmann.ac.il/Grace/"
-  url "https://mirrors.kernel.org/debian/pool/main/g/grace/grace_5.1.25.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/g/grace/grace_5.1.25.orig.tar.gz"
   sha256 "751ab9917ed0f6232073c193aba74046037e185d73b77bab0f5af3e3ff1da2ac"
   revision 2
 

--- a/Formula/grap.rb
+++ b/Formula/grap.rb
@@ -2,7 +2,7 @@ class Grap < Formula
   desc "Language for typesetting graphs"
   homepage "https://www.lunabase.org/~faber/Vault/software/grap/"
   url "https://www.lunabase.org/~faber/Vault/software/grap/grap-1.45.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/g/grap/grap_1.45.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/g/grap/grap_1.45.orig.tar.gz"
   sha256 "906743cdccd029eee88a4a81718f9d0777149a3dc548672b3ef0ceaaf36a4ae0"
 
   bottle do

--- a/Formula/grib-api.rb
+++ b/Formula/grib-api.rb
@@ -1,8 +1,8 @@
 class GribApi < Formula
   desc "Encode and decode grib messages (editions 1 and 2)"
   homepage "https://software.ecmwf.int/wiki/display/GRIB/Home"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
   sha256 "81078fb9946c38cd292c4eaa50f0acf0093f709a247e83493b3181955177ba09"
   revision 1
 

--- a/Formula/grib-api.rb
+++ b/Formula/grib-api.rb
@@ -2,7 +2,6 @@ class GribApi < Formula
   desc "Encode and decode grib messages (editions 1 and 2)"
   homepage "https://software.ecmwf.int/wiki/display/GRIB/Home"
   url "https://deb.debian.org/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
-  mirror "https://deb.debian.org/debian/pool/main/g/grib-api/grib-api_1.27.0.orig.tar.xz"
   sha256 "81078fb9946c38cd292c4eaa50f0acf0093f709a247e83493b3181955177ba09"
   revision 1
 

--- a/Formula/icon-naming-utils.rb
+++ b/Formula/icon-naming-utils.rb
@@ -5,7 +5,6 @@ class IconNamingUtils < Formula
   # is problematic when the cert is for www rather than a wildcard or similar.
   # url "http://tango.freedesktop.org/releases/icon-naming-utils-0.8.90.tar.gz"
   url "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
   sha256 "044ab2199ed8c6a55ce36fd4fcd8b8021a5e21f5bab028c0a7cdcf52a5902e1c"
 
   bottle do

--- a/Formula/icon-naming-utils.rb
+++ b/Formula/icon-naming-utils.rb
@@ -4,8 +4,8 @@ class IconNamingUtils < Formula
   # Upstream seem to have enabled by default SSL/TLS across whole domain which
   # is problematic when the cert is for www rather than a wildcard or similar.
   # url "http://tango.freedesktop.org/releases/icon-naming-utils-0.8.90.tar.gz"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
   sha256 "044ab2199ed8c6a55ce36fd4fcd8b8021a5e21f5bab028c0a7cdcf52a5902e1c"
 
   bottle do

--- a/Formula/intercal.rb
+++ b/Formula/intercal.rb
@@ -2,7 +2,7 @@ class Intercal < Formula
   desc "Esoteric, parody programming language"
   homepage "http://catb.org/~esr/intercal/"
   url "http://catb.org/~esr/intercal/intercal-0.30.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/i/intercal/intercal_0.30.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/intercal/intercal_0.30.orig.tar.gz"
   sha256 "b38b62a61a3cb5b0d3ce9f2d09c97bd74796979d532615073025a7fff6be1715"
   revision 1
 

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -2,7 +2,7 @@ class Ipmitool < Formula
   desc "Utility for IPMI control with kernel driver or LAN interface"
   homepage "https://ipmitool.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
   revision 2
 

--- a/Formula/iprint.rb
+++ b/Formula/iprint.rb
@@ -1,8 +1,8 @@
 class Iprint < Formula
   desc "Provides a print_one function"
   homepage "https://www.samba.org/ftp/unpacked/junkcode/i.c"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
   version "1.3-9"
   sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
 

--- a/Formula/iprint.rb
+++ b/Formula/iprint.rb
@@ -2,7 +2,6 @@ class Iprint < Formula
   desc "Provides a print_one function"
   homepage "https://www.samba.org/ftp/unpacked/junkcode/i.c"
   url "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3.orig.tar.gz"
   version "1.3-9"
   sha256 "1079b2b68f4199bc286ed08abba3ee326ce3b4d346bdf77a7b9a5d5759c243a3"
 

--- a/Formula/ircii.rb
+++ b/Formula/ircii.rb
@@ -2,7 +2,7 @@ class Ircii < Formula
   desc "IRC and ICB client"
   homepage "http://www.eterna.com.au/ircii/"
   url "https://ircii.warped.com/ircii-20170704.tar.bz2"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/ircii/ircii_20170704.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/i/ircii/ircii_20170704.orig.tar.bz2"
   sha256 "4e5a70fc4577de06fd5855ab7ca0a501fd16e02d5fd34e434a2b5abac80a2eda"
 
   bottle do

--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -8,7 +8,7 @@ class Isl < Formula
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
   url "http://isl.gforge.inria.fr/isl-0.20.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.20.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.20.orig.tar.xz"
   sha256 "a5596a9fb8a5b365cb612e4b9628735d6e67e9178fae134a816ae195017e77aa"
 
   bottle do

--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -2,7 +2,7 @@ class Ispell < Formula
   desc "International Ispell"
   homepage "https://lasr.cs.ucla.edu/geoff/ispell.html"
   url "https://www.cs.hmc.edu/~geoff/tars/ispell-3.4.00.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/i/ispell/ispell_3.4.00.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/i/ispell/ispell_3.4.00.orig.tar.gz"
   sha256 "5dc42e458635f218032d3ae929528e5587b1e7247564f0e9f9d77d5ccab7aec2"
 
   bottle do

--- a/Formula/jbigkit.rb
+++ b/Formula/jbigkit.rb
@@ -2,7 +2,7 @@ class Jbigkit < Formula
   desc "JBIG1 data compression standard implementation"
   homepage "https://www.cl.cam.ac.uk/~mgk25/jbigkit/"
   url "https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/jbigkit-2.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/j/jbigkit/jbigkit_2.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/j/jbigkit/jbigkit_2.1.orig.tar.gz"
   sha256 "de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"
   head "https://www.cl.cam.ac.uk/~mgk25/git/jbigkit",
        :using => :git

--- a/Formula/jhead.rb
+++ b/Formula/jhead.rb
@@ -22,7 +22,6 @@ class Jhead < Formula
 
   patch do
     url "https://deb.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
-    mirror "https://deb.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
     sha256 "d2553bb7e7e47c33fa1136841e4b5bfbad6b92edce1dcad639ab5d74ace606aa"
     apply "patches/31_CVE-2016-3822"
   end

--- a/Formula/jhead.rb
+++ b/Formula/jhead.rb
@@ -21,8 +21,8 @@ class Jhead < Formula
   patch :DATA
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
+    mirror "https://deb.debian.org/debian/pool/main/j/jhead/jhead_3.00-4.debian.tar.xz"
     sha256 "d2553bb7e7e47c33fa1136841e4b5bfbad6b92edce1dcad639ab5d74ace606aa"
     apply "patches/31_CVE-2016-3822"
   end

--- a/Formula/jxrlib.rb
+++ b/Formula/jxrlib.rb
@@ -1,8 +1,8 @@
 class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
   homepage "https://archive.codeplex.com/?p=jxrlib"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   sha256 "c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303"
 
   bottle do

--- a/Formula/jxrlib.rb
+++ b/Formula/jxrlib.rb
@@ -2,7 +2,6 @@ class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
   homepage "https://archive.codeplex.com/?p=jxrlib"
   url "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   sha256 "c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303"
 
   bottle do

--- a/Formula/lcrack.rb
+++ b/Formula/lcrack.rb
@@ -2,7 +2,6 @@ class Lcrack < Formula
   desc "Generic password cracker"
   homepage "https://packages.debian.org/sid/lcrack"
   url "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
   version "20040914"
   sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
 

--- a/Formula/lcrack.rb
+++ b/Formula/lcrack.rb
@@ -1,8 +1,8 @@
 class Lcrack < Formula
   desc "Generic password cracker"
   homepage "https://packages.debian.org/sid/lcrack"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
   version "20040914"
   sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
 

--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -2,8 +2,8 @@ class Libffi < Formula
   desc "Portable Foreign Function Interface library"
   homepage "https://sourceware.org/libffi/"
   url "https://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
   sha256 "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"
 
   bottle do

--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -3,7 +3,6 @@ class Libffi < Formula
   homepage "https://sourceware.org/libffi/"
   url "https://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/libf/libffi/libffi_3.2.1.orig.tar.gz"
   sha256 "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37"
 
   bottle do

--- a/Formula/libicns.rb
+++ b/Formula/libicns.rb
@@ -2,7 +2,7 @@ class Libicns < Formula
   desc "Library for manipulation of the macOS .icns resource format"
   homepage "https://icns.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
   sha256 "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
   revision 3
 

--- a/Formula/libkate.rb
+++ b/Formula/libkate.rb
@@ -2,7 +2,7 @@ class Libkate < Formula
   desc "Overlay codec for multiplexed audio/video in Ogg"
   homepage "https://code.google.com/archive/p/libkate/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libkate/libkate-0.4.1.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/libk/libkate/libkate_0.4.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libk/libkate/libkate_0.4.1.orig.tar.gz"
   sha256 "c40e81d5866c3d4bf744e76ce0068d8f388f0e25f7e258ce0c8e76d7adc87b68"
   revision 1
 

--- a/Formula/liblockfile.rb
+++ b/Formula/liblockfile.rb
@@ -2,7 +2,6 @@ class Liblockfile < Formula
   desc "Library providing functions to lock standard mailboxes"
   homepage "https://tracker.debian.org/pkg/liblockfile"
   url "https://deb.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
   sha256 "ab40d4a3e8cbc204f7e87fea637a4e4ddf9a1149aaa0a723a4267febd0b1d060"
 
   bottle do

--- a/Formula/liblockfile.rb
+++ b/Formula/liblockfile.rb
@@ -1,8 +1,8 @@
 class Liblockfile < Formula
   desc "Library providing functions to lock standard mailboxes"
   homepage "https://tracker.debian.org/pkg/liblockfile"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/libl/liblockfile/liblockfile_1.14.orig.tar.gz"
   sha256 "ab40d4a3e8cbc204f7e87fea637a4e4ddf9a1149aaa0a723a4267febd0b1d060"
 
   bottle do

--- a/Formula/libpoker-eval.rb
+++ b/Formula/libpoker-eval.rb
@@ -2,7 +2,7 @@ class LibpokerEval < Formula
   desc "C library to evaluate poker hands"
   homepage "https://pokersource.sourceforge.io/"
   # http://download.gna.org/pokersource/sources/poker-eval-138.0.tar.gz is offline
-  url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/poker-eval/poker-eval_138.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/poker-eval/poker-eval_138.0.orig.tar.gz"
   sha256 "92659e4a90f6856ebd768bad942e9894bd70122dab56f3b23dd2c4c61bdbcf68"
 
   bottle do

--- a/Formula/libquicktime.rb
+++ b/Formula/libquicktime.rb
@@ -21,7 +21,6 @@ class Libquicktime < Formula
   # by Debian since 30 Jun 2017.
   patch do
     url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
-    mirror "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
     sha256 "e5b5fa3ec8391b92554d04528568d04ea9eb5145835e0c246eac7961c891a91a"
     apply "patches/CVE-2016-2399.patch"
     apply "patches/CVE-2017-9122_et_al.patch"

--- a/Formula/libquicktime.rb
+++ b/Formula/libquicktime.rb
@@ -20,8 +20,8 @@ class Libquicktime < Formula
   # Also, fixes from upstream for CVE-2017-9122 through CVE-2017-9128, applied
   # by Debian since 30 Jun 2017.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
+    mirror "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
     sha256 "e5b5fa3ec8391b92554d04528568d04ea9eb5145835e0c246eac7961c891a91a"
     apply "patches/CVE-2016-2399.patch"
     apply "patches/CVE-2017-9122_et_al.patch"

--- a/Formula/libresample.rb
+++ b/Formula/libresample.rb
@@ -1,7 +1,7 @@
 class Libresample < Formula
   desc "Audio resampling C library"
   homepage "https://ccrma.stanford.edu/~jos/resample/Available_Software.html"
-  url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/libr/libresample/libresample_0.1.3.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libr/libresample/libresample_0.1.3.orig.tar.gz"
   sha256 "20222a84e3b4246c36b8a0b74834bb5674026ffdb8b9093a76aaf01560ad4815"
 
   bottle do

--- a/Formula/logcheck.rb
+++ b/Formula/logcheck.rb
@@ -1,8 +1,8 @@
 class Logcheck < Formula
   desc "Mail anomalies in the system logfiles to the administrator"
   homepage "https://packages.debian.org/sid/logcheck"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
   sha256 "06294c092b2115eca3d054c57778718c91dd2e0fd1c46650b7343c2a92672ca9"
 
   bottle do

--- a/Formula/logcheck.rb
+++ b/Formula/logcheck.rb
@@ -2,7 +2,6 @@ class Logcheck < Formula
   desc "Mail anomalies in the system logfiles to the administrator"
   homepage "https://packages.debian.org/sid/logcheck"
   url "https://deb.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
-  mirror "https://deb.debian.org/debian/pool/main/l/logcheck/logcheck_1.3.19.tar.xz"
   sha256 "06294c092b2115eca3d054c57778718c91dd2e0fd1c46650b7343c2a92672ca9"
 
   bottle do


### PR DESCRIPTION
This is a larger pull request updating mirrors in several formulas to use https://deb.debian.org/debian/ as recommended by the audit system rather than scattered across several mirror sources.