### PR TITLE
node: fix clang 11

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -23,6 +23,13 @@ class Node < Formula
     sha256 "d6194c36bf612f1b2a6fbe351a7cb6f44dfb9a87a1d5336b1303dc1c07e87276"
   end
 
+  # Fixes detecting Apple clang 11.
+  # This is an upstream patch and will be in the next release.
+  patch do
+    url "https://github.com/nodejs/node/commit/1f143b8625c2985b4317a40f279232f562417077.patch?full_index=1"
+    sha256 "12d8af6647e9a5d81f68f610ad0ed17075bf14718f4d484788baac37a0d3f842"
+  end
+
   def install
     # Never install the bundled "npm", always prefer our
     # installation from tarball for better packaging control.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apple clang 11 is misdetected by the configure script, preventing node from building with it. This is already fixed upstream, just not in a release yet.