### PR TITLE
Migrate some formulas to openssl 1.1 (A)

### DIFF
--- a/Formula/activemq-cpp.rb
+++ b/Formula/activemq-cpp.rb
@@ -3,6 +3,7 @@ class ActivemqCpp < Formula
   homepage "https://activemq.apache.org/cms/index.html"
   url "https://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.9.5/activemq-cpp-library-3.9.5-src.tar.bz2"
   sha256 "6bd794818ae5b5567dbdaeb30f0508cc7d03808a4b04e0d24695b2501ba70c15"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class ActivemqCpp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "apr"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/aircrack-ng.rb
+++ b/Formula/aircrack-ng.rb
@@ -3,6 +3,7 @@ class AircrackNg < Formula
   homepage "https://aircrack-ng.org/"
   url "https://download.aircrack-ng.org/aircrack-ng-1.5.2.tar.gz"
   sha256 "9e592fe7658046220e0ac0a6d05c4026903f3077b248893e0056ccbe4ee88241"
+  revision 1
 
   bottle do
     sha256 "6aaae61586ea0f80f466e1eaa3740ff64cb5a68d457ee248c6561339778246bf" => :mojave
@@ -14,7 +15,7 @@ class AircrackNg < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
   depends_on "sqlite"
 

--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -4,6 +4,7 @@ class Alpine < Formula
   url "https://ftp.osuosl.org/pub/blfs/conglomeration/alpine/alpine-2.21.tar.xz"
   mirror "https://fossies.org/linux/misc/alpine-2.21.tar.xz"
   sha256 "6030b6881b8168546756ab3a5e43628d8d564539b0476578e287775573a77438"
+  revision 1
 
   bottle do
     rebuild 1
@@ -14,15 +15,15 @@ class Alpine < Formula
     sha256 "5b57214d7c4603dea4081f4aa8edee42c148a7daad1ed1fd881d4fb01a28d778" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.deparallelize
 
     args = %W[
       --disable-debug
-      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
-      --with-ssl-certs-dir=#{etc}/openssl
+      --with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl-certs-dir=#{etc}/openssl@1.1
       --prefix=#{prefix}
       --with-passfile=.pine-passfile
     ]

--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -4,7 +4,7 @@ class Amap < Formula
   url "https://www.thc.org/releases/amap-5.4.tar.gz"
   mirror "https://downloads.sourceforge.net/project/slackbuildsdirectlinks/amap/amap-5.4.tar.gz"
   sha256 "a75ea58de75034de6b10b0de0065ec88e32f9e9af11c7d69edbffc4da9a5b059"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -16,11 +16,11 @@ class Amap < Formula
     sha256 "18d4464b634e7aec9fefc45079dd97d0867b956ee71f189dc7f0393e77f7dba7" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Last release was 2011 & there's nowhere supported to report this.
-    openssl = Formula["openssl"]
+    openssl = Formula["openssl@1.1"]
     inreplace "configure" do |s|
       s.gsub! 'SSL_IPATH=""', "SSL_IPATH=\"#{openssl.opt_include}/openssl\""
       s.gsub! 'SSL_PATH=""', "SSL_PATH=\"#{openssl.opt_lib}\""
@@ -37,7 +37,7 @@ class Amap < Formula
   end
 
   test do
-    openssl_linked = MachO::Tools.dylibs("#{bin}/amap").any? { |d| d.include? Formula["openssl"].opt_lib.to_s }
+    openssl_linked = MachO::Tools.dylibs("#{bin}/amap").any? { |d| d.include? Formula["openssl@1.1"].opt_lib.to_s }
     assert openssl_linked
     # We can do more than this, but unsure how polite it is to port-scan
     # someone's domain every time this goes through CI.

--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -3,6 +3,7 @@ class AmqpCpp < Formula
   homepage "https://github.com/CopernicaMarketingSoftware/AMQP-CPP"
   url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.1.5.tar.gz"
   sha256 "9840c7fb17bb0c0b601d269e528b7f9cac5ec008dcf8d66bef22434423b468aa"
+  revision 1
   head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git"
 
   bottle do
@@ -13,7 +14,7 @@ class AmqpCpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.cxx11

--- a/Formula/apib.rb
+++ b/Formula/apib.rb
@@ -3,7 +3,7 @@ class Apib < Formula
   homepage "https://github.com/apigee/apib"
   url "https://github.com/apigee/apib/archive/APIB_1_0.tar.gz"
   sha256 "1592e55c01f2f9bc8085b39f09c49cd7b786b6fb6d02441ca665eef262e7b87e"
-  revision 1
+  revision 2
   head "https://github.com/apigee/apib.git"
 
   bottle do
@@ -17,7 +17,8 @@ class Apib < Formula
   end
 
   depends_on "apr"
-  depends_on "openssl"
+  depends_on "apr-util"
+  depends_on "openssl@1.1"
 
   def install
     # Upstream hardcodes finding apr in /usr/include. When CLT is not present

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -3,6 +3,7 @@ class Arangodb < Formula
   homepage "https://www.arangodb.com/"
   url "https://download.arangodb.com/Source/ArangoDB-3.5.0.tar.gz"
   sha256 "b81e30da4249f72b8daa88584cd05388c86ab12eb3185f6558a774e8db5dc9ab"
+  revision 1
   head "https://github.com/arangodb/arangodb.git", :branch => "devel"
 
   bottle do
@@ -14,7 +15,7 @@ class Arangodb < Formula
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on :macos => :yosemite
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87665
   fails_with :gcc => "7"

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -12,7 +12,7 @@ class Asdf < Formula
   depends_on "coreutils"
   depends_on "libtool"
   depends_on "libyaml"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "readline"
   depends_on "unixodbc"
 

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -3,6 +3,7 @@ class Avfs < Formula
   homepage "https://avf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avf/avfs/1.1.1/avfs-1.1.1.tar.bz2"
   sha256 "c83eef7f8676db6fed0a18373c433e0ff55af1651246303ebe1181e8ef8bbf3b"
+  revision 1
 
   bottle do
     sha256 "80e240dd2ddab63987b7da1e3a641f5736838e5c648db37e349358aa28bff1c0" => :mojave
@@ -12,7 +13,7 @@ class Avfs < Formula
 
   depends_on "pkg-config" => :build
   depends_on :macos => :sierra # needs clock_gettime
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on :osxfuse
   depends_on "xz"
 
@@ -24,7 +25,7 @@ class Avfs < Formula
       --disable-silent-rules
       --enable-fuse
       --enable-library
-      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/axel.rb
+++ b/Formula/axel.rb
@@ -3,7 +3,7 @@ class Axel < Formula
   homepage "https://github.com/eribertomota/axel"
   url "https://github.com/axel-download-accelerator/axel/archive/v2.17.3.tar.gz"
   sha256 "13cc30194a2d52cdb87b0deca6e472ac75fbb2d8af72d554ba3936f1e2a416a7"
-  revision 1
+  revision 2
   head "https://github.com/eribertomota/axel.git"
 
   bottle do
@@ -17,7 +17,7 @@ class Axel < Formula
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Fixes the macOS build by esuring some _POSIX_C_SOURCE

--- a/Formula/azure-storage-cpp.rb
+++ b/Formula/azure-storage-cpp.rb
@@ -3,7 +3,7 @@ class AzureStorageCpp < Formula
   homepage "https://azure.github.io/azure-storage-cpp"
   url "https://github.com/Azure/azure-storage-cpp/archive/v6.1.0.tar.gz"
   sha256 "a0b6107372125f756783bf6e5d57d24e2c8330a4941f4c72e8ddcf13c31618ed"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,7 +16,7 @@ class AzureStorageCpp < Formula
   depends_on "boost"
   depends_on "cpprestsdk"
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # patch submitted upstream at https://github.com/Azure/azure-storage-cpp/pull/261
   patch :DATA
@@ -45,11 +45,11 @@ class AzureStorageCpp < Formula
     EOS
     flags = ["-stdlib=libc++", "-std=c++11", "-I#{include}",
              "-I#{Formula["boost"].include}",
-             "-I#{Formula["openssl"].include}",
+             "-I#{Formula["openssl@1.1"].include}",
              "-I#{Formula["cpprestsdk"].include}",
              "-L#{Formula["boost"].lib}",
              "-L#{Formula["cpprestsdk"].lib}",
-             "-L#{Formula["openssl"].lib}",
+             "-L#{Formula["openssl@1.1"].lib}",
              "-L#{lib}",
              "-lcpprest", "-lboost_system-mt", "-lssl", "-lcrypto", "-lazurestorage"] + ENV.cflags.to_s.split
     system ENV.cxx, "-o", "test_azurestoragecpp", "test.cpp", *flags

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -5,6 +5,7 @@ class Cpprestsdk < Formula
   url "https://github.com/Microsoft/cpprestsdk.git",
       :tag      => "v2.10.14",
       :revision => "6f602bee67b088a299d7901534af3bce6334ab38"
+  revision 1
   head "https://github.com/Microsoft/cpprestsdk.git", :branch => "development"
 
   bottle do
@@ -16,7 +17,7 @@ class Cpprestsdk < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # Fix for boost 1.70.0 https://github.com/microsoft/cpprestsdk/issues/1054
   # From websocketpp pull request https://github.com/zaphoyd/websocketpp/pull/814
@@ -38,8 +39,8 @@ class Cpprestsdk < Formula
     EOS
     flags = ["-stdlib=libc++", "-std=c++11", "-I#{include}",
              "-I#{Formula["boost"].include}",
-             "-I#{Formula["openssl"].include}", "-L#{lib}",
-             "-L#{Formula["openssl"].lib}", "-L#{Formula["boost"].lib}",
+             "-I#{Formula["openssl@1.1"].include}", "-L#{lib}",
+             "-L#{Formula["openssl@1.1"].lib}", "-L#{Formula["boost"].lib}",
              "-lssl", "-lcrypto", "-lboost_random", "-lboost_chrono",
              "-lboost_thread-mt", "-lboost_system-mt", "-lboost_regex",
              "-lboost_filesystem", "-lcpprest"] + ENV.cflags.to_s.split


### PR DESCRIPTION
Formula beginning with `a` that depend on `openssl` and are not part of more complex dependency chains. Let's see how many build with openssl 1.1