### PR TITLE
Add Phive (phar.io) installation formulae.

### DIFF
--- a/Formula/phive.rb
+++ b/Formula/phive.rb
@@ -1,0 +1,18 @@
+class Phive < Formula
+  desc "The Phar Installation and Verification Environment (PHIVE)"
+  homepage "https://phar.io"
+  url "https://github.com/phar-io/phive/releases/download/0.12.1/phive-0.12.1.phar"
+  sha256 "6e39a2764b11e6823fa27c637b263e83d02929661a4f230b1b57dae35c6c6f30"
+
+  bottle :unneeded
+
+  depends_on "php" => :test
+
+  def install
+    bin.install "phive-#{version}.phar" => "phive"
+  end
+
+  test do
+    assert_match /PHARs configured in phive.xml/, shell_output("#{bin}/phive status")
+  end
+end


### PR DESCRIPTION
Phive is a new tool which allows to install Phar based software without polluting the composer.json file.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
