### PR TITLE
packer 1.4.3

### DIFF
--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -2,8 +2,8 @@ class Packer < Formula
   desc "Tool for creating identical machine images for multiple platforms"
   homepage "https://packer.io"
   url "https://github.com/hashicorp/packer.git",
-      :tag      => "v1.4.2",
-      :revision => "deb133452d38a0e3e71851e05a2af23cc2cc062e"
+      :tag      => "v1.4.3",
+      :revision => "613d8ef6ab6f8182039e2d430497f5f6457d6a42"
   head "https://github.com/hashicorp/packer.git"
 
   bottle do
@@ -15,7 +15,6 @@ class Packer < Formula
 
   depends_on "coreutils" => :build
   depends_on "go" => :build
-  depends_on "govendor" => :build
   depends_on "gox" => :build
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update [Hashicorp Packer](https://www.packer.io/) to v1.4.3.

The build-time dependency on `govendor` is removed, since this package is using Go modules.