### PR TITLE
go-md2man 1.0.10 (new formula)

### DIFF
--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -4,6 +4,7 @@ class Docker < Formula
   url "https://github.com/docker/docker-ce.git",
       :tag      => "v19.03.2",
       :revision => "6a30dfca03664a0b6bf0646a7d389ee7d0318e6e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,6 +14,7 @@ class Docker < Formula
   end
 
   depends_on "go" => :build
+  depends_on "go-md2man" => :build
 
   def install
     ENV["GOPATH"] = buildpath
@@ -27,6 +29,12 @@ class Docker < Formula
                  "-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\""]
       system "go", "build", "-o", bin/"docker", "-ldflags", ldflags.join(" "),
              "github.com/docker/cli/cmd/docker"
+
+      Pathname.glob("man/*.[1-8].md") do |md|
+        section = md.to_s[/\.(\d+)\.md\Z/, 1]
+        (man/"man#{section}").mkpath
+        system "go-md2man", "-in=#{md}", "-out=#{man/"man#{section}"/md.stem}"
+      end
 
       bash_completion.install "contrib/completion/bash/docker"
       fish_completion.install "contrib/completion/fish/docker.fish"

--- a/Formula/go-md2man.rb
+++ b/Formula/go-md2man.rb
@@ -1,0 +1,32 @@
+class GoMd2man < Formula
+  desc "Converts markdown into roff (man pages)"
+  homepage "https://github.com/cpuguy83/go-md2man"
+  url "https://github.com/cpuguy83/go-md2man.git",
+      :tag      => "v1.0.10",
+      :revision => "7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19"
+
+  depends_on "go" => :build
+
+  def install
+    contents = Dir["*"]
+    gopath = buildpath/"gopath"
+    (gopath/"src/github.com/cpuguy83/go-md2man").install contents
+
+    ENV["GOPATH"] = buildpath
+    ENV["GO111MODULES"] = "enabled"
+
+    cd gopath/"src/github.com/cpuguy83/go-md2man" do
+      system "go", "build", "-o", "go-md2man"
+      system "./go-md2man", "-in=go-md2man.1.md", "-out=go-md2man.1"
+
+      bin.install "go-md2man"
+      man1.install "go-md2man.1"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_includes pipe_output(bin/"go-md2man", "# manpage\nand a half\n"),
+                    ".TH manpage\n.PP\nand a half\n"
+  end
+end


### PR DESCRIPTION
go-md2man is a tool used by some go projects to generate manpages from markdown files. The most notable example is the Docker CLI, build in [the docker formula](https://github.com/Homebrew/homebrew-core/tree/master/Formula/docker.rb). So do other Docker-adjacent tools like [skopeo](https://github.com/Homebrew/homebrew-core/blob/master/Formula/skopeo.rb).

This PR adds a formula for [go-md2man](https://github.com/cpuguy83/go-md2man) and updates the docker formula to generate and install manpages for the docker CLI. I have [another branch](https://github.com/Homebrew/homebrew-core/compare/master...sj26:skopeo-man) which uses the same go-md2man tool to build manpages for the skopeo formula.