### PR TITLE
bochs: add missing dependency

### DIFF
--- a/Formula/bochs.rb
+++ b/Formula/bochs.rb
@@ -13,6 +13,7 @@ class Bochs < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libtool"
   depends_on "sdl2"
 
   # Fix pointer cast issue


### PR DESCRIPTION
Our bochs bottle is linked against libltdl, so it needs libtool to
be installed in order to work.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The bochs formula is linked against libltdl, which comes from libtool. Without an explicitly defined libtool dependency, the bottle will be broken.