### PR TITLE
limiting all binded ports to localhost only

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -91,6 +91,7 @@ class Mysql < Formula
       [mysqld]
       # Only allow connections from localhost
       bind-address = 127.0.0.1
+      mysqlx-bind-address = 127.0.0.1
     EOS
     etc.install "my.cnf"
   end


### PR DESCRIPTION
my install has mysqlx enabled by default (not investigating if this is desirable or a bug on mysql, since having that setting added will not harm anything in case it is later off by default)

with mysqlx enabled, it will bind by default on `*:33060`, this change 'fixes' it to listen to localhost only too.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
