### PR TITLE
corectl: fix build due to OCaml shift

### DIFF
--- a/Formula/corectl.rb
+++ b/Formula/corectl.rb
@@ -3,7 +3,7 @@ class Corectl < Formula
   homepage "https://github.com/TheNewNormal/corectl"
   url "https://github.com/TheNewNormal/corectl/archive/v0.7.18.tar.gz"
   sha256 "9bdf7bc8c6a7bd861e2b723c0566d0a093ed5d5caf370a065a1708132b4ab98a"
-  revision 1
+  revision 2
   head "https://github.com/TheNewNormal/corectl.git", :branch => "golang"
 
   bottle do
@@ -19,6 +19,7 @@ class Corectl < Formula
   depends_on "go" => :build
   depends_on "ocaml" => :build
   depends_on "opam" => :build
+  depends_on :x11 => :build
   depends_on "libev"
   depends_on :macos => :yosemite
 
@@ -37,18 +38,12 @@ class Corectl < Formula
     args << "VERSION=#{version}" if build.stable?
 
     cd path do
-      system "opam", "init", "--no-setup"
-
-      # Upstream issue "OCaml 4.05.0 support - cannot build in Homebrew"
-      # Reported 23 Jul 2017 https://github.com/TheNewNormal/corectl/issues/119
-      inreplace "opamroot/compilers/4.04.2/4.04.2/4.04.2.comp",
-        '["./configure"', '["./configure" "-no-graph"'
-      system "opam", "switch", "4.04.2"
-
-      system "opam", "config", "exec", "--", "opam", "install", "uri",
-             "ocamlfind", "qcow-format", "conf-libev", "io-page<2",
-             "mirage-block-unix>2.3.0", "lwt<3.1.0"
-      (opamroot/"system/bin").install_symlink opamroot/"4.04.2/bin/qcow-tool"
+      system "opam", "init", "--no-setup", "--disable-sandboxing"
+      system "opam", "switch", "create", "ocaml-base-compiler.4.05.0"
+      system "opam", "config", "exec", "--", "opam", "install", "uri.2.2.0",
+             "ocamlfind.1.8.0", "qcow-format.0.5.0", "conf-libev.4-11", "io-page.1.6.1",
+             "mirage-block-unix.2.4.0", "lwt.3.0.0"
+      (opamroot/"system/bin").install_symlink opamroot/"ocaml-base-compiler.4.05.0/bin/qcow-tool"
       system "opam", "config", "exec", "--", "make", "tarball", *args
 
       bin.install Dir["bin/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, `brew install --build-from-source hyperkit` fails. This fixes the build.