### PR TITLE
mesos, rapidjson: denote conflict

### DIFF
--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -18,8 +18,8 @@ class Mesos < Formula
   depends_on "python@2"
   depends_on "subversion"
 
-  conflicts_with "nanopb-generator",
-    :because => "they depend on an incompatible version of protobuf"
+  conflicts_with "nanopb-generator", :because => "they depend on an incompatible version of protobuf"
+  conflicts_with "rapidjson", :because => "mesos installs a copy of rapidjson headers"
 
   if DevelopmentTools.clang_build_version >= 802 # does not affect < Xcode 8.3
     # _scheduler.so segfault when Mesos is built with Xcode 8.3.2

--- a/Formula/rapidjson.rb
+++ b/Formula/rapidjson.rb
@@ -18,6 +18,8 @@ class Rapidjson < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 
+  conflicts_with "mesos", :because => "mesos installs a copy of rapidjson headers"
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[As of Mesos 1.7.0, Mesos now ships with `rapidjson` headers](https://mesos.apache.org/blog/mesos-1-7-0-performance-improvements/), which conflict with the headers from the `rapidjson` formula.