### PR TITLE
tag: bump version, change description and simplify installation

### DIFF
--- a/Formula/tag.rb
+++ b/Formula/tag.rb
@@ -13,8 +13,7 @@ class Tag < Formula
   end
 
   def install
-    system "make"
-    bin.install "bin/tag"
+    system "make", "install", "prefix=#{prefix}"
   end
 
   test do

--- a/Formula/tag.rb
+++ b/Formula/tag.rb
@@ -1,5 +1,5 @@
 class Tag < Formula
-  desc "Manipulate and query tags on Mavericks files"
+  desc "Manipulate and query tags on macOS files"
   homepage "https://github.com/jdberry/tag/"
   url "https://github.com/jdberry/tag/archive/v0.10.tar.gz"
   sha256 "5ab057d3e3f0dbb5c3be3970ffd90f69af4cb6201c18c1cbaa23ef367e5b071e"

--- a/Formula/tag.rb
+++ b/Formula/tag.rb
@@ -3,8 +3,8 @@ class Tag < Formula
   homepage "https://github.com/jdberry/tag/"
   url "https://github.com/jdberry/tag/archive/v0.10.tar.gz"
   sha256 "5ab057d3e3f0dbb5c3be3970ffd90f69af4cb6201c18c1cbaa23ef367e5b071e"
-  head "https://github.com/jdberry/tag.git"
   revision 1
+  head "https://github.com/jdberry/tag.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/tag.rb
+++ b/Formula/tag.rb
@@ -4,6 +4,7 @@ class Tag < Formula
   url "https://github.com/jdberry/tag/archive/v0.10.tar.gz"
   sha256 "5ab057d3e3f0dbb5c3be3970ffd90f69af4cb6201c18c1cbaa23ef367e5b071e"
   head "https://github.com/jdberry/tag.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is an old problem with tag: the formula didn't install the manual page. This was already discussed in #12036 which tried to fix it. It was concluded that `make install` would be the preferred way.

Since that post resulted in no changes and was locked, I decided to open a thread on discourse to find a solution: [Tag Formula - Using make install vs. manually installing](https://discourse.brew.sh/t/tag-formula-using-make-install-vs-manually-installing/4926).

After that I submitted a PR to tag ([\#47](https://github.com/jdberry/tag/pull/47)) with an updated Makefile which had the side-effect of producing a cleaner brew recipe (also complete, including the man page).

This PR was approved and recently a new tag version was released (v0.10). Unfortunately I wasn't fast enough to submit a PR here updating the recipe — @igas was faster and bumped the version on #41842 (already closed by @lembacon).

So I'm not sure how we could work this out, but I'm submitting this anyway. Three separated commits dedicated to three small changes:
 - Fixing the install procedure.
 - Bumping version to _0.10_.
 - Updating its description which still mentioned Mavericks.
