### PR TITLE
bat: install bundled fish completions

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -17,6 +17,7 @@ class Bat < Formula
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", "--root", prefix, "--path", "."
     man1.install "doc/bat.1"
+    fish_completion.install "assets/completions/bat.fish"
   end
 
   test do

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -3,6 +3,7 @@ class Bat < Formula
   homepage "https://github.com/sharkdp/bat"
   url "https://github.com/sharkdp/bat/archive/v0.11.0.tar.gz"
   sha256 "bb4e39efadfab71c0c929a92b82dac58deacfe2a4eb527d4256ac0634e042ed2"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Installs bundled fish completions for [`bat`](https://github.com/sharkdp/bat).

In `bat` version [v0.11.0](https://github.com/sharkdp/bat/releases/tag/v0.11.0), they added manually written fish completions (in sharkdp/bat#524 and sharkdp/bat#555) since they disabled the automatically generated completions in [v0.10.0](https://github.com/sharkdp/bat/releases/tag/v0.10.0). This update simply installs them during `brew install`. Note that this is a sort of soft reversion of #36116.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - Unfortunately, my Homebrew errors out when I try to run `brew audit` like in #5561, so I could not. I attempted troubleshooting, but to no avail.

-----