### PR TITLE
Fix tfenv + terragrunt conflict

### DIFF
--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -14,7 +14,7 @@ class Terragrunt < Formula
 
   depends_on "dep" => :build
   depends_on "go" => :build
-  depends_on "terraform"
+  depends_on "terraform" => :optional
 
   def install
     ENV["GOPATH"] = buildpath
@@ -23,6 +23,23 @@ class Terragrunt < Formula
       system "dep", "ensure", "-vendor-only"
       system "go", "build", "-o", bin/"terragrunt", "-ldflags", "-X main.VERSION=v#{version}"
     end
+  end
+
+  def caveats
+    <<~EOS
+      Terraform dependency is marked as optional so it will not create conflicts
+      with tfenv users. You can install the current Terraform version by issuing
+      the following command:
+
+        brew install terragrunt --with-terraform
+
+      If you want to use specific Terraform version (which is recommended) you
+      can use tfenv. 
+      
+      Without locking Terraform version (if you have more than one machine 
+      running Terraform modules) you may have problems with state files which are
+      always not backwards compatible.
+    EOS
   end
 
   test do

--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -7,8 +7,6 @@ class Tfenv < Formula
 
   bottle :unneeded
 
-  conflicts_with "terraform", :because => "tfenv symlinks terraform binaries"
-
   def install
     prefix.install ["bin", "libexec"]
   end


### PR DESCRIPTION
Fix tfenv + terragrunt conflict by marking terraform dependency as
optional.

Fixes gruntwork-io/terragrunt#580

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
