### PR TITLE
ripgrep 11.0.0

### DIFF
--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -1,8 +1,8 @@
 class Ripgrep < Formula
   desc "Search tool like grep and The Silver Searcher"
   homepage "https://github.com/BurntSushi/ripgrep"
-  url "https://github.com/BurntSushi/ripgrep/archive/0.10.0.tar.gz"
-  sha256 "a2a6eb7d33d75e64613c158e1ae450899b437e37f1bfbd54f713b011cd8cc31e"
+  url "https://github.com/BurntSushi/ripgrep/archive/11.0.0.tar.gz"
+  sha256 "be7a7f4a39bd6d408691c65b74f78f5329115085fa1ea2045079d71d0c0abbd8"
   head "https://github.com/BurntSushi/ripgrep.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

<https://github.com/BurntSushi/ripgrep/releases/tag/11.0.0>

There was a version-scheme change here (from `0.x.y` to `x.y.z`), but comparisons between the old and new schemes should work as expected, so i didn't do anything special about it