### PR TITLE
cataclysm: remove obsolete lua dependency

### DIFF
--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -17,6 +17,7 @@ class Cataclysm < Formula
   depends_on "gettext"
   depends_on "libogg"
   depends_on "libvorbis"
+  depends_on "lua" unless build.head?
   depends_on "sdl2"
   depends_on "sdl2_image"
   depends_on "sdl2_mixer"

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -22,6 +22,10 @@ class Cataclysm < Formula
   depends_on "sdl2_mixer"
   depends_on "sdl2_ttf"
 
+  if !build.head?
+    depends_on "lua"
+  end
+
   def install
     ENV.cxx11
 

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -17,7 +17,6 @@ class Cataclysm < Formula
   depends_on "gettext"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "lua"
   depends_on "sdl2"
   depends_on "sdl2_image"
   depends_on "sdl2_mixer"
@@ -30,7 +29,6 @@ class Cataclysm < Formula
       NATIVE=osx
       RELEASE=1
       OSX_MIN=#{MacOS.version}
-      LUA=1
       USE_HOME_DIR=1
       TILES=1
       SOUND=1
@@ -41,7 +39,7 @@ class Cataclysm < Formula
     system "make", *args
 
     # no make install, so we have to do it ourselves
-    libexec.install "cataclysm-tiles", "data", "gfx", "lua"
+    libexec.install "cataclysm-tiles", "data", "gfx"
 
     inreplace "cataclysm-launcher" do |s|
       s.change_make_var! "DIR", libexec

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -23,10 +23,6 @@ class Cataclysm < Formula
   depends_on "sdl2_mixer"
   depends_on "sdl2_ttf"
 
-  if !build.head?
-    depends_on "lua"
-  end
-
   def install
     ENV.cxx11
 
@@ -40,11 +36,13 @@ class Cataclysm < Formula
     ]
 
     args << "CLANG=1" if ENV.compiler == :clang
+    args << "LUA=1" if build.stable?
 
     system "make", *args
 
     # no make install, so we have to do it ourselves
     libexec.install "cataclysm-tiles", "data", "gfx"
+    libexec.install "lua" if build.stable?
 
     inreplace "cataclysm-launcher" do |s|
       s.change_make_var! "DIR", libexec


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Due to recent removal of lua modding (https://github.com/CleverRaven/Cataclysm-DDA/pull/28572) the `--HEAD` option for this formula is currently broken (https://github.com/CleverRaven/Cataclysm-DDA/issues/28861).  This fixes that by removing the obsolete references to lua in this formula.