### PR TITLE
velero: fix version injection

### DIFF
--- a/Formula/velero.rb
+++ b/Formula/velero.rb
@@ -3,7 +3,7 @@ class Velero < Formula
   homepage "https://github.com/heptio/velero"
   url "https://github.com/heptio/velero/archive/v0.11.0.tar.gz"
   sha256 "366f4c1ed5800dbdddefa60ed88bdd82b406b69b76a214b1d7108997a2f973ac"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -22,7 +22,7 @@ class Velero < Formula
     cd dir do
       system "go", "build", "-o", bin/"velero", "-installsuffix", "static",
                    "-ldflags",
-                   "-X github.com/heptio/velero/pkg/buildinfo.Version=#{version}",
+                   "-X github.com/heptio/velero/pkg/buildinfo.Version=v#{version}",
                    "./cmd/velero"
 
       # Install bash completion
@@ -40,7 +40,7 @@ class Velero < Formula
   test do
     output = shell_output("#{bin}/velero 2>&1")
     assert_match "Velero is a tool for managing disaster recovery", output
-    assert_match "Version: #{version}", shell_output("#{bin}/velero version --client-only 2>&1")
+    assert_match "Version: v#{version}", shell_output("#{bin}/velero version --client-only 2>&1")
     system bin/"velero", "client", "config", "set", "TEST=value"
     assert_match "value", shell_output("#{bin}/velero client config get 2>&1")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The injected version matters to velero as it uses this version to line up with a published docker image. We were missing the "v", which was causing tag not found errors when deploying the in-cluster component.