### PR TITLE
platformio 4.0.0

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Ecosystem for IoT development (Arduino and ARM mbed compatible)"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/dc/19/b92d62fdb3937f9f46ed833e27005923949a960fa3fe78185d4f3549bd09/platformio-3.6.7.tar.gz"
-  sha256 "eb698b93bfc06010a2a210aacadc5d08efd4f05fe5494eaf171ef54618cead36"
+  url "https://files.pythonhosted.org/packages/c6/a3/43c6cc37584d055e81d86c67239bbbc9d54e5fce3bef345185ab925171ef/platformio-4.0.0.tar.gz"
+  sha256 "d37a4022349e1d2eb7babe94fbc62b196b87e94eb43785304f365d06bb74c195"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,16 +13,16 @@ class Platformio < Formula
     sha256 "15d1add995b55416e0d42dad9e884e099416a14650e975e90ec91ff6a418a5bf" => :sierra
   end
 
-  depends_on "python@2" # does not support Python 3
+  depends_on "python"  # Homebrew’s Python 2.7.x (if installed) otherwise the macOS system Python
 
   resource "bottle" do
-    url "https://files.pythonhosted.org/packages/32/4e/ed046324d5ec980c252987c1dca191e001b9f06ceffaebf037eef469937c/bottle-0.12.16.tar.gz"
-    sha256 "9c310da61e7df2b6ac257d8a90811899ccb3a9743e77e947101072a2e3186726"
+    url "https://files.pythonhosted.org/packages/c4/a5/6bf41779860e9b526772e1b3b31a65a22bd97535572988d16028c5ab617d/bottle-0.12.17.tar.gz"
+    sha256 "e9eaa412a60cc3d42ceb42f58d15864d9ed1b92e9d630b8130c871c5bb16107c"
   end
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/06/b8/d1ea38513c22e8c906275d135818fee16ad8495985956a9b7e2bb21942a1/certifi-2019.3.9.tar.gz"
-    sha256 "b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+    url "https://files.pythonhosted.org/packages/c5/67/5d0548226bcc34468e23a0333978f0e23d28d0b3f0c71a151aef9c3f7680/certifi-2019.6.16.tar.gz"
+    sha256 "945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
   end
 
   resource "chardet" do
@@ -31,8 +31,8 @@ class Platformio < Formula
   end
 
   resource "click" do
-    url "https://files.pythonhosted.org/packages/b7/34/a496632c4fb6c1ee76efedf77bb8d28b29363d839953d95095b12defe791/click-5.1.tar.gz"
-    sha256 "678c98275431fad324275dec63791e4a17558b40e5a110e20a82866139a85a5a"
+    url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
+    sha256 "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
   end
 
   resource "colorama" do
@@ -51,8 +51,8 @@ class Platformio < Formula
   end
 
   resource "requests" do
-    url "https://files.pythonhosted.org/packages/52/2c/514e4ac25da2b08ca5a464c50463682126385c4272c18193876e91f4bc38/requests-2.21.0.tar.gz"
-    sha256 "502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e"
+    url "https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz"
+    sha256 "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
   end
 
   resource "semantic_version" do
@@ -61,8 +61,8 @@ class Platformio < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/fd/fa/b21f4f03176463a6cccdb612a5ff71b927e5224e83483012747c12fc5d62/urllib3-1.24.2.tar.gz"
-    sha256 "9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+    url "https://files.pythonhosted.org/packages/4c/13/2386233f7ee40aa8444b47f7463338f3cbdf00c316627558784e3f542f07/urllib3-1.25.3.tar.gz"
+    sha256 "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
   end
 
   def install

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -13,7 +13,7 @@ class Platformio < Formula
     sha256 "15d1add995b55416e0d42dad9e884e099416a14650e975e90ec91ff6a418a5bf" => :sierra
   end
 
-  depends_on "python" # Homebrew's Python 2.7.x (if installed) otherwise the macOS system Python
+  depends_on "python"
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/c4/a5/6bf41779860e9b526772e1b3b31a65a22bd97535572988d16028c5ab617d/bottle-0.12.17.tar.gz"

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -13,7 +13,7 @@ class Platformio < Formula
     sha256 "15d1add995b55416e0d42dad9e884e099416a14650e975e90ec91ff6a418a5bf" => :sierra
   end
 
-  depends_on "python"  # Homebrew’s Python 2.7.x (if installed) otherwise the macOS system Python
+  depends_on "python" # Homebrew's Python 2.7.x (if installed) otherwise the macOS system Python
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/c4/a5/6bf41779860e9b526772e1b3b31a65a22bd97535572988d16028c5ab617d/bottle-0.12.17.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[Migration Guide from 3.0 to 4.0](http://docs.platformio.org/page/migration.html).

* [PlatformIO Plus Goes Open Source](https://community.platformio.org/t/platformio-plus-goes-open-source-improving-embedded-development-community-worldwide/8240/4)

  - Built-in [PIO Unified Debugger](http://docs.platformio.org/page/plus/debugging.html)
  - Built-in [PIO Unit Testing](http://docs.platformio.org/page/plus/unit-testing.html)

* **Project Configuration**

  - New project configuration parser with a strict options typing ([API](https://github.com/platformio/platformio-core/blob/develop/platformio/project/options.py))
  - Unified workspace storage ([workspace_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#workspace-dir) -> ``.pio``) for PlatformIO Build System, Library Manager, and other internal services ([issue #1778](https://github.com/platformio/platformio-core/issues/1778))
  - Share common (global) options between project environments using [[env]](http://docs.platformio.org/page/projectconf/section_env.html#global-scope-env) section ([issue #1643](https://github.com/platformio/platformio-core/issues/1643))
  - Include external configuration files with [extra_configs](http://docs.platformio.org/page/projectconf/section_platformio.html#extra-configs) option ([issue #1590](https://github.com/platformio/platformio-core/issues/1590))
  - Custom project ``***_dir`` options declared in [platformio](http://docs.platformio.org/page/projectconf/section_platformio.html) section have higher priority than [Environment variables](http://docs.platformio.org/page/envvars.html)
  - Added support for Unix shell-style wildcards for [monitor_port](http://docs.platformio.org/page/projectconf/section_env_monitor.html#monitor-port) option ([issue #2541](https://github.com/platformio/platformio-core/issues/2541))
  - Added new [monitor_flags](http://docs.platformio.org/page/projectconf/section_env_monitor.html#monitor-flags) option which allows passing extra flags and options to [platformio device monitor](http://docs.platformio.org/page/userguide/cmd_device.html#cmd-device-monitor) command ([issue #2165](https://github.com/platformio/platformio-core/issues/2165))
  - Added support for [PLATFORMIO_DEFAULT_ENVS](http://docs.platformio.org/page/envvars.html#envvar-PLATFORMIO_DEFAULT_ENVS) system environment variable ([issue #1967](https://github.com/platformio/platformio-core/issues/1967))
  - Added support for [shared_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#shared-dir) where you can place an extra files (extra scripts, LD scripts, etc.) which should be transferred to a [PIO Remote](http://docs.platformio.org/page/plus/pio-remote.html) machine

* **Library Management**

  - Switched to workspace ``.pio/libdeps`` folder for project dependencies instead of ``.piolibdeps``
  - Save libraries passed to [platformio lib install](http://docs.platformio.org/page/userguide/lib/cmd_install.html) command into the project dependency list ([lib_deps](http://docs.platformio.org/page/projectconf/section_env_library.html#lib-deps)) with a new ``--save`` flag ([issue #1028](https://github.com/platformio/platformio-core/issues/1028))
  - Install all project dependencies declared via [lib_deps](http://docs.platformio.org/page/projectconf/section_env_library.html#lib-deps) option using a simple [platformio lib install](http://docs.platformio.org/page/userguide/lib/cmd_install.html) command ([issue #2147](https://github.com/platformio/platformio-core/issues/2147))
  - Use isolated library dependency storage per project build environment ([issue #1696](https://github.com/platformio/platformio-core/issues/1696))
  - Look firstly in built-in library storages for a missing dependency instead of PlatformIO Registry ([issue #1654](https://github.com/platformio/platformio-core/issues/1654))
  - Override default source and include directories for a library via [library.json](http://docs.platformio.org/page/librarymanager/config.html) manifest using ``includeDir`` and ``srcDir`` fields
  - Fixed an issue when library keeps reinstalling for non-latin path ([issue #1252](https://github.com/platformio/platformio-core/issues/1252))
  - Fixed an issue when [lib_compat_mode = strict](http://docs.platformio.org/page/librarymanager/ldf.html#ldf-compat-mode) does not ignore libraries incompatible with a project framework

* **Build System**

  - Switched to workspace ``.pio/build`` folder for build artifacts instead of ``.pioenvs``
  - Switch between [Build Configurations](http://docs.platformio.org/page/projectconf/build_configurations.html) (``release`` and ``debug``) with a new project configuration option [build_type](http://docs.platformio.org/page/projectconf/section_env_build.html#build-type)
  - Custom [platform_packages](http://docs.platformio.org/page/projectconf/section_env_general.html#platform) per a build environment with an option to override default ([issue #1367](https://github.com/platformio/platformio-core/issues/1367))
  - Print platform package details, such as version, VSC source and commit ([issue #2155](https://github.com/platformio/platformio-core/issues/2155))
  - Control a number of parallel build jobs with a new [-j, --jobs](http://docs.platformio.org/page/userguide/cmd_run.html#cmdoption-platformio-run-j) option
  - Override default ["platformio.ini" (Project Configuration File)](https://docs.platformio.org/page/projectconf.html) with a custom using ``-c, --project-conf`` option for [platformio run](http://docs.platformio.org/page/userguide/cmd_run.html), [platformio debug](http://docs.platformio.org/page/userguide/cmd_debug.html), or [platformio test](http://docs.platformio.org/page/userguide/cmd_test.html) commands ([issue #1913](https://github.com/platformio/platformio-core/issues/1913))
  - Override default development platform upload command with a custom [upload_command](http://docs.platformio.org/page/projectconf/section_env_upload.html#upload-command) ([issue #2599](https://github.com/platformio/platformio-core/issues/2599))
  - Configure a shared folder for the derived files (objects, firmwares, ELFs) from a build system using [build_cache_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#build-cache-dir) option ([issue #2674](https://github.com/platformio/platformio-core/issues/2674))
  - Fixed an issue when ``-U`` in ``build_flags`` does not remove macro previously defined via ``-D`` flag ([issue #2508](https://github.com/platformio/platformio-core/issues/2508))

* **Infrastructure**

  - Python 3 support ([issue #895](https://github.com/platformio/platformio-core/issues/895))
  - Significantly speedup back-end for PIO Home. It works super fast now!
  - Added support for the latest Python "Click" package (CLI) ([issue #349](https://github.com/platformio/platformio-core/issues/349))
  - Added options to override default locations used by PlatformIO Core ([core_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#core-dir), [globallib_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#globallib-dir), [platforms_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#platforms-dir), [packages_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#packages-dir), [cache_dir](http://docs.platformio.org/page/projectconf/section_platformio.html#cache-dir)) ([issue #1615](https://github.com/platformio/platformio-core/issues/1615))
  - Removed line-buffering from [platformio run](http://docs.platformio.org/page/userguide/cmd_run.html) command which was leading to omitting progress bar from upload tools ([issue #856](https://github.com/platformio/platformio-core/issues/856))
  - Fixed numerous issues related to "UnicodeDecodeError" and international locales, or when project path contains non-ASCII chars ([issue #143](https://github.com/platformio/platformio-core/issues/143), [issue #1342](https://github.com/platformio/platformio-core/issues/1342), [issue #1959](https://github.com/platformio/platformio-core/issues/1959), [issue #2100](https://github.com/platformio/platformio-core/issues/2100))

* **Integration**

  - Support custom CMake configuration for CLion IDE using ``CMakeListsUser.txt`` file
  - Fixed an issue with hardcoded C standard version when generating project for CLion IDE ([issue #2527](https://github.com/platformio/platformio-core/issues/2527))
  - Fixed an issue with Project Generator when an include path search order is inconsistent to what passed to the compiler ([issue #2509](https://github.com/platformio/platformio-core/issues/2509))
  - Fixed an issue when generating invalid "Eclipse CDT Cross GCC Built-in Compiler Settings" if a custom [PLATFORMIO_CORE_DIR](http://docs.platformio.org/page/envvars.html#envvar-PLATFORMIO_CORE_DIR) is used ([issue #806](https://github.com/platformio/platformio-core/issues/806))

* **Miscellaneous**

  - Deprecated ``--only-check`` PlatformIO Core CLI option for "update" sub-commands, please use ``--dry-run`` instead
  - Fixed "systemd-udevd" warnings in [99-platformio-udev.rules](http://docs.platformio.org/page/faq.html#platformio-udev-rules) ([issue #2442](https://github.com/platformio/platformio-core/issues/2442))
  - Fixed an issue when package cache (Library Manager) expires too fast ([issue #2559](https://github.com/platformio/platformio-core/issues/2559))