### PR TITLE
libheif: depend on shared-mime-info to prevent conflict

### DIFF
--- a/Formula/libheif.rb
+++ b/Formula/libheif.rb
@@ -15,6 +15,7 @@ class Libheif < Formula
   depends_on "jpeg"
   depends_on "libde265"
   depends_on "libpng"
+  depends_on "shared-mime-info"
   depends_on "x265"
 
   def install
@@ -23,6 +24,10 @@ class Libheif < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
     pkgshare.install "examples/example.heic"
+  end
+
+  def post_install
+    system Formula["shared-mime-info"].opt_bin/"update-mime-database", "#{HOMEBREW_PREFIX}/share/mime"
   end
 
   test do


### PR DESCRIPTION
Prior to this, libheif installed its `heif.xml` mime package file in
`/usr/local/share/mime` which conflicted with shared-mime-info if you
later wanted to install that package.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Steps to reproduce original issue:

```
$ brew install libheif
   ...
$ brew install shared-mime-info
==> Downloading https://homebrew.bintray.com/bottles/shared-mime-info-1.12.mojave.bottle.tar.gz
Already downloaded: /Users/mb/Library/Caches/Homebrew/downloads/300e5dc0aa46b80404e9637f029aea8a25079f7ff9c50b9fd5f821a61c133903--shared-mime-info-1.12.mojave.bottle.tar.gz
==> Pouring shared-mime-info-1.12.mojave.bottle.tar.gz
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall shared-mime-info`
==> Summary
🍺  /usr/local/Cellar/shared-mime-info/1.12: 85 files, 4.4MB
```

Output from `postinstall -d`:
```
$ brew postinstall -d shared-mime-info
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/shared-mime-info.rb
==> Postinstalling shared-mime-info
/usr/local/Homebrew/Library/Homebrew/postinstall.rb (Formulary::FromPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/shared-mime-info.rb
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall shared-mime-info`
==> An exception occurred within a child process:
  Errno::EPERM: Operation not permitted @ rb_file_s_symlink - (/usr/local/share/mime,
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:359:in `symlink'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:359:in `block in ln_s'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1586:in `fu_each_src_dest0'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:357:in `ln_s'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:380:in `ln_sf'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/shared-mime-info.rb:44:in `post_install'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1007:in `block (2 levels) in run_post_install'
/usr/local/Homebrew/Library/Homebrew/formula.rb:864:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1006:in `block in run_post_install'
/usr/local/Homebrew/Library/Homebrew/utils.rb:476:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:998:in `run_post_install'
/usr/local/Homebrew/Library/Homebrew/postinstall.rb:16:in `<main>'
```

```
$ ls -l /usr/local/share/mime
lrwxr-xr-x  1 mb  admin  36 28 feb 09:50 /usr/local/share/mime -> ../Cellar/libheif/1.3.2_2/share/mime
```