### PR TITLE
python@2: drop docs building

### DIFF
--- a/Formula/python@2.rb
+++ b/Formula/python@2.rb
@@ -23,7 +23,6 @@ class PythonAT2 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "sphinx-doc" => :build
   depends_on "gdbm"
   depends_on "openssl"
   depends_on "readline"
@@ -166,11 +165,6 @@ class PythonAT2 < Formula
     (libexec/"setuptools").install resource("setuptools")
     (libexec/"pip").install resource("pip")
     (libexec/"wheel").install resource("wheel")
-
-    cd "Doc" do
-      system "make", "html"
-      doc.install Dir["build/html/*"]
-    end
   end
 
   def post_install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- `python@2` is no longer able to be build its docs after `sphinx-doc` 2.0.0. #38591
- We've previously dropped docs building for `python` due to a circular dependency involved, and we also declined to use the upstream released docs tarball due to theirs checksums are not stable and are subject to change from time to time.
- `spinx-doc` now depends on `python`, so it seems weird to pull `python` in for building `python@2`.