### PR TITLE
.github/issue-close-app: Fix YAML syntax

### DIFF
--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -6,6 +6,7 @@ From the issue template:
 
 If you add the necessary information to this issue (don't create a new one, please) then this issue may be reopened.
 # There can be several configs for different kind of issues.
+issueConfigs:
 - content:
 # reproducible bug report
   - "are reporting a bug others will be able to reproduce"

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -5,8 +5,8 @@ From the issue template:
 \> **Please note we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
 
 If you add the necessary information to this issue (don't create a new one, please) then this issue may be reopened.
-# There can be several configs for different kind of issues.
 issueConfigs:
+# There can be several configs for different kind of issues.
 - content:
 # reproducible bug report
   - "are reporting a bug others will be able to reproduce"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- According to the [app's README](https://github.com/offu/close-issue-app#usage) it was missing an `issueConfigs` key. This was causing errors to be posted to new issues (example: 40349) rather than the desired text.