### PR TITLE
Remove libffi keg-only since Mojave

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -21,7 +21,9 @@ class Libffi < Formula
     depends_on "libtool" => :build
   end
 
-  keg_only :provided_by_macos, "some formulae require a newer version of libffi"
+  if MacOS.version < "10.14"
+    keg_only :provided_by_macos, "some formulae require a newer version of libffi"
+  end
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove libffi being keg-only since Mojave, as libffi isn't provided by macOS (I couldn't find header files or `.pc` files). If there are other reasons to mark a formula as keg-only, please let me know.

Fixes #40179