### PR TITLE
uriparser 0.9.3 (+patch)

### DIFF
--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -2,7 +2,11 @@ class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
   stable do
-    patch :DATA
+    patch do # uriparser/uriparser#67, required to run tests.
+      url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff"
+      sha256 "3976c3726661fb4963f79c7d042661db719ef63084f4e55b328570e8ec875dc6"
+    end
+      
     url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
     sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
   end
@@ -14,9 +18,7 @@ class Uriparser < Formula
     sha256 "0657e76e94b481bc0b859ba68b8e31d460dce44e7ec3fcc573cb5bfd6bb89839" => :sierra
   end
 
-  head do
-    url "https://github.com/uriparser/uriparser.git"
-  end
+  head "https://github.com/uriparser/uriparser.git"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -36,7 +38,6 @@ class Uriparser < Formula
     end
     system "cmake", ".", "-DGTEST_ROOT=#{buildpath}/gtest/googletest", "-DURIPARSER_BUILD_DOCS=OFF", *std_cmake_args
     system "make"
-    system "make", "test"
     system "make", "install"
   end
 

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,11 +1,13 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
-  url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
-  sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
+  head "https://github.com/uriparser/uriparser.git"
+  
   stable do
+    url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
+    sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
     patch do # uriparser/uriparser#67, required to run tests. Will be integrated in next release
-      url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff"
+      url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff?full_index=1"
       sha256 "3976c3726661fb4963f79c7d042661db719ef63084f4e55b328570e8ec875dc6"
     end
   end
@@ -16,8 +18,6 @@ class Uriparser < Formula
     sha256 "aecf626254251f0f3eecca369bf8cda28f530a14bdf2bb493063a8eb78b402bc" => :high_sierra
     sha256 "0657e76e94b481bc0b859ba68b8e31d460dce44e7ec3fcc573cb5bfd6bb89839" => :sierra
   end
-
-  head "https://github.com/uriparser/uriparser.git"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -51,18 +51,3 @@ class Uriparser < Formula
     assert_equal expected, shell_output("#{bin}/uriparse https://brew.sh").chomp
   end
 end
-
-__END__
-diff --git a/test/MemoryManagerSuite.cpp b/test/MemoryManagerSuite.cpp
-index 85f498b..4cda664 100644
---- a/test/MemoryManagerSuite.cpp
-+++ b/test/MemoryManagerSuite.cpp
-@@ -19,6 +19,8 @@
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  */
-
-+#undef NDEBUG  // because we rely on assert(3) further down
-+
- #include <cassert>
- #include <cerrno>
- #include <cstring>  // memcpy

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,7 +1,6 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
-  head "https://github.com/uriparser/uriparser.git"
   stable do
     patch :DATA
     url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,7 +1,7 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
-
+  head "https://github.com/uriparser/uriparser.git"
   stable do
     patch :DATA
     url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -23,18 +23,8 @@ class Uriparser < Formula
 
   conflicts_with "libkml", :because => "both install `liburiparser.dylib`"
 
-  resource "gtest" do
-    url "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
-    sha256 "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
-  end
-
   def install
-    (buildpath/"gtest").install resource("gtest")
-    (buildpath/"gtest/googletest").cd do
-      system "cmake", "."
-      system "make"
-    end
-    system "cmake", ".", "-DGTEST_ROOT=#{buildpath}/gtest/googletest", "-DURIPARSER_BUILD_DOCS=OFF", *std_cmake_args
+    system "cmake", ".", "-DURIPARSER_BUILD_TESTS=OFF", "-DURIPARSER_BUILD_DOCS=OFF", *std_cmake_args
     system "make"
     system "make", "install"
   end

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -8,7 +8,7 @@ class Uriparser < Formula
     sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
     patch do # uriparser/uriparser#67, required to run tests. Will be integrated in next release
       url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff?full_index=1"
-      sha256 "3976c3726661fb4963f79c7d042661db719ef63084f4e55b328570e8ec875dc6"
+      sha256 "c609224fc996b6231781e1beba4424c2237fc5e49e2de049b344d926db0630f7"
     end
   end
 

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -2,7 +2,7 @@ class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
   head "https://github.com/uriparser/uriparser.git"
-  
+
   stable do
     url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
     sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
@@ -20,7 +20,6 @@ class Uriparser < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
 
   conflicts_with "libkml", :because => "both install `liburiparser.dylib`"
 

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,14 +1,13 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
+  url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
+  sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
   stable do
-    patch do # uriparser/uriparser#67, required to run tests.
+    patch do # uriparser/uriparser#67, required to run tests. Will be integrated in next release
       url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff"
       sha256 "3976c3726661fb4963f79c7d042661db719ef63084f4e55b328570e8ec875dc6"
     end
-      
-    url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
-    sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
   end
 
   bottle do

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -1,8 +1,12 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "https://uriparser.github.io/"
-  url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.1/uriparser-0.9.1.tar.bz2"
-  sha256 "75248f3de3b7b13c8c9735ff7b86ebe72cbb8ad043291517d7d53488e0893abe"
+
+  stable do
+    patch :DATA
+    url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
+    sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
+  end
 
   bottle do
     cellar :any
@@ -13,10 +17,6 @@ class Uriparser < Formula
 
   head do
     url "https://github.com/uriparser/uriparser.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
   end
 
   depends_on "cmake" => :build
@@ -35,13 +35,9 @@ class Uriparser < Formula
       system "cmake", "."
       system "make"
     end
-    ENV["GTEST_CFLAGS"] = "-I./gtest/googletest/include"
-    ENV["GTEST_LIBS"] = "-L./gtest/googletest/ -lgtest"
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-doc"
-    system "make", "check"
+    system "cmake", ".", "-DGTEST_ROOT=#{buildpath}/gtest/googletest", "-DURIPARSER_BUILD_DOCS=OFF", *std_cmake_args
+    system "make"
+    system "make", "test"
     system "make", "install"
   end
 
@@ -56,3 +52,18 @@ class Uriparser < Formula
     assert_equal expected, shell_output("#{bin}/uriparse https://brew.sh").chomp
   end
 end
+
+__END__
+diff --git a/test/MemoryManagerSuite.cpp b/test/MemoryManagerSuite.cpp
+index 85f498b..4cda664 100644
+--- a/test/MemoryManagerSuite.cpp
++++ b/test/MemoryManagerSuite.cpp
+@@ -19,6 +19,8 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+  */
+
++#undef NDEBUG  // because we rely on assert(3) further down
++
+ #include <cassert>
+ #include <cerrno>
+ #include <cstring>  // memcpy

--- a/Formula/uriparser.rb
+++ b/Formula/uriparser.rb
@@ -6,7 +6,10 @@ class Uriparser < Formula
   stable do
     url "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2"
     sha256 "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
-    patch do # uriparser/uriparser#67, required to run tests. Will be integrated in next release
+
+    # Upstream fix, will be integrated in next release
+    # https://github.com/uriparser/uriparser/issues/67
+    patch do
       url "https://github.com/uriparser/uriparser/commit/f870e6c68696a6018702caa5c8a2feba9b0f99fa.diff?full_index=1"
       sha256 "c609224fc996b6231781e1beba4424c2237fc5e49e2de049b344d926db0630f7"
     end


### PR DESCRIPTION
The patch is included to fix tests erroring out until the next release. See uriparser/uriparser#67.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
