### PR TITLE
[WIP] Add gwnum v29.8b3

### DIFF
--- a/Formula/gwnum.rb
+++ b/Formula/gwnum.rb
@@ -1,0 +1,23 @@
+class Gwnum < Formula
+  desc "A multi-precision arithmetic library"
+  homepage "https://www.mersenne.org/"
+  url "http://www.mersenne.org/ftp_root/gimps/p95v298b3.source.zip"
+  sha256 "dac67702e45689e058519164222b6a1f0b32d9e7c88049f7c59f9699174105f0"
+  version "29.8b3"
+
+  depends_on "automake" => :build
+  depends_on "gcc" => :build
+
+  def install
+    cd "gwnum" do
+      system "make", "--file=makemac", "release/gwnum.a"
+      lib.install "release/gwnum.a"
+    end
+  end
+
+  test do
+    system ENV.cc, "gwnum/test.c", "-L#{lib}", "-lgwnum",
+                   "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I need some help with this formula. Running `make --file=makemac release/gwnum.a` works fine when I download the code and run the command manually, however when I try to install this formula it produces the following error during the make process:
```
==> make --file=makemac release/gwnum.a
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/cpuid.o cpuid.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwnum.o gwnum.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwtables.o gwtables.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwthread.o gwthread.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwini.o gwini.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwbench.o gwbench.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/gwutil.o gwutil.c
MACOSX_DEPLOYMENT_TARGET=10.3 g++ -I.. -I../qd -O2 -m32 -march=i686 -fno-exceptions -fno-rtti -Wno-stdlibcxx-not-found -c -o release/gwdbldbl.o gwdbldbl.cpp
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/giants.o giants.c
MACOSX_DEPLOYMENT_TARGET=10.3 gcc -I.. -I../sqlite-amalgamation-3180000 -O2 -m32 -march=i686 -fno-exceptions -c -o release/ecmstag1.o ecmstag1.c
cp macosx/gwnum.a release
ar -rs release/gwnum.a release/cpuid.o release/gwnum.o release/gwtables.o release/gwthread.o release/gwini.o release/gwbench.o release/gwutil.o release/gwdbldbl.o release/giants.o release/ecmstag1.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(cpuid.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwnum.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwtables.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwthread.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwini.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwbench.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwutil.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(gwdbldbl.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(giants.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive member: release/gwnum.a(ecmstag1.o) cputype (16777223) does not match previous archive members cputype (7) (all members must match)
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: release/gwnum.a will be fat and ar(1) will not be able to operate on it
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar: internal ranlib command failed
make: *** [release/gwnum.a] Error 1
```
The output of the make command when running it manually is the exact same up to and including the `ar -rs release/gwnum.a...` line. Could not reproduce the error even when using gcc-9/g++-9. I am not sure what would be different or what I can try next to fix this.