### PR TITLE
isync: remove superfluous channel

### DIFF
--- a/Formula/isync.rb
+++ b/Formula/isync.rb
@@ -55,7 +55,6 @@ class Isync < Formula
         <array>
           <string>#{opt_bin}/mbsync</string>
           <string>-a</string>
-          <string>Periodic</string>
         </array>
         <key>StartInterval</key>
         <integer>300</integer>


### PR DESCRIPTION
In commit fa71798, Periodic was rendered superfluous by -a.

This commit avoids users having to check documentation to find that
`mbsync -a Periodic` is the same as `mbsync -a`.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
