### PR TITLE
Update to riff 0.3.0

### DIFF
--- a/Formula/riff.rb
+++ b/Formula/riff.rb
@@ -4,8 +4,8 @@ class Riff < Formula
   desc "Function As A Service on top of Knative, riff is for functions"
   homepage "https://www.projectriff.io/"
   url "https://github.com/projectriff/riff.git",
-      :tag      => "v0.2.0",
-      :revision => "1ae190ff3c7edf4b375ee935f746ebfd1d8eaf5c"
+      :tag      => "v0.3.0",
+      :revision => "4e474f57a463d4d2c1159af64d562532fcb3ac1b"
 
   bottle do
     cellar :any_skip_relocation
@@ -18,21 +18,17 @@ class Riff < Formula
   depends_on "kubernetes-cli"
 
   def install
-    ENV["GOPATH"] = buildpath
-    contents = Dir["{*,.git,.gitattributes,.gitignore,.travis.yml}"]
-    (buildpath/"src/github.com/projectriff/riff").install contents
-
-    cd "src/github.com/projectriff/riff" do
+    cd buildpath do
       system "make", "build"
       bin.install "riff"
     end
   end
 
   test do
-    stdout, stderr, status = Open3.capture3("#{bin}/riff --kubeconfig not-a-kube-config-file channel list")
+    stdout, stderr, status = Open3.capture3("#{bin}/riff --kubeconfig not-a-kube-config-file service list")
 
     assert_equal false, status.success?
-    assert_match "List channels", stdout
+    assert_match "List service resources", stdout
     assert_match "Error: stat not-a-kube-config-file: no such file or directory", stderr
   end
 end


### PR DESCRIPTION
riff is now using go modules, hence the simplification of the
installation logic.

The test command has been changed as the Knative eventing-related
subcommands (`channel`, `subscription`...) are now deprecated.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
