### PR TITLE
Enable gobject-introspection support for Aravis

### DIFF
--- a/Formula/aravis.rb
+++ b/Formula/aravis.rb
@@ -16,8 +16,8 @@ class Aravis < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "adwaita-icon-theme"
-  depends_on "gobject-introspection"
   depends_on "glib"
+  depends_on "gobject-introspection"
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
   depends_on "gtk+3"

--- a/Formula/aravis.rb
+++ b/Formula/aravis.rb
@@ -12,12 +12,12 @@ class Aravis < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "gobject-introspection" => :build
   depends_on "gtk-doc" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "adwaita-icon-theme"
   depends_on "glib"
-  depends_on "gobject-introspection"
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
   depends_on "gtk+3"

--- a/Formula/aravis.rb
+++ b/Formula/aravis.rb
@@ -16,6 +16,7 @@ class Aravis < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "adwaita-icon-theme"
+  depends_on "gobject-introspection"
   depends_on "glib"
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
@@ -28,6 +29,7 @@ class Aravis < Formula
     inreplace "viewer/Makefile.am", "gtk-update-icon-cache", "gtk3-update-icon-cache"
     system "./autogen.sh", "--disable-dependency-tracking",
                            "--disable-silent-rules",
+                           "--enable-introspection",
                            "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
This patch enables PyGObject bindings for Aravis.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
