### PR TITLE
k6 0.24.0 (New Formula)

### DIFF
--- a/Formula/k6.rb
+++ b/Formula/k6.rb
@@ -1,0 +1,29 @@
+class K6 < Formula
+  desc "Modern load testing tool, using Go and JavaScript"
+  homepage "https://k6.io"
+  url "https://github.com/loadimpact/k6.git",
+    :tag      => "v0.24.0",
+    :revision => "f597e5f66d22f697a386752ea0f4b0361765ab34"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    dir = buildpath/"src/github.com/loadimpact/k6"
+    dir.install buildpath.children
+
+    cd dir do
+      system "dep", "ensure", "-vendor-only"
+      system "go", "build", "-o", bin/"k6"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    output = "Test finished"
+    assert_match output, shell_output("#{bin}/k6 run github.com/loadimpact/k6/samples/http_get.js 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/k6 version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Closes https://github.com/loadimpact/homebrew-k6/issues/6
Closes https://github.com/loadimpact/k6/issues/380

Question from upstream repo:

> If we remove this formula after it's in homebrew-core, would any existing k6 users that have installed it automagically get the new k6 versions when we release them? Or would they have to re-install k6 from the new formula?