### PR TITLE
cfengine 3.12.2 sha256 update

### DIFF
--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -3,7 +3,7 @@ class Cfengine < Formula
   homepage "https://cfengine.com/"
   url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-3.12.2.tar.gz"
   sha256 "0b583ca546e4ae1896e6390c1a0ef53e7673b6ca6a5597502e9d1ba35f02c2ea"
-  revision 2
+  revision 1
 
   bottle do
     sha256 "71f81ecc7298760f4505feeb0da87c3e590a43fbd01d1c96694f8b84cd8f8e44" => :mojave

--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -2,7 +2,8 @@ class Cfengine < Formula
   desc "Help manage and understand IT infrastructure"
   homepage "https://cfengine.com/"
   url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-3.12.2.tar.gz"
-  sha256 "0285e039f576b4cf2c8a2f795fdb1687b7637e932bb1d963093546f2abee11b0"
+  sha256 "0b583ca546e4ae1896e6390c1a0ef53e7673b6ca6a5597502e9d1ba35f02c2ea"
+  revision 2
 
   bottle do
     sha256 "71f81ecc7298760f4505feeb0da87c3e590a43fbd01d1c96694f8b84cd8f8e44" => :mojave
@@ -16,7 +17,7 @@ class Cfengine < Formula
 
   resource "masterfiles" do
     url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-masterfiles-3.12.2.tar.gz"
-    sha256 "4abeeb23f6c5c50bed6ece5e2ba09d3d485ccccfff88852bf8d2668c73ef2caa"
+    sha256 "1183c892e050c39645b7d79171fca8e829fba63628d29c3b776fc7840599573b"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~Package seems not did published to `https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-3.12.2-2.tar.gz`?~ (released with the same artifact URL, so I updated the sha256 values accordingly)