### PR TITLE
dbus: fix launch agent plist's name

### DIFF
--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -54,6 +54,10 @@ class Dbus < Formula
     system "make", "install"
   end
 
+  def plist_name
+    "org.freedesktop.dbus-session"
+  end
+
   def post_install
     # Generate D-Bus's UUID for this machine
     system "#{bin}/dbus-uuidgen", "--ensure=#{var}/lib/dbus/machine-id"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request fixes #39092 by explicitly specifying the plist's name.