### PR TITLE
swi-prolog 8.0.2

### DIFF
--- a/Formula/swi-prolog.rb
+++ b/Formula/swi-prolog.rb
@@ -1,9 +1,8 @@
 class SwiProlog < Formula
   desc "ISO/Edinburgh-style Prolog interpreter"
   homepage "http://www.swi-prolog.org/"
-  url "http://www.swi-prolog.org/download/stable/src/swipl-7.6.4.tar.gz"
-  sha256 "2d3d7aabd6d99a02dcc2da5d7604e3500329e541c6f857edc5aa06a3b1267891"
-  revision 1
+  url "http://www.swi-prolog.org/download/stable/src/swipl-8.0.2.tar.gz"
+  sha256 "abb81b55ac5f2c90997c0005b1f15b74ed046638b64e784840a139fe21d0a735"
 
   bottle do
     sha256 "4ce8634e10c98507c9a56d69a3793194f1997918643e4d2c0b1a76c62a238e3d" => :mojave
@@ -17,35 +16,25 @@ class SwiProlog < Formula
     depends_on "cmake" => :build
   end
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "berkeley-db"
   depends_on "gmp"
+  depends_on "jpeg"
   depends_on "libarchive"
+  depends_on "libyaml"
   depends_on "openssl"
+  depends_on "ossp-uuid"
+  depends_on "pcre"
   depends_on "readline"
+  depends_on "unixodbc"
 
   def install
-    if build.head?
-      mkdir "build" do
-        system "cmake", "..", *std_cmake_args,
-                        "-DSWIPL_PACKAGES_JAVA=OFF",
-                        "-DSWIPL_PACKAGES_JAVA=OFF",
-                        "-DSWIPL_PACKAGES_X=OFF",
-                        "-DCMAKE_INSTALL_PREFIX=#{libexec}"
-        system "make", "install"
-      end
-    else
-      ENV["ARPREFIX"] = Formula["libarchive"].opt_prefix
-      ENV.append "DISABLE_PKGS", "jpl"
-      ENV.append "DISABLE_PKGS", "xpce"
-
-      # SWI-Prolog's Makefiles don't add CPPFLAGS to the compile command, but do
-      # include CIFLAGS. Setting it here. Also, they clobber CFLAGS, so including
-      # the Homebrew-generated CFLAGS into COFLAGS here.
-      ENV["CIFLAGS"] = ENV.cppflags
-      ENV["COFLAGS"] = ENV.cflags
-
-      system "./configure", "--prefix=#{libexec}", "--mandir=#{man}"
-      system "make"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args,
+                      "-DSWIPL_PACKAGES_JAVA=OFF",
+                      "-DSWIPL_PACKAGES_X=OFF",
+                      "-DCMAKE_INSTALL_PREFIX=#{libexec}"
       system "make", "install"
     end
 

--- a/Formula/swi-prolog.rb
+++ b/Formula/swi-prolog.rb
@@ -3,17 +3,12 @@ class SwiProlog < Formula
   homepage "http://www.swi-prolog.org/"
   url "http://www.swi-prolog.org/download/stable/src/swipl-8.0.2.tar.gz"
   sha256 "abb81b55ac5f2c90997c0005b1f15b74ed046638b64e784840a139fe21d0a735"
+  head "https://github.com/SWI-Prolog/swipl-devel.git"
 
   bottle do
     sha256 "4ce8634e10c98507c9a56d69a3793194f1997918643e4d2c0b1a76c62a238e3d" => :mojave
     sha256 "6e1bbd48b46ecedbeddff4b6a23138fe5b1784c8f8152772fbe945bfb27425f2" => :high_sierra
     sha256 "503b3bf2fb95bd8914617732ac23970789b471e44211c240bab6a63d5a210513" => :sierra
-  end
-
-  head do
-    url "https://github.com/SWI-Prolog/swipl-devel.git"
-
-    depends_on "cmake" => :build
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Bumps swi-prolog to current stable v8.0.2,
and updates the Formula to use only CMake build
for both HEAD and stable builds.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
