### PR TITLE
Python: remove obsolete “xz” dependency

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -28,7 +28,6 @@ class Python < Formula
   depends_on "openssl"
   depends_on "readline"
   depends_on "sqlite"
-  depends_on "xz"
 
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5", "bin/pip-3.6", "bin/pip-3.7"
   skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5", "bin/easy_install-3.6", "bin/easy_install-3.7"


### PR DESCRIPTION
The Python formula still `depends_on "xz"` despite the fact that all downloadable assets have been straightforward, vanilla tarballs or zipwads for several revisions and updates – this PR removes the “xz” dependency.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

-----
