### PR TITLE
ipopt: bump revision for gcc and improve test

### DIFF
--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -3,6 +3,7 @@ class Ipopt < Formula
   homepage "https://projects.coin-or.org/Ipopt/"
   url "https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.13.tgz"
   sha256 "aac9bb4d8a257fdfacc54ff3f1cbfdf6e2d61fb0cf395749e3b0c0664d3e7e96"
+  revision 1
   head "https://github.com/coin-or/Ipopt.git"
 
   bottle do
@@ -12,6 +13,7 @@ class Ipopt < Formula
     sha256 "d12d4f3546ab13a397c0c2e9c7420a73449463d2145c79c76d389eff2e1d1459" => :sierra
   end
 
+  depends_on "pkg-config" => [:build, :test]
   depends_on "gcc"
   depends_on "openblas"
 
@@ -72,8 +74,8 @@ class Ipopt < Formula
         return 0;
       }
     EOS
-
-    system ENV.cxx, "test.cpp", "-I#{include}/coin", "-L#{lib}", "-lipopt"
+    pkg_config_flags = `pkg-config --cflags --libs ipopt`.chomp.split
+    system ENV.cxx, "test.cpp", *pkg_config_flags
     system "./a.out"
   end
 end


### PR DESCRIPTION
`ipopt.pc` contains links to directories relative to the path `{prefix}/lib/gcc/{x}/gcc/x86_64-apple-darwin18/{x}.{y}.{z}` so breaks when a new version of gcc is released.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----