### PR TITLE
vice: add --HEAD build

### DIFF
--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -3,6 +3,7 @@ class Vice < Formula
   homepage "https://vice-emu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/vice-emu/releases/vice-3.3.tar.gz"
   sha256 "1a55b38cc988165b077808c07c52a779d181270b28c14b5c9abf4e569137431d"
+  head "https://svn.code.sf.net/p/vice-emu/code/trunk/vice"
 
   bottle do
     sha256 "0b76399d14543c4b7d8ef37779b2d1f79861dd2647650b8739f7f77cfaba4de5" => :mojave
@@ -14,9 +15,12 @@ class Vice < Formula
   depends_on "texinfo" => :build
   depends_on "xa" => :build
   depends_on "yasm" => :build
+  depends_on "autoconf" if build.head?
+  depends_on "automake" if build.head?
   depends_on "ffmpeg"
   depends_on "flac"
   depends_on "giflib"
+  depends_on "gtk+3" if build.head?
   depends_on "jpeg"
   depends_on "lame"
   depends_on "libogg"
@@ -24,16 +28,27 @@ class Vice < Formula
   depends_on "libvorbis"
   depends_on "mpg123"
   depends_on "portaudio"
-  depends_on "sdl2"
+  depends_on "sdl2" unless build.head?
   depends_on "xz"
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
-                          "--disable-arch",
-                          "--disable-bundle",
-                          "--enable-external-ffmpeg",
-                          "--enable-sdlui2"
+    configure_flags = [
+      "--prefix=#{prefix}",
+      "--disable-dependency-tracking",
+      "--disable-arch",
+      "--disable-bundle",
+      "--enable-external-ffmpeg",
+    ]
+
+    if build.head?
+      configure_flags << "--enable-native-gtk3ui"
+      configure_flags << "--disable-hwscale"
+    else
+      configure_flags << "--enable-sdlui2"
+    end
+
+    system "./autogen.sh" if build.head?
+    system "./configure", *configure_flags
     system "make", "install"
   end
 


### PR DESCRIPTION
In addition to providing a simple way for people to test the new Gtk3 UI,
developers can now obtain an appropriate set of build dependencies by running
brew install --only-dependencies --HEAD vice.
