### PR TITLE
Update debian mirrors to fix audit

### DIFF
--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -16,8 +16,7 @@ class Bazaar < Formula
   # CVE-2017-14176
   # https://bugs.launchpad.net/brz/+bug/1710979
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/b/bzr/bzr_2.7.0+bzr6622-9.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/b/bzr/bzr_2.7.0+bzr6622-9.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/b/bzr/bzr_2.7.0+bzr6622-9.debian.tar.xz"
     sha256 "fef6f9a8c3e2f227bf42d0f2f93ea60251a60cb420f7b561d97f0eb685f6ecb6"
     apply "patches/27_fix_sec_ssh"
   end

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -1,8 +1,7 @@
 class Castxml < Formula
   desc "C-family Abstract Syntax Tree XML Output"
   homepage "https://github.com/CastXML/CastXML"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/castxml_0.1+git20180702.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20180702.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/c/castxml/castxml_0.1+git20180702.orig.tar.xz"
   version "0.1+git20180702"
   sha256 "00c58b28523496fbeda731656bb022ad55e7c390609f189ebe03b4468292da40"
   head "https://github.com/CastXML/castxml.git"

--- a/Formula/ccze.rb
+++ b/Formula/ccze.rb
@@ -1,8 +1,7 @@
 class Ccze < Formula
   desc "Robust and modular log colorizer"
   homepage "https://packages.debian.org/wheezy/ccze"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/c/ccze/ccze_0.2.1.orig.tar.gz"
   sha256 "8263a11183fd356a033b6572958d5a6bb56bfd2dba801ed0bff276cfae528aa3"
   revision 1
 

--- a/Formula/cd-discid.rb
+++ b/Formula/cd-discid.rb
@@ -6,7 +6,7 @@ class CdDiscid < Formula
 
   stable do
     url "http://linukz.org/download/cd-discid-1.4.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/cd-discid/cd-discid_1.4.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/c/cd-discid/cd-discid_1.4.orig.tar.gz"
     sha256 "ffd68cd406309e764be6af4d5cbcc309e132c13f3597c6a4570a1f218edd2c63"
 
     # macOS fix; see https://github.com/Homebrew/homebrew/issues/46267

--- a/Formula/corkscrew.rb
+++ b/Formula/corkscrew.rb
@@ -1,8 +1,7 @@
 class Corkscrew < Formula
   desc "Tunnel SSH through HTTP proxies"
   homepage "https://packages.debian.org/sid/corkscrew"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
   sha256 "0d0fcbb41cba4a81c4ab494459472086f377f9edb78a2e2238ed19b58956b0be"
 
   bottle do

--- a/Formula/delta.rb
+++ b/Formula/delta.rb
@@ -1,8 +1,7 @@
 class Delta < Formula
   desc "Programatically minimize files to isolate features of interest"
   homepage "http://delta.tigris.org/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
   sha256 "38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0"
 
   bottle do

--- a/Formula/iprint.rb
+++ b/Formula/iprint.rb
@@ -17,8 +17,7 @@ class Iprint < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/i/iprint/iprint_1.3-9.diff.gz"
     sha256 "3a1ff260e6d639886c005ece754c2c661c0d3ad7f1f127ddb2943c092e18ab74"
   end
 

--- a/Formula/mdf2iso.rb
+++ b/Formula/mdf2iso.rb
@@ -1,8 +1,7 @@
 class Mdf2iso < Formula
   desc "Tool to convert MDF (Alcohol 120% images) images to ISO images"
   homepage "https://packages.debian.org/sid/mdf2iso"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
   sha256 "906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7"
 
   bottle do

--- a/Formula/mecab-ipadic.rb
+++ b/Formula/mecab-ipadic.rb
@@ -2,8 +2,7 @@ class MecabIpadic < Formula
   desc "IPA dictionary compiled for MeCab"
   homepage "https://taku910.github.io/mecab/"
   # Canonical url is https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mecab-ipadic/mecab-ipadic_2.7.0-20070801+main.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mecab-ipadic/mecab-ipadic_2.7.0-20070801+main.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mecab-ipadic/mecab-ipadic_2.7.0-20070801+main.orig.tar.gz"
   version "2.7.0-20070801"
   sha256 "b62f527d881c504576baed9c6ef6561554658b175ce6ae0096a60307e49e3523"
 

--- a/Formula/mecab.rb
+++ b/Formula/mecab.rb
@@ -2,8 +2,7 @@ class Mecab < Formula
   desc "Yet another part-of-speech and morphological analyzer"
   homepage "https://taku910.github.io/mecab/"
   # Canonical url is https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mecab/mecab_0.996.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mecab/mecab_0.996.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mecab/mecab_0.996.orig.tar.gz"
   sha256 "e073325783135b72e666145c781bb48fada583d5224fb2490fb6c1403ba69c59"
 
   bottle do

--- a/Formula/minicom.rb
+++ b/Formula/minicom.rb
@@ -1,8 +1,7 @@
 class Minicom < Formula
   desc "Menu-driven communications program"
   homepage "https://packages.debian.org/sid/minicom"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minicom/minicom_2.7.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/minicom/minicom_2.7.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/minicom/minicom_2.7.1.orig.tar.gz"
   sha256 "532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1"
 
   bottle do

--- a/Formula/minimodem.rb
+++ b/Formula/minimodem.rb
@@ -2,7 +2,7 @@ class Minimodem < Formula
   desc "General-purpose software audio FSK modem"
   homepage "http://www.whence.com/minimodem/"
   url "http://www.whence.com/minimodem/minimodem-0.24.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minimodem/minimodem_0.24.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/m/minimodem/minimodem_0.24.orig.tar.gz"
   sha256 "f8cca4db8e3f284d67f843054d6bb4d88a3db5e77b26192410e41e9a06f4378e"
 
   bottle do

--- a/Formula/mkcue.rb
+++ b/Formula/mkcue.rb
@@ -1,8 +1,7 @@
 class Mkcue < Formula
   desc "Generate a CUE sheet from a CD"
   homepage "https://packages.debian.org/sid/mkcue"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
   version "1"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
 

--- a/Formula/mmv.rb
+++ b/Formula/mmv.rb
@@ -1,8 +1,7 @@
 class Mmv < Formula
   desc "Move, copy, append, and link multiple files"
   homepage "https://packages.debian.org/unstable/utils/mmv"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz"
   sha256 "0399c027ea1e51fd607266c1e33573866d4db89f64a74be8b4a1d2d1ff1fdeef"
 
   bottle do
@@ -17,7 +16,7 @@ class Mmv < Formula
   end
 
   patch do
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
     sha256 "9ad3e3d47510f816b4a18bae04ea75913588eec92248182f85dd09bc5ad2df13"
   end
 

--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -1,8 +1,7 @@
 class Monkeysphere < Formula
   desc "Use the OpenPGP web of trust to verify ssh connections"
   homepage "https://web.monkeysphere.info/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.41.orig.tar.gz"
   sha256 "911a2f1622ddb81151b0f41cf569ccf2154d10a09b2f446dbe98fac7279fe74b"
   head "git://git.monkeysphere.info/monkeysphere"
 

--- a/Formula/nvi.rb
+++ b/Formula/nvi.rb
@@ -1,8 +1,7 @@
 class Nvi < Formula
   desc "44BSD re-implementation of vi"
   homepage "https://sites.google.com/a/bostic.com/keithbostic/vi/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6.orig.tar.gz"
   sha256 "8bc348889159a34cf268f80720b26f459dbd723b5616107d36739d007e4c978d"
   revision 5
 
@@ -37,8 +36,7 @@ class Nvi < Formula
   # Upstream have been pretty inactive for a while, so we may want to kill this
   # formula at some point unless that changes. We're leaning hard on Debian now.
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-13.debian.tar.xz"
     sha256 "306c6059d386a161b9884535f0243134c8c9b5b15648e09e595fd1b349a7b9e1"
     apply "patches/03db4.patch",
           "patches/19include_term_h.patch",

--- a/Formula/omega.rb
+++ b/Formula/omega.rb
@@ -2,7 +2,7 @@ class Omega < Formula
   desc "Packaged search engine for websites, built on top of Xapian"
   homepage "https://xapian.org/"
   url "https://oligarchy.co.uk/xapian/1.4.3/xapian-omega-1.4.3.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/x/xapian-omega/xapian-omega_1.4.3.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/x/xapian-omega/xapian-omega_1.4.3.orig.tar.xz"
   sha256 "2eea0344a0703ba379d845b86d08a9c2e9faf0deb21834d9ea6939b712c6216e"
 
   bottle do

--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -1,8 +1,7 @@
 class OsspUuid < Formula
   desc "ISO-C API and CLI for generating UUIDs"
   homepage "https://web.archive.org/web/www.ossp.org/pkg/lib/uuid/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
   sha256 "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"
   revision 2
 

--- a/Formula/p7zip.rb
+++ b/Formula/p7zip.rb
@@ -14,8 +14,7 @@ class P7zip < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/p7zip/p7zip_16.02+dfsg-6.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/p7zip/p7zip_16.02+dfsg-6.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/p/p7zip/p7zip_16.02+dfsg-6.debian.tar.xz"
     sha256 "fab0be1764efdbde1804072f1daa833de4e11ea65f718ad141a592404162643c"
     apply "patches/12-CVE-2016-9296.patch",
           "patches/13-CVE-2017-17969.patch"

--- a/Formula/pipebench.rb
+++ b/Formula/pipebench.rb
@@ -3,8 +3,7 @@ class Pipebench < Formula
   homepage "http://www.habets.pp.se/synscan/programs.php?prog=pipebench"
   # Upstream server behaves oddly: https://github.com/Homebrew/homebrew/issues/40897
   # url "http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
   sha256 "ca764003446222ad9dbd33bbc7d94cdb96fa72608705299b6cc8734cd3562211"
 
   bottle do

--- a/Formula/pmccabe.rb
+++ b/Formula/pmccabe.rb
@@ -1,8 +1,7 @@
 class Pmccabe < Formula
   desc "Calculate McCabe-style cyclomatic complexity for C/C++ code"
   homepage "https://packages.debian.org/sid/pmccabe"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
   sha256 "e490fe7c9368fec3613326265dd44563dc47182d142f579a40eca0e5d20a7028"
 
   bottle do

--- a/Formula/postmark.rb
+++ b/Formula/postmark.rb
@@ -1,8 +1,7 @@
 class Postmark < Formula
   desc "File system benchmark from NetApp"
   homepage "https://packages.debian.org/sid/postmark"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/p/postmark/postmark_1.53.orig.tar.gz"
   sha256 "8a88fd322e1c5f0772df759de73c42aa055b1cd36cbba4ce6ee610ac5a3c47d3"
 
   bottle do

--- a/Formula/raine.rb
+++ b/Formula/raine.rb
@@ -101,7 +101,7 @@ class Raine < Formula
 
   resource "sdl_sound" do
     url "https://icculus.org/SDL_sound/downloads/SDL_sound-1.0.3.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
+    mirror "https://deb.debian.org/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
     sha256 "3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
   end
 

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -1,8 +1,7 @@
 class Rtmpdump < Formula
   desc "Tool for downloading RTMP streaming media"
   homepage "https://rtmpdump.mplayerhq.hu/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
   version "2.4+20151223"
   sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
   head "https://git.ffmpeg.org/rtmpdump", :shallow => false

--- a/Formula/scrub.rb
+++ b/Formula/scrub.rb
@@ -2,7 +2,7 @@ class Scrub < Formula
   desc "Writes patterns on magnetic media to thwart data recovery"
   homepage "https://code.google.com/archive/p/diskscrub/"
   url "https://github.com/chaos/scrub/releases/download/2.6.1/scrub-2.6.1.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/scrub/scrub_2.6.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/scrub/scrub_2.6.1.orig.tar.gz"
   sha256 "43d98d3795bc2de7920efe81ef2c5de4e9ed1f903c35c939a7d65adc416d6cb8"
 
   bottle do

--- a/Formula/tmpreaper.rb
+++ b/Formula/tmpreaper.rb
@@ -1,8 +1,7 @@
 class Tmpreaper < Formula
   desc "Clean up files in directories based on their age"
   homepage "https://packages.debian.org/sid/tmpreaper"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.13+nmu1.tar.gz"
   version "1.6.13_nmu1"
   sha256 "c88f05b5d995b9544edb7aaf36ac5ce55c6fac2a4c21444e5dba655ad310b738"
 

--- a/Formula/unac.rb
+++ b/Formula/unac.rb
@@ -1,8 +1,7 @@
 class Unac < Formula
   desc "C library and command that removes accents from a string"
   homepage "https://savannah.nongnu.org/projects/unac"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/unac/unac_1.8.0.orig.tar.gz"
   sha256 "29d316e5b74615d49237556929e95e0d68c4b77a0a0cfc346dc61cf0684b90bf"
 
   bottle do
@@ -34,8 +33,7 @@ class Unac < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/u/unac/unac_1.8.0-6.diff.gz"
     sha256 "13a362f8d682670c71182ab5f0bbf3756295a99fae0d7deb9311e611a43b8111"
   end
 

--- a/Formula/uni2ascii.rb
+++ b/Formula/uni2ascii.rb
@@ -3,8 +3,7 @@ class Uni2ascii < Formula
   # homepage/url: "the website you are looking for is suspended"
   # Switched to Debian mirrors June 2015.
   homepage "https://billposer.org/Software/uni2ascii.html"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
   sha256 "9e24bb6eb2ced0a2945e2dabed5e20c419229a8bf9281c3127fa5993bfa5930e"
 
   bottle do

--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -19,8 +19,7 @@ class Zip < Formula
   # Upstream is unmaintained so we use the Debian patchset:
   # https://packages.debian.org/sid/zip
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
     sha256 "c5c0714a88592f9e02146bfe4a8d26cd9bd97e8d33b1efc8b37784997caa40ed"
     apply %w[
       patches/01-typo-it-is-transferring-not-transfering


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed an audit failure related to debian mirrors during #38307, so I thought I would update a few other formulae. I checked and these all have clean audits with `--strict --online` without being installed. We shouldn't need to pull new bottles for this.