### PR TITLE
crystal 0.30.0

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -3,8 +3,8 @@ class Crystal < Formula
   homepage "https://crystal-lang.org/"
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.29.0.tar.gz"
-    sha256 "c2265b2a904ded282751f59a3bd0367072058eee1cf51ebe0af03a572f8e19b9"
+    url "https://github.com/crystal-lang/crystal/archive/0.30.0.tar.gz"
+    sha256 "fc884970089e382344540676a9c5aa4f369c9a0f45d1858e079b4ce26878164a"
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz"
@@ -34,7 +34,7 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "llvm@6"
+  depends_on "llvm"
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
@@ -51,9 +51,9 @@ class Crystal < Formula
   end
 
   resource "boot" do
-    url "https://github.com/crystal-lang/crystal/releases/download/0.28.0/crystal-0.28.0-1-darwin-x86_64.tar.gz"
-    version "0.28.0-1"
-    sha256 "f3ba24c297a99382d749344f319947f807da03371240e373d5c3d13117d4a113"
+    url "https://github.com/crystal-lang/crystal/releases/download/0.29.0/crystal-0.29.0-1-darwin-x86_64.tar.gz"
+    version "0.29.0-1"
+    sha256 "6de700d88dc0486c0d56e4d5c6852dc675256aa6f2c571ed8e4b15e0fc72a0b9"
   end
 
   def install
@@ -92,6 +92,9 @@ class Crystal < Formula
     # Build shards
     resource("shards").stage do
       system buildpath/"bin/crystal", "build", "-o", buildpath/".build/shards", "src/shards.cr"
+
+      man1.install "man/shards.1"
+      man5.install "man/shard.yml.5"
     end
 
     bin.install ".build/shards"
@@ -101,6 +104,8 @@ class Crystal < Formula
 
     bash_completion.install "etc/completion.bash" => "crystal"
     zsh_completion.install "etc/completion.zsh" => "_crystal"
+
+    man1.install "man/crystal.1"
   end
 
   test do


### PR DESCRIPTION
* Version bump of sources
* Upgrade _finally_ llvm to llvm@8. I would've prefered to use `llvm@8` explicitly put the audit complain about using an alias.
* man pages for crystal and shards included
