### PR TITLE
wtfutil 0.19.0 (new formula)

### DIFF
--- a/Formula/wtfutil.rb
+++ b/Formula/wtfutil.rb
@@ -1,0 +1,69 @@
+class Wtfutil < Formula
+  desc "The personal information dashboard for your terminal"
+  homepage "https://wtfutil.com"
+  url "https://github.com/wtfutil/wtf.git",
+    :tag      => "v0.19.0",
+    :revision => "31fb0208d0de6ac27ade7fa0f4f14bf8b8d77e8b"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GO111MODULE"] = "on"
+    ENV["GOPATH"] = buildpath
+    ENV["GOPROXY"] = "https://gocenter.io"
+
+    dir = buildpath/"src/github.com/wtfutil/wtf"
+    dir.install buildpath.children
+
+    cd dir do
+      system "go", "build", "-o", bin/"wtfutil"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    testconfig = testpath/"config.yml"
+    testconfig.write <<~EOS
+      wtf:
+        colors:
+          background: "red"
+          border:
+            focusable: "darkslateblue"
+            focused: "orange"
+            normal: "gray"
+          checked: "gray"
+          highlight:
+            fore: "black"
+            back: "green"
+          text: "white"
+          title: "white"
+        grid:
+          # How _wide_ the columns are, in terminal characters. In this case we have
+          # six columns, each of which are 35 characters wide
+          columns: [35, 35, 35, 35, 35, 35]
+
+          # How _high_ the rows are, in terminal lines. In this case we have five rows
+          # that support ten line of text, one of three lines, and one of four
+          rows: [10, 10, 10, 10, 10, 3, 4]
+        navigation:
+          shortcuts: true
+        openFileUtil: "open"
+        sigils:
+          checkbox:
+            checked: "x"
+            unchecked: " "
+          paging:
+            normal: "*"
+            selected: "_"
+        term: "xterm-256color"
+    EOS
+
+    begin
+      pid = fork do
+        exec "#{bin}/wtfutil", "--config=#{testconfig}"
+      end
+    ensure
+      Process.kill("HUP", pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
worth mentioning starting 0.15.0, the binary has been renamed to `wtfutil` to avoid conflict:
https://wtfutil.com/blog/2019-07-10-wtfutil-release/

Thanks @senorprogrammer for helping fixing the test step issue (https://github.com/wtfutil/wtf/issues/509). 

Previous efforts: #39962 #39896