### PR TITLE
coreutils: remove obsolete fix for El Capitan

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -32,20 +32,6 @@ class Coreutils < Formula
   conflicts_with "truncate", :because => "both install `truncate` binaries"
 
   def install
-    if MacOS.version == :el_capitan
-      # Work around unremovable, nested dirs bug that affects lots of
-      # GNU projects. See:
-      # https://github.com/Homebrew/homebrew/issues/45273
-      # https://github.com/Homebrew/homebrew/issues/44993
-      # This is thought to be an el_capitan bug:
-      # https://lists.gnu.org/archive/html/bug-tar/2015-10/msg00017.html
-      ENV["gl_cv_func_getcwd_abort_bug"] = "no"
-
-      # renameatx_np and RENAME_EXCL are available at compile time from Xcode 8
-      # (10.12 SDK), but the former is not available at runtime.
-      inreplace "lib/renameat2.c", "defined RENAME_EXCL", "defined UNDEFINED_GIBBERISH"
-    end
-
     system "./bootstrap" if build.head?
 
     args = %W[


### PR DESCRIPTION
The fix made building v8.31 fail with the following error:
```
    Error: An exception occurred within a child process:
      Errno::ENOENT: No such file or directory @ rb_sysopen - lib/renameat2.c
```