### PR TITLE
Fix OpenRCT2 not being able to find RCT1 files

### DIFF
--- a/Formula/openrct2.rb
+++ b/Formula/openrct2.rb
@@ -26,23 +26,19 @@ class Openrct2 < Formula
   depends_on "speexdsp"
 
   resource "title-sequences" do
-    url "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2/title-sequence-v0.1.2.zip",
-        :using => :nounzip
-    sha256 "dcb1648739b351e857e2d19fed1626bec561d5e9f4b49201568f42c475ee7e61"
+    url "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2a/title-sequence-v0.1.2a.zip"
+    sha256 "7536dbd7c8b91554306e5823128f6bb7e94862175ef09d366d25e4bce573d155"
   end
 
   resource "objects" do
-    url "https://github.com/OpenRCT2/objects/releases/download/v1.0.6/objects.zip",
-        :using => :nounzip
-    sha256 "714257dcf6dc4af8761ecda1b313bfa63b3ef93ab7e46572a3e499fe4bf26e02"
+    url "https://github.com/OpenRCT2/objects/releases/download/v1.0.10/objects.zip"
+    sha256 "4f261964f1c01a04b7600d3d082fb4d3d9ec0d543c4eb66a819eb2ad01417aa0"
   end
 
   def install
     # Avoid letting CMake download things during the build process.
     (buildpath/"data/title").install resource("title-sequences")
     (buildpath/"data/object").install resource("objects")
-    tversion = resource("title-sequences").version
-    mv buildpath/"data/title/title-sequence-v#{tversion}.zip", "title-sequences.zip"
 
     mkdir "build" do
       system "cmake", "..", *std_cmake_args


### PR DESCRIPTION
Not sure what behaviour changed, but the resources were not getting unzipped, whether it was intentional or not. This caused the game to fail to find the RCT1 files at runtime.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
