### PR TITLE
Update Cromwell to v41

### DIFF
--- a/Formula/cromwell.rb
+++ b/Formula/cromwell.rb
@@ -1,8 +1,8 @@
 class Cromwell < Formula
   desc "Workflow Execution Engine using Workflow Description Language"
   homepage "https://github.com/broadinstitute/cromwell"
-  url "https://github.com/broadinstitute/cromwell/releases/download/40/cromwell-40.jar"
-  sha256 "8e1f9c8777bb3b860fd1bf6b6dc05a51145889620f0510cb2fa89aa7e1dfd3ec"
+  url "https://github.com/broadinstitute/cromwell/releases/download/41/cromwell-41.jar"
+  sha256 "a4cade2008858e6d088f2123c2026f2cc90e02fffee12b36c40be8ace235776d"
 
   head do
     url "https://github.com/broadinstitute/cromwell.git"
@@ -14,8 +14,8 @@ class Cromwell < Formula
   depends_on :java => "1.8+"
 
   resource "womtool" do
-    url "https://github.com/broadinstitute/cromwell/releases/download/40/womtool-40.jar"
-    sha256 "1904ebc87c605b4330ddd88770b522104d0bd506be2b9bcfe8424e90d38e4fb9"
+    url "https://github.com/broadinstitute/cromwell/releases/download/41/womtool-41.jar"
+    sha256 "d4c0f6130862fa57b0bc253772cfb9b59148d1e438c66ab6d9ce3773dd89d8ec"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm seeing unrelated errors running `brew audit --strict <formula>`:
```
[...]
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
[...]
An error occurred while installing unf_ext (0.0.7.6), and Bundler cannot continue.
Make sure that `gem install unf_ext -v '0.0.7.6' --source 'https://rubygems.org/'` succeeds before bundling.
[...]
```

I managed to make that "make sure that ... succeeds" command work, but apparently not from within the strict audit command.