### PR TITLE
cypher-shell 1.1.9

### DIFF
--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -1,0 +1,24 @@
+class CypherShell < Formula
+  desc "Command-line shell where you can execute Cypher against Neo4j"
+  homepage "https://github.com/neo4j/cypher-shell"
+  url "https://github.com/neo4j/cypher-shell/releases/download/1.1.9/cypher-shell.zip"
+  version "1.1.9"
+  sha256 "027dd83ff10ac24077dc9ab7e1be4a624f8cadeab4039bb6800584d94fecf49f"
+
+  depends_on :java => "1.8"
+
+  def install
+    rm_f Dir["bin/*.bat"]
+
+    ENV["NEO4J_HOME"] = share
+    share.install ["cypher-shell.jar"]
+
+    bin.install ["cypher-shell"]
+    bin.env_script_all_files(share, :NEO4J_HOME => ENV["NEO4J_HOME"])
+  end
+
+  test do
+    ENV["NEO4J_HOME"] = libexec
+    system "#{bin}/cypher-shell", "--version"
+  end
+end

--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -19,7 +19,7 @@ class CypherShell < Formula
   end
 
   test do
-    # `doesntexist` is printed, but shell_output captures //, unsure why
-    assert_match //, shell_output("#{bin}/cypher-shell -a bolt://doesntexist", 1)
+    # The connection will fail and print the name of the host
+    assert_match /doesntexist/, shell_output("#{bin}/cypher-shell -a bolt://doesntexist 2>&1", 1)
   end
 end

--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -10,15 +10,16 @@ class CypherShell < Formula
   def install
     rm_f Dir["bin/*.bat"]
 
-    ENV["NEO4J_HOME"] = share
+    # Needs the jar, but cannot go in bin
     share.install ["cypher-shell.jar"]
 
+    # Copy the bin
     bin.install ["cypher-shell"]
     bin.env_script_all_files(share, :NEO4J_HOME => ENV["NEO4J_HOME"])
   end
 
   test do
-    ENV["NEO4J_HOME"] = libexec
-    system "#{bin}/cypher-shell", "--version"
+    # `doesntexist` is printed, but shell_output captures //, unsure why
+    assert_match //, shell_output("#{bin}/cypher-shell -a bolt://doesntexist", 1)
   end
 end

--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -5,6 +5,8 @@ class CypherShell < Formula
   version "1.1.9"
   sha256 "027dd83ff10ac24077dc9ab7e1be4a624f8cadeab4039bb6800584d94fecf49f"
 
+  bottle :unneeded
+
   depends_on :java => "1.8"
 
   def install


### PR DESCRIPTION
cypher-shell is not currently available as a standalone and is much lighter than a full install of neo4j

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
