### PR TITLE
tomcat 9.0.24

### DIFF
--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -1,8 +1,8 @@
 class Tomcat < Formula
   desc "Implementation of Java Servlet and JavaServer Pages"
   homepage "https://tomcat.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-9/v9.0.22/bin/apache-tomcat-9.0.22.tar.gz"
-  sha256 "86b30768f7674409dfe1091e0917637bfa3b1b699851112bef99b65673039168"
+  url "https://www.apache.org/dyn/closer.cgi?path=/tomcat/tomcat-9/v9.0.24/bin/apache-tomcat-9.0.24.tar.gz"
+  sha256 "22064138e25f7ab899802804775259a156c06770535b8ce93856beba13dfcf6d"
 
   bottle :unneeded
 


### PR DESCRIPTION
Updated tomcat version to 9.0.24.
I've checked the sha256 sum and updated the tomcat version, however it seems starting the version 9.0.22, none of the sha256 sum from the next versions are in the apache checker.
https://checker.apache.org/paths/tomcat/tomcat-9/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
