### PR TITLE
ptpd 2.3.1 (new formula)

### DIFF
--- a/Formula/ptpd.rb
+++ b/Formula/ptpd.rb
@@ -1,0 +1,19 @@
+class Ptpd < Formula
+  desc "Precision Time Protocol daemon"
+  homepage "https://github.com/ptpd/ptpd"
+  url "https://downloads.sourceforge.net/project/ptpd/ptpd/2.3.1/ptpd-2.3.1.tar.gz"
+  sha256 "0dbf54dd2c178bd9fe62481d2c37513ee36636d8bf137cfdad96891490cdbf93"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-snmp",
+                          "--without-net-snmp-config",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{sbin}/ptpd2", "--default-config"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Precision Time Protocol daemon version 2.3.1

I disabled SNMP support because I couldn't get it to compile with SNMP enabled.
