### PR TITLE
Update activemq.rb to activemq 5.18.9

### DIFF
--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -1,8 +1,8 @@
 class Activemq < Formula
   desc "Apache ActiveMQ: powerful open source messaging server"
   homepage "https://activemq.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/activemq/5.15.8/apache-activemq-5.15.8-bin.tar.gz"
-  sha256 "186c9c4b0d351ffa5e5370536e5fe6650ae53f696dfd69d4f10a807e006f7779"
+  url "https://www.apache.org/dyn/closer.cgi?path=/activemq/5.15.9/apache-activemq-5.15.9-bin.tar.gz"
+  sha256 "e193d3a8b0a978103eb2f9dbddbd9e86fed0af53d2ac4e01c5a6c0d351ced279"
 
   bottle :unneeded
 

--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -6,7 +6,7 @@ class Activemq < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   def install
     rm_rf Dir["bin/linux-x86-*"]


### PR DESCRIPTION
Update activemq.rb to activemq 5.18.9, because 5.18.8  DownloadError: Failed to download resource "activemq"
Download failed: https://www-us.apache.org/dist/activemq/5.15.8/apache-activemq-5.15.8-bin.tar.gz

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
