### PR TITLE
Secure/update URLs

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -1,6 +1,6 @@
 class Libtiff < Formula
   desc "TIFF library and utilities"
-  homepage "http://libtiff.maptools.org/"
+  homepage "https://libtiff.gitlab.io/libtiff/"
   url "https://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz"
   mirror "https://fossies.org/linux/misc/tiff-4.0.10.tar.gz"
   sha256 "2c52d11ccaf767457db0c46795d9c7d1a8d8f76f68b0b800a3dfe45786b996e4"

--- a/Formula/tcsh.rb
+++ b/Formula/tcsh.rb
@@ -1,6 +1,6 @@
 class Tcsh < Formula
   desc "Enhanced, fully compatible version of the Berkeley C shell"
-  homepage "https://web.archive.org/web/20170609182511/www.tcsh.org/Home"
+  homepage "https://www.tcsh.org/"
   url "ftp://ftp.astron.com/pub/tcsh/tcsh-6.21.00.tar.gz"
   mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/tcsh/tcsh-6.21.00.tar.gz"
   sha256 "c438325448371f59b12a4c93bfd3f6982e6f79f8c5aef4bc83aac8f62766e972"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

FWIW, here at the formulae, sort by number of installs that still have insecure URLs in them (606 formulae in total — a minor portion of them may be false positives):
```
libpng: 2182790
isl: 665924
little-cms2: 592419
libxml2: 589157
x265: 571860
redis: 535601
libmpc: 506789
unixodbc: 442597
jemalloc: 408731
tree: 355668
leptonica: 351525
jansson: 318333
aspell: 299665
libev: 288680
libsndfile: 274017
libsamplerate: 239624
adns: 219071
libmagic: 137553
zeromq: 136905
gnuplot: 130056
libcroco: 123543
graphicsmagick: 119089
socat: 113314
dnsmasq: 111758
libtermkey: 107321
makedepend: 105987
fftw: 103601
highlight: 101848
doxygen: 99696
popt: 95382
libvterm: 94092
swig: 89589
jenkins: 74411
portaudio: 72222
augeas: 69374
suite-sparse: 57078
rename: 51642
pygtk: 49176
arpoison: 48581
libxslt: 48497
pstoedit: 46428
sfcgal: 45281
qhull: 39679
sbcl: 36521
metis: 35898
md5sha1sum: 33887
epstool: 31828
sqlmap: 31778
little-cms: 31561
openconnect: 29668
vapoursynth: 29267
mutt: 27399
ossp-uuid: 24931
libgphoto2: 24142
rpm: 23940
mplayer: 23465
links: 22861
pstree: 21424
libcaca: 20787
asciidoc: 20168
net-snmp: 19753
siege: 16982
itstool: 16422
swi-prolog: 15562
figlet: 14532
valgrind: 14488
supervisor: 13662
cloog: 12467
re2c: 12250
sane-backends: 11960
iftop: 11774
ipcalc: 11331
fluid-synth: 11305
tnftp: 11063
optipng: 11041
tinyxml2: 10839
less: 10694
byobu: 10440
assimp: 10000
fcrackzip: 9955
pcl: 9717
root: 9606
tinyxml: 9376
libpqxx: 8601
dlib: 8382
flake8: 8340
hping: 8270
mpich: 7837
jenkins-lts: 7633
czmq: 6927
calc: 6912
file-formula: 6895
ncftp: 6888
libccd: 6745
entr: 6392
wavpack: 6311
pidof: 6261
openslide: 6176
ceres-solver: 6165
jack: 6132
lbzip2: 5989
libvidstab: 5940
f3: 5917
squid: 5856
libgsm: 5816
two-lame: 5654
elinks: 5561
rrdtool: 5420
cminpack: 5269
mvnvm: 5257
redis@3.2: 5124
git-annex: 5086
caffe: 5085
udunits: 4953
icarus-verilog: 4857
smlnj: 4715
bchunk: 4693
crosstool-ng: 4406
gmt: 4259
antiword: 4238
dash: 3936
gphoto2: 3916
xrootd: 3859
unoconv: 3628
pdf2svg: 3583
rmtrash: 3581
gnu-prolog: 3525
pngcheck: 3386
grace: 3367
cdrtools: 3339
knock: 3304
most: 3274
toilet: 3202
nload: 3198
hexedit: 2990
rsyslog: 2942
ttyrec: 2885
tcptrace: 2830
jhead: 2818
libstfl: 2786
todo-txt: 2765
appledoc: 2578
ncview: 2410
eye-d3: 2344
libharu: 2314
mr: 2299
theharvester: 2260
ansifilter: 2228
libiodbc: 2166
x11vnc: 2122
ifstat: 2086
libnfc: 2050
httping: 2031
darcs: 2022
opencolorio: 2016
basex: 2015
profanity: 1954
hmmer: 1935
sipcalc: 1885
gearman: 1844
verilator: 1838
mesos: 1749
purescript: 1740
mypy: 1723
homebank: 1689
proftpd: 1591
html2text: 1578
gwyddion: 1558
pow: 1549
chkrootkit: 1544
websocketd: 1510
cling: 1503
gromacs: 1477
tsung: 1444
cimg: 1423
sendemail: 1381
libmaa: 1354
fox: 1328
dict: 1321
rpl: 1281
proselint: 1256
glslviewer: 1232
moc: 1225
petsc: 1218
gnu-smalltalk: 1185
c-kermit: 1164
xdelta: 1156
ascii: 1151
swftools: 1149
squirrel: 1134
gti: 1113
bmake: 1097
patchutils: 1079
mytop: 1069
psutils: 1066
redshift: 1060
ren: 1049
gerbv: 1048
yafc: 1043
dosbox-x: 1023
geeqie: 1015
pgplot: 1001
gmt@4: 990
jsonschema2pojo: 976
fondu: 932
afl-fuzz: 910
pycodestyle: 909
libstrophe: 909
tcsh: 906
icon-naming-utils: 904
fceux: 902
hevea: 884
memtester: 873
yaz: 868
scalastyle: 862
runit: 853
jumanpp: 850
bastet: 840
abyss: 838
pdfsandwich: 832
libdaemon: 824
u-boot-tools: 818
iozone: 807
dhex: 801
raptor: 772
xsane: 765
groonga: 749
grsync: 748
ircii: 730
swig@3.04: 725
mscgen: 699
x3270: 696
rxvt-unicode: 696
spades: 684
nailgun: 662
ocaml-findlib: 655
hercules: 636
jshon: 631
tup: 623
ksh: 623
anjuta: 620
juman: 607
gpsd: 604
opencoarrays: 599
openrtsp: 577
io: 576
open-zwave: 574
xtensor: 573
tinycdb: 563
orocos-kdl: 555
id3tool: 551
lv2: 549
p0f: 544
c-blosc: 537
whatmask: 528
makeself: 528
getmail: 525
geoserver: 525
bib-tool: 524
abcm2ps: 519
par: 516
libcec: 513
druid: 511
fdclone: 508
gpredict: 503
jigdo: 493
coturn: 492
apcupsd: 492
ldapvi: 489
shapelib: 487
libcanberra: 481
libre: 476
yosys: 473
gambit-scheme: 473
corsixth: 470
fetchmail: 467
cdpr: 460
cd-discid: 457
hspell: 456
gnuplot@4: 449
gtk-chtheme: 437
menhir: 436
lablgtk: 429
mikutter: 428
redpen: 425
abuse: 423
ne: 420
geogram: 413
sshtrix: 411
ppl: 410
shogun: 404
webalizer: 402
ipinfo: 401
sfk: 391
dnstop: 391
baresip: 390
jed: 388
bgpq3: 379
ssdb: 377
montage: 373
augustus: 372
zsync: 369
gwt: 369
ptex: 365
osrm-backend: 362
mlton: 362
lrzip: 359
daemon: 359
chmlib: 359
enet: 355
openslp: 346
polyglot: 344
xidel: 332
grepcidr: 331
zint: 322
dar: 322
woof: 318
genometools: 316
libtecla: 312
yaws: 311
simh: 305
cvs2svn: 301
schismtracker: 291
newlisp: 290
monkeysphere: 286
ahoy: 286
gkrellm: 283
minimodem: 279
opentsdb: 278
ssss: 277
patchelf: 277
nwchem: 276
sile: 273
get-flash-videos: 272
lockrun: 269
rancid: 267
libopendkim: 262
convertlit: 254
dmg2img: 252
contacts: 249
lfe: 247
zanata-client: 244
greed: 242
qmmp: 241
skinny: 240
fibjs: 240
zbackup: 238
bar: 238
when: 237
wiremock-standalone: 235
tgif: 235
delta: 232
librem: 229
freeling: 229
bigloo: 228
opencsg: 219
darkice: 218
pcb: 216
libinfinity: 216
libsoundio: 215
ledit: 215
cksfv: 213
pacparser: 212
coda-cli: 210
aap: 210
gobby: 205
aamath: 204
mpir: 202
fairymax: 201
nrg2iso: 199
hapi-fhir-cli: 199
gsar: 199
luaradio: 196
hfsutils: 195
dterm: 195
libdiscid: 193
cvsps: 193
ats2-postiats: 193
rasqal: 192
xmlformat: 191
udns: 188
abduco: 187
kite: 181
unarj: 180
tcptunnel: 180
compcert: 180
man-db: 179
id3ed: 178
unittest: 177
redir: 175
zorba: 171
nestopia-ue: 164
libpcl: 164
speech-tools: 163
picat: 163
stuntman: 161
zpaq: 160
sgrep: 160
blastem: 160
colorsvn: 158
ephemeralpg: 155
petsc-complex: 154
galen: 152
gnustep-make: 151
tin: 149
parrot: 146
libxdiff: 140
autobench: 139
metashell: 137
jing-trang: 136
geomview: 136
dupseek: 136
fastme: 135
weighttp: 134
aterm: 134
gif2png: 132
kakasi: 131
iniparser: 131
reposurgeon: 130
pound: 129
wiredtiger: 126
vapoursynth-sub: 126
ino: 125
hashcash: 125
upscaledb: 124
scheme48: 124
gambit: 124
treefrog: 122
pc6001vx: 122
epic5: 122
aardvark_shell_utils: 122
avce00: 121
chibi-scheme: 120
aggregate: 120
zebra: 118
dvd+rw-tools: 118
cherokee: 117
liblzf: 116
jove: 116
tiff2png: 114
voro++: 113
tidyp: 112
zero-install: 111
unac: 111
mftrace: 111
dmalloc: 111
urweb: 110
slrn: 110
vapoursynth-ocr: 108
rc: 108
deheader: 108
atlantis: 108
vapoursynth-imwri: 107
udpxy: 107
uudeview: 106
flasm: 106
ibex: 105
wordplay: 103
libdill: 103
gbdfed: 103
coccinelle: 103
cpmtools: 102
libgusb: 101
zzuf: 100
gf-complete: 100
xmlsh: 99
redland: 98
metaproxy: 96
rssh: 92
titlecase: 91
jerasure: 91
txr: 89
traildb: 89
robotfindskitten: 89
cuba: 89
afio: 89
rest-shell: 88
concurrencykit: 87
visitors: 86
ape: 85
openhmd: 84
bibclean: 84
ndiff: 83
mallet: 83
pdnsd: 82
color-code: 82
viewvc: 81
falcon: 81
inadyn: 80
noweb: 77
freediameter: 77
sisc-scheme: 76
stone: 75
src: 75
mrboom: 75
mmix: 75
nu-smv: 74
pgtune: 73
walkmod: 71
peg: 71
slashem: 69
linklint: 69
cassandra-reaper: 69
snow: 68
lysp: 68
pce: 66
morse: 64
cppcms: 64
sdhash: 62
lcdproc: 62
apel: 62
libpoker-eval: 61
wdfs: 60
adplug: 60
abnfgen: 60
htpdate: 59
wumpus: 58
bzrtools: 58
omega-rpg: 56
mkhexgrid: 56
libnatpmp: 56
pipebench: 53
kytea: 52
hyperspec: 52
ori: 50
mairix: 50
libopkele: 50
flickcurl: 49
ski: 48
libdrawtext: 48
solid: 47
lwtools: 47
sproxy: 46
bookloupe: 46
blahtexml: 45
sdf: 44
cgvg: 44
synscan: 43
pazpar2: 43
tinysvm: 42
olsrd: 42
whohas: 41
libcello: 41
ck: 41
tth: 40
ip_relay: 40
unp64: 38
cgoban: 38
kedge: 37
ucon64: 36
since: 36
libagar: 36
leafnode: 36
ircd-hybrid: 36
titan-server: 33
openjazz: 33
midgard2: 33
stormlib: 32
ejdb: 32
scws: 31
ratfor: 31
mpegdemux: 31
yazpp: 30
magnetix: 30
namazu: 29
libslax: 28
uade: 27
precomp: 27
qsoas: 26
libmill: 26
dwatch: 26
tractorgen: 25
sbuild: 25
restund: 25
opendbx: 25
yaze-ag: 24
dnsrend: 23
snobol4: 22
libchewing: 22
griffon: 22
wbox: 21
tenyr: 20
libggz: 20
yamcha: 19
libquantum: 19
whitedb: 18
srmio: 18
intercal: 18
clipsafe: 18
chcase: 18
binkd: 18
libming: 17
blazeblogger: 17
reminiscence: 15
nordugrid-arc: 15
ircd-irc2: 14
vstr: 13
vc4asm: 13
libguess: 13
kanif: 12
sc68: 11
rmcast: 0
plod: 0
finatra: 0
depqbf: 0
classads: 0
```
