### PR TITLE
Update coturn.rb for adding a dependency: hiredis.

### DIFF
--- a/Formula/coturn.rb
+++ b/Formula/coturn.rb
@@ -3,7 +3,7 @@ class Coturn < Formula
   homepage "https://github.com/coturn/coturn"
   url "http://turnserver.open-sys.org/downloads/v4.5.1.1/turnserver-4.5.1.1.tar.gz"
   sha256 "e020ce90ea0301213451d37099185ff25d93f97fa0f2b48bf21b2946fc3696a4"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "40ae9111624e581b825f1fb3a7701512f1b8bf86d26ca17c59e5e9d673cd3270" => :mojave
@@ -11,6 +11,7 @@ class Coturn < Formula
     sha256 "2b2ef532930f01cf3b5a2deb3d22e0f706e19febfb60dd8e5ef270f6a2000d12" => :sierra
   end
 
+  depends_on "hiredis"
   depends_on "libevent"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without hiredis, test command will be failed `turnadmin -l`.

```bash
$ turnadmin -l
dyld: Library not loaded: /usr/local/opt/hiredis/lib/libhiredis.0.14.dylib
  Referenced from: /usr/local/bin/turnadmin
  Reason: image not found
Abort trap: 6
```