### PR TITLE
nghttp2: add a patch for OS X El Capitan 10.11.6

### DIFF
--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -28,6 +28,8 @@ class Nghttp2 < Formula
   depends_on "libevent"
   depends_on "openssl"
 
+  patch :DATA
+
   def install
     ENV.cxx11
 
@@ -53,3 +55,19 @@ class Nghttp2 < Formula
     system bin/"nghttp", "-nv", "https://nghttp2.org"
   end
 end
+
+__END__
+diff --git a/src/shrpx_client_handler.cc b/src/shrpx_client_handler.cc
+index 6266c5f..3c5946e 100644
+--- a/src/shrpx_client_handler.cc
++++ b/src/shrpx_client_handler.cc
+@@ -994,7 +994,7 @@ ClientHandler::get_downstream_connection(int &err, Downstream *downstream) {
+   auto http2session = get_http2_session(group, addr);
+   auto dconn = std::make_unique<Http2DownstreamConnection>(http2session);
+   dconn->set_client_handler(this);
+-  return dconn;
++  return std::move(dconn);
+ }
+ 
+ MemchunkPool *ClientHandler::get_mcpool() { return worker_->get_mcpool(); }
+


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
`An error occurred while installing nokogiri (1.10.3), and Bundler cannot continue.`
Hope somebody can run this line for me while I'm trying to resolve the issue on my system.

-----
