### PR TITLE
folly: revert depend on zstd to fix build

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -3,7 +3,7 @@ class Folly < Formula
   homepage "https://github.com/facebook/folly"
   url "https://github.com/facebook/folly/archive/v2018.09.24.00.tar.gz"
   sha256 "99b6ddb92ee9cf3db262b372ee7dc6a29fe3e2de14511ecc50458bf77fc29c6e"
-  revision 2
+  revision 3
   head "https://github.com/facebook/folly.git"
 
   bottle do
@@ -28,7 +28,6 @@ class Folly < Formula
   depends_on "openssl"
   depends_on "snappy"
   depends_on "xz"
-  depends_on "zstd"
 
   # Known issue upstream. They're working on it:
   # https://github.com/facebook/folly/pull/445


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The folly formula is failing to build in #35030 with complaints about the zstd API (also see my [gist-logs](https://gist.github.com/scpeters/ab010535bf1e0ed756b19888f5c61483)). The dependency on zstd was added in #34018 after noticing opportunistic linkage, but since zstd was updated to 1.3.8 in #35523, though the folly bottle still works, I haven't seen any times when the folly formula could build from source again successfully.

Removing the zstd dependency appears to fix the build.