### PR TITLE
Remove `scons` method

### DIFF
--- a/Formula/field3d.rb
+++ b/Formula/field3d.rb
@@ -18,7 +18,7 @@ class Field3d < Formula
   depends_on "ilmbase"
 
   def install
-    scons
+    system "scons"
     include.install Dir["install/**/**/release/include/*"]
     lib.install Dir["install/**/**/release/lib/*"]
     man1.install "man/f3dinfo.1"

--- a/Formula/huexpress.rb
+++ b/Formula/huexpress.rb
@@ -22,7 +22,7 @@ class Huexpress < Formula
   depends_on "sdl2_mixer"
 
   def install
-    scons
+    system "scons"
     bin.install ["src/huexpress", "src/hucrc"]
   end
 

--- a/Formula/rmlint.rb
+++ b/Formula/rmlint.rb
@@ -21,7 +21,7 @@ class Rmlint < Formula
 
   def install
     system "scons", "config"
-    scons
+    system "scons"
     bin.install "rmlint"
     man1.install "docs/rmlint.1.gz"
   end


### PR DESCRIPTION
The `scons` method was deprecated in https://github.com/Homebrew/brew/pull/5477 and removed later. Now these formulas fail to build with ```undefined local variable or method `scons'```.