### PR TITLE
update to armadillo 9.400.3

### DIFF
--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -1,8 +1,8 @@
 class Armadillo < Formula
   desc "C++ linear algebra library"
   homepage "https://arma.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/arma/armadillo-9.300.2.tar.xz"
-  sha256 "362541af7eb7f343bff893a3ac11fbb2c5cfc5966f0b6ed67f7f2779f5d256b4"
+  url "https://downloads.sourceforge.net/project/arma/armadillo-9.400.3.tar.xz"
+  sha256 "f4c9ce4ee719e935f0046dcafb3fe40ffd8e1b80cc16a4d2c03332ea37d857a6"
 
   bottle do
     cellar :any


### PR DESCRIPTION
**Note:** This PR upgrades to Armadillo 9.400.3 (from 9.300.2).  There is a pull request for gcc 9.1 which modifies the Armadillo formula: https://github.com/Homebrew/homebrew-core/pull/39454. However, PR https://github.com/Homebrew/homebrew-core/pull/39454 doesn't upgrade to a newer version of armadillo; instead it only adds a revision tag: https://github.com/Homebrew/homebrew-core/pull/39454/commits/b2eefe7f8a6491c30e307505583d68df369a9247

The update to Armadillo 9.400.3 (this PR) in effect supersedes the above.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
