### PR TITLE
Update Io formula URL and build steps

### DIFF
--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -22,10 +22,6 @@ class Io < Formula
     # FSF GCC needs this to build the ObjC bridge
     ENV.append_to_cflags "-fobjc-exceptions"
 
-    # Turn off all add-ons in main cmake file
-    inreplace "CMakeLists.txt", "add_subdirectory(addons)",
-                                "#add_subdirectory(addons)"
-
     mkdir "buildroot" do
       system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
                             "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -31,6 +31,13 @@ class Io < Formula
     end
   end
 
+  def caveats; <<~EOS
+    Make sure to update your shell's environment variables before using Eerie, like:
+      EERIEDIR=~/.eerie
+      PATH=$PATH:$EERIEDIR/base/bin:$EERIEDIR/activeEnv/bin
+  EOS
+  end
+
   test do
     (testpath/"test.io").write <<~EOS
       "it works!" println

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -36,6 +36,12 @@ class Io < Formula
     Make sure to update your shell's environment variables before using Eerie, like:
       EERIEDIR=~/.eerie
       PATH=$PATH:$EERIEDIR/base/bin:$EERIEDIR/activeEnv/bin
+
+    When running eerie for the first time, you may encounter an error like:
+      Exception: unable to open file path '/home/<user>/.eerie/config.json': Permission denied
+
+    If this occurs, this is because the ~/.eerie/ folder isn't accessible due to your user permissions. To fix this, go to your home folder and run:
+      sudo chown -R <your username> ~/.eerie/
   EOS
   end
 

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -25,6 +25,7 @@ class Io < Formula
     mkdir "buildroot" do
       system "cmake", "..", "-DCMAKE_DISABLE_FIND_PACKAGE_ODE=ON",
                             "-DCMAKE_DISABLE_FIND_PACKAGE_Theora=ON",
+                            "-DCMAKE_BUILD_TYPE=release",
                             *std_cmake_args
       system "make"
       system "make", "install"

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -1,9 +1,9 @@
 class Io < Formula
   desc "Small prototype-based programming language"
   homepage "http://iolanguage.com/"
-  url "https://github.com/stevedekorte/io/archive/2017.09.06.tar.gz"
+  url "https://github.com/IoLanguage/io/archive/2017.09.06.tar.gz"
   sha256 "9ac5cd94bbca65c989cd254be58a3a716f4e4f16480f0dc81070457aa353c217"
-  head "https://github.com/stevedekorte/io.git"
+  head "https://github.com/IoLanguage/io.git"
 
   bottle do
     sha256 "9e628fa0879d7d2e370ae5275393d1d52b578f6f10d3f005faf9d0360caf8851" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, running `brew install io --HEAD` results in a build error during the `inreplace` line as that line was removed by a pull request merged into the Io codebase last year that incorporated, Eerie, a new package manager (IoLanguage/io#411). This PR removes that line and adds a cavaets section – that mostly borrows from Io's [install docs](https://github.com/IoLanguage/io#linux-build-instructions) – about configuring a user's `PATH` variable to set up Eerie.

In addition, I updated the GitHub URLs in the formula, as Io's canonical Github link is now https://github.com/IoLanguage/io/, not https://github.com/stevedekorte/io. This was changed in [March last year](https://github.com/IoLanguage/io/issues/400#issuecomment-372139903). Note that https://github.com/stevedekorte/io redirects to https://github.com/IoLanguage/io, which is why this formula continued to work after the change.