### PR TITLE
pulseaudio: fix service launchdaemon plist

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -59,30 +59,19 @@ class Pulseaudio < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/pulseaudio</string>
+        <string>--verbose</string>
+      </array>
       <key>RunAtLoad</key>
       <true/>
       <key>KeepAlive</key>
-      <dict>
-        <key>OtherJobActive</key>
-        <dict>
-          <key>com.apple.audio.coreaudiod</key>
-          <true/>
-        </dict>
-        <key>OtherJobEnabled</key>
-        <dict>
-          <key>com.apple.audio.coreaudiod</key>
-          <true/>
-        </dict>
-      </dict>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{bin}/pulseaudio</string>
-        <string>--verbose</string>
-      </array>
+      <true/>
       <key>StandardErrorPath</key>
-      <string>/Users/#{ENV["LOGNAME"]}/Library/Logs/#{name}.log</string>
+      <string>#{var}/log/#{name}.log</string>
       <key>StandardOutPath</key>
-      <string>/Users/#{ENV["LOGNAME"]}/Library/Logs/#{name}.log</string>
+      <string>#{var}/log/#{name}.log</string>
     </dict>
     </plist>
   EOS

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -62,6 +62,7 @@ class Pulseaudio < Formula
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/pulseaudio</string>
+        <string>--exit-idle-time=-1</string>
         <string>--verbose</string>
       </array>
       <key>RunAtLoad</key>

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -80,9 +80,9 @@ class Pulseaudio < Formula
         <string>--verbose</string>
       </array>
       <key>StandardErrorPath</key>
-      <string>#{ENV["HOME"]}/Library/Logs/pulseaudio.log</string>
+      <string>#{home}/Library/Logs/pulseaudio.log</string>
       <key>StandardOutPath</key>
-      <string>#{ENV["HOME"]}/Library/Logs/pulseaudio.log</string>
+      <string>#{home}/Library/Logs/pulseaudio.log</string>
     </dict>
     </plist>
   EOS

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -80,9 +80,9 @@ class Pulseaudio < Formula
         <string>--verbose</string>
       </array>
       <key>StandardErrorPath</key>
-      <string>#{ENV["HOME"]}/Library/Logs/#{name}.log</string>
+      <string>/Users/#{ENV["LOGNAME"]}/Library/Logs/#{name}.log</string>
       <key>StandardOutPath</key>
-      <string>#{ENV["HOME"]}/Library/Logs/#{name}.log</string>
+      <string>/Users/#{ENV["LOGNAME"]}/Library/Logs/#{name}.log</string>
     </dict>
     </plist>
   EOS

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -59,13 +59,30 @@ class Pulseaudio < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/pulseaudio</string>
-        <string>--start</string>
-      </array>
       <key>RunAtLoad</key>
       <true/>
+      <key>KeepAlive</key>
+      <dict>
+        <key>OtherJobActive</key>
+        <dict>
+          <key>com.apple.audio.coreaudiod</key>
+          <true/>
+        </dict>
+        <key>OtherJobEnabled</key>
+        <dict>
+          <key>com.apple.audio.coreaudiod</key>
+          <true/>
+        </dict>
+      </dict>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{bin}/pulseaudio</string>
+        <string>--verbose</string>
+      </array>
+      <key>StandardErrorPath</key>
+      <string>#{ENV["HOME"]}/Library/Logs/pulseaudio.log</string>
+      <key>StandardOutPath</key>
+      <string>#{ENV["HOME"]}/Library/Logs/pulseaudio.log</string>
     </dict>
     </plist>
   EOS

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -80,9 +80,9 @@ class Pulseaudio < Formula
         <string>--verbose</string>
       </array>
       <key>StandardErrorPath</key>
-      <string>#{home}/Library/Logs/#{name}.log</string>
+      <string>#{ENV["HOME"]}/Library/Logs/#{name}.log</string>
       <key>StandardOutPath</key>
-      <string>#{home}/Library/Logs/#{name}.log</string>
+      <string>#{ENV["HOME"]}/Library/Logs/#{name}.log</string>
     </dict>
     </plist>
   EOS

--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -80,9 +80,9 @@ class Pulseaudio < Formula
         <string>--verbose</string>
       </array>
       <key>StandardErrorPath</key>
-      <string>#{home}/Library/Logs/pulseaudio.log</string>
+      <string>#{home}/Library/Logs/#{name}.log</string>
       <key>StandardOutPath</key>
-      <string>#{home}/Library/Logs/pulseaudio.log</string>
+      <string>#{home}/Library/Logs/#{name}.log</string>
     </dict>
     </plist>
   EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The previous launchd service plist had noot been updated in a long time, and thus was not functional. The changes:
 - Set `<ProgramArguments>` to `pulseaudio --verbose`
 - Set `<KeepAlive>` to `true`
 - Set `<StandardOutPath>` to `#{var}/log/#{name}.log`
 - Set `<StandardErrorPath>` to `#{var}/log/#{name}.log`