### PR TITLE
nss: support logging TLS secrets

### DIFF
--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -26,6 +26,7 @@ class Nss < Formula
 
     args = %W[
       BUILD_OPT=1
+      NSS_ALLOW_SSLKEYLOGFILE=1
       NSS_USE_SYSTEM_SQLITE=1
       NSPR_INCLUDE_DIR=#{Formula["nspr"].opt_include}/nspr
       NSPR_LIB_DIR=#{Formula["nspr"].opt_lib}


### PR DESCRIPTION
As described at [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format), starting with NSS 3.24, optimized builds using the Makefile must set the make variable `NSS_ALLOW_SSLKEYLOGFILE=1` to support logging TLS secrets.

Please note that with this change, users must still set the `SSLKEYLOGFILE` environment variable at runtime to enable logging of TLS secrets.

## Example

### Before change

```
% env CURL_SSL_BACKEND=nss SSLKEYLOGFILE="${HOME}/tls-secrets.log" curl -s https://www.google.com > /dev/null

% cat "${HOME}/tls-secrets.log"
cat: /Users/manselmi/tls-secrets.log: No such file or directory
```

### After change

```
% env CURL_SSL_BACKEND=nss SSLKEYLOGFILE="${HOME}/tls-secrets.log" curl -s https://www.google.com > /dev/null

% cat "${HOME}/tls-secrets.log"
# SSL/TLS secrets log file, generated by NSS
CLIENT_RANDOM a0388fe83d79a1e70f18fc86398e5081e6dda7bc35f740244b5f62d150a7ec6f 4b53a5750c892d74ef16ced6e356abb8b9b1885763a38c65cddf169e395ab89a2ac1e2ab5c0c1f8af5217a4d90acb94e
```

---

- [✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?