### PR TITLE
Migrate more formulas to openssl 1.1 (B)

### DIFF
--- a/Formula/bacula-fd.rb
+++ b/Formula/bacula-fd.rb
@@ -3,6 +3,7 @@ class BaculaFd < Formula
   homepage "https://www.bacula.org/"
   url "https://downloads.sourceforge.net/project/bacula/bacula/9.4.4/bacula-9.4.4.tar.gz"
   sha256 "0fe37a02ca768a720099d0d03509c364aff2390c05544d663f4819f8e7fc20be"
+  revision 1
 
   bottle do
     sha256 "e517896c2e4313eaec9cd15bee61376b3b8b74559acfcd304a9e59a8ede502d2" => :mojave
@@ -10,7 +11,7 @@ class BaculaFd < Formula
     sha256 "7c992aa6372bc82318c58b7b50f5a2c5bc6162ced7c1723755749a45912a4852" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "readline"
 
   conflicts_with "bareos-client",

--- a/Formula/bareos-client.rb
+++ b/Formula/bareos-client.rb
@@ -3,6 +3,7 @@ class BareosClient < Formula
   homepage "https://www.bareos.org/"
   url "https://github.com/bareos/bareos/archive/Release/17.2.7.tar.gz"
   sha256 "99a5f907e3422532c783ee254dcf5c737d2b1b53522c00924d3e1009289d2fd2"
+  revision 1
 
   bottle do
     sha256 "01f5bffbfc61c4727bd33e1ac7a3fac8141dcd912c926ef1334727eb44ca703b" => :mojave
@@ -11,7 +12,7 @@ class BareosClient < Formula
     sha256 "396b873eb5b9a55611ce2f8342547d2dc452f636e01acca5323db0dcb92c3a0b" => :el_capitan
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "readline"
 
   conflicts_with "bacula-fd",

--- a/Formula/bbftp-client.rb
+++ b/Formula/bbftp-client.rb
@@ -4,7 +4,7 @@ class BbftpClient < Formula
   url "https://software.in2p3.fr/bbftp/dist/bbftp-client-3.2.1.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/bbftp-client-3.2.1.tar.gz"
   sha256 "4000009804d90926ad3c0e770099874084fb49013e8b0770b82678462304456d"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "3870e56ecb6d593bddd4fee86e931392e689d1ce24a9f0de5953c379e5b218dd" => :mojave
@@ -15,7 +15,7 @@ class BbftpClient < Formula
     sha256 "8619a2f08f735d7e2387ba67ca53bf6f503f37835db08b127033d5c66019688d" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     # Fix ntohll errors; reported 14 Jan 2015.
@@ -23,7 +23,8 @@ class BbftpClient < Formula
 
     cd "bbftpc" do
       system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                            "--with-ssl=#{Formula["openssl"].opt_prefix}", "--prefix=#{prefix}"
+                            "--with-ssl=#{Formula["openssl"].opt_prefix}",
+                            "--prefix=#{prefix}"
       system "make", "install"
     end
   end

--- a/Formula/bibtexconv.rb
+++ b/Formula/bibtexconv.rb
@@ -3,6 +3,7 @@ class Bibtexconv < Formula
   homepage "https://www.uni-due.de/~be0001/bibtexconv/"
   url "https://www.uni-due.de/~be0001/bibtexconv/download/bibtexconv-1.1.13.tar.gz"
   sha256 "90d9a65ef6cbb9e61197a54c292105981b5a3528268f76eb61067112332f4538"
+  revision 1
   head "https://github.com/dreibh/bibtexconv.git"
 
   bottle do
@@ -13,11 +14,11 @@ class Bibtexconv < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "cmake", *std_cmake_args,
-                    "-DCRYPTO_LIBRARY=#{Formula["openssl"].opt_lib}/libcrypto.dylib"
+                    "-DCRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_lib}/libcrypto.dylib"
     system "make", "install"
   end
 

--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -4,6 +4,7 @@ class Bigloo < Formula
   url "ftp://ftp-sop.inria.fr/indes/fp/Bigloo/bigloo4.3e.tar.gz"
   version "4.3e"
   sha256 "43363cb968c57925f402117ff8ec4b47189e2747b02350805a34fa617d9f618a"
+  revision 1
 
   bottle do
     sha256 "d034117c6d060275241be0e0e1043782a04f8dd30f14bea3c7d26a6a7e6feb35" => :mojave
@@ -16,7 +17,7 @@ class Bigloo < Formula
   depends_on "libtool" => :build
 
   depends_on "gmp"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[

--- a/Formula/bitchx.rb
+++ b/Formula/bitchx.rb
@@ -13,7 +13,7 @@ class Bitchx < Formula
     sha256 "494fd5d6084f70158e82d49a067439770935d5aeeb6223d1c229a27e6f7f9e8f" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # OpenSSL 1.1 support in next version (1.2.2)
 
   def install
     plugins = %w[acro aim arcfour amp autocycle blowfish cavlink encrypt

--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -3,6 +3,7 @@ class Botan < Formula
   homepage "https://botan.randombit.net/"
   url "https://botan.randombit.net/releases/Botan-2.11.0.tar.xz"
   sha256 "f7874da2aeb8c018fd77df40b2137879bf90b66f5589490c991e83fb3e8094be"
+  revision 1
   head "https://github.com/randombit/botan.git"
 
   bottle do
@@ -12,7 +13,7 @@ class Botan < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.cxx11

--- a/Formula/btpd.rb
+++ b/Formula/btpd.rb
@@ -3,7 +3,7 @@ class Btpd < Formula
   homepage "https://github.com/btpd/btpd"
   url "https://github.com/downloads/btpd/btpd/btpd-0.16.tar.gz"
   sha256 "296bdb718eaba9ca938bee56f0976622006c956980ab7fc7a339530d88f51eb8"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class Btpd < Formula
     sha256 "62a5bcf9db33b7b543053ce0a7d6ce4ed1fdfc43c9fca2500adc289c8bf34dc8" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/bulk_extractor.rb
+++ b/Formula/bulk_extractor.rb
@@ -14,7 +14,7 @@ class BulkExtractor < Formula
   end
 
   depends_on "boost"
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -1,6 +1,7 @@
 class Burp < Formula
   desc "Network backup and restore"
   homepage "https://burp.grke.org/"
+  revision 1
 
   stable do
     url "https://downloads.sourceforge.net/project/burp/burp-2.2.18/burp-2.2.18.tar.bz2"
@@ -32,7 +33,7 @@ class Burp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "librsync"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   uses_from_macos "zlib"
 
   def install


### PR DESCRIPTION
Formula beginning with B that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1