### PR TITLE
gel: narrow installed bin

### DIFF
--- a/Formula/gel.rb
+++ b/Formula/gel.rb
@@ -7,7 +7,8 @@ class Gel < Formula
   bottle :unneeded
 
   def install
-    prefix.install "bin", "exe", "lib"
+    prefix.install "lib"
+    bin.install "exe/gel"
     share.install "man"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We don't want to install the distributed `bin/` -- that contains development utilities, including e.g. a horribly customized `rake`.

@MikeMcQuaid sorry it took me a while to get this sorted out, between flights etc. Follow-up to https://github.com/Homebrew/homebrew-core/pull/39036#issuecomment-484566131. 

Bottling is probably the better choice for the manpages, but that seems more involved for me to figure out, and especially given how empty the current pages are, it seems lower priority than helping this avoid `Could not symlink bin/rake`-type errors.