### PR TITLE
carthage: update 0.33.0 bottle — removing Mojave bottle listing.

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -9,7 +9,6 @@ class Carthage < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "3e2ac935092f11a43bf2f45811a176bbb6c37a48f41eea1222a46a35b81555c6" => :mojave
     sha256 "7f88034cfbd51439cd45467745ea3b1a21e6eec2cdd8a7eb2a8945382404b5f0" => :high_sierra
   end
 


### PR DESCRIPTION
As discussed in <https://github.com/Homebrew/brew/pull/5940#issuecomment-479008608> and <https://github.com/Homebrew/brew/pull/5940#issuecomment-479014669>.

/cc @MikeMcQuaid

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
