### PR TITLE
gimme-aws-creds 2.1.1 (new formula)

### DIFF
--- a/Formula/gimme-aws-creds.rb
+++ b/Formula/gimme-aws-creds.rb
@@ -1,0 +1,31 @@
+class GimmeAwsCreds < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI to retrieve AWS credentials from Okta"
+  homepage "https://github.com/Nike-Inc/gimme-aws-creds"
+  url "https://files.pythonhosted.org/packages/2b/7a/e0e905e6f4e7d90b99fcaa94f56a24f67852c75d38399997073b006487cb/gimme%20aws%20creds-2.1.1.tar.gz"
+  sha256 "87ab4a0bd1ce758f24c8302416779c38ca376cf38a58e68fe332512071004c5a"
+
+  depends_on "python"
+
+  def install
+    venv = virtualenv_create(libexec, "python3")
+    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
+                              "--ignore-installed", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", "gimme-aws-creds"
+    venv.pip_install_and_link buildpath
+  end
+
+  test do
+    # Workaround gimme-aws-creds bug which runs action-configure twice when config file is missing.
+    config_file = Pathname(".okta_aws_login_config")
+    touch(config_file)
+
+    output = pipe_output("#{bin}/gimme-aws-creds --action-configure 2>&1", "TESTPROFILE\nhttps://something.oktapreview.com\n\n\n\n\n\n\n\n\n\n\n")
+    assert_match "Okta Configuration Profile Name", output
+    assert_match "[TESTPROFILE]", config_file.read
+
+    installed_version = shell_output("#{bin}/gimme-aws-creds --version")
+    assert_match version.to_s, installed_version
+  end
+end


### PR DESCRIPTION
`gimme-aws-creds` is [okta's preferred tool](https://support.okta.com/help/s/article/Integrating-the-Amazon-Web-Services-Command-Line-Interface-Using-Okta) for setting up AWS credentials for `awscli`. It would be great to have it available in homebrew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
