### PR TITLE
stubby: update to v0.2.6 and reduce service log verbose level

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -44,7 +44,8 @@ class Stubby < Formula
           <string>#{opt_bin}/stubby</string>
           <string>-C</string>
           <string>#{etc}/stubby/stubby.yml</string>
-          <string>-l</string>
+          <string>-v</string>
+          <string>0</string>
         </array>
         <key>StandardErrorPath</key>
         <string>#{var}/log/stubby/stubby.log</string>

--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -1,8 +1,8 @@
 class Stubby < Formula
   desc "DNS privacy enabled stub resolver service based on getdns"
   homepage "https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby"
-  url "https://github.com/getdnsapi/stubby/archive/v0.2.5.tar.gz"
-  sha256 "56ee63f4b9ee00476a168e6ba5614f6830f93e89baa305c2d38577b2e39eae5b"
+  url "https://github.com/getdnsapi/stubby/archive/v0.2.6.tar.gz"
+  sha256 "634b0b9fb8f36416e210fa65800a6c1672bcf9f4f276a042ccf89567ad8ef781"
   head "https://github.com/getdnsapi/stubby.git", :branch => "develop"
 
   bottle do


### PR DESCRIPTION
* [x]  Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
* [x]  Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
* [x]  Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? I used `brew create  and then removed the comment
* [x]  Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
* [x]  Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


update to v0.2.6; also,  for the service plist, `-l` corresponds to most verbose log (https://github.com/getdnsapi/stubby/blob/14444aaf167ccacbfae4c618affb5a572eb719f1/src/stubby.c#L201), can potentially lead to big log files; changed to `-v 0`