### PR TITLE
fontforge 20190801

### DIFF
--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -12,7 +12,6 @@ class Fontforge < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python"
   depends_on "cairo"
   depends_on "fontconfig"
   depends_on "freetype"
@@ -26,6 +25,7 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
+  depends_on "python"
   depends_on "readline"
   uses_from_macos "libxml2"
 

--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -1,9 +1,8 @@
 class Fontforge < Formula
   desc "Command-line outline and bitmap font editor/converter"
   homepage "https://fontforge.github.io"
-  url "https://github.com/fontforge/fontforge/releases/download/20190413/fontforge-20190413.tar.gz"
-  sha256 "6762a045aba3d6ff1a7b856ae2e1e900a08a8925ccac5ebf24de91692b206617"
-  revision 2
+  url "https://github.com/fontforge/fontforge/releases/download/20190801/fontforge-20190801.tar.gz"
+  sha256 "d92075ca783c97dc68433b1ed629b9054a4b4c74ac64c54ced7f691540f70852"
 
   bottle do
     cellar :any
@@ -13,11 +12,13 @@ class Fontforge < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python" => [:build, :test]
+  depends_on "python"
   depends_on "cairo"
   depends_on "fontconfig"
+  depends_on "freetype"
   depends_on "gettext"
   depends_on "giflib"
+  depends_on "glib"
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libspiro"
@@ -25,6 +26,7 @@ class Fontforge < Formula
   depends_on "libtool"
   depends_on "libuninameslist"
   depends_on "pango"
+  depends_on "readline"
   uses_from_macos "libxml2"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`fontforge` has some indirect dependencies with linkage, which this PR also fixes.

```
• brew linkage fontforge
System libraries:
  /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libiconv.2.dylib
  /usr/lib/libxml2.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/cairo/lib/libcairo.2.dylib (cairo)
  /usr/local/Cellar/fontforge/20190801/lib/libfontforge.3.dylib (fontforge)
  /usr/local/Cellar/fontforge/20190801/lib/libfontforgeexe.3.dylib (fontforge)
  /usr/local/Cellar/fontforge/20190801/lib/libgunicode.5.dylib (fontforge)
  /usr/local/Cellar/fontforge/20190801/lib/libgutils.3.dylib (fontforge)
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
  /usr/local/opt/giflib/lib/libgif.7.dylib (giflib)
  /usr/local/opt/glib/lib/libgio-2.0.0.dylib (glib)
  /usr/local/opt/glib/lib/libglib-2.0.0.dylib (glib)
  /usr/local/opt/glib/lib/libgobject-2.0.0.dylib (glib)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libspiro/lib/libspiro.0.dylib (libspiro)
  /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
  /usr/local/opt/libuninameslist/lib/libuninameslist.1.dylib (libuninameslist)
  /usr/local/opt/pango/lib/libpango-1.0.0.dylib (pango)
  /usr/local/opt/pango/lib/libpangocairo-1.0.0.dylib (pango)
  /usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/Python (python)
  /usr/local/opt/readline/lib/libreadline.8.dylib (readline)
Indirect dependencies with linkage:
  freetype
  glib
  python
  readline
```