### PR TITLE
libmodbus 3.1.6

### DIFF
--- a/Formula/libmodbus.rb
+++ b/Formula/libmodbus.rb
@@ -1,9 +1,8 @@
 class Libmodbus < Formula
   desc "Portable modbus library"
   homepage "https://libmodbus.org/"
-  url "https://libmodbus.org/releases/libmodbus-3.1.4.tar.gz"
-  mirror "https://librecmc.org/librecmc/downloads/sources/v1.3.4/libmodbus-3.1.4.tar.gz"
-  sha256 "c8c862b0e9a7ba699a49bc98f62bdffdfafd53a5716c0e162696b4bf108d3637"
+  url "https://libmodbus.org/releases/libmodbus-3.1.6.tar.gz"
+  sha256 "d7d9fa94a16edb094e5fdf5d87ae17a0dc3f3e3d687fead81835d9572cf87c16"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
So, I'm really confused about this package. The last version we have on file is 3.1.4. Since then, the package versioning has diverged into 3.0.8 ("old stable") and 3.1.6 ("development but really stable and pretty much about to become the new stable"):

> Two branches of libmodbus are currently maintained: development release v3.1.6, released on 2019-07-31. [...] This development version is very stable and will be marked as stable very soon; and old release v3.0.8. Almost no changes since 2013-10-06, should NOT be used on new project.

I know we usually ship stable, but it seems like the better option here is to go to 3.1.6, considering the confusion (and we can avoid having to use `version_scheme`).

The reason I'm bumping in the first place is because 3.1.5 and above mitigate [CVE-2019-14462](https://www.cvedetails.com/cve/CVE-2019-14462/), and the change is also backported to 3.0.8. So if we don't want to bump into a development version or backtrack to an older version, another alternative is just to apply the patches on the existing 3.1.4 and not change the version until 3.1.6 is marked stable.
