### PR TITLE
libtorrent@1.1 1.1.13 (new formula)

### DIFF
--- a/Aliases/libtorrent-rasterbar@1.2
+++ b/Aliases/libtorrent-rasterbar@1.2
@@ -1,0 +1,1 @@
+../Formula/libtorrent-rasterbar.rb

--- a/Formula/libtorrent-rasterbar@1.1.rb
+++ b/Formula/libtorrent-rasterbar@1.1.rb
@@ -1,0 +1,48 @@
+class LibtorrentRasterbarAT11 < Formula
+  desc "C++ bittorrent library with Python bindings"
+  homepage "https://www.libtorrent.org/"
+  url "https://github.com/arvidn/libtorrent/releases/download/libtorrent-1_1_13/libtorrent-rasterbar-1.1.13.tar.gz"
+  sha256 "30040719858e3c06634764e0c1778738eb42ecd0b45e814afa746329a948ead7"
+
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "boost-python3"
+  depends_on "openssl"
+  depends_on "python"
+
+  def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-encryption
+      --enable-python-binding
+      --with-boost=#{Formula["boost"].opt_prefix}
+      --with-boost-python=boost_python37-mt
+      PYTHON=python3
+    ]
+
+    if build.head?
+      system "./bootstrap.sh", *args
+    else
+      system "./configure", *args
+    end
+
+    system "make", "install"
+    libexec.install "examples"
+  end
+
+  test do
+    system ENV.cxx, "-std=c++11", "-I#{Formula["boost"].include}/boost",
+                    "-L#{lib}", "-ltorrent-rasterbar",
+                    "-L#{Formula["boost"].lib}", "-lboost_system",
+                    "-framework", "SystemConfiguration",
+                    "-framework", "CoreFoundation",
+                    libexec/"examples/make_torrent.cpp", "-o", "test"
+    system "./test", test_fixtures("test.mp3"), "-o", "test.torrent"
+    assert_predicate testpath/"test.torrent", :exist?
+  end
+end


### PR DESCRIPTION
Although libtorrent 1.2 is the latest release with new features, 1.1 is the most stable version, especially with regards the the Python bindings so it is useful to have the older version still available e.g. for Deluge.

I only have a macos VM and need the time to confirm _test_ and _audit_ tick the boxes:

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
