### PR TITLE
fftw: build with --enable-avx

### DIFF
--- a/Formula/fftw.rb
+++ b/Formula/fftw.rb
@@ -27,7 +27,7 @@ class Fftw < Formula
       "--enable-mpi",
       "--enable-openmp",
     ]
-    simd_args = ["--enable-sse2"]
+    simd_args = ["--enable-sse2", "--enable-avx"]
 
     # single precision
     # enable-sse2, enable-avx and enable-avx2 work for both single and double precision

--- a/Formula/fftw.rb
+++ b/Formula/fftw.rb
@@ -33,7 +33,7 @@ class Fftw < Formula
     # at http://www.fftw.org/fftw3_doc/Installation-on-Unix.html:
     #
     # "You need compiler that supports the given SIMD extensions, but FFTW will try to
-    # detect at runtime whether the CPU supports these extensions. That is, you can 
+    # detect at runtime whether the CPU supports these extensions. That is, you can
     # compile with--enable-avx and the code will still run on a CPU without AVX support."
     #
     # For this reason we enable AVX instructions for faster code on all x86-64 CPUS

--- a/Formula/fftw.rb
+++ b/Formula/fftw.rb
@@ -27,6 +27,18 @@ class Fftw < Formula
       "--enable-mpi",
       "--enable-openmp",
     ]
+
+    # FFTW supports runtime detection of CPU capabilities, so it is safe to use more
+    # capable SIMD compiler flags. Specifically, from the FFTW documentation
+    # at http://www.fftw.org/fftw3_doc/Installation-on-Unix.html:
+    #
+    # "You need compiler that supports the given SIMD extensions, but FFTW will try to
+    # detect at runtime whether the CPU supports these extensions. That is, you can 
+    # compile with--enable-avx and the code will still run on a CPU without AVX support."
+    #
+    # For this reason we enable AVX instructions for faster code on all x86-64 CPUS
+    # newer than ~2011.
+
     simd_args = ["--enable-sse2", "--enable-avx"]
 
     # single precision


### PR DESCRIPTION
The FFTW library is used when speed is important, and is highly optimised.
When being built, there are a number of SIMD flags that can be passed,
such as --enable-sse2, --enable-avx and --enable-avx2. Currently the fftw
formula only builds the fftw libraries with --enable-sse2.

Building with at least --enable-avx additionally would enable a significant
improvement in speed.

There is no obvious down side to including this flag. The fftw libraries
perform runtime detection of CPU features, so that if the CPU doesn't
have AXV instructions, the SSE code path will be used instead. In addition
AVX instructions are included in all x86-64 chips since ~2011, so most
users out there will benefit from this change.

For similar reasons I'd also recommend including the --enable-axv2 flag,
but I'm starting off with the minimal possible change to see if it's acceptable.

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
