### PR TITLE
quickjs 2019-07-21 | updates version and improves formula/build

### DIFF
--- a/Formula/quickjs.rb
+++ b/Formula/quickjs.rb
@@ -10,18 +10,8 @@ class Quickjs < Formula
     sha256 "3fbf3dfc902c9e68415088325ec7ec6f16e1c69204b3cd3432046d6bed14896e" => :sierra
   end
 
-  patch :DATA
-
   def install
-    system "make", "prefix=#{prefix}", "CONFIG_M32="
-    # Tests are dependent on having a TTY, so fake it with `script`
-    system "script", "-q", "/dev/stdout", "make", "test", "prefix=#{prefix}", "CONFIG_M32="
     system "make", "install", "prefix=#{prefix}", "CONFIG_M32="
-
-    mkdir_p pkgshare
-
-    cp_r "examples", pkgshare
-    cp_r "doc", pkgshare
   end
 
   test do
@@ -35,39 +25,3 @@ class Quickjs < Formula
     assert_equal "hello", output
   end
 end
-
-__END__
-diff --git a/Makefile b/Makefile.patched
-index 7ca93f0..dde78ff 100644
---- a/Makefile
-+++ b/Makefile.patched
-@@ -120,2 +120,8 @@ endif
- 
-+# LDFLAGS for building dynamically-loadable JS binary modules
-+LDFLAGS_DYNLOAD=$(LDFLAGS)
-+ifdef CONFIG_DARWIN
-+LDFLAGS_DYNLOAD += -undefined dynamic_lookup
-+endif
-+
- PROGS=qjs$(EXE) qjsbn$(EXE) qjsc qjsbnc run-test262 run-test262-bn
-@@ -370,7 +376,3 @@ doc/%.html: doc/%.texi
- 
--ifndef CONFIG_DARWIN
--test: bjson.so
--endif
--
--test: qjs qjsbn
-+test: qjs qjsbn bjson.so
- 	./qjs tests/test_closure.js
-@@ -380,5 +382,3 @@ test: qjs qjsbn
- 	./qjs -m tests/test_std.js
--ifndef CONFIG_DARWIN
- 	./qjs -m tests/test_bjson.js
--endif
- 	./qjsbn tests/test_closure.js
-@@ -460,3 +460,3 @@ bench-v8: qjs qjs32
- bjson.so: $(OBJDIR)/bjson.pic.o
--	$(CC) $(LDFLAGS) -shared -o $@ $^ $(LIBS)
-+	$(CC) $(LDFLAGS_DYNLOAD) -shared -o $@ $^ $(LIBS)
- 
-

--- a/Formula/quickjs.rb
+++ b/Formula/quickjs.rb
@@ -1,8 +1,8 @@
 class Quickjs < Formula
   desc "Small and embeddable JavaScript engine"
   homepage "https://bellard.org/quickjs/"
-  url "https://bellard.org/quickjs/quickjs-2019-07-09.tar.xz"
-  sha256 "350c1cd9dd318ad75e15c9991121c80b85c2ef873716a8900f811554017cd564"
+  url "https://bellard.org/quickjs/quickjs-2019-07-21.tar.xz"
+  sha256 "a906bed24c57dc9501b84a5bb4514f7eac58db82b721116ec5abe868490e53cc"
 
   bottle do
     sha256 "989215f264fc3240904342524457b923da278d6edd53e8fb44dad1f370b4e64f" => :mojave
@@ -10,13 +10,23 @@ class Quickjs < Formula
     sha256 "3fbf3dfc902c9e68415088325ec7ec6f16e1c69204b3cd3432046d6bed14896e" => :sierra
   end
 
+  patch :DATA
+
   def install
-    system "make", "install", "prefix=#{prefix}"
+    system "make", "prefix=#{prefix}", "CONFIG_M32="
+    # Tests are dependent on having a TTY, so fake it with `script`
+    system "script", "-q", "/dev/stdout", "make", "test", "prefix=#{prefix}", "CONFIG_M32="
+    system "make", "install", "prefix=#{prefix}", "CONFIG_M32="
+
+    mkdir_p pkgshare
+
+    cp_r "examples", pkgshare
+    cp_r "doc", pkgshare
   end
 
   test do
-    output = shell_output("#{bin}/qjs -e 'console.log(\"hello\");'").strip
-    assert_equal "hello", output
+    output = shell_output("#{bin}/qjs --eval 'const js=\"JS\"; console.log(`Q${js}${(7 + 35)}`);'").strip
+    assert_match /^QJS42/, output
 
     path = testpath/"test.js"
     path.write "console.log('hello');"
@@ -25,3 +35,39 @@ class Quickjs < Formula
     assert_equal "hello", output
   end
 end
+
+__END__
+diff --git a/Makefile b/Makefile.patched
+index 7ca93f0..dde78ff 100644
+--- a/Makefile
++++ b/Makefile.patched
+@@ -120,2 +120,8 @@ endif
+ 
++# LDFLAGS for building dynamically-loadable JS binary modules
++LDFLAGS_DYNLOAD=$(LDFLAGS)
++ifdef CONFIG_DARWIN
++LDFLAGS_DYNLOAD += -undefined dynamic_lookup
++endif
++
+ PROGS=qjs$(EXE) qjsbn$(EXE) qjsc qjsbnc run-test262 run-test262-bn
+@@ -370,7 +376,3 @@ doc/%.html: doc/%.texi
+ 
+-ifndef CONFIG_DARWIN
+-test: bjson.so
+-endif
+-
+-test: qjs qjsbn
++test: qjs qjsbn bjson.so
+ 	./qjs tests/test_closure.js
+@@ -380,5 +382,3 @@ test: qjs qjsbn
+ 	./qjs -m tests/test_std.js
+-ifndef CONFIG_DARWIN
+ 	./qjs -m tests/test_bjson.js
+-endif
+ 	./qjsbn tests/test_closure.js
+@@ -460,3 +460,3 @@ bench-v8: qjs qjs32
+ bjson.so: $(OBJDIR)/bjson.pic.o
+-	$(CC) $(LDFLAGS) -shared -o $@ $^ $(LIBS)
++	$(CC) $(LDFLAGS_DYNLOAD) -shared -o $@ $^ $(LIBS)
+ 
+


### PR DESCRIPTION
- Update source to version "2019-07-21"
- Avoid building 32bit libraries because they are not needed and unsupported by newer XCode versions
- Add patch for Makefile which fixes the issue with building JS module as shared library
- Run full testsuite provided by original source authors
- Improve formula tests
- Copy examples and docs to the package

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Original e-mail with changelog from the software's author:
> Hi,
> 
> A new release of QuickJS is available:
> 
> 2019-07-21:
> 
> - updated test262 tests
> - updated to Unicode version 12.1.0
> - fixed missing Date object in qjsc
> - fixed multi-context creation
> - misc ES2020 related fixes
> - simplified power and division operators in bignum extension
> - fixed several crash conditions
> 
> Best regards,
> 
> Fabrice.


