### PR TITLE
argon2: add pc_file libargon2.pc

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -3,6 +3,7 @@ class Argon2 < Formula
   homepage "https://github.com/P-H-C/phc-winner-argon2"
   url "https://github.com/P-H-C/phc-winner-argon2/archive/20171227.tar.gz"
   sha256 "eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8"
+  revision 1
   head "https://github.com/P-H-C/phc-winner-argon2.git"
 
   bottle do
@@ -17,7 +18,19 @@ class Argon2 < Formula
     system "make"
     system "make", "test"
     system "make", "install", "PREFIX=#{prefix}"
+    (buildpath/"pkgconfig/libargon2.pc").write pc_file
+    lib.install "pkgconfig"
     doc.install "argon2-specs.pdf"
+  end
+
+  def pc_file; <<~EOS
+    Name: libargon2
+    Description: Development libraries for libargon2
+    Version: #{version}
+    Libs: -L#{lib} -largon2 -ldl
+    Cflags: -I#{include}
+    URL: https://github.com/P-H-C/phc-winner-argon2
+  EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is a pc file in the upstream project. However, it is more like an example and is not build during `make` process. The librt which is linked in that file is not exist in mac. I tend to add one which is more specific for mac environment.
