### PR TITLE
mmark: update to v2.0.40

### DIFF
--- a/Formula/mmark.rb
+++ b/Formula/mmark.rb
@@ -3,8 +3,8 @@ require "language/go"
 class Mmark < Formula
   desc "Powerful markdown processor in Go geared towards the IETF"
   homepage "https://mmark.nl/"
-  url "https://github.com/mmarkdown/mmark/archive/v2.0.7.tar.gz"
-  sha256 "8ab83495b21d0b05fd763f3a79aeaf983c6905eccfbcca48f63c169ef3705639"
+  url "https://github.com/mmarkdown/mmark/archive/v2.0.40.tar.gz"
+  sha256 "6013da8bd80f68d627d8f7c147d9c0370d0543bd100dd6f7c7adc1dcc68be6b3"
 
   bottle do
     cellar :any_skip_relocation
@@ -23,12 +23,12 @@ class Mmark < Formula
 
   go_resource "github.com/gomarkdown/markdown" do
     url "https://github.com/gomarkdown/markdown.git",
-        :revision => "6fda95a9e93f739db582f4a3514309830fd47354"
+        :revision => "ee6a7931a1e4b802c9ff93e4dabcabacf4cb91db"
   end
 
   go_resource "github.com/mmarkdown/markdown" do
     url "https://github.com/mmarkdown/markdown.git",
-        :revision => "6fda95a9e93f739db582f4a3514309830fd47354"
+        :revision => "d1d0edeb5d8598895150da44907ccacaff7f08bc"
   end
 
   resource "test" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Still uses deprecated `go_resource` as they haven't added support for go modules yet