### PR TITLE
pastel 0.5.3 (new formula)

### DIFF
--- a/Formula/pastel.rb
+++ b/Formula/pastel.rb
@@ -1,0 +1,24 @@
+class Pastel < Formula
+  desc "Command-line tool to generate, analyze, convert and manipulate colors"
+  homepage "https://github.com/sharkdp/pastel"
+  url "https://github.com/sharkdp/pastel/archive/v0.5.3.tar.gz"
+  sha256 "0850e37b92b8d2f5a396d5b9114a21a64dce5c6cce736039151c800f35abaa1e"
+
+  depends_on "rust" => :build
+
+  def install
+    ENV["SHELL_COMPLETIONS_DIR"] = buildpath/"completions"
+
+    system "cargo", "install", "--root", prefix, "--path", "."
+
+    bash_completion.install "completions/pastel.bash"
+    zsh_completion.install "completions/_pastel"
+    fish_completion.install "completions/pastel.fish"
+  end
+
+  test do
+    output = shell_output("#{bin}/pastel format hex rebeccapurple").strip
+
+    assert_equal "#663399", output
+  end
+end


### PR DESCRIPTION
Add the pastel command-line utility, for working with colors

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Found this tool I'm looking forward to integrating in my workflow, would be awesome to have it in brew to make that easier.

https://github.com/sharkdp/pastel