### PR TITLE
augustus: fix bug in proteinprofile on macOS

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -3,6 +3,7 @@ class Augustus < Formula
   homepage "http://bioinf.uni-greifswald.de/augustus/"
   url "http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.2.tar.gz"
   sha256 "989a95fe3a83d62af4d323a9727d11b2c566adcf4d789d5d86d7b842d83e7671"
+  head "https://github.com/Gaius-Augustus/Augustus.git"
 
   bottle do
     sha256 "2d7449f08dbf38ee7a46d51e2f17032221b0567e4a215e7d309602cee8724ce5" => :mojave
@@ -10,8 +11,9 @@ class Augustus < Formula
     sha256 "020e9e8531aeaad48d06a96ca78eda64eae25e3737e69941f9069e6abd4e898d" => :sierra
   end
 
+  depends_on "boost" => :build
   depends_on "bamtools"
-  depends_on "boost"
+  depends_on "gcc"
 
   def install
     # Avoid "fatal error: 'sam.h' file not found" by not building bam2wig
@@ -30,10 +32,20 @@ class Augustus < Formula
 
     # Compile executables for macOS. Tarball ships with executables for Linux.
     system "make", "clean"
-    system "make"
 
+    # Clang breaks proteinprofile on macOS. This issue has been first reported
+    # to upstream in 2016 (see https://github.com/nextgenusfs/funannotate/issues/3).
+    # See also https://github.com/Gaius-Augustus/Augustus/issues/64
+    cd "src" do
+      with_env("HOMEBREW_CC" => "gcc-9") do
+        system "make"
+      end
+    end
+
+    system "make"
     system "make", "install", "INSTALLDIR=#{prefix}"
     bin.env_script_all_files libexec/"bin", :AUGUSTUS_CONFIG_PATH => prefix/"config"
+    pkgshare.install "examples"
   end
 
   test do
@@ -43,5 +55,10 @@ class Augustus < Formula
     EOS
     cmd = "#{bin}/augustus --species=human test.fasta"
     assert_match "Predicted genes", shell_output(cmd)
+
+    cp pkgshare/"examples/example.fa", testpath
+    cp pkgshare/"examples/profile/HsDHC.prfl", testpath
+    cmd = "#{bin}/augustus --species=human --proteinprofile=HsDHC.prfl example.fa 2> /dev/null"
+    assert_match "HS04636	AUGUSTUS	gene	966	6903	1	+	.	g1", shell_output(cmd)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is a bug in `augustus` when built on macOS with Clang that has been reported to upstream as far back as 2016 (see https://github.com/nextgenusfs/funannotate/issues/3). I ran into this when revising a formula on `brewsci/bio` (https://github.com/brewsci/homebrew-bio/pull/642).
```
 ❯ augustus --species=human --proteinprofile=profile/HsDHC.prfl example.fa
# This output was generated with AUGUSTUS (version 3.3.2).
# AUGUSTUS is a gene prediction tool written by M. Stanke (mario.stanke@uni-greifswald.de),
# O. Keller, S. König, L. Gerischer, L. Romoth and Katharina Hoff.
# Please cite: Mario Stanke, Mark Diekhans, Robert Baertsch, David Haussler (2008),
# Using native and syntenically mapped cDNA alignments to improve de novo gene finding
# Bioinformatics 24: 637-644, doi 10.1093/bioinformatics/btn013
# No extrinsic information on sequences given.
# Initialising the parameters using config directory /usr/local/Cellar/augustus/3.3.2/config/ ...

/usr/local/Cellar/augustus/3.3.2/libexec/bin/augustus: ERROR
	PP::Profile: Error parsing pattern file"profile/HsDHC.prfl", line 9.
```
As suggested by @nextgenusfs, this can be resolved by comping `augustus` with `gcc` on `macOS`.

I've also added an explicit test for this to the formula. The bug can be recreated by removing `with_env`. `fails_with :clang` cannot be used because of dependencies on `boost` in the `auxprogs`, which aren't interoperable between `clang` and `gcc`.

With the patch,
```
 ❯ brew test augustus
Testing augustus
==> /usr/local/Cellar/augustus/3.3.2/bin/augustus --species=human test.fasta
==> /usr/local/Cellar/augustus/3.3.2/bin/augustus --species=human --proteinprofile=HsDHC.prfl example.fa 2> /dev/null
```

I've also removed the run-time dependency on `boost`:
```
 ❯ brew linkage augustus
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/lib/gcc/9/libgcc_s.1.dylib (gcc)
  /usr/local/opt/gcc/lib/gcc/9/libstdc++.6.dylib (gcc)
Dependencies with no linkage:
  boost
```