### PR TITLE
mpop: use GnuTLS instead of OpenSSL

### DIFF
--- a/Formula/mpop.rb
+++ b/Formula/mpop.rb
@@ -3,6 +3,7 @@ class Mpop < Formula
   homepage "https://marlam.de/mpop/"
   url "https://marlam.de/mpop/releases/mpop-1.4.4.tar.xz"
   sha256 "7d9cffe30999a7b2ea503df9b23ccbf42439b62271c45ebd7b5b04bed0654148"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +13,7 @@ class Mpop < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "gnutls"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

OpenSSL support in mpop is not maintained.
See https://marlam.de/msmtp/news/openssl-discouraged