### PR TITLE
carthage: fix install from HEAD

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -15,7 +15,7 @@ class Carthage < Formula
   depends_on :xcode => ["10.0", :build]
 
   def install
-    if MacOS::Xcode.version >= "10.2" && MacOS.version < "10.14.4" && MacOS.version >= "10.14"
+    if MacOS::Xcode.version >= "10.2" && MacOS.full_version < "10.14.4" && MacOS.version >= "10.14"
       odie "Xcode >=10.2 requires macOS >=10.14.4 to build Swift formulae."
     end
 


### PR DESCRIPTION
`MacOS.version` doesn't contain the patch number,
as a result the compare statement was always true.
This changes it to `MacOS.full_version`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
