### PR TITLE
node@10: fix build with clang 11

### DIFF
--- a/Formula/node@10.rb
+++ b/Formula/node@10.rb
@@ -17,6 +17,12 @@ class NodeAT10 < Formula
   depends_on "python@2" => :build
   depends_on "icu4c"
 
+  # Fixes detecting Apple clang 11.
+  patch do
+    url "https://github.com/nodejs/node/commit/1f143b8625c2985b4317a40f279232f562417077.patch?full_index=1"
+    sha256 "12d8af6647e9a5d81f68f610ad0ed17075bf14718f4d484788baac37a0d3f842"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--with-intl=system-icu"
     system "make", "install"


### PR DESCRIPTION
same fix as needed for latest node,
in https://github.com/Homebrew/homebrew-core/pull/40978

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  * I do not know how to make "brew audit" use an appropriate ruby, it uses the system ruby and can't find headers to build native gems