### PR TITLE
gtk-doc: install Pygments

### DIFF
--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -3,6 +3,7 @@ class GtkDoc < Formula
   homepage "https://www.gtk.org/gtk-doc/"
   url "https://download.gnome.org/sources/gtk-doc/1.30/gtk-doc-1.30.tar.xz"
   sha256 "a4f6448eb838ccd30d76a33b1fd095f81aea361f03b12c7b23df181d21b7069e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -20,7 +21,18 @@ class GtkDoc < Formula
   depends_on "python"
   depends_on "source-highlight"
 
+  resource "Pygments" do
+    url "https://files.pythonhosted.org/packages/1d/55/55cd82a72af652d71eb14f318e2d12d2fd14ded43d6fd105e50ed395198c/Pygments-2.4.0.tar.gz"
+    sha256 "31cba6ffb739f099a85e243eff8cb717089fdd3c7300767d9fc34cb8e1b065f5"
+  end
+
   def install
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
+    resource("Pygments").stage do
+      system "python3", *Language::Python.setup_install_args(libexec/"vendor")
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ gtkdoc-fixxref                                                                                                                                                                (git)-[master]
Traceback (most recent call last):
  File "/usr/local/Cellar/gtk-doc/1.30/libexec/bin/gtkdoc-fixxref", line 28, in <module>
    from gtkdoc import common, config, fixxref
  File "/usr/local/Cellar/gtk-doc/1.30/share/gtk-doc/python/gtkdoc/fixxref.py", line 28, in <module>
    from . import common, highlight
  File "/usr/local/Cellar/gtk-doc/1.30/share/gtk-doc/python/gtkdoc/highlight.py", line 28, in <module>
    from pygments import highlight
ModuleNotFoundError: No module named 'pygments'
```