### PR TITLE
terragrunt 0.18.7 (new formula)

### DIFF
--- a/Formula/terragrunt@0.18.rb
+++ b/Formula/terragrunt@0.18.rb
@@ -1,0 +1,24 @@
+class TerragruntAT018 < Formula
+  desc "Thin wrapper for Terraform e.g. for locking state"
+  homepage "https://github.com/gruntwork-io/terragrunt"
+  url "https://github.com/gruntwork-io/terragrunt/archive/v0.18.7.tar.gz"
+  sha256 "1db9838f2f774599938eca25d7f8266da48693bcfd814292d083ad320f72c742"
+  keg_only :versioned_formula
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+  depends_on "terraform@0.11"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/gruntwork-io/terragrunt").install buildpath.children
+    cd "src/github.com/gruntwork-io/terragrunt" do
+      system "dep", "ensure", "-vendor-only"
+      system "go", "build", "-o", bin/"terragrunt", "-ldflags", "-X main.VERSION=v#{version}"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/terragrunt --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A little reasoning here is that Terragrunt v0.19 is neither backward compatible with v0.18 nor with Terraform v0.11.  There are still plenty of people using Terraform v0.11 out there, due to the complexity of upgrading from 11 to 12, so I presume I won't be the only one who will find this version useful.