### PR TITLE
google-benchmark 1.5.0

### DIFF
--- a/Formula/google-benchmark.rb
+++ b/Formula/google-benchmark.rb
@@ -1,8 +1,8 @@
 class GoogleBenchmark < Formula
   desc "C++ microbenchmark support library"
   homepage "https://github.com/google/benchmark"
-  url "https://github.com/google/benchmark/archive/v1.5.tar.gz"
-  sha256 "feba1c44cbace01627435a675aa271f4b012068dbea9922443c58fedd56eb5eb"
+  url "https://github.com/google/benchmark/archive/v1.5.0.tar.gz"
+  sha256 "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a"
   head "https://github.com/google/benchmark.git"
 
   bottle do


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/40054

The `https://github.com/google/benchmark/archive/v1.5.tar.gz` is gone because of the version tag change.