### PR TITLE
[fstar.rb] Fix HEAD build by guarding inreplace

### DIFF
--- a/Formula/fstar.rb
+++ b/Formula/fstar.rb
@@ -33,8 +33,10 @@ class Fstar < Formula
     ENV["OPAMYES"] = "1"
 
     # Avoid having to depend on coreutils
-    inreplace "src/ocaml-output/Makefile", "$(DATE_EXEC) -Iseconds",
-                                           "$(DATE_EXEC) '+%Y-%m-%dT%H:%M:%S%z'"
+    unless build.head?
+      inreplace "src/ocaml-output/Makefile", "$(DATE_EXEC) -Iseconds",
+                                             "$(DATE_EXEC) '+%Y-%m-%dT%H:%M:%S%z'"
+    end
 
     resource("z3").stage do
       # F* warns if the Z3 git hash doesn't match


### PR DESCRIPTION
`819274735e2` in fstar.git updated `src/ocaml-output/Makefile` to not contain `-Iseconds`. To prevent `brew install fstar --HEAD` from breaking due to this, guard the inreplace with `unless build.head?`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
