### PR TITLE
Update gdcm to 3.0.0

### DIFF
--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -1,8 +1,8 @@
 class Gdcm < Formula
   desc "Grassroots DICOM library and utilities for medical files"
   homepage "https://sourceforge.net/projects/gdcm/"
-  url "https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.8.9/gdcm-2.8.9.tar.gz"
-  sha256 "a2da88b7b3cbf9e76a9df3e89d06d057cca9ce54fc62fb059e04f47bf056b727"
+  url "https://github.com/malaterre/GDCM/archive/v3.0.0.tar.gz"
+  sha256 "3de524690102bfa3e9c3a81ff3f17733138183f76b7a5f7d072b20024a255680"
 
   bottle do
     sha256 "2b35bf311cd1fc39e0fc1b73e7dfe665eb252a5dfc9e5c0c9895bfd62d852b80" => :mojave
@@ -11,11 +11,13 @@ class Gdcm < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
   depends_on "openjpeg"
   depends_on "openssl"
   depends_on "python"
+  depends_on "vtk"
 
   def install
     ENV.cxx11
@@ -25,12 +27,13 @@ class Gdcm < Formula
     python_executable = Utils.popen_read("python3 -c 'import sys;print(sys.executable)'").chomp
 
     args = std_cmake_args + %W[
-      -DGDCM_BUILD_APPLICATIONS=ON
+      -GNinja
+      -DGDCM_BUILD_APPLICATIONS=OFF
       -DGDCM_BUILD_SHARED_LIBS=ON
       -DGDCM_BUILD_TESTING=OFF
       -DGDCM_BUILD_EXAMPLES=OFF
       -DGDCM_BUILD_DOCBOOK_MANPAGES=OFF
-      -DGDCM_USE_VTK=OFF
+      -DGDCM_USE_VTK=ON
       -DGDCM_USE_SYSTEM_OPENJPEG=ON
       -DGDCM_USE_SYSTEM_OPENSSL=ON
       -DGDCM_WRAP_PYTHON=ON
@@ -45,7 +48,8 @@ class Gdcm < Formula
       ENV.append "LDFLAGS", "-undefined dynamic_lookup"
 
       system "cmake", "..", *args
-      system "make", "install"
+      system "ninja"
+      system "ninja", "install"
     end
   end
 
@@ -59,8 +63,8 @@ class Gdcm < Formula
       }
     EOS
 
-    system ENV.cxx, "-isystem", "#{include}/gdcm-2.8", "-o", "test.cxx.o", "-c", "test.cxx"
-    system ENV.cxx, "test.cxx.o", "-o", "test", "-L#{lib}", "-lgdcmDSED"
+    system ENV.cxx, "-std=c++11", "-isystem", "#{include}/gdcm-3.0", "-o", "test.cxx.o", "-c", "test.cxx"
+    system ENV.cxx, "-std=c++11", "test.cxx.o", "-o", "test", "-L#{lib}", "-lgdcmDSED"
     system "./test"
 
     system "python3", "-c", "import gdcm"

--- a/Formula/itk.rb
+++ b/Formula/itk.rb
@@ -3,6 +3,7 @@ class Itk < Formula
   homepage "https://www.itk.org/"
   url "https://downloads.sourceforge.net/project/itk/itk/4.13/InsightToolkit-4.13.2.tar.gz"
   sha256 "d8760b279de20497c432e7cdf97ed349277da1ae435be1f6f0f00fbe8d4938c1"
+  revision 1
   head "https://itk.org/ITK.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates GDCM to last upstream version (3.0.0). Also compiles with VTK support. I needed to use Ninja instead of Make, because it doesn't compile with Make. Turned off the GDCM Applications because they (seems) to no be ported to last VTK version.