### PR TITLE
Update CGAL  to 4.14

### DIFF
--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -51,8 +51,14 @@ class Cgal < Formula
           return 0;
       }
     EOS
-    system ENV.cxx, "-I#{include}", "-L#{lib}", "-lCGAL",
-                    "surprise.cpp", "-o", "test"
-    assert_equal "15\n15", shell_output("./test").chomp
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.1...3.13)
+      find_package(CGAL)
+      add_executable(surprise surprise.cpp)
+      target_link_libraries(surprise PRIVATE CGAL::CGAL)
+    EOS
+    system "cmake", "-L", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
+    system "cmake", "--build", ".", "-v"
+    assert_equal "15\n15", shell_output("./surprise").chomp
   end
 end

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -12,7 +12,7 @@ class Cgal < Formula
     sha256 "0a368594840007d0a433b702ef5392f332d38e7bc68a83ffc4771f8ca5fa5877" => :sierra
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
   depends_on "boost"
   depends_on "eigen"
   depends_on "gmp"

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -1,8 +1,8 @@
 class Cgal < Formula
   desc "Computational Geometry Algorithm Library"
   homepage "https://www.cgal.org/"
-  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.14-beta4/CGAL-4.14-beta4.tar.xz"
-  sha256 "83a50c61835a029f4a7b6fe885e77b83f4f6dc928d7d5acb00e3381f11f23733"
+  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.14/CGAL-4.14.tar.xz"
+  sha256 "59464b1eaee892f2223ba570a7642892c999e29524ab102a6efd7c29c94a29f7"
 
   bottle do
     cellar :any

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -1,8 +1,8 @@
 class Cgal < Formula
   desc "Computational Geometry Algorithm Library"
   homepage "https://www.cgal.org/"
-  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.14-beta2/CGAL-4.14-beta2.tar.xz"
-  sha256 "c1a5c7f1170813dfc31cfd1ad387956fbe2da080fc5d401ceb084a1d9a9bb6e0"
+  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.14-beta4/CGAL-4.14-beta4.tar.xz"
+  sha256 "83a50c61835a029f4a7b6fe885e77b83f4f6dc928d7d5acb00e3381f11f23733"
 
   bottle do
     cellar :any

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -1,8 +1,8 @@
 class Cgal < Formula
   desc "Computational Geometry Algorithm Library"
   homepage "https://www.cgal.org/"
-  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.13/CGAL-4.13.tar.xz"
-  sha256 "3e3dd7a64febda58be54c3cbeba329ab6a73b72d4d7647ba4931ecd1fad0e3bc"
+  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.14-beta2/CGAL-4.14-beta2.tar.xz"
+  sha256 "c1a5c7f1170813dfc31cfd1ad387956fbe2da080fc5d401ceb084a1d9a9bb6e0"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This PR is a work in progress to update CGAL to version 4.14.
For now, it is an update to 4.14-beta2 and therefore should not be integrated. It will be updated to 4.14 when it is out, and the name of the PR will be changed then.