### PR TITLE
argon2: add prefix for make and release a new version

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -13,9 +13,9 @@ class Argon2 < Formula
   end
 
   def install
-    system "make", "PREFIX=#{prefix}"
+    system "make", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
     system "make", "test"
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
     doc.install "argon2-specs.pdf"
   end
 

--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -13,7 +13,7 @@ class Argon2 < Formula
   end
 
   def install
-    system "make"
+    system "make", "PREFIX=#{prefix}"
     system "make", "test"
     system "make", "install", "PREFIX=#{prefix}"
     doc.install "argon2-specs.pdf"

--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -3,6 +3,7 @@ class Argon2 < Formula
   homepage "https://github.com/P-H-C/phc-winner-argon2"
   url "https://github.com/P-H-C/phc-winner-argon2/archive/20190702.tar.gz"
   sha256 "daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
+  revision 1
   head "https://github.com/P-H-C/phc-winner-argon2.git"
 
   bottle do


### PR DESCRIPTION
Signed-off-by: Jim Yeh <jim@bitmark.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up PR of https://github.com/Homebrew/homebrew-core/pull/39029, to update the `Makefile` from upstream.
As well as https://github.com/Homebrew/homebrew-core/pull/40110, to create a new release of  argon2.
