### PR TITLE
gdk-pixbuf: fix failing inreplace

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -62,13 +62,6 @@ class GdkPixbuf < Formula
       s.change_make_var! "gdk_pixbuf_binarydir",
         HOMEBREW_PREFIX/"lib/gdk-pixbuf-#{gdk_so_ver}"/libv
     end
-
-    # fix gobject-introspection support
-    # will not be necessary after next release of gobject-introspection
-    %w[GdkPixbuf-2.0 GdkPixdata-2.0].each do |gir|
-      inreplace share/"gir-1.0/#{gir}.gir", "@rpath", lib.to_s
-      system "g-ir-compiler", "--includedir=#{share}/gir-1.0", "--output=#{lib}/girepository-1.0/#{gir}.typelib", share/"gir-1.0/#{gir}.gir"
-    end
   end
 
   # The directory that loaders.cache gets linked into, also has the "loaders"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR resolves the failing `inreplace` during the installation of `gdk-pixbuf`:
```
==> ninja install
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
/usr/local/Cellar/gdk-pixbuf/2.38.1/share/gir-1.0/GdkPixbuf-2.0.gir:
  expected replacement of "@rpath" with "/usr/local/Cellar/gdk-pixbuf/2.38.1/lib"
```

References:
https://github.com/Homebrew/homebrew-core/pull/37445/files#diff-e6e88612e8b12281bcb1087e68d23547R68
https://gitlab.gnome.org/GNOME/gobject-introspection/issues/222

/cc @tschoonj