### PR TITLE
nwchem: fix test

### DIFF
--- a/Formula/nwchem.rb
+++ b/Formula/nwchem.rb
@@ -64,7 +64,7 @@ class Nwchem < Formula
       ENV["NWCHEM_TOP"] = pkgshare
       ENV["NWCHEM_TARGET"] = "MACX64"
       ENV["NWCHEM_EXECUTABLE"] = "#{bin}/nwchem"
-      system "./runtests.mpi.unix", "procs", "2", "dft_he2+", "prop_mep_gcube", "pspw", "tddft_h2o", "tce_n2"
+      system "./runtests.mpi.unix", "procs", "0", "dft_he2+", "prop_mep_gcube", "pspw", "tddft_h2o", "tce_n2"
     end
   end
 end


### PR DESCRIPTION
`nwchem` tests fail often on CI nodes with:

```
==> ./runtests.mpi.unix procs 2 dft_he2+ prop_mep_gcube pspw tddft_h2o tce_n2
 Mpirun is not in your current path. Please do:
 setenv MPIRUN_PATH /home/guido/bagheria/bin/mpirun 
 Please make sure you have the right mpirun for your system.
 Alternatively set the number of processors to 0.
```

Locally they run fine for me, so I'm not sure what the issue is. But let's try to follow their hint…