### PR TITLE
stubby log fix

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -44,7 +44,8 @@ class Stubby < Formula
           <string>#{opt_bin}/stubby</string>
           <string>-C</string>
           <string>#{etc}/stubby/stubby.yml</string>
-          <string>-l</string>
+          <string>-v</string>
+          <string>-0</string>
         </array>
         <key>StandardErrorPath</key>
         <string>#{var}/log/stubby/stubby.log</string>

--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -44,8 +44,6 @@ class Stubby < Formula
           <string>#{opt_bin}/stubby</string>
           <string>-C</string>
           <string>#{etc}/stubby/stubby.yml</string>
-          <string>-v</string>
-          <string>-0</string>
         </array>
         <key>StandardErrorPath</key>
         <string>#{var}/log/stubby/stubby.log</string>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix default log verbosity for the launchd service plist:

`-l` corresponds to most verbose log (https://github.com/getdnsapi/stubby/blob/14444aaf167ccacbfae4c618affb5a572eb719f1/src/stubby.c#L201), can potentially lead to big log files; changed to `-v 0`