### PR TITLE
sane-backends 1.0.28

### DIFF
--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -1,11 +1,9 @@
 class SaneBackends < Formula
   desc "Backends for scanner access"
   homepage "http://www.sane-project.org/"
-  url "https://deb.debian.org/debian/pool/main/s/sane-backends/sane-backends_1.0.27.orig.tar.gz"
-  mirror "https://fossies.org/linux/misc/sane-backends-1.0.27.tar.gz"
-  sha256 "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
-  revision 5
-  head "https://salsa.debian.org/debian/sane-backends.git"
+  url "https://gitlab.com/sane-project/backends/uploads/9e718daff347826f4cfe21126c8d5091/sane-backends-1.0.28.tar.gz"
+  sha256 "31260f3f72d82ac1661c62c5a4468410b89fb2b4a811dabbfcc0350c1346de03"
+  head "https://gitlab.com/sane-project/backends.git"
 
   bottle do
     sha256 "19a5dd6aab043b2552e4ddb785c4f41c184019a7854e5bf28054ee809839a81f" => :mojave
@@ -23,18 +21,16 @@ class SaneBackends < Formula
   depends_on "openssl"
 
   def install
+    # malloc lives in malloc/malloc.h instead of just malloc.h on macOS.
+    # Merge request opened upstream: https://gitlab.com/sane-project/backends/merge_requests/90
+    inreplace "backend/ricoh2_buffer.c", "#include <malloc.h>", "#include <malloc/malloc.h>"
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
                           "--without-gphoto2",
                           "--enable-local-backends",
                           "--with-usb=yes"
-
-    # Remove for > 1.0.27
-    # Workaround for bug in Makefile.am described here:
-    # https://lists.alioth.debian.org/pipermail/sane-devel/2017-August/035576.html
-    # It's already fixed in commit 519ff57.
-    system "make"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[This download page](http://www.sane-project.org/source.html) now links to the GitLab instance given in the `url` and `head` links.

Build fails due to `malloc` residing at `malloc/malloc.h` instead of just `malloc.h` on macOS. For now, fix with an `inreplace` call while upstream fix has been submitted at https://gitlab.com/sane-project/backends/merge_requests/90.