### PR TITLE
Update LDC bootstrap compiler version

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -3,6 +3,7 @@ class Ldc < Formula
   homepage "https://wiki.dlang.org/LDC"
   url "https://github.com/ldc-developers/ldc/releases/download/v1.16.0/ldc-1.16.0-src.tar.gz"
   sha256 "426d9d0dc65b7d3d739809c9c8bf022177aeaa8e65999be7145e052be3357302"
+  revision 1
   head "https://github.com/ldc-developers/ldc.git", :shallow => false
 
   bottle do
@@ -16,9 +17,9 @@ class Ldc < Formula
   depends_on "llvm"
 
   resource "ldc-bootstrap" do
-    url "https://github.com/ldc-developers/ldc/releases/download/v1.12.0/ldc2-1.12.0-osx-x86_64.tar.xz"
-    version "1.12.0"
-    sha256 "a946e658aaff1eed80bffeb4d69b572f259368fac44673731781f6d487dea3cd"
+    url "https://github.com/ldc-developers/ldc/releases/download/v1.16.0/ldc2-1.16.0-osx-x86_64.tar.xz"
+    version "1.16.0"
+    sha256 "78876a76e50e67f5944dcef25744186bf86bd9414fb75e9ab8099a1b7582f5e2"
   end
 
   def install


### PR DESCRIPTION
This formula revision updates the bootstrap compiler used to build LDC from version 1.12.0 to 1.16.0, the current version of the compiler.

It should result in rebuilding the binary bottles for each OS using the newer compiler.  

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
