### PR TITLE
Migrate more formulas to openssl 1.1 (D/E)

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -3,6 +3,7 @@ class Dcmtk < Formula
   homepage "https://dicom.offis.de/dcmtk.php.en"
   url "https://dicom.offis.de/download/dcmtk/dcmtk364/dcmtk-3.6.4.tar.gz"
   sha256 "a93ff354fae091689a0740a1000cde7d4378fdf733aef9287a70d7091efa42c0"
+  revision 1
   head "https://git.dcmtk.org/dcmtk.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Dcmtk < Formula
   depends_on "cmake" => :build
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/dmg2img.rb
+++ b/Formula/dmg2img.rb
@@ -3,6 +3,7 @@ class Dmg2img < Formula
   homepage "http://vu1tur.eu.org/tools/"
   url "http://vu1tur.eu.org/tools/dmg2img-1.6.7.tar.gz"
   sha256 "02aea6d05c5b810074913b954296ddffaa43497ed720ac0a671da4791ec4d018"
+
   bottle do
     cellar :any
     sha256 "c7989c8d06b954b4d9601e5d550d1767ac0b26d48db71160dfa63bcc2135e0e1" => :mojave
@@ -10,7 +11,7 @@ class Dmg2img < Formula
     sha256 "d106c5d7e6b759ccceabda3d54ebc633ed5367f9d9fdfeff752ab1f8574a7ffe" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     system "make"

--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -3,6 +3,7 @@ class Dovecot < Formula
   homepage "https://dovecot.org/"
   url "https://dovecot.org/releases/2.3/dovecot-2.3.7.1.tar.gz"
   sha256 "c5a51d6f76e6e9c843df69e52a364a4c65c4c60e0c51d992eaa45f22f71803c3"
+  revision 1
 
   bottle do
     sha256 "cc93b55278a6e76bd30bcba4e91b19fb00aa62f6b4385537db09a40ce6f04e3c" => :mojave
@@ -10,7 +11,7 @@ class Dovecot < Formula
     sha256 "7f02d5d2a741fcfaa8a0ded924dd27460973649f439b5cbb4bba9b6c975c5042" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   resource "pigeonhole" do
     url "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.7.1.tar.gz"

--- a/Formula/duo_unix.rb
+++ b/Formula/duo_unix.rb
@@ -3,6 +3,7 @@ class DuoUnix < Formula
   homepage "https://www.duosecurity.com/docs/duounix"
   url "https://github.com/duosecurity/duo_unix/archive/duo_unix-1.11.2.tar.gz"
   sha256 "e1ec2f43036ba639743d631f308419c9a88618a93d4038bf40a9cdeef89ca6db"
+  revision 1
 
   bottle do
     sha256 "006db27f7e6d2370e6a5e318c5c5eb0105c1dd5092c0fe397b0c9196d7298432" => :mojave
@@ -13,7 +14,7 @@ class DuoUnix < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./bootstrap"
@@ -22,7 +23,7 @@ class DuoUnix < Formula
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--includedir=#{include}/duo",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
                           "--with-pam=#{lib}/pam/"
     system "make", "install"
   end

--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -3,6 +3,7 @@ class Ejabberd < Formula
   homepage "https://www.ejabberd.im"
   url "https://www.process-one.net/downloads/ejabberd/19.05/ejabberd-19.05.tgz"
   sha256 "f03c672bfd3c151a16615f685d1bd340df1f33d9bd30bc0fd56c0173c4649fd1"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,7 +22,7 @@ class Ejabberd < Formula
   depends_on "erlang"
   depends_on "gd"
   depends_on "libyaml"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV["TARGET_DIR"] = ENV["DESTDIR"] = "#{lib}/ejabberd/erlang/lib/ejabberd-#{version}"

--- a/Formula/ekg2.rb
+++ b/Formula/ekg2.rb
@@ -4,7 +4,7 @@ class Ekg2 < Formula
   url "https://src.fedoraproject.org/lookaside/extras/ekg2/ekg2-0.3.1.tar.gz/68fc05b432c34622df6561eaabef5a40/ekg2-0.3.1.tar.gz"
   mirror "https://web.archive.org/web/20161227025528/pl.ekg2.org/ekg2-0.3.1.tar.gz"
   sha256 "6ad360f8ca788d4f5baff226200f56922031ceda1ce0814e650fa4d877099c63"
-  revision 3
+  revision 4
 
   bottle do
     rebuild 1
@@ -14,12 +14,18 @@ class Ekg2 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "readline"
 
   # Fix the build on OS X 10.9+
   # bugs.ekg2.org/issues/152 [LOST LINK]
   patch :DATA
+
+  # Upstream commit, fix build against OpenSSL 1.1
+  patch do
+    url "https://github.com/ekg2/ekg2/commit/f05815.diff?full_index=1"
+    sha256 "5a27388497fd4537833807a0ba064af17fa13d7dd55abec6b185f499d148de1a"
+  end
 
   def install
     readline = Formula["readline"].opt_prefix

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -23,7 +23,7 @@ class Elinks < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     ENV.deparallelize

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -3,7 +3,7 @@ class Encfs < Formula
   homepage "https://vgough.github.io/encfs/"
   url "https://github.com/vgough/encfs/archive/v1.9.5.tar.gz"
   sha256 "4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63"
-  revision 2
+  revision 3
   head "https://github.com/vgough/encfs.git"
 
   bottle do
@@ -15,7 +15,7 @@ class Encfs < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on :osxfuse
 
   def install

--- a/Formula/epic5.rb
+++ b/Formula/epic5.rb
@@ -4,6 +4,7 @@ class Epic5 < Formula
   url "http://ftp.epicsol.org/pub/epic/EPIC5-PRODUCTION/epic5-2.1.1.tar.xz"
   mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/epic5/epic5-2.1.1.tar.xz"
   sha256 "81e18b5f6aa32c5c4b5d01d4cd94e3124b538e3ba42cf7dbb74a6f1f5081f9df"
+  revision 1
   head "http://git.epicsol.org/epic5.git"
 
   bottle do
@@ -12,7 +13,7 @@ class Epic5 < Formula
     sha256 "db98c71f129c0d8bf7d012cc35e5627a6a623db2909153bbebca71b0c19b507e" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-debug",
@@ -20,7 +21,7 @@ class Epic5 < Formula
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--with-ipv6",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
     system "make"
     system "make", "test"
     system "make", "install"

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -4,6 +4,7 @@ class ErlangAT21 < Formula
   # Download tarball from GitHub; it is served faster than the official tarball.
   url "https://github.com/erlang/otp/archive/OTP-21.3.8.6.tar.gz"
   sha256 "7d96d11143b8ad71448acc0427c2c34756712aa2972d9aaa6d100f87f29918c6"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,7 +18,7 @@ class ErlangAT21 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "wxmac" # for GUI apps like observer
 
   resource "man" do
@@ -51,7 +52,7 @@ class ErlangAT21 < Formula
       --enable-smp-support
       --enable-threads
       --enable-wx
-      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
       --without-javac
       --enable-darwin-64bit
     ]

--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -3,6 +3,7 @@ class Exim < Formula
   homepage "https://exim.org"
   url "https://ftp.exim.org/pub/exim/exim4/exim-4.92.1.tar.xz"
   sha256 "2c64a871dd7ac464c14df8eb0dcf5cf766b46fff5af0316aaa4bf0268dde24b4"
+  revision 1
 
   bottle do
     sha256 "9ca6d89272f0de541e605e0b1ac08a9fb4561f2292090f09f2c1d08a8ced3e56" => :mojave
@@ -11,7 +12,7 @@ class Exim < Formula
   end
 
   depends_on "berkeley-db@4"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
 
   def install


### PR DESCRIPTION
Formula beginning with D and E, that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1