### PR TITLE
jp2a 1.0.7

### DIFF
--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -1,9 +1,8 @@
 class Jp2a < Formula
   desc "Convert JPG images to ASCII"
   homepage "https://csl.name/jp2a/"
-  url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
-  sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
-  revision 1
+  url "https://github.com/cslarsen/jp2a/archive/v1.0.7.tar.gz"
+  sha256 "e509d8bbf9434afde5c342568b21d11831a61d9942ca8cb1633d4295b7bc5059"
 
   bottle do
     cellar :any
@@ -14,11 +13,13 @@ class Jp2a < Formula
     sha256 "2a175fef16afed3e74c834ff250f0278eedc60c4deb0296e62f073954605d97d" => :yosemite
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "jpeg"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "autoreconf", "-ivf"
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "test"
     system "make", "install"

--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -21,7 +21,6 @@ class Jp2a < Formula
     system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make", "test"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The homepage now links to the specified GitHub repository:
> You can install jp2a from your favourite package manager. If jp2a is not there, you can download and build the source from https://github.com/cslarsen/jp2a. 

This release is not available on the existing SourceForge site.