### PR TITLE
pidgin: Fix build on High Sierra

### DIFF
--- a/Formula/pidgin.rb
+++ b/Formula/pidgin.rb
@@ -49,6 +49,8 @@ class Pidgin < Formula
       --without-x
     ]
 
+    ENV["ac_cv_func_perl_run"] = "yes" if MacOS.version == :high_sierra
+
     system "./configure", *args
     system "make", "install"
 


### PR DESCRIPTION
On macOS High Sierra `./configure` does not detect the `perl_run()` function and therefore errors out. This skips the problematic test.

Compilation still works. Perl plugin support has been verified to work with the Perl Test Plugin from https://docs.pidgin.im/pidgin/2.x.y/perl-howto.html

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
