### PR TITLE
New Formula: rio

### DIFF
--- a/Formula/rio.rb
+++ b/Formula/rio.rb
@@ -1,0 +1,31 @@
+class Rio < Formula
+  desc "Kubernetes based MicroPaaS"
+  homepage "https://rio.io"
+  url "https://github.com/rancher/rio.git",
+    :using    => :git,
+    :tag      => "v0.1.0",
+    :revision => "5edeac11b52dc18364c8a130188e936dfbd6eb14"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/rancher/rio"
+    dir.install buildpath.children
+    cd dir
+
+    system "scripts/build"
+    bin.install "bin/rio"
+  end
+
+  test do
+    run_output = shell_output("#{bin}/rio 2>&1")
+    assert_match "rio - Containers made simple, as they should be", run_output
+
+    version_output = shell_output("#{bin}/rio --version 2>&1")
+    assert_match "rio version v#{version}", version_output
+
+    run_output = shell_output("env KUBECONFIG=#{testpath}/non-existing-kubecfg #{bin}/rio install 2>&1", result = 1)
+    assert_match "can't contact Kubernetes cluster. Please make sure your cluster is accessable", run_output
+  end
+end

--- a/Formula/rio.rb
+++ b/Formula/rio.rb
@@ -26,6 +26,6 @@ class Rio < Formula
     assert_match "rio version v#{version}", version_output
 
     run_output = shell_output("env KUBECONFIG=#{testpath}/non-existing-kubecfg #{bin}/rio install 2>&1", 1)
-    assert_match "can't contact Kubernetes cluster. Please make sure your cluster is accessable", run_output
+    assert_match "Get http://localhost:8080/api/v1/nodes: dial tcp [::1]:8080: connect: connection refuse", run_output
   end
 end

--- a/Formula/rio.rb
+++ b/Formula/rio.rb
@@ -25,7 +25,7 @@ class Rio < Formula
     version_output = shell_output("#{bin}/rio --version 2>&1")
     assert_match "rio version v#{version}", version_output
 
-    run_output = shell_output("env KUBECONFIG=#{testpath}/non-existing-kubecfg #{bin}/rio install 2>&1", result = 1)
+    run_output = shell_output("env KUBECONFIG=#{testpath}/non-existing-kubecfg #{bin}/rio install 2>&1", 1)
     assert_match "can't contact Kubernetes cluster. Please make sure your cluster is accessable", run_output
   end
 end

--- a/Formula/rio.rb
+++ b/Formula/rio.rb
@@ -3,8 +3,8 @@ class Rio < Formula
   homepage "https://rio.io"
   url "https://github.com/rancher/rio.git",
     :using    => :git,
-    :tag      => "v0.1.0",
-    :revision => "5edeac11b52dc18364c8a130188e936dfbd6eb14"
+    :tag      => "v0.1.1",
+    :revision => "271d91966f46b9dc3b7113af43c64cac61576831"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
This adds a formula for https://rio.io/ from Rancher a _Kubernetes based MicroPaaS_

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
