### PR TITLE
fontconfig: recognize downloadable fonts on macOS Catalina

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -37,7 +37,7 @@ class Fontconfig < Formula
     ]
 
     if MacOS.version >= :sierra
-      font_dirs << Dir["/System/Library/Assets/com_apple_MobileAsset_Font*"].max
+      font_dirs << Dir["/System/Library/Assets{,V2}/com_apple_MobileAsset_Font*"].max
     end
 
     system "autoreconf", "-iv" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

On macOS Catalina, the directory is relocated to `/System/Library/AssetsV2/com_apple_MobileAsset_Font6/`.