### PR TITLE
crystal 0.28.0

### DIFF
--- a/Formula/crystal-icr.rb
+++ b/Formula/crystal-icr.rb
@@ -3,7 +3,7 @@ class CrystalIcr < Formula
   homepage "https://github.com/crystal-community/icr"
   url "https://github.com/crystal-community/icr/archive/v0.6.0.tar.gz"
   sha256 "970d5ecbde6bb370c8178339db42e7812b7a2f3a5db3eec868cc18c19523c0ea"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "b623200d377ee356c083db16c9a27b5f8b4a49439d308291de3e866d06229fcf" => :mojave

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -3,8 +3,8 @@ class Crystal < Formula
   homepage "https://crystal-lang.org/"
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.27.2.tar.gz"
-    sha256 "d2fe8a025668b143e8ff70b3cd407765140ed10e52523dd08253139f9322171b"
+    url "https://github.com/crystal-lang/crystal/archive/0.28.0.tar.gz"
+    sha256 "4206f57c6345454504ec4cd8cbd1b9354b9be29fae4cdcdd173f4a28cc13b102"
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz"
@@ -27,8 +27,11 @@ class Crystal < Formula
     end
   end
 
+  depends_on "autoconf"      => :build # for building bdw-gc
+  depends_on "automake"      => :build # for building bdw-gc
   depends_on "libatomic_ops" => :build # for building bdw-gc
-  depends_on "bdw-gc"
+  depends_on "libtool"       => :build # for building bdw-gc
+
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
@@ -36,10 +39,22 @@ class Crystal < Formula
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
+  # Crystal uses an extended version of bdw-gc to handle multi-threading
+  resource "bdw-gc" do
+    url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
+    sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
+
+    # extension to handle multi-threading
+    patch :p1 do
+      url "https://raw.githubusercontent.com/crystal-lang/distribution-scripts/ab683792f34c60159f0e697adf792ff5b0fcbf91/linux/files/feature-thread-stackbottom.patch"
+      sha256 "acbae8cfe10e3efac403a629490cfd05e809554d23e9c3a88acddbb66f8ef7e0"
+    end
+  end
+
   resource "boot" do
-    url "https://github.com/crystal-lang/crystal/releases/download/0.27.1/crystal-0.27.1-1-darwin-x86_64.tar.gz"
-    version "0.27.1-1"
-    sha256 "f5102f34b6801a1bae3afe66fb6da15308cc304c3a9fba5799f4379c1e3010b1"
+    url "https://github.com/crystal-lang/crystal/releases/download/0.27.2/crystal-0.27.2-1-darwin-x86_64.tar.gz"
+    version "0.27.2-1"
+    sha256 "2fcd11a3c3d12176004c13aa90d8ca15acde7d1ffa9a82cbaadcd526984a8691"
   end
 
   def install
@@ -50,11 +65,31 @@ class Crystal < Formula
     end
 
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
+    ENV["CRYSTAL_CONFIG_LIBRARY_PATH"] = prefix/"embedded/lib"
     ENV.append_path "PATH", "boot/bin"
 
-    system "make", "deps"
-    (buildpath/".build").mkpath
+    resource("bdw-gc").stage(buildpath/"gc")
+    cd(buildpath/"gc") do
+      system "./configure", "--disable-debug",
+                            "--disable-dependency-tracking",
+                            "--disable-shared",
+                            "--enable-large-config"
+      system "make"
+    end
 
+    # TODO: in 0.29.0 this can be replaced with CRYSTAL_LIBRARY_PATH
+    #       in order to build the compiler binary with a static libgc.a
+    ENV.prepend_path "PKG_CONFIG_PATH", buildpath
+    (buildpath/"gc.pc").write <<~EOS
+      Name: bdwgc
+      Description:
+      Version: 8.0.4+mt
+      Libs: #{buildpath/"gc"}/.libs/libgc.a
+    EOS
+
+    # Build crystal
+    (buildpath/".build").mkpath
+    system "make", "deps"
     system "bin/crystal", "build",
                           "-D", "without_openssl",
                           "-D", "without_zlib",
@@ -63,6 +98,7 @@ class Crystal < Formula
                           "src/compiler/crystal.cr",
                           "--release", "--no-debug"
 
+    # Build shards
     resource("shards").stage do
       system buildpath/"bin/crystal", "build", "-o", buildpath/".build/shards", "src/shards.cr"
     end
@@ -70,6 +106,8 @@ class Crystal < Formula
     bin.install ".build/shards"
     bin.install ".build/crystal"
     prefix.install "src"
+    (prefix/"embedded/lib").install "#{buildpath/"gc"}/.libs/libgc.a"
+
     bash_completion.install "etc/completion.bash" => "crystal"
     zsh_completion.install "etc/completion.zsh" => "_crystal"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is a new crystal release.

The compiler is starting to use an extended version of bdw-gc and other packaging encourage the usage of the gc as a static library. With this PR both things: the extension and the static library are implemented. The version used of bdw-gc and libatomic are also aligned with the other packages. (Note: bdw-gc stable is 8.0.0 in brew, but libatomics is actually outdated in brew)

I was not sure how to handle the build of the dependencies with the patch. So there might things to change based on reviews.

In this version, there is a temporal pkg-config configuration file used, but in the next version that will be able to go away.