### PR TITLE
sonobuoy 0.15.0 => Use new build target

### DIFF
--- a/Formula/sonobuoy.rb
+++ b/Formula/sonobuoy.rb
@@ -23,10 +23,7 @@ class Sonobuoy < Formula
     (buildpath/"src/github.com/heptio/sonobuoy").install buildpath.children
 
     cd "src/github.com/heptio/sonobuoy" do
-      system "go", "build", "-o", bin/"sonobuoy", "-installsuffix", "static",
-                   "-ldflags",
-                   "-s -w -X github.com/heptio/sonobuoy/pkg/buildinfo.Version=#{version}",
-                   "./"
+      system "make", "native"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
Changing the build process based on these PRs / issues:

* https://github.com/Homebrew/homebrew-core/pull/40977
* https://github.com/heptio/sonobuoy/issues/715#issuecomment-503317919

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
