### PR TITLE
pass-top: Fix test and add info message

### DIFF
--- a/Formula/pass-otp.rb
+++ b/Formula/pass-otp.rb
@@ -11,6 +11,7 @@ class PassOtp < Formula
     sha256 "4b123f03ae8a1237e7b04731d3d39e66e9acf031924f757becf889c8b12f1efc" => :sierra
   end
 
+  depends_on "gnupg" => :test
   depends_on "oath-toolkit"
   depends_on "pass"
 


### PR DESCRIPTION
I noticed that the test of this formula is not working locally. With two set environment variables the installed command can be found and the test succeeds. 

I also added an info message telling users which environment variables to set in order to make the command work.