### PR TITLE
gnu-getopt 2.32.1 (update and change source)

### DIFF
--- a/Formula/gnu-getopt.rb
+++ b/Formula/gnu-getopt.rb
@@ -1,10 +1,8 @@
 class GnuGetopt < Formula
-  desc "Command-line option parsing library"
-  homepage "http://frodo.looijaard.name/project/getopt"
-  url "http://frodo.looijaard.name/system/files/software/getopt/getopt-1.1.6.tar.gz"
-  mirror "https://distfiles.macports.org/getopt/getopt-1.1.6.tar.gz"
-  mirror "https://fossies.org/linux/misc/getopt-1.1.6.tar.gz"
-  sha256 "d0bf1dc642a993e7388a1cddfb9409bed375c21d5278056ccca3a0acd09dc5fe"
+  desc "Command-line option parsing utility"
+  homepage "https://github.com/karelzak/util-linux"
+  url "https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.xz"
+  sha256 "86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2"
 
   bottle do
     sha256 "e905a353b1ef1688e569ee28f5caa35bbfa6a4b99f044e255087d0a8adbe092a" => :mojave
@@ -17,15 +15,16 @@ class GnuGetopt < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "gettext"
-
   def install
-    inreplace "Makefile" do |s|
-      gettext = Formula["gettext"]
-      s.change_make_var! "CPPFLAGS", "\\1 -I#{gettext.include}"
-      s.change_make_var! "LDFLAGS", "\\1 -L#{gettext.lib} -lintl"
-    end
-    system "make", "prefix=#{prefix}", "mandir=#{man}", "install"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+
+    system "make", "getopt"
+
+    bin.install "getopt"
+    man1.install "misc-utils/getopt.1"
+    bash_completion.install "bash-completion/getopt"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current `gnu-getopt` formula is derived from the project hosted by the original developer, which is seemingly no longer maintained — it has been merged into util-linux, and needed bug fixes can be found only there. Homebrew has a `util-linux` formula, but it can't provide `getopt` because it (`getopt`) has to be keg-only. So what i've done is rework the `gnu-getopt` formula to *also* build from util-linux.

I couldn't find anything in the Formula Cookbook about multiple formulae derived from the same project, nor any existing examples in the repo, so i'm not sure if there's a policy for this. My main concern is that updates to util-linux now have to be applied in two different places, which is kind of weird for maintenance. But they're completely independent of each other, so i guess in practice it'll probably work the same as any other formula — when someone notices that an update to `gnu-getopt` is needed, they'll make the change.

Also, `util-linux`'s bottle section doesn't include Yosemite or Mavericks, and i assumed there was a technical reason for that, so i dropped them here too.

Is this OK?