### PR TITLE
cmus: Add opusfile dep.

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -3,6 +3,7 @@ class Cmus < Formula
   homepage "https://cmus.github.io/"
   url "https://github.com/cmus/cmus/archive/v2.8.0.tar.gz"
   sha256 "756ce2c6241b2104dc19097488225de559ac1802a175be0233cfb6fbc02f3bd2"
+  revision 1
   head "https://github.com/cmus/cmus.git"
 
   bottle do
@@ -20,6 +21,7 @@ class Cmus < Formula
   depends_on "libvorbis"
   depends_on "mad"
   depends_on "mp4v2"
+  depends_on "opusfile"
 
   def install
     system "./configure", "prefix=#{prefix}", "mandir=#{man}"


### PR DESCRIPTION
Opusfile is needed if one wants to play audio encoded with the Opus
codec.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
