### PR TITLE
bfg: fix java minimum version

### DIFF
--- a/Formula/bfg.rb
+++ b/Formula/bfg.rb
@@ -6,7 +6,7 @@ class Bfg < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8+"
 
   def install
     libexec.install "bfg-#{version}.jar"


### PR DESCRIPTION
As of v1.13.0, the minimum supported Java version is 1.8
See: https://github.com/rtyley/bfg-repo-cleaner/releases/tag/v1.13.0

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
