### PR TITLE
Enable lame in gst-plugins-good

### DIFF
--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -30,6 +30,7 @@ class GstPluginsGood < Formula
   depends_on "gst-plugins-base"
   depends_on "gtk+3"
   depends_on "jpeg"
+  depends_on "lame"
   depends_on "libpng"
   depends_on "libshout"
   depends_on "libsoup"
@@ -43,7 +44,6 @@ class GstPluginsGood < Formula
       --prefix=#{prefix}
       --disable-gtk-doc
       --disable-goom
-      --disable-lame
       --with-default-videosink=ximagesink
       --disable-debug
       --disable-dependency-tracking

--- a/Formula/gst-plugins-ugly.rb
+++ b/Formula/gst-plugins-ugly.rb
@@ -24,7 +24,6 @@ class GstPluginsUgly < Formula
   depends_on "gettext"
   depends_on "gst-plugins-base"
   depends_on "jpeg"
-  depends_on "lame"
   depends_on "libmms"
   depends_on "libshout"
   depends_on "libvorbis"


### PR DESCRIPTION
lame was disabled in commit 8a3f431c3cde698a502e106bcd23bc90baa7d42f - Not sure why.
It's also incorrectly listed as a dependency in ugly while it should be in good.