### PR TITLE
csound 6.13_1

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -1,8 +1,8 @@
 class Csound < Formula
   desc "Sound and music computing system"
   homepage "https://csound.com"
-  url "https://github.com/csound/csound/archive/6.13.tar.gz"
-  sha256 "6118ffc1ee04eaeffe7483afc3d48190d93d0e97b51e25f0f3d71e44293827d6"
+  url "https://github.com/csound/csound/archive/6.13.0.tar.gz"
+  sha256 "183beeb3b720bfeab6cc8af12fbec0bf9fef2727684ac79289fd12d0dfee728b"
   revision 1
 
   bottle do

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -3,6 +3,7 @@ class Csound < Formula
   homepage "https://csound.com"
   url "https://github.com/csound/csound/archive/6.13.tar.gz"
   sha256 "6118ffc1ee04eaeffe7483afc3d48190d93d0e97b51e25f0f3d71e44293827d6"
+  revision 1
 
   bottle do
     sha256 "5a2380000f04fa02589d37040c1771a0e07b7a7a944f8355c38b58cb9a06229f" => :mojave
@@ -14,6 +15,7 @@ class Csound < Formula
   depends_on "python" => [:build, :test]
   depends_on "python@2" => [:build, :test]
   depends_on "fltk"
+  depends_on "fluid-synth"
   depends_on "liblo"
   depends_on "libsamplerate"
   depends_on "libsndfile"
@@ -26,16 +28,12 @@ class Csound < Formula
   conflicts_with "pkcrack", :because => "both install `extract` binaries"
 
   def install
-    inreplace "CMakeLists.txt",
-      %r{^set\(CS_FRAMEWORK_DEST\s+"~\/Library\/Frameworks" CACHE PATH "Csound framework path"\)$},
-      "set(CS_FRAMEWORK_DEST \"#{frameworks}\")"
-
     args = std_cmake_args + %W[
-      -DBUILD_FLUID_OPCODES=OFF
       -DBUILD_JAVA_INTERFACE=OFF
       -DBUILD_LUA_INTERFACE=OFF
       -DBUILD_PYTHON_INTERFACE=OFF
       -DCMAKE_INSTALL_RPATH=#{frameworks}
+      -DCS_FRAMEWORK_DEST:PATH=#{frameworks}
     ]
 
     mkdir "build" do
@@ -65,6 +63,7 @@ class Csound < Formula
     (testpath/"test.orc").write <<~EOS
       0dbfs = 1
       FLrun
+      giFluidEngineNumber fluidEngine
       pyinit
       instr 1
           pyruni "from __future__ import print_function; print('hello, world')"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There may be a few issues with the Csound formula added in pull request #41684:

1. The error described at https://github.com/Homebrew/homebrew-core/pull/41684#issuecomment-509012855 is because of a CMakeLists.txt replacement that’s [no longer necessary](https://github.com/csound/csound/pull/1141).

2. The 6.13 tag in the https://github.com/csound/csound repository was apparently [pushed inadvertently](https://listserv.heanet.ie/cgi-bin/wa?A2=ind1907&L=CSOUND-DEV&P=5733). At this time, there is no 6.13 tag, and visiting https://github.com/csound/csound/releases/tag/6.13 results in a 404 error.

3. Since Csound’s 6.13 tag wasn’t intended to be pushed, the SHA-256 hash of the source code archive may change when 6.13 is actually released.

This pull request addresses the first issue, but I’m really not sure if it’s possible to address the others (other than another formula revision).