### PR TITLE
Run `rbenv rehash` post install

### DIFF
--- a/Formula/rbenv.rb
+++ b/Formula/rbenv.rb
@@ -36,6 +36,11 @@ class Rbenv < Formula
     prefix.install ["bin", "completions", "libexec", "rbenv.d"]
   end
 
+  def post_install
+    # Update shims, when the older version is removed things get broken
+    system "#{bin}/rbenv", "rehash"
+  end
+
   test do
     shell_output("eval \"$(#{bin}/rbenv init -)\" && rbenv versions")
   end


### PR DESCRIPTION
Homebrew automatically removes older versions after https://github.com/Homebrew/brew/pull/5472, any existing shims written out by rbenv end up broken due to the missing executable.

This change forces a rehash during post install that will fix this.