### PR TITLE
github/issue-close-app: autoclose missing issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Reproducible-Bug-Report.md
+++ b/.github/ISSUE_TEMPLATE/Reproducible-Bug-Report.md
@@ -14,6 +14,7 @@ about: Submit an issue so we can investigate
 - [ ] if `brew gist-logs` didn't work: ran `brew config` and `brew doctor` and included their output with your issue?
 
 To help us debug your issue please explain:
+
 - What you were trying to do (and why)
 - What happened (include command output)
 - What you expected to happen

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,0 +1,28 @@
+# Comment that will be sent if an issue is judged to be closed
+comment: >
+From the issue template:
+
+\> **Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
+
+If you add the necessary information to this issue (don't create a new one, please) then this issue may be reopened.
+# There can be several configs for different kind of issues.
+- content:
+# reproducible bug report
+  - "are reporting a bug others will be able to reproduce"
+  - "have a problem with "
+  - "brew update"
+  - "brew doctor"
+  - "brew gist-logs"
+  - "brew config"
+  - "brew doctor"
+  - "What you were trying to do (and why)"
+  - "What happened (include command output)"
+  - "What you expected to happen"
+  - "Step-by-step reproduction instructions (by running `brew install` commands)"
+# Optional configuration:
+#
+# whether the keywords are case-insensitive
+# default value is false, which means keywords are case-sensitive
+caseInsensitive: false
+# The issue is judged to be legal if it includes all keywords from any of these two configs.
+# Or it will be closed by the app.


### PR DESCRIPTION
It's not a good use of maintainer time to handle these manually.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----