### PR TITLE
coursera-dl 0.11.4 (new formula)

### DIFF
--- a/Formula/coursera-dl.rb
+++ b/Formula/coursera-dl.rb
@@ -1,0 +1,83 @@
+class CourseraDl < Formula
+  include Language::Python::Virtualenv
+
+  desc "Script for downloading Coursera.org videos and naming them"
+  homepage "https://github.com/coursera-dl/coursera-dl"
+  url "https://github.com/coursera-dl/coursera-dl/archive/0.11.4.tar.gz"
+  sha256 "63db680e92f130fc308bdeb0f69b947f57cfe3c4f5901837038a3887c4b47e8c"
+
+  depends_on "python"
+
+  resource "attrs" do
+    url "https://pypi.python.org/packages/source/a/attrs/attrs-18.1.0.tar.gz"
+    sha256 "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+  end
+
+  resource "beautifulsoup4" do
+    url "https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.7.1.tar.gz"
+    sha256 "945065979fb8529dd2f37dbb58f00b661bdbcbebf954f93b32fdf5263ef35348"
+  end
+
+  resource "certifi" do
+    url "https://pypi.python.org/packages/source/c/certifi/certifi-2018.11.29.tar.gz"
+    sha256 "47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7"
+  end
+
+  resource "chardet" do
+    url "https://pypi.python.org/packages/source/c/chardet/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+  end
+
+  resource "ConfigArgParse" do
+    url "https://pypi.python.org/packages/source/C/ConfigArgParse/ConfigArgParse-0.14.0.tar.gz"
+    sha256 "2e2efe2be3f90577aca9415e32cb629aa2ecd92078adbe27b53a03e53ff12e91"
+  end
+
+  resource "entrypoints" do
+    url "https://pypi.python.org/packages/source/e/entrypoints/entrypoints-0.3.tar.gz"
+    sha256 "c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+  end
+
+  resource "idna" do
+    url "https://pypi.python.org/packages/source/i/idna/idna-2.8.tar.gz"
+    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+  end
+
+  resource "keyring" do
+    url "https://pypi.python.org/packages/source/k/keyring/keyring-18.0.0.tar.gz"
+    sha256 "12833d2b05d2055e0e25931184af9cd6a738f320a2264853cabbd8a3a0f0b65d"
+  end
+
+  resource "pyasn1" do
+    url "https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.4.5.tar.gz"
+    sha256 "da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7"
+  end
+
+  resource "requests" do
+    url "https://pypi.python.org/packages/source/r/requests/requests-2.21.0.tar.gz"
+    sha256 "502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e"
+  end
+
+  resource "six" do
+    url "https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  resource "soupsieve" do
+    url "https://pypi.python.org/packages/source/s/soupsieve/soupsieve-1.8.tar.gz"
+    sha256 "eaed742b48b1f3e2d45ba6f79401b2ed5dc33b2123dfe216adb90d4bfa0ade26"
+  end
+
+  resource "urllib3" do
+    url "https://pypi.python.org/packages/source/u/urllib3/urllib3-1.24.1.tar.gz"
+    sha256 "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system bin/"coursera-dl", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

<details><summary>FAILED output</summary>

```bash
$ brew install --build-from-source coursera-dl
==> Downloading https://github.com/coursera-dl/coursera-dl/archive/0.11.4.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/5be92427034a0275fe37eabea151e7f624205bd1e6ade2c1ff739cc6cf04e4fc--coursera-dl-0.11.4.tar.gz
==> Downloading https://files.pythonhosted.org/packages/37/db/89d6b043b22052109da35416abc3c397655e4bd
Already downloaded: ~/Library/Caches/Homebrew/downloads/5ef64a64cc03693fde53fa854689f38961d1645c648e8a47d4235e714a07e04d--virtualenv-16.4.3.tar.gz
==> python3 -c import setuptools... --no-user-cfg install --prefix=/private/tmp/coursera-dl--homebrew
==> python3 -s /private/tmp/coursera-dl--homebrew-virtualenv-20190309-67830-1r8gfn0/target/bin/virtua
==> Downloading https://pypi.python.org/packages/source/a/attrs/attrs-18.1.0.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/059c01fb8306111f27110eb015ba16bc6ba9d8d0da70365fa93ce7b123d0be1f--attrs-18.1.0.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
==> Downloading https://pypi.python.org/packages/source/b/beautifulsoup4/beautifulsoup4-4.7.1.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/c12191b5ade4e15f52b8cc112191d519aff540180a6484da2d15a28ccd633482--beautifulsoup4-4.7.1.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
==> Downloading https://pypi.python.org/packages/source/c/certifi/certifi-2018.11.29.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/ec747f9cec1b1d4812327a19c9f3f39da6e662f61c59d04d89bc981faa8c79d9--certifi-2018.11.29.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
==> Downloading https://pypi.python.org/packages/source/c/chardet/chardet-3.0.4.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/fff386bfa506090cc004fccafbf4df9a67f4687ee8975074f200b23334b770db--chardet-3.0.4.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
==> Downloading https://pypi.python.org/packages/source/C/ConfigArgParse/ConfigArgParse-0.14.0.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/c02fb18cc9f3bc0ac461484de5c16aeba93d2e22b0e4a984b123073a458726ce--ConfigArgParse-0.14.0.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
==> Downloading https://pypi.python.org/packages/source/e/entrypoints/entrypoints-0.3.tar.gz
Already downloaded: ~/Library/Caches/Homebrew/downloads/e89761a49d6dd67999959417b0dd7e3bbf3c1300f258f959f35a8afe9c9b0cf0--entrypoints-0.3.tar.gz
==> /usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/pip install -v --no-deps --no-binary :all: --ign
Last 15 lines from ~/Library/Logs/Homebrew/coursera-dl/08.pip:
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/resolve.py", line 131, in resolve
    self._resolve_one(requirement_set, req)
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/resolve.py", line 294, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/resolve.py", line 242, in _get_abstract_dist_for
    self.require_hashes
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 349, in prepare_linked_requirement
    abstract_dist.prep_for_dist(finder, self.build_isolation)
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 125, in prep_for_dist
    "Installing build dependencies"
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/build_env.py", line 195, in install_requirements
    call_subprocess(args, show_stdout=False, spinner=spinner)
  File "/usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip/_internal/utils/misc.py", line 761, in call_subprocess
    % (command_desc, proc.returncode, cwd))
pip._internal.exceptions.InstallationError: Command "/usr/local/Cellar/coursera-dl/0.11.4/libexec/bin/python3.7 /usr/local/Cellar/coursera-dl/0.11.4/libexec/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /private/tmp/pip-build-env-_eilxjuu/overlay --no-warn-script-location -v --no-binary :all: --only-binary :none: -i https://pypi.org/simple -- flit" failed with error code 1 in None

READ THIS: https://docs.brew.sh/Troubleshooting

```
</details>

- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
