### PR TITLE
libvpx: --enable-vp9-highbitdepth

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -21,6 +21,7 @@ class Libvpx < Formula
       --disable-examples
       --disable-unit-tests
       --enable-pic
+      --enable-vp9-highbitdepth
     ]
 
     # https://bugs.chromium.org/p/webm/issues/detail?id=1475


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This enables profile 2 (high bit depth) for libvpx. Profile 2 is a prerequisite to encoding HDR video. Without this, ffmpeg cannot encode proper HDR videos (it will emit the error "Profile > 1 not supported in this build configuration").