### PR TITLE
Fix the remaining 'please use deb.debian.org' failures from `brew audit --strict`

### DIFF
--- a/Formula/dirac.rb
+++ b/Formula/dirac.rb
@@ -3,7 +3,7 @@ class Dirac < Formula
   homepage "https://sourceforge.net/projects/dirac/"
   url "https://downloads.sourceforge.net/project/dirac/dirac-codec/Dirac-1.0.2/dirac-1.0.2.tar.gz"
   mirror "https://launchpad.net/ubuntu/+archive/primary/+files/dirac_1.0.2.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dirac/dirac_1.0.2.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dirac/dirac_1.0.2.orig.tar.gz"
   sha256 "816b16f18d235ff8ccd40d95fc5b4fad61ae47583e86607932929d70bf1f00fd"
 
   bottle do

--- a/Formula/dvorak7min.rb
+++ b/Formula/dvorak7min.rb
@@ -1,8 +1,7 @@
 class Dvorak7min < Formula
   desc "Dvorak (simplified keyboard layout) typing tutor"
   homepage "https://web.archive.org/web/dvorak7min.sourcearchive.com/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
   version "1.6.1"
   sha256 "4cdef8e4c8c74c28dacd185d1062bfa752a58447772627aded9ac0c87a3b8797"
 

--- a/Formula/minbif.rb
+++ b/Formula/minbif.rb
@@ -1,8 +1,7 @@
 class Minbif < Formula
   desc "IRC-to-other-IM-networks gateway using Pidgin library"
   homepage "https://symlink.me/projects/minbif/wiki/"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
   version "1.0.5-20150505"
   sha256 "4e264fce518a0281de9fc3d44450677c5fa91097a0597ef7a0d2a688ee66d40b"
   revision 2

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -2,8 +2,7 @@ class Mytop < Formula
   desc "Top-like query monitor for MySQL"
   homepage "http://www.mysqlfanboy.com/mytop-3/"
   url "http://www.mysqlfanboy.com/mytop-3/mytop-1.9.1.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
   revision 6
 
@@ -46,8 +45,7 @@ class Mytop < Formula
   # Pick up some patches from Debian to improve functionality & fix
   # some syntax warnings when using recent versions of Perl.
   patch do
-    url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
-    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
+    url "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1-2.debian.tar.xz"
     sha256 "9c97b7d2a2d4d169c5f263ce0adb6340b71e3a0afd4cdde94edcead02421489a"
     apply "patches/01_fix_pod.patch",
           "patches/02_remove_db_test.patch",

--- a/Formula/ppl.rb
+++ b/Formula/ppl.rb
@@ -1,8 +1,7 @@
 class Ppl < Formula
   desc "Parma Polyhedra Library: numerical abstractions for analysis, verification"
   homepage "https://bugseng.com/ppl"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/p/ppl/ppl_1.2.orig.tar.xz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/p/ppl/ppl_1.2.orig.tar.xz"
+  url "https://deb.debian.org/debian/pool/main/p/ppl/ppl_1.2.orig.tar.xz"
   sha256 "691f0d5a4fb0e206f4e132fc9132c71d6e33cdda168470d40ac3cf62340e9a60"
 
   bottle do

--- a/Formula/schroedinger.rb
+++ b/Formula/schroedinger.rb
@@ -2,7 +2,7 @@ class Schroedinger < Formula
   desc "High-speed implementation of the Dirac codec"
   homepage "https://launchpad.net/schroedinger"
   url "https://launchpad.net/schroedinger/trunk/1.0.11/+download/schroedinger-1.0.11.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/schroedinger/schroedinger_1.0.11.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/schroedinger/schroedinger_1.0.11.orig.tar.gz"
   sha256 "1e572a0735b92aca5746c4528f9bebd35aa0ccf8619b22fa2756137a8cc9f912"
 
   bottle do

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -2,7 +2,7 @@ class SdlSound < Formula
   desc "Library to decode several popular sound file formats"
   homepage "https://icculus.org/SDL_sound/"
   url "https://icculus.org/SDL_sound/downloads/SDL_sound-1.0.3.tar.gz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/s/sdl-sound1.2/sdl-sound1.2_1.0.3.orig.tar.gz"
   sha256 "3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
   revision 1
 

--- a/Formula/toilet.rb
+++ b/Formula/toilet.rb
@@ -3,7 +3,6 @@ class Toilet < Formula
   homepage "http://caca.zoy.org/wiki/toilet"
   url "http://caca.zoy.org/raw-attachment/wiki/toilet/toilet-0.3.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/t/toilet/toilet_0.3.orig.tar.gz"
   sha256 "89d4b530c394313cc3f3a4e07a7394fa82a6091f44df44dfcd0ebcb3300a81de"
 
   bottle do

--- a/Formula/unp.rb
+++ b/Formula/unp.rb
@@ -1,8 +1,7 @@
 class Unp < Formula
   desc "Unpack everything with one command"
   homepage "https://packages.debian.org/source/stable/unp"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
+  url "https://deb.debian.org/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2"
   version "2.0-pre7-nmu1"
   sha256 "7c2d6f2835a5a59ee2588b66d8015d97accd62e71e38ba90ebd4d71d8fd78227"
 

--- a/Formula/urlview.rb
+++ b/Formula/urlview.rb
@@ -1,8 +1,7 @@
 class Urlview < Formula
   desc "URL extractor/launcher"
   homepage "https://packages.debian.org/sid/misc/urlview"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
-  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
   version "0.9-20"
   sha256 "746ff540ccf601645f500ee7743f443caf987d6380e61e5249fc15f7a455ed42"
 
@@ -15,8 +14,7 @@ class Urlview < Formula
   end
 
   patch do
-    url "https://mirrors.ocf.berkeley.edu/debian/pool/main/u/urlview/urlview_0.9-20.diff.gz"
-    mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/u/urlview/urlview_0.9-20.diff.gz"
+    url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9-20.diff.gz"
     sha256 "0707956fd7195aefe6d6ff2eaabe8946e3d18821a1ce97c0f48d0f8d6e37514e"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

After #39413, I discovered the ability to scope `brew audit` to just some cops 😅, so here are the remaining `brew audit --strict` changes for mirror URLs to be `deb.debian.org`.

As before, where changing them would have introduced duplicates, I've deleted the would-be duplicate lines.