### PR TITLE
Switch to `ksh-2020.0.0-alpha1` from GitHub

### DIFF
--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -1,46 +1,24 @@
 class Ksh < Formula
   desc "KornShell, ksh93"
   homepage "http://www.kornshell.com"
-  url "https://opensource.apple.com/source/ksh/ksh-23/ast-ksh.2012-08-01.tgz",
-    :using => :nounzip
-  mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/ast-ksh.2012-08-01.tgz"
-  version "93u+" # Versioning scheme: + means "+ patches", - means "beta/alpha".
-  sha256 "e6192cfa52a6a9fd20618cbaf3fa81f0cc9fd83525500757e83017275e962851"
+  url "https://github.com/att/ast/releases/download/2020.0.0-alpha1/ksh-2020.0.0-alpha1.tar.gz"
+  version "2020.0.0.1-alpha"
+  sha256 "48b150392038b0592bd0b07817ff4838dc038f53bb564d4a73a35357fc88802e"
 
-  bottle do
-    cellar :any_skip_relocation
-    rebuild 3
-    sha256 "d6a44587ba5c9ef60ccd4df40bb4e5b4be2a6fbf6c3269d1732ba7376b341c8c" => :mojave
-    sha256 "5ca742b83c55b817a0fa09f737d73530c0f73d89618c60a19ec2ea5251ef8cd4" => :high_sierra
-    sha256 "37a9f6c57702896fabe762fe90ebe454f04f3523aea311a28d34dc884d53736e" => :sierra
-    sha256 "5148e18444c7f1a4e7b71f72982362491aa5581101296acaa6d9c2a782d620b1" => :el_capitan
-    sha256 "13f85c7df7f44b68f1e5560c05b61eff8145230d94986537bdee5702c1e72e68" => :yosemite
-    sha256 "7c665466fb323fc0cb6ffb87ec9fe1630d75afcd3b12864e2424677473db4924" => :mavericks
-  end
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
 
   resource "init" do
-    url "https://opensource.apple.com/source/ksh/ksh-23/INIT.2012-08-01.tgz"
-    mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/INIT.2012-08-01.tgz"
-    sha256 "c40cf57e9b2186271a9c362a560aa4a6e25ba911a8258ab931d2bbdbce44cfe5"
+    url "https://github.com/att/ast/releases/download/2020.0.0-alpha1/ksh-2020.0.0-alpha1.tar.gz"
+    sha256 "48b150392038b0592bd0b07817ff4838dc038f53bb564d4a73a35357fc88802e"
   end
 
   def install
-    resource("init").stage buildpath
-    (buildpath/"lib/package/tgz").install Dir["*.tgz"]
-    system "/bin/ksh", "bin/package", "read"
-
-    # Needed due to unusal build system.
-    ENV.refurbish_args
-
-    # From Apple"s ksh makefile.
-    kshcppdefines = "-DSHOPT_SPAWN=0 -D_ast_int8_t=int64_t -D_lib_memccpy"
-    system "/bin/ksh", "bin/package", "make", "CCFLAGS=#{kshcppdefines}"
-
-    bin.install "arch/darwin.i386-64/bin/ksh" => "ksh93"
-    bin.install_symlink "ksh93" => "ksh"
-
-    man1.install "arch/darwin.i386-64/man/man1/sh.1" => "ksh93.1"
-    man1.install_symlink "ksh93.1" => "ksh.1"
+    mkdir "build" do
+      system "meson", "--prefix=#{prefix}", ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
   end
 
   def caveats


### PR DESCRIPTION
Although it's an alpha release, it features switch to new (and saner)
build system, hundreds of bug fixes, better test coverage and cleans up
lot of mess that has accumulated over the years. It is already rebased
in Fedora, Debian, Gentoo, FreeBSD and several other well known distros.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
