### PR TITLE
mosh: patch to fix mojave build

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -3,7 +3,7 @@ class Mosh < Formula
   homepage "https://mosh.org"
   url "https://mosh.org/mosh-1.3.2.tar.gz"
   sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any
@@ -22,6 +22,12 @@ class Mosh < Formula
   depends_on "pkg-config" => :build
   depends_on "tmux" => :build
   depends_on "protobuf"
+
+  # Fix mojave build.
+  patch do
+    url "https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0.patch?full_index=1"
+    sha256 "022bf82de1179b2ceb7dc6ae7b922961dfacd52fbccc30472c527cb7c87c96f0"
+  end
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The mosh formula is failing to build on mojave in https://github.com/Homebrew/homebrew-core/pull/40438 for protobuf 3.9.1 with compilation errors like the following:

~~~
network.cc:338:57: error: invalid operands to binary expression ('__bind<int, sockaddr *, unsigned int &>' and 'int')
    if ( bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
~~~

https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/46354/version=mojave/testReport/junit/brew-test-bot/mojave/install___build_bottle_mosh/

I was able to reproduce the mosh build failure on `master` and found an upstream commit that fixes it: https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0