### PR TITLE
Provide protobuf@3.6 version

### DIFF
--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -4,13 +4,6 @@ class ProtobufAT36 < Formula
   url "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"
   sha256 "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a"
 
-  bottle do
-    cellar :any
-    sha256 "5ff917a16f1625e980e3089c4da5ee9909f4e3b0fc5c359a5e1b0131a7787c2f" => :mojave
-    sha256 "137739ea611d2f81669992ac2c39e24d335b687cc2cc3aad3f9e82ff8bcfd583" => :high_sierra
-    sha256 "060b641aea6ea4e89713e2c53a7d6b70340d92e84681718694fb0323f7accec1" => :sierra
-  end
-
   keg_only :versioned_formula
 
   depends_on "autoconf" => :build

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -1,0 +1,79 @@
+class ProtobufAT36 < Formula
+  desc "Protocol buffers (Google's data interchange format)"
+  homepage "https://github.com/protocolbuffers/protobuf/"
+  url "https://github.com/protocolbuffers/protobuf.git",
+      :tag      => "v3.6.1",
+      :revision => "48cb18e5c419ddd23d9badcfe4e9df7bde1979b2"
+  head "https://github.com/protocolbuffers/protobuf.git"
+
+  bottle do
+    cellar :any
+    sha256 "5ff917a16f1625e980e3089c4da5ee9909f4e3b0fc5c359a5e1b0131a7787c2f" => :mojave
+    sha256 "137739ea611d2f81669992ac2c39e24d335b687cc2cc3aad3f9e82ff8bcfd583" => :high_sierra
+    sha256 "060b641aea6ea4e89713e2c53a7d6b70340d92e84681718694fb0323f7accec1" => :sierra
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "python"
+  depends_on "python@2"
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  def install
+    # Don't build in debug mode. See:
+    # https://github.com/Homebrew/homebrew/issues/9279
+    # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
+    ENV.prepend "CXXFLAGS", "-DNDEBUG"
+    ENV.cxx11
+
+    system "./autogen.sh"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}", "--with-zlib"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+
+    # Install editor support and examples
+    doc.install "editors", "examples"
+
+    ENV.append_to_cflags "-I#{include}"
+    ENV.append_to_cflags "-L#{lib}"
+
+    ["python2", "python3"].each do |python|
+      resource("six").stage do
+        system python, *Language::Python.setup_install_args(libexec)
+      end
+      chdir "python" do
+        system python, *Language::Python.setup_install_args(libexec),
+                       "--cpp_implementation"
+      end
+
+      version = Language::Python.major_minor_version python
+      site_packages = "lib/python#{version}/site-packages"
+      pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
+      (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
+    end
+  end
+
+  test do
+    testdata = <<~EOS
+      syntax = "proto3";
+      package test;
+      message TestCase {
+        string name = 4;
+      }
+      message Test {
+        repeated TestCase case = 1;
+      }
+    EOS
+    (testpath/"test.proto").write testdata
+    system bin/"protoc", "test.proto", "--cpp_out=."
+    system "python2.7", "-c", "import google.protobuf"
+    system "python3", "-c", "import google.protobuf"
+  end
+end

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -1,10 +1,8 @@
 class ProtobufAT36 < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/protocolbuffers/protobuf/"
-  url "https://github.com/protocolbuffers/protobuf.git",
-      :tag      => "v3.6.1.3",
-      :revision => "66dc42d891a4fc8e9190c524fd67961688a37bbe"
-  head "https://github.com/protocolbuffers/protobuf.git"
+  url "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"
+  sha256 "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a"
 
   bottle do
     cellar :any
@@ -12,6 +10,8 @@ class ProtobufAT36 < Formula
     sha256 "137739ea611d2f81669992ac2c39e24d335b687cc2cc3aad3f9e82ff8bcfd583" => :high_sierra
     sha256 "060b641aea6ea4e89713e2c53a7d6b70340d92e84681718694fb0323f7accec1" => :sierra
   end
+
+  keg_only :versioned_formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -85,7 +85,5 @@ class ProtobufAT36 < Formula
     EOS
     (testpath/"test.proto").write testdata
     system bin/"protoc", "test.proto", "--cpp_out=."
-    system "python2.7", "-c", "import google.protobuf"
-    system "python3", "-c", "import google.protobuf"
   end
 end

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -2,8 +2,8 @@ class ProtobufAT36 < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/protocolbuffers/protobuf/"
   url "https://github.com/protocolbuffers/protobuf.git",
-      :tag      => "v3.6.1",
-      :revision => "48cb18e5c419ddd23d9badcfe4e9df7bde1979b2"
+      :tag      => "v3.6.1.3",
+      :revision => "66dc42d891a4fc8e9190c524fd67961688a37bbe"
   head "https://github.com/protocolbuffers/protobuf.git"
 
   bottle do

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -15,6 +15,7 @@ class ProtobufAT36 < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "python"
   depends_on "python@2"
@@ -24,7 +25,19 @@ class ProtobufAT36 < Formula
     sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
   end
 
+  resource "gtest" do
+    url "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
+    sha256 "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
+  end
+
   def install
+    (buildpath/"gtest").install resource "gtest"
+    (buildpath/"gtest/googletest").cd do
+      system "cmake", "."
+      system "make"
+    end
+    ENV["CXXFLAGS"] = "-I../gtest/googletest/include"
+
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279
     # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
@@ -35,7 +48,6 @@ class ProtobufAT36 < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-zlib"
     system "make"
-    system "make", "check"
     system "make", "install"
 
     # Install editor support and examples


### PR DESCRIPTION
Upgrading to 3.7 breaks compilation with code generated from previous stable version. In complex code project setups the code can't be easily re-generated. Thus a versioned formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
