### PR TITLE
allegro 5.2.5.0

### DIFF
--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -1,8 +1,8 @@
 class Allegro < Formula
   desc "C/C++ multimedia library for cross-platform game development"
   homepage "https://liballeg.org/"
-  url "https://github.com/liballeg/allegro5/releases/download/5.2.4.0/allegro-5.2.4.0.tar.gz"
-  sha256 "346163d456c5281c3b70271ecf525e1d7c754172aef4bab15803e012b12f2af1"
+  url "https://github.com/liballeg/allegro5/releases/download/5.2.5.0/allegro-5.2.5.0.tar.gz"
+  sha256 "59968da34a0353913868b8299aaff9520d19a3b0960c6406be8323a6ac9bb719"
   head "https://github.com/liballeg/allegro5.git"
 
   bottle do
@@ -15,6 +15,7 @@ class Allegro < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "dumb"
   depends_on "flac"
   depends_on "freetype"
   depends_on "libogg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In addition to bumping the version, I added back the dumb dependency removed in https://github.com/Homebrew/homebrew-core/commit/daff2f228504d300af0f8bb33c25619c5fee0e2d#diff-977691d758f87e74f0ec9734342ad685. This time it is not listed as an optional dependency (it's enables a oft-used feature of the library).