### PR TITLE
faudio 19.04 (new formula)

### DIFF
--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -13,6 +13,11 @@ class Faudio < Formula
     system "make", "install"
   end
 
+  def caveats; <<~EOS
+    FAudio is built without FFmpeg support for decoding xWMA resources.
+  EOS
+  end
+
   test do
     (testpath/"test.c").write <<~EOS
       #include <FAudio.h>

--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -9,13 +9,20 @@ class Faudio < Formula
   depends_on "sdl2"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DBUILD_TESTS=1"
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
-    mkdir_p prefix/"tests"
-    mv "faudio_tests", prefix/"tests/faudio_tests"
   end
 
   test do
-    system prefix/"tests/faudio_tests"
+    (testpath/"test.c").write <<~EOS
+      #include <FAudio.h>
+      int main(int argc, char const *argv[])
+      {
+        FAudio *audio;
+        return FAudioCreate(&audio, 0, FAUDIO_DEFAULT_PROCESSOR);
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lfaudio", "-o", "test"
+    system "./test"
   end
 end

--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -1,8 +1,8 @@
 class Faudio < Formula
   desc "Accuracy-focused XAudio reimplementation for open platforms"
   homepage "https://fna-xna.github.io/"
-  url "https://github.com/FNA-XNA/FAudio/archive/19.03.tar.gz"
-  sha256 "5ab1c2b00e0348264bd959e437d590d6240d2527964d7c5ee0d02b711e089fa8"
+  url "https://github.com/FNA-XNA/FAudio/archive/19.04.tar.gz"
+  sha256 "8d28c7a67bf67953c27173f33393ccee10f7b3ad52b9767a7e33c98387b67bdf"
   head "https://github.com/FNA-XNA/FAudio.git"
 
   depends_on "cmake" => :build

--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -1,0 +1,21 @@
+class Faudio < Formula
+  desc "Accuracy-focused XAudio reimplementation for open platforms"
+  homepage "https://fna-xna.github.io/"
+  url "https://github.com/FNA-XNA/FAudio/archive/19.03.tar.gz"
+  sha256 "5ab1c2b00e0348264bd959e437d590d6240d2527964d7c5ee0d02b711e089fa8"
+  head "https://github.com/FNA-XNA/FAudio.git"
+
+  depends_on "cmake" => :build
+  depends_on "sdl2"
+
+  def install
+    system "cmake", ".", *std_cmake_args, "-DBUILD_TESTS=1"
+    system "make", "install"
+    mkdir_p prefix/"tests"
+    mv "faudio_tests", prefix/"tests/faudio_tests"
+  end
+
+  test do
+    system prefix/"tests/faudio_tests"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

**Old information below. This formula now passes `brew audit --new-formula`**.

~~Not currently passing `brew audit --new-formula faudio` due to the following error:~~

```Missing libraries:
  /tmp/faudio-20190326-88011-e0913c/FAudio-19.03/libFAudio.0.dylib
faudio:
  * faudio has broken dynamic library links:
```

~~However, `ls -la /usr/local/Cellar/faudio/19.03/lib` shows all expected files are present:~~

```
total 352
drwxr-xr-x  6 user  admin   192B Mar 26 23:47 ./
drwxr-xr-x  9 user  admin   288B Mar 26 23:47 ../
drwxr-xr-x  3 user  admin    96B Mar 26 23:47 cmake/
-r--r--r--  1 user  admin   173K Mar 26 23:47 libFAudio.0.19.03.dylib
lrwxr-xr-x  1 user  admin    23B Mar 26 23:47 libFAudio.0.dylib@ -> libFAudio.0.19.03.dylib
lrwxr-xr-x  1 user  admin    17B Mar 26 23:47 libFAudio.dylib@ -> libFAudio.0.dylib
```

~~`brew test faudio` using the developer-provided test suite also runs flawlessly.
Possibly there's an issue in the handling of the double symlink?~~