### PR TITLE
Fixes #43532 - Stubby 0.2.6 fails to start

### DIFF
--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -3,7 +3,7 @@ class Getdns < Formula
   homepage "https://getdnsapi.net"
   url "https://getdnsapi.net/releases/getdns-1-5-2/getdns-1.5.2.tar.gz"
   sha256 "1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -21,7 +21,7 @@ class Getdns < Formula
   end
 
   depends_on "libevent"
-  depends_on "libidn"
+  depends_on "libidn2"
   depends_on "openssl"
   depends_on "unbound"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes  #43532