### PR TITLE
bdw-gc: build static library

### DIFF
--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -26,7 +26,8 @@ class BdwGc < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-cplusplus"
+                          "--enable-cplusplus",
+                          "--enable-static"
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
Many libraries (e.g. libyaml, libevent) available on Homebrew
contain both the static and dynamic versions of the library.
bdw-gc by default only compiles the dynamic version. This
commit enables building the static libgc.a to allow for
consumers to statically link this library in their applications.

One primary use-case is programs written in Crystal, which uses
bdw-gc for garbage collection by default.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
