### PR TITLE
podofo: fix dylib install name

### DIFF
--- a/Formula/podofo.rb
+++ b/Formula/podofo.rb
@@ -3,6 +3,7 @@ class Podofo < Formula
   homepage "https://podofo.sourceforge.io"
   url "https://downloads.sourceforge.net/podofo/podofo-0.9.6.tar.gz"
   sha256 "e9163650955ab8e4b9532e7aa43b841bac45701f7b0f9b793a98c8ca3ef14072"
+  revision 1
 
   bottle do
     cellar :any
@@ -29,6 +30,8 @@ class Podofo < Formula
 
   def install
     args = std_cmake_args + %W[
+      -DCMAKE_INSTALL_NAME_DIR=#{opt_lib}
+      -DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON
       -DCMAKE_DISABLE_FIND_PACKAGE_CppUnit=ON
       -DCMAKE_DISABLE_FIND_PACKAGE_LUA=ON
       -DPODOFO_BUILD_SHARED:BOOL=ON


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is preventing #41289 from being merged.