### PR TITLE
 unison: install fsmonitor helper

### DIFF
--- a/Formula/unison.rb
+++ b/Formula/unison.rb
@@ -20,6 +20,8 @@ class Unison < Formula
     ENV.delete "NAME" # https://github.com/Homebrew/homebrew/issues/28642
     system "make", "UISTYLE=text"
     bin.install "src/unison"
+    bin.install "src/unison-fsmonitor"
+    bin.install "src/fsmonitor.py"
     prefix.install_metafiles "src"
   end
 


### PR DESCRIPTION
This fixes/enables the `--retry=watch` option, which specifies continuous synchronization of files.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is ported back to homebrew from https://github.com/BigDanG/linuxbrew-core/commit/53ec5340f5f2f5270477d9eba3faa58b037aa4f3