### PR TITLE
hidapi 0.9.0

### DIFF
--- a/Formula/hidapi.rb
+++ b/Formula/hidapi.rb
@@ -1,9 +1,9 @@
 class Hidapi < Formula
   desc "Library for communicating with USB and Bluetooth HID devices"
-  homepage "https://github.com/signal11/hidapi"
-  url "https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.tar.gz"
-  sha256 "3c147200bf48a04c1e927cd81589c5ddceff61e6dac137a605f6ac9793f4af61"
-  head "https://github.com/signal11/hidapi.git"
+  homepage "https://github.com/libusb/hidapi"
+  url "https://github.com/libusb/hidapi/archive/hidapi-0.9.0.tar.gz"
+  sha256 "630ee1834bdd5c5761ab079fd04f463a89585df8fcae51a7bfe4229b1e02a652"
+  head "https://github.com/libusb/hidapi.git"
 
   bottle do
     cellar :any
@@ -20,17 +20,6 @@ class Hidapi < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-
-  # This patch addresses a bug discovered in the HidApi IOHidManager back-end
-  # that is being used with Macs.
-  # The bug was dramatically changing the behaviour of the function
-  # "hid_get_feature_report". As a consequence, many applications working
-  # with HidApi were not behaving correctly on OSX.
-  # pull request on Hidapi's repo: https://github.com/signal11/hidapi/pull/219
-  patch do
-    url "https://github.com/signal11/hidapi/pull/219.patch?full_index=1"
-    sha256 "c0ff6eb370d6b875c06d72724a1a12fa0bafcbd64b2610014abc50a516760240"
-  end
 
   def install
     system "./bootstrap"


### PR DESCRIPTION
hidapi has a new home at libusb - and 0.9.0 has been released

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
