### PR TITLE
2.4.2 version link not working fixed to 2.4.3

### DIFF
--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -1,8 +1,8 @@
 class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz"
-  version "2.4.2"
+  url "https://www.apache.org/dyn/closer.lua?path=spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz"
+  version "2.4.3"
   sha256 "e68dd25227ddf616f1212d34b8f537fdf0b217f31f8e385eea48e04e2aa5482c"
   head "https://github.com/apache/spark.git"
 

--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -3,7 +3,7 @@ class ApacheSpark < Formula
   homepage "https://spark.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz"
   version "2.4.3"
-  sha256 "e68dd25227ddf616f1212d34b8f537fdf0b217f31f8e385eea48e04e2aa5482c"
+  sha256 "80a4c564ceff0d9aff82b7df610b1d34e777b45042e21e2d41f3e497bb1fa5d8"
   head "https://github.com/apache/spark.git"
 
   bottle :unneeded


### PR DESCRIPTION
Getting the following issue:

```
$ brew install apache-spark
==> Downloading https://www.apache.org/dyn/closer.lua?path=spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz
==> Downloading from http://mirrors.gigenet.com/apache/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz

curl: (22) The requested URL returned error: 404 Not Found
Trying a mirror...
==> Downloading https://www-eu.apache.org/dist/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz

curl: (22) The requested URL returned error: 404 Not Found
Trying a mirror...
==> Downloading https://www-us.apache.org/dist/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz

curl: (22) The requested URL returned error: 404 Not Found
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "apache-spark"
Download failed: https://www-us.apache.org/dist/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz

```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
