### PR TITLE
Add ffmpeg dependency to Formula/cmus.rb

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -13,6 +13,7 @@ class Cmus < Formula
 
   depends_on "pkg-config" => :build
   depends_on "faad2"
+  depends_on "ffmpeg"
   depends_on "flac"
   depends_on "libao"
   depends_on "libcue"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The ffmpeg dependency adds support for playing additional input file types like `wma`. Related to #37217.