### PR TITLE
silk 3.18.2

### DIFF
--- a/Formula/silk.rb
+++ b/Formula/silk.rb
@@ -1,9 +1,8 @@
 class Silk < Formula
   desc "Collection of traffic analysis tools"
   homepage "https://tools.netsa.cert.org/silk/"
-  url "https://tools.netsa.cert.org/releases/silk-3.18.1.tar.gz"
-  sha256 "0900a5a0d08c786be280d97e5bb6d9ec09e8aec69f4495a91b32e254014ef8e9"
-  revision 1
+  url "https://tools.netsa.cert.org/releases/silk-3.18.2.tar.gz"
+  sha256 "855ce1ce862fc2cb7146a04cbe60ba2584ff7df176e07494a2f14d26976b4c2b"
 
   bottle do
     sha256 "5bc6286c86c29a9e3004e5023796a7c5dcbc43951541a290f9433f141dd8e207" => :mojave

--- a/Formula/yaf.rb
+++ b/Formula/yaf.rb
@@ -13,8 +13,11 @@ class Yaf < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "gettext"
   depends_on "glib"
   depends_on "libfixbuf"
+  depends_on "libtool"
+  depends_on "pcre"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
CI was broken with:
```
brew test silk --verbose
==> FAILED
Testing silk
/usr/bin/sandbox-exec -f /private/tmp/homebrew20190726-49031-gds0mf.sb /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -W0 -I /usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-cobertura-1.3.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ruby-macho-2.2.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-rspec-1.34.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-performance-1.4.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-0.73.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unicode-display_width-1.6.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ruby-progressbar-1.10.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-wait-0.0.9/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-retry-0.6.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-its-1.3.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-3.8.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-mocks-3.8.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-expectations-3.8.4/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-core-3.8.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-support-3.8.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ronn-0.7.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rdiscount-2.2.0.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/rdiscount-2.2.0.1:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rainbow-3.0.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/plist-3.5.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parser-2.6.3.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parallel_tests-2.29.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parallel-1.17.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mustache-1.1.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mechanize-2.7.6/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/webrobots-0.1.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ntlm-http-0.1.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/nokogiri-1.10.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/nokogiri-1.10.3:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mini_portile2-2.4.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/net-http-persistent-3.0.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/net-http-digest_auth-1.4.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mime-types-3.2.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mime-types-data-3.2019.0331/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/jaro_winkler-1.5.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/jaro_winkler-1.5.3:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/http-cookie-1.0.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/hpricot-0.8.6/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/hpricot-0.8.6:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/domain_name-0.5.20190701/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unf-0.1.4/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unf_ext-0.0.7.6/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/unf_ext-0.0.7.6:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/diff-lcs-1.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/coveralls-0.8.23/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/thor-0.20.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/term-ansicolor-1.7.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/tins-1.21.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-0.16.1/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-html-0.10.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/docile-1.3.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/json-2.2.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/json-2.2.0:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/connection_pool-2.2.2/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/backports-3.15.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ast-2.4.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/activesupport-5.2.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/tzinfo-1.2.5/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/thread_safe-0.3.6/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/minitest-5.11.3/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/i18n-1.6.0/lib:/usr/local/Homebrew/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/concurrent-ruby-1.1.5/lib:/Library/Ruby/Gems/2.3.0/gems/power_assert-0.2.6/lib:/Library/Ruby/Gems/2.3.0/gems/test-unit-3.1.5/lib:/Library/Ruby/Site/2.3.0:/Library/Ruby/Site/2.3.0/x86_64-darwin18:/Library/Ruby/Site/2.3.0/universal-darwin18:/Library/Ruby/Site:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0/x86_64-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0/universal-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/x86_64-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/universal-darwin18:/usr/local/Homebrew/Library/Homebrew -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/silk.rb --verbose
==> yaf --in /usr/local/Homebrew/Library/Homebrew/test/support/fixtures/test.pcap | /usr/local/Cellar/silk/3.18.2/bin/rwipfix2silk | /usr/local/Cellar/silk/3.18.2/bin/rwcount --no-titles --no-column
dyld: Library not loaded: /usr/local/opt/libtool/lib/libltdl.7.dylib
  Referenced from: /usr/local/bin/yaf
  Reason: image not found
Error: silk: failed
```

It seemed that `yaf` was not able to find `libtool`. I verified on my local machine that the `libtool` installation did indeed include `libltdl.7.dylib`, and then checked `yaf`'s linkage. Sure enough, `libtool` had slipped through the cracks, so this PR patches up the undeclared dependency issue while we're at it.


```
• brew linkage yaf
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libpcap.A.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
  /usr/local/opt/glib/lib/libglib-2.0.0.dylib (glib)
  /usr/local/opt/glib/lib/libgthread-2.0.0.dylib (glib)
  /usr/local/opt/libfixbuf/lib/libfixbuf.9.dylib (libfixbuf)
  /usr/local/opt/libtool/lib/libltdl.7.dylib (libtool)
  /usr/local/opt/pcre/lib/libpcre.1.dylib (pcre)
  /usr/local/Cellar/yaf/2.11.0_1/lib/libairframe-2.11.0.4.dylib (yaf)
  /usr/local/Cellar/yaf/2.11.0_1/lib/libyaf-2.11.0.4.dylib (yaf)
Indirect dependencies with linkage:
  gettext
  pcre
Undeclared dependencies with linkage:
  libtool
```