### PR TITLE
libtorrent 1.2.1

### DIFF
--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -1,9 +1,8 @@
 class LibtorrentRasterbar < Formula
-  desc "C++ bittorrent library by Rasterbar Software"
+  desc "C++ bittorrent library with Python bindings"
   homepage "https://www.libtorrent.org/"
-  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent_1_2_0/libtorrent-rasterbar-1.2.0.tar.gz"
-  sha256 "428eefcf6a603abc0dc87e423dbd60caa00795ece07696b65f8ee8bceaa37c30"
-  revision 1
+  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_2_1/libtorrent-rasterbar-1.2.1.tar.gz"
+  sha256 "cceba9842ec7d87549cee9e39d95fd5ce68b0eb9b314a2dd0d611cfa9798762d"
 
   bottle do
     cellar :any
@@ -24,12 +23,6 @@ class LibtorrentRasterbar < Formula
   depends_on "boost-python3"
   depends_on "openssl"
   depends_on "python"
-
-  # Upstream commit for Boost 1.70.0
-  patch do
-    url "https://github.com/arvidn/libtorrent/commit/76c27949.diff?full_index=1"
-    sha256 "c44db22b3eabcefc8e2ace5d8e0d39364c1a8a49dbee3d3f2223bee13395921a"
-  end
 
   def install
     args = %W[


### PR DESCRIPTION
Add to the description that Python binding are included.
Remove Rasterbar Software as libtorrent.org no longer mentions this and
shortens desc length.

I only have a macos VM need time to confirm update works to tick the boxes:

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
