### PR TITLE
Fix compilation error for mp4v2

### DIFF
--- a/Formula/mp4v2.rb
+++ b/Formula/mp4v2.rb
@@ -17,6 +17,7 @@ class Mp4v2 < Formula
 
   conflicts_with "bento4",
     :because => "both install `mp4extract` and `mp4info` binaries"
+  patch :DATA
 
   def install
     system "./configure", "--disable-debug", "--prefix=#{prefix}"
@@ -29,3 +30,17 @@ class Mp4v2 < Formula
     assert_match version.to_s, shell_output("#{bin}/mp4art --version")
   end
 end
+__END__
+diff --git a/src/rtphint.cpp b/src/rtphint.cpp
+index e07309d..1eb01f5 100644
+--- a/src/rtphint.cpp
++++ b/src/rtphint.cpp
+@@ -339,7 +339,7 @@ void MP4RtpHintTrack::GetPayload(
+                 pSlash = strchr(pSlash, '/');
+                 if (pSlash != NULL) {
+                     pSlash++;
+-                    if (pSlash != '\0') {
++                    if (*pSlash != '\0') {
+                         length = (uint32_t)strlen(pRtpMap) - (pSlash - pRtpMap);
+                         *ppEncodingParams = (char *)MP4Calloc(length + 1);
+                         strncpy(*ppEncodingParams, pSlash, length);


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I tested my install on ubuntu 18.10 with gcc (Ubuntu 8.3.0-6ubuntu1~18.10) 8.3.0. My failure of installing this package from brew gist-logs is here https://gist.github.com/cmdcolin/59f220c9b715f401a5fd1c3918781379


Output of installation of my new formula is successful, detail panel below

```
% brew install mp4v2
==> Downloading https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/mp4v2-2.0.0.tar.bz2                                                    
Already downloaded: /home/cdiesh/.cache/Homebrew/downloads/0fd60ec619552cfdbedd4bf479c43830d74771d787efe41d450055b85f24a4c9--mp4v2-2.0.0.tar.bz2                             
==> Patching
patching file src/rtphint.cpp
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/mp4v2/2.0.0
==> make
==> make install
==> make install-man
🍺  /home/linuxbrew/.linuxbrew/Cellar/mp4v2/2.0.0: 35 files, 6.0MB, built in 28 seconds   
```