### PR TITLE
ecCodes - enable NetCDF support

### DIFF
--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -14,6 +14,7 @@ class Eccodes < Formula
   depends_on "gcc" # for gfortran
   depends_on "jasper"
   depends_on "libpng"
+  depends_on "netcdf"
 
   conflicts_with "grib-api",
     :because => "eccodes and grib-api install the same binaries."
@@ -22,7 +23,7 @@ class Eccodes < Formula
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 
     mkdir "build" do
-      system "cmake", "..", "-DENABLE_NETCDF=OFF", "-DENABLE_PNG=ON", *std_cmake_args
+      system "cmake", "..", "-DENABLE_NETCDF=ON", "-DENABLE_PNG=ON", *std_cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
ecCodes is a popular library to read weather data in the GRIB file format. Many data scientists prefer to work with the NetCDF data format. Therefore a converted from GRIB to NetCDF was added. This converter is now enabled with this change.
I am working at ECMWF, the developers of ecCodes, and I will be happy to help with the future maintenance of this package.   

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----