### PR TITLE
modsman 0.20.1 (new formula)

### DIFF
--- a/Formula/modsman.rb
+++ b/Formula/modsman.rb
@@ -1,21 +1,31 @@
 class Modsman < Formula
   desc "Minecraft mod manager for the command-line"
   homepage "https://gitlab.com/sargunv-mc-mods/modsman"
-  url "https://gitlab.com/sargunv-mc-mods/modsman.git",
-      :tag      => "0.20.1",
-      :revision => "b23331f7080b5a2718ab43e4120372bcf3421b6d"
 
-  depends_on :java => "1.8+"
+  # for new versions, update the url's build number and artifact name, the sha256, and the version
+  url "https://dev.azure.com/sargunvohra/modsman/_apis/build/builds/37/artifacts?artifactName=modsman-cli-0.20.1&api-version=5.0&%24format=zip"
+  version "0.20.1"
+  sha256 "136609552bbddbe3dbbd64c6a7731e8ff7cb8fcf8b92532172142f3b0d3d9da2"
+  
+  head "https://gitlab.com/sargunv-mc-mods/modsman.git"
+
+  depends_on :java => "11+"
 
   def install
-    system "./gradlew", ":modsman-cli:installDist"
-    libexec.install Dir["modsman-cli/build/install/modsman-cli/*"]
+    if build.head?
+      system "./gradlew", ":modsman-cli:installDist"
+      libexec.install Dir["modsman-cli/build/install/modsman-cli/*"]
+    else
+      libexec.install %w[bin lib]
+      chmod "+x", "#{libexec}/bin/modsman-cli"
+    end
+
     rm_f Dir["#{libexec}/bin/*.bat"]
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
   test do
-    # TODO: replace this with a proper test
-    system "#{bin}/modsman-cli", "--version"
+    (testpath/".modlist.json").write('{"config": {"game_version": "1.14"}, "mods": []}')
+    system bin/"modsman-cli", "list"
   end
 end

--- a/Formula/modsman.rb
+++ b/Formula/modsman.rb
@@ -1,21 +1,13 @@
 class Modsman < Formula
   desc "Minecraft mod manager for the command-line"
   homepage "https://gitlab.com/sargunv-mc-mods/modsman"
-  url "https://gitlab.com/sargunv-mc-mods/modsman/-/archive/0.20.1/modsman-0.20.1.tar.gz"
+  url "https://gitlab.com/sargunv-mc-mods/modsman.git",
+      :tag      => "0.20.1"
   sha256 "09834f6b34014652e6dd46a4e3c0ecb9d353002d44053854d05faffd3efc022b"
 
   depends_on :java => "1.8+"
 
   def install
-    # since gitlab's download doesn't come with the git repo, we need to fake a commit so
-    #   the gradle-git-version plugin can get the version
-    system "git", "init"
-    system "git", "config", "user.email", "fake@example.com"
-    system "git", "config", "user.name", "Fake Committer"
-    system "git", "add", "."
-    system "git", "commit", "-m", "fake commit"
-    system "git", "tag", "0.20.1"
-
     system "./gradlew", ":modsman-cli:installDist"
     libexec.install Dir["modsman-cli/build/install/modsman-cli/*"]
     rm_f Dir["#{libexec}/bin/*.bat"]

--- a/Formula/modsman.rb
+++ b/Formula/modsman.rb
@@ -1,0 +1,29 @@
+class Modsman < Formula
+  desc "Minecraft mod manager for the command-line"
+  homepage "https://gitlab.com/sargunv-mc-mods/modsman"
+  url "https://gitlab.com/sargunv-mc-mods/modsman/-/archive/0.20.1/modsman-0.20.1.tar.gz"
+  sha256 "09834f6b34014652e6dd46a4e3c0ecb9d353002d44053854d05faffd3efc022b"
+
+  depends_on :java => "1.8+"
+
+  def install
+    # since gitlab's download doesn't come with the git repo, we need to fake a commit so
+    #   the gradle-git-version plugin can get the version
+    system "git", "init"
+    system "git", "config", "user.email", "fake@example.com"
+    system "git", "config", "user.name", "Fake Committer"
+    system "git", "add", "."
+    system "git", "commit", "-m", "fake commit"
+    system "git", "tag", "0.20.1"
+
+    system "./gradlew", ":modsman-cli:installDist"
+    libexec.install Dir["modsman-cli/build/install/modsman-cli/*"]
+    rm_f Dir["#{libexec}/bin/*.bat"]
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # TODO: replace this with a proper test
+    system "#{bin}/modsman-cli", "--version"
+  end
+end

--- a/Formula/modsman.rb
+++ b/Formula/modsman.rb
@@ -2,8 +2,8 @@ class Modsman < Formula
   desc "Minecraft mod manager for the command-line"
   homepage "https://gitlab.com/sargunv-mc-mods/modsman"
   url "https://gitlab.com/sargunv-mc-mods/modsman.git",
-      :tag      => "0.20.1"
-  sha256 "09834f6b34014652e6dd46a4e3c0ecb9d353002d44053854d05faffd3efc022b"
+      :tag      => "0.20.1",
+      :revision => "b23331f7080b5a2718ab43e4120372bcf3421b6d"
 
   depends_on :java => "1.8+"
 


### PR DESCRIPTION
This adds a formula for the modsman tool, which is a command-line mod manager for Minecraft.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
