### PR TITLE
Update argon2.rb

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -7,7 +7,7 @@ class Argon2 < Formula
 
   bottle do
     cellar :any
-    sha256 "da0c88fc168a19ebaf26d4f1289b88ef35bc837412846d5bbd144ed22dee4059" => :mojave
+    sha256 "922dae39eb90c1f47531ad331470a3a23ff9196ef7e380f4f3f172055c38bb0f" => :mojave
     sha256 "7edff048989954edc68bc53d37d447a868dd5cc2c9f32af6644a839b0ab65659" => :high_sierra
     sha256 "a19f433693c3e3778a9163c36bb8296725ae2a8dd1cdd2f69d0d63f7e05383ef" => :sierra
   end


### PR DESCRIPTION
Error: SHA256 mismatch
Expected: da0c88fc168a19ebaf26d4f1289b88ef35bc837412846d5bbd144ed22dee4059
     Actual: 922dae39eb90c1f47531ad331470a3a23ff9196ef7e380f4f3f172055c38bb0f

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
