### PR TITLE
vert.x 3.7.0

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.6.3-full.tar.gz"
-  sha256 "8025c994f1ef3b80ace23a9d92975abe3b3f41e75f6060127e3f95bc2ee8e9fd"
+  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.7.0-full.tar.gz"
+  sha256 "2a664b214f7be40d38c823d936a48474f7f0b4901bbd5c2c0e7e173676235b1c"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.7.0.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

NOTE: The Vert.x web page is not updated yet (https://vertx.io) as having the homebrew formula is part of the release process.
