### PR TITLE
Support new build system for OCaml 4.08.1

### DIFF
--- a/Formula/camlp4.rb
+++ b/Formula/camlp4.rb
@@ -1,10 +1,9 @@
 class Camlp4 < Formula
   desc "Tool to write extensible parsers in OCaml"
   homepage "https://github.com/ocaml/camlp4"
-  url "https://github.com/ocaml/camlp4/archive/4.07+1.tar.gz"
-  version "4.07+1"
-  sha256 "ecdb8963063f41b387412317685f79823a26b3f53744f0472058991876877090"
-  revision 1
+  url "https://github.com/ocaml/camlp4/archive/4.08+1.tar.gz"
+  version "4.08+1"
+  sha256 "655cd3bdcafbf8435877f60f4b47dd2eb69feef5afd8881291ef01ba12bd9d88"
   head "https://github.com/ocaml/camlp4.git", :branch => "trunk"
 
   bottle do

--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -4,6 +4,7 @@ class Camlp5 < Formula
   url "https://github.com/camlp5/camlp5/archive/rel708.tar.gz"
   version "7.08"
   sha256 "46e67d8e36e5e4558c414f0b569532a33d3a12d7120ffdc474a6b3da1bfff163"
+  revision 1
   head "https://gforge.inria.fr/anonscm/git/camlp5/camlp5.git"
 
   bottle do

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -1,9 +1,8 @@
 class Lablgtk < Formula
   desc "Objective Caml interface to gtk+"
   homepage "http://lablgtk.forge.ocamlcore.org"
-  url "https://forge.ocamlcore.org/frs/download.php/1726/lablgtk-2.18.6.tar.gz"
-  sha256 "4ddca243066418e2a88ac49ebf2d846fac4b667b1b1753efadd078ae777368f8"
-  revision 4
+  url "https://github.com/garrigue/lablgtk/releases/download/lablgtk2188/lablgtk-2.18.8.tar.gz"
+  sha256 "91f59bafd07989ea00080f4fd65512ce339878c7117bf5116bad3b93b64d4de3"
 
   bottle do
     cellar :any

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -3,6 +3,7 @@ class OcamlFindlib < Formula
   homepage "http://projects.camlcity.org/projects/findlib.html"
   url "http://download.camlcity.org/download/findlib-1.8.1.tar.gz"
   sha256 "8e85cfa57e8745715432df3116697c8f41cb24b5ec16d1d5acd25e0196d34303"
+  revision 1
 
   bottle do
     sha256 "b59570c74713f43320a8990e0dcc0943952b21d5aa838efc9adcfe13c3ec505c" => :mojave
@@ -22,6 +23,9 @@ class OcamlFindlib < Formula
     system "make", "opt"
     inreplace "findlib.conf", prefix, HOMEBREW_PREFIX
     system "make", "install"
+
+    # Avoid conflict with ocaml-num package
+    rm_rf Dir[lib/"ocaml/num", lib/"ocaml/num-top"]
   end
 
   test do

--- a/Formula/ocaml-num.rb
+++ b/Formula/ocaml-num.rb
@@ -3,6 +3,7 @@ class OcamlNum < Formula
   homepage "https://github.com/ocaml/num"
   url "https://github.com/ocaml/num/archive/v1.2.tar.gz"
   sha256 "c5023104925ff4a79746509d4d85294d8aafa98da6733e768ae53da0355453de"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,8 +22,8 @@ class OcamlNum < Formula
     cp Formula["ocaml"].opt_lib/"ocaml/Makefile.config", lib/"ocaml"
 
     # install in #{lib}/ocaml not #{HOMEBREW_PREFIX}/lib/ocaml
-    inreplace lib/"ocaml/Makefile.config", /^PREFIX=#{HOMEBREW_PREFIX}$/,
-                                           "PREFIX=#{prefix}"
+    inreplace lib/"ocaml/Makefile.config", /^prefix=#{HOMEBREW_PREFIX}$/,
+                                           "prefix=#{prefix}"
 
     system "make"
     (lib/"ocaml/stublibs").mkpath # `make install` assumes this directory exists

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -14,8 +14,8 @@
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
-  url "https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.xz"
-  sha256 "dfe48b1da31da9c82d77612582fae74c80e8d1ac650e1c24f5ac9059e48307b8"
+  url "https://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.1.tar.xz"
+  sha256 "cd4f180453ffd7cc6028bb18954b3d7c3f715af13157df2f7c68bdfa07655ea3"
   head "https://github.com/ocaml/ocaml.git", :branch => "trunk"
 
   bottle do
@@ -36,17 +36,15 @@ class Ocaml < Formula
     ENV.deparallelize # Builds are not parallel-safe, esp. with many cores
 
     # the ./configure in this package is NOT a GNU autoconf script!
-    args = [
-      "-prefix",
-      HOMEBREW_PREFIX.to_s,
-      "-with-debug-runtime",
-      "-mandir",
-      man.to_s,
-      "-no-graph",
+    args = %W[
+      --prefix=#{HOMEBREW_PREFIX}
+      --enable-debug-runtime
+      --mandir=#{man}
+      --disable-graph-lib
     ]
     system "./configure", *args
     system "make", "world.opt"
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "prefix=#{prefix}", "install"
   end
 
   test do

--- a/Formula/ocamlbuild.rb
+++ b/Formula/ocamlbuild.rb
@@ -3,6 +3,7 @@ class Ocamlbuild < Formula
   homepage "https://github.com/ocaml/ocamlbuild"
   url "https://github.com/ocaml/ocamlbuild/archive/0.14.0.tar.gz"
   sha256 "87b29ce96958096c0a1a8eeafeb6268077b2d11e1bf2b3de0f5ebc9cf8d42e78"
+  revision 1
   head "https://github.com/ocaml/ocamlbuild.git"
 
   bottle do

--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -3,7 +3,7 @@ class Ocamlsdl < Formula
   homepage "https://ocamlsdl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha256 "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f"
-  revision 11
+  revision 12
 
   bottle do
     cellar :any


### PR DESCRIPTION
OCaml 4.08.1 now uses autoconf to prepare a configure script; previous versions did not. Changes to the configure and installation args were necessary to build 4.08.1.