### PR TITLE
nats-streaming-server 0.15.1

### DIFF
--- a/Formula/nats-streaming-server.rb
+++ b/Formula/nats-streaming-server.rb
@@ -1,8 +1,8 @@
 class NatsStreamingServer < Formula
   desc "Lightweight cloud messaging system"
   homepage "https://nats.io"
-  url "https://github.com/nats-io/nats-streaming-server/archive/v0.15.0.tar.gz"
-  sha256 "102fb5499e51144e48d38b72cd064287874b08379b8806ae2c86b644cff62850"
+  url "https://github.com/nats-io/nats-streaming-server/archive/v0.15.1.tar.gz"
+  sha256 "d2c2fba9efb7a0c6c2706a2ec1ccd19cb8b3dc0441cb35c71d851d60917f5091"
   head "https://github.com/nats-io/nats-streaming-server.git"
 
   bottle do
@@ -16,15 +16,11 @@ class NatsStreamingServer < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GO111MODULE"] = "on"
-
-    dir = buildpath/"src/github.com/nats-io/nats-streaming-server"
-    dir.install buildpath.children
-
-    cd dir do
-      system "go", "build", "-o", bin/"nats-streaming-server"
-      prefix.install_metafiles
-    end
+    ENV["GO111MODULE"] = "off"
+    mkdir_p "src/github.com/nats-io"
+    ln_s buildpath, "src/github.com/nats-io/nats-streaming-server"
+    buildfile = buildpath/"src/github.com/nats-io/nats-streaming-server/nats-streaming-server.go"
+    system "go", "build", "-v", "-o", bin/"nats-streaming-server", buildfile
   end
 
   plist_options :manual => "nats-streaming-server"


### PR DESCRIPTION
Realized that previous version 0.15.0 was created by a non maintainer and ended up using go modules. We still want to publish with module off and rely on included vendor directory. Later release will be full go.mod, but not for now.
