### PR TITLE
erlang 22.0.5

### DIFF
--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -2,8 +2,8 @@ class Erlang < Formula
   desc "Programming language for highly scalable real-time systems"
   homepage "https://www.erlang.org/"
   # Download tarball from GitHub; it is served faster than the official tarball.
-  url "https://github.com/erlang/otp/archive/OTP-22.0.4.tar.gz"
-  sha256 "71b2fe49ed5ac386ebc189dd2e5f4b95b11b4427936be0e3c5695a903ea9ffcd"
+  url "https://github.com/erlang/otp/archive/OTP-22.0.5.tar.gz"
+  sha256 "28e42e2cf2e43c187f273540987b0f297c46cff2c5eeba453144bc0d41dafd31"
   head "https://github.com/erlang/otp.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Regarding the last check (`audit`) [it seems to be passing in CI](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/44522/version=mojave/testReport/brew-test-bot/mojave/audit_erlang___online/), I got this error locally instead:

```shell
$ brew audit --strict Formula/erlang.rb
erlang:
  * Formula has other versions so create an alias named erlang@22.
Error: 1 problem in 1 formula detected
```

But I don't understand why it does throw this error, since this alias actually exists https://github.com/Homebrew/homebrew-core/blob/master/Aliases/erlang@22