### PR TITLE
nethack: Also build the curses interface if we're >= mojave

### DIFF
--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -23,7 +23,9 @@ class Nethack < Formula
 
     # Generate makefiles for OS X
     cd "sys/unix" do
-      if MacOS.version >= :yosemite
+      if MacOS.version >= :mojave
+        hintfile = "macosx10.14"
+      elsif MacOS.version >= :yosemite
         hintfile = "macosx10.10"
       else
         hintfile = "macosx10.7"
@@ -32,6 +34,13 @@ class Nethack < Formula
       inreplace "hints/#{hintfile}",
                 /^HACKDIR=.*/,
                 "HACKDIR=#{libexec}"
+
+      if MacOS.version >= :mojave
+        # Also build the new curses interface
+        inreplace "hints/#{hintfile}",
+                  /^#WANT_WIN_CURSES=1$/,
+                  "WANT_WIN_CURSES=1"
+      end
 
       system "sh", "setup.sh", "hints/#{hintfile}"
     end
@@ -52,5 +61,19 @@ class Nethack < Formula
     # These need to be group-writable in multi-user situations
     chmod "g+w", libexec
     chmod "g+w", libexec+"save"
+  end
+
+  if MacOS.version >= :mojave
+    def caveats
+      <<~EOS
+        You can activate the new curses interface using
+        NETHACKOPTIONS=windowtype:curses on the CLI or by editing your
+        options file at `~/Library/Preferences/NetHack Defaults.txt`
+      EOS
+    end
+  end
+
+  test do
+    system "#{bin}/nethack", "--version"
   end
 end


### PR DESCRIPTION
One of the new features of nethack 3.6.2 was the adoption of the curses
interface popular on several servers. This change just makes that
available if we're >= Mojave and displays the caveat for how you might
enable it.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----