### PR TITLE
ivykis 0.42.4

### DIFF
--- a/Formula/ivykis.rb
+++ b/Formula/ivykis.rb
@@ -1,8 +1,9 @@
 class Ivykis < Formula
   desc "Async I/O-assisting library"
   homepage "https://sourceforge.net/projects/libivykis"
-  url "https://downloads.sourceforge.net/project/libivykis/0.42.3/ivykis-0.42.3.tar.gz"
-  sha256 "c9b025d55cefe9c58958d1012f36d63aa0a5caf22075617fff648751ea940aec"
+  url "https://github.com/buytenh/ivykis/archive/v0.42.4-trunk.tar.gz"
+  version "0.42.4"
+  sha256 "b724516d6734f4d5c5f86ad80bde8fc7213c5a70ce2d46b9a2d86e8d150402b5"
 
   bottle do
     cellar :any
@@ -19,6 +20,8 @@ class Ivykis < Formula
   def install
     system "autoreconf", "-i"
     system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates ivykis to version 0.42.4.

Note:
I had to change the `url` and use the GitHub trunk archive, because the original tarball contains autotools-generated scripts that do not work on macOS:
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/42145/

I don't think this is an issue with ivykis, because regenerating those scripts with a newer version of autotools fixes the problem.