### PR TITLE
ipmitool: sf.net site indicates it moved to github

### DIFF
--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -1,6 +1,6 @@
 class Ipmitool < Formula
   desc "Utility for IPMI control with kernel driver or LAN interface"
-  homepage "https://ipmitool.sourceforge.io/"
+  homepage "https://github.com/ipmitool/ipmitool"
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
   mirror "https://deb.debian.org/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"


### PR DESCRIPTION
https://ipmitool.sourceforge.io/ indicated it moved to https://github.com/ipmitool/ipmitool

Verified there is activity at https://github.com/ipmitool/ipmitool and the status of the latest release there (the same as it was on sourceforge: https://github.com/ipmitool/ipmitool/releases/tag/IPMITOOL_1_8_18)

Decided not to update the link to the archive as it has the same content as the old one (if someones thinks it needs to be updated: it is at https://github.com/ipmitool/ipmitool/archive/IPMITOOL_1_8_18.tar.gz )

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
