### PR TITLE
Brew audit mirror url fixes

### DIFF
--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -5,8 +5,7 @@ class Bash < Formula
 
   stable do
     url "https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.0.tar.gz"
-    mirror "https://mirrors.kernel.org/gnu/bash/bash-5.0.tar.gz"
+    mirror "https://deb.debian.org/gnu/bash/bash-5.0.tar.gz"
     mirror "https://ftpmirror.gnu.org/bash/bash-5.0.tar.gz"
     mirror "https://gnu.cu.be/bash/bash-5.0.tar.gz"
     mirror "https://mirror.unicorncloud.org/gnu/bash/bash-5.0.tar.gz"
@@ -25,7 +24,7 @@ class Bash < Formula
       patch :p0 do
         url "https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-#{p}"
         mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.0-patches/bash50-#{p}"
-        mirror "https://mirrors.kernel.org/gnu/bash/bash-5.0-patches/bash50-#{p}"
+        mirror "https://deb.debian.org/gnu/bash/bash-5.0-patches/bash50-#{p}"
         mirror "https://ftpmirror.gnu.org/bash/bash-5.0-patches/bash50-#{p}"
         mirror "https://gnu.cu.be/bash/bash-5.0-patches/bash50-#{p}"
         mirror "https://mirror.unicorncloud.org/gnu/bash/bash-5.0-patches/bash50-#{p}"

--- a/Formula/cmatrix.rb
+++ b/Formula/cmatrix.rb
@@ -2,7 +2,7 @@ class Cmatrix < Formula
   desc "Console Matrix"
   homepage "https://www.asty.org/cmatrix/"
   url "https://www.asty.org/cmatrix/dist/cmatrix-1.2a.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/cmatrix/cmatrix_1.2a.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/cmatrix/cmatrix_1.2a.orig.tar.gz"
   sha256 "1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c"
 
   bottle do

--- a/Formula/cxxtest.rb
+++ b/Formula/cxxtest.rb
@@ -2,7 +2,7 @@ class Cxxtest < Formula
   desc "xUnit-style unit testing framework for C++"
   homepage "https://cxxtest.com/"
   url "https://github.com/CxxTest/cxxtest/releases/download/4.4/cxxtest-4.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/c/cxxtest/cxxtest_4.4.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/c/cxxtest/cxxtest_4.4.orig.tar.gz"
   sha256 "1c154fef91c65dbf1cd4519af7ade70a61d85a923b6e0c0b007dc7f4895cf7d8"
 
   bottle do

--- a/Formula/dhcpdump.rb
+++ b/Formula/dhcpdump.rb
@@ -2,7 +2,7 @@ class Dhcpdump < Formula
   desc "Monitor DHCP traffic for debugging purposes"
   homepage "https://www.mavetju.org/"
   url "https://www.mavetju.org/download/dhcpdump-1.8.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
   sha256 "6d5eb9418162fb738bc56e4c1682ce7f7392dd96e568cc996e44c28de7f77190"
 
   bottle do

--- a/Formula/dhcping.rb
+++ b/Formula/dhcping.rb
@@ -2,7 +2,7 @@ class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
   homepage "https://www.mavetju.org/unix/general.php"
   url "https://www.mavetju.org/download/dhcping-1.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 
   bottle do

--- a/Formula/diffstat.rb
+++ b/Formula/diffstat.rb
@@ -26,10 +26,10 @@ class Diffstat < Formula
       --- a/diffstat.rb
       +++ b/diffstat.rb
       @@ -2,9 +2,8 @@
-      -  url 'https://mirrors.kernel.org/debian/pool/main/d/diffstat/diffstat_1.58.orig.tar.gz'
+      -  url 'https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.58.orig.tar.gz'
       -  version '1.58'
       -  sha256 'fad5135199c3b9aea132c5d45874248f4ce0ff35f61abb8d03c3b90258713793'
-      +  url 'https://mirrors.kernel.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz'
+      +  url 'https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz'
       +  sha256 '7f09183644ed77a156b15346bbad4e89c93543e140add9dab18747e30522591f'
     EOS
     output = shell_output("#{bin}/diffstat diff.diff")

--- a/Formula/dnstracer.rb
+++ b/Formula/dnstracer.rb
@@ -2,7 +2,7 @@ class Dnstracer < Formula
   desc "Trace a chain of DNS servers to the source"
   homepage "https://www.mavetju.org/unix/dnstracer.php"
   url "https://www.mavetju.org/download/dnstracer-1.9.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
 
   bottle do

--- a/Formula/dvorak7min.rb
+++ b/Formula/dvorak7min.rb
@@ -2,7 +2,7 @@ class Dvorak7min < Formula
   desc "Dvorak (simplified keyboard layout) typing tutor"
   homepage "https://web.archive.org/web/dvorak7min.sourcearchive.com/"
   url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
   version "1.6.1"
   sha256 "4cdef8e4c8c74c28dacd185d1062bfa752a58447772627aded9ac0c87a3b8797"
 

--- a/Formula/netcat6.rb
+++ b/Formula/netcat6.rb
@@ -1,8 +1,7 @@
 class Netcat6 < Formula
   desc "Rewrite of netcat that supports IPv6, plus other improvements"
   homepage "https://www.deepspace6.net/projects/netcat6.html"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/n/nc6/nc6_1.0.orig.tar.gz"
   sha256 "db7462839dd135ff1215911157b666df8512df6f7343a075b2f9a2ef46fe5412"
 
   bottle do

--- a/Formula/num-utils.rb
+++ b/Formula/num-utils.rb
@@ -2,7 +2,7 @@ class NumUtils < Formula
   desc "Programs for dealing with numbers from the command-line"
   homepage "https://suso.suso.org/programs/num-utils/"
   url "https://suso.suso.org/programs/num-utils/downloads/num-utils-0.5.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
   sha256 "03592760fc7844492163b14ddc9bb4e4d6526e17b468b5317b4a702ea7f6c64e"
 
   bottle do

--- a/Formula/ophcrack.rb
+++ b/Formula/ophcrack.rb
@@ -2,7 +2,7 @@ class Ophcrack < Formula
   desc "Microsoft Windows password cracker using rainbow tables"
   homepage "https://ophcrack.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ophcrack/ophcrack/3.8.0/ophcrack-3.8.0.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/o/ophcrack/ophcrack_3.8.0.orig.tar.bz2"
+  mirror "https://deb.debian.org/debian/pool/main/o/ophcrack/ophcrack_3.8.0.orig.tar.bz2"
   sha256 "048a6df57983a3a5a31ac7c4ec12df16aa49e652a29676d93d4ef959d50aeee0"
 
   bottle do

--- a/Formula/patchutils.rb
+++ b/Formula/patchutils.rb
@@ -2,7 +2,7 @@ class Patchutils < Formula
   desc "Small collection of programs that operate on patch files"
   homepage "http://cyberelk.net/tim/software/patchutils/"
   url "http://cyberelk.net/tim/data/patchutils/stable/patchutils-0.3.4.tar.xz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/p/patchutils/patchutils_0.3.4.orig.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/p/patchutils/patchutils_0.3.4.orig.tar.xz"
   sha256 "cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876"
 
   bottle do

--- a/Formula/rdesktop.rb
+++ b/Formula/rdesktop.rb
@@ -2,7 +2,7 @@ class Rdesktop < Formula
   desc "UNIX client for connecting to Windows Remote Desktop Services"
   homepage "https://www.rdesktop.org/"
   url "https://downloads.sourceforge.net/project/rdesktop/rdesktop/1.8.3/rdesktop-1.8.3.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/r/rdesktop/rdesktop_1.8.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/r/rdesktop/rdesktop_1.8.3.orig.tar.gz"
   sha256 "88b20156b34eff5f1b453f7c724e0a3ff9370a599e69c01dc2bf0b5e650eece4"
   revision 1
 

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -1,7 +1,7 @@
 class SaneBackends < Formula
   desc "Backends for scanner access"
   homepage "http://www.sane-project.org/"
-  url "https://mirrors.kernel.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
   sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
   revision 5

--- a/Formula/stress.rb
+++ b/Formula/stress.rb
@@ -2,7 +2,7 @@ class Stress < Formula
   desc "Tool to impose load on and stress test a computer system"
   homepage "https://people.seas.harvard.edu/~apw/stress/"
   url "https://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
   sha256 "057e4fc2a7706411e1014bf172e4f94b63a12f18412378fca8684ca92408825b"
 
   bottle do

--- a/Formula/toilet.rb
+++ b/Formula/toilet.rb
@@ -2,7 +2,7 @@ class Toilet < Formula
   desc "Color-based alternative to figlet (uses libcaca)"
   homepage "http://caca.zoy.org/wiki/toilet"
   url "http://caca.zoy.org/raw-attachment/wiki/toilet/toilet-0.3.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
   sha256 "89d4b530c394313cc3f3a4e07a7394fa82a6091f44df44dfcd0ebcb3300a81de"
 

--- a/Formula/webalizer.rb
+++ b/Formula/webalizer.rb
@@ -2,7 +2,7 @@ class Webalizer < Formula
   desc "Web server log file analysis"
   homepage "http://www.webalizer.org"
   url "ftp://ftp.mrunix.net/pub/webalizer/webalizer-2.23-08-src.tgz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/w/webalizer/webalizer_2.23.08.orig.tar.gz"
   sha256 "edaddb5aa41cc4a081a1500e3fa96615d4b41bc12086bcedf9938018ce79ed8d"
   revision 2
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I ran `brew audit` and thought I'd fix these (common) failures about mirror URLs not being `deb.debian.org`. I've only fixed _some_ `mirror` stanzas, not the `url` stanzas that the audit also complains about in cases like the `netcat6` formula.

I've left some existing `brew audit --strict` failures alone for the next contributor. As this changeset hasn't made any of the existing ones _worse_, I'm counting that "passes" checkmark as a success.