### PR TITLE
Update gpgme.rb

### DIFF
--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -11,12 +11,8 @@ class Gpgme < Formula
     sha256 "e25704cd86fc95fc9e630c0631729eb8315d8c7d27dc45abd0b08fd6d2d6937f" => :sierra
   end
 
-  depends_on "doxygen" => :build
-  depends_on "graphviz" => :build
-  depends_on "pkg-config" => :build
   depends_on "python" => [:build, :test]
   depends_on "swig" => :build
-  depends_on "cmake" => :test
   depends_on "gnupg"
   depends_on "libassuan"
   depends_on "libgpg-error"
@@ -37,6 +33,5 @@ class Gpgme < Formula
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
     system "python2.7", "-c", "import gpg; print gpg.version.versionstr"
     system "python3", "-c", "import gpg; print(gpg.version.versionstr)"
-    system "cmake", ".", "-Wno-dev"
   end
 end

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -15,7 +15,6 @@ class Gpgme < Formula
   depends_on "graphviz" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => [:build, :test]
-  depends_on "qt" => :optional
   depends_on "swig" => :build
   depends_on "cmake" => :test
   depends_on "gnupg"
@@ -38,7 +37,6 @@ class Gpgme < Formula
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
     system "python2.7", "-c", "import gpg; print gpg.version.versionstr"
     system "python3", "-c", "import gpg; print(gpg.version.versionstr)"
-    (testpath/"CMakeLists.txt").write("find_package(QGpgme REQUIRED)")
     system "cmake", ".", "-Wno-dev"
   end
 end

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -15,7 +15,7 @@ class Gpgme < Formula
   depends_on "graphviz" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => [:build, :test]
-  depends_on "qt" => [:build, :test, :optional]
+  depends_on "qt" => :optional
   depends_on "swig" => :build
   depends_on "cmake" => :test
   depends_on "gnupg"

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -15,7 +15,7 @@ class Gpgme < Formula
   depends_on "graphviz" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => [:build, :test]
-  depends_on "qt" => [:build, :test]
+  depends_on "qt" => [:build, :test, :optional]
   depends_on "swig" => :build
   depends_on "cmake" => :test
   depends_on "gnupg"


### PR DESCRIPTION
GnuPG fails brew linkage test with GPGME because of the QT bindings. It's not a required dependency for GPGME but is actually an optional framework/language support for just a few hosted formula and casks. I believe this should be passed '--with-qt' instead of requiring it for compatibility.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
