### PR TITLE
Add formula for xchtmlreport

### DIFF
--- a/Formula/xchtmlreport.rb
+++ b/Formula/xchtmlreport.rb
@@ -1,0 +1,12 @@
+class Xchtmlreport < Formula
+  desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
+  homepage "https://github.com/TitouanVanBelle/XCTestHTMLReport"
+  url "https://github.com/TitouanVanBelle/XCTestHTMLReport/archive/1.7.0.tar.gz"
+  sha256 "85ac4fd6110e9919006e3ae8a66e6ff31917495312435d0faa49d4325cbb1170"
+  head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git", :branch => "develop"
+
+  def install
+    system "xcodebuild clean build CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO -workspace XCTestHTMLReport.xcworkspace -scheme XCTestHTMLReport -configuration Release"
+    bin.install "xchtmlreport"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Old PR: https://github.com/Homebrew/homebrew-core/pull/26977

The original PR from over a year ago was closed because the repo wasn't notable enough, however now [xchtmlreport](https://github.com/TitouanVanBelle/XCTestHTMLReport) has 232 stars.

I am not sure how to write a test for this formula because it would require downloading and building an external Xcode project.