### PR TITLE
fix for installing/building HEAD for haxe

### DIFF
--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -17,7 +17,7 @@ class Haxe < Formula
     url "https://github.com/HaxeFoundation/haxe.git", :branch => "development"
 
     depends_on "aspcud" => :build
-    depends_on "opam@2.0" => :build
+    depends_on "opam" => ["2.0", :build]
     depends_on "pkg-config" => :build
   end
 

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -17,7 +17,7 @@ class Haxe < Formula
     url "https://github.com/HaxeFoundation/haxe.git", :branch => "development"
 
     depends_on "aspcud" => :build
-    depends_on "opam" => ["2.0", :build]
+    depends_on "opam" => :build
     depends_on "pkg-config" => :build
   end
 

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -17,7 +17,7 @@ class Haxe < Formula
     url "https://github.com/HaxeFoundation/haxe.git", :branch => "development"
 
     depends_on "aspcud" => :build
-    depends_on "opam" => :build
+    depends_on "opam@2.0" => :build
     depends_on "pkg-config" => :build
   end
 
@@ -37,7 +37,7 @@ class Haxe < Formula
       Dir.mktmpdir("opamroot") do |opamroot|
         ENV["OPAMROOT"] = opamroot
         ENV["OPAMYES"] = "1"
-        system "opam", "init", "--no-setup"
+        system "opam", "init", "--no-setup", "--disable-sandboxing"
         system "opam", "config", "exec", "--",
                "opam", "pin", "add", "haxe", buildpath, "--no-action"
         system "opam", "config", "exec", "--",


### PR DESCRIPTION
basically requires opam >= 2.0 and calling `opam init` with `--disable-sandboxing`