### PR TITLE
Deprecate accelerate for openblas

### DIFF
--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -3,7 +3,7 @@ class Dynare < Formula
   homepage "https://www.dynare.org/"
   url "https://www.dynare.org/release/source/dynare-4.5.7.tar.xz"
   sha256 "9224ec5279d79d55d91a01ed90022e484f66ce93d56ca6d52933163f538715d4"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -30,8 +30,8 @@ class Dynare < Formula
   depends_on "libmatio"
   depends_on "metis"
   depends_on "octave"
+  depends_on "openblas"
   depends_on "suite-sparse"
-  depends_on "veclibfort"
 
   resource "slicot" do
     url "https://deb.debian.org/debian/pool/main/s/slicot/slicot_5.0+20101122.orig.tar.gz"

--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -3,6 +3,7 @@ class Hypre < Formula
   homepage "https://computation.llnl.gov/casc/hypre/software.html"
   url "https://github.com/hypre-space/hypre/archive/v2.16.0.tar.gz"
   sha256 "33f8a27041e697343b820d0426e74694670f955e21bbf3fcb07ee95b22c59e90"
+  revision 1
   head "https://github.com/hypre-space/hypre.git"
 
   bottle do
@@ -14,20 +15,10 @@ class Hypre < Formula
 
   depends_on "gcc" # for gfortran
   depends_on "open-mpi"
-  depends_on "veclibfort"
 
   def install
     cd "src" do
-      ENV["CC"] = ENV["MPICC"]
-      ENV["CXX"] = ENV["MPICXX"]
-
       system "./configure", "--prefix=#{prefix}",
-                            "--with-blas=yes",
-                            "--with-blas-libs=blas cblas",
-                            "--with-blas-lib-dirs=/usr/lib",
-                            "--with-lapack=yes",
-                            "--with-lapack-libs=lapack clapack f77lapack",
-                            "--with-lapack-lib-dirs=/usr/lib",
                             "--with-MPI",
                             "--enable-bigint"
       system "make", "install"

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,7 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-5.1.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/octave/octave-5.1.0.tar.xz"
   sha256 "87b4df6dfa28b1f8028f69659f7a1cabd50adfb81e1e02212ff22c863a29454e"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "c01c0bb0bc269810f92d603c7e3ca69c38707d6a23a0ce4ac58753b4cd9db3fa" => :mojave
@@ -24,7 +24,7 @@ class Octave < Formula
 
   # Complete list of dependencies at https://wiki.octave.org/Building
   depends_on "gnu-sed" => :build # https://lists.gnu.org/archive/html/octave-maintainers/2016-09/msg00193.html
-  depends_on :java => ["1.6+", :build]
+  depends_on :java => ["1.7+", :build]
   depends_on "pkg-config" => :build
   depends_on "arpack"
   depends_on "epstool"
@@ -42,6 +42,7 @@ class Octave < Formula
   depends_on "hdf5"
   depends_on "libsndfile"
   depends_on "libtool"
+  depends_on "openblas"
   depends_on "pcre"
   depends_on "portaudio"
   depends_on "pstoedit"
@@ -52,7 +53,6 @@ class Octave < Formula
   depends_on "suite-sparse"
   depends_on "sundials"
   depends_on "texinfo"
-  depends_on "veclibfort"
 
   # Dependencies use Fortran, leading to spurious messages about GCC
   cxxstdlib_check :skip
@@ -85,15 +85,16 @@ class Octave < Formula
                           "--with-hdf5-includedir=#{Formula["hdf5"].opt_include}",
                           "--with-hdf5-libdir=#{Formula["hdf5"].opt_lib}",
                           "--with-x=no",
-                          "--with-blas=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort",
+                          "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
                           "--with-portaudio",
                           "--with-sndfile"
     system "make", "all"
 
-    # Avoid revision bumps whenever fftw's or gcc's Cellar paths change
+    # Avoid revision bumps whenever fftw's, gcc's or OpenBLAS' Cellar paths change
     inreplace "src/mkoctfile.cc" do |s|
       s.gsub! Formula["fftw"].prefix.realpath, Formula["fftw"].opt_prefix
       s.gsub! Formula["gcc"].prefix.realpath, Formula["gcc"].opt_prefix
+      s.gsub! Formula["openblas"].prefix.realpath, Formula["openblas"].opt_prefix
     end
 
     # Make sure that Octave uses the modern texinfo at run time
@@ -105,7 +106,7 @@ class Octave < Formula
 
   test do
     system bin/"octave", "--eval", "(22/7 - pi)/pi"
-    # This is supposed to crash octave if there is a problem with veclibfort
+    # This is supposed to crash octave if there is a problem with BLAS
     system bin/"octave", "--eval", "single ([1+i 2+i 3+i]) * single ([ 4+i ; 5+i ; 6+i])"
   end
 end

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -57,6 +57,14 @@ class Octave < Formula
   # Dependencies use Fortran, leading to spurious messages about GCC
   cxxstdlib_check :skip
 
+  # Octave fails to build due to error with java. See also
+  # https://github.com/Homebrew/homebrew-core/issues/39848
+  # Patch submitted upstream at: https://savannah.gnu.org/patch/index.php?9806
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/octave/5.1.0-java-version.patch"
+    sha256 "7ea1e9b410a759fa136d153fb8482ecfc3425a39bfe71c1e71b3ff0f7d9a0b54"
+  end
+
   def install
     # Default configuration passes all linker flags to mkoctfile, to be
     # inserted into every oct/mex build. This is unnecessary and can cause
@@ -94,7 +102,6 @@ class Octave < Formula
     inreplace "src/mkoctfile.cc" do |s|
       s.gsub! Formula["fftw"].prefix.realpath, Formula["fftw"].opt_prefix
       s.gsub! Formula["gcc"].prefix.realpath, Formula["gcc"].opt_prefix
-      s.gsub! Formula["openblas"].prefix.realpath, Formula["openblas"].opt_prefix
     end
 
     # Make sure that Octave uses the modern texinfo at run time

--- a/Formula/qrupdate.rb
+++ b/Formula/qrupdate.rb
@@ -3,7 +3,7 @@ class Qrupdate < Formula
   homepage "https://sourceforge.net/projects/qrupdate/"
   url "https://downloads.sourceforge.net/qrupdate/qrupdate-1.1.2.tar.gz"
   sha256 "e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08"
-  revision 9
+  revision 10
 
   bottle do
     cellar :any
@@ -13,7 +13,7 @@ class Qrupdate < Formula
   end
 
   depends_on "gcc" # for gfortran
-  depends_on "veclibfort"
+  depends_on "openblas"
 
   def install
     # Parallel compilation not supported. Reported on 2017-07-21 at
@@ -21,7 +21,7 @@ class Qrupdate < Formula
     ENV.deparallelize
 
     system "make", "lib", "solib",
-                   "BLAS=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort"
+                   "BLAS=-L#{Formula["openblas"].opt_lib} -lopenblas"
 
     # Confuses "make install" on case-insensitive filesystems
     rm "INSTALL"
@@ -38,7 +38,7 @@ class Qrupdate < Formula
   test do
     system "gfortran", "-o", "test", pkgshare/"tch1dn.f", pkgshare/"utils.f",
                        "-L#{lib}", "-lqrupdate",
-                       "-L#{Formula["veclibfort"].opt_lib}", "-lvecLibFort"
+                       "-L#{Formula["openblas"].opt_lib}", "-lopenblas"
     assert_match "PASSED   4     FAILED   0", shell_output("./test")
   end
 end

--- a/Formula/suite-sparse.rb
+++ b/Formula/suite-sparse.rb
@@ -3,6 +3,7 @@ class SuiteSparse < Formula
   homepage "http://faculty.cse.tamu.edu/davis/suitesparse.html"
   url "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-5.3.0.tar.gz"
   sha256 "90e69713d8c454da5a95a839aea5d97d8d03d00cc1f667c4bdfca03f640f963d"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,6 +15,7 @@ class SuiteSparse < Formula
 
   depends_on "cmake" => :build
   depends_on "metis"
+  depends_on "openblas"
 
   conflicts_with "mongoose", :because => "suite-sparse vendors libmongoose.dylib"
 
@@ -24,7 +26,7 @@ class SuiteSparse < Formula
 
     args = [
       "INSTALL=#{prefix}",
-      "BLAS=-framework Accelerate",
+      "BLAS=-L#{Formula["openblas"].opt_lib} -lopenblas",
       "LAPACK=$(BLAS)",
       "MY_METIS_LIB=-L#{Formula["metis"].opt_lib} -lmetis",
       "MY_METIS_INC=#{Formula["metis"].opt_include}",
@@ -37,7 +39,8 @@ class SuiteSparse < Formula
 
   test do
     system ENV.cc, "-o", "test", pkgshare/"klu_simple.c",
-                   "-L#{lib}", "-lsuitesparseconfig", "-lklu"
-    system "./test"
+           "-L#{lib}", "-lsuitesparseconfig", "-lklu"
+    assert_predicate testpath/"test", :exist?
+    assert_match "x [0] = 1", shell_output("./test")
   end
 end

--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -3,6 +3,7 @@ class Sundials < Formula
   homepage "https://computation.llnl.gov/casc/sundials/main.html"
   url "https://computation.llnl.gov/projects/sundials/download/sundials-4.1.0.tar.gz"
   sha256 "280de1c27b2360170a6f46cb3799b2aee9dff3bddbafc8b08c291a47ab258aa5"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,11 +15,11 @@ class Sundials < Formula
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
   depends_on "open-mpi"
+  depends_on "openblas"
   depends_on "suite-sparse"
-  depends_on "veclibfort"
 
   def install
-    blas = "-L#{Formula["veclibfort"].opt_lib} -lvecLibFort"
+    blas = "-L#{Formula["openblas"].opt_lib} -lopenblas"
     args = std_cmake_args + %W[
       -DCMAKE_C_COMPILER=#{ENV["CC"]}
       -DBUILD_SHARED_LIBS=ON
@@ -26,6 +27,7 @@ class Sundials < Formula
       -DKLU_LIBRARY_DIR=#{Formula["suite-sparse"].opt_lib}
       -DKLU_INCLUDE_DIR=#{Formula["suite-sparse"].opt_include}
       -DLAPACK_ENABLE=ON
+      -DBLA_VENDOR=OpenBLAS
       -DLAPACK_LIBRARIES=#{blas};#{blas}
       -DMPI_ENABLE=ON
     ]

--- a/Formula/superlu.rb
+++ b/Formula/superlu.rb
@@ -3,7 +3,7 @@ class Superlu < Formula
   homepage "https://crd-legacy.lbl.gov/~xiaoye/SuperLU/"
   url "https://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_5.2.1.tar.gz"
   sha256 "28fb66d6107ee66248d5cf508c79de03d0621852a0ddeba7301801d3d859f463"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +14,8 @@ class Superlu < Formula
     sha256 "a20af0692236e73bce9cdd4c659ba7b0c98d7dbaf2953bbf0eae4255abec0e1d" => :el_capitan
   end
 
-  depends_on "veclibfort"
+  depends_on "gcc"
+  depends_on "openblas"
 
   def install
     ENV.deparallelize
@@ -23,9 +24,12 @@ class Superlu < Formula
     args = ["SuperLUroot=#{buildpath}",
             "SUPERLULIB=$(SuperLUroot)/lib/libsuperlu.a",
             "CC=#{ENV.cc}",
-            "BLASLIB=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort"]
+            "BLASLIB=-L#{Formula["openblas"].opt_lib} -lopenblas"]
 
     system "make", "lib", *args
+    cd "EXAMPLE" do
+      system "make", *args
+    end
     lib.install Dir["lib/*"]
     (include/"superlu").install Dir["SRC/*.h"]
     doc.install Dir["Doc/*"]
@@ -38,7 +42,7 @@ class Superlu < Formula
   test do
     system ENV.cc, pkgshare/"dlinsol.c", "-o", "test",
                    "-I#{include}/superlu", "-L#{lib}", "-lsuperlu",
-                   "-L#{Formula["veclibfort"].opt_lib}", "-lvecLibFort"
+                   "-L#{Formula["openblas"].opt_lib}", "-lopenblas"
     assert_match "No of nonzeros in L+U = 11886",
                  shell_output("./test < #{pkgshare}/g20.rua")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

PR for https://github.com/Homebrew/homebrew-core/issues/39226

It might be wise to also set `-DBLA_VENDOR=OpenBLAS` in the `std_cmake_args`... this might also break all the things, not sure. ¯\\_(ツ)\_/¯ 