### PR TITLE
LLVM 8.0.1

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -4,52 +4,52 @@ class Llvm < Formula
   revision 1
 
   stable do
-    url "https://releases.llvm.org/8.0.0/llvm-8.0.0.src.tar.xz"
-    sha256 "8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c"
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz"
+    sha256 "44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7"
 
     resource "clang" do
-      url "https://releases.llvm.org/8.0.0/cfe-8.0.0.src.tar.xz"
-      sha256 "084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/cfe-8.0.1.src.tar.xz"
+      sha256 "70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646"
     end
 
     resource "clang-extra-tools" do
-      url "https://releases.llvm.org/8.0.0/clang-tools-extra-8.0.0.src.tar.xz"
-      sha256 "4f00122be408a7482f2004bcf215720d2b88cf8dc78b824abb225da8ad359d4b"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/clang-tools-extra-8.0.1.src.tar.xz"
+      sha256 "187179b617e4f07bb605cc215da0527e64990b4a7dd5cbcc452a16b64e02c3e1"
     end
 
     resource "compiler-rt" do
-      url "https://releases.llvm.org/8.0.0/compiler-rt-8.0.0.src.tar.xz"
-      sha256 "b435c7474f459e71b2831f1a4e3f1d21203cb9c0172e94e9d9b69f50354f21b1"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/compiler-rt-8.0.1.src.tar.xz"
+      sha256 "11828fb4823387d820c6715b25f6b2405e60837d12a7469e7a8882911c721837"
     end
 
     resource "libcxx" do
-      url "https://releases.llvm.org/8.0.0/libcxx-8.0.0.src.tar.xz"
-      sha256 "c2902675e7c84324fb2c1e45489220f250ede016cc3117186785d9dc291f9de2"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/libcxx-8.0.1.src.tar.xz"
+      sha256 "7f0652c86a0307a250b5741ab6e82bb10766fb6f2b5a5602a63f30337e629b78"
     end
 
     resource "libunwind" do
-      url "https://releases.llvm.org/8.0.0/libunwind-8.0.0.src.tar.xz"
-      sha256 "ff243a669c9cef2e2537e4f697d6fb47764ea91949016f2d643cb5d8286df660"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/libunwind-8.0.1.src.tar.xz"
+      sha256 "1870161dda3172c63e632c1f60624564e1eb0f9233cfa8f040748ca5ff630f6e"
     end
 
     resource "lld" do
-      url "https://releases.llvm.org/8.0.0/lld-8.0.0.src.tar.xz"
-      sha256 "9caec8ec922e32ffa130f0fb08e4c5a242d7e68ce757631e425e9eba2e1a6e37"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/lld-8.0.1.src.tar.xz"
+      sha256 "9fba1e94249bd7913e8a6c3aadcb308b76c8c3d83c5ce36c99c3f34d73873d88"
     end
 
     resource "lldb" do
-      url "https://releases.llvm.org/8.0.0/lldb-8.0.0.src.tar.xz"
-      sha256 "49918b9f09816554a20ac44c5f85a32dc0a7a00759b3259e78064d674eac0373"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/lldb-8.0.1.src.tar.xz"
+      sha256 "e8a79baa6d11dd0650ab4a1b479f699dfad82af627cbbcd49fa6f2dc14e131d7"
     end
 
     resource "openmp" do
-      url "https://releases.llvm.org/8.0.0/openmp-8.0.0.src.tar.xz"
-      sha256 "f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/openmp-8.0.1.src.tar.xz"
+      sha256 "3e85dd3cad41117b7c89a41de72f2e6aa756ea7b4ef63bb10dcddf8561a7722c"
     end
 
     resource "polly" do
-      url "https://releases.llvm.org/8.0.0/polly-8.0.0.src.tar.xz"
-      sha256 "e3f5a3d6794ef8233af302c45ceb464b74cdc369c1ac735b6b381b21e4d89df4"
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/polly-8.0.1.src.tar.xz"
+      sha256 "e8a1f7e8af238b32ce39ab5de1f3317a2e3f7d71a8b1b8bbacbd481ac76fd2d1"
     end
   end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -1,7 +1,6 @@
 class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
-  revision 1
 
   stable do
     url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz"


### PR DESCRIPTION
Bumped LLVM to 8.0.1.

Also, updated URLs to point to GitHub, as this version doesn't seem to be getting uploaded to the old location. (These new GH URLs are what the [official download page](https://releases.llvm.org/download.html#8.0.1) points at, so I think it's probably more correct anyway.)