### PR TITLE
serial 1.3.2

### DIFF
--- a/Formula/serial.rb
+++ b/Formula/serial.rb
@@ -1,0 +1,28 @@
+class Serial < Formula
+  desc "Cross-platform, Serial Port library written in C++"
+  homepage "https://gitlab.com/johnbarton/serial"
+  url "https://gitlab.com/johnbarton/serial/-/archive/1.3.2/serial-1.3.2.tar.gz"
+  sha256 "381ed4e4b76b414232b89ae044e3d6c1b6c2e2c99fdbea2625ce9888089fee72"
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <serial/serial.h>
+      int main(int argc, char **argv) {
+        auto port = new serial::Serial();
+        delete(port);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.c", "-L#{lib}", "-lserial", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Hello! I forked GitHub user wjwwood's cross-platform C++ serial library (https://github.com/wjwwood/serial) and tweaked it for release through Homebrew. I have found this library particularly helpful with Arduino projects and other serial-enabled microcontrollers, and thought this would be a nice addition to homebrew-core.

The reason for forking the current library and not building a formula to work around his code base is that he designed the library to work with [ROS](http://www.ros.org/), which is built on Ubuntu and has a very clunky library. The build system, catkin, also has many portability issues. This merge would enable Mac users to seamlessly use wjwwood's library without tweaking it themselves.

Thank you for consideration!