### PR TITLE
change wiredtiger build option

### DIFF
--- a/Formula/wiredtiger.rb
+++ b/Formula/wiredtiger.rb
@@ -15,7 +15,7 @@ class Wiredtiger < Formula
 
   def install
     system "./configure", "--with-builtins=snappy,zlib",
-                          "--with-python",
+                          "--enable-python",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
build option "--with-python" is "unrecognized options"
reference  `http://source.wiredtiger.com/3.2.0/build-posix.html`

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
