### PR TITLE
pari: remove x11 dependency

### DIFF
--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -12,17 +12,23 @@ class Pari < Formula
 
   depends_on "gmp"
   depends_on "readline"
-  depends_on :x11
 
   def install
     readline = Formula["readline"].opt_prefix
     gmp = Formula["gmp"].opt_prefix
     system "./Configure", "--prefix=#{prefix}",
                           "--with-gmp=#{gmp}",
-                          "--with-readline=#{readline}"
+                          "--with-readline=#{readline}",
+                          "--graphic=ps"
     # make needs to be done in two steps
     system "make", "all"
     system "make", "install"
+  end
+
+  def caveats; <<~EOS
+    If you need the graphical plotting functions you need to install X11 with:
+      brew cask install xquartz
+  EOS
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, I would like to make a plea with this PR: having access to an X11 server is of extremely marginal utility for PARI/GP. The whole software package can be used without it and since homebrew/homebrew-core doesn't support optional depdencies anymore it is better to implement a `caveat` than force a `depends_on` onto every single user.

This much is described in the first paragraph of the [PARI/GP homepage](https://pari.math.u-bordeaux.fr): the focus of the software is algebra and number theory. It provides a wealth of functions and operator to work with number fields, elliptic curves, modular forms, and other number-theoretic and algebraic objects. This is what the vast majority of PARI/GP users depend on it for.

It also provides a few [functions related to plotting](https://pari.math.u-bordeaux.fr/dochtml/html-stable/Plotting_functions) graphs and some graphical primitives. All of them are device-independent in the sense that the output device can be chosen by the user.

Now observe that the default for `plot()` is (a rather cute) textual output:

```
? plot(x=-5,5,exp(-abs(x/2))*sin(2*x))

 0.692608 |''''''''''''''''''''''''''''''''''x"''''''''''''''''''''''''''|
          |                                 _  "                         |
          |                                 :   _                        |
          |                                :    :                        |
          |                                x     :                       |
          |                                :     "                       |
          |               x""_            :                              |
          |              x    _           :       x                      |
          |             x                 x       :              ___     |
          |            x       _          :        :           x"   x_   |
          "x          _                   :        "          "       x_ |
          ``"x```````_``````````_````````:```````````````````"``````````x_
          |   "x   _x           :        :          "       x            |
          |     """              :       x                 x             |
          |                      x       :           "    x              |
          |                             :             "__x               |
          |                       _     :                                |
          |                       :     x                                |
          |                        :    :                                |
          |                        "   :                                 |
          |                         _  "                                 |
-0.692608 |.........................._x..................................|
          -5                                                             5
```

Furthermore it is very easy to produce PostScript and/or SVG output as follows:

```
? plotinit(0,300,300);
? s=plothexport("ps",x=-5,5,exp(-abs(x/2))*sin(2*x));
? write("/tmp/graph.ps",s);
```

![Screenshot 2019-06-23 at 12 10 02](https://user-images.githubusercontent.com/2104122/59977374-a8d86180-95d0-11e9-9fbf-2a8319c7d937.png)

Lastly there is the option to have the software fork a process that creates an X11 window in which the results can be shown as well. Please note that none of the functionality is impeded by removing the `depends_on :x11` constraint.

It seems to me this is a perfect example for the use of the [`caveats`](https://docs.brew.sh/Formula-Cookbook#caveats) feature: the software works, but the user needs to perform extra steps to unveil this tiny last corner of functionality.

Furthermore the steps to take are straightforward now that [X11/XQuartz](https://github.com/Homebrew/brew/blob/6b2dbbc96f7d8aa12f9b8c9c60107c9cc58befc4/Library/Homebrew/os/mac/xquartz.rb) is part of the [official homebrew/homebrew-cask tap](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/xquartz.rb). A `brew cask install xquartz` will immediately allow access to the `plotdraw()` function.

Thank you for taking the time to read and review this proposal, it is appreciated!
