### PR TITLE
Migrate more formulas to openssl 1.1 (X/Y/Z)

### DIFF
--- a/Formula/xaric.rb
+++ b/Formula/xaric.rb
@@ -14,12 +14,12 @@ class Xaric < Formula
     sha256 "3b8f2a6b837e43ff57ef626b4d46142562c1eda120ac5889124eab11d8b46b86" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/xidel.rb
+++ b/Formula/xidel.rb
@@ -13,7 +13,7 @@ class Xidel < Formula
   end
 
   depends_on "fpc"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     cd "programs/internet/xidel" do

--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -17,7 +17,7 @@ class Yara < Formula
   depends_on "libtool" => :build
   depends_on "jansson"
   depends_on "libmagic"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./bootstrap.sh"

--- a/Formula/yubico-piv-tool.rb
+++ b/Formula/yubico-piv-tool.rb
@@ -13,7 +13,7 @@ class YubicoPivTool < Formula
 
   depends_on "check" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -10,7 +10,7 @@ class Zabbix < Formula
     sha256 "db1aaa5e4614747bc2a07fb921719e24ea606538249b79374008ec08284d156a" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
 
   def brewed_or_shipped(db_config)
@@ -28,7 +28,7 @@ class Zabbix < Formula
       --enable-agent
       --with-iconv=#{sdk}/usr
       --with-libpcre=#{Formula["pcre"].opt_prefix}
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     if MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0"


### PR DESCRIPTION
Formula beginning with X/Y/Z that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1