### PR TITLE
Add `uses_from_macos` to formulae, part 1 (a-j)

### DIFF
--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -15,6 +15,8 @@ class Advancecomp < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/advancemenu.rb
+++ b/Formula/advancemenu.rb
@@ -13,6 +13,7 @@ class Advancemenu < Formula
   end
 
   depends_on "sdl"
+  uses_from_macos "expat"
 
   conflicts_with "advancemame", :because => "both install `advmenu` binaries"
 

--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -34,6 +34,7 @@ class Agda < Formula
   depends_on "cabal-install" => [:build, :test]
   depends_on "emacs"
   depends_on "ghc"
+  uses_from_macos "zlib"
 
   def install
     # install Agda core

--- a/Formula/aide.rb
+++ b/Formula/aide.rb
@@ -20,6 +20,7 @@ class Aide < Formula
   depends_on "libgcrypt"
   depends_on "libgpg-error"
   depends_on "pcre"
+  uses_from_macos "curl"
 
   def install
     system "sh", "./autogen.sh" if build.head?

--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -19,6 +19,7 @@ class Analog < Formula
   depends_on "gd"
   depends_on "jpeg"
   depends_on "libpng"
+  uses_from_macos "zlib"
 
   def install
     system "make", "CC=#{ENV.cc}",

--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -18,6 +18,7 @@ class AptDater < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "popt"
+  uses_from_macos "libxml2"
 
   def install
     system "autoreconf", "-ivf"

--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -20,6 +20,7 @@ class Arabica < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "boost"
+  uses_from_macos "expat"
 
   def install
     system "autoreconf", "-fvi"

--- a/Formula/arping.rb
+++ b/Formula/arping.rb
@@ -16,6 +16,7 @@ class Arping < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libnet"
+  uses_from_macos "libpcap"
 
   def install
     system "./bootstrap.sh"

--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -15,6 +15,7 @@ class Assimp < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  uses_from_macos "zlib"
 
   # Fix "unzip.c:150:11: error: unknown type name 'z_crc_t'"
   # Upstream PR from 12 Dec 2017 "unzip: fix build with older zlib"

--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -17,6 +17,7 @@ class Atomicparsley < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  uses_from_macos "zlib"
 
   # Fix Xcode 9 pointer warnings
   # https://bitbucket.org/wez/atomicparsley/issues/52/xcode-9-build-failure

--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -21,6 +21,7 @@ class Augeas < Formula
 
   depends_on "pkg-config" => :build
   depends_on "readline"
+  uses_from_macos "libxml2"
 
   def install
     args = %W[--disable-debug --disable-dependency-tracking --prefix=#{prefix}]

--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -14,6 +14,7 @@ class Autogen < Formula
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "guile"
+  uses_from_macos "libxml2"
 
   def install
     # Uses GNU-specific mktemp syntax: https://sourceforge.net/p/autogen/bugs/189/

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -12,6 +12,8 @@ class Autojump < Formula
     sha256 "c95107719bd784e0e348be6dbfb3a780240d96f8d76710271c3642335babbd8f" => :sierra
   end
 
+  uses_from_macos "python@2"
+
   def install
     system "./install.py", "-d", prefix, "-z", zsh_completion
 

--- a/Formula/avian.rb
+++ b/Formula/avian.rb
@@ -17,6 +17,7 @@ class Avian < Formula
   end
 
   depends_on :java => "1.8"
+  uses_from_macos "zlib"
 
   def install
     system "make", "use-clang=true"

--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -15,6 +15,7 @@ class AvroC < Formula
   depends_on "jansson"
   depends_on "snappy"
   depends_on "xz"
+  uses_from_macos "zlib"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -12,6 +12,8 @@ class AwsElasticbeanstalk < Formula
     sha256 "e88ba1b0777ae69d037fb3fe933b833ed8147d34b85aa0adb97b2d63df08a87f" => :high_sierra
   end
 
+  uses_from_macos "python@2"
+
   resource "backports.ssl_match_hostname" do
     url "https://files.pythonhosted.org/packages/76/21/2dc61178a2038a5cb35d14b61467c6ac632791ed05131dda72c20e7b9e23/backports.ssl_match_hostname-3.5.0.1.tar.gz"
     sha256 "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2"

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -14,6 +14,7 @@ class AwsSdkCpp < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "curl"
 
   def install
     mkdir "build" do

--- a/Formula/bamtools.rb
+++ b/Formula/bamtools.rb
@@ -14,6 +14,7 @@ class Bamtools < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "zlib"
 
   def install
     mkdir "build" do

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -13,6 +13,7 @@ class Bat < Formula
   end
 
   depends_on "rust" => :build
+  uses_from_macos "zlib"
 
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath

--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -13,6 +13,8 @@ class Bazaar < Formula
     sha256 "6d1409dc49d838c0209bc59ebeb4ec5b70c5c1caef3b27b97f0ebedd6d8ff515" => :el_capitan
   end
 
+  uses_from_macos "python@2"
+
   # CVE-2017-14176
   # https://bugs.launchpad.net/brz/+bug/1710979
   patch do

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -11,6 +11,8 @@ class Binutils < Formula
     sha256 "7fabb9b6e95bbc156469a765189e153917adb9b8fbdc24a7662f42b4995ba825" => :sierra
   end
 
+  uses_from_macos "zlib"
+
   keg_only :provided_by_macos,
            "because Apple provides the same tools and binutils is poorly supported on macOS"
 

--- a/Formula/bison.rb
+++ b/Formula/bison.rb
@@ -11,6 +11,8 @@ class Bison < Formula
     sha256 "606a6ec0b5fa0adaa07ba8cdcb2c99e40d3b6c9a690d324f1688e5a832c2452b" => :sierra
   end
 
+  uses_from_macos "m4"
+
   keg_only :provided_by_macos, "some formulae require a newer version of bison"
 
   def install

--- a/Formula/blockhash.rb
+++ b/Formula/blockhash.rb
@@ -15,6 +15,7 @@ class Blockhash < Formula
 
   depends_on "pkg-config" => :build
   depends_on "imagemagick"
+  uses_from_macos "python@2"
 
   resource "testdata" do
     url "https://raw.githubusercontent.com/commonsmachinery/blockhash/ce08b465b658c4e886d49ec33361cee767f86db6/testdata/clipper_ship.jpg"

--- a/Formula/brogue.rb
+++ b/Formula/brogue.rb
@@ -14,6 +14,8 @@ class Brogue < Formula
     sha256 "b5f6a25670f2eeb737bcde972b78801892971e2af4e3f7df1bbaa237eb4db50f" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   # put the highscores file in HOMEBREW_PREFIX/var/brogue/ instead of a
   # version-dependent location.
   patch do

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -33,6 +33,7 @@ class Burp < Formula
   depends_on "pkg-config" => :build
   depends_on "librsync"
   depends_on "openssl"
+  uses_from_macos "zlib"
 
   def install
     resource("uthash").stage do

--- a/Formula/bvi.rb
+++ b/Formula/bvi.rb
@@ -13,6 +13,8 @@ class Bvi < Formula
     sha256 "7ec90f6665011faa3f1715cf6cc855270a536993633d8a4600cdb0492db16686" => :mavericks
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"

--- a/Formula/bwa.rb
+++ b/Formula/bwa.rb
@@ -12,6 +12,8 @@ class Bwa < Formula
     sha256 "bee09d138e9d8f45c12d6c99b48a3e6891b6e4d3f5c6a6847bfeaa28afc2f362" => :el_capitan
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "make"
 

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -13,6 +13,7 @@ class CabalInstall < Formula
   end
 
   depends_on "ghc"
+  uses_from_macos "zlib"
 
   def install
     cd "cabal-install" if build.head?

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -11,6 +11,8 @@ class Ccache < Formula
     sha256 "b41e0434efa91fa46caae563d5866fcfee17915c52a8983b8c898d59a5646440" => :sierra
   end
 
+  uses_from_macos "zlib"
+
   head do
     url "https://github.com/ccache/ccache.git"
 

--- a/Formula/cdk.rb
+++ b/Formula/cdk.rb
@@ -12,6 +12,8 @@ class Cdk < Formula
     sha256 "fc9f42aad5f855408583a604ab54f8241c85464f5a7e44492452904aab55dfb4" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--prefix=#{prefix}", "--with-ncurses"
     system "make", "install"

--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -12,6 +12,7 @@ class Chezscheme < Formula
   end
 
   depends_on :x11 => :build
+  uses_from_macos "ncurses"
 
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime

--- a/Formula/clib.rb
+++ b/Formula/clib.rb
@@ -14,6 +14,8 @@ class Clib < Formula
     sha256 "ea221a1093f4bdb63209c30fc29a888ae5312baa9f50f1bc8c5b56dac75cbb46" => :yosemite
   end
 
+  uses_from_macos "curl"
+
   def install
     ENV["PREFIX"] = prefix
     system "make", "install"

--- a/Formula/clucene.rb
+++ b/Formula/clucene.rb
@@ -17,6 +17,7 @@ class Clucene < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "zlib"
 
   # Portability fixes for 10.9+
   # Upstream ticket: https://sourceforge.net/p/clucene/bugs/219/

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -22,6 +22,7 @@ class Collectd < Formula
   depends_on "libtool"
   depends_on "net-snmp"
   depends_on "riemann-client"
+  uses_from_macos "perl"
 
   def install
     args = %W[

--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -19,6 +19,7 @@ class Cryptol < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "z3"
+  uses_from_macos "ncurses"
 
   def install
     install_cabal_package :using => ["alex", "happy"]

--- a/Formula/cscope.rb
+++ b/Formula/cscope.rb
@@ -11,6 +11,8 @@ class Cscope < Formula
     sha256 "7eef899511b0d7eb0d6a35acf677d9b19f89528aae0272d5c414bbafbe5daaaf" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}"

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -22,6 +22,7 @@ class Curl < Formula
   keg_only :provided_by_macos
 
   depends_on "pkg-config" => :build
+  uses_from_macos "openssl"
 
   def install
     system "./buildconf" if build.head?

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -15,6 +15,7 @@ class Dcmtk < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "openssl"
+  uses_from_macos "libxml2"
 
   def install
     mkdir "build" do

--- a/Formula/dhex.rb
+++ b/Formula/dhex.rb
@@ -11,6 +11,8 @@ class Dhex < Formula
     sha256 "b83e63ad0f1e2910e1f2495903ac4077aa5caaabe8cb2702094f42c3921c7a9c" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   def install
     inreplace "Makefile", "$(DESTDIR)/man", "$(DESTDIR)/share/man"
     bin.mkpath

--- a/Formula/dialog.rb
+++ b/Formula/dialog.rb
@@ -11,6 +11,8 @@ class Dialog < Formula
     sha256 "bc2e02e165c9fc28dd339d511944c22cdedbd97ec9d02d897d097f9e41535565" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install-full"

--- a/Formula/diamond.rb
+++ b/Formula/diamond.rb
@@ -12,6 +12,7 @@ class Diamond < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "zlib"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -13,6 +13,8 @@ class Docbook < Formula
     sha256 "6ac70ee56739ffbe8d99e18164bc42d8d0df9ce62cc2a5c55be4b65cd74092aa" => :el_capitan
   end
 
+  uses_from_macos "libxml2"
+
   resource "xml412" do
     url "https://docbook.org/xml/4.1.2/docbkx412.zip"
     sha256 "30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772"

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -15,6 +15,7 @@ class Docbook2x < Formula
   end
 
   depends_on "docbook"
+  uses_from_macos "libxslt"
 
   def install
     inreplace "perl/db2x_xsltproc.pl", "http://docbook2x.sf.net/latest/xslt", "#{share}/docbook2X/xslt"

--- a/Formula/dub.rb
+++ b/Formula/dub.rb
@@ -15,6 +15,7 @@ class Dub < Formula
 
   depends_on "dmd" => :build
   depends_on "pkg-config"
+  uses_from_macos "curl"
 
   def install
     ENV["GITVER"] = version.to_s

--- a/Formula/dwarf.rb
+++ b/Formula/dwarf.rb
@@ -14,6 +14,7 @@ class Dwarf < Formula
 
   depends_on "flex"
   depends_on "readline"
+  uses_from_macos "bison"
 
   def install
     %w[src/libdwarf.c doc/dwarf.man doc/xdwarf.man.html].each do |f|

--- a/Formula/ejdb.rb
+++ b/Formula/ejdb.rb
@@ -15,6 +15,7 @@ class Ejdb < Formula
   end
 
   depends_on "cmake" => :build
+  uses_from_macos "bzip2"
 
   def install
     mkdir "build" do

--- a/Formula/exempi.rb
+++ b/Formula/exempi.rb
@@ -12,6 +12,7 @@ class Exempi < Formula
   end
 
   depends_on "boost"
+  uses_from_macos "expat"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -17,6 +17,7 @@ class Expect < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  uses_from_macos "tcl-tk"
 
   def install
     args = %W[

--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -12,6 +12,7 @@ class Fail2ban < Formula
 
   depends_on "help2man" => :build
   depends_on "sphinx-doc" => :build
+  uses_from_macos "python@2"
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"

--- a/Formula/fdclone.rb
+++ b/Formula/fdclone.rb
@@ -12,6 +12,7 @@ class Fdclone < Formula
   end
 
   depends_on "nkf" => :build
+  uses_from_macos "ncurses"
 
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/86107cf/fdclone/3.01b.patch"

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -19,6 +19,7 @@ class Fish < Formula
 
   depends_on "cmake" => :build
   depends_on "pcre2"
+  uses_from_macos "ncurses"
 
   def install
     # In Homebrew's 'superenv' sed's path will be incompatible, so

--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -14,6 +14,7 @@ class Fits < Formula
 
   depends_on "ant" => :build
   depends_on :java => "1.7+"
+  uses_from_macos "zlib"
 
   def install
     system "ant", "clean-compile-jar", "-noinput"

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -25,6 +25,7 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
+  uses_from_macos "libxml2"
 
   def install
     ENV["PYTHON_CFLAGS"] = `python3-config --cflags`.chomp

--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -13,6 +13,7 @@ class Fossil < Formula
   end
 
   depends_on "openssl"
+  uses_from_macos "zlib"
 
   def install
     args = [

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -13,6 +13,7 @@ class FreeradiusServer < Formula
 
   depends_on "openssl"
   depends_on "talloc"
+  uses_from_macos "perl"
 
   def install
     ENV.deparallelize

--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -22,6 +22,7 @@ class Freetds < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl"
   depends_on "unixodbc"
+  uses_from_macos "readline"
 
   def install
     args = %W[

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -13,6 +13,7 @@ class Fzf < Formula
   end
 
   depends_on "go" => :build
+  uses_from_macos "ncurses"
 
   def install
     ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"

--- a/Formula/gconf.rb
+++ b/Formula/gconf.rb
@@ -21,6 +21,7 @@ class Gconf < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "orbit"
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/get_iplayer.rb
+++ b/Formula/get_iplayer.rb
@@ -15,6 +15,7 @@ class GetIplayer < Formula
   depends_on "atomicparsley"
   depends_on "ffmpeg"
   depends_on :macos => :yosemite
+  uses_from_macos "libxml2"
 
   resource "IO::Socket::IP" do
     url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/IO-Socket-IP-0.39.tar.gz"

--- a/Formula/ghi.rb
+++ b/Formula/ghi.rb
@@ -14,6 +14,8 @@ class Ghi < Formula
     sha256 "d2b59c4b0326bd4d4b2de6da0310e1d5228cc63d57adb9eb37c5f5c5a9471131" => :el_capitan
   end
 
+  uses_from_macos "ruby"
+
   resource "multi_json" do
     url "https://rubygems.org/gems/multi_json-1.12.1.gem"
     sha256 "b387722b0a31fff619a2682c7011affb5a13fed2cce240c75c5d6ca3e910ecf2"

--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -14,6 +14,7 @@ class Ginac < Formula
   depends_on "pkg-config" => :build
   depends_on "cln"
   depends_on "readline"
+  uses_from_macos "python@2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/git-cinnabar.rb
+++ b/Formula/git-cinnabar.rb
@@ -13,6 +13,7 @@ class GitCinnabar < Formula
   end
 
   depends_on "mercurial"
+  uses_from_macos "curl"
 
   conflicts_with "git-remote-hg", :because => "both install `git-remote-hg` binaries"
 

--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -14,6 +14,7 @@ class GitFtp < Formula
 
   depends_on "pandoc" => :build
   depends_on "libssh2"
+  uses_from_macos "zlib"
 
   resource "curl" do
     url "https://curl.haxx.se/download/curl-7.62.0.tar.bz2"

--- a/Formula/git-lfs.rb
+++ b/Formula/git-lfs.rb
@@ -12,6 +12,7 @@ class GitLfs < Formula
   end
 
   depends_on "go" => :build
+  uses_from_macos "ruby"
 
   # System Ruby uses old TLS versions no longer supported by RubyGems.
   depends_on "ruby" => :build if MacOS.version <= :sierra

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -18,6 +18,7 @@ class Glib < Formula
   depends_on "libffi"
   depends_on "pcre"
   depends_on "python"
+  uses_from_macos "util-linux" # for libmount.so
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
   # but needed to fix an assumption about the location of the d-bus machine

--- a/Formula/globus-toolkit.rb
+++ b/Formula/globus-toolkit.rb
@@ -15,6 +15,7 @@ class GlobusToolkit < Formula
   depends_on "pkg-config" => :build
   depends_on "libtool"
   depends_on "openssl"
+  uses_from_macos "zlib"
 
   def install
     ENV.deparallelize

--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -30,6 +30,7 @@ class Goffice < Formula
   depends_on "librsvg"
   depends_on "pango"
   depends_on "pcre"
+  uses_from_macos "libxslt"
 
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]

--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -20,6 +20,7 @@ class GtkDoc < Formula
   depends_on "libxml2"
   depends_on "python"
   depends_on "source-highlight"
+  uses_from_macos "libxslt"
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/1d/55/55cd82a72af652d71eb14f318e2d12d2fd14ded43d6fd105e50ed395198c/Pygments-2.4.0.tar.gz"

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -14,6 +14,7 @@ class H2o < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
+  uses_from_macos "zlib"
 
   def install
     # https://github.com/Homebrew/homebrew-core/pull/1046

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -17,6 +17,7 @@ class HaskellStack < Formula
   end
 
   depends_on "cabal-install" => :build
+  uses_from_macos "zlib"
 
   # Stack requires stack to build itself. Yep.
   resource "bootstrap-stack" do

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -17,6 +17,7 @@ class Hdf5 < Formula
   depends_on "libtool" => :build
   depends_on "gcc" # for gfortran
   depends_on "szip"
+  uses_from_macos "zlib"
 
   def install
     inreplace %w[c++/src/h5c++.in fortran/src/h5fc.in tools/src/misc/h5cc.in],

--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -16,6 +16,7 @@ class Hfstospell < Formula
   depends_on "icu4c"
   depends_on "libarchive"
   depends_on "libxml++"
+  uses_from_macos "libxml2"
 
   # Fix "error: no template named 'auto_ptr' in namespace 'std'"
   # Upstream PR 20 Jun 2018 "C++14 (C++1y) should be the highest supported standard."

--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -14,8 +14,10 @@ class Hledger < Formula
     sha256 "5150a38fc8378410ca9b7b9d2fca755ccc7fe0eef6805fc07650fd836460a0bb" => :high_sierra
     sha256 "60422bb49e6e62f26780cec246007cfa38dc8fcb33c6718591e7f7e72fb44c2a" => :sierra
   end
+
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
+  uses_from_macos "ncurses"
 
   resource "hledger_web" do
     url "https://hackage.haskell.org/package/hledger-web-1.14.1/hledger-web-1.14.1.tar.gz"

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -16,6 +16,7 @@ class Httpd < Formula
   depends_on "nghttp2"
   depends_on "openssl"
   depends_on "pcre"
+  uses_from_macos "zlib"
 
   def install
     # fixup prefix references in favour of opt_prefix references

--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -14,6 +14,8 @@ class Icecast < Formula
   depends_on "pkg-config" => :build
   depends_on "libvorbis"
   depends_on "openssl"
+  uses_from_macos "curl"
+  uses_from_macos "libxslt"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -16,7 +16,6 @@ class Imagemagick < Formula
   end
 
   depends_on "pkg-config" => :build
-
   depends_on "freetype"
   depends_on "jpeg"
   depends_on "libheif"
@@ -29,6 +28,8 @@ class Imagemagick < Formula
   depends_on "openjpeg"
   depends_on "webp"
   depends_on "xz"
+  uses_from_macos "bzip2"
+  uses_from_macos "libxml2"
 
   skip_clean :la
 

--- a/Formula/io.rb
+++ b/Formula/io.rb
@@ -15,6 +15,7 @@ class Io < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  uses_from_macos "libxml2"
 
   def install
     ENV.deparallelize

--- a/Formula/ipbt.rb
+++ b/Formula/ipbt.rb
@@ -13,6 +13,8 @@ class Ipbt < Formula
     sha256 "81dfccfb83c374d509ab37f7ad4cf8cc0d40bfb3b47e45d9d05ea3880e3d03aa" => :sierra
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking"

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -21,6 +21,7 @@ class Irssi < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "openssl"
+  uses_from_macos "perl"
 
   def install
     ENV.delete "HOMEBREW_SDKROOT" if MacOS.version == :high_sierra

--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -14,6 +14,8 @@ class Ispell < Formula
     sha256 "f1ee90dcc76682d17c2b758d2a896493448753acc0e556e9b0c8bf7ec0f552df" => :mavericks
   end
 
+  uses_from_macos "ncurses"
+
   def install
     ENV.deparallelize
 

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -20,6 +20,8 @@ class Jack < Formula
     sha256 "ee93da9885f06dde0f305fca2d5af6d6213c2133466ca93857a87ffb731ce43f" => :el_capitan
   end
 
+  uses_from_macos "util-linux"
+
   depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "libsamplerate"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

c.f. https://github.com/Homebrew/brew/issues/6150

Note that there are many instances in linuxbrew-core where `uses_from_macos` is (I believe) used improperly. For example, `uses_from_macos "python"` is incorrect because macOS does not provide a Python 3 installation. Something to think about for a follow up issue.

I'll open a pull request for part 2 once this is merged.