### PR TITLE
percona-xtrabackup conflicts with percona-server

### DIFF
--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -18,6 +18,9 @@ class PerconaXtrabackup < Formula
   depends_on "mysql-client"
   depends_on "openssl"
 
+  conflicts_with "percona-server",
+    :because => "both install lib/plugin/keyring_vault.so"
+
   resource "DBI" do
     url "https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.641.tar.gz"
     sha256 "5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`percona-xtrabackup` failed to install in the jenkins job for #37353 because it was trying to install a file that was already installed by `percona-server`

* https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/39540/version=mojave/testReport/junit/brew-test-bot/mojave/install_percona_xtrabackup/

I think adding a conflict should be enough to fix it.