### PR TITLE
meson: fix detection of Xcode 11 compilers

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -15,6 +15,14 @@ class Meson < Formula
   depends_on "ninja"
   depends_on "python"
 
+  # Fixes support for Xcode 11.
+  # Backported from https://github.com/mesonbuild/meson/commit/b28e76f6bf6898a7de01f5dd103d5ad7c54bea45
+  # Should be in the next release.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/bd45b828dc74b33b35a89dc02dd1f556064d227f/meson/xcode_11.patch"
+    sha256 "7b03f81036478d234d94aa8731d7248007408e56917b07d083f1c4db9bb48c8b"
+  end
+
   def install
     version = Language::Python.major_minor_version("python3")
     ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Xcode 11 clang detection is currently broken in meson, preventing software that uses it from building with clang. This fixes it by backporting the following commit: https://github.com/mesonbuild/meson/commit/b28e76f6bf6898a7de01f5dd103d5ad7c54bea45