### PR TITLE
goreleaser: use go modules

### DIFF
--- a/Formula/goreleaser.rb
+++ b/Formula/goreleaser.rb
@@ -1,8 +1,9 @@
 class Goreleaser < Formula
   desc "Deliver Go binaries as fast and easily as possible"
   homepage "https://goreleaser.com/"
-  url "https://github.com/goreleaser/goreleaser/archive/v0.109.0.tar.gz"
-  sha256 "ec48ff424ce1b35144f0fbad22e74029bfe657b3582309a0a198ff74f34afa96"
+  url "https://github.com/goreleaser/goreleaser.git",
+      :tag      => "v0.109.0",
+      :revision => "7ee486fc9b58171e70eec99ecdbeac4c99cc82d0"
 
   bottle do
     cellar :any_skip_relocation
@@ -23,7 +24,7 @@ class Goreleaser < Formula
     cd dir do
       system "go", "mod", "vendor"
       system "go", "build", "-ldflags",
-                   "-s -w -X main.version=#{version} -X main.builtBy=homebrew",
+                   "-s -w -X main.version=#{version} -X main.commit=#{stable.specs[:revision]} -X main.builtBy=homebrew",
                    "-o", bin/"goreleaser"
       prefix.install_metafiles
     end

--- a/Formula/goreleaser.rb
+++ b/Formula/goreleaser.rb
@@ -1,8 +1,8 @@
 class Goreleaser < Formula
   desc "Deliver Go binaries as fast and easily as possible"
   homepage "https://goreleaser.com/"
-  url "https://github.com/goreleaser/goreleaser/archive/v0.107.0.tar.gz"
-  sha256 "254dd8fc5c2055048d382c0107f0d9d3d2b4b361c6e18691eac373e380d2cdca"
+  url "https://github.com/goreleaser/goreleaser/archive/v0.109.0.tar.gz"
+  sha256 "ec48ff424ce1b35144f0fbad22e74029bfe657b3582309a0a198ff74f34afa96"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/goreleaser.rb
+++ b/Formula/goreleaser.rb
@@ -14,10 +14,16 @@ class Goreleaser < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/goreleaser/goreleaser").install buildpath.children
-    cd "src/github.com/goreleaser/goreleaser" do
-      system "go", "build", "-ldflags", "-X main.version=#{version}",
+    ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "on"
+
+    dir = buildpath/"src/github.com/goreleaser/goreleaser"
+    dir.install buildpath.children
+
+    cd dir do
+      system "go", "mod", "vendor"
+      system "go", "build", "-ldflags",
+                   "-s -w -X main.version=#{version} -X main.builtBy=homebrew",
                    "-o", bin/"goreleaser"
       prefix.install_metafiles
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixed the formula to use go modules and also added additional ldflags.

I would also like to pass `-X main.commit=d9e89f69c72cec19014fdcee327eedc92950b92a -X main.date=2019-05-19T14:06:26Z` but I don't know how to get this information in the formula...

refs https://github.com/goreleaser/goreleaser/issues/1019
