### PR TITLE
Add xdelta as dependency to snapcraft formula

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -18,6 +18,7 @@ class Snapcraft < Formula
   depends_on "lxc"
   depends_on "python"
   depends_on "squashfs"
+  depends_on "xdelta"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/15/d4/2f888fc463d516ff7bf2379a4e9a552fef7f22a94147655d9b1097108248/certifi-2018.1.18.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi there!

When I tried to push a snap package via snapcraft, I got the error:
```
A tool snapcraft depends on could not be found: 'xdelta3'.
Ensure the tool is installed and available, and try again.
Sorry, an error occurred in Snapcraft:
Traceback (most recent call last):
  File "/usr/local/bin/snapcraft", line 11, in <module>
    load_entry_point('snapcraft==3.0.1', 'console_scripts', 'snapcraft')()
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/cli/__main__.py", line 81, in run
    run_snapcraft(prog_name="snapcraft")
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/cli/store.py", line 161, in push
    snapcraft.push(snap_file, channel_list)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/_store.py", line 552, in push
    result = _push_delta(snap_name, snap_filename, source_snap)
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/_store.py", line 595, in _push_delta
    source_path=source_snap, target_path=target_snap
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/internal/deltas/_xdelta3.py", line 28, in __init__
    delta_tool_path = file_utils.get_tool_path("xdelta3")
  File "/usr/local/Cellar/snapcraft/3.0.1/libexec/lib/python3.7/site-packages/snapcraft/file_utils.py", line 355, in get_tool_path
    raise ToolMissingError(command_name=command_name)
snapcraft.internal.errors.ToolMissingError: A tool snapcraft depends on could not be found: 'xdelta3'.
```

So, I added xdelta as a dependency to the snapcraft formula.