### PR TITLE
gel: add head url

### DIFF
--- a/Formula/gel.rb
+++ b/Formula/gel.rb
@@ -3,6 +3,7 @@ class Gel < Formula
   homepage "https://gel.dev"
   url "https://github.com/gel-rb/gel/archive/v0.3.0.tar.gz"
   sha256 "fe7c4bd67a2ea857b85b754f5b4d336e26640eda7199bc99b9a1570043362551"
+  head "https://github.com/gel-rb/gel.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Add the head url for the gel formula so that the master version may be installed for use.