### PR TITLE
ospray 1.8.4 (new formula)

### DIFF
--- a/Formula/ospray.rb
+++ b/Formula/ospray.rb
@@ -1,0 +1,45 @@
+class Ospray < Formula
+  desc "Ray-tracing-based rendering engine for high-fidelity visualization"
+  homepage "https://www.ospray.org/"
+  url "https://github.com/ospray/ospray/archive/v1.8.4.tar.gz"
+  sha256 "36527eb01a09b0f30608550373aa305ecbfa2faea23cd929cc731af5864ca326"
+  head "https://github.com/ospray/ospray.git"
+
+  depends_on "cmake" => :build
+  depends_on "ispc" => :build
+  depends_on "embree"
+  depends_on :macos => :mojave # Needs embree bottle built with SSE4.2.
+  depends_on "tbb"
+
+  def install
+    args = std_cmake_args + %w[
+      -DCMAKE_INSTALL_NAME_DIR=#{opt_lib}
+      -DCMAKE_INSTALL_RPATH=#{opt_lib}
+      -DOSPRAY_ENABLE_APPS=OFF
+      -DOSPRAY_ENABLE_TESTING=OFF
+      -DOSPRAY_ENABLE_TUTORIALS=OFF
+    ]
+
+    mkdir "build" do
+      system "cmake", *args, ".."
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <assert.h>
+      #include <ospray/ospray.h>
+      int main(int argc, const char **argv) {
+        OSPError error = ospInit(&argc, argv);
+        assert(error == OSP_NO_ERROR);
+        ospShutdown();
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lospray"
+    system "./a.out"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] Needs #37655 (`embree 3.5.0 (new formula)`) which has been approved by @fxcoudert but not yet merged.
- [x] Needs #38643 (`ispc 1.10.0: fix standard library generation and add meaningful test`).