### PR TITLE
git-flow-avh 1.12.2

### DIFF
--- a/Formula/git-flow-avh.rb
+++ b/Formula/git-flow-avh.rb
@@ -3,8 +3,8 @@ class GitFlowAvh < Formula
   homepage "https://github.com/petervanderdoes/gitflow-avh"
 
   stable do
-    url "https://github.com/petervanderdoes/gitflow-avh/archive/1.12.0.tar.gz"
-    sha256 "3de0d33376fbbfa11d0a0f7d49e2d743f322ff89920c070593b2bbb4187f2af5"
+    url "https://github.com/petervanderdoes/gitflow-avh/archive/1.12.2.tar.gz"
+    sha256 "9f9345e151fef8fb1049122f9fe5b02af7ec207a2bbfa98700b8940159280c46"
 
     resource "completion" do
       url "https://github.com/petervanderdoes/git-flow-completion/archive/0.6.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

NOTE: there is no brew formula for git-flow-avh 1.12.1 because that version failed to pass `brew test git-flow-avh`; fix in https://github.com/petervanderdoes/gitflow-avh/commit/aad4610f5dfe133b323d4ccb97e44af0825b0d9d and included in the 1.12.2 release