### PR TITLE
Update ccache homepage

### DIFF
--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -1,6 +1,6 @@
 class Ccache < Formula
   desc "Object-file caching compiler wrapper"
-  homepage "https://ccache.samba.org/"
+  homepage "https://ccache.dev/"
   url "https://github.com/ccache/ccache/releases/download/v3.7/ccache-3.7.tar.xz"
   sha256 "409f38bec6161288749a499c82060c99a551c3aced406827e28d183e9c070575"
 


### PR DESCRIPTION
<https://ccache.samba.org/> redirects to <https://ccache.dev/>. The website has an announcement about the move at <https://ccache.dev/news.html#2019-04-03>. I don't use ccache myself.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----