### PR TITLE
libpostal 1.0.0 (new formula)

### DIFF
--- a/Formula/libpostal.rb
+++ b/Formula/libpostal.rb
@@ -1,0 +1,45 @@
+class Libpostal < Formula
+  desc "C library for parsing/normalizing street addresses around the world"
+  homepage "https://github.com/openvenues/libpostal"
+  url "https://github.com/openvenues/libpostal/archive/v1.0.0.tar.gz"
+  sha256 "3035af7e15b2894069753975d953fa15a86d968103913dbf8ce4b8aa26231644"
+  head "https://github.com/openvenues/libpostal.git"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    cpus = `sysctl -n hw.ncpu`.strip
+    system "./bootstrap.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-data-download",
+                          "--prefix=#{prefix}",
+                          "--datadir=#{prefix}/data"
+    system "make", "--jobs=#{cpus}"
+    system "make", "install"
+    system "#{prefix}/bin/libpostal_data", "download", "all", "#{prefix}/data/libpostal"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <libpostal/libpostal.h>
+          int main(int argc, char **argv) {
+              if (!libpostal_setup() || !libpostal_setup_parser()) {
+                  exit(EXIT_FAILURE);
+              }
+              libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
+              libpostal_address_parser_response_t *parsed = libpostal_parse_address("781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA", options);
+              libpostal_address_parser_response_destroy(parsed);
+              libpostal_teardown();
+              libpostal_teardown_parser();
+          }
+        EOS
+
+        system ENV.cc, "test.c", "-I#{prefix}/include", "-L#{prefix}/lib", "-lpostal", "-o", "test"
+        system "./test"
+      end
+end


### PR DESCRIPTION
This adds a formula for the libpostal address parsing/normalization
library (https://github.com/openvenues/libpostal).

Looks like there's an open issue on libpostal for packaging in Homebrew
(https://github.com/openvenues/libpostal/issues/380), and a much older closed issue within Homebrew (https://github.com/Homebrew/homebrew-core/pull/5172) but no recent PRs that I can find.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
