### PR TITLE
Proteinortho

### DIFF
--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,7 +2,7 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "5fbfe0e7cb28f5f614a97fc2286d5df55f4c355ebbf3590a61005c56b915b53a"
+  sha256 "1df4460f7cd5654c1e0c0c7abf546b50288265c895b1bf28dde618d7f080e805"
 
   depends_on "cmake" => :build
   fails_with :clang # needs fortran
@@ -10,6 +10,7 @@ class Proteinortho < Formula
   def install
     mkdir bin.to_s
     system "make", "install", "PREFIX=#{bin}"
+    doc.install "manual.html"
   end
 
   test do

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -11,11 +11,11 @@ class Proteinortho < Formula
 
   def install
     system "make", "clean"
-    system "make", "CPP=#{CXX}" , "install", "PREFIX=#{prefix}"
+    system "make", "CPP=#{CXX}" , "install", "PREFIX=#{prefix}/bin"
   end
 
   test do
-    system "#{bin}/proteinortho", "-help"
-    system "#{bin}/proteinortho_clustering", "-test"
+    system "#{bin}/proteinortho -help"
+    system "#{bin}/proteinortho_clustering -test"
   end
 end

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,7 +2,7 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "d4f6e90c7e930b85bbab4722636c2348f5cc4fb24764088663f16cf9e1145638"
+  sha256 "043cdbb1f9d46a6fecf952b3201c2018f9726f4e79adb79bcb8b7037ddfd3701"
 
   depends_on "diamond"
   depends_on "openblas"

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -1,15 +1,18 @@
 class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
-  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "1df4460f7cd5654c1e0c0c7abf546b50288265c895b1bf28dde618d7f080e805"
+#  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
+  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/master/proteinortho-master.tar.gz"
+#  sha256 "1df4460f7cd5654c1e0c0c7abf546b50288265c895b1bf28dde618d7f080e805"
+  sha256 "1eef1429adb5658b48575b0621863a4bfbafa4f858484427c413d3153f4ca61d"
 
   depends_on "cmake" => :build
-  fails_with :clang # needs fortran
+  depends_on "gcc"
+  #fails_with :clang # needs fortran
 
   def install
-    mkdir bin.to_s
-    system "make", "install", "PREFIX=#{bin}"
+    bin.mkpath
+    system "make", "CXX=g++", "install", "PREFIX=#{bin}"
     doc.install "manual.html"
   end
 

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,11 +2,11 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "e82522cdae62c182fc3bb75903e8ce3a388573fccbea16b72a0a8c47a653a34b"
+  sha256 "5fbfe0e7cb28f5f614a97fc2286d5df55f4c355ebbf3590a61005c56b915b53a"
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "lapack"
   depends_on "gcc" # for gfortran
+  depends_on "lapack"
 
   def install
     mkdir bin.to_s

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -11,6 +11,7 @@ class Proteinortho < Formula
 
   def install
     system "make", "clean"
+    system "mkdir", "#{prefix}/bin"
     system "make", "CPP=#{CXX}" , "install", "PREFIX=#{prefix}/bin"
   end
 

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,9 +2,9 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
+  sha256 "400e5a6e147b43e9bb0e6bc977715516043b3e5035586b58b7b48748975c178c"
   depends_on "cmake" => :build
-  depends_on "gcc"
+  depends_on "gcc" # for gfortran
   depends_on "pkg-config" => :build
 
   def install

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -3,16 +3,13 @@ class Proteinortho < Formula
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
   sha256 "5fbfe0e7cb28f5f614a97fc2286d5df55f4c355ebbf3590a61005c56b915b53a"
+
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
-  depends_on "gcc" # for gfortran
-  depends_on "lapack"
+  fails_with :clang # needs fortran
 
   def install
     mkdir bin.to_s
-    ENV["LIBRARY_PATH"] = `pkg-config --libs --static lapack`.chomp
-    ENV["CXX"] = `ls #{Formula["gcc"].opt_bin.realpath}/g++-* | sort | tail -n1`.chomp
-    system "make", "CXX=#{ENV["CXX"]}", "CXXLIBRARY='#{ENV["LIBRARY_PATH"]}'", "install", "PREFIX=#{bin}"
+    system "make", "install", "PREFIX=#{bin}"
   end
 
   test do

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -1,15 +1,18 @@
 class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
-  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0b/proteinortho-v6.0b.tar.gz"
-  sha256 "f59c436f6461f318ccebc1177a67eb70c29ef9ba222ad724de1fb2a769a120b5"
+  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
+  sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
   depends_on "cmake" => :build  
-  depends_on "gcc"
+  depends_on "pkg-config" => :build  
+  depends_on "lapack" => :build  
+  depends_on "gcc" => :build  
 
   def install
     system "mkdir", "#{prefix}/bin"
+    ENV["LIBRARY_PATH"] = `pkg-config --libs --static lapack`.chomp
     ENV["CXX"] = `ls #{Formula["gcc"].opt_bin.realpath}/g++-* | sort | tail -n1`.chomp
-    system "make", "CPP=$CXX" , "install", "PREFIX=#{prefix}/bin"
+    system "make", "CXX=#{ENV["CXX"]}", "CXXLIBRARY='#{ENV["LIBRARY_PATH"]}'" , "install", "PREFIX=#{prefix}/bin"
   end
 
   test do

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -4,7 +4,7 @@ class Proteinortho < Formula
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
   sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
   depends_on "cmake" => :build
-  depends_on "gcc" => :build
+  depends_on "gcc"
   depends_on "pkg-config" => :build
 
   def install

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -3,16 +3,15 @@ class Proteinortho < Formula
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
   sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
-  depends_on "cmake" => :build  
-  depends_on "pkg-config" => :build  
-  depends_on "lapack" => :build  
-  depends_on "gcc" => :build  
+  depends_on "cmake" => :build
+  depends_on "gcc" => :build
+  depends_on "pkg-config" => :build
 
   def install
-    system "mkdir", "#{prefix}/bin"
+    mkdir "#{bin}"
     ENV["LIBRARY_PATH"] = `pkg-config --libs --static lapack`.chomp
     ENV["CXX"] = `ls #{Formula["gcc"].opt_bin.realpath}/g++-* | sort | tail -n1`.chomp
-    system "make", "CXX=#{ENV["CXX"]}", "CXXLIBRARY='#{ENV["LIBRARY_PATH"]}'" , "install", "PREFIX=#{prefix}/bin"
+    system "make", "CXX=#{ENV["CXX"]}", "CXXLIBRARY='#{ENV["LIBRARY_PATH"]}'", "install", "PREFIX=#{bin}"
   end
 
   test do

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -6,9 +6,12 @@ class Proteinortho < Formula
   depends_on "cmake" => :build
   depends_on "gcc"
 
+  # get the latest g++ compiler from brew (Cellar)
+  CXX = `ls /usr/local/Cellar/gcc/*/bin/g++* | sort | tail -n1 | tr -d '\n'`
+
   def install
     system "make", "clean"
-    system "make", "CPP=/usr/local/Cellar/gcc/*/bin/g++*" , "install"
+    system "make", "CPP=#{CXX}" , "install", "PREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,7 +2,7 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
+  sha256 "400e5a6e147b43e9bb0e6bc977715516043b3e5035586b58b7b48748975c178c"
   depends_on "cmake" => :build
   depends_on "lapack" => :build
   depends_on "pkg-config" => :build

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,13 +2,14 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "400e5a6e147b43e9bb0e6bc977715516043b3e5035586b58b7b48748975c178c"
+  sha256 "b28f05c8c90a98bd65f2f1c1d9ed78e585959428c9f1a8deac1f53e72912de2c"
   depends_on "cmake" => :build
-  depends_on "gcc" # for gfortran
+  depends_on "lapack" => :build
   depends_on "pkg-config" => :build
+  depends_on "gcc" # for gfortran
 
   def install
-    mkdir "#{bin}"
+    mkdir bin.to_s
     ENV["LIBRARY_PATH"] = `pkg-config --libs --static lapack`.chomp
     ENV["CXX"] = `ls #{Formula["gcc"].opt_bin.realpath}/g++-* | sort | tail -n1`.chomp
     system "make", "CXX=#{ENV["CXX"]}", "CXXLIBRARY='#{ENV["LIBRARY_PATH"]}'", "install", "PREFIX=#{bin}"

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -1,0 +1,18 @@
+class Proteinortho < Formula
+  desc "Proteinortho is a tool to detect orthologous genes within different species"
+  homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
+  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0b/proteinortho-v6.0b.tar.gz"
+  sha256 "f59c436f6461f318ccebc1177a67eb70c29ef9ba222ad724de1fb2a769a120b5"
+  depends_on "cmake" => :build
+  depends_on "gcc"
+
+  def install
+    system "make", "clean"
+    system "make", "CPP=/usr/local/Cellar/gcc/*/bin/g++*" , "install"
+  end
+
+  test do
+    system "#{bin}/proteinortho", "-help"
+    system "#{bin}/proteinortho_clustering", "-test"
+  end
+end

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -1,23 +1,20 @@
 class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
-#  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/master/proteinortho-master.tar.gz"
-#  sha256 "1df4460f7cd5654c1e0c0c7abf546b50288265c895b1bf28dde618d7f080e805"
-  sha256 "1eef1429adb5658b48575b0621863a4bfbafa4f858484427c413d3153f4ca61d"
+  url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
+  sha256 "d4f6e90c7e930b85bbab4722636c2348f5cc4fb24764088663f16cf9e1145638"
 
-  depends_on "cmake" => :build
-  depends_on "gcc"
-  #fails_with :clang # needs fortran
+  depends_on "diamond"
+  depends_on "openblas"
 
   def install
     bin.mkpath
-    system "make", "CXX=g++", "install", "PREFIX=#{bin}"
+    system "make", "install", "PREFIX=#{bin}"
     doc.install "manual.html"
   end
 
   test do
-    system "#{bin}/proteinortho", "-help"
+    system "#{bin}/proteinortho", "-test"
     system "#{bin}/proteinortho_clustering", "-test"
   end
 end

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -1,22 +1,19 @@
 class Proteinortho < Formula
-  desc "Proteinortho is a tool to detect orthologous genes within different species"
+  desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0b/proteinortho-v6.0b.tar.gz"
   sha256 "f59c436f6461f318ccebc1177a67eb70c29ef9ba222ad724de1fb2a769a120b5"
-  depends_on "cmake" => :build
+  depends_on "cmake" => :build  
   depends_on "gcc"
 
-  # get the latest g++ compiler from brew (Cellar)
-  CXX = `ls /usr/local/Cellar/gcc/*/bin/g++* | sort | tail -n1 | tr -d '\n'`
-
   def install
-    system "make", "clean"
     system "mkdir", "#{prefix}/bin"
-    system "make", "CPP=#{CXX}" , "install", "PREFIX=#{prefix}/bin"
+    ENV["CXX"] = `ls #{Formula["gcc"].opt_bin.realpath}/g++-* | sort | tail -n1`.chomp
+    system "make", "CPP=$CXX" , "install", "PREFIX=#{prefix}/bin"
   end
 
   test do
-    system "#{bin}/proteinortho -help"
-    system "#{bin}/proteinortho_clustering -test"
+    system "#{bin}/proteinortho", "-help"
+    system "#{bin}/proteinortho_clustering", "-test"
   end
 end

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,7 +2,7 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "043cdbb1f9d46a6fecf952b3201c2018f9726f4e79adb79bcb8b7037ddfd3701"
+  sha256 "c49337f8b737408deaa04a391595cce892415fd1aa8623eb3c88507b1b8ed3b1"
 
   depends_on "diamond"
   depends_on "openblas"

--- a/Formula/proteinortho.rb
+++ b/Formula/proteinortho.rb
@@ -2,10 +2,10 @@ class Proteinortho < Formula
   desc "Detecting orthologous genes within different species"
   homepage "https://gitlab.com/paulklemm_PHD/proteinortho"
   url "https://gitlab.com/paulklemm_PHD/proteinortho/-/archive/v6.0/proteinortho-v6.0.tar.gz"
-  sha256 "400e5a6e147b43e9bb0e6bc977715516043b3e5035586b58b7b48748975c178c"
+  sha256 "e82522cdae62c182fc3bb75903e8ce3a388573fccbea16b72a0a8c47a653a34b"
   depends_on "cmake" => :build
-  depends_on "lapack" => :build
   depends_on "pkg-config" => :build
+  depends_on "lapack"
   depends_on "gcc" # for gfortran
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source proteinortho`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test proteinortho`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict proteinortho` (after doing `brew install <formula>`)?

-----

`brew audit --strict proteinortho` fails with the following message:

```
An error occurred while installing nokogiri (1.10.3), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.10.3' --source 'https://rubygems.org/'` succeeds before bundling.
```

But `brew audit --strict nokogiri` fails too (even without proteinortho installed). The installation of nokogiri fails too `sudo gem install nokogiri -v '1.10.3' --source 'https://rubygems.org/'` with 
> ld: warning: ignoring file /usr/local/Cellar/xz/5.2.4/lib/liblzma.dylib, file was built for x86_64 which is not the architecture being linked (i386): /usr/local/Cellar/xz/5.2.4/lib/liblzma.dylib
> extconf failed, exit code 1

I am not sure if this XML parser is neccessary for my program ?