### PR TITLE
Remove stale caveats from s3fs

### DIFF
--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -27,15 +27,6 @@ class S3fs < Formula
     system "make", "install"
   end
 
-  def caveats; <<~EOS
-    Be aware that s3fs has some caveats concerning S3 "directories"
-    that have been created by other tools. See the following issue for
-    details:
-
-      https://code.google.com/p/s3fs/issues/detail?id=73
-  EOS
-  end
-
   test do
     system "#{bin}/s3fs", "--version"
   end


### PR DESCRIPTION
s3fs now provides default permissions for external objects.
References s3fs-fuse/s3fs-fuse#1112.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?