### PR TITLE
go@1.11: fix for linux, don't bootstrap with macos compiler.

### DIFF
--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -22,18 +22,28 @@ class GoAT111 < Formula
 
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
-    url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+    if OS.mac?
+      url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+      sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+    elsif OS.linux?
+      url "https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz"
+      sha256 "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+    end
     version "1.7"
-    sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
   end
 
   def install
+    ENV["CGO_ENABLED"] = "1"
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
+      if OS.mac?
+        ENV["GOOS"]         = "darwin"
+      elsif OS.linux?
+        ENV["GOOS"]         = "linux"
+      end
       system "./make.bash", "--no-clean"
     end
 


### PR DESCRIPTION
This changes copies the pattern used in go@1.10. Go 1.11 compiles the std
library with the -race flag which requires cgo, so that environment variable
is set too.

https://gist.github.com/c9fa7c3dc17a417509b6f4167c801f54

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
