### PR TITLE
tgenv 0.0.2 (new formula)

### DIFF
--- a/Formula/tgenv.rb
+++ b/Formula/tgenv.rb
@@ -1,0 +1,19 @@
+class Tgenv < Formula
+  desc "Terragrunt version manager inspired by tfenv"
+  homepage "https://github.com/cunymatthieu/tgenv"
+  url "https://github.com/cunymatthieu/tgenv/archive/v0.0.2.tar.gz"
+  sha256 "0f6dcf1ab3fdf8bfd3d237bfb1cc20e97c2b1895dc40aaae7ea17f2711a444d3"
+  head "https://github.com/cunymatthieu/tgenv.git"
+
+  bottle :unneeded
+
+  conflicts_with "terragrunt", :because => "tgenv symlinks terragrunt binaries"
+
+  def install
+    prefix.install ["bin", "libexec"]
+  end
+
+  test do
+    system bin/"tgenv", "list-remote"
+  end
+end


### PR DESCRIPTION
Terragrunt version manager inspired by tfenv.

I'm submitting this formula, for managing Terragrunt versions, to compliment the functionality of an existing formula (tfenv) that is used to manage Terraform versions.

The maintainer of tfenv has not submitted this as a homebrew formula, so I am submitting it instead, as I would like to have the same manageability of tgenv as I do for the tfenv utility (i.e. via homebrew).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
