### PR TITLE
update Minetest formula to version 5.0.1

### DIFF
--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -35,7 +35,6 @@ class Minetest < Formula
   depends_on "libogg"
   depends_on "libvorbis"
   depends_on "luajit"
-  depends_on :x11
 
   def install
     (buildpath/"games/minetest_game").install resource("minetest_game")

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -3,12 +3,12 @@ class Minetest < Formula
   homepage "https://www.minetest.net/"
 
   stable do
-    url "https://github.com/minetest/minetest/archive/0.4.17.1.tar.gz"
-    sha256 "cd25d40c53f492325edabd2f6397250f40a61cb9fe4a1d4dd6eb030e0d1ceb59"
+    url "https://github.com/minetest/minetest/archive/5.0.1.tar.gz"
+    sha256 "aa771cf178ad1b436d5723e5d6dd24e42b5d56f1cfe9c930f6426b7f24bb1635"
 
     resource "minetest_game" do
-      url "https://github.com/minetest/minetest_game/archive/0.4.17.tar.gz"
-      sha256 "f0ab07cb47c1540b2016bf76a36e2eec28b0ea7827bf66fc5447e0c5e5d4495d"
+      url "https://github.com/minetest/minetest_game/archive/5.0.1.tar.gz"
+      sha256 "965d2cf3ac8c822bc9e60fb8f508182fb2f24dde46f46b000caf225ebe2ec519"
     end
   end
 
@@ -44,10 +44,6 @@ class Minetest < Formula
     args << "-DCMAKE_BUILD_TYPE=Release" << "-DBUILD_CLIENT=1" << "-DBUILD_SERVER=0"
     args << "-DENABLE_FREETYPE=1" << "-DCMAKE_EXE_LINKER_FLAGS='-L#{Formula["freetype"].opt_lib}'"
     args << "-DENABLE_GETTEXT=1" << "-DCUSTOM_GETTEXT_PATH=#{Formula["gettext"].opt_prefix}"
-
-    # -ffast-math compiler flag is an issue on Mac
-    # https://github.com/minetest/minetest/issues/4274
-    inreplace "src/CMakeLists.txt", "-ffast-math", ""
 
     system "cmake", ".", *args
     system "make", "package"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] _See note 1 /_ Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] _See note 1 /_ Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Upgrading Minetest to latest stable release: https://github.com/minetest/minetest/releases/tag/5.0.1

**Note 1** - there is no test defined, however I have run the compiled program multiple times in the past week without any problems