### PR TITLE
qt: remove erroneous "cellar :any"

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -11,7 +11,6 @@ class Qt < Formula
   head "https://code.qt.io/qt/qt5.git", :branch => "dev", :shallow => false
 
   bottle do
-    cellar :any
     sha256 "b669ba7803986326f32e9fe5d2b7229e6ecd806517e8bf750ea4ec59fa8da45f" => :mojave
     sha256 "4c95d0f48f2a933f6d339c7ccd13e9e3a7aaaef69fe84bec5ede7ae8d86dd053" => :high_sierra
     sha256 "fbffb16a29c8f755f0efeceb015554e685f616cdecbf70177f6992fffc698496" => :sierra


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? _No, because this change only affects bottle installation._
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? 

-----

The `qt` formula's `bottle` block claims to be `cellar :any`. I think this is erroneous: when I install it into a Homebrew installation at a non-default location, some of the Qt command line tools don't work.

Can we remove the `cellar :any` line to prevent broken installations from bottle to non-default Cellar locations?

No revision bump needed, because this doesn't affect bottle contents; just whether the bottle is used in some cases.
