### PR TITLE
openshift-cli: add "oc" alias

### DIFF
--- a/Aliases/oc
+++ b/Aliases/oc
@@ -1,0 +1,1 @@
+../Formula/openshift-cli.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add "oc" as an alias for the openshift-cli tool (oc is the main binary provided by the Formula)