### PR TITLE
ettercap: add missing geoip dependency

### DIFF
--- a/Formula/ettercap.rb
+++ b/Formula/ettercap.rb
@@ -23,6 +23,7 @@ class Ettercap < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "geoip"
   depends_on "gtk+3"
   depends_on "libnet"
   depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

On Mojave 10.14.3, `brew install --HEAD ettercap` is unable to complete configuration at:

==> cmake .. -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/ettercap/HEAD-5fb6048_1 -DCMAKE_BUILD_TY

Last 15 lines from ~/Library/Logs/Homebrew/ettercap/01.cmake:
-- Looking for strndup
-- Looking for strndup - found
-- GeoIP support requested. Will look for the legacy GeoIP C library
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.29.2")
-- Checking for one of the modules 'geoip'
-- Could NOT find GEOIP (missing: GEOIP_LIBRARY GEOIP_INCLUDE_DIR)
CMake Error at cmake/Modules/EttercapLibCheck.cmake:211 (message):
  GeoIP not found!
Call Stack (most recent call first):
  CMakeLists.txt:106 (include)
-- Configuring incomplete, errors occurred!

Proposed fix is to add dependency for:
```
✘ brew info geoip
geoip: stable 1.6.12 (bottled), HEAD
This library is for the GeoIP Legacy format (dat)
https://github.com/maxmind/geoip-api-c
```