### PR TITLE
maxima 5.43.0_1 because sbcl has been upgraded

### DIFF
--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -3,6 +3,7 @@ class Maxima < Formula
   homepage "https://maxima.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/maxima/Maxima-source/5.43.0-source/maxima-5.43.0.tar.gz"
   sha256 "dcfda54511035276fd074ac736e97d41905171e43a5802bb820914c3c885ca77"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I hope adding/increasing the revision is the correct way to do it when maxima has no new release.
Is it alright to do this in one PR, as was done in https://github.com/Homebrew/homebrew-core/pull/36558 , or is there a risk that `maxima` will be built with the old `sbcl` before the new `sbcl` is installed?