### PR TITLE
Update mg.rb

### DIFF
--- a/Formula/mg.rb
+++ b/Formula/mg.rb
@@ -1,8 +1,9 @@
 class Mg < Formula
-  desc "Small Emacs-like editor from OpenBSD"
+  desc "Small Emacs-like editor"
   homepage "https://github.com/ibara/mg"
   url "https://github.com/ibara/mg/releases/download/mg-6.5/mg-6.5.tar.gz"
   sha256 "3e4bb4582c8d1a72fb798bc320a9eede04f41e7e72a1421193174b1a6fc43cd8"
+  version_scheme 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/mg.rb
+++ b/Formula/mg.rb
@@ -1,10 +1,8 @@
 class Mg < Formula
-  desc "Small Emacs-like editor"
-  # https://devio.us/~bcallah/mg/ is temporarily offline
+  desc "Small Emacs-like editor from OpenBSD"
   homepage "https://github.com/ibara/mg"
-  # https://devio.us/~bcallah/mg/mg-20180421.tar.gz is temporarily offline
-  url "https://dl.bintray.com/homebrew/mirror/mg-20180421.tar.gz"
-  sha256 "11215613a360cf72ff16c2b241ea4e71b4b80b2be32c62a770c1969599e663b2"
+  url "https://github.com/ibara/mg/releases/download/mg-6.5/mg-6.5.tar.gz"
+  sha256 "3e4bb4582c8d1a72fb798bc320a9eede04f41e7e72a1421193174b1a6fc43cd8"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,8 +11,6 @@ class Mg < Formula
     sha256 "e8df146cd84a6d153066c1c5398fb0846dace0529d090dbb063624f46556fb00" => :sierra
     sha256 "f0ea843971bc8cdabbfdfbc663b7ef0d89c8b1d37b5eb303bfcebf83ff6d97a7" => :el_capitan
   end
-
-  depends_on :macos => :yosemite # older versions don't support fstatat(2)
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
Hi --

This probably needs some adjusting, and I don't own a Mac running Mac OS X so I can't be too much help. But hopefully this gives enough for someone to update properly.

I'm upstream for mg. I noticed that it seems to be decently used via homebrew, which is nice. I noticed though that the version is outdated so this PR so this is a blind attempt at updating.

Some notes:
* I redid the numbering scheme so that the mg version number matches the OpenBSD release from which the code derives. This means the numbering scheme is going backwards for this update (and only this update). Not sure if you require special handling for this case.

* I make real releases through GitHub now, so use that tarball (it's a real tarball that I create and upload not one of GH's autogenerated ones).

* Removed note about older versions of Mac OS X. In the interim, we had extensive testing done and mg runs at least as far back as Mac OS X 10.4 now. Probably earlier, since just about every potentially missing function has a portable fallback version in the mg codebase now. This includes fstatat(2).

* This update is untested. I'm an OpenBSD developer so my one (PowerPC) Mac is running OpenBSD, so I have little to no way to check this. Please adapt as you need.

Thanks!

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
