### PR TITLE
python: gdbm fix

### DIFF
--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -74,15 +74,23 @@ class Python < Formula
     ldflags  = []
     cppflags = []
 
+    # Need this to use homebrew installed libraries.
+    if HOMEBREW_PREFIX.to_s != "/usr/local"
+      cppflags << "-I#{HOMEBREW_PREFIX}/include"
+      ldflags << "-L#{HOMEBREW_PREFIX}/lib"
+    end
+
     if MacOS.sdk_path_if_needed
       # Help Python's build system (setuptools/pip) to build things on SDK-based systems
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-      cflags  << "-isysroot #{MacOS.sdk_path}" << "-I#{MacOS.sdk_path}/usr/include"
+      cflags  << "-isysroot #{MacOS.sdk_path}"
+      cppflags << "-I#{MacOS.sdk_path}/usr/include"
       ldflags << "-isysroot #{MacOS.sdk_path}"
+
       # For the Xlib.h, Python needs this header dir with the system Tk
       # Yep, this needs the absolute path where zlib needed a path relative
       # to the SDK.
-      cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+      cppflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
     args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"


### PR DESCRIPTION
Similar to #38241.
gdbm libraries are not picked up by `configure` when homebrew is not installed in `/usr/local`. To address this, the compilation flags are adjusted when needed.
Moreover, "-I..." directives were moved to CPPFLAGS where they belong.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
