### PR TITLE
mmv: uncompressed patch at formula-patches

### DIFF
--- a/Formula/mmv.rb
+++ b/Formula/mmv.rb
@@ -16,8 +16,8 @@ class Mmv < Formula
   end
 
   patch do
-    url "https://deb.debian.org/debian/pool/main/m/mmv/mmv_1.01b-15.diff.gz"
-    sha256 "9ad3e3d47510f816b4a18bae04ea75913588eec92248182f85dd09bc5ad2df13"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/0f8a80f7b337416d1a63ce453740fbe5bb5d158d/mmv/mmv_1.01b-15.diff"
+    sha256 "76f111f119c3e69e5b543276b3c680f453b9b72a0bfc12b4e95fb40770db60c1"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The compressed patch has been removed from debian, but I managed to find it elsewhere and upload it in uncompressed form to https://github.com/Homebrew/formula-patches/pull/269

We should be able to pull this without new bottles.