### PR TITLE
ack: fix head url

### DIFF
--- a/Formula/ack.rb
+++ b/Formula/ack.rb
@@ -5,7 +5,7 @@ class Ack < Formula
   sha256 "8e49c66019af3a5bf5bce23c005231b2980e93889aa047ee54d857a75ab4a062"
 
   head do
-    url "https://github.com/petdance/ack2.git", :branch => "dev"
+    url "https://github.com/beyondgrep/ack3.git", :branch => "dev"
 
     resource "File::Next" do
       url "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/File-Next-1.16.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


-----

Formula installs ack v3, so it seems to make sense for HEAD to point to v3 as well.