### PR TITLE
gcc: patch and revision for Xcode bug

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -4,6 +4,7 @@ class Gcc < Formula
   url "https://ftp.gnu.org/gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz"
   sha256 "64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c"
+  revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
   bottle do
@@ -26,6 +27,15 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+
+  # Patch for Xcode bug, taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
+  # This should be removed in the next release of GCC; this is an xcode bug, but
+  # this patch is a work around committed to trunk and planned to backport to
+  # 6, 7, 8 branches
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/gcc/8.3.0-xcode-bug-_Atomic-fix.patch"
+    sha256 "33ee92bf678586357ee8ab9d2faddf807e671ad37b97afdd102d5d153d03ca84"
+  end
 
   def version_suffix
     if build.head?


### PR DESCRIPTION
 - See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864
 - See also https://discourse.brew.sh/t/atomic-does-not-name-a-type-gcc8-should-be-updated-patched/4516/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm still building and testing locally, please do not merge yet.

This is a work around for an Xcode bug, introduced in the latest Xcode release.

See:
- https://discourse.brew.sh/t/atomic-does-not-name-a-type-gcc8-should-be-updated-patched/4516/
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864