### PR TITLE
ctop: drop dep dependency

### DIFF
--- a/Formula/ctop.rb
+++ b/Formula/ctop.rb
@@ -1,8 +1,9 @@
 class Ctop < Formula
   desc "Top-like interface for container metrics"
   homepage "https://bcicen.github.io/ctop/"
-  url "https://github.com/bcicen/ctop/archive/v0.7.2.tar.gz"
-  sha256 "bb40939b3d420864db6abc82e885a755f6de5b2e84eef3c7b956a8508f931811"
+  url "https://github.com/bcicen/ctop.git",
+    :tag      => "v0.7.2",
+    :revision => "70bd2ae3a3476969cae3c7f921d38b130ceec648"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,14 +12,14 @@ class Ctop < Formula
     sha256 "fa9113c826584235dfbe6e96092c3c0fe74dfb5ae37719b0f5f1726191f3f051" => :sierra
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     ENV["GO111MODULE"] = "on"
-    (buildpath/"src/github.com/bcicen/ctop").install buildpath.children
-    cd "src/github.com/bcicen/ctop" do
+    src = buildpath/"src/github.com/bcicen/ctop"
+    src.install buildpath.children
+    src.cd do
       system "make", "build"
       bin.install "ctop"
       prefix.install_metafiles


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Drop `dep` dependency
- Switch to `git` as `make` internally use revision history
- audit fails due to sha removal