### PR TITLE
bash-completion: Backport ssh_config Include directive parsing

### DIFF
--- a/Formula/bash-completion.rb
+++ b/Formula/bash-completion.rb
@@ -28,6 +28,13 @@ class BashCompletion < Formula
   # Backports (a variant of) an upstream patch to fix man completion.
   patch :DATA
 
+  # Backports ssh_config Include directive parsing for ssh hostname tab
+  # completion
+  patch :p0 do
+    url "https://gist.githubusercontent.com/timvisher/93444e4ca4e1ad9cc2eb90c1d71294e3/raw/2277a816bfeead13744244cb9d906422ad0d442b/ssh_config_include_1.3_homebrew_backport.patch"
+    sha256 "b9f899d3ed61213ae102ec379cd226cb8aacb756ebd238aa293144975fb2713d"
+  end
+
   def install
     inreplace "bash_completion" do |s|
       s.gsub! "/etc/bash_completion", etc/"bash_completion"


### PR DESCRIPTION
openssh 7.3p1 and up have the ability to specify additional config files
in an Include directive. This is supported on the stock openssh
implementation in macOS 10.14.6 at least.

Version 2.5 and onward of bash-completion have the ability to parse these
Include directives for hostname completion but require an upgraded version
of bash (4 or 5 specifically) to utilize on any version of macOS.

That said, nothing about the implementation of Include directive parsing
required bash 4 so this commit pulls down a patch file which applies it
back to the version of bash-completion provided by homebrew.