### PR TITLE
Remove cluster name from data path.

### DIFF
--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -61,7 +61,7 @@ class Elasticsearch < Formula
 
   def post_install
     # Make sure runtime directories exist
-    (var/"lib/elasticsearch/#{cluster_name}").mkpath
+    (var/"lib/elasticsearch").mkpath
     (var/"log/elasticsearch").mkpath
     ln_s etc/"elasticsearch", libexec/"config" unless (libexec/"config").exist?
     (var/"elasticsearch/plugins").mkpath
@@ -72,7 +72,7 @@ class Elasticsearch < Formula
 
   def caveats
     s = <<~EOS
-      Data:    #{var}/lib/elasticsearch/#{cluster_name}/
+      Data:    #{var}/lib/elasticsearch/
       Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
       Plugins: #{var}/elasticsearch/plugins/
       Config:  #{etc}/elasticsearch/


### PR DESCRIPTION
Elasticsearch no longer supports having the cluster name as part of path.data and fails at startup if the cluster name is in that path. This change removes cluster name from path.data and prevents that directory from being created.

Steps to reproduce issue:
After a clean install of Elasticsearch with no existing Elasticsearch configuration or data directories, Elasticsearch will fail at startup with a message like:
`ERROR: Cluster name [elasticsearch_aaronwalker] subdirectory exists in data paths [/usr/local/var/lib/elasticsearch/elasticsearch_aaronwalker]. All data under these paths must be moved up one directory to paths [/usr/local/var/lib/elasticsearch]`

This issue has been seen by other users:
- https://discuss.elastic.co/t/elasticsearch-6-7-0-homebrew-install-macos-10-14-4-fails-to-run-error-cluster-name-elasticsearch-nathan-subdirectory-exists-in-data-paths/174747
- https://stackoverflow.com/questions/55437753/cant-start-elasticsearch-on-mac

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----