### PR TITLE
yarn 1.16.0

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -2,7 +2,7 @@ class Yarn < Formula
   desc "JavaScript package manager"
   homepage "https://yarnpkg.com/"
   # Should only be updated if the new version is listed as a stable release on the homepage
-  url "https://yarnpkg.com/downloads/1.15.2/yarn-v1.15.2.tar.gz"
+  url "https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz"
   sha256 "c4feca9ba5d6bf1e820e8828609d3de733edf0e4722d17ed7ce493ed39f61abd"
 
   bottle :unneeded

--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -3,7 +3,7 @@ class Yarn < Formula
   homepage "https://yarnpkg.com/"
   # Should only be updated if the new version is listed as a stable release on the homepage
   url "https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz"
-  sha256 "c4feca9ba5d6bf1e820e8828609d3de733edf0e4722d17ed7ce493ed39f61abd"
+  sha256 "df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I tried using `brew bump-formula-pr yarn --url=https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz` to automatically generate this PR but it failed on installing gems while building gem native extensions (see below).

Not sure off the top of my head how to fix this - maybe my ruby version or something? (`ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]`) Didn't find a guide for setting up the system environment with a quick 10 minute look.

```

➜ brew bump-formula-pr yarn --url=https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz
==> Downloading https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/49970642/4ea79e00-6a70-11e9-8a21-46a123284fc5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F
######################################################################## 100.0%
==> replace /https:\/\/yarnpkg\.com\/downloads\/1\.15\.2\/yarn\-v1\.15\.2\.tar\.gz/ with "https://yarnpkg.com/downloads/1.16.0/yarn-v1.16.0.tar.gz"
==> replace "c4feca9ba5d6bf1e820e8828609d3de733edf0e4722d17ed7ce493ed39f61abd" with "df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029"
==> Installing 'bundler' gem
Fetching: bundler-2.0.1.gem (100%)
Successfully installed bundler-2.0.1
1 gem installed
Fetching gem metadata from https://rubygems.org/.........
Fetching concurrent-ruby 1.1.5
Fetching minitest 5.11.3
Fetching thread_safe 0.3.6
Installing thread_safe 0.3.6

...

Installing rspec-retry 0.6.1
Installing rspec 3.8.0
Installing nokogiri 1.10.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.2.0/ext/json/ext/parser
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby -r ./siteconf20190510-25433-12ku5a6.rb extconf.rb
checking for rb_enc_raise() in ruby.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/$(RUBY_BASE_NAME)
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:456:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:535:in `block in try_link0'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:532:in `try_link0'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:556:in `try_link'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:765:in `try_func'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:1051:in `block in have_func'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:942:in `block in checking_for'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:350:in `block (2 levels) in postpone'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:320:in `open'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:350:in `block in postpone'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:320:in `open'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:346:in `postpone'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:941:in `checking_for'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/mkmf.rb:1050:in `have_func'
	from extconf.rb:4:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/extensions/universal-darwin-9/2.3.0-static/json-2.2.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.2.0 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/extensions/universal-darwin-9/2.3.0-static/json-2.2.0/gem_make.out

An error occurred while installing json (2.2.0), and Bundler cannot continue.
Make sure that `gem install json -v '2.2.0' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  coveralls was resolved to 0.8.23, which depends on
    simplecov was resolved to 0.16.1, which depends on
      json

...

Error: failed to run `/Users/k/.gem/ruby/2.3.0/bin/bundle install`!
Error: brew audit failed!
```