### PR TITLE
phplint 4.0

### DIFF
--- a/Formula/phplint.rb
+++ b/Formula/phplint.rb
@@ -2,7 +2,7 @@ class Phplint < Formula
   desc "Validator and documentator for PHP 5 and 7 programs"
   homepage "https://www.icosaedro.it/phplint/"
   url "https://www.icosaedro.it/phplint/phplint-4.0_20190206.tar.gz"
-  version "4.0_20190206"
+  version "4.0-20190206"
   sha256 "8a2d4b128fff23b469e5c64847187c2550d9775602f80859475ad686f2317cc0"
 
   bottle :unneeded

--- a/Formula/phplint.rb
+++ b/Formula/phplint.rb
@@ -55,6 +55,6 @@ class Phplint < Formula
         }
     EOS
     output = shell_output("#{bin}/phpl Email.php", 1)
-    assert_match "Overall test results: 15 errors, 0 warnings.", output
+    assert_match "Overall test results: 6 errors, 0 warnings.", output
   end
 end

--- a/Formula/phplint.rb
+++ b/Formula/phplint.rb
@@ -1,9 +1,9 @@
 class Phplint < Formula
   desc "Validator and documentator for PHP 5 and 7 programs"
   homepage "https://www.icosaedro.it/phplint/"
-  url "https://www.icosaedro.it/phplint/phplint-3.2_20180727.tar.gz"
-  version "3.2-20180727"
-  sha256 "337b7a0d717ea7ff454ded7b3298d65f0cabeaf309598357b8354c96ce4e9f85"
+  url "https://www.icosaedro.it/phplint/phplint-4.0_20190206.tar.gz"
+  version "4.0_20190206"
+  sha256 "8a2d4b128fff23b469e5c64847187c2550d9775602f80859475ad686f2317cc0"
 
   bottle :unneeded
 


### PR DESCRIPTION
This updates [phplint](https://www.icosaedro.it/phplint/) to 4.0. It felt somewhat urgent because the prior version was not running on 3.2 with homebrew's stock `php` recipe (7.3). I was receiving this deprecation error when running `phpl --help`

```
Uncaught ErrorException: E_DEPRECATED: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/err
ors.php:219                                                                                        
Stack trace:                                                                                   
#0 [internal function]: phplint_error_handler(8192, 'strpos(): Non-s...', '/usr/local/Cell...', 267, Array)
#1 /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/it/icosaedro/io/File.php(267): strpos('/Users/afowler/...', 0)
#2 /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/it/icosaedro/io/File.php(357): it\icosaedro\io\File::normalize(NULL, '/Users/afowler/...')
#3 /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/it/icosaedro/io/File.php(395): it\icosaedro\io\File->__construct(Object(it\icosaedro\utils\UString), NULL)
#4 /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/it/icosaedro/io/File.php(591): it\icosaedro\io\File::fromLocaleEncoded('/Users/afowler/...', NULL)
#5 /usr/local/Cellar/phplint/3.2-20180727/libexec/stdlib/it/icosaedro/lint/Linter.php(146): it\icosaedro\io\File::getCWD()                                                                                                    
#6 /usr/local/Cellar/phplint/3.2-20180727/libexec/utils/PHPLint.php(24): it\icosaedro\lint\Linter::main(Object(it\icosaedro\io\ResourceOutputStream), Array)                                                                  
#7 {main}
```

This has been fixed in upstream phplint.

### test change

I've also corrected the test to reflect the number of warnings thrown for this fixture. I don't know the provenance of the fixture, but the git history shows that others have simply changed the number of expected warnings as `phplint` changes.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----