### PR TITLE
Formula/operator-sdk.rb: Upgrade to v0.7.0

### DIFF
--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -1,8 +1,8 @@
 class OperatorSdk < Formula
   desc "SDK for building Kubernetes applications"
   homepage "https://coreos.com/operators/"
-  url "https://github.com/operator-framework/operator-sdk/archive/v0.6.0.tar.gz"
-  sha256 "d6c21b9289cae221026a21df2a333f1e4d8d08c996c2104a94b8514e836dfe9f"
+  url "https://github.com/operator-framework/operator-sdk/archive/v0.7.0.tar.gz"
+  sha256 "19c1fd70e4ca1242667552dc6a087bfeb2e019fffcfdbe2d7295475a7596126c"
   head "https://github.com/operator-framework/operator-sdk.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Note: had some problems with running `brew test operator-sdk`, it seems to have timed out. When I ran the command it tries to test, manually, it works fine. 

Closes https://github.com/operator-framework/operator-sdk/issues/1318 