### PR TITLE
New Formula: docker-machine-driver-vmware

### DIFF
--- a/Formula/docker-machine-driver-vmware.rb
+++ b/Formula/docker-machine-driver-vmware.rb
@@ -1,0 +1,29 @@
+class DockerMachineDriverVmware < Formula
+  desc "VMware Fusion & Workstation docker-machine driver"
+  homepage "https://www.vmware.com/products/personal-desktop-virtualization.html"
+  url "https://github.com/machine-drivers/docker-machine-driver-vmware.git",
+    :tag      => "v0.1.1",
+    :revision => "cd992887ede19ae63e030c63dda5593f19ed569c"
+
+  depends_on "go" => :build
+  depends_on "docker-machine"
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    dir = buildpath/"src/github.com/machine-drivers/docker-machine-driver-vmware"
+    dir.install buildpath.children
+
+    cd dir do
+      system "go", "build", "-o", "#{bin}/docker-machine-driver-vmware",
+            "-ldflags", "-X main.version=#{version}"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    docker_machine = Formula["docker-machine"].opt_bin/"docker-machine"
+    output = shell_output("#{docker_machine} create --driver vmware -h")
+    assert_match "engine-env", output
+  end
+end


### PR DESCRIPTION
This driver allows docker-machine to use VMware Fusion on Mac and VMware Workstation on Windows or Linux to launch and run docker container host vms using standard docker tools.

- [✓] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✓] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✓] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✓] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
