### PR TITLE
Remove mercurial dependency from kubernetes-helm

### DIFF
--- a/Formula/kubernetes-helm.rb
+++ b/Formula/kubernetes-helm.rb
@@ -15,7 +15,6 @@ class KubernetesHelm < Formula
 
   depends_on "glide" => :build
   depends_on "go" => :build
-  depends_on "mercurial" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Mercurial is a dependency of "kubernetes-helm". However, that is not a build dependency anymore, since [this commit](https://github.com/helm/helm/commit/87cd8ce79a16e3a17d97c7668b8d021a42932006) which was introduced in version 2.10

Proposed earlier in https://github.com/Homebrew/linuxbrew-core/pull/12562

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Output from `brew test kubernetes-helm` (exit code 0):

```
Testing kubernetes-helm
==> /home/users/maarten/.linuxbrew/Cellar/kubernetes-helm/2.13.1/bin/helm create foo
==> /home/users/maarten/.linuxbrew/Cellar/kubernetes-helm/2.13.1/bin/helm version --client 2>&1
```

Output from `brew audit --strict kubernetes-helm` (exit code: 0):

```
brew audit --strict kubernetes-helm
==> Installing 'bundler' gem
Ignoring bond-0.5.1 because its extensions are not built.  Try: gem pristine bond --version 0.5.1
Ignoring ffi-1.9.18 because its extensions are not built.  Try: gem pristine ffi --version 1.9.18
Fetching: bundler-2.0.1.gem (100%)
Successfully installed bundler-2.0.1
1 gem installed
Ignoring bond-0.5.1 because its extensions are not built.  Try: gem pristine bond --version 0.5.1
Ignoring ffi-1.9.18 because its extensions are not built.  Try: gem pristine ffi --version 1.9.18
Fetching gem metadata from https://rubygems.org/..........
Fetching concurrent-ruby 1.1.5
Fetching minitest 5.11.3
Fetching thread_safe 0.3.6
Installing thread_safe 0.3.6
Installing concurrent-ruby 1.1.5
Fetching ast 2.4.0
Installing ast 2.4.0
Fetching backports 3.13.0
Using bundler 2.0.1
Fetching connection_pool 2.2.2
Installing connection_pool 2.2.2
Fetching json 2.2.0
Installing backports 3.13.0
Installing json 2.2.0 with native extensions
Fetching docile 1.3.1
Installing docile 1.3.1
Fetching simplecov-html 0.10.2
Installing simplecov-html 0.10.2
Fetching tins 1.20.2
Installing tins 1.20.2
Fetching thor 0.19.4
Installing thor 0.19.4
Fetching diff-lcs 1.3
Fetching unf_ext 0.0.7.5
Installing unf_ext 0.0.7.5 with native extensions
Installing diff-lcs 1.3
Installing minitest 5.11.3
Fetching hpricot 0.8.6
Fetching jaro_winkler 1.5.2
Installing jaro_winkler 1.5.2 with native extensions
Installing hpricot 0.8.6 with native extensions
Fetching mime-types-data 3.2019.0331
Installing mime-types-data 3.2019.0331
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching mini_portile2 2.4.0
Fetching ntlm-http 0.1.1
Installing ntlm-http 0.1.1
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching mustache 1.1.0
Installing mustache 1.1.0
Fetching parallel 1.17.0
Installing parallel 1.17.0
Installing mini_portile2 2.4.0
Fetching plist 3.5.0
Installing plist 3.5.0
Fetching psych 3.1.0
Installing psych 3.1.0 with native extensions
Fetching rainbow 3.0.0
Installing rainbow 3.0.0
Fetching rdiscount 2.2.0.1
Installing rdiscount 2.2.0.1 with native extensions
Fetching rspec-support 3.8.0
Installing rspec-support 3.8.0
Fetching ruby-progressbar 1.10.0
Installing ruby-progressbar 1.10.0
Fetching unicode-display_width 1.5.0
Installing unicode-display_width 1.5.0
Fetching ruby-macho 2.2.0
Installing ruby-macho 2.2.0
Fetching tzinfo 1.2.5
Installing tzinfo 1.2.5
Fetching parser 2.6.2.1
Installing parser 2.6.2.1
Fetching i18n 1.6.0
Installing i18n 1.6.0
Fetching net-http-persistent 3.0.0
Installing net-http-persistent 3.0.0
Fetching term-ansicolor 1.7.1
Installing term-ansicolor 1.7.1
Fetching simplecov 0.16.1
Installing simplecov 0.16.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching mime-types 3.2.2
Installing mime-types 3.2.2
Fetching parallel_tests 2.28.0
Installing parallel_tests 2.28.0
Fetching nokogiri 1.10.2
Installing nokogiri 1.10.2 with native extensions
Fetching rspec-core 3.8.0
Installing rspec-core 3.8.0
Fetching rspec-expectations 3.8.2
Installing rspec-expectations 3.8.2
Fetching rspec-mocks 3.8.0
Installing rspec-mocks 3.8.0
Fetching activesupport 5.2.3
Installing activesupport 5.2.3
Fetching coveralls 0.8.22
Installing coveralls 0.8.22
Fetching simplecov-cobertura 1.3.1
Installing simplecov-cobertura 1.3.1
Fetching domain_name 0.5.20180417
Installing domain_name 0.5.20180417
Fetching rubocop 0.67.2
Installing rubocop 0.67.2
Fetching rspec-retry 0.6.1
Installing rspec-retry 0.6.1
Fetching rspec-its 1.3.0
Installing rspec-its 1.3.0
Fetching rspec 3.8.0
Installing rspec 3.8.0
Fetching http-cookie 1.0.3
Installing http-cookie 1.0.3
Fetching rubocop-rspec 1.32.0
Installing rubocop-rspec 1.32.0
Fetching rspec-wait 0.0.9
Installing rspec-wait 0.0.9
Fetching ronn 0.7.3
Installing ronn 0.7.3
Fetching mechanize 2.7.6
Installing mechanize 2.7.6
Bundle complete! 17 Gemfile dependencies, 57 gems now installed.
Bundled gems are installed into `../../../Homebrew/vendor/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Post-install message from rubocop:
Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.

Put this in your Gemfile.

  gem 'rubocop-performance'

And then execute:

  $ bundle install

Put this into your .rubocop.yml.

  require: rubocop-performance

More information: https://github.com/rubocop-hq/rubocop-performance
```

