### PR TITLE
kubecfg 0.11.0

### DIFF
--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -1,8 +1,8 @@
 class Kubecfg < Formula
   desc "Manage complex enterprise Kubernetes environments as code"
-  homepage "https://github.com/ksonnet/kubecfg"
-  url "https://github.com/ksonnet/kubecfg/archive/v0.9.1.tar.gz"
-  sha256 "22255007b6b9fd7e30f0af0456ba49eb405e714b3236a88926c776716096f5ac"
+  homepage "https://github.com/bitnami/kubecfg"
+  url "https://github.com/bitnami/kubecfg/archive/v0.11.0.tar.gz"
+  sha256 "79dcd7e680e2bba156e48ef7ecfa47b151560265b7bac9fdbe7bf193cddf3c28"
 
   bottle do
     cellar :any_skip_relocation
@@ -14,10 +14,9 @@ class Kubecfg < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/ksonnet/kubecfg").install buildpath.children
+    (buildpath/"src/github.com/bitnami/kubecfg").install buildpath.children
 
-    cd "src/github.com/ksonnet/kubecfg" do
+    cd "src/github.com/bitnami/kubecfg" do
       system "make", "VERSION=v#{version}"
       bin.install "kubecfg"
       pkgshare.install Dir["examples/*"], "testdata/kubecfg_test.jsonnet"


### PR DESCRIPTION
Since kubecfg now uses Go modules to manage its dependencies, it's no longer necessary to set the "GOPATH" environment variable when building it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?  
  Please see below.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---
Note that I could not get _bump-formula-pr_ to work, perhaps because I already had a fork of this repository. It fails in the block involving the call to `GitHub.create_fork`:
```
Error: Unable to fork: Not Found!
Error: Kernel.exit
/usr/local/Homebrew/Library/Homebrew/utils.rb:65:in `exit'
/usr/local/Homebrew/Library/Homebrew/utils.rb:65:in `odie'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:335:in `rescue in block in bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:315:in `block in bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:256:in `block in cd'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:256:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:256:in `cd'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:299:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:100:in `<main>'
```
