### PR TITLE
msmtp 1.8.4

### DIFF
--- a/Formula/msmtp.rb
+++ b/Formula/msmtp.rb
@@ -1,8 +1,8 @@
 class Msmtp < Formula
   desc "SMTP client that can be used as an SMTP plugin for Mutt"
   homepage "https://marlam.de/msmtp/"
-  url "https://marlam.de/msmtp/releases/msmtp-1.8.3.tar.xz"
-  sha256 "3cb2eefd33d048f0f82de100ef39a494e44fd1485e376ead31f733d2f36b92b4"
+  url "https://marlam.de/msmtp/releases/msmtp-1.8.4.tar.xz"
+  sha256 "e5dd7fe95bc8e2f5eea3e4894ec9628252f30bd700a7fd1a568b10efa91129f7"
 
   bottle do
     cellar :any
@@ -12,14 +12,15 @@ class Msmtp < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "gnutls"
 
   def install
     args = %W[
+      --disable-debug
       --disable-dependency-tracking
+      --disable-silent-rules
       --with-macosx-keyring
       --prefix=#{prefix}
-      --with-tls=openssl
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Switching dependency from `openssl` to `gnutls` because [the upstream developer strongly discourages use of `openssl` instead of `gnutls`](https://marlam.de/msmtp/news/openssl-discouraged/), suggesting that `openssl` support may be dropped sometime in the future.

> I have given up on OpenSSL years ago and will not work to improve and update the OpenSSL-related code in msmtp. If someone wants to do that work, I will accept patches, but I will continue to recommend using GnuTLS instead. If the OpenSSL support in msmtp remains in its current state, it will eventually be removed.