### PR TITLE
react-native-cli: fix test by pinning to react-native 0.59.x

### DIFF
--- a/Formula/react-native-cli.rb
+++ b/Formula/react-native-cli.rb
@@ -21,7 +21,7 @@ class ReactNativeCli < Formula
   end
 
   test do
-    output = shell_output("#{bin}/react-native init test")
+    output = shell_output("#{bin}/react-native init test --version=react-native@0.59.x")
     assert_match "Run instructions for Android", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes the test failure / timeout observed in #41585 by telling `react-native-cli` to use the 0.59.x version of `react-native` during the test. This is the case because `react-native` 0.60+ tries to `gem install cocoapods` during the installation, which would fail because of test sandbox permissions.