### PR TITLE
icu4c: force use of python2

### DIFF
--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -24,6 +24,10 @@ class Icu4c < Formula
       --with-library-bits=64
     ]
 
+    # Works around an issue detecting /usr/bin/python3
+    # https://github.com/Homebrew/homebrew-core/pull/40962
+    args << "ac_cv_prog_PYTHON=/usr/bin/python"
+
     cd "source" do
       system "./configure", *args
       system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

icu4c's configure script will make use of `python3` if it finds it in the path. 10.15 includes a `python3`, but it doesn't work by default. This adds Homebrew's `python` as a build dependency in order to get around this.