### PR TITLE
Test linking against camlp4 (fix #39399)

### DIFF
--- a/Formula/camlp4.rb
+++ b/Formula/camlp4.rb
@@ -38,6 +38,6 @@ class Camlp4 < Formula
                  (testpath/"foo.ml.out").read.strip
 
     (testpath/"try_camlp4.ml").write "open Camlp4"
-    system "ocamlc", "-c", "-I", "/usr/local/lib/ocaml/camlp4", "-o", testpath/"try_camlp4.cmo", testpath/"try_camlp4.ml"
+    system "ocamlc", "-c", "-I", "#{HOMEBREW_PREFIX}/lib/ocaml/camlp4", "-o", testpath/"try_camlp4.cmo", testpath/"try_camlp4.ml"
   end
 end

--- a/Formula/camlp4.rb
+++ b/Formula/camlp4.rb
@@ -4,6 +4,7 @@ class Camlp4 < Formula
   url "https://github.com/ocaml/camlp4/archive/4.07+1.tar.gz"
   version "4.07+1"
   sha256 "ecdb8963063f41b387412317685f79823a26b3f53744f0472058991876877090"
+  revision 1
   head "https://github.com/ocaml/camlp4.git", :branch => "trunk"
 
   bottle do
@@ -35,5 +36,8 @@ class Camlp4 < Formula
                             "foo.ml", "-o", testpath/"foo.ml.out"
     assert_equal "type t = [ Homebrew | Rocks ];",
                  (testpath/"foo.ml.out").read.strip
+
+    (testpath/"try_camlp4.ml").write "open Camlp4"
+    system "ocamlc", "-c", "-I", "/usr/local/lib/ocaml/camlp4", "-o", testpath/"try_camlp4.cmo", testpath/"try_camlp4.ml"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Bump revision to rebuild against 4.07.1, and add test to detect that linking against camlp4 fails. I verified that `brew test` succeeds after rebuilding from source and fails with the current bottle.

Fix #39399.