### PR TITLE
presto: make path for connectors consistent across versions

### DIFF
--- a/Formula/presto.rb
+++ b/Formula/presto.rb
@@ -62,7 +62,7 @@ class Presto < Formula
   end
 
   def caveats; <<~EOS
-    Add connectors to #{libexec}/etc/catalog/. See:
+    Add connectors to #{opt_libexec}/etc/catalog/. See:
     https://prestodb.io/docs/current/connector.html
   EOS
   end


### PR DESCRIPTION
Use `opt_libexec` instead of `libexec` in caveats so path for connectors is consistent across versions.

Previous: `Add connectors to /usr/local/Cellar/presto/0.221/libexec/etc/catalog/`
New: `Add connectors to /usr/local/opt/presto/libexec/etc/catalog/`