### PR TITLE
hfst 3.15.0 (new formula)

### DIFF
--- a/Formula/hfst.rb
+++ b/Formula/hfst.rb
@@ -1,0 +1,21 @@
+class Hfst < Formula
+  desc "Helsinki Finite-State Technology (library and application suite)"
+  homepage "https://hfst.github.io/"
+  url "https://github.com/hfst/hfst/releases/download/v3.15.0/hfst-3.15.0.tar.gz"
+  sha256 "bf50099174a0e14a53ab4d37d514bec2347dea3d4f2ff69d652659357cdd667f"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    # Create a very simple transducer and enumerate its strings
+    expected = "test\ntests\ntested\ntesting\n"
+    (testpath / "test.regexp").write "test[0|s|ed|ing]"
+    system (bin / "hfst-regexp2fst"), (testpath / "test.regexp"), "-o", (testpath / "test.hfst")
+    assert_equal expected, shell_output("#{bin}/hfst-fst2strings #{testpath}/test.hfst")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/hfst/hfst/releases/tag/v3.15.0

```
 $ brew install --build-from-source hfst
==> Downloading https://github.com/hfst/hfst/releases/download/v3.15.0/hfst-3.15.0.tar.gz
Already downloaded: /Users/santoseadmin/Library/Caches/Homebrew/downloads/8df8839e6282ebc5da99af0556edd52bd245106abe9879c18d2d5ab655f236b4--hfst-3.15.0.tar.gz
==> ./configure --disable-silent-rules --prefix=/usr/local/Cellar/hfst/3.15.0
==> make install
🍺  /usr/local/Cellar/hfst/3.15.0: 248 files, 21.1MB, built in 4 minutes 12 seconds
 $ brew audit --strict hfst
 $ brew test hfst
Testing hfst
==> /usr/local/Cellar/hfst/3.15.0/bin/hfst-regexp2fst /private/tmp/hfst-test-20190327-44632-btsqj8/test.regexp -o /private/tmp/hfst-test-20190327-44632-btsqj8/test.hfst
==> /usr/local/Cellar/hfst/3.15.0/bin/hfst-fst2strings /private/tmp/hfst-test-20190327-44632-btsqj8/test.hfst
```