### PR TITLE
postgis formula-revision 2 adding protobuf-c dependency

### DIFF
--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -3,7 +3,7 @@ class Postgis < Formula
   homepage "https://postgis.net/"
   url "https://download.osgeo.org/postgis/source/postgis-2.5.2.tar.gz"
   sha256 "b6cb286c5016029d984f8c440947bf9178da72e1f6f840ed639270e1c451db5e"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -28,6 +28,7 @@ class Postgis < Formula
   depends_on "pcre"
   depends_on "postgresql"
   depends_on "proj"
+  depends_on "protobuf-c" # for MVT (map vector tiles) support
   depends_on "sfcgal" # for advanced 2D/3D functions
 
   def install
@@ -37,6 +38,7 @@ class Postgis < Formula
       "--with-projdir=#{Formula["proj"].opt_prefix}",
       "--with-jsondir=#{Formula["json-c"].opt_prefix}",
       "--with-pgconfig=#{Formula["postgresql"].opt_bin}/pg_config",
+      "--with-protobufdir=#{Formula["protobuf-c"].opt_bin}",
       # Unfortunately, NLS support causes all kinds of headaches because
       # PostGIS gets all of its compiler flags from the PGXS makefiles. This
       # makes it nigh impossible to tell the buildsystem where our keg-only


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

At present, the formula builds postgis without support for protocol buffers, meaning it is unable to use generate structured binary data (bytea or byte array) outputs for queries, which causes certain functions, such as ST_AsMVT (MVT = map vector tile) to just give an error about protobuf-c missing.  

GDAL, another optional component, is primarily used for dealing with raster data and handling geometry projections to that effect.  There would be little need for this unless someone was planning to ultimately export this projected geometry to a tile server.  So I think it is only reasonable that, if we are already including GDAL, we ought to include the one other dependency that is almost always wanted with GDAL: protobuf-c.  

It's also a very lightweight dependency and doesn't impact the rest of PostGIS operation in any way (as far as I know).  Unless anyone has a good reason not to include protobuf-c by default, I think this very minor change to the formula will make a lot of people happy.  Or at least it will make me happy :).  I created this request entirely because I ran into the exact hurdle I described: I needed my postgres database to talk to a tile server, and it couldn't due to not being compiled with protobuf-c enabled.  

Anyway, thanks for your time!