### PR TITLE
netmask 2.4.4 (new formula)

### DIFF
--- a/Formula/netmask.rb
+++ b/Formula/netmask.rb
@@ -1,0 +1,21 @@
+class Netmask < Formula
+  desc "IP address formatting tool"
+  homepage "https://github.com/tlby/netmask"
+  url "https://github.com/tlby/netmask/archive/v2.4.4.tar.gz"
+  sha256 "7e4801029a1db868cfb98661bcfdf2152e49d436d41f8748f124d1f4a3409d83"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
+  def install
+    system "./autogen"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    assert_equal "10.0.0.0/23", shell_output("#{bin}/netmask 10.0.0.0:10.0.1.255").strip
+  end
+end


### PR DESCRIPTION
Netmask, a handy tool for converting between netmasks and ranges in different formats.

I originally found this in Debian years ago, and was disappointed that it wasn't immediately available with brew on my mac laptop.  `brew audit --new-formula netmask` complains that the github repo isn't popular enough, but I find it immensely useful on a weekly basis, so I hope that's not a showstopper.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
