### PR TITLE
Update open-mpi.rb

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -19,6 +19,7 @@ class OpenMpi < Formula
   end
 
   depends_on "gcc"
+  depends_on "hwloc"
   depends_on "libevent"
 
   conflicts_with "mpich", :because => "both install MPI compiler wrappers"


### PR DESCRIPTION
added hwloc dependency otherwise we get a 
```
> mpicxx
dyld: Library not loaded: /usr/local/opt/hwloc/lib/libhwloc.15.dylib
  Referenced from: /usr/local/bin/mpicxx
  Reason: image not found
Abort trap: 6
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
