### PR TITLE
Add static library builds for glog and gflags

### DIFF
--- a/Formula/gflags.rb
+++ b/Formula/gflags.rb
@@ -3,6 +3,7 @@ class Gflags < Formula
   homepage "https://gflags.github.io/gflags/"
   url "https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
   sha256 "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,8 @@ class Gflags < Formula
   def install
     mkdir "buildroot" do
       system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
+      system "make", "install"
+      system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=OFF"
       system "make", "install"
     end
   end

--- a/Formula/glog.rb
+++ b/Formula/glog.rb
@@ -4,6 +4,7 @@ class Glog < Formula
   url "https://github.com/google/glog/archive/v0.4.0.tar.gz"
   sha256 "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c"
   head "https://github.com/google/glog.git"
+  revision 4
 
   bottle do
     cellar :any
@@ -18,6 +19,8 @@ class Glog < Formula
   def install
     mkdir "cmake-build" do
       system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+      system "make", "install"
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args
       system "make", "install"
     end
 
@@ -49,9 +52,7 @@ class Glog < Formula
       }
     EOS
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}",
-                    "-lglog", "-I#{Formula["gflags"].opt_lib}",
-                    "-L#{Formula["gflags"].opt_lib}", "-lgflags",
-                    "-o", "test"
+                    "-lglog", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds static library builds to glog and gflags. The reason for adding static builds is that folly supports static linkage but depends on glog and gflags, which currently only provide dynamic library builds. Without static builds for these upstream libraries, a program linking to folly cannot be fully statically linked. This PR resolves this enabling a program linking to folly to also have static linkage to folly's dependencies.