### PR TITLE
Lynis formula update from 2.7.1 to 2.7.2

### DIFF
--- a/Formula/lynis.rb
+++ b/Formula/lynis.rb
@@ -1,8 +1,8 @@
 class Lynis < Formula
   desc "Security and system auditing tool to harden systems"
   homepage "https://cisofy.com/lynis/"
-  url "https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz"
-  sha256 "f23dd57561f273a7e39e4597277571973dadbab6a131a4712340a6d0b36091f5"
+  url "https://downloads.cisofy.com/lynis/lynis-2.7.2.tar.gz"
+  sha256 "fde6ccf8d6ec0ae1e9c9f4a6d640cddcde4bf7a92f8437d47d16a5477e21bfda"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ See Below ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updating the formula manually without `brew brew bump-formula-pr` to do it for me. However I cannot do an audit either as for several weeks now every brew command gives me ruby gem errors. I still haven't figured out why.

```shell
brew install --build-from-source lynis
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- rubygems/core_ext/kernel_warn (LoadError)
	from /Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Library/Ruby/Site/2.3.0/rubygems.rb:1395:in `<top (required)>'
	from <internal:gem_prelude>:4:in `require'
	from <internal:gem_prelude>:4:in `<internal:gem_prelude>'
Updating Homebrew...
Warning: lynis 2.7.2 is already installed and up-to-date
To reinstall 2.7.2, run `brew reinstall lynis`
```

```shell
brew install --build-from-source lynis
/Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- rubygems/core_ext/kernel_warn (LoadError)
	from /Library/Ruby/Site/2.3.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Library/Ruby/Site/2.3.0/rubygems.rb:1395:in `<top (required)>'
	from <internal:gem_prelude>:4:in `require'
	from <internal:gem_prelude>:4:in `<internal:gem_prelude>'
==> Downloading https://downloads.cisofy.com/lynis/lynis-2.7.2.tar.gz
Already downloaded: /Users/jahhein/Library/Caches/Homebrew/downloads/3b8745d64eb8fd6fb23292cfbb68f16a359697d30c4b8dd71c25f82103096a37--lynis-2.7.2.tar.gz
🍺  /usr/local/Cellar/lynis/2.7.2: 100 files, 1.3MB, built in 3 seconds
```

ruby & ruby gems are broken on my system so I can't audit.

```shell
brew audit --strict lynis
==> Installing 'bundler' gem
ERROR:  Can't use --version w/ multiple gems. Use name:ver instead.
Error: failed to install the 'bundler' gem.
```
I tried for weeks to fix it.

Hoping someone can finish it since I can't. Thanks.