### PR TITLE
p7zip: enhanced encryption strength

### DIFF
--- a/Formula/p7zip.rb
+++ b/Formula/p7zip.rb
@@ -3,7 +3,7 @@ class P7zip < Formula
   homepage "https://p7zip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/p7zip/p7zip/16.02/p7zip_16.02_src_all.tar.bz2"
   sha256 "5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -18,6 +18,11 @@ class P7zip < Formula
     sha256 "fab0be1764efdbde1804072f1daa833de4e11ea65f718ad141a592404162643c"
     apply "patches/12-CVE-2016-9296.patch",
           "patches/13-CVE-2017-17969.patch"
+  end
+
+  patch :p4 do
+    url "https://github.com/aonez/Keka/files/2940620/15-Enhanced-encryption-strength.patch.zip"
+    sha256 "838dd2175c3112dc34193e99b8414d1dc1b2b20b861bdde0df2b32dbf59d1ce4"
   end
 
   def install


### PR DESCRIPTION
There was a bug in 7zip AES encryption. To fix this the size of the random initialization vector was
increased from 64-bit to 128-bit and the pseudo-random number generator was improved.
It has been reported here: https://sourceforge.net/p/sevenzip/bugs/2176/

[Keka](https://www.keka.io) fixes this in https://github.com/aonez/Keka/issues/379 and provides a patch against p7zip.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
