### PR TITLE
evince 3.32.0

### DIFF
--- a/Formula/appstream-glib.rb
+++ b/Formula/appstream-glib.rb
@@ -1,0 +1,84 @@
+class AppstreamGlib < Formula
+  desc "Helper library for reading and writing AppStream metadata"
+  homepage "https://github.com/hughsie/appstream-glib"
+  url "https://github.com/hughsie/appstream-glib/archive/appstream_glib_0_7_15.tar.gz"
+  sha256 "ad4463e96870accc9a179849555f5c5c4146ec412ec3ecf3c594dce85e027d59"
+
+  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gdk-pixbuf"
+  depends_on "glib"
+  depends_on "json-glib"
+  depends_on "libarchive"
+  depends_on "libsoup"
+  depends_on "util-linux"
+
+  # see https://github.com/hughsie/appstream-glib/issues/258
+  patch :DATA
+
+  def install
+    # Find our docbook catalog
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    mkdir "build" do
+      system "meson", "--prefix=#{prefix}", "-Dbuilder=false", "-Drpm=false", "-Ddep11=false", "-Dstemmer=false", ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <appstream-glib.h>
+
+      int main(int argc, char *argv[]) {
+        AsScreenshot *screen_shot = as_screenshot_new();
+        g_assert_nonnull(screen_shot);
+        return 0;
+      }
+    EOS
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    flags = %W[
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/gio-unix-2.0/
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/libappstream-glib
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -lappstream-glib
+      -lgdk_pixbuf-2.0
+      -lgio-2.0
+      -lglib-2.0
+      -lgobject-2.0
+      -lintl
+    ]
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+    system "#{bin}/appstream-util", "--help"
+  end
+end
+
+__END__
+diff --git a/libappstream-glib/meson.build b/libappstream-glib/meson.build
+index 5f726b0..7d29ac8 100644
+--- a/libappstream-glib/meson.build
++++ b/libappstream-glib/meson.build
+@@ -136,7 +136,6 @@ asglib = shared_library(
+   dependencies : deps,
+   c_args : cargs,
+   include_directories : include_directories('..'),
+-  link_args : vflag,
+   link_depends : mapfile,
+   install : true,
+ )
+

--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -1,9 +1,8 @@
 class Evince < Formula
   desc "GNOME document viewer"
   homepage "https://wiki.gnome.org/Apps/Evince"
-  url "https://download.gnome.org/sources/evince/3.30/evince-3.30.2.tar.xz"
-  sha256 "a95bbdeb452c9cc910bba751e7c782ce60ffe7972c461bccbe8bbcdb8ca5f24c"
-  revision 2
+  url "https://download.gnome.org/sources/evince/3.32/evince-3.32.0.tar.xz"
+  sha256 "f0d977216466ed2f5a6de64476ef7113dc7c7c9832336f1ff07f3c03c5324c40"
 
   bottle do
     sha256 "47f74e9d5ea7d016b8d8eb13f0ac8d5879b08254d7831ff6aa81685b117e6c23" => :mojave
@@ -11,6 +10,7 @@ class Evince < Formula
     sha256 "7d7fea09c433f50734de80cbd63bb719196fd45ec0b3e651857d5f1d57b5b54e" => :sierra
   end
 
+  depends_on "appstream-glib" => :build
   depends_on "gobject-introspection" => :build
   depends_on "intltool" => :build
   depends_on "itstool" => :build
@@ -31,6 +31,8 @@ class Evince < Formula
   patch :DATA
 
   def install
+    ENV["GETTEXTDATADIR"] = "#{Formula["appstream-glib"].opt_share}/gettext"
+
     # Fix build failure "ar: illegal option -- D"
     # Reported 15 Sep 2017 https://bugzilla.gnome.org/show_bug.cgi?id=787709
     inreplace "configure", "AR_FLAGS=crD", "AR_FLAGS=r"

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -3,6 +3,7 @@ class UtilLinux < Formula
   homepage "https://github.com/karelzak/util-linux"
   url "https://www.kernel.org/pub/linux/utils/util-linux/v2.33/util-linux-2.33.2.tar.xz"
   sha256 "631be8eac6cf6230ba478de211941d526808dba3cd436380793334496013ce97"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class UtilLinux < Formula
     sha256 "02c15639cc3e40c7553dbcb23e94a5e679feeaad8881ed6ddce91c4cb0a015b2" => :sierra
   end
 
-  conflicts_with "rename", :because => "both install `rename` binaries"
+  keg_only "macOS provides the uuid.h header"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -20,7 +21,7 @@ class UtilLinux < Formula
                           "--disable-ipcs",        # does not build on macOS
                           "--disable-ipcrm",       # does not build on macOS
                           "--disable-wall",        # already comes with macOS
-                          "--disable-libuuid",     # conflicts with ossp-uuid
+                          "--enable-libuuid",      # conflicts with ossp-uuid
                           "--disable-libsmartcols" # macOS already ships 'column'
 
     system "make", "install"


### PR DESCRIPTION
Also:

* Add new formula `appstream-glib`, which is now a build-time requirement of evince (see https://gitlab.gnome.org/GNOME/evince/issues/1106)

