### PR TITLE
Adding formula for pinkfloymotd

### DIFF
--- a/Formula/pinkfloydmotd.rb
+++ b/Formula/pinkfloydmotd.rb
@@ -1,0 +1,20 @@
+class Pinkfloydmotd < Formula
+  desc "Program to generate dynamic qoutes based on pinkfloyd's music"
+  homepage "https://github.com/skashyap7/PinkFloydMOTD"
+  url "https://github.com/skashyap7/PinkFloydMOTD/raw/master/pinkfloydmotd.zip"
+  version "1.0.0"
+  sha256 "9d2202eb2b479086f355e91bfd3e074081d40fb6b50711fa5b1aa83ebf040a7d"
+  depends_on "python"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
Adding a new formula for a motd script that displays Pink Floyd song qoutes as message of the day
using fortune. This script updates the bashrc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)? Yes
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? Yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? Yes
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? Yes
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? No. Failed for 
* GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
 * GitHub repository too new (<30 days old)-----
