### PR TITLE
doxygen 1.8.16

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -1,20 +1,10 @@
 class Doxygen < Formula
   desc "Generate documentation for several programming languages"
   homepage "http://www.doxygen.org/"
+  url "http://doxygen.nl/files/doxygen-1.8.16.src.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.8.16/doxygen-1.8.16.src.tar.gz"
+  sha256 "ff981fb6f5db4af9deb1dd0c0d9325e0f9ba807d17bd5750636595cf16da3c82"
   head "https://github.com/doxygen/doxygen.git"
-
-  stable do
-    url "http://doxygen.nl/files/doxygen-1.8.15.src.tar.gz"
-    mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.8.15/doxygen-1.8.15.src.tar.gz"
-    sha256 "bd9c0ec462b6a9b5b41ede97bede5458e0d7bb40d4cfa27f6f622eb33c59245d"
-
-    # Fix build breakage for 1.8.15 and CMake 3.13
-    # https://github.com/Homebrew/homebrew-core/issues/35815
-    patch do
-      url "https://github.com/doxygen/doxygen/commit/889eab308b564c4deba4ef58a3f134a309e3e9d1.diff?full_index=1"
-      sha256 "ba4f9251e2057aa4da3ae025f8c5f97ea11bf26065a3f0e3b313b9acdad0b938"
-    end
-  end
 
   bottle do
     cellar :any_skip_relocation
@@ -24,7 +14,7 @@ class Doxygen < Formula
     sha256 "305156f3d060deeee197759c5ce6ea8a1da36ad52f8104b42cd7ccbb2b20c0e7" => :sierra
   end
 
-  depends_on "bison" => :build if build.head?
+  depends_on "bison" => :build
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The patch was merged into upstream and is now present so the patch is no longer needed. The version of `bison` that macOS ships is also now too old.