### PR TITLE
tbb: fix CMake config generation

### DIFF
--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -4,6 +4,7 @@ class Tbb < Formula
   url "https://github.com/01org/tbb/archive/2019_U5.tar.gz"
   version "2019_U5"
   sha256 "2ea82d74dec50e18075b4982b8d360f8bd2bf2950f38e2db483aef82e0047444"
+  revision 1
 
   bottle do
     cellar :any
@@ -32,10 +33,10 @@ class Tbb < Formula
       system "python3", *Language::Python.setup_install_args(prefix)
     end
 
-    system "cmake", "-DTBB_ROOT=#{prefix}",
-                    "-DTBB_OS=Darwin",
-                    "-DSAVE_TO=lib/cmake/TBB",
-                    "-P", "cmake/tbb_config_generator.cmake"
+    system "cmake", "-DINSTALL_DIR=lib/cmake/TBB",
+                    "-DSYSTEM_NAME=Darwin",
+                    "-DTBB_VERSION_FILE=#{include}/tbb/tbb_stddef.h",
+                    "-P", "cmake/tbb_config_installer.cmake"
 
     (lib/"cmake"/"TBB").install Dir["lib/cmake/TBB/*.cmake"]
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change addresses the issue #36164.

A new [TBBInstallConfig](https://github.com/01org/tbb/tree/tbb_2019/cmake#tbbinstallconfig) module is used to install proper TBBConfig.cmake / TBBConfigVersion.cmake.
[TBBMakeConfig](https://github.com/01org/tbb/tree/tbb_2019/cmake#tbbmakeconfig) is intended for internal TBB use, so it should not be used here.
