### PR TITLE
bind 9.14.0 revision 3

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -3,7 +3,7 @@ class Bind < Formula
   homepage "https://www.isc.org/downloads/bind/"
   url "https://ftp.isc.org/isc/bind9/9.14.0/bind-9.14.0.tar.gz"
   sha256 "4edd459830bb97f749e25a5d42a2a4a093d7800e9962fca4300996cf7ea680af"
-  revision 3
+  revision 2
   head "https://gitlab.isc.org/isc-projects/bind9.git"
 
   bottle do

--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -3,7 +3,7 @@ class Bind < Formula
   homepage "https://www.isc.org/downloads/bind/"
   url "https://ftp.isc.org/isc/bind9/9.14.0/bind-9.14.0.tar.gz"
   sha256 "4edd459830bb97f749e25a5d42a2a4a093d7800e9962fca4300996cf7ea680af"
-  revision 2
+  revision 3
   head "https://gitlab.isc.org/isc-projects/bind9.git"
 
   bottle do
@@ -40,8 +40,6 @@ class Bind < Formula
     ENV["STD_CDEFINES"] = "-DDIG_SIGCHASE=1"
 
     system "./configure", "--prefix=#{prefix}",
-                          "--enable-threads",
-                          "--enable-ipv6",
                           "--with-openssl=#{Formula["openssl"].opt_prefix}",
                           "--with-libjson=#{Formula["json-c"].opt_prefix}",
                           "--with-python=#{Formula["python"].opt_bin}/python3",


### PR DESCRIPTION
Remove two deprecated options to the configure script. They are
emitting this warning:

configure: WARNING: unrecognized options: --enable-threads, --enable-ipv6