### PR TITLE
octave: revision bump for gcc 8.3.0

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,6 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-5.1.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/octave/octave-5.1.0.tar.xz"
   sha256 "87b4df6dfa28b1f8028f69659f7a1cabd50adfb81e1e02212ff22c863a29454e"
+  revision 1
 
   bottle do
     sha256 "dd428970e2ad65bb84d5f34777b3fe262ebcca08a5fe44a4d2677714fb7469cc" => :mojave


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I believe `octave` requires a revision bump to handle the recent `gcc` update. It hasn't been bumped since.

```
$ brew log gcc | head -6
commit ddde81887459bc4855031fb5b6919032f35f277b
Author: BrewTestBot <homebrew-test-bot@lists.sfconservancy.org>
Date:   Fri Apr 19 09:46:10 2019 +0000

    gcc: update 8.3.0_1 bottle.

$ brew log octave | head -6
commit 33a5454868538fee44e7d398b5259b95a5f53f44
Author: BrewTestBot <homebrew-test-bot@lists.sfconservancy.org>
Date:   Tue Mar 26 20:40:27 2019 +0000

    octave: update 5.1.0 bottle.

```

I think this was missed by Homebrew's CI because the dependency/linkage isn't in the Octave binary itself, or exercised by `brew test octave`, but is in the `mkoctfile` mechanism that Octave uses to build extension/plug-in files, which depends on `gfortran` from `gcc`.

I'm currently experiencing `mkoctfile` breakage in my up-to-date brewed poured-from-bottle `octave`, complaining about `-lgfortran` linkage failure. Doing a `brew reinstall -s octave` fixed it. I think that confirms that a bottle rebuild is required. The fact that the `gcc` update was today, and this is the first we (Octave upstream) are hearing about this issue, is consistent.

See https://savannah.gnu.org/bugs/index.php?56171 for an upstream bug report with more details.