### PR TITLE
carthage 0.33.0

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -2,8 +2,8 @@ class Carthage < Formula
   desc "Decentralized dependency manager for Cocoa"
   homepage "https://github.com/Carthage/Carthage"
   url "https://github.com/Carthage/Carthage.git",
-      :tag      => "0.32.0",
-      :revision => "6e1e70541ce8692945569cbcf6c9f108ee69af98",
+      :tag      => "0.33.0",
+      :revision => "c8ac06e106b6b61f907918bfb2b7a5c432de4678",
       :shallow  => false
   head "https://github.com/Carthage/Carthage.git", :shallow => false
 
@@ -13,9 +13,20 @@ class Carthage < Formula
     sha256 "576468454342dc278837901358ce2f325584307cafd457ae9ada46436b84a941" => :high_sierra
   end
 
-  depends_on :xcode => ["9.4", :build]
+  depends_on :xcode => ["10.0", :build]
 
   def install
+    if MacOS::Xcode.version >= "10.2" && (0..3).any? { |x| String(MacOS.full_version) == "10.14.#{x}" }
+      odie [
+        "If a user on sub-10.14.4-Mojave using a Swift 5 CLI app happens to remove or relocate " \
+        "`Xcode.app`, say to make room for `Xcode-beta.app`, without the additional package " \
+        "installed to `/usr/lib/swift`, an app like this will no longer run.",
+        "See <https://github.com/Homebrew/brew/pull/5940#issuecomment-477583315>.",
+        "Perhaps, try `--force-bottle` with `DEVELOPER_DIR='/var/empty' HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=true brew`?",
+        "Or, perhaps, if Xcode 10.1 is available, `xcode-select` that?",
+      ].join("\n• ")
+    end
+
     system "make", "prefix_install", "PREFIX=#{prefix}"
     bash_completion.install "Source/Scripts/carthage-bash-completion" => "carthage"
     zsh_completion.install "Source/Scripts/carthage-zsh-completion" => "_carthage"

--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -16,15 +16,8 @@ class Carthage < Formula
   depends_on :xcode => ["10.0", :build]
 
   def install
-    if MacOS::Xcode.version >= "10.2" && (0..3).any? { |x| String(MacOS.full_version) == "10.14.#{x}" }
-      odie [
-        "If a user on sub-10.14.4-Mojave using a Swift 5 CLI app happens to remove or relocate " \
-        "`Xcode.app`, say to make room for `Xcode-beta.app`, without the additional package " \
-        "installed to `/usr/lib/swift`, an app like this will no longer run.",
-        "See <https://github.com/Homebrew/brew/pull/5940#issuecomment-477583315>.",
-        "Perhaps, try `--force-bottle` with `DEVELOPER_DIR='/var/empty' HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=true brew`?",
-        "Or, perhaps, if Xcode 10.1 is available, `xcode-select` that?",
-      ].join("\n• ")
+    if MacOS::Xcode.version >= "10.2" && MacOS.version < "10.14.4" && MacOS.version >= "10.14.4"
+      odie "Xcode >=10.2 requires macOS >=10.14.4 to build Swift formulae."
     end
 
     system "make", "prefix_install", "PREFIX=#{prefix}"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> If a user on sub-10.14.4-Mojave using a Swift 5 CLI app happens to remove or relocate Xcode.app, say to make room for Xcode-beta.app, without [the additional package installed to `/usr/lib/swift`](https://forums.swift.org/t/command-line-applications-crashes-with-xcode-10-2/22192/12), all they will see is [the very unhelpful `dyld: Library not loaded: @rpath/libswiftCore.dylib → Abort trap: 6`](https://forums.swift.org/t/command-line-applications-crashes-with-xcode-10-2/22192).

> We'd like to steer them in the direction of getting a 10.1-build bottle, `xcode-select`ing 10.1 for a local build, or upgrading (if corporate allows) to macOS 10.14.4.

→ @MikeMcQuaid 

> @jdhealy Cool, makes sense. I'd suggest a PR to add an `odie` to `def install` that fails to build from source if they are on macOS >=10.14, macOS <10.14.4 and with Xcode >=10.2.

https://github.com/Homebrew/brew/pull/5940#issuecomment-478992020