### PR TITLE
Adds zstd dependency for boost

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -14,6 +14,7 @@ class Boost < Formula
   end
 
   depends_on "icu4c"
+  depends_on "zstd"
 
   def install
     # Force boost to compile with the desired compiler


### PR DESCRIPTION
Homebrew's boost 1.69 includes support for iostreams-mt, which establishes a dependency on zstd.

Fixes #39111

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/pull/38890 takes boost to 1.70 but this problem is preventing use of at least one formula presently.