### PR TITLE
git-series: add missing openssl dependency / OPENSSL_DIR env var

### DIFF
--- a/Formula/git-series.rb
+++ b/Formula/git-series.rb
@@ -15,8 +15,13 @@ class GitSeries < Formula
   depends_on "cmake" => :build
   depends_on "rust" => :build
   depends_on "libssh2"
+  depends_on "openssl"
 
   def install
+    # Ensure that the `openssl` crate picks up the intended library.
+    # https://crates.io/crates/openssl#manual-configuration
+    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+
     system "cargo", "install", "--root", prefix, "--path", "."
     man1.install "git-series.1"
   end


### PR DESCRIPTION
Fixes build when Homebrew is not installed to /usr/local.

The snippet added to `install` is copied and pasted from some other packages.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
