### PR TITLE
nudoku: switch to head do block

### DIFF
--- a/Formula/nudoku.rb
+++ b/Formula/nudoku.rb
@@ -3,7 +3,6 @@ class Nudoku < Formula
   homepage "https://jubalh.github.io/nudoku/"
   url "https://github.com/jubalh/nudoku/archive/1.0.0.tar.gz"
   sha256 "80fb9996c28642920951c20cfd5ca6e370d75240255bc6f11067ae68b6e44eca"
-  head "https://github.com/jubalh/nudoku.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,6 +10,12 @@ class Nudoku < Formula
     sha256 "b6a14adadee0fb01f92397a5fdc31189492468e3d87875bed408ca41824d09b4" => :high_sierra
     sha256 "d4cea1e1c0f97655feb301910aa70c65a223959ba39a8493f31ca1a614eec175" => :sierra
     sha256 "8f4cd53a9cd87ac8b9b1b48a986329708134608e3ff4423e8f449e1a6c81d6f1" => :el_capitan
+  end
+
+  head do
+    url "https://github.com/jubalh/nudoku.git"
+
+    depends_on "gettext" => :build
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - **It fails due to the description not beginning with an uppercase letter, which predates this PR. `ncurses` is usually stylised as completely lowercase.**

-----
Version `2.0.0` of `nudoku` [introduced some welcome changes](https://github.com/jubalh/nudoku/releases/tag/2.0.0), however, the build will currently fail due to a `gettext` version conflict. This has been resolved in https://github.com/jubalh/nudoku/pull/32 but may not be included in a release for a while.