### PR TITLE
Fix the link to the Linuxbrew formulae in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Core formulae for the Homebrew package manager.
 
-Core formulae for the Linuxbrew package manager (Homebrew on Linux or Windows 10 Subsystem for Linux) are in [Linuxbrew/homebrew-core](https://github.com/Linuxbrew/homebrew-core).
+Core formulae for the Linuxbrew package manager (Homebrew on Linux or Windows 10 Subsystem for Linux) are in [Homebrew/linuxbrew-core](https://github.com/Homebrew/linuxbrew-core).
 
 ## How do I install these formulae?
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [ ] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [ ] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- Linuxbrew formulae live in the Homebrew org at `linuxbrew-core`. While
  GitHub redirects the old to the new, seeing the old URL was odd.