### PR TITLE
Gemstash 2.0.0 (new formula)

### DIFF
--- a/Formula/gemstash.rb
+++ b/Formula/gemstash.rb
@@ -1,0 +1,124 @@
+class Gemstash < Formula
+  desc "RubyGems.org cache and private gem server"
+  homepage "https://github.com/bundler/gemstash"
+  url "https://rubygems.org/downloads/gemstash-2.0.0.gem"
+  sha256 "511a5773c43507b913c4f2f57d33a3d972bd71378b2669c22a357b3351a82bf4"
+  head "https://github.com/bundler/gemstash.git"
+
+  if MacOS.version < :mojave
+    depends_on "openssl"
+    depends_on "ruby"
+  end
+
+  def install
+    if build.head?
+      system "gem", "build", "gemstash.gemspec"
+      gem_file = Dir["*.gem"].first
+    else
+      gem_file = "gemstash-#{version}.gem"
+    end
+
+    ENV["GEM_HOME"] = libexec
+
+    if MacOS.version < :mojave
+      gem = Formula["ruby"].bin/"gem"
+    else
+      gem = "gem"
+    end
+
+    system gem, "install", "--no-document", gem_file
+
+    (bin/"gemstash").write_env_script libexec/"bin/gemstash",
+      :GEM_HOME                      => ENV["GEM_HOME"],
+      :SINATRA_ACTIVESUPPORT_WARNING => false
+
+    (var/"gemstash").mkpath
+    (etc/"gemstash").mkpath
+    config_file.write <<~EOS
+      ---
+      :base_path: "#{var}/gemstash"
+      :bind: tcp://127.0.0.1:#{port}
+      :cache_type: memory
+      :db_adapter: sqlite3
+      :protected_fetch: false
+      :fetch_timeout: 20
+    EOS
+  end
+
+  def caveats; <<~EOS
+    With the server running, you can bundle install against it. Tell Bundler
+    that you want to use gemstash to find gems from rubygems.org:
+
+        $ bundle config mirror.https://rubygems.org http://localhost:#{port}
+
+    The configuration file can be found at #{config_file}.
+  EOS
+  end
+
+  plist_options :manual => "gemstash"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{bin}/gemstash</string>
+            <string>start</string>
+            <string>--no-daemonize</string>
+            <string>--config-file</string>
+            <string>#{config_file}</string>
+        </array>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/gemstash.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/gemstash.log</string>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    require "pty"
+
+    ohai "Starting gemstash"
+
+    PTY.spawn("#{bin}/gemstash start --no-daemonize") do |r, _, pid|
+      begin
+        loop do
+          available = IO.select([r], [], [], 15)
+          assert_not_equal available, nil
+
+          line = r.readline.strip
+
+          if line.include?("Starting gemstash!")
+            ohai "Server is up (pid=#{pid})"
+            break
+          end
+        end
+      ensure
+        Process.kill("SIGINT", pid)
+        ohai "Shuting down"
+      end
+    end
+  end
+
+  private
+
+  def port
+    29292
+  end
+
+  def config_file
+    etc/"gemstash/config.yml"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula helps setting up a gemstash server by installing the required gems, providing a launchctl plist and a configuration file. Running a local RubyGems mirror helps speed up bundle installs, especially for projects that have multiple Gemfiles.

The install step does a `gem install gemstash-2.0.0.gem` (with dependencies). I don't know if this is allowed in core, I wasn't sure how to interpret this sentence:

> Note that we now allow tools like cargo, gem and pip to download specifically versioned libraries during installation.

The gemstash gem depends on activesupport among others, so there are a few too many to go the `resource "gem" do … end` route.

Test approach is stolen from [arangodb][].

[arangodb]: https://github.com/Homebrew/homebrew-core/blob/41ef6e2ec125139657545247f4673641e0aafab3/Formula/arangodb.rb#L103