### PR TITLE
cmus: Remove libao dep.

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -14,7 +14,6 @@ class Cmus < Formula
   depends_on "pkg-config" => :build
   depends_on "faad2"
   depends_on "flac"
-  depends_on "libao"
   depends_on "libcue"
   depends_on "libogg"
   depends_on "libvorbis"


### PR DESCRIPTION
Core Audio support is included in cmus so libao is unecessary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

-----

If anyone is interested here is the `cmus --plugins` output:

```
Input Plugins: /usr/local/Cellar/cmus/2.8.0/lib/cmus/ip
  mad:
    Priority: 55
    File Types: mp3 mp2
    MIME Types: audio/mpeg audio/x-mp3 audio/x-mpeg
  opus:
    Priority: 50
    File Types: opus
    MIME Types:
  wav:
    Priority: 50
    File Types: wav
    MIME Types:
  mp4:
    Priority: 50
    File Types: mp4 m4a m4b
    MIME Types:
  cue:
    Priority: 50
    File Types:
    MIME Types: application/x-cue
  aac:
    Priority: 50
    File Types: aac
    MIME Types: audio/aac audio/aacp
  flac:
    Priority: 50
    File Types: flac fla
    MIME Types:
  vorbis:
    Priority: 50
    File Types: ogg oga ogx
    MIME Types: application/ogg audio/x-ogg

Output Plugins: /usr/local/Cellar/cmus/2.8.0/lib/cmus/op
  coreaudio
```