### PR TITLE
Maxima 5.43.0

### DIFF
--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -1,8 +1,8 @@
 class Maxima < Formula
   desc "Computer algebra system"
   homepage "https://maxima.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/maxima/Maxima-source/5.42.2-source/maxima-5.42.2.tar.gz"
-  sha256 "167e11d6513a65c829a35f24d4ba539bcd0a82fc3dc7a6721e4f9f118c67b64d"
+  url "https://downloads.sourceforge.net/project/maxima/Maxima-source/5.43.0-source/maxima-5.43.0.tar.gz"
+  sha256 "dcfda54511035276fd074ac736e97d41905171e43a5802bb820914c3c885ca77"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -24,6 +24,7 @@ class Maxima < Formula
                           "--enable-gettext",
                           "--enable-sbcl",
                           "--enable-sbcl-exec",
+                          "--with-emacs-prefix=#{share}/emacs/site-lisp/#{name}",
                           "--with-sbcl=#{Formula["sbcl"].opt_bin}/sbcl"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Tested `wxmaxima`, `xmaxima` and `maxima`.

Added `--with-emacs-prefix`, because

`brew audit --strict maxima`

returned
```
maxima:
  * Emacs Lisp files were linked directly to /usr/local/share/emacs/site-lisp
    This may cause conflicts with other packages.
    They should instead be installed into:
      /usr/local/opt/maxima/share/emacs/site-lisp/maxima

    The offending files are:
      /usr/local/opt/maxima/share/emacs/site-lisp/emaxima.el
            /usr/local/opt/maxima/share/emacs/site-lisp/imath.el
            /usr/local/opt/maxima/share/emacs/site-lisp/maxima-font-lock.el
            /usr/local/opt/maxima/share/emacs/site-lisp/setup-imaxima-imath.el
            /usr/local/opt/maxima/share/emacs/site-lisp/bookmode.el
            /usr/local/opt/maxima/share/emacs/site-lisp/imaxima.el
            /usr/local/opt/maxima/share/emacs/site-lisp/dbl.el
            /usr/local/opt/maxima/share/emacs/site-lisp/sshell.el
            /usr/local/opt/maxima/share/emacs/site-lisp/maxima.el
            /usr/local/opt/maxima/share/emacs/site-lisp/smart-complete.el
            /usr/local/opt/maxima/share/emacs/site-lisp/imaxima-autoconf-variables.el
Error: 1 problem in 1 formula detected
```

The ChangeLog states
```
* "make install" now installs emaxima and imaxima in a place emacs will 
   find by default. configure's --emacs-prefix= option allows to choose
   a different directory.
```
but the option is actually `--with-emacs-prefix`.