### PR TITLE
swiftlint: realm/SwiftLint#2736

### DIFF
--- a/Formula/swiftlint.rb
+++ b/Formula/swiftlint.rb
@@ -12,6 +12,20 @@ class Swiftlint < Formula
     sha256 "bf5cb8a3e20775e0ef4e224c5b0146910695c9b1b15be8a9f71045f4220c3dde" => :high_sierra
   end
 
+  pour_bottle? do
+    reason <<~EOS
+      The bottle needs the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998) to be installed on macOS Mojave 10.14.3 or earlier.
+        Alternatively, you can:
+        * Update to macOS 10.14.4 or later
+        * Install Xcode 10.2 or later at `/Applications/Xcode.app`
+    EOS
+    satisfy do
+      MacOS.version < "10.14.0" ||
+        (MacOS.version < "10.14.4" && (MacOS::Xcode.version >= "10.2" || File.directory?("/usr/lib/swift"))) ||
+        MacOS.version >= "10.14.4"
+    end
+  end
+
   depends_on :xcode => ["10.0", :build]
   depends_on :xcode => "8.0"
 


### PR DESCRIPTION
Workaround to https://github.com/realm/SwiftLint/issues/2736

Following message will be printed on macOS Mojave 10.14.0-.3 without Swift 5 Runtime Support.
```terminal.sh-session
$ brew install swiftlint
Warning: Building swiftlint from source:
  The bottle needs the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998) to be installed on macOS Mojave 10.14.3 or earlier.
  Alternatively, you can:
  * Update to macOS 10.14.4 or later
  * Install Xcode 10.2 or later at `/Applications/Xcode.app`

```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

/cc: @jpsim @phatblat