### PR TITLE
run-one 1.18 (new formula)

### DIFF
--- a/Formula/run-one.rb
+++ b/Formula/run-one.rb
@@ -1,0 +1,23 @@
+class RunOne < Formula
+  desc "Run one instance of a unique combination of command and args at a time"
+  homepage "https://launchpad.net/run-one"
+  url "https://github.com/datamade/run-one/archive/ea3d7744043bf737aa52c3093f068a49b7621d02.tar.gz"
+  version "1.18"
+  sha256 "8094b26db3efca2a419737ab26d1926e98c116d9e687dc32cd841192c3192dfc"
+  depends_on "flock"
+
+  def install
+    bin.install "run-one",
+                "run-this-one",
+                "run-one-constantly",
+                "keep-one-running",
+                "run-one-until-failure",
+                "run-one-until-success"
+    man1.install "run-one.1"
+  end
+
+  test do
+    assert_equal "0", shell_output("#{bin}/run-one-until-success true && echo $?").strip
+    assert_equal "0", shell_output("#{bin}/run-one-until-failure false && echo $?").strip
+  end
+end


### PR DESCRIPTION
Initial formula for the run-one bash scripts to help you run one
and only command with args. (standard part of the ubuntu distro)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
