### PR TITLE
btparse 0.35

### DIFF
--- a/Formula/btparse.rb
+++ b/Formula/btparse.rb
@@ -1,8 +1,8 @@
 class Btparse < Formula
   desc "BibTeX utility libraries"
-  homepage "https://www.gerg.ca/software/btOOL/"
-  url "https://www.gerg.ca/software/btOOL/btparse-0.34.tar.gz"
-  sha256 "e8e2b6ae5de85d1c6f0dc52e8210aec51faebeee6a6ddc9bd975b110cec62698"
+  homepage "https://metacpan.org/pod/distribution/Text-BibTeX/btparse/doc/btparse.pod"
+  url "https://cpan.metacpan.org/authors/id/A/AM/AMBS/btparse/btparse-0.35.tar.gz"
+  sha256 "631bf1b79dfd4c83377b416a12c349fe88ee37448dc82e41424b2f364a99477b"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The previous homepage states:
>  Note: btOOL is now maintained by Alberto Simões <albie at alfarrabio dot di dot uminho dot pt>. Please contact Alberto for support. The rest of this page is maintained for historical interest.

The new maintainer has pushed a release, hence the change in `homepage` and `url`.