### PR TITLE
ctags: fix build on recent macOS 10.14 - conflict with __unused__

### DIFF
--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -115,3 +115,14 @@ diff -ur a/ctags-5.8/read.h b/ctags-5.8/read.h
  
  /*
  *   FUNCTION PROTOTYPES
+--- a/ctags-5.8/general.h	2007-05-02 23:21:08.000000000 -0400
++++ b/ctags-5.8/general.h	2019-07-18 19:09:43.000000000 -0400
+@@ -56,7 +56,7 @@
+ /*  This is a helpful internal feature of later versions (> 2.7) of GCC
+  *  to prevent warnings about unused variables.
+  */
+-#if (__GNUC__ > 2  ||  (__GNUC__ == 2  &&  __GNUC_MINOR__ >= 7)) && !defined (__GNUG__)
++#if 0
+ # define __unused__  __attribute__((unused))
+ # define __printf__(s,f)  __attribute__((format (printf, s, f)))
+ #else


### PR DESCRIPTION
The build failed on latest macOS 10.14.5 like so:

    In file included from main.c:62:
    /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/dirent.h:80:2: error: use of undeclared identifier 'unused'
            __unused long   __padding; /* (__dd_rewind space left for bincompat) */
            ^
    /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:161:40: note: expanded from macro '__unused'
    #define __unused        __attribute__((__unused__))
                                           ^
    ./general.h:60:37: note: expanded from macro '__unused__'
    # define __unused__  __attribute__((unused))
                                        ^
    1 error generated.
    make: *** [main.o] Error 1

As you can see, exuberant-ctags has defined `__unused__` but the
macOS toolchain also uses `__unused__` and it is confused.

The easiest fix is to pretend this is unsupported and disable/blank
`__unused__` (which should only affect compiler warnings, and the
same for the printf format string warnings which are also disabled).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  * not really - it tries to use my system ruby, but that doesn't have development headers, so it fails to install gems