### PR TITLE
tfenv: install share directory for gpg verification

### DIFF
--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -10,7 +10,7 @@ class Tfenv < Formula
   conflicts_with "terraform", :because => "tfenv symlinks terraform binaries"
 
   def install
-    prefix.install ["bin", "libexec"]
+    prefix.install ["bin", "libexec", "share"]
   end
 
   test do


### PR DESCRIPTION
tfenv has logic for verifying the Terraform releases that it downloads
with gpg or gpgv. [When gpgv is used, tfenv tries to verify the
download's signature based on a key for Hashicorp that is bundled with
the tfenv release in the `share` directory](https://github.com/tfutils/tfenv#tfenv-install-version) - but the homebrew formula is
not installing that directory.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
