### PR TITLE
ispc 1.10.0: fix standard library generation and add meaningful test

### DIFF
--- a/Formula/ispc.rb
+++ b/Formula/ispc.rb
@@ -3,6 +3,7 @@ class Ispc < Formula
   homepage "https://ispc.github.io"
   url "https://github.com/ispc/ispc/archive/v1.10.0.tar.gz"
   sha256 "0aa30e989f8d446b2680c9078d5c5db70634f40b9aa07db387aa35aa08dd0b81"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,9 +18,16 @@ class Ispc < Formula
   depends_on "llvm@4"
 
   def install
+    # The standard include paths for clang supplied by the llvm@4 formula do not include
+    # C headers such as unistd.h. Add the path to those headers explicitly so that
+    # generation of the ispc builtins and standard library do not silently fail.
+    inreplace "cmake/GenerateBuiltins.cmake", "${CLANG_EXECUTABLE}",
+      "${CLANG_EXECUTABLE} -I#{MacOS.sdk_path}/usr/include"
+
     args = std_cmake_args + %W[
       -DISPC_INCLUDE_EXAMPLES=OFF
       -DISPC_INCLUDE_TESTS=OFF
+      -DISPC_INCLUDE_UTILS=OFF
       -DLLVM_TOOLS_BINARY_DIR='#{Formula["llvm@4"]}'
     ]
 
@@ -31,6 +39,33 @@ class Ispc < Formula
   end
 
   test do
-    system "#{bin}/ispc", "-v"
+    (testpath/"simple.ispc").write <<~EOS
+      export void simple(uniform float vin[], uniform float vout[], uniform int count) {
+        foreach (index = 0 ... count) {
+          float v = vin[index];
+          if (v < 3.)
+            v = v * v;
+          else
+            v = sqrt(v);
+          vout[index] = v;
+        }
+      }
+    EOS
+    system bin/"ispc", "--arch=x86-64", "--target=sse2", testpath/"simple.ispc",
+      "-o", "simple_ispc.o", "-h", "simple_ispc.h"
+
+    (testpath/"simple.cpp").write <<~EOS
+      #include "simple_ispc.h"
+      int main() {
+        float vin[9], vout[9];
+        for (int i = 0; i < 9; ++i) vin[i] = static_cast<float>(i);
+        ispc::simple(vin, vout, 9);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-I#{testpath}", "-c", "-o", testpath/"simple.o", testpath/"simple.cpp"
+    system ENV.cxx, "-o", testpath/"simple", testpath/"simple.o", testpath/"simple_ispc.o"
+
+    system testpath/"simple"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#38637 is failing because the ispc standard library is not available. Closer inspection of the build of this formula shows a silent failure (other than console output when compiled verbosely). This is specific to the use of the `llvm@4` formula as a dependency of this formula and not necessarily an upstream bug (though the silent failure is not very helpful). Note also https://github.com/jvo203/fits_web_ql/commit/62ba2e29fc0676fca6315d0021581bba38476cd2#diff-04c6e90faac2675aa89e2176d2eec7d8R73. Also adds a test that would have failed without this fix.