### PR TITLE
BoringTun 0.2.0 (new formula)

### DIFF
--- a/Formula/boringtun.rb
+++ b/Formula/boringtun.rb
@@ -1,0 +1,22 @@
+class Boringtun < Formula
+  desc "Userspace WireGuard implementation in Rust"
+  homepage "https://github.com/cloudflare/boringtun"
+  url "https://github.com/cloudflare/boringtun/archive/v0.2.0.tar.gz"
+  sha256 "544c72fc482b636e7f6460bfee205adafc55de534067819e4e4914980f0d1350"
+  head "https://github.com/cloudflare/boringtun.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/boringtun", "--help"
+    assert_match "boringtun " + version.to_s, shell_output("#{bin}/boringtun -V").chomp
+    assert_match /failed to start/, shell_output("#{bin}/boringtun utun --log #{testpath}/boringtun.log")
+    assert_predicate testpath/"boringtun.log", :exist?
+    boringtun_log = File.read(testpath/"boringtun.log")
+    assert_match /Success, daemonized/, boringtun_log.split("/n").first
+  end
+end


### PR DESCRIPTION
Add a formula for BoringTun, "an implementation of the WireGuard protocol designed for portability and speed."

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not aware of any functionality that does not involve root privileges and the creation of a network interface, so currently the test is simply running `boringtun --help`. I'm happy to update it if there's something better that can be done.