### PR TITLE
oksh: 6.5 (new formula)

### DIFF
--- a/Formula/oksh.rb
+++ b/Formula/oksh.rb
@@ -1,0 +1,24 @@
+class Oksh < Formula
+  desc "Portable OpenBSD Korn Shell"
+  homepage "https://github.com/ibara/oksh"
+  url "https://github.com/ibara/oksh/releases/download/oksh-6.5/oksh-6.5.tar.gz"
+  sha256 "2adf52ab718249462a41e1172d0bfb8670731daa0618e560be58064cac23a0bd"
+
+  head "https://github.com/ibara/oksh.git"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --enable-curses
+    ]
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_equal "42", shell_output("#{bin}/oksh -c 'printf 42'").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the portable version of OpenBSD ksh, which is used as default shell in OpenBSD.

There has been a submission of oksh in the past (#26176) which has not been followed-up. 

The difference between oksh and other ksh variants (pdksh, mksh) is that oksh offers few features borrowed from Bash, such as `\h \w` in PS1, user-customizable auto-completion and few syntaxes. It also has conformability with latest POSIX.1 (e.g. hash/ulimit/type built-ins which were bash-specific, is now in POSIX and is available under oksh). 