### PR TITLE
Enable SDL for Qemu.

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -22,8 +22,8 @@ class Qemu < Formula
   depends_on "lzo"
   depends_on "ncurses"
   depends_on "pixman"
-  depends_on "vde"
   depends_on "sdl2"
+  depends_on "vde"
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do

--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -23,6 +23,7 @@ class Qemu < Formula
   depends_on "ncurses"
   depends_on "pixman"
   depends_on "vde"
+  depends_on "sdl2"
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
@@ -44,7 +45,7 @@ class Qemu < Formula
       --enable-vde
       --extra-cflags=-DNCURSES_WIDECHAR=1
       --enable-cocoa
-      --disable-sdl
+      --enable-sdl
       --disable-gtk
     ]
     # Sharing Samba directories in QEMU requires the samba.org smbd which is

--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -34,6 +34,8 @@ class Qemu < Formula
   def install
     ENV["LIBTOOL"] = "glibtool"
 
+    # Upstream Qemu doesn't currently support Cocoa and SDL being built at
+    # the same time.
     args = %W[
       --prefix=#{prefix}
       --cc=#{ENV.cc}
@@ -44,7 +46,7 @@ class Qemu < Formula
       --enable-libssh
       --enable-vde
       --extra-cflags=-DNCURSES_WIDECHAR=1
-      --enable-cocoa
+      --disable-cocoa
       --enable-sdl
       --disable-gtk
     ]


### PR DESCRIPTION
The Qemu Cocoa UI backend is broken on macOS Catalina onwards. 
Enabling the SDL backend allows to use Qemu with a UI on Catalina.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
