### PR TITLE
plan9port 20181114

### DIFF
--- a/Formula/plan9port.rb
+++ b/Formula/plan9port.rb
@@ -1,8 +1,9 @@
 class Plan9port < Formula
   desc "Many Plan 9 programs ported to UNIX-like operating systems"
-  homepage "https://swtch.com/plan9port/"
-  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/plan9port/plan9port-20140306.tgz"
-  sha256 "cbb826cde693abdaa2051c49e7ebf75119bf2a4791fe3b3229f1ac36a408eaeb"
+  homepage "https://9fans.github.io/plan9port/"
+  url "https://github.com/9fans/plan9port/archive/de43b162.tar.gz"
+  version "20181114"
+  sha256 "4a7e3eff1ed52d49728bb5a3f9787915e38b006962e7ff8c196a556d272470de"
   head "https://github.com/9fans/plan9port.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

plan9port has had significant changes made since the project was moved from Google Code to GitHub, including fixing a load of bugs. However, this formula has not been updated since before the move to GitHub (2014).

This PR updates the stable version of the formula to the last that does not use the Metal backend (https://github.com/9fans/plan9port/commit/de43b1629d008aa6cdf4f6beb2b06e3859616a3e), as this doesn't seem to work on all Macs.