### PR TITLE
cockroach 19.1.1

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,9 +1,9 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/cockroach-v2.1.6.src.tgz"
-  version "2.1.6"
-  sha256 "04a399a619fc898fbd457c60784416e17af22b05f02be101b2fe64c536163eeb"
+  url "https://binaries.cockroachdb.com/cockroach-v19.1.1.src.tgz"
+  version "19.1.1"
+  sha256 "cc05d2f0a4310d23007985a91a2e3ac4ab17b9cd853934536228e6e4812c7fed"
   head "https://github.com/cockroachdb/cockroach.git"
 
   bottle do
@@ -18,6 +18,17 @@ class Cockroach < Formula
   depends_on "go" => :build
   depends_on "make" => :build
   depends_on "xz" => :build
+
+  # Compiling CockroachDB v19.1 with Go 1.12 changes the behavior of setrlimit
+  # in a way that causes CockroachDB to crash upon startup if kern.maxfiles is
+  # too low. This patch backports the upstream fix from
+  # cockroachdb/cockroach#37705, which will be included in the next release.
+  # Note that the pull request patch cannot be used directly, as the paths in
+  # the release tarball do not exactly match the paths in the Git repository.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/cockroach/v19.1.1-kern-maxfiles-w-go-1.12.patch"
+    sha256 "7735ef5d3598214100f0bb3dbb718a499386987b99296ceb9c9f97a3945fd0ba"
+  end
 
   def install
     # The GNU Make that ships with macOS Mojave (v3.81 at the time of writing) has a bug
@@ -88,6 +99,15 @@ class Cockroach < Formula
         id,balance
         1,1000.50
       EOS
+    rescue => e
+      # If an error occurs, attempt to print out any messages from the
+      # server.
+      begin
+        $stderr.puts "server messages:", File.read("start.out")
+      rescue
+        $stderr.puts "unable to load messages from start.out"
+      end
+      raise e
     ensure
       system "#{bin}/cockroach", "quit", "--insecure"
     end


### PR DESCRIPTION
Additionally adjust the test so that it prints output from the server if
the test fails.

This intentionally duplicates #40103, with the hope of getting a better error message from CI.