### PR TITLE
qemu: depend on lzo

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -3,7 +3,7 @@ class Qemu < Formula
   homepage "https://www.qemu.org/"
   url "https://download.qemu.org/qemu-4.0.0.tar.xz"
   sha256 "13a93dfe75b86734326f8d5b475fde82ec692d5b5a338b4262aeeb6b0fa4e469"
-  revision 1
+  revision 2
   head "https://git.qemu.org/git/qemu.git"
 
   bottle do
@@ -20,6 +20,7 @@ class Qemu < Formula
   depends_on "libpng"
   depends_on "libssh2"
   depends_on "libusb"
+  depends_on "lzo"
   depends_on "ncurses"
   depends_on "pixman"
   depends_on "vde"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Instead of avoiding its opportunistic linkage against `lzo`, simply adding `lzo` as another dependency since `qemu` already has lots of dependencies as pointed out by @fxcoudert. 😅