### PR TITLE
update version of liquidprompt

### DIFF
--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -1,9 +1,9 @@
 class Liquidprompt < Formula
   desc "Adaptive prompt for bash and zsh shells"
   homepage "https://github.com/nojhan/liquidprompt"
-  url "https://github.com/nojhan/liquidprompt/archive/eda83efe4e0044f880370ed5e92aa7e3fdbef971.tar.gz"
-  sha256 "ed4715bebe2ef573a244a49780ab6809403b25645a4b16cc30cac6b71cdaf25c"
-  head "https://github.com/nojhan/liquidprompt.git", :branch => "master"
+  url "https://github.com/nojhan/liquidprompt/archive/v_1.11.tar.gz"
+  sha256 "669dde6b8274a57b3e39dc41539d157a86252e40e39bcc4c3102b5a81bd8f2f5"
+  head "https://github.com/nojhan/liquidprompt.git"
 
   bottle :unneeded
 

--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -1,8 +1,8 @@
 class Liquidprompt < Formula
   desc "Adaptive prompt for bash and zsh shells"
   homepage "https://github.com/nojhan/liquidprompt"
-  url "https://github.com/nojhan/liquidprompt/archive/eda83efe4e0044f880370ed5e92aa7e3fdbef971.zip"
-  sha256 "a8684ee8157f78e8e4d982b51fc1ade0100ddbdfe4eeb7158e0ab1c45b020a17"
+  url "https://github.com/nojhan/liquidprompt/archive/eda83efe4e0044f880370ed5e92aa7e3fdbef971.tar.gz"
+  sha256 "ed4715bebe2ef573a244a49780ab6809403b25645a4b16cc30cac6b71cdaf25c"
   head "https://github.com/nojhan/liquidprompt.git", :branch => "master"
 
   bottle :unneeded

--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -1,9 +1,9 @@
 class Liquidprompt < Formula
   desc "Adaptive prompt for bash and zsh shells"
   homepage "https://github.com/nojhan/liquidprompt"
-  url "https://github.com/nojhan/liquidprompt/archive/v_1.11.tar.gz"
-  sha256 "669dde6b8274a57b3e39dc41539d157a86252e40e39bcc4c3102b5a81bd8f2f5"
-  head "https://github.com/nojhan/liquidprompt.git", :branch => "develop"
+  url "https://github.com/nojhan/liquidprompt/archive/eda83efe4e0044f880370ed5e92aa7e3fdbef971.zip"
+  sha256 "a8684ee8157f78e8e4d982b51fc1ade0100ddbdfe4eeb7158e0ab1c45b020a17"
+  head "https://github.com/nojhan/liquidprompt.git", :branch => "master"
 
   bottle :unneeded
 


### PR DESCRIPTION
liquidprompt has moved away from named versions. The master branch always contains the latest stable version. 
Given that, I've updated the zip file path and the sha256sum of the zip file. 
PS: This is is my first change to a formula. Not sure if I've covered everything. 

Reason for this change: https://github.com/nojhan/liquidprompt/issues/581#issuecomment-522010931
> Note that liquidprompt version 1.11 is very out of date, and reported issues are only supported on the latest version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
