### PR TITLE
update vips.rb to 8.8.0

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -1,9 +1,8 @@
 class Vips < Formula
   desc "Image processing library"
   homepage "https://github.com/libvips/libvips"
-  url "https://github.com/libvips/libvips/releases/download/v8.7.4/vips-8.7.4.tar.gz"
-  sha256 "ce7518a8f31b1d29a09b3d7c88e9852a5a2dcb3ee1501524ab477e433383f205"
-  revision 2
+  url "https://github.com/libvips/libvips/releases/download/v8.8.0/vips-8.8.0.tar.gz"
+  sha256 "8e78b451adfe59288bded74c9ec6b8c5eb0574ecbba7a0352de4f34266e021b0"
 
   bottle do
     sha256 "692e5f23a3aa7d99cee8c703781e7f2857fa35586677576dd487d3c7ef37b2ca" => :mojave
@@ -11,7 +10,6 @@ class Vips < Formula
     sha256 "9c56b78629089148a227a81816dfed7b94bbd2d4a016ea5c5bfbd50dde52ab10" => :sierra
   end
 
-  depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
   depends_on "fftw"
   depends_on "fontconfig"
@@ -32,6 +30,9 @@ class Vips < Formula
   depends_on "pango"
   depends_on "poppler"
   depends_on "webp"
+  depends_on "libheif"
+  depends_on "libmatio"
+  depends_on "cfitsio"
 
   def install
     args = %W[

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -11,6 +11,7 @@ class Vips < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "cfitsio"
   depends_on "fftw"
   depends_on "fontconfig"
   depends_on "gettext"
@@ -20,6 +21,8 @@ class Vips < Formula
   depends_on "jpeg"
   depends_on "libexif"
   depends_on "libgsf"
+  depends_on "libheif"
+  depends_on "libmatio"
   depends_on "libpng"
   depends_on "librsvg"
   depends_on "libtiff"
@@ -30,9 +33,6 @@ class Vips < Formula
   depends_on "pango"
   depends_on "poppler"
   depends_on "webp"
-  depends_on "libheif"
-  depends_on "libmatio"
-  depends_on "cfitsio"
 
   def install
     args = %W[


### PR DESCRIPTION
- add new deps: libheif, matio, cfitsio
- remove build dep on gobject-introspection since the py binding no longer needs it

https://libvips.github.io/libvips/2019/04/22/What's-new-in-8.8.html

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
