### PR TITLE
png++: Fix compilation and add tests

### DIFF
--- a/Formula/png++.rb
+++ b/Formula/png++.rb
@@ -3,6 +3,7 @@ class Pngxx < Formula
   homepage "https://www.nongnu.org/pngpp/"
   url "https://download.savannah.gnu.org/releases/pngpp/png++-0.2.9.tar.gz"
   sha256 "abbc6a0565122b6c402d61743451830b4faee6ece454601c5711e1c1b4238791"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,38 @@ class Pngxx < Formula
 
   depends_on "libpng"
 
+  # Issues with GNU strerror_r being used because Darwin libc does not define _POSIX_C_SOURCE
+  patch :DATA
+
   def install
     system "make", "PREFIX=#{prefix}", "install"
   end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <png++/png.hpp>
+      int main() {
+        png::image<png::rgb_pixel> image(200, 300);
+        if (image.get_width() != 200) return 1;
+        if (image.get_height() != 300) return 2;
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test"
+    system "./test"
+  end
 end
+
+__END__
+diff -Naur png++-0.2.9-orig/error.hpp png++-0.2.9/error.hpp
+--- png++-0.2.9-orig/error.hpp	2015-10-25 15:42:45.000000000 -0400
++++ png++-0.2.9/error.hpp	2019-07-18 12:24:10.000000000 -0400
+@@ -100,7 +100,7 @@
+             strerror_s(buf, ERRBUF_SIZE, errnum);
+             return std::string(buf);
+ #else
+-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE
++#if ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE) || (!__GLIBC__)
+             strerror_r(errnum, buf, ERRBUF_SIZE);
+             return std::string(buf);
+ #else


### PR DESCRIPTION
Projects that do not define _POSIX_C_LEVEL will not compile with png++.
The package also provides integrated tests, but they do not work out of
the box. Debian maintainer patched the test script to use imagemagick
instead of binary comparison to fix the issue.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
