### PR TITLE
libelf 0.8.12 (downgrade to solve linkrot)

### DIFF
--- a/Formula/libelf.rb
+++ b/Formula/libelf.rb
@@ -1,9 +1,9 @@
 class Libelf < Formula
   desc "ELF object file access library"
-  homepage "http://www.mr511.de/software/"
-  url "http://www.mr511.de/software/libelf-0.8.13.tar.gz"
-  sha256 "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d"
-  revision 1
+  homepage "https://github.com/WolfgangSt/libelf"
+  url "https://github.com/WolfgangSt/libelf.git",
+      :revision => "dbbf0eddb1f7d243f5f909cba13597ad76fc4fcb"
+  version "0.8.12"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Fixes #39870. Contradicts #39871 -- and keeps all the dependents that one removes working.

http://www.mr511.de/software/ is dead; it 301s to http://leere.seite/ which is not a website.
Apparently linux has moved on from this libelf; now libelf is part of https://sourceware.org/elfutils/
However that library depends on glibc, so it can't work on Darwin.

This points libelf at a mirror someone made 10 years ago on github,
which is one point release behind where libelf was, but that should...be...okay...hopefully.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The only audit this fails is
>   * stable version should not decrease (from 0.8.13 to 0.8.12)

which is unfortunate but unavoidable unless someone finds a more recent mirror. I doubt it's a huge problem though since it's only a single patch release behind. I don't know. testing welcome I guess?

It might be a good idea to fork that libelf mirror into someone related to the homebrew project to make sure it stays online.