### PR TITLE
libgit2 0.28.1

### DIFF
--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -5,7 +5,7 @@ class Gitfs < Formula
   homepage "https://www.presslabs.com/gitfs"
   url "https://github.com/PressLabs/gitfs/archive/0.4.5.1.tar.gz"
   sha256 "6049fd81182d9172e861d922f3e2660f76366f85f47f4c2357f769d24642381c"
-  revision 3
+  revision 4
   head "https://github.com/PressLabs/gitfs.git"
 
   bottle do

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -35,8 +35,8 @@ class Gitfs < Formula
   end
 
   resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/3b/0d/c11844421c7c3b9cb84c5503185bbb5ba780144fd64f5adde572bcdcdd8a/pygit2-0.27.0.tar.gz"
-    sha256 "6febce4aea72f12ed5a1e7529b91119f21d93cb2ccb3f834eea26af76cc9a4cb"
+    url "https://files.pythonhosted.org/packages/ec/56/9f591bee962dcdc3c4268c4bf0a836d5188b1604e58e3618df12a963573b/pygit2-0.28.1.tar.gz"
+    sha256 "2ccdb865ef530c799a6430d0e52952925ffc0d7c856e7608f4cf42f4b821412b"
   end
 
   resource "six" do

--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -5,7 +5,7 @@ class Gitless < Formula
   homepage "https://gitless.com/"
   url "https://github.com/sdg-mit/gitless/archive/v0.8.6.tar.gz"
   sha256 "e1d009bf9d7c89428d7029394cc85a0d91bd2af73f019508ddc92c98faeed8e5"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -52,6 +52,12 @@ class Gitless < Formula
     sha256 "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
   end
 
+  # restores compatibility with recent pygit2 releases (0.27.1+)
+  patch do
+    url "https://github.com/sdg-mit/gitless/commit/4eb3a971d1d7d63fa359b60812a5a5df8b8a72db.patch?full_index=1"
+    sha256 "6b75c448f9a93e814610cb20b8dca4a85c89ee9f11181f03604923c040d67aa6"
+  end
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -38,8 +38,8 @@ class Gitless < Formula
   end
 
   resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/3b/0d/c11844421c7c3b9cb84c5503185bbb5ba780144fd64f5adde572bcdcdd8a/pygit2-0.27.0.tar.gz"
-    sha256 "6febce4aea72f12ed5a1e7529b91119f21d93cb2ccb3f834eea26af76cc9a4cb"
+    url "https://files.pythonhosted.org/packages/ec/56/9f591bee962dcdc3c4268c4bf0a836d5188b1604e58e3618df12a963573b/pygit2-0.28.1.tar.gz"
+    sha256 "2ccdb865ef530c799a6430d0e52952925ffc0d7c856e7608f4cf42f4b821412b"
   end
 
   resource "sh" do

--- a/Formula/libgit2-glib.rb
+++ b/Formula/libgit2-glib.rb
@@ -1,8 +1,8 @@
 class Libgit2Glib < Formula
   desc "Glib wrapper library around libgit2 git access library"
   homepage "https://github.com/GNOME/libgit2-glib"
-  url "https://download.gnome.org/sources/libgit2-glib/0.27/libgit2-glib-0.27.7.tar.xz"
-  sha256 "1131df6d45e405756ef2d9b7613354d542ce99883f6a89582d6236d01bd2efc2"
+  url "https://download.gnome.org/sources/libgit2-glib/0.27/libgit2-glib-0.27.8.tar.xz"
+  sha256 "c199d69efd69e27e38a650d78357a135f961501d734967bc8c449064dce31935"
   head "https://github.com/GNOME/libgit2-glib.git"
 
   bottle do
@@ -12,31 +12,31 @@ class Libgit2Glib < Formula
   end
 
   depends_on "gobject-introspection" => :build
-  depends_on "meson-internal" => :build
+  depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "vala" => :build
   depends_on "gettext"
   depends_on "glib"
   depends_on "libgit2"
 
+  # submitted upstream as https://gitlab.gnome.org/GNOME/libgit2-glib/merge_requests/16
+  patch :DATA
+
+  # fixes compilation error
+  patch do
+    url "https://gitlab.gnome.org/GNOME/libgit2-glib/commit/10da7624b3b2d786b602037cec66e22ee4e7dc13.patch"
+    sha256 "16ebcfa89594dd1c2b83950b9fba8636581bd4a6ad4c68b48237fc3fddb5f562"
+  end
+
   def install
-    ENV.refurbish_args
-
-    # Fix "ld: unknown option: -Bsymbolic-functions"
-    # Reported 2 Apr 2018 https://bugzilla.gnome.org/show_bug.cgi?id=794889
-    inreplace "libgit2-glib/meson.build",
-              "libgit2_glib_link_args = [ '-Wl,-Bsymbolic-functions' ]",
-              "libgit2_glib_link_args = []"
-
     mkdir "build" do
       system "meson", "--prefix=#{prefix}",
                       "-Dpython=false",
                       "-Dvapi=true",
                       ".."
-      system "ninja"
-      system "ninja", "install"
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
       libexec.install Dir["examples/*"]
     end
   end
@@ -48,3 +48,57 @@ class Libgit2Glib < Formula
     system "#{libexec}/general", testpath/"horatio"
   end
 end
+
+__END__
+diff --git a/libgit2-glib/meson.build b/libgit2-glib/meson.build
+index a6cb0c4..9158178 100644
+--- a/libgit2-glib/meson.build
++++ b/libgit2-glib/meson.build
+@@ -205,21 +205,15 @@ platform_deps = [
+   libgit2_dep,
+ ]
+
+-if cc.get_id() == 'msvc'
+-  libgit2_glib_link_args = []
+-else
+-  libgit2_glib_link_args = ['-Wl,-Bsymbolic-functions']
+-endif
+-
+ libgit2_glib = shared_library(
+   'git2-glib-' + libgit2_glib_api_version,
+   version: libversion,
+   soversion: soversion,
++  darwin_versions: darwin_versions,
+   sources: sources + enum_sources,
+   include_directories: top_inc,
+   dependencies: platform_deps,
+   c_args: cflags + ['-DG_LOG_DOMAIN="@0@"'.format(libgit2_glib_ns)],
+-  link_args: libgit2_glib_link_args,
+   install: true,
+ )
+
+diff --git a/meson.build b/meson.build
+index 29d73ce..b24c268 100644
+--- a/meson.build
++++ b/meson.build
+@@ -35,6 +35,7 @@ soversion = 0
+ current = libgit2_glib_minor_version * 100 + libgit2_glib_micro_version - libgit2_glib_interface_age
+ revision = libgit2_glib_interface_age
+ libversion = '@0@.@1@.@2@'.format(soversion, current, revision)
++darwin_versions = [current + 1, '@0@.@1@'.format(current + 1, revision)]
+
+ libgit2_glib_prefix = get_option('prefix')
+ libgit2_glib_libdir = get_option('libdir')
+@@ -106,6 +107,11 @@ endif
+
+ add_project_arguments(common_flags, language: 'c')
+
++if cc.has_link_argument('-Wl,-Bsymbolic-functions')
++  add_project_link_arguments('-Wl,-Bsymbolic-functions', language : 'c')
++endif
++
++
+ # Termios
+ have_termios = cc.has_header('termios.h')
+
+

--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -1,8 +1,8 @@
 class Libgit2 < Formula
   desc "C library of Git core methods that is re-entrant and linkable"
   homepage "https://libgit2.github.com/"
-  url "https://github.com/libgit2/libgit2/archive/v0.27.8.tar.gz"
-  sha256 "8313873d49dc01e8b880ec334d7430ae67496a89aaa8c6e7bbd3affb47a00c76"
+  url "https://github.com/libgit2/libgit2/archive/v0.28.1.tar.gz"
+  sha256 "0ca11048795b0d6338f2e57717370208c2c97ad66c6d5eac0c97a8827d13936b"
   head "https://github.com/libgit2/libgit2.git"
 
   bottle do

--- a/Formula/salt.rb
+++ b/Formula/salt.rb
@@ -86,8 +86,8 @@ class Salt < Formula
   end
 
   resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/64/49/a7a621f1c2fde3dc263c10f2b2be5b42807bfdafe8465fc8e0f4c5524016/pygit2-0.27.3.tar.gz"
-    sha256 "9b7613be3f6ee6ffcfdfa9c64762d4e36a31161bd561a6f7d340a8b3f486ca10"
+    url "https://files.pythonhosted.org/packages/ec/56/9f591bee962dcdc3c4268c4bf0a836d5188b1604e58e3618df12a963573b/pygit2-0.28.1.tar.gz"
+    sha256 "2ccdb865ef530c799a6430d0e52952925ffc0d7c856e7608f4cf42f4b821412b"
   end
 
   resource "pyzmq" do

--- a/Formula/salt.rb
+++ b/Formula/salt.rb
@@ -5,6 +5,7 @@ class Salt < Formula
   homepage "https://s.saltstack.com/community/"
   url "https://files.pythonhosted.org/packages/41/d4/7f6d6bb139506741771ff9feb8429d5a5ed860de9ab5a358e771e8cc3b76/salt-2019.2.0.tar.gz"
   sha256 "5695bb2b3fa288bcfc0e3b93d9449afd75220bd8f0deefb5e7fc03af381df6cd"
+  revision 1
   head "https://github.com/saltstack/salt.git", :branch => "develop", :shallow => false
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#38263 has been opened already, but this PR has all the required changes. All changes built/tested/audited on Mojave.

Currently running into an issue with `libgit2-glib` not building from source because of `meson-internal` version being too old. Not sure what the course of action should be:

```
homebrew-core whobbs$ brew install --build-from-source Formula/libgit2-glib.rb
==> Downloading https://download.gnome.org/sources/libgit2-glib/0.27/libgit2-glib-0.27.8.tar.xz
Already downloaded: /Users/whobbs/Library/Caches/Homebrew/downloads/d3fe0e2f5e31878891ee4f71a4a6cef428faeb2a2f7bb6c20cf69f6e3ee1b373--libgit2-glib-0.27.8.tar.xz
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
libgit2-glib/meson.build:
  expected replacement of "libgit2_glib_link_args = [ '-Wl,-Bsymbolic-functions' ]" with "libgit2_glib_link_args = []"
```

So I removed that section and now I get:

```
==> Downloading https://download.gnome.org/sources/libgit2-glib/0.27/libgit2-glib-0.27.8.tar.xz
Already downloaded: /Users/whobbs/Library/Caches/Homebrew/downloads/d3fe0e2f5e31878891ee4f71a4a6cef428faeb2a2f7bb6c20cf69f6e3ee1b373--libgit2-glib-0.27.8.tar.xz
==> meson --prefix=/usr/local/Cellar/libgit2-glib/0.27.8 -Dpython=false -Dvapi=true ..
Last 15 lines from /Users/whobbs/Library/Logs/Homebrew/libgit2-glib/01.meson:
meson
--prefix=/usr/local/Cellar/libgit2-glib/0.27.8
-Dpython=false
-Dvapi=true
..

The Meson build system
Version: 0.46.1
Source dir: /private/tmp/libgit2-glib-20190402-31281-iao806/libgit2-glib-0.27.8
Build dir: /private/tmp/libgit2-glib-20190402-31281-iao806/libgit2-glib-0.27.8/build
Build type: native build

meson.build:1:0: ERROR:  Meson version is 0.46.1 but project requires >= 0.48.0.

A full log can be found at /private/tmp/libgit2-glib-20190402-31281-iao806/libgit2-glib-0.27.8/build/meson-logs/meson-log.txt

Do not report this issue to Homebrew/brew or Homebrew/core!
```