### PR TITLE
miniconda 3 (new formula)

### DIFF
--- a/Formula/miniconda.rb
+++ b/Formula/miniconda.rb
@@ -1,0 +1,26 @@
+class Miniconda < Formula
+  desc "Continuum Analytics Miniconda"
+  homepage "https://conda.io/miniconda.html"
+  url "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh"
+
+  # Miniconda3 (aka Python 3 envs), exact version not managed by Brew
+  version "3"
+
+  sha256 "2ec958508139289df3b5e2c10257311af4f0ebf39242f61d39f11e7fa14ebb40"
+
+  def install
+    system "/bin/bash",
+      "Miniconda3-4.6.14-MacOSX-x86_64.sh",
+      "-b", "-p", "#{prefix}/opt"
+
+    bin.install_symlink Dir["#{prefix}/opt/condabin/*"]
+  end
+
+  test do
+    # Make sure our bin runs
+    system "#{bin}/conda", "info"
+
+    # Ensure it is our bin
+    assert_equal "#{prefix}/opt\n", shell_output("#{bin}/conda info --base")
+  end
+end


### PR DESCRIPTION
Prompted by the comments from @reitermarkus and @janosh in the PR https://github.com/Homebrew/homebrew-cask/pull/65618 this ports the Brew Cask over to a normal Formula.

This should be valid because:
- Stable, miniconda is stable and actively developed upstream
- Has OSI-approved license
- No GUI
- No manual post install steps

Some rules that this may violate in [Acceptable Formulae](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md):
- We don’t like tools that upgrade themselves -- conda/miniconda upgrades itself in this case the "version" for this formula is specified as `3` because it's Miniconda3 which installs Python 3 in new envs by default. However exact conda version is not referenced in the Formula which kinda break this rule a bit.
- We don’t like binary formulae -- while not a binary the install script from Anaconda, Inc is a giant .sh file.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
