### PR TITLE
ship 0.41.0 on Sierra

### DIFF
--- a/Formula/ship.rb
+++ b/Formula/ship.rb
@@ -14,8 +14,6 @@ class Ship < Formula
   depends_on "node" => :build
   depends_on "yarn" => :build
 
-  depends_on :macos => :high_sierra # Ship fails to build with Golang 1.12 on Sierra
-
   def install
     ENV["GOPATH"] = buildpath
     srcpath = buildpath/"src/github.com/replicatedhq/ship"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

golang updates have fixed builds on Sierra, so we can allow Sierra installs again

This removes the MacOS version restriction added by #37925
