### PR TITLE
sdl 1.2.15_1: add mouse cursor transparency patch

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -3,6 +3,7 @@ class Sdl < Formula
   homepage "https://www.libsdl.org/"
   url "https://www.libsdl.org/release/SDL-1.2.15.tar.gz"
   sha256 "d6d316a793e5e348155f0dd93b979798933fb98aa1edebcc108829d6474aad00"
+  revision 1
 
   bottle do
     cellar :any
@@ -33,6 +34,14 @@ class Sdl < Formula
   patch do
     url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1324"
     sha256 "ee7eccb51cefff15c6bf8313a7cc7a3f347dc8e9fdba7a3c3bd73f958070b3eb"
+  end
+
+  # Fix mouse cursor transparency on 10.13, https://bugzilla.libsdl.org/show_bug.cgi?id=4076
+  if MacOS.version == :high_sierra
+    patch do
+      url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3721"
+      sha256 "954875a277d9246bcc444b4e067e75c29b7d3f3d2ace5318a6aab7d7a502f740"
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

SDL 1.x (not 2.x) has bug with custom mouse cursor (mouse pointer) having XOR pixels instead of transparent pixels, occuring only on Mac OS 10.13 (High Sierra).

Upstream bug: https://bugzilla.libsdl.org/show_bug.cgi?id=4076
Related bug in macports: https://trac.macports.org/ticket/55804