### PR TITLE
transmission-cli: rename from transmission

### DIFF
--- a/Formula/transmission-cli.rb
+++ b/Formula/transmission-cli.rb
@@ -1,4 +1,4 @@
-class Transmission < Formula
+class TransmissionCli < Formula
   desc "Lightweight BitTorrent client"
   homepage "https://www.transmissionbt.com/"
   url "https://github.com/transmission/transmission-releases/raw/dc77bea/transmission-2.94.tar.xz"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -189,6 +189,7 @@
   "todolist": "ultralist",
   "tomcat7": "tomcat@7",
   "transfig": "fig2dev",
+  "transmission": "transmission-cli",
   "unison240": "unison@2.40",
   "v8-315": "v8@3.15",
   "varnish4": "varnish@4",


### PR DESCRIPTION
This makes the binaries shipping with this formula to be linked, even when the Cask `transmission` is also installed. The latter doesn't provide any command-line tool, so there is no conflict.

IOW, it fixes this:
```
==> Pouring transmission-2.94_1.mojave.bottle.tar.gz
==> transmission cask is installed, skipping link.
```

Ref: https://github.com/Homebrew/homebrew-cask/tree/1411942200c63ef2a4eb04ad6d1ef2db80fc46ca/Casks/transmission.rb