### PR TITLE
sleepwatcher 2.2.1

### DIFF
--- a/Formula/sleepwatcher.rb
+++ b/Formula/sleepwatcher.rb
@@ -1,5 +1,5 @@
 class Sleepwatcher < Formula
-  desc "Monitors sleep, wakeup, and idleness of a Mac. 64-bit as of v2.2.1"
+  desc "Monitors sleep, wakeup, and idleness of a Mac"
   homepage "https://www.bernhard-baehr.de/"
   url "https://www.bernhard-baehr.de/sleepwatcher_2.2.1.tgz"
   sha256 "4bf1656702167871141fbc119a844d1363d89994e1a67027f0e773023ae9643e"

--- a/Formula/sleepwatcher.rb
+++ b/Formula/sleepwatcher.rb
@@ -1,8 +1,8 @@
 class Sleepwatcher < Formula
-  desc "Monitors sleep, wakeup, and idleness of a Mac"
+  desc "Monitors sleep, wakeup, and idleness of a Mac. 64-bit as of v2.2.1"
   homepage "https://www.bernhard-baehr.de/"
-  url "https://www.bernhard-baehr.de/sleepwatcher_2.2.tgz"
-  sha256 "c04ac1c49e2b5785ed5d5c375854c9c0b9e959affa46adab57985e4123e8b6be"
+  url "https://www.bernhard-baehr.de/sleepwatcher_2.2.1.tgz"
+  sha256 "4bf1656702167871141fbc119a844d1363d89994e1a67027f0e773023ae9643e"
 
   bottle do
     cellar :any_skip_relocation
@@ -18,12 +18,12 @@ class Sleepwatcher < Formula
     # Adjust Makefile to build native binary only
     inreplace "sources/Makefile" do |s|
       s.gsub! /^(CFLAGS)_PPC.*$/, "\\1 = #{ENV.cflags} -prebind"
-      s.gsub! /^(CFLAGS_X86)/, "#\\1"
+      s.gsub! /^(CFLAGS_I386|CFLAGS_X86_64)/, "#\\1"
       s.change_make_var! "BINDIR", "$(PREFIX)/sbin"
       s.change_make_var! "MANDIR", "$(PREFIX)/share/man"
-      s.gsub! /^(.*?)CFLAGS_PPC(.*?)[.]ppc/, "\\1CFLAGS\\2"
-      s.gsub! /^(.*?CFLAGS_X86.*?[.]x86)/, "#\\1"
-      s.gsub! /^(\t(lipo|rm).*?[.](ppc|x86))/, "#\\1"
+      s.gsub! /^(.*?)CFLAGS_I386(.*?)[.]i386/, "\\1CFLAGS\\2"
+      s.gsub! /^(.*?CFLAGS_X86_64.*?[.]x86_64)/, "#\\1"
+      s.gsub! /^(\t(lipo|rm).*?[.](i386|x86_64))/, "#\\1"
       s.gsub! "-o root -g wheel", ""
     end
 


### PR DESCRIPTION
v2.2.1 is the first version to build as 64-bit binary. This is required by macOS 10.15 Catalina.

As for point 4 and 5 in the task list below:

- `brew test sleepwatcher` failed as there’s no ‘test do’ block in the formula and I don’t know how to add an appropriate one (as sleepwatcher performs action on sleep or wake only).
- That’s also the only reason why `brew audit --strict sleepwatcher` failed. This was its output in Terminal:

```
sleepwatcher:
  * C: 1: col 1: A `test do` test block should be added
Error: 1 problem in 1 formula detected
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
