### PR TITLE
Fix typo in tesseract caveats

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -63,7 +63,7 @@ class Tesseract < Formula
   end
 
   def caveats; <<~EOS
-    This formula containes only the "eng", "osd", and "snum" language data files.
+    This formula contains only the "eng", "osd", and "snum" language data files.
     If you need all the other supported languages, `brew install tesseract-lang`.
   EOS
   end


### PR DESCRIPTION
Caveats for formula tesseract included the misspelled word "containes." Because I'm changing only text in the caveats, I haven't run any of the checks below. If that seems necessary I'm happy to do so.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?