### PR TITLE
xapian 1.4.12

### DIFF
--- a/Formula/sphinx-doc.rb
+++ b/Formula/sphinx-doc.rb
@@ -5,6 +5,7 @@ class SphinxDoc < Formula
   homepage "https://www.sphinx-doc.org/"
   url "https://files.pythonhosted.org/packages/89/1e/64c77163706556b647f99d67b42fced9d39ae6b1b86673965a2cd28037b5/Sphinx-2.1.2.tar.gz"
   sha256 "f9a79e746b87921cabc3baa375199c6076d1270cee53915dbd24fdbeaaacc427"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -1,8 +1,9 @@
 class Xapian < Formula
   desc "C++ search engine library"
   homepage "https://xapian.org/"
-  url "https://oligarchy.co.uk/xapian/RELEASE/1.4/xapian-core-1.4.11_git103.tar.xz"
-  sha256 "7402311ac96c4386894eab8e240c5c022ad695757710dc437514a551e6f1d3f1"
+  url "https://oligarchy.co.uk/xapian/1.4.12/xapian-core-1.4.12.tar.xz"
+  sha256 "4f8a36da831712db41d38a039fefb5251869761a58be28ba802994bb930fac7c"
+  version_scheme 1
 
   bottle do
     cellar :any
@@ -17,8 +18,8 @@ class Xapian < Formula
   skip_clean :la
 
   resource "bindings" do
-    url "https://oligarchy.co.uk/xapian/RELEASE/1.4/xapian-bindings-1.4.11_git103.tar.xz"
-    sha256 "cb38fb5d5bb68b7181d1ff1be9a9405c2c7e8dfb4d878e0ab540224c7fc08d79"
+    url "https://oligarchy.co.uk/xapian/1.4.12/xapian-bindings-1.4.12.tar.xz"
+    sha256 "7577174efbee2b893b5387fb0bdf3b630e82f55288a00a4c3ec9fdc463e42a49"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In #34835, changes were made to `sphinx-doc` to allow it to build the Python bindings for `xapian`. However, the `revision` was not bumped, so anyone using the bottled version of `sphinx-doc` 2.1.2 who attempts to build `xapian` will continue to face the error encountered in that PR (`AttributeError: type object 'Callable' has no attribute '_abc_registry'`); I had to `--build-from-source` to get a copy of `sphinx-doc` in order to test the PR. The first commit fixes this issue by creating a fresh bottle without the extra files that were causing the build error.

`version_scheme` bump is needed on `xapian` because the autodetect on the previous URL picked up `103` instead of `1.4.11`.