### PR TITLE
New formula for Paperspace CLI for cloud computing

### DIFF
--- a/Formula/paperspace-cli.rb
+++ b/Formula/paperspace-cli.rb
@@ -1,0 +1,26 @@
+require "language/node"
+
+class PaperspaceCli < Formula
+  desc "Paperspace CLI to manage Paperspace cloud compute resources"
+  homepage "https://www.paperspace.com/api"
+  url "https://github.com/Paperspace/paperspace-node/archive/0.1.13.tar.gz"
+  sha256 "d94951ba05bcf8f5c093503904299c6ed705111ec79eedda85081b82ee77ed8f"
+
+  depends_on "node" => :build
+
+  def install
+    system "npm", "install", *Language::Node.local_npm_install_args
+    system "npm", "install", "pkg", *Language::Node.local_npm_install_args
+    # Use node10 because it's the latest node that pkg can work with.
+    system "./node_modules/.bin/pkg", "-t", "node10", "."
+    File.rename("paperspace-node", "paperspace")
+    bin.install "paperspace"
+  end
+
+  test do
+    system "#{bin}/paperspace", "--version"
+    system "#{bin}/paperspace", "--help"
+    # Unfortunately testing all other paperspace functionality requires user
+    #   credentials. (i.e. paperspace login)
+  end
+end


### PR DESCRIPTION
This is a formula that uses node but builds a stand-alone binary that
doesn't require node to run.
Paperspace calls the github project "paperspace-node" and lists its
homepage as the Paperspace API homepage, but the CLI is the command-line
embodiment of the API.  Its specific URL:
https://paperspace.github.io/paperspace-node/#paperspace-cli
It is (as far as my communications with Paperspace support) the
reference CLI for managing and monitoring your Paperspace remote jobs.
Paperspace is a cloud compute service popular for running Machine
Learning compute jobs.
https://www.paperspace.com/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
