### PR TITLE
vapor 18.0.0 (new formula)

### DIFF
--- a/Formula/vapor.rb
+++ b/Formula/vapor.rb
@@ -1,0 +1,19 @@
+class Vapor < Formula
+  desc "Vapor Toolbox"
+  homepage "https://vapor.codes"
+  head "https://github.com/vapor/toolbox.git"
+  depends_on :xcode => "11"
+  depends_on "openssl"
+
+  stable do
+    version "18.0.0-beta.17"
+    url "https://github.com/vapor/toolbox/archive/18.0.0-beta.17.tar.gz"
+    sha256 "202208026843dbf68ec54a13fe08db1c41d3d39e8c060fdbb723f192b88ecd8d"
+  end
+
+  def install
+    system "swift", "build", "--disable-sandbox"
+    system "mv", ".build/debug/Executable", "vapor"
+    bin.install "vapor"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a continuation of https://github.com/Homebrew/homebrew-core/pull/19895. We've updated our CLI tool to not have any cross tap dependencies and to build from source. 

I'm opening this as a draft since the new version of the tool is still in beta (release should be in a month or two). We'd like to get early feedback on whether this new formula looks correct and hopefully pre-approve this PR. 
