### PR TITLE
[New Formula] chntpw

### DIFF
--- a/Formula/cdrkit.rb
+++ b/Formula/cdrkit.rb
@@ -1,0 +1,17 @@
+class Cdrkit < Formula
+  desc "Collection of computer programs for CD and DVD authoring"
+  homepage "https://en.wikipedia.org/wiki/Cdrkit"
+  url "https://github.com/sidneys/cdrkit/archive/v2.0.0.tar.gz"
+  sha256 "bf07b0e011532c1f96bbab71efe75537c5ec1614fd9636ce551fcaf56b03579c"
+  head "https://github.com/sidneys/cdrkit.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  test do
+    assert_match "genisoimage 1.1.11 (Darwin)", shell_output("#{bin}/genisoimage --version")
+  end
+end

--- a/Formula/chntpw.rb
+++ b/Formula/chntpw.rb
@@ -1,0 +1,18 @@
+class Chntpw < Formula
+  desc "The Offline NT Password Editor"
+  homepage "https://github.com/Tody-Guo/chntpw"
+  url "https://github.com/sidneys/chntpw/archive/0.99.6.tar.gz"
+  sha256 "e915f5addc2673317285c6f022c94da7fdee415d9800cd38540a13706706786b"
+  head "https://github.com/sidneys/chntpw.git"
+
+  depends_on "openssl"
+
+  def install
+    system "make"
+    bin.install "chntpw"
+  end
+
+  test do
+    assert_match "chntpw version 0.99.6 080526 (sixtyfour)", shell_output("#{bin}/chntpw -h")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR makes this classic Windows security tool available to macOS users too. Previous users did not even provide a documentation of its functionaity from macOS (e.g. https://tumblr.tristesse.org/post/77878625429/chntpw-on-os-x), now it can be installed via Homebrew.