### PR TITLE
Fix issue with PG upgrade command when `initdb` fails

### DIFF
--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -64,8 +64,8 @@ begin
 
   sql_for_lc_collate = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate';"
   sql_for_lc_ctype = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_ctype';"
-  lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).gsub(/Time: ([\d.])+ ms/, "").strip
-  lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_ctype).gsub(/Time: ([\d.])+ ms/, "").strip
+  lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAX", "-U", ENV["USER"], "-c", sql_for_lc_collate)
+  lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAX", "-U", ENV["USER"], "-c", sql_for_lc_ctype)
   initdb_args = []
   initdb_args += ["--lc-collate", lc_collate] unless lc_collate.empty?
   initdb_args += ["--lc-ctype", lc_ctype] unless lc_ctype.empty?

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -79,7 +79,7 @@ begin
   moved_data = true
 
   (var/"postgres").mkpath
-  system "#{bin}/initdb", *initdb_args, "#{var}/postgres"
+  safe_system "#{bin}/initdb", *initdb_args, "#{var}/postgres"
   initdb_run = true
 
   (var/"log").cd do

--- a/cmd/brew-postgresql-upgrade-database.rb
+++ b/cmd/brew-postgresql-upgrade-database.rb
@@ -64,8 +64,8 @@ begin
 
   sql_for_lc_collate = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_collate';"
   sql_for_lc_ctype = "SELECT setting FROM pg_settings WHERE name LIKE 'lc_ctype';"
-  lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).strip
-  lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_ctype).strip
+  lc_collate = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_collate).gsub(/Time: ([\d.])+ ms/, "").strip
+  lc_ctype = Utils.popen_read("#{old_bin}/psql", "postgres", "-qtAc", sql_for_lc_ctype).gsub(/Time: ([\d.])+ ms/, "").strip
   initdb_args = []
   initdb_args += ["--lc-collate", lc_collate] unless lc_collate.empty?
   initdb_args += ["--lc-ctype", lc_ctype] unless lc_ctype.empty?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **NB: not a formula**
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **NB: not a formula**
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **NB: not a formula**

-----

This morning I attempted to upgrade my local PostgreSQL version from 10 -> 11 using Homebrew and the `brew postgresql-upgrade-database` command. It failed on me and ended up corrupting some data. I spent a good time debugging this and it turns out some small edits to the command could've prevented the issue, which I'm submitting here.

The first commit uses a regex to strip out extra timing information that can be returned from the `pgsql` command.

The upgrade command queries the database for some information before calling `initdb` here: https://github.com/Homebrew/homebrew-core/blob/a326c8dd5bf9efae9eb880c8d00094d7ab5d1ac9/cmd/brew-postgresql-upgrade-database.rb#L67-L68

These lines expect an output that looks something like this: `en_US.UTF-8\n`.

The problem is in my `~/.psqlrc` I have this:

```pg
-- Show how long each query takes to execute
\timing
```

So the output actually looks something like this: `en_US.UTF-8\nTime: 1.471 ms`. That, of course, is an invalid locale. 

The second commit uses `safe_system` over `system` to catch errors with the `initdb` call.

After the `initdb` command failed, the script keeps running, which sets `initdb_run` to `true`. That happens here: https://github.com/Homebrew/homebrew-core/blob/af4911631eeab0bcee5d71ad0c5f371fe172882b/cmd/brew-postgresql-upgrade-database.rb#L83

The entire `postgresql-upgrade-database` command doesn't fail until the `pg_upgrade` call. (It fails to find the version file since `initdb` fails.) That happens here: https://github.com/Homebrew/homebrew-core/blob/a326c8dd5bf9efae9eb880c8d00094d7ab5d1ac9/cmd/brew-postgresql-upgrade-database.rb#L86-L92

Because `initdb_run` is `true`, when we get to the failure and invoke the `ensure` block, we end up removing the `datadir`. Using `safe_system` instead fixes this.

<details> 
<summary>For reference, here are the full install logs from when I encountered the described errors</summary>
<p>

```
$ brew postgresql-upgrade-database
==> brew install postgresql@10
==> Downloading https://homebrew.bintray.com/bottles/postgresql@10-10.6_2.mojave.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/59/5967e87fa3e33b7781e8dfa5bc9282eb0d16c32c90a07ff887433ea0da2aa6c1?__
######################################################################## 100.0%
==> Pouring postgresql@10-10.6_2.mojave.bottle.tar.gz
==> /usr/local/Cellar/postgresql@10/10.6_2/bin/initdb /usr/local/var/postgresql@10
==> Caveats
To migrate existing data from a previous major version of PostgreSQL run:
  brew postgresql-upgrade-database

postgresql@10 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

If you need to have postgresql@10 first in your PATH run:
  echo 'export PATH="/usr/local/opt/postgresql@10/bin:$PATH"' >> ~/.zshrc

For compilers to find postgresql@10 you may need to set:
  export LDFLAGS="-L/usr/local/opt/postgresql@10/lib"
  export CPPFLAGS="-I/usr/local/opt/postgresql@10/include"

For pkg-config to find postgresql@10 you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/postgresql@10/lib/pkgconfig"


To have launchd start postgresql@10 now and restart at login:
  brew services start postgresql@10
Or, if you don't want/need a background service you can just run:
  pg_ctl -D /usr/local/var/postgresql@10 start
==> Summary
🍺  /usr/local/Cellar/postgresql@10/10.6_2: 1,706 files, 20.7MB
==> Upgrading postgresql data from 10 to 11...
Stopping `postgresql`... (might take a while)
==> Successfully stopped `postgresql` (label: homebrew.mxcl.postgresql)
pg_ctl: another server might be running; trying to start server anyway
waiting for server to start....2019-05-15 07:57:38.082 CDT [7379] LOG:  listening on IPv6 address "::1", port 5432
2019-05-15 07:57:38.082 CDT [7379] LOG:  listening on IPv4 address "127.0.0.1", port 5432
2019-05-15 07:57:38.083 CDT [7379] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2019-05-15 07:57:38.124 CDT [7380] LOG:  database system was interrupted; last known up at 2019-05-15 07:55:51 CDT
2019-05-15 07:57:38.735 CDT [7380] LOG:  database system was not properly shut down; automatic recovery in progress
2019-05-15 07:57:38.742 CDT [7380] LOG:  redo starts at 0/D40A248
2019-05-15 07:57:38.743 CDT [7380] LOG:  invalid record length at 0/D41ECC0: wanted 24, got 0
2019-05-15 07:57:38.743 CDT [7380] LOG:  redo done at 0/D41EC88
2019-05-15 07:57:38.743 CDT [7380] LOG:  last completed transaction was at log time 2019-05-15 07:56:09.930523-05
2019-05-15 07:57:38.763 CDT [7379] LOG:  database system is ready to accept connections
 done
server started
waiting for server to shut down....2019-05-15 07:57:38.847 CDT [7379] LOG:  received fast shutdown request
2019-05-15 07:57:38.847 CDT [7379] LOG:  aborting any active transactions
2019-05-15 07:57:38.848 CDT [7379] LOG:  worker process: logical replication launcher (PID 7386) exited with exit code 1
2019-05-15 07:57:38.848 CDT [7381] LOG:  shutting down
2019-05-15 07:57:38.853 CDT [7379] LOG:  database system is shut down
 done
server stopped
==> Moving postgresql data from /usr/local/var/postgres to /usr/local/var/postgres.old...
The files belonging to this database system will be owned by user "loganleger".
This user must also own the server process.

initdb: invalid locale name "en_US.UTF-8
Time: 1.471 ms"

could not open version file: /usr/local/var/postgres/PG_VERSION
Failure, exiting
Error: Upgrading postgresql data from 10 to 11 failed!
==> Removing empty postgresql initdb database...
==> Moving postgresql data back from /usr/local/var/postgres.old to /usr/local/var/postgres...
==> Successfully started `postgresql` (label: homebrew.mxcl.postgresql)
Error: Failure while executing; `/usr/local/opt/postgresql/bin/pg_upgrade -r -b /usr/local/Cellar/postgresql@10/10.6_2/bin -B /usr/local/opt/postgresql/bin -d /usr/local/var/postgres.old -D /usr/local/var/postgres -j 12` exited with 1.
```
</p>
</details>