### PR TITLE
New formula: leela-zero 0.17

### DIFF
--- a/Formula/leela-zero.rb
+++ b/Formula/leela-zero.rb
@@ -1,0 +1,31 @@
+class LeelaZero < Formula
+  desc "Neural Network Go engine with no human-provided knowledge"
+  homepage "https://zero.sjeng.org/"
+  # pull from git tag to get submodules
+  url "https://github.com/leela-zero/leela-zero.git",
+      :tag      => "v0.17",
+      :revision => "3f297889563bcbec671982c655996ccff63fa253"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+
+  resource "network" do
+    url "https://zero.sjeng.org/networks/00ff08ebcdc92a2554aaae815fbf5d91e8d76b9edfe82c9999427806e30eae77.gz", :using => :nounzip
+    sha256 "5302f23818c23e1961dff986ba00f5df5c58dc9c780ed74173402d58fdb6349c"
+  end
+
+  def install
+    mkdir "build"
+    cd "build" do
+      system "cmake", ".."
+      system "cmake", "--build", "."
+      bin.install "leelaz"
+    end
+    pkgshare.install resource("network")
+  end
+
+  test do
+    system "#{bin}/leelaz", "--help"
+    assert_match /^= [A-T][0-9]+$/, pipe_output("#{bin}/leelaz --cpu-only --gtp -w #{pkgshare}/*.gz", "genmove b\n", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'd like to just pre-answer some questions that came up [the last time I submitted](https://github.com/Homebrew/homebrew-core/pull/37366) the previous version of this, because for some reason after answering them the reviewer stopped responding completely until the PR was marked as stale.

  - The weights file that gets downloaded as a resource _is_ a mandatory part of the package; without it, the software is useless since it is a neural network engine.
  - The weights file _is_ versioned; that long jumble of characters in the URL is not some sort of session ID, it is a checksum of that particular network prior to compression. All networks are properly versioned by the project [going back to the very beginning of the project](https://zero.sjeng.org/network-profiles). That network URL will work and have a consistent hash for many years to come.
  - The latest upstream release does fix the bug where non-GPU Macs would segfault unless built with `-DUSE_CPU_ONLY`, so that parameter has been removed now. OpenCL for everybody! 🎉 
  - The formula `test` _does_ exercise the application. It loads up the entire network and generates a move.

All other comments from the previous PR have already been incorporated so it shouldn't be an issue :)

Thanks! The entire Go community eagerly awaits having this in Homebrew :)