### PR TITLE
irssi 1.2.0

### DIFF
--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -1,9 +1,8 @@
 class Irssi < Formula
   desc "Modular IRC client"
   homepage "https://irssi.org/"
-  url "https://github.com/irssi/irssi/releases/download/1.1.1/irssi-1.1.1.tar.xz"
-  sha256 "784807e7a1ba25212347f03e4287cff9d0659f076edfb2c6b20928021d75a1bf"
-  revision 1
+  url "https://github.com/irssi/irssi/releases/download/1.2.0/irssi-1.2.0.tar.xz"
+  sha256 "1643fca1d8b35e5a5d7b715c9c889e1e9cdb7e578e06487901ea959e6ab3ebe5"
 
   bottle do
     sha256 "ca5e86cee8f481f3a442ee91030236c16346f47dffe880526e4e6f1058cadb68" => :mojave
@@ -24,6 +23,8 @@ class Irssi < Formula
   depends_on "openssl"
 
   def install
+    ENV.delete "HOMEBREW_SDKROOT" if MacOS.version == :high_sierra
+
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
@@ -42,9 +43,6 @@ class Irssi < Formula
       system "./autogen.sh", *args
     end
 
-    # https://github.com/irssi/irssi/pull/927
-    inreplace "configure", "^DUIfm", "^DUIifm"
-
     system "./configure", *args
     # "make" and "make install" must be done separately on some systems
     system "make"
@@ -60,6 +58,8 @@ class Irssi < Formula
     # This is not how you'd use Perl with Irssi but it is enough to be
     # sure the Perl element didn't fail to compile, which is needed
     # because upstream treats Perl build failures as non-fatal.
+    # To debug a Perl problem copy the following test at the end of the install
+    # block to surface the relevant information from the build warnings.
     ENV["PERL5LIB"] = lib/"perl5/site_perl"
     system "perl", "-e", "use Irssi"
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed this was attempted already [3 times](https://github.com/Homebrew/homebrew-core/pulls?utf8=✓&q=is%3Apr+is%3Aclosed+irssi+1.2.0+created%3A%3C2019-06-10) unsuccessfully so far. Unfortunately the buildbot logs are not available anymore to investigate the matter thoroughly.

I did the same thing they did: bump up the version in the URL, calculate the new sha256, and remove the [temporary `inreplace`](https://github.com/Homebrew/homebrew-core/blob/e363a481972d9b01b82cd91612b57af65fb2ce9d/Formula/irssi.rb#L46-L47).

This works straight out of the box [on macOS Mojave 10.14.5](https://gist.github.com/ear/1e4c556a94d4f2cfebda2630c23fb82c).

The older PRs mentioned a build failure on High Sierra. I don't have such a machine available so I enlisted the help of a random person running a clean install of High Sierra w/ Homebrew willing to try out my updated formula.

I was expecting to see the build error and delve deeper but no, it worked straight out of the box [on macOS High Sierra 10.13.6 as well](https://gist.github.com/ear/a56d9248213f9e9317ea17bfe8857942).

Now to see what the buildbot has to say about this. I'm very curious.

Lastly a couple notes for when the results of the CI pipeline come back with its errors and surprises!

## inreplace

```
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
configure:
  expected replacement of "^DUIfm" with "^DUIifm"
```

The PR mentioned in the current formula https://github.com/irssi/irssi/pull/927 was merged upstream so the whole thing can be taken out, pending confirmation from the buildbot.

## configure warning

```
configure: WARNING: unrecognized options: --with-ncurses
```

Depending on the buildbot output we can either drop `--with-ncurses`, ignore the warning, or maybe even use `--disable-option-checking`.

```
$ ./configure --help
[...snip...]
Optional Features:
  --disable-option-checking  ignore unrecognized --enable/--with options
[...snip...]
```
