### PR TITLE
nats-server 2.0.0 (New Formula)

### DIFF
--- a/Formula/nats-server.rb
+++ b/Formula/nats-server.rb
@@ -1,0 +1,56 @@
+class NatsServer < Formula
+  desc "Lightweight cloud messaging system"
+  homepage "https://nats.io"
+  url "https://github.com/nats-io/nats-server/archive/v2.0.0.tar.gz"
+  sha256 "e74e9b79c89d24e19aa4d755be02f57e63eefb501c053b7a9bfd373246370b47"
+  head "https://github.com/nats-io/nats-server.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "off"
+    mkdir_p "src/github.com/nats-io"
+    ln_s buildpath, "src/github.com/nats-io/nats-server"
+    buildfile = buildpath/"src/github.com/nats-io/nats-server/main.go"
+    system "go", "build", "-v", "-o", bin/"nats-server", buildfile
+  end
+
+  plist_options :manual => "nats-server"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/nats-server/string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    pid = fork do
+      exec bin/"nats-server",
+           "--port=8085",
+           "--pid=#{testpath}/pid",
+           "--log=#{testpath}/log"
+    end
+    sleep 3
+
+    begin
+      assert_match version.to_s, shell_output("curl localhost:8085")
+      assert_predicate testpath/"log", :exist?
+    ensure
+      Process.kill "SIGINT", pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is an existing formula ([gnatsd.rb](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnatsd.rb)) but since NATS Server has a major release v2.0.0 and repository path and executable name was changed, I am thinking that a new formula is needed.
Let me know if that is not the case.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
