### PR TITLE
pipenv: remove symlink `pewtwo`

### DIFF
--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -39,11 +39,10 @@ class Pipenv < Formula
     venv.pip_install resources
     venv.pip_install buildpath
 
-    # `pipenv` needs to be able to find `virtualenv` and `pewtwo` on PATH. So we
+    # `pipenv` needs to be able to find `virtualenv` on PATH. So we
     # install symlinks for those scripts in `#{libexec}/tools` and create a
     # wrapper script for `pipenv` which adds `#{libexec}/tools` to PATH.
-    (libexec/"tools").install_symlink libexec/"bin/pewtwo", libexec/"bin/pip",
-                                      libexec/"bin/virtualenv"
+    (libexec/"tools").install_symlink libexec/"bin/pip", libexec/"bin/virtualenv"
     env = {
       :PATH => "#{libexec}/tools:$PATH",
     }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `pipenv` no longer use `pewtwo` and purged that from its dependencies at [2018.10.9](https://github.com/pypa/pipenv/releases/tag/v2018.10.9).

Please check below issue.
https://github.com/pypa/pipenv/pull/2521

Currently, this formula make broken symlinks.

```
$ fd -L --show-errors pewtwo /usr/local
[fd error]: /usr/local/opt/pipenv/libexec/tools/pewtwo: No such file or directory (os error 2)
[fd error]: /usr/local/Cellar/pipenv/2018.11.26_2/libexec/tools/pewtwo: No such file or directory (os error 2)
[fd error]: /usr/local/var/homebrew/linked/pipenv/libexec/tools/pewtwo: No such file or directory (os error 2)
```
