### PR TITLE
libnfc devel

### DIFF
--- a/Formula/libnfc.rb
+++ b/Formula/libnfc.rb
@@ -13,10 +13,19 @@ class Libnfc < Formula
     sha256 "cabb3f773d92c2cd95af437d6f4c567529229b26b82d568af1c89ec50b674f59" => :mavericks
   end
 
+  head do
+    url "https://github.com/nfc-tools/libnfc.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "libusb-compat"
 
   def install
+    system "autoreconf", "-vfi" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--enable-serial-autoprobe",
                           "--with-drivers=all"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libnfc has had [a fair number of changes](https://github.com/nfc-tools/libnfc/compare/libnfc-1.7.1...master) since the last release was cut on 13 May 2015. Since no release candidates have been published either, Homebrew users are currently unable to take advantage of these enhancements.

This formula tells Homebrew about libnfc's git repository so users can opt-into bleeding edge changes using `--head`.