### PR TITLE
jq: disable docs

### DIFF
--- a/Formula/jq.rb
+++ b/Formula/jq.rb
@@ -27,6 +27,7 @@ class Jq < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--disable-maintainer-mode",
+                          "--disable-docs",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Installing the HEAD revision of `jq` fails on macOS 10.14.5 as it cannot find `pipenv`:

```
$ brew install --HEAD jq
...
/Library/Developer/CommandLineTools/usr/bin/make  install-recursive
( cd /private/tmp/jq-20190815-74094-1rxyaz/docs; pipenv run python build_manpage.py ) > jq.1 || { rm -f jq.1; false; }
/bin/sh: pipenv: command not found
```

Installing `pipenv` via homebrew does not help as the `jq` installation process seems to not look at `/usr/local/bin` for the binary. Even if you overcome this problem, the installation still fails as the `lxml` Python module cannot be found:

```
$ brew install --HEAD jq
...
✔ Successfully created virtual environment!
Virtualenv location: /private/tmp/jq-20190815-2613-qdvu3k/.brew_home/.local/share/virtualenvs/docs-ts6Wktau
Traceback (most recent call last):
  File "build_manpage.py", line 4, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```

Circumvent all this trouble by not creating/installing the docs.