### PR TITLE
shogun: use github tarball

### DIFF
--- a/Formula/shogun.rb
+++ b/Formula/shogun.rb
@@ -1,8 +1,8 @@
 class Shogun < Formula
   desc "Large scale machine learning toolbox"
   homepage "http://www.shogun-toolbox.org/"
-  url "http://shogun-toolbox.org/archives/shogun/releases/6.1/sources/shogun-6.1.3.tar.bz2"
-  sha256 "57169dc8c05b216771c567b2ee2988f14488dd13f7d191ebc9d0703bead4c9e6"
+  url "https://github.com/shogun-toolbox/shogun/archive/shogun_6.1.3.tar.gz"
+  sha256 "75f4d555efe06eaa7c4c12a1dc942f6e4d41a8ed495777a790b9bd9df936c19c"
   revision 5
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed in #40438 jenkins builds that the shogun tarball isn't accessible on the shogun website. I reported it in https://github.com/shogun-toolbox/shogun/issues/4696, and they said "yes we intend to host those ... but the website is nonfunctional atm. The tarballs will be back once the website runs again, in the meantime, please use github" ( https://github.com/shogun-toolbox/shogun/issues/4696#issuecomment-506704554 ).

This probably doesn't need new bottles, and I expect the audit to fail. I can't find a tarball with the matching sha256 to compare against, but it seems safe to pull from the github tagged tarball.
