### PR TITLE
Kubepod - List/search pods faster in kubectl

### DIFF
--- a/Formula/kubepod.rb
+++ b/Formula/kubepod.rb
@@ -1,0 +1,24 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+class Kubepod < Formula
+  desc "List/Search pods faster in kubectl"
+  homepage "https://github.com/kdthanvi/kubepod"
+  url "https://github.com/kdthanvi/kubepod/archive/v1.0.0.tar.gz"
+  sha256 "84dbe84e83d9d1445631978f54f93c3d9d592e518b2d52848413696674cb56e2"
+  # depends_on "cmake" => :build
+
+  bottle :unneeded
+ 
+  option "with-short-names", "link as \"kpod\" instead"
+  depends_on "grep"
+  depends_on "kubernetes-cli" => :recommended
+
+  def install
+	bin.install "kubepod"  => build.with?("short-names") ? "kpod" : "kubepod"
+  end
+
+  test do
+	assert_match "USAGE:", shell_output("#{bin}/kubepod -h 2>&1")  
+  end
+end

--- a/Formula/kubepod.rb
+++ b/Formula/kubepod.rb
@@ -5,7 +5,7 @@ class Kubepod < Formula
   sha256 "84dbe84e83d9d1445631978f54f93c3d9d592e518b2d52848413696674cb56e2"
 
   bottle :unneeded
- 
+
   depends_on "grep"
   depends_on "kubernetes-cli"
 
@@ -14,6 +14,6 @@ class Kubepod < Formula
   end
 
   test do
-    assert_match "USAGE:", shell_output("#{bin}/kubepod -h 2>&1")  
+    assert_match "USAGE:", shell_output("#{bin}/kubepod -h 2>&1")
   end
 end

--- a/Formula/kubepod.rb
+++ b/Formula/kubepod.rb
@@ -1,24 +1,19 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook
-#                https://rubydoc.brew.sh/Formula
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class Kubepod < Formula
   desc "List/Search pods faster in kubectl"
   homepage "https://github.com/kdthanvi/kubepod"
   url "https://github.com/kdthanvi/kubepod/archive/v1.0.0.tar.gz"
   sha256 "84dbe84e83d9d1445631978f54f93c3d9d592e518b2d52848413696674cb56e2"
-  # depends_on "cmake" => :build
 
   bottle :unneeded
  
-  option "with-short-names", "link as \"kpod\" instead"
   depends_on "grep"
-  depends_on "kubernetes-cli" => :recommended
+  depends_on "kubernetes-cli"
 
   def install
-	bin.install "kubepod"  => build.with?("short-names") ? "kpod" : "kubepod"
+    bin.install "kubepod"  => build.with?("short-names") ? "kpod" : "kubepod"
   end
 
   test do
-	assert_match "USAGE:", shell_output("#{bin}/kubepod -h 2>&1")  
+    assert_match "USAGE:", shell_output("#{bin}/kubepod -h 2>&1")  
   end
 end


### PR DESCRIPTION
This commits adds the first version(v1.0.0) of the utility kubepod.
While listing kubernetes pods using kubectl utility, it's difficult to search specific pod.
Kubepod simplifies this and let user list specific pods by text pattern matching.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
