### PR TITLE
radare2 3.5.1

### DIFF
--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -1,21 +1,10 @@
 class Radare2 < Formula
   desc "Reverse engineering framework"
   homepage "https://radare.org"
-  revision 1
 
   stable do
-    url "https://radare.mikelloc.com/get/2.8.0/radare2-2.8.0.tar.gz"
-    sha256 "015c0b54cbeab2f055ca45ea57675ac5fcddb9be788249143e20bb64554a769e"
-
-    resource "bindings" do
-      url "https://radare.mikelloc.com/get/2.8.0/radare2-bindings-2.8.0.tar.gz"
-      sha256 "4a3b6e8101093033342e862b6834c92072bc6d902583dbca36b45a4684a4d40f"
-    end
-
-    resource "extras" do
-      url "https://radare.mikelloc.com/get/2.8.0/radare2-extras-2.8.0.tar.gz"
-      sha256 "f11f16faec355eddc509e3615e42b5c9de565858d68790a5c7591b6525488f75"
-    end
+    url "https://radare.mikelloc.com/get/3.5.1/radare2-3.5.1.tar.gz"
+    sha256 "bc927aec4d29fa647fdc56afc2d7b04bf47c2234a43d0080f356705748299d9c"
   end
 
   bottle do
@@ -26,103 +15,12 @@ class Radare2 < Formula
 
   head do
     url "https://github.com/radare/radare2.git"
-
-    resource "bindings" do
-      url "https://github.com/radare/radare2-bindings.git"
-    end
-
-    resource "extras" do
-      url "https://github.com/radare/radare2-extras.git"
-    end
   end
 
-  depends_on "gobject-introspection" => :build
-  depends_on "pkg-config" => :build
-  depends_on "swig" => :build
-  depends_on "valabind" => :build
-
-  depends_on "gmp"
-  depends_on "jansson"
-  depends_on "libewf"
-  depends_on "libmagic"
-  depends_on "lua"
-  depends_on "openssl"
-  depends_on "yara"
-
   def install
-    # Build Radare2 before bindings, otherwise compile = nope.
-    system "./configure", "--prefix=#{prefix}", "--with-openssl"
-    system "make", "CS_PATCHES=0"
-    ENV.deparallelize { system "make", "install" }
-
-    # remove leftover symlinks
-    # https://github.com/radare/radare2/issues/8688
-    rm_f bin/"r2-docker"
-    rm_f bin/"r2-indent"
-
-    resource("extras").stage do
-      ENV.append_path "PATH", bin
-      ENV.append_path "PKG_CONFIG_PATH", "#{lib}/pkgconfig"
-      (lib/"radare2/#{version}").mkpath
-
-      system "./configure", "--prefix=#{prefix}"
-      system "make", "R2PM_PLUGDIR=#{lib}/radare2/#{version}", "all"
-      system "make", "R2PM_PLUGDIR=#{lib}/radare2/#{version}", "install"
-    end
-
-    resource("bindings").stage do
-      ENV.append_path "PATH", bin
-      ENV.append_path "PKG_CONFIG_PATH", "#{lib}/pkgconfig"
-
-      # Language versions.
-      perl_version = `/usr/bin/perl -e 'printf "%vd", $^V;'`
-      lua_version = Formula["lua"].version.to_s.match(/\d\.\d/)
-
-      # Lazily bind to Python.
-      inreplace "do-swig.sh", "VALABINDFLAGS=\"\"", "VALABINDFLAGS=\"--nolibpython\""
-      make_binding_args = ["CFLAGS=-undefined dynamic_lookup"]
-
-      # Ensure that plugins and bindings are installed in the Cellar.
-      inreplace "libr/lang/p/Makefile" do |s|
-        s.gsub! "R2_PLUGIN_PATH=", "#R2_PLUGIN_PATH="
-        s.gsub! "~/.config/radare2/plugins", "#{lib}/radare2/#{version}"
-      end
-
-      # We don't want to place json.lua in lib/lua/#{lua_version} because
-      # the name is very generic, which introduces a strong possibility of
-      # clashes with other formulae or in general usage.
-      inreplace "libr/lang/p/lua.c",
-                'os.getenv(\"HOME\")..\"/.config/radare2/plugins/lua/?.lua;',
-                "\\\"#{libexec}/lua/#{lua_version}/?.lua;"
-
-      # Really the Lua libraries should be dumped in libexec too but
-      # since they're named fairly specifically it's semi-acceptable.
-      inreplace "Makefile" do |s|
-        s.gsub! "LUAPKG=", "#LUAPKG="
-        s.gsub! "${DESTDIR}$$_LUADIR", "#{lib}/lua/#{lua_version}"
-        s.gsub! "ls lua/*so*$$_LUAVER", "ls lua/*so"
-      end
-
-      make_install_args = %W[
-        R2_PLUGIN_PATH=#{lib}/radare2/#{version}
-        LUAPKG=lua-#{lua_version}
-        PERLPATH=#{lib}/perl5/site_perl/#{perl_version}
-        PYTHON_PKGDIR=#{lib}/python2.7/site-packages
-        RUBYPATH=#{lib}/ruby/#{RUBY_VERSION}
-      ]
-
-      system "./configure", "--prefix=#{prefix}"
-      ["lua", "perl", "python"].each do |binding|
-        system "make", "-C", binding, *make_binding_args
-      end
-      system "make"
-      system "make", "install", *make_install_args
-
-      # This should be being handled by the Makefile but for some reason
-      # it doesn't want to work. If this ever breaks it's likely because
-      # the Makefile has started functioning as expected & placing it in lib.
-      (libexec/"lua/#{lua_version}").install Dir["libr/lang/p/lua/*.lua"]
-    end
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
   end
 
   test do

--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -1,20 +1,14 @@
 class Radare2 < Formula
   desc "Reverse engineering framework"
   homepage "https://radare.org"
-
-  stable do
-    url "https://radare.mikelloc.com/get/3.5.1/radare2-3.5.1.tar.gz"
-    sha256 "bc927aec4d29fa647fdc56afc2d7b04bf47c2234a43d0080f356705748299d9c"
-  end
+  url "https://radare.mikelloc.com/get/3.5.1/radare2-3.5.1.tar.gz"
+  sha256 "bc927aec4d29fa647fdc56afc2d7b04bf47c2234a43d0080f356705748299d9c"
+  head "https://github.com/radare/radare2.git"
 
   bottle do
     sha256 "2e54078d5cff62cd5593ba2390a0f230e334b94024954e5b6329d52c0401aafc" => :mojave
     sha256 "18dad4749aba2e1d3b5ecb55a1b3c55656bf0e604fc6e739b45a249809053a98" => :high_sierra
     sha256 "67705968143b7235843ad4a494ffca8bbfb886168656a4171bb730dec615a0d2" => :sierra
-  end
-
-  head do
-    url "https://github.com/radare/radare2.git"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`radare2` formula hasn't been updated for a while since lots of internal patches applied in the formula no longer compatible with upstream. Here I suggest we start afresh with minimal configuration.

- `bindings` and `extras` resources are removed because most of them can be later installed by own package manager `r2pm`. It also removes hiccups we had with previous formulae (#32335, #38105)
- with that, no longer insist on plugins/binds inside `Cellar`, rather leave it to the default (i.e. `~/.local/share/radare2/plugins` which users can change if they want
- remove no longer relevant code (i.e. `ENV.deparallelize`, dead symlinks cleanup)
- remove `CS_PATCHES=0` (skip patches for internal Capstone framework) as it should be automatically handled depending on build source (git vs. tarball)
- remove forced `openssl` dependency, otherwise package installations later with `r2pm` may encounter missing `openssl` header/library issue
- all other dependencies are also removed, since they were not needed (perhaps they were needed for building bindings/extras)

I confirmed both `stable` and `HEAD` built and worked fine for my limited use case.