### PR TITLE
inlets 0.6.3 (new formula) 

### DIFF
--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -8,7 +8,6 @@ class Inlets < Formula
   depends_on "go" => :build
 
   def install
-    ENV["XC_ARCH"] = "amd64"
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/alexellis/inlets").install buildpath.children
     cd "src/github.com/alexellis/inlets" do

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -2,8 +2,8 @@ class Inlets < Formula
   desc "Expose your local endpoints to the Internet"
   homepage "https://github.com/alexellis/inlets"
   url "https://github.com/alexellis/inlets.git",
-      :tag      => "0.6.2",
-      :revision => "fbc9f4fe98cf48e44300736140bd013d64d6f980"
+      :tag      => "0.6.3",
+      :revision => "01b26ba23791041121e4996609c96cfa4e25bf64"
 
   depends_on "go" => :build
 

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -1,0 +1,37 @@
+class Inlets < Formula
+  desc "Expose your local endpoints to the Internet"
+  homepage "https://github.com/alexellis/inlets"
+  url "https://github.com/alexellis/inlets.git",
+      :tag      => "0.5.7",
+      :revision => "4c5a519b669cfb92d3ced715fc8e82489aded46a"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["XC_OS"] = "darwin"
+    ENV["XC_ARCH"] = "amd64"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/alexellis/inlets").install buildpath.children
+    cd "src/github.com/alexellis/inlets" do
+      project = "github.com/alexellis/inlets"
+      commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+      system "go", "build", "-ldflags",
+             "-s -w -X main.GitCommit=#{commit} -X main.Version=#{version}", "-a",
+             "-installsuffix", "cgo", "-o", bin/"inlets"
+
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    begin
+      stable_resource = stable.instance_variable_get(:@resource)
+      commit = stable_resource.instance_variable_get(:@specs)[:revision]
+      inlets_version = shell_output("#{bin}/inlets -version")
+      assert_match /\s#{commit}$/, inlets_version
+      assert_match /\s#{version}$/, inlets_version
+    end
+  end
+
+end
+

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -22,7 +22,6 @@ class Inlets < Formula
   end
 
   test do
-
     server = TCPServer.new(0)
     port = server.addr[1]
     server.close
@@ -56,16 +55,16 @@ class Inlets < Formula
         response_key = Digest::SHA1.base64digest([websocket_key, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"].join)
         puts "Responding to handshake with key: \#\{response_key\}"
 
-        socket.write <<-eos
-    HTTP/1.1 101 Switching Protocols
-    Upgrade: websocket
-    Connection: Upgrade
-    Sec-WebSocket-Accept: \#\{response_key\}
+        response = "HTTP/1.1 101 Switching Protocols\\n" +
+        "Upgrade: websocket\\n" +
+        "Connection: Upgrade\\n" +
+        "Sec-WebSocket-Accept: \#\{response_key\}\\n" +
+        "\\n"
 
-        eos
+        socket.write response
 
         puts 'Handshake completed. Starting to parse the websocket frame.'
-        
+
         count = 0
         loop do
           count += 1
@@ -111,9 +110,9 @@ class Inlets < Formula
 
       # Client websocket ping-pong test
       sleep 3 # wait for server to start
-      output = shell_output("#{bin}/inlets client -r 127.0.0.1:#{port} -u http://127.0.0.1:8080 -p 1s 2>&1", 0)
-      assert_match /\sUpstream:  => http:\/\/127.0.0.1:8080$/, output
-      assert_match /\sconnecting to ws:\/\/127\.0\.0\.1:#{port}\/tunnel with ping=1s$/, output
+      output = shell_output("#{bin}/inlets client -r 127.0.0.1:#{port} -u http://127.0.0.1:8080 -p 1s 2>&1")
+      assert_match %r{\sUpstream:  => http://127.0.0.1:8080$}, output
+      assert_match %r{\sconnecting to ws://127\.0\.0\.1:#{port}/tunnel with ping=1s$}, output
       assert_match /\sPing duration: 1.000000s$/, output
       assert_match /\sConnected to websocket: 127.0.0.1/, output
 

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -14,10 +14,7 @@ class Inlets < Formula
     cd "src/github.com/alexellis/inlets" do
       commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-ldflags",
-             "-s",
-             "-w",
-             "-X main.GitCommit=#{commit}",
-             "-X main.Version=#{version}",
+             "-s -w -X main.GitCommit=#{commit} -X main.Version=#{version}",
              "-a",
              "-installsuffix", "cgo", "-o", bin/"inlets"
       prefix.install_metafiles

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -8,17 +8,18 @@ class Inlets < Formula
   depends_on "go" => :build
 
   def install
-    ENV["XC_OS"] = "darwin"
     ENV["XC_ARCH"] = "amd64"
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/alexellis/inlets").install buildpath.children
     cd "src/github.com/alexellis/inlets" do
-      project = "github.com/alexellis/inlets"
       commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-ldflags",
-             "-s -w -X main.GitCommit=#{commit} -X main.Version=#{version}", "-a",
+             "-s",
+             "-w",
+             "-X main.GitCommit=#{commit}",
+             "-X main.Version=#{version}",
+             "-a",
              "-installsuffix", "cgo", "-o", bin/"inlets"
-
       prefix.install_metafiles
     end
   end
@@ -32,6 +33,5 @@ class Inlets < Formula
       assert_match /\s#{version}$/, inlets_version
     end
   end
-
 end
 

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -2,8 +2,8 @@ class Inlets < Formula
   desc "Expose your local endpoints to the Internet"
   homepage "https://github.com/alexellis/inlets"
   url "https://github.com/alexellis/inlets.git",
-      :tag      => "0.5.7",
-      :revision => "4c5a519b669cfb92d3ced715fc8e82489aded46a"
+      :tag      => "0.6.2",
+      :revision => "fbc9f4fe98cf48e44300736140bd013d64d6f980"
 
   depends_on "go" => :build
 
@@ -22,13 +22,106 @@ class Inlets < Formula
   end
 
   test do
+
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    server.close
+
+    puts "Listening on: #{port}"
+
+    (testpath/"ws_server.rb").write <<~EOS
+      require "socket"
+      require "digest/sha1"
+
+      server = TCPServer.new("127.0.0.1", #{port})
+      websocket_port = server.addr[1]
+
+      loop do
+        socket = server.accept
+        puts 'Incoming Request'
+
+        http_request = ""
+        while (line = socket.gets) && (line != "\\r\\n")
+          http_request += line
+        end
+
+        if matches = http_request.match(/^Sec-WebSocket-Key: (\\S+)/)
+          websocket_key = matches[1]
+          puts "Websocket handshake detected with key: \#\{websocket_key\}"
+        else
+          puts "Ignoring non-websocket connection"
+          next
+        end
+
+        response_key = Digest::SHA1.base64digest([websocket_key, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"].join)
+        puts "Responding to handshake with key: \#\{response_key\}"
+
+        socket.write <<-eos
+    HTTP/1.1 101 Switching Protocols
+    Upgrade: websocket
+    Connection: Upgrade
+    Sec-WebSocket-Accept: \#\{response_key\}
+
+        eos
+
+        puts 'Handshake completed. Starting to parse the websocket frame.'
+        
+        count = 0
+        loop do
+          count += 1
+          first_byte = socket.getbyte
+          fin = first_byte & 0b10000000
+          opcode = first_byte & 0b00001111
+
+          second_byte = socket.getbyte
+          is_masked = second_byte & 0b10000000
+          payload_size = second_byte & 0b01111111
+
+          keys = socket.read(4).bytes
+
+          # Ping Message - see rfc6455
+          if opcode == 9
+            puts 'Received Ping'
+            puts 'Sending Pong'
+            output = [0b10001010, 0, ""]
+            socket.write output.pack("CCA0")
+          end
+
+          # Exit after 2 ping-pongs
+          if count == 2
+            puts 'Exiting websocket server'
+            exit 0
+          end
+        end
+      end
+    EOS
+
+    pid = fork do
+      exec "ruby ws_server.rb"
+    end
+
     begin
       stable_resource = stable.instance_variable_get(:@resource)
       commit = stable_resource.instance_variable_get(:@specs)[:revision]
-      inlets_version = shell_output("#{bin}/inlets -version")
+
+      # Basic --version test
+      inlets_version = shell_output("#{bin}/inlets --version")
       assert_match /\s#{commit}$/, inlets_version
       assert_match /\s#{version}$/, inlets_version
+
+      # Client websocket ping-pong test
+      sleep 3 # wait for server to start
+      output = shell_output("#{bin}/inlets client -r 127.0.0.1:#{port} -u http://127.0.0.1:8080 -p 1s 2>&1", 0)
+      assert_match /\sUpstream:  => http:\/\/127.0.0.1:8080$/, output
+      assert_match /\sconnecting to ws:\/\/127\.0\.0\.1:#{port}\/tunnel with ping=1s$/, output
+      assert_match /\sPing duration: 1.000000s$/, output
+      assert_match /\sConnected to websocket: 127.0.0.1/, output
+
+      ping_ping_count = output.scan(/PongHandler\. Extend deadline/).size
+      assert_equal ping_ping_count, 2
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
     end
   end
 end
-


### PR DESCRIPTION
Project:
Expose your local endpoints to the Internet

CLI: inlets

2k GitHub stars

Tested locally with brew test.

Signed-off-by: Alex Ellis alexellis2@gmail.com
Signed-off-by: John McCabe john@johnmccabe.net

*NOTE* This PR supercedes #37420 and adds a non-trivial test of the client where the ping-pong keep alive messaging is tested between the client and a mock server.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

