### PR TITLE
msgpack-tools 0.6.0

### DIFF
--- a/Formula/msgpack-tools.rb
+++ b/Formula/msgpack-tools.rb
@@ -1,0 +1,19 @@
+class MsgpackTools < Formula
+  desc "Command-line tools for converting between MessagePack and JSON"
+  homepage "https://github.com/ludocode/msgpack-tools"
+  url "https://github.com/ludocode/msgpack-tools/releases/download/v0.6/msgpack-tools-0.6.tar.gz"
+  sha256 "98c8b789dced626b5b48261b047e2124d256e5b5d4fbbabdafe533c0bd712834"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install", "PREFIX=#{prefix}/"
+  end
+
+  test do
+    json_data = '{"hello":"world"}'
+    assert_equal json_data,
+      pipe_output("#{bin}/json2msgpack | #{bin}/msgpack2json", json_data, 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

msgpack-tools contains a pair of command line programs to convert between the JSON and MessagePack file formats, as they are structurally isomorphic.

msgpack-tools needs RapidJSON, but we cannot `depends_on "rapidjson" => :build` because 1) homebrew-core has 1.1.0 but msgpack-tools needs 1.0.2, and 2) the build process for msgpack-tools downloads a private copy of RapidJSON and doesn't support using a system-wide version. This should be okay because RapidJSON is a header-only library and so doesn't add any artifacts to `brew install`, which means no conflicts even if a user has previously done `brew install rapidjson`. If a user has done a `brew install rapidjson`, msgpack-tools finds and uses its own private 1.0.2 version instead of using the Homebrew version, so it still builds successfully.

So I think the build process for the formula should be okay.