### PR TITLE
liboping: use brew ncurses

### DIFF
--- a/Formula/liboping.rb
+++ b/Formula/liboping.rb
@@ -12,7 +12,13 @@ class Liboping < Formula
     sha256 "c4f46d01bdace450a49e2c4fc4ba4056070bf1b869ed07f1b0a1d6a4f7646bc9" => :yosemite
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "ncurses"
+
   def install
+    # See https://github.com/octo/liboping/issues/36
+    inreplace "src/oping.c", "HAVE_NCURSESW_NCURSES_H", "HAVE_NCURSESW_CURSES_H"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula update makes liboping use brew's ncurses, which allows much prettier output from `noping`.