### PR TITLE
Triton CLI formula should install bash completions

### DIFF
--- a/Formula/triton.rb
+++ b/Formula/triton.rb
@@ -5,6 +5,7 @@ class Triton < Formula
   homepage "https://www.npmjs.com/package/triton"
   url "https://registry.npmjs.org/triton/-/triton-7.1.1.tgz"
   sha256 "24a1f697ee71451893f108dba9e4a5a7830cefe22028d98b504b3d2fe65ab2fe"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -18,6 +19,7 @@ class Triton < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
+    (bash_completion/"triton").write `#{bin}/triton completion`
   end
 
   test do


### PR DESCRIPTION
(This commit uses a pattern that I've seen in other formula with
similar install methods for completions, notably doctl.)

Signed-off-by: Alexander Lent <git@xanderlent.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
