### PR TITLE
Revert "jboss-forge 3.9.3.Final"

### DIFF
--- a/Formula/jboss-forge.rb
+++ b/Formula/jboss-forge.rb
@@ -1,9 +1,9 @@
 class JbossForge < Formula
   desc "Tools to help set up and configure a project"
   homepage "https://forge.jboss.org/"
-  url "https://downloads.jboss.org/forge/releases/3.9.3.Final/forge-distribution-3.9.3.Final-offline.zip"
-  version "3.9.3.Final"
-  sha256 "5a9cfe8b45c07766107043213a729a8125ef2b88c228762f48e27c36514ea7c1"
+  url "https://downloads.jboss.org/forge/releases/3.9.2.Final/forge-distribution-3.9.2.Final-offline.zip"
+  version "3.9.2.Final"
+  sha256 "b94c28ad136c611e9aae5cce4df0fec9828ee14f87389657d23e3d591d07dfc7"
 
   bottle :unneeded
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#41459

There is something wrong with downloads.jboss.org. We're investigating