### PR TITLE
Add static library builds for glog and gflags

### DIFF
--- a/Formula/gflags.rb
+++ b/Formula/gflags.rb
@@ -3,6 +3,7 @@ class Gflags < Formula
   homepage "https://gflags.github.io/gflags/"
   url "https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
   sha256 "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,8 @@ class Gflags < Formula
   def install
     mkdir "buildroot" do
       system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
+      system "make", "install"
+      system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=OFF"
       system "make", "install"
     end
   end

--- a/Formula/glog.rb
+++ b/Formula/glog.rb
@@ -3,7 +3,7 @@ class Glog < Formula
   homepage "https://github.com/google/glog"
   url "https://github.com/google/glog/archive/v0.3.5.tar.gz"
   sha256 "7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0"
-  revision 3
+  revision 4
   head "https://github.com/google/glog.git"
 
   bottle do
@@ -20,6 +20,8 @@ class Glog < Formula
   def install
     mkdir "build" do
       system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+      system "make", "install"
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args
       system "make", "install"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds static library builds to glog and gflags. The reason for adding static builds is that folly supports static linkage but depends on glog and gflags, which currently only provide dynamic library builds. Without static builds for these upstream libraries, a program linking to folly cannot be fully statically linked. This PR resolves this enabling a program linking to folly to also have static linkage to folly's dependencies.