### PR TITLE
Patch irrlicht for macOS Mojave and add bottle

### DIFF
--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -7,6 +7,7 @@ class Irrlicht < Formula
 
   bottle do
     cellar :any_skip_relocation
+    sha256 "88ef6a24a237c71b1342f4cd6a8dbf6d797d2460b1020cdf7f49b7ef0d2a24a2" => :mojave
     sha256 "73fd50ff1e1270c213c5395eceb3997d0ab3e535b3f62eb256d99b0f612d5ea4" => :high_sierra
     sha256 "bf23da843d21ab650999c6766b20c4940d589caaaaf2b651726a2c09acb472e0" => :sierra
     sha256 "4f75c007fac42d0c5970afcbac919ccf32a2f827ea1d153461a2f6bffb638be8" => :el_capitan
@@ -24,6 +25,12 @@ class Irrlicht < Formula
       "[NSApp setDelegate:(id<NSFileManagerDelegate>)",
       "[NSApp setDelegate:(id<NSApplicationDelegate>)"
 
+    # Fix "error: ZLIB_VERNUM != PNG_ZLIB_VERNUM" on Mojave (picking up system zlib)
+    # Reported 21 Oct 2018 https://sourceforge.net/p/irrlicht/bugs/442/
+    inreplace "source/Irrlicht/libpng/pngpriv.h",
+      "#  error ZLIB_VERNUM != PNG_ZLIB_VERNUM \\",
+      "#  warning ZLIB_VERNUM != PNG_ZLIB_VERNUM \\"
+    
     xcodebuild "-project", "source/Irrlicht/MacOSX/MacOSX.xcodeproj",
                "-configuration", "Release",
                "-target", "libIrrlicht.a",

--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -7,7 +7,6 @@ class Irrlicht < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "88ef6a24a237c71b1342f4cd6a8dbf6d797d2460b1020cdf7f49b7ef0d2a24a2" => :mojave
     sha256 "73fd50ff1e1270c213c5395eceb3997d0ab3e535b3f62eb256d99b0f612d5ea4" => :high_sierra
     sha256 "bf23da843d21ab650999c6766b20c4940d589caaaaf2b651726a2c09acb472e0" => :sierra
     sha256 "4f75c007fac42d0c5970afcbac919ccf32a2f827ea1d153461a2f6bffb638be8" => :el_capitan
@@ -30,7 +29,7 @@ class Irrlicht < Formula
     inreplace "source/Irrlicht/libpng/pngpriv.h",
       "#  error ZLIB_VERNUM != PNG_ZLIB_VERNUM \\",
       "#  warning ZLIB_VERNUM != PNG_ZLIB_VERNUM \\"
-    
+
     xcodebuild "-project", "source/Irrlicht/MacOSX/MacOSX.xcodeproj",
                "-configuration", "Release",
                "-target", "libIrrlicht.a",


### PR DESCRIPTION
To allow building from source, replace the user-triggered error with a warning for now, until irrlicht updates. Hopefully, the edge case of broken PNGs isn't a big enough problem to warrant an entire broken build.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
