### PR TITLE
Fix minio LaunchAgent

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -5,6 +5,7 @@ class Minio < Formula
       :tag      => "RELEASE.2019-06-19T18-24-42Z",
       :revision => "43e0ef4248e45e4ba404dc9781abd008005f53b2"
   version "20190619182442"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -63,7 +64,7 @@ class Minio < Formula
             <string>#{opt_bin}/minio</string>
             <string>server</string>
             <string>--config-dir=#{etc}/minio</string>
-            <string>--address :9000</string>
+            <string>--address=:9000</string>
             <string>#{var}/minio</string>
           </array>
           <key>RunAtLoad</key>
@@ -73,9 +74,9 @@ class Minio < Formula
           <key>WorkingDirectory</key>
           <string>#{HOMEBREW_PREFIX}</string>
           <key>StandardErrorPath</key>
-          <string>#{var}/log/minio/output.log</string>
+          <string>#{var}/log/minio.log</string>
           <key>StandardOutPath</key>
-          <string>#{var}/log/minio/output.log</string>
+          <string>#{var}/log/minio.log</string>
           <key>RunAtLoad</key>
           <true/>
         </dict>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently `brew services start minio` fails silently. This PR fixes two issues.

1. `--address` parameter for the service plist config had incorrect format
2. The plist tries to write logs to `var/log/minio/output.log` file, but for whatever reason the containing directory is owned by `root` and thus the service can't create the file. I don't know what creates the directory during install or why it's owned by root, but I think we can just log to `var/log/minio.log` similarly to how Postgresql logs to `var/log/postgresql.log`.