### PR TITLE
go: update DWARF patch

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -46,6 +46,16 @@ class Go < Formula
     sha256 "25a361bd4aa1155be06e2239c1974aa9c59f971210f19e16a3b7b576b9d4f677"
   end
 
+  patch do
+    url "https://github.com/golang/go/commit/0fe1986a72ea578390d4909988a1d7cb3a687544.patch?full_index=1"
+    sha256 "320c11208313fc74e0bba7f323791416e5316451b109c440f56be361df8306ea"
+  end
+
+  patch do
+    url "https://github.com/golang/go/commit/3f1422c799edb143303c86c0e875d44c3612df64.patch?full_index=1"
+    sha256 "d071f0415cd2712cbed373682c4a84661147df1aabf38bbc0f3179532a988a4f"
+  end
+
   def install
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"

--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -36,6 +36,16 @@ class GoAT111 < Formula
     sha256 "25a361bd4aa1155be06e2239c1974aa9c59f971210f19e16a3b7b576b9d4f677"
   end
 
+  patch do
+    url "https://github.com/golang/go/commit/0fe1986a72ea578390d4909988a1d7cb3a687544.patch?full_index=1"
+    sha256 "320c11208313fc74e0bba7f323791416e5316451b109c440f56be361df8306ea"
+  end
+
+  patch do
+    url "https://github.com/golang/go/commit/3f1422c799edb143303c86c0e875d44c3612df64.patch?full_index=1"
+    sha256 "d071f0415cd2712cbed373682c4a84661147df1aabf38bbc0f3179532a988a4f"
+  end
+
   def install
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This backports an extra DWARF patch to 1.12 and 1.11: https://github.com/golang/go/commit/3f1422c799edb143303c86c0e875d44c3612df64

The patch doesn't apply to 1.10 or 1.9. More work would be needed to adapt it to them.