### PR TITLE
cataclysm: cleanup formula

### DIFF
--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -24,8 +24,6 @@ class Cataclysm < Formula
   depends_on "sdl2_ttf"
 
   def install
-    ENV.cxx11
-
     args = %W[
       NATIVE=osx
       RELEASE=1
@@ -33,6 +31,9 @@ class Cataclysm < Formula
       USE_HOME_DIR=1
       TILES=1
       SOUND=1
+      RUNTESTS=0
+      ASTYLE=0
+      LINTJSON=0
     ]
 
     args << "CLANG=1" if ENV.compiler == :clang


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
#### Changes
 - Remove vestigial code
 - Set additional make environment variables to speed up build

#### Additional Context 
The `Process.kill` call in the test for this formula doesn't seem to be working, but I couldn't figure out how to fix it (my ruby's not too great).  However, the test still runs fine, you just have to exit the game manually.