### PR TITLE
Added lua support to lighttpd.

### DIFF
--- a/Formula/lighttpd.rb
+++ b/Formula/lighttpd.rb
@@ -13,6 +13,7 @@ class Lighttpd < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "lua" => :build
   depends_on "pkg-config" => :build
   depends_on "openldap"
   depends_on "openssl"
@@ -47,6 +48,7 @@ class Lighttpd < Formula
       --with-ldap
       --with-zlib
       --with-bzip2
+      --with-lua
     ]
 
     # autogen must be run, otherwise prebuilt configure may complain


### PR DESCRIPTION
I need module mod_magnet for support Apache-like .htaccess file in Lighttpd. Unfornutelly, this module needs Lua which wasn't as dependency for lighttpd and there wasn't configure parameter --with-lua. This PR change this behaviour and compile support for Lua modules in lighttpd.   


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

