### PR TITLE
minikube-nfs v0.1 (new formula)

### DIFF
--- a/Formula/minikube-nfs.rb
+++ b/Formula/minikube-nfs.rb
@@ -1,0 +1,16 @@
+class MinikubeNfs < Formula
+  desc "Activates NFS on minikube"
+  homepage "https://github.com/kunalparmar/minikube-nfs"
+  url "https://github.com/kunalparmar/minikube-nfs/archive/v0.1.tar.gz"
+  sha256 "6022a3adbbea1ef0351808ff06d8570436fdd9adb28fff1dae8dde3cbe758a3d"
+
+  bottle :unneeded
+
+  def install
+    bin.install "minikube-nfs.sh" => "minikube-nfs"
+  end
+
+  test do
+    system "#{bin}/minikube-nfs", "-h"
+  end
+end


### PR DESCRIPTION
Minikube NFS activates NFS for minikube. It was inspired by
https://github.com/adlogix/docker-machine-nfs.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
