### PR TITLE
mtn 3.3.2 (new formula)

### DIFF
--- a/Formula/mtn.rb
+++ b/Formula/mtn.rb
@@ -1,0 +1,20 @@
+class Mtn < Formula
+  desc "Saves thumbnails (screenshots) of movie or video files to jpeg files"
+  homepage "https://gitlab.com/movie_thumbnailer/mtn/wikis/home"
+  url "https://gitlab.com/movie_thumbnailer/mtn/-/archive/3.3.2/mtn-3.3.2.tar.gz"
+  sha256 "471ec0172a1753d684032edb8296ef01af115538619daa417678ac037328daf5"
+
+  depends_on "ffmpeg"
+  depends_on "gd"
+
+  def install
+    system "make", "-Csrc", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "curl", "--output", "sample.avi", "-L", "https://bitbucket.org/wahibre/mtn/downloads/sample.avi"
+    system "echo '918243383bc9a3a8ff37da451f4b6b17f9636769  sample_s.jpg' > checksum"
+    system "#{bin}/mtn", "sample.avi"
+    system "shasum", "--check", "checksum"
+  end
+end


### PR DESCRIPTION
New formula mtn - Movie Thumbnailer. First introduced in 2009, now
modified for macOS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
