### PR TITLE
Fix gnutls checksum #43156

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -29,8 +29,8 @@ class Gnutls < Formula
   #
   # This patch has been merged upstream and this issue should be fixed in the 3.6.10 release.
   patch do
-    url "https://gitlab.com/gnutls/gnutls/commit/ef80617d1e17e0878a909baad62a75ba265c0e00.patch"
-    sha256 "3b1634fa348c0f0064e43f3fb673e30a5e46f2b51cd6cd0d4a0cbf326e71c90e"
+    url "https://gitlab.com/gnutls/gnutls/commit/ef80617d1e17e0878a909baad62a75ba265c0e00.diff"
+    sha256 "aa8b92375e3bced3f81fe8a820d5dabaa68cac332aed097d45be01080f517460"
   end
 
   def install


### PR DESCRIPTION
Hi,

I've got a fix for #43156.

Fixes #43156.

`$ openssl dgst -sha256 ef80617d1e17e0878a909baad62a75ba265c0e00.diff
SHA256(ef80617d1e17e0878a909baad62a75ba265c0e00.diff)= aa8b92375e3bced3f81fe8a820d5dabaa68cac332aed097d45be01080f517460`

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
_There are no proper PR with a correct fix at the moment of submitting the PR_
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?