### PR TITLE
mono: fix formula for ckan

### DIFF
--- a/Formula/ckan.rb
+++ b/Formula/ckan.rb
@@ -1,8 +1,8 @@
 class Ckan < Formula
   desc "The Comprehensive Kerbal Archive Network"
   homepage "https://github.com/KSP-CKAN/CKAN/"
-  url "https://github.com/KSP-CKAN/CKAN/releases/download/v1.25.4/ckan.exe"
-  sha256 "e992982615c6afcfe5f52d9872df22f4a2fadb3bf97c37931393ea767e7c3ffc"
+  url "https://github.com/KSP-CKAN/CKAN/releases/download/v1.26.2/ckan.exe"
+  sha256 "a0b4c43640d91ef5a0c3171906152636de75bf8497a1dc85d116a97c2c416185"
 
   bottle :unneeded
 

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -3,6 +3,7 @@ class Mono < Formula
   homepage "https://www.mono-project.com/"
   url "https://download.mono-project.com/sources/mono/mono-5.20.1.19.tar.bz2"
   sha256 "0574b61efb9bfc3364211d03d87a12c91dc7b03e8d6242cd4d8d953ef145d468"
+  revision 1
 
   bottle do
     sha256 "08e012d25c888d0b0f40ef7757ba929ad48421c8ba5c8f4f66dc7d0d15c6f49d" => :mojave
@@ -41,10 +42,8 @@ class Mono < Formula
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--enable-nls=no",
-                          "--build=x86_64-apple-darwin"
+                          "--enable-nls=no"
     system "make"
     system "make", "install"
     # mono-gdb.py and mono-sgen-gdb.py are meant to be loaded by gdb, not to be


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This should fix the issues brought up earlier in https://github.com/Homebrew/homebrew-core/issues/35848. `ckan version` now prints the proper version as expected.

Note that ckan GUI is still broken; this commit does not fix that. The broken GUI occurs with the official distribution from Mono as well due to the UI relying on some parts of the 32-bit Mono framework.

I had a go at trying to compile 32-bit Mono to see if we can ship both 32-bit and 64-bit Mono but it seems like the compiler doesn't play nice with it. For now, this should at least get the `ckan` basic functionality working.

The removal of `--build=...` doesn't fix anything, rather it's just that 64-bit build is default now and thus we don't need to explicitly specify. The only thing that seemed to have fixed it is the removal of `--disable-dependency-tracking`.