### PR TITLE
argon2: add the `PREFIX` parameter for make

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -14,7 +14,7 @@ class Argon2 < Formula
   end
 
   def install
-    system "make"
+    system "make", "PREFIX=#{prefix}"
     system "make", "test"
     system "make", "install", "PREFIX=#{prefix}"
     doc.install "argon2-specs.pdf"

--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -3,6 +3,7 @@ class Argon2 < Formula
   homepage "https://github.com/P-H-C/phc-winner-argon2"
   url "https://github.com/P-H-C/phc-winner-argon2/archive/20171227.tar.gz"
   sha256 "eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8"
+  revision 1
   head "https://github.com/P-H-C/phc-winner-argon2.git"
 
   bottle do


### PR DESCRIPTION
Signed-off-by: Jim Yeh <jim@bitmark.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up PR for https://github.com/Homebrew/homebrew-core/pull/39029. The Makefile of that project has updated. It takes an additional `PREFIX` parameter for `make` to substitute prefix variable in pc file.