### PR TITLE
proguard 6.1.1 (with retrace tool)

### DIFF
--- a/Formula/proguard.rb
+++ b/Formula/proguard.rb
@@ -1,16 +1,18 @@
 class Proguard < Formula
   desc "Java class file shrinker, optimizer, and obfuscator"
   homepage "https://proguard.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/proguard/proguard/6.1/proguard6.1.0.tar.gz"
-  sha256 "0b71d441ac2df4d5186277c6050328903dd9b0062cb9d9f02937d1a00b55ea18"
+  url "https://downloads.sourceforge.net/project/proguard/proguard/6.1/proguard6.1.1.tar.gz"
+  sha256 "f76444c49d1d4f8e9a635ed812a33c4ea586bef308479dacc19ee55ae0289186"
 
   bottle :unneeded
 
   def install
     libexec.install "lib/proguard.jar"
     libexec.install "lib/proguardgui.jar"
+    libexec.install "lib/retrace.jar"
     bin.write_jar_script libexec/"proguard.jar", "proguard"
     bin.write_jar_script libexec/"proguardgui.jar", "proguardgui"
+    bin.write_jar_script libexec/"retrace.jar", "retrace"
   end
 
   test do
@@ -19,5 +21,11 @@ class Proguard < Formula
       Usage: java proguard.ProGuard [options ...]
     EOS
     assert_equal expect, shell_output("#{bin}/proguard", 1)
+
+    expect = <<~EOS
+      Picked up _JAVA_OPTIONS: #{ENV["_JAVA_OPTIONS"]}
+      Usage: java proguard.retrace.ReTrace [-regex <regex>] [-verbose] <mapping_file> [<stacktrace_file>]
+    EOS
+    assert_equal expect, pipe_output("#{bin}/retrace 2>&1")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR updates `ProGuard` to version `6.1.1` and includes missing `retrace.jar` tool in the formula.