### PR TITLE
tidb-server 2.1.7 (new formula)

### DIFF
--- a/Formula/tidb-server.rb
+++ b/Formula/tidb-server.rb
@@ -1,0 +1,76 @@
+class TidbServer < Formula
+  desc "TiDB is a MySQL compatible distributed database"
+  homepage "https://www.pingcap.com/en/"
+  url "https://github.com/pingcap/tidb.git",
+      :tag      => "v2.1.7",
+      :revision => "f5b52cb9dc5a8a546121aa6ce1fc672bd567ca48"
+
+  depends_on "go" => :build
+
+  def install
+    # Change the default datadir
+    inreplace "config/config.go", "/tmp/tidb", var/"tidb"
+    inreplace "tidb-server/main.go", "/tmp/tidb", var/"tidb"
+
+    # Removing the go.sum file
+    # fixes a problem in go mod hashes:
+    # https://stackoverflow.com/questions/54133789/go-modules-checksum-mismatch
+    rm "go.sum"
+    system "make", "server"
+    bin.install "bin/tidb-server"
+  end
+
+  def caveats
+    s = <<~EOS
+      This install of TiDB uses goleveldb as the storage engine instead of TiKV,
+      and is slower than a production install. Any benchmarks will be unreliable.
+
+      tidb-server does not bundle any clients. To use the MySQL client:
+      brew install mysql-client
+      mysql -h 127.0.0.1 -P4000 -uroot
+    EOS
+    s
+  end
+
+  plist_options :manual => "tidb-server"
+
+  def plist
+    s = <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/tidb-server</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+      </plist>
+    EOS
+    s
+  end
+
+  test do
+    begin
+      dir = Dir.mktmpdir
+
+      pid = fork do
+        exec bin/"tidb-server -path #{dir} -P 3999"
+      end
+      sleep 2
+
+      output = shell_output("curl 127.0.0.1:3999")
+      output.force_encoding("ASCII-8BIT") if output.respond_to?(:force_encoding)
+      assert_match "5.7.25", output # MySQL 5.7
+    ensure
+      Process.kill(9, pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?

Yes.  There is one major difference from guidelines, which is that I built from the git repo instead of a tarball.  I know the packaging guidelines prefer to build from a tarball, but when doing this with TiDB it will not know its version, since it relies on git tags.  i.e. commands like `select version(), select tidb_version()` will not behave as expected.

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This provides tidb-server without TiKV or PD (the usual [required components](https://pingcap.com/docs/architecture/) for a distributed TiDB server).

It is useful for:
- Developers who wish to test TiDB's mysql compatibility locally
- Developers who want a MySQL-like system with a smaller footprint (the minimal install is much smaller than MySQL, MariaDB, Percona Server in terms of memory and disk space).

Notes:
- It requires go 1.11 to compile, but it looks like this version is skipped in homebrew packaging. 
 Dependencies install via go module support.
- I assume that a homebrew admin adds bottle support, so I have left this out for now.

Thank you in advance for your review!