### PR TITLE
use separate CATALINA_BASE for tomcat, fix #43311

### DIFF
--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -17,42 +17,42 @@ class Tomcat < Formula
     libexec.install Dir["*"]
 
     (bin/"catalina").write <<~'EOS'
-    #!/bin/sh
+      #!/bin/sh
 
-    export CATALINA_HOME="$(brew --prefix tomcat)/libexec"
-    export CATALINA_BASE="$(brew --prefix)/var/tomcat"
+      export CATALINA_HOME="$(brew --prefix tomcat)/libexec"
+      export CATALINA_BASE="${CATALINA_BASE:-$(brew --prefix)/var/tomcat}"
 
-    catalina_init() {
-      if [ ! -e "$CATALINA_BASE/conf" ]; then
-        mkdir -p "$CATALINA_BASE"
-        cp -r "$CATALINA_HOME/conf" "$CATALINA_BASE/"
-      fi
-
-      if [ ! -e "$CATALINA_BASE/conf/Catalina/localhost/" ]; then
-        mkdir -p "$CATALINA_BASE/conf/Catalina/localhost/"
-      fi
-
-      for app in "$CATALINA_HOME/webapps"/*/; do
-        app_name=$(basename "$app")
-        context_file="$CATALINA_BASE/conf/Catalina/localhost/${app_name/ROOT/tomcat}.xml"
-
-        if [ ! -e "$context_file" ]; then
-          if [ -e "$app/META-INF/context.xml" ]; then
-            cp "$app/META-INF/context.xml" "$context_file"
-            sed -i "s,<Context,<Context docBase=\"\${catalina.home}/webapps/${app_name}\"," "$context_file"
-          else
-            printf '<?xml version="1.0" encoding="UTF-8"?>\n<Context docBase="${catalina.home}/webapps/%s" />\n' \
-              "${app_name}" > "$context_file"
-          fi
+      catalina_init() {
+        if [ ! -e "$CATALINA_BASE/conf" ]; then
+          mkdir -p "$CATALINA_BASE"
+          cp -r "$CATALINA_HOME/conf" "$CATALINA_BASE/"
         fi
-      done
-    }
 
-    if [ ! -e "$CATALINA_BASE" ]; then
-      catalina_init
-    fi
+        if [ ! -e "$CATALINA_BASE/conf/Catalina/localhost/" ]; then
+          mkdir -p "$CATALINA_BASE/conf/Catalina/localhost/"
+        fi
 
-    "$CATALINA_HOME/bin/catalina.sh" "$@"
+        for app in "$CATALINA_HOME/webapps"/*/; do
+          app_name=$(basename "$app")
+          context_file="$CATALINA_BASE/conf/Catalina/localhost/${app_name/ROOT/tomcat}.xml"
+
+          if [ ! -e "$context_file" ]; then
+            if [ -e "$app/META-INF/context.xml" ]; then
+              cp "$app/META-INF/context.xml" "$context_file"
+              sed -i "s,<Context,<Context docBase=\"\${catalina.home}/webapps/${app_name}\"," "$context_file"
+            else
+              printf '<?xml version="1.0" encoding="UTF-8"?>\n<Context docBase="${catalina.home}/webapps/%s" />\n' \
+                "${app_name}" > "$context_file"
+            fi
+          fi
+        done
+      }
+
+      if [ ! -e "$CATALINA_BASE" ]; then
+        catalina_init
+      fi
+
+      "$CATALINA_HOME/bin/catalina.sh" "$@"
     EOS
   end
 

--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -15,7 +15,45 @@ class Tomcat < Formula
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
     libexec.install Dir["*"]
-    bin.install_symlink "#{libexec}/bin/catalina.sh" => "catalina"
+
+    (bin/"catalina").write <<~'EOS'
+    #!/bin/sh
+
+    export CATALINA_HOME="$(brew --prefix tomcat)/libexec"
+    export CATALINA_BASE="$(brew --prefix)/var/tomcat"
+
+    catalina_init() {
+      if [ ! -e "$CATALINA_BASE/conf" ]; then
+        mkdir -p "$CATALINA_BASE"
+        cp -r "$CATALINA_HOME/conf" "$CATALINA_BASE/"
+      fi
+
+      if [ ! -e "$CATALINA_BASE/conf/Catalina/localhost/" ]; then
+        mkdir -p "$CATALINA_BASE/conf/Catalina/localhost/"
+      fi
+
+      for app in "$CATALINA_HOME/webapps"/*/; do
+        app_name=$(basename "$app")
+        context_file="$CATALINA_BASE/conf/Catalina/localhost/${app_name/ROOT/tomcat}.xml"
+
+        if [ ! -e "$context_file" ]; then
+          if [ -e "$app/META-INF/context.xml" ]; then
+            cp "$app/META-INF/context.xml" "$context_file"
+            sed -i "s,<Context,<Context docBase=\"\${catalina.home}/webapps/${app_name}\"," "$context_file"
+          else
+            printf '<?xml version="1.0" encoding="UTF-8"?>\n<Context docBase="${catalina.home}/webapps/%s" />\n' \
+              "${app_name}" > "$context_file"
+          fi
+        fi
+      done
+    }
+
+    if [ ! -e "$CATALINA_BASE" ]; then
+      catalina_init
+    fi
+
+    "$CATALINA_HOME/bin/catalina.sh" "$@"
+    EOS
   end
 
   plist_options :manual => "catalina run"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This tries to fix #43311, to use a separate `$CATALINA_BASE` so that the content in it are correctly reused when brew updating tomcat.