### PR TITLE
csound: conflicts with libextractor and pkcrack

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -23,6 +23,9 @@ class Csound < Formula
   depends_on "portmidi"
   depends_on "stk"
 
+  conflicts_with "libextractor", :because => "both install `extract` binaries"
+  conflicts_with "pkcrack", :because => "both install `extract` binaries"
+
   def install
     inreplace "CMakeLists.txt",
       %r{^set\(CS_FRAMEWORK_DEST\s+"~/Library/Frameworks"\)$},

--- a/Formula/libextractor.rb
+++ b/Formula/libextractor.rb
@@ -14,6 +14,7 @@ class Libextractor < Formula
   depends_on "pkg-config" => :build
   depends_on "libtool"
 
+  conflicts_with "csound", :because => "both install `extract` binaries"
   conflicts_with "pkcrack", :because => "both install `extract` binaries"
 
   def install

--- a/Formula/pkcrack.rb
+++ b/Formula/pkcrack.rb
@@ -14,6 +14,7 @@ class Pkcrack < Formula
     sha256 "47f2ffa2e27f0dc5e6df45de7335e316a8ea83288153b274ae5d8e11c7157055" => :yosemite
   end
 
+  conflicts_with "csound", :because => "both install `extract` binaries"
   conflicts_with "libextractor", :because => "both install `extract` binaries"
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When looking through the jenkins results from #40395, I noticed a conflict between csound and libextractor, since they both install `bin/extract`:

* https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/43176/version=sierra/testReport/junit/brew-test-bot/sierra/install___only_dependencies_gnunet/

Apparently `pkcrack` installs that binary as well, so I've made sure all three formulae conflict with each other.