### PR TITLE
Fix misfiring assertion with wxGLCanvas on 10.14

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -18,7 +18,9 @@ class Wxmac < Formula
   depends_on "libpng"
   depends_on "libtiff"
 
-  # Adjust assertion which fails for wxGLCanvas due to changes in macOS 10.14
+  # Adjust assertion which fails for wxGLCanvas due to changes in macOS 10.14.
+  # Patch taken from upstream WX_3_0_BRANCH:
+  # https://github.com/wxWidgets/wxWidgets/commit/531fdbcb64b265e6f24f1f0cc7469f308b9fb697
   patch :DATA
 
   def install

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -3,7 +3,7 @@ class Wxmac < Formula
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2"
   sha256 "96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"
-  revision 1
+  revision 2
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   bottle do
@@ -17,6 +17,9 @@ class Wxmac < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
+
+  # Adjust assertion which fails for wxGLCanvas due to changes in macOS 10.14
+  patch :DATA
 
   def install
     args = [
@@ -59,3 +62,29 @@ class Wxmac < Formula
     system bin/"wx-config", "--libs"
   end
 end
+
+__END__
+--- a/src/osx/carbon/dcclient.cpp
++++ b/src/osx/carbon/dcclient.cpp
+@@ -189,10 +189,20 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner )
+ {
+ }
+ 
++#if wxDEBUG_LEVEL
++static bool IsGLCanvas( wxWindow * window )
++{
++    // If the wx gl library isn't loaded then ciGLCanvas will be NULL.
++    static const wxClassInfo* const ciGLCanvas = wxClassInfo::FindClass("wxGLCanvas");
++    return ciGLCanvas && window->IsKindOf(ciGLCanvas);
++}
++#endif
++
+ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *window ) :
+     wxWindowDCImpl( owner, window )
+ {
+-    wxASSERT_MSG( window->MacGetCGContextRef() != NULL, wxT("using wxPaintDC without being in a native paint event") );
++    // With macOS 10.14, wxGLCanvas windows have a NULL CGContextRef.
++    wxASSERT_MSG( window->MacGetCGContextRef() != NULL || IsGLCanvas(window), wxT("using wxPaintDC without being in a native paint event") );
+     wxPoint origin = window->GetClientAreaOrigin() ;
+     m_window->GetClientSize( &m_width , &m_height);
+     SetDeviceOrigin( origin.x, origin.y );


### PR DESCRIPTION
With macOS 10.14, wxGLCanvas windows now have a NULL CGContextRef
which an assertion in the wxWidgets code doesn't expect.

Patch taken from upstream WX_3_0_BRANCH:

https://github.com/wxWidgets/wxWidgets/commit/531fdbcb64b265e6f24f1f0cc7469f308b9fb697

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
