### PR TITLE
gromacs 2019.3

### DIFF
--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -1,27 +1,34 @@
 class Gromacs < Formula
   desc "Versatile package for molecular dynamics calculations"
   homepage "http://www.gromacs.org/"
-  url "https://ftp.gromacs.org/pub/gromacs/gromacs-2019.1.tar.gz"
-  sha256 "b2c37ed2fcd0e64c4efcabdc8ee581143986527192e6e647a197c76d9c4583ec"
-
-  bottle do
-    sha256 "94d33c3b2aab69176bb9ae38225a4486f8e648e775628046cc376d6110f70c64" => :mojave
-    sha256 "f5e98222c231b867623809636fe56ec550bf533f517b7312bb554a915bdf4fe9" => :high_sierra
-    sha256 "c4479eb9a92d1615c2247c9ba3ab185de46a35cc37b55c2a6443f0f73eb7c0cb" => :sierra
-  end
+  url "https://ftp.gromacs.org/pub/gromacs/gromacs-2019.3.tar.gz"
+  sha256 "4211a598bf3b7aca2b14ad991448947da9032566f13239b1a05a2d4824357573"
 
   depends_on "cmake" => :build
   depends_on "fftw"
-  depends_on "gsl"
+  depends_on "gcc@8" # Compilation using gcc 9.1 failed for some reason.
 
   def install
-    inreplace "scripts/CMakeLists.txt", "CMAKE_INSTALL_BINDIR",
-                                        "CMAKE_INSTALL_DATADIR"
+    # fix an error on detecting CPU. see https://redmine.gromacs.org/issues/2927
+    inreplace "cmake/gmxDetectCpu.cmake",
+              "\"${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}\")",
+              "${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})"
+    # Use gnu compiler to enable OpenMP instead of Apple llvm
+    args = std_cmake_args + %w[
+      -DCMAKE_C_COMPILER=gcc-8
+      -DCMAKE_CXX_COMPILER=g++-8
+      -DGMX_MPI=OFF
+      -DGMX_DOUBLE=OFF
+      -DGMX_OPENMP=ON
+      -DGMX_GPU=OFF
+      -DBUILD_SHARED_LIBS=ON
+      -DGMX_PREFER_STATIC_LIBS=OFF
+      -DGMX_FFT_LIBRARY=FFTW3
+    ]
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DGMX_GSL=ON"
-      system "make"
-      ENV.deparallelize { system "make", "install" }
+      system "cmake", "..", *args
+      system "make", "install"
     end
 
     bash_completion.install "build/scripts/GMXRC" => "gromacs-completion.bash"

--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -4,26 +4,28 @@ class Gromacs < Formula
   url "https://ftp.gromacs.org/pub/gromacs/gromacs-2019.3.tar.gz"
   sha256 "4211a598bf3b7aca2b14ad991448947da9032566f13239b1a05a2d4824357573"
 
+  bottle do
+    sha256 "94d33c3b2aab69176bb9ae38225a4486f8e648e775628046cc376d6110f70c64" => :mojave
+    sha256 "f5e98222c231b867623809636fe56ec550bf533f517b7312bb554a915bdf4fe9" => :high_sierra
+    sha256 "c4479eb9a92d1615c2247c9ba3ab185de46a35cc37b55c2a6443f0f73eb7c0cb" => :sierra
+  end
+
   depends_on "cmake" => :build
   depends_on "fftw"
-  depends_on "gcc@8" # Compilation using gcc 9.1 failed for some reason.
+  depends_on "gcc" # for OpenMP
 
   def install
+    # Non-executable GMXRC files should be installed in DATADIR
+    inreplace "scripts/CMakeLists.txt", "CMAKE_INSTALL_BINDIR",
+                                        "CMAKE_INSTALL_DATADIR"
     # fix an error on detecting CPU. see https://redmine.gromacs.org/issues/2927
     inreplace "cmake/gmxDetectCpu.cmake",
               "\"${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}\")",
               "${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})"
-    # Use gnu compiler to enable OpenMP instead of Apple llvm
+
     args = std_cmake_args + %w[
-      -DCMAKE_C_COMPILER=gcc-8
-      -DCMAKE_CXX_COMPILER=g++-8
-      -DGMX_MPI=OFF
-      -DGMX_DOUBLE=OFF
-      -DGMX_OPENMP=ON
-      -DGMX_GPU=OFF
-      -DBUILD_SHARED_LIBS=ON
-      -DGMX_PREFER_STATIC_LIBS=OFF
-      -DGMX_FFT_LIBRARY=FFTW3
+      -DCMAKE_C_COMPILER=gcc-9
+      -DCMAKE_CXX_COMPILER=g++-9
     ]
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Update to Gromacs 2019.3. In this formula, gcc-8 compiler was used because gcc-9 and Apple LLVM could not compile successfully.

I also fix an error on detecting CPU. see https://redmine.gromacs.org/issues/2927