### PR TITLE
scala formulae: test without start the fsc daemon

### DIFF
--- a/Formula/scala@2.10.rb
+++ b/Formula/scala@2.10.rb
@@ -36,9 +36,7 @@ class ScalaAT210 < Formula
       }
     EOS
 
-    out = shell_output("#{bin}/scala #{file}").strip
-    # Shut down the compile server so as not to break Travis
-    system bin/"fsc", "-shutdown"
+    out = shell_output("#{bin}/scala -nc #{file}").strip
 
     assert_equal "4", out
   end

--- a/Formula/scala@2.11.rb
+++ b/Formula/scala@2.11.rb
@@ -36,9 +36,7 @@ class ScalaAT211 < Formula
       }
     EOS
 
-    out = shell_output("#{bin}/scala #{file}").strip
-    # Shut down the compile server so as not to break Travis
-    system bin/"fsc", "-shutdown"
+    out = shell_output("#{bin}/scala -nc #{file}").strip
 
     assert_equal "4", out
   end


### PR DESCRIPTION
Sync with the main scala.rb formula.

The -nc flag was available back in Scala 2.10 and 2.11.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----