### PR TITLE
evince build with comic book archive support

### DIFF
--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -3,7 +3,7 @@ class Evince < Formula
   homepage "https://wiki.gnome.org/Apps/Evince"
   url "https://download.gnome.org/sources/evince/3.30/evince-3.30.2.tar.xz"
   sha256 "a95bbdeb452c9cc910bba751e7c782ce60ffe7972c461bccbe8bbcdb8ca5f24c"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -21,6 +21,7 @@ class Evince < Formula
   depends_on "gspell"
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
+  depends_on "libarchive"
   depends_on "libsecret"
   depends_on "libspectre"
   depends_on "libxml2"
@@ -34,6 +35,11 @@ class Evince < Formula
     # Fix build failure "ar: illegal option -- D"
     # Reported 15 Sep 2017 https://bugzilla.gnome.org/show_bug.cgi?id=787709
     inreplace "configure", "AR_FLAGS=crD", "AR_FLAGS=r"
+
+    # Add MacOS mime-types to the list of supported comic book archive mime-types
+    # Submitted upstream at https://gitlab.gnome.org/GNOME/evince/merge_requests/157
+    inreplace "configure", "COMICS_MIME_TYPES=\"",
+      "COMICS_MIME_TYPES=\"application/x-rar;application/zip;application/x-cb7;application/x-7z-comperssed;application/x-tar;"
 
     # forces use of gtk3-update-icon-cache instead of gtk-update-icon-cache. No bugreport should
     # be filed for this since it only occurs because Homebrew renames gtk+3's gtk-update-icon-cache


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add `libarchive` as a dependency and patches a list of MacOS specific mime types to the configure file to build with comic book archive support.