### PR TITLE
latex2html 2019

### DIFF
--- a/Formula/latex2html.rb
+++ b/Formula/latex2html.rb
@@ -1,10 +1,8 @@
 class Latex2html < Formula
   desc "LaTeX-to-HTML translator"
-  homepage "https://www.ctan.org/pkg/latex2html"
-  url "http://mirrors.ctan.org/support/latex2html/latex2html-2018.tar.gz"
-  mirror "https://ftp.gnome.org/mirror/CTAN/support/latex2html/latex2html-2018.tar.gz"
-  sha256 "09e37526d169e77c266c23122348998a0841c3d50866e45ff2550128157ad4e2"
-  revision 1
+  homepage "https://www.latex2html.org"
+  url "https://github.com/latex2html/latex2html/archive/v2019.tar.gz"
+  sha256 "095b6d43599506aa0936b548ee92c7742c8b127d64e3829000f7681a254a7917"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Current homepage (CTAN) has "package links" section which has link to the new homepage. New homepage has links to GitHub repo where the new URL is now. Previous URL and mirror are returning 404 (current formula is broken).