### PR TITLE
encfs: remove boost dependency

### DIFF
--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -3,6 +3,7 @@ class Encfs < Formula
   homepage "https://vgough.github.io/encfs/"
   url "https://github.com/vgough/encfs/archive/v1.9.5.tar.gz"
   sha256 "4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63"
+  revision 1
   head "https://github.com/vgough/encfs.git"
 
   bottle do
@@ -14,7 +15,6 @@ class Encfs < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "boost"
   depends_on "gettext"
   depends_on "openssl"
   depends_on :osxfuse


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

encfs dropped boost dependency in the 1.9.x releases (see https://github.com/vgough/encfs/commit/671ff0e3f2affd739d5990dd42b2d8f274947c04)