### PR TITLE
k6: migrate to homebrew/core

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -19,6 +19,7 @@
   "horndis": "homebrew/cask",
   "inkscape": "homebrew/cask",
   "jsl": "homebrew/cask",
+  "k6": "homebrew/core",
   "kdiff3": "homebrew/cask",
   "keybase": "homebrew/cask",
   "meld": "homebrew/cask",


### PR DESCRIPTION
Relates to https://github.com/Homebrew/homebrew-core/pull/40689
Relates to loadimpact/homebrew-k6#6

cc @na--