### PR TITLE
Release Gradle 5.4

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -1,8 +1,8 @@
 class Gradle < Formula
   desc "Open-source build automation tool based on the Groovy and Kotlin DSL"
   homepage "https://www.gradle.org/"
-  url "https://services.gradle.org/distributions/gradle-5.3.1-all.zip"
-  sha256 "b018a7308cb43633662363d100c14a3c41c66fd4e32b59e1dfc644d6fd2109f6"
+  url "https://services.gradle.org/distributions/gradle-5.4-all.zip"
+  sha256 "f177768e7a032727e4338c8fd047f8f263e5bd283f67a7766c1ba4182c8455a6"
 
   bottle :unneeded
 


### PR DESCRIPTION
This commit upgrades the latest Gradle version to 5.4.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
