### PR TITLE
gcc 9.2.0

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -1,8 +1,8 @@
 class Gcc < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
   sha256 "79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0"
   head "https://gcc.gnu.org/git/gcc.git"
 


### PR DESCRIPTION
GCC 9.2 released: https://gcc.gnu.org/ml/gcc/2019-08/msg00092.html