### PR TITLE
xplanet : added support for gif, jpg and tiff

### DIFF
--- a/Formula/xplanet.rb
+++ b/Formula/xplanet.rb
@@ -3,7 +3,7 @@ class Xplanet < Formula
   homepage "https://xplanet.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/xplanet/xplanet/1.3.1/xplanet-1.3.1.tar.gz"
   sha256 "4380d570a8bf27b81fb629c97a636c1673407f4ac4989ce931720078a90aece7"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "08b96065da38ab4b0783d6b49cdba670276690a1024557ec3d1aff2de475c3b0" => :mojave
@@ -40,10 +40,9 @@ class Xplanet < Formula
                           "--with-aqua",
                           "--without-cspice",
                           "--without-cygwin",
-                          "--without-gif",
-                          "--without-jpeg",
-                          "--without-libpng",
-                          "--without-libtiff",
+                          "--with-gif",
+                          "--with-jpeg",
+                          "--with-libtiff",
                           "--without-pango",
                           "--without-pnm",
                           "--without-x",
@@ -52,7 +51,11 @@ class Xplanet < Formula
     system "make", "install"
   end
 
+  # Test all the supported image formats, jpg, png, gif and tiff, as well as the -num_times 2 patch
   test do
-    system "#{bin}/xplanet", "-geometry", "4096x2160", "-projection", "mercator", "-gmtlabel", "-num_times", "1", "-output", "#{testpath}/xp-test.png"
+    system "#{bin}/xplanet", "-target", "earth", "-output", "#{testpath}/test.jpg", "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system "#{bin}/xplanet", "-target", "earth", "--transpng", "#{testpath}/test.png", "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system "#{bin}/xplanet", "-target", "earth", "--output", "#{testpath}/test.gif", "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system "#{bin}/xplanet", "-target", "earth", "--output", "#{testpath}/test.tiff", "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
   end
 end


### PR DESCRIPTION
Hi,

This fix to xplanet is adding support for the following image formats : JPG, GIF, TIFF, which were not included in the configure options despite being listed in the dependancies.

The test covers all of the aforementioned formats (as well as PNG) and the patch for the `-num_times 2` option.

`brew test xplanet` and `brew audit --strict xplanet` are running just fine.