### PR TITLE
qt: depends on Sierra (10.12)

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -22,6 +22,8 @@ class Qt < Formula
   depends_on "pkg-config" => :build
   depends_on :xcode => :build
 
+  depends_on :macos => :sierra
+
   def install
     args = %W[
       -verbose


### PR DESCRIPTION
This fixes an error in the build process on 10.11.6 El Capitan:

    Sorry, "rcc" can not be run on this version of macOS. Qt requires
    macOS 10.12.0 or later, you have macOS 10.11.6.