### PR TITLE
Secure URLs

### DIFF
--- a/Formula/hapi-fhir-cli.rb
+++ b/Formula/hapi-fhir-cli.rb
@@ -1,6 +1,6 @@
 class HapiFhirCli < Formula
   desc "Command-line interface for the HAPI FHIR library"
-  homepage "http://hapifhir.io/doc_cli.html"
+  homepage "https://hapifhir.io/doc_cli.html"
   url "https://github.com/jamesagnew/hapi-fhir/releases/download/v3.8.0/hapi-fhir-3.8.0-cli.zip"
   sha256 "0446005f23b8b8319d20474d309e3b7f423cf02b88d4c59dc517a0aaf9535943"
 

--- a/Formula/rsyslog.rb
+++ b/Formula/rsyslog.rb
@@ -14,7 +14,7 @@ class Rsyslog < Formula
   depends_on "libestr"
 
   resource "libfastjson" do
-    url "http://download.rsyslog.com/libfastjson/libfastjson-0.99.8.tar.gz"
+    url "https://download.rsyslog.com/libfastjson/libfastjson-0.99.8.tar.gz"
     sha256 "3544c757668b4a257825b3cbc26f800f59ef3c1ff2a260f40f96b48ab1d59e07"
   end
 

--- a/Formula/shogun.rb
+++ b/Formula/shogun.rb
@@ -1,7 +1,7 @@
 class Shogun < Formula
   desc "Large scale machine learning toolbox"
-  homepage "http://www.shogun-toolbox.org/"
-  url "http://shogun-toolbox.org/archives/shogun/releases/6.1/sources/shogun-6.1.3.tar.bz2"
+  homepage "https://www.shogun-toolbox.org/"
+  url "https://www.shogun-toolbox.org/archives/shogun/releases/6.1/sources/shogun-6.1.3.tar.bz2"
   sha256 "57169dc8c05b216771c567b2ee2988f14488dd13f7d191ebc9d0703bead4c9e6"
   revision 5
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Notice that the `shogun` `url` is broken (regardless of HTTPS or HTTP). Releases moved to GitHub, so it can be fixed by updating the formula to the latest version 6.1.4.