### PR TITLE
atlantis 0.7.2 (new formula)

### DIFF
--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -4,6 +4,7 @@ class Atlantis < Formula
   url "https://github.com/runatlantis/atlantis/archive/v0.7.2.tar.gz"
   sha256 "ecb0068f6ee1cacc4710b4f77e67b88e5d6b5d1dfae3bf6ce480980c93efa50d"
   depends_on "go" => :build
+  depends_on "curl" => :test
   depends_on "terraform"
 
   def install
@@ -21,5 +22,13 @@ class Atlantis < Formula
 
   test do
     system bin/"atlantis", "version"
+    port = 4141
+    loglevel = "info"
+    gh_args = "--gh-user INVALID --gh-token INVALID --gh-webhook-secret INVALID --repo-whitelist INVALID"
+    command = bin/"atlantis server --atlantis-url http://in.va.lid --port #{port} #{gh_args} --log-level #{loglevel}"
+    pid = Process.spawn(command)
+    system "sleep", "5"
+    system "curl", "-vk#", "http://localhost:4141/"
+    Process.kill("TERM", pid)
   end
 end

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -15,7 +15,6 @@ class Atlantis < Formula
     cd dir do
       system "go", "build", "-o", "atlantis"
       bin.install "atlantis"
-      prefix.install_metafiles
     end
   end
 
@@ -27,7 +26,7 @@ class Atlantis < Formula
     command = bin/"atlantis server --atlantis-url http://in.va.lid --port #{port} #{gh_args} --log-level #{loglevel}"
     pid = Process.spawn(command)
     system "sleep", "5"
-    system "curl", "-vk#", "http://localhost:4141/"
+    system "curl", "-vk#", "http://localhost:#{port}/"
     Process.kill("TERM", pid)
   end
 end

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -27,7 +27,7 @@ class Atlantis < Formula
     pid = Process.spawn(command)
     system "sleep", "5"
     output = `curl -vk# 'http://localhost:#{port}/' 2>&1`
-    assert_match /HTTP\/1.1 200 OK/m, output
+    assert_match %r{HTTP\/1.1 200 OK}m, output
     assert_match "atlantis", output
     Process.kill("TERM", pid)
   end

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -1,0 +1,25 @@
+class Atlantis < Formula
+  desc "Terraform Pull Request Automation tool"
+  homepage "https://www.runatlantis.io"
+  url "https://github.com/runatlantis/atlantis/archive/v0.7.2.tar.gz"
+  sha256 "ecb0068f6ee1cacc4710b4f77e67b88e5d6b5d1dfae3bf6ce480980c93efa50d"
+  depends_on "go" => :build
+  depends_on "terraform"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = "src/github.com/runatlantis/atlantis"
+    build_dir = buildpath/dir
+    build_dir.install buildpath.children
+
+    cd dir do
+      system "go", "build", "-o", "atlantis"
+      bin.install "atlantis"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system bin/"atlantis", "version"
+  end
+end

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -26,7 +26,9 @@ class Atlantis < Formula
     command = bin/"atlantis server --atlantis-url http://in.va.lid --port #{port} #{gh_args} --log-level #{loglevel}"
     pid = Process.spawn(command)
     system "sleep", "5"
-    system "curl", "-vk#", "http://localhost:#{port}/"
+    output = `curl -vk# 'http://localhost:#{port}/' 2>&1`
+    assert_match /HTTP\/1.1 200 OK/m, output
+    assert_match "atlantis", output
     Process.kill("TERM", pid)
   end
 end

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -4,7 +4,6 @@ class Atlantis < Formula
   url "https://github.com/runatlantis/atlantis/archive/v0.7.2.tar.gz"
   sha256 "ecb0068f6ee1cacc4710b4f77e67b88e5d6b5d1dfae3bf6ce480980c93efa50d"
   depends_on "go" => :build
-  depends_on "curl" => :test
   depends_on "terraform"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add formulae for runatlantis.io v0.7.2

Atlantis is a Terraform Pull Request Automation tool

Atlantis is an application for automating Terraform via pull requests.
It is deployed as a standalone application into your infrastructure.
No third-party has access to your credentials.

Atlantis listens for GitHub, GitLab or Bitbucket webhooks about
Terraform pull requests. It then runs terraform plan and comments with
the output back on the pull request.

When you want to _apply_, comment `atlantis apply` on the _pull request_ and 
Atlantis will run `terraform apply` and comment back with the output.

Highlights:

- Depends on Terraform
- Main website: https://runatlantis.io
- Git repository: https://github.com/runatlantis/atlantis.git
- Releases Website: https://github.com/runatlantis/atlantis/releases