### PR TITLE
mkvtoolnix 36.0.0

### DIFF
--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -1,8 +1,8 @@
 class Mkvtoolnix < Formula
   desc "Matroska media files manipulation tools"
   homepage "https://mkvtoolnix.download/"
-  url "https://mkvtoolnix.download/sources/mkvtoolnix-35.0.0.tar.xz"
-  sha256 "5144e77ce0bd4653733bd07eed143870fb5cdcda31c5e943a3f22a069da4e6fd"
+  url "https://mkvtoolnix.download/sources/mkvtoolnix-36.0.0.tar.xz"
+  sha256 "2697321755a277fd499000b7888e6beced1a1d67230110f1d631b4b83922a704"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
# Version 36.0.0 "Is That Jazz?" 2019-08-10

## New features and enhancements

* mkvmerge: mkvmerge now allows appending AV1, VP8, VP9, H.264/AVC and
  H.265/HEVC tracks whose pixel dimensions differ. Implements #2582.

## Bug fixes

* source code: fixed building with Boost 1.71.0. Fixes #2599.
* all: fixed the spelling of the H.264 & H.265 codec names.
* mkvmerge: Blu-ray MPLS handling: mkvmerge will now find corresponding M2TS
  files even if the `clip_codec_identifier` playlist item field is not set to
  `M2TS` in the MPLS file. Fixes #2601.
* mkvmerge: fixed handling of text files that use both DOS-style and
  Unix-style line endings resulting in problems such as text subtitle files
  not being parsed correctly. Fixes #2594.
```