### PR TITLE
boost: avoid zstd opportunistic linkage

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -3,7 +3,7 @@ class Boost < Formula
   homepage "https://www.boost.org/"
   url "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
   sha256 "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
-  revision 1
+  revision 2
   head "https://github.com/boostorg/boost.git"
 
   bottle do
@@ -47,6 +47,7 @@ class Boost < Formula
       --layout=tagged-1.66
       --user-config=user-config.jam
       -sNO_LZMA=1
+      -sNO_ZSTD=1
       install
       threading=multi,single
       link=shared,static


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an alternative to #39112 that fixes #39111 that tries to avoid opportunistic linkage rather than adding a new dependency to boost. I'm not sure if more things downstream will need revision bumps as well.

cc @colindean 