### PR TITLE
nibtools 2014r649 (new formula)

### DIFF
--- a/Formula/nibtools.rb
+++ b/Formula/nibtools.rb
@@ -7,6 +7,7 @@ class Nibtools < Formula
 
   depends_on "cc65" => :build
   depends_on "opencbm" => :build
+  depends_on "opencbm"
 
   def install
     system "make", "-f", "GNU/Makefile", "linux"

--- a/Formula/nibtools.rb
+++ b/Formula/nibtools.rb
@@ -1,0 +1,25 @@
+class Nibtools < Formula
+  desc "Commodore 1541/1571 disk image nibbler"
+  homepage "https://c64preservation.com/dp.php?pg=nibtools"
+  url "https://c64preservation.com/svn/nibtools/trunk", :using => :svn, :revision => "649"
+  version "2014"
+  sha256 "4e4bb0d2872084ae45d208ccf0868e1901fab99eb17e972e2f0351de63ac840a"
+
+  depends_on "cc65" => :build
+  depends_on "opencbm" => :build
+
+  def install
+    system "make", "-f", "GNU/Makefile", "linux"
+    mkdir bin.to_s
+    cp %w[nibread nibwrite nibconv nibscan nibrepair nibsrqtest], bin.to_s
+  end
+
+  test do
+    assert_path_exist("#{bin}/nibread")
+    assert_path_exist("#{bin}/nibwrite")
+    assert_path_exist("#{bin}/nibconv")
+    assert_path_exist("#{bin}/nibscan")
+    assert_path_exist("#{bin}/nibrepair")
+    assert_path_exist("#{bin}/nibsrqtest")
+  end
+end


### PR DESCRIPTION
Commodore 1541/1571 disk image nibbler

Disk image nibbler tools that complement the opencbm brew formula.
I have contacted the owner of the source, Pete Rittwage, and he
has agreed to allow me to share this formula that will pull from
his svn repository, compile, and install the tools. CC65 and OpenCBM
are dependencies, and brew formulas cc65 and opencbm exist for them
both respectfully. It is my hope Commodore enthusiasts on Mac will
find this formula useful.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
