### PR TITLE
crystfel 0.8.0 (new formula)

### DIFF
--- a/Formula/crystfel.rb
+++ b/Formula/crystfel.rb
@@ -1,0 +1,109 @@
+class Crystfel < Formula
+  desc "Suite for processing Serial Femtosecond Crystallography (SFX) data"
+  homepage "https://www.desy.de/~twhite/crystfel/index.html"
+
+  stable do
+    url "https://www.desy.de/~twhite/crystfel/crystfel-0.8.0.tar.gz"
+    sha256 "6139b818079a16aa4da90344d4f413810e741c321013a1d6980c01f5d79c7b3a"
+
+    # 1. Patch to increase tolerance in gpu_sim_check v. 0.8.0 from 1.0% to 1.2%
+    # 2. Patch to Use LIBRARIES instead of LDFLAGS
+    patch :DATA
+  end
+
+  head do
+    url "https://stash.desy.de/scm/crys/crystfel.git"
+  end
+
+  depends_on "bison" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "fftw"
+  depends_on "gdk-pixbuf"
+  depends_on "gsl"
+  depends_on "gtk+3"
+  depends_on "hdf5"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "pango"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "test"
+      system "make", "install"
+    end
+  end
+
+  test do
+    # All functionality tests are done in the above section with make test
+    system bin/"ambigator", "--help"
+    system bin/"cell_explorer", "--help"
+    system bin/"check_hkl", "--help"
+    system bin/"compare_hkl", "--help"
+    system bin/"geoptimiser", "--help"
+    system bin/"get_hkl", "--help"
+    system bin/"hdfsee", "--help"
+    system bin/"indexamajig", "--help"
+    system bin/"list_events", "--help"
+    system bin/"make_pixelmap", "--help"
+    system bin/"partial_sim", "--help"
+    system bin/"partialator", "--help"
+    system bin/"pattern_sim", "--help"
+    system bin/"process_hkl", "--help"
+    system bin/"render_hkl", "--help"
+    system bin/"whirligig", "--help"
+  end
+end
+
+__END__
+diff --git a/tests/gpu_sim_check.c b/tests/gpu_sim_check.c
+index aee7a068..d9e6cb5d 100644
+--- a/tests/gpu_sim_check.c
++++ b/tests/gpu_sim_check.c
+@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
+ 	STATUS("CPU: min=%8e, max=%8e, total=%8e\n", cpu_min, cpu_max, cpu_tot);
+ 	STATUS("dev = %8e (%5.2f%% of CPU total)\n", dev, perc);
+ 
+-	if ( perc > 1.0 ) {
++	if ( perc > 1.2 ) {
+ 
+ 		STATUS("Test failed!  I'm writing cpu-sim.h5 and gpu-sim.h5"
+ 		       " for you to inspect.\n");
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 43a61e4..87513ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -245,7 +245,7 @@ if (CAIRO_FOUND)
+   add_executable(render_hkl ${RENDER_HKL_SOURCES})
+ 
+   target_include_directories(render_hkl PRIVATE ${COMMON_INCLUDES} ${CAIRO_INCLUDE_DIRS})
+-  target_link_libraries(render_hkl ${COMMON_LIBRARIES} ${CAIRO_LDFLAGS})
++  target_link_libraries(render_hkl ${COMMON_LIBRARIES} ${CAIRO_LIBRARIES})
+ 
+   list(APPEND CRYSTFEL_EXECUTABLES render_hkl)
+ 
+@@ -349,17 +349,17 @@ list(APPEND CRYSTFEL_EXECUTABLES geoptimiser)
+ # If Cairo, gdk-pixbuf and GDK are all found, geoptimiser will add PNG support
+ if (CAIRO_FOUND)
+   target_include_directories(geoptimiser PRIVATE ${CAIRO_INCLUDE_DIRS})
+-  target_link_libraries(geoptimiser ${CAIRO_LDFLAGS})
++  target_link_libraries(geoptimiser ${CAIRO_LIBRARIES})
+ endif (CAIRO_FOUND)
+ 
+ if (GDKPIXBUF_FOUND)
+   target_include_directories(geoptimiser PRIVATE ${GDKPIXBUF_INCLUDE_DIRS})
+-  target_link_libraries(geoptimiser ${GDKPIXBUF_LDFLAGS})
++  target_link_libraries(geoptimiser ${GDKPIXBUF_LIBRARIES})
+ endif (GDKPIXBUF_FOUND)
+ 
+ if (GDK_FOUND)
+   target_include_directories(geoptimiser PRIVATE ${GDK_INCLUDE_DIRS})
+-  target_link_libraries(geoptimiser ${GDK_LDFLAGS})
++  target_link_libraries(geoptimiser ${GDK_LIBRARIES})
+ endif (GDK_FOUND)
+ 
+ if (TIFF_FOUND)


### PR DESCRIPTION
Suite for processing Serial Femtosecond Crystallography (SFX) data

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The formula builds and tests well on macOS 10.14.6, both stable version 0.8.0 (default) and current git version with --HEAD. The bison package is outdated on macOS and therefore has been included as the :build dependency. Both patches are fixed in the git version.
