### PR TITLE
* FontForge: Install Python3 bindings instead of Python2

### DIFF
--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -2,8 +2,8 @@ class Fontforge < Formula
   desc "Command-line outline and bitmap font editor/converter"
   homepage "https://fontforge.github.io"
   url "https://github.com/fontforge/fontforge/releases/download/20190413/fontforge-20190413.tar.gz"
-  revision 1
   sha256 "6762a045aba3d6ff1a7b856ae2e1e900a08a8925ccac5ebf24de91692b206617"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,6 +13,7 @@ class Fontforge < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "python" => [:build, :test]
   depends_on "cairo"
   depends_on "fontconfig"
   depends_on "gettext"
@@ -24,7 +25,6 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
-  depends_on "python"
 
   def install
     ENV["PYTHON_CFLAGS"] = `python3-config --cflags`.chomp

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -2,6 +2,7 @@ class Fontforge < Formula
   desc "Command-line outline and bitmap font editor/converter"
   homepage "https://fontforge.github.io"
   url "https://github.com/fontforge/fontforge/releases/download/20190413/fontforge-20190413.tar.gz"
+  revision 1
   sha256 "6762a045aba3d6ff1a7b856ae2e1e900a08a8925ccac5ebf24de91692b206617"
 
   bottle do
@@ -23,13 +24,14 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
-  depends_on "python@2"
+  depends_on "python"
 
   def install
-    ENV["PYTHON_CFLAGS"] = `python-config --cflags`.chomp
-    ENV["PYTHON_LIBS"] = `python-config --ldflags`.chomp
+    ENV["PYTHON_CFLAGS"] = `python3-config --cflags`.chomp
+    ENV["PYTHON_LIBS"] = `python3-config --ldflags`.chomp
 
     system "./configure", "--prefix=#{prefix}",
+                          "--enable-python-scripting=3",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--without-x"
@@ -60,8 +62,8 @@ class Fontforge < Formula
   test do
     system bin/"fontforge", "-version"
     system bin/"fontforge", "-lang=py", "-c", "import fontforge; fontforge.font()"
-    xy = Language::Python.major_minor_version "python"
+    xy = Language::Python.major_minor_version "python3"
     ENV.append_path "PYTHONPATH", lib/"python#{xy}/site-packages"
-    system "python", "-c", "import fontforge; fontforge.font()"
+    system "python3", "-c", "import fontforge; fontforge.font()"
   end
 end

--- a/Formula/mftrace.rb
+++ b/Formula/mftrace.rb
@@ -21,6 +21,7 @@ class Mftrace < Formula
 
   depends_on "fontforge"
   depends_on "potrace"
+  depends_on "python"
   depends_on "t1utils"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
> After testing, if you think it is needed to force the corresponding bottles to be rebuilt and redistributed, add a line of the form revision 1 to the formula, or add 1 to the revision number already present.

I think I'm right in adding `revision 1` here, as the existing bottles have python2 bindings.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://discourse.brew.sh/t/python-2-eol-2020/4647/11
