### PR TITLE
passenger: fix vendored boost lib compilation issue with latest clang

### DIFF
--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -3,7 +3,7 @@ class Passenger < Formula
   homepage "https://www.phusionpassenger.com/"
   url "https://github.com/phusion/passenger/releases/download/release-6.0.2/passenger-6.0.2.tar.gz"
   sha256 "56b2273312e6dc9880f6ba83e381583b8759085a0b41338b782c9575d58346bc"
-  revision 1
+  revision 2
   head "https://github.com/phusion/passenger.git", :branch => "stable-6.0"
 
   bottle do
@@ -17,6 +17,11 @@ class Passenger < Formula
   depends_on "nginx" => [:build, :test]
   depends_on "openssl"
   depends_on "pcre"
+
+  patch do
+    url "https://github.com/phusion/passenger/commit/09df7df0.patch?full_index=1"
+    sha256 "397707a788029f4abac4780d2e04ddba37ec9285b44c9d3e4ff0c91c5121d2b7"
+  end
 
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
