### PR TITLE
Bump librdkafka to v1.0.0

### DIFF
--- a/Formula/librdkafka.rb
+++ b/Formula/librdkafka.rb
@@ -1,8 +1,8 @@
 class Librdkafka < Formula
   desc "The Apache Kafka C/C++ library"
   homepage "https://github.com/edenhill/librdkafka"
-  url "https://github.com/edenhill/librdkafka/archive/v0.11.6.tar.gz"
-  sha256 "9c0afb8b53779d968225edf1e79da48a162895ad557900f75e7978f65e642032"
+  url "https://github.com/edenhill/librdkafka/archive/v1.0.0.tar.gz"
+  sha256 "b00a0d9f0e8c7ceb67b93b4ee67f3c68279a843a15bf4a6742eb64897519aa09"
   head "https://github.com/edenhill/librdkafka.git"
 
   bottle do
@@ -16,10 +16,10 @@ class Librdkafka < Formula
   depends_on "lz4"
   depends_on "lzlib"
   depends_on "openssl"
+  depends_on "zstd"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end
@@ -31,6 +31,7 @@ class Librdkafka < Formula
       int main (int argc, char **argv)
       {
         int partition = RD_KAFKA_PARTITION_UA; /* random */
+        int version = rd_kafka_version();
         return 0;
       }
     EOS


### PR DESCRIPTION
Add zstd dependency and make sure the brew test also tries to use a linked symbol, not just a define.

Remove no-op --disable-depency-tracking configure flag.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
