### PR TITLE
makensis 3.04: Increase max string length to match special builds

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -28,6 +28,7 @@ class Makensis < Formula
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
       "STRIP=0",
       "VERSION=#{version}",
+      "NSIS_MAX_STRLEN=8192",
     ]
     system "scons", "makensis", *args
     bin.install "build/urelease/makensis/makensis"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds the `NSIS_MAX_STRLEN=8192` build argument to match a [special build from upstream](https://nsis.sourceforge.io/Special_Builds#Large_strings) and to match the [package for Fedora/Red Hat Enterprise Linux](https://src.fedoraproject.org/rpms/mingw-nsis/blob/master/f/mingw-nsis.spec#_1) to increase usability of this formula (this used to be an option for installation via brew, but that was removed at some point).