### PR TITLE
chrome-export: install man pages

### DIFF
--- a/Formula/chrome-export.rb
+++ b/Formula/chrome-export.rb
@@ -3,12 +3,15 @@ class ChromeExport < Formula
   homepage "https://github.com/bdesham/chrome-export"
   url "https://github.com/bdesham/chrome-export/archive/v2.0.2.tar.gz"
   sha256 "41b667b407bc745a57105cc7969ec80cd5e50d67e1cce73cf995c2689d306e97"
+  revision 1
 
   bottle :unneeded
 
   def install
     bin.install "export-chrome-bookmarks"
     bin.install "export-chrome-history"
+    man1.install "man_pages/export-chrome-bookmarks.1"
+    man1.install "man_pages/export-chrome-history.1"
     pkgshare.install "test"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula was updated to v2.0.2 in #41029, but that version also added man pages. This PR updates the formula to install the man pages.

I added `revision 1`, although this is a `bottle :unneeded` formula. Is the revision number unnecessary in this case?