### PR TITLE
cracklib 2.9.7

### DIFF
--- a/Formula/cracklib.rb
+++ b/Formula/cracklib.rb
@@ -1,8 +1,8 @@
 class Cracklib < Formula
   desc "LibCrack password checking library"
   homepage "https://github.com/cracklib/cracklib"
-  url "https://github.com/cracklib/cracklib/releases/download/cracklib-2.9.6/cracklib-2.9.6.tar.gz"
-  sha256 "17cf76943de272fd579ed831a1fd85339b393f8d00bf9e0d17c91e972f583343"
+  url "https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-2.9.7.tar.gz"
+  sha256 "8b6fd202f3f1d8fa395d3b7a5d821227cfd8bb4a9a584a7ae30cf62cea6287dd"
 
   bottle do
     rebuild 1
@@ -15,14 +15,8 @@ class Cracklib < Formula
   depends_on "gettext"
 
   resource "cracklib-words" do
-    url "https://github.com/cracklib/cracklib/releases/download/cracklib-2.9.6/cracklib-words-2.9.6.bz2"
-    sha256 "460307bb9b46dfd5068d62178285ac2f70279e64b968972fe96f5ed07adc1a77"
-  end
-
-  # Upstream commit from 25 Aug 2016 "Apply patch to fix CVE-2016-6318"
-  patch :p2 do
-    url "https://github.com/cracklib/cracklib/commit/47e5dec.patch?full_index=1"
-    sha256 "7b3604d503208365951038b04990eef24b8ef90ce845fd84e2d2ab88a9a4f56b"
+    url "https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-words-2.9.7.gz"
+    sha256 "7f0c45faf84a2494f15d1e2720394aca4a379163a70c4acad948186c0047d389"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Previous patch addressing CVE-2016-6318 has been addressed in this release, so our patch is no longer necessary.