### PR TITLE
kube-aws homepage update

### DIFF
--- a/Formula/kube-aws.rb
+++ b/Formula/kube-aws.rb
@@ -1,6 +1,6 @@
 class KubeAws < Formula
-  desc "CoreOS Kubernetes on AWS"
-  homepage "https://coreos.com/kubernetes/docs/latest/kubernetes-on-aws.html"
+  desc "A command-line tool to declaratively manage Kubernetes clusters on AWS"
+  homepage "https://kubernetes-incubator.github.io/kube-aws/"
   url "https://github.com/kubernetes-incubator/kube-aws.git",
       :tag      => "v0.12.3",
       :revision => "99cfc470a46e6c3c0121675ab41c01841849c077"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1580956/57584926-1e6bf080-74af-11e9-9e62-fee189de4b9d.png)

CoreOS has donated the project and currently maintained by k8s-incubator. 