### PR TITLE
Revert makensis "Increase max string length to match special builds"

### DIFF
--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -3,7 +3,7 @@ class Makensis < Formula
   homepage "https://nsis.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04-src.tar.bz2"
   sha256 "609536046c50f35cfd909dd7df2ab38f2e835d0da3c1048aa0d48c59c5a4f4f5"
-  revision 1 
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -3,6 +3,7 @@ class Makensis < Formula
   homepage "https://nsis.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.04/nsis-3.04-src.tar.bz2"
   sha256 "609536046c50f35cfd909dd7df2ab38f2e835d0da3c1048aa0d48c59c5a4f4f5"
+  revision 1 
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/makensis.rb
+++ b/Formula/makensis.rb
@@ -29,7 +29,6 @@ class Makensis < Formula
       # Don't strip, see https://github.com/Homebrew/homebrew/issues/28718
       "STRIP=0",
       "VERSION=#{version}",
-      "NSIS_MAX_STRLEN=8192",
     ]
     system "scons", "makensis", *args
     bin.install "build/urelease/makensis/makensis"


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This reverts commit 799df198b87d12fe2cde56e07d331cea558a96df.

The PR introducing the error was https://github.com/Homebrew/homebrew-core/pull/39928

As explained in https://github.com/Homebrew/homebrew-core/pull/39928#issuecomment-520263137 #39928 completely broke makensis on macOS; AFAIK there was no explicit testing to verify its behavior. Anyway, brew-installed makensis is nonfunctional as it is currently distributed by homebrew.

/cc @rhwood original PR submitter
/cc @fxcoudert original PR reviewer

