### PR TITLE
Migrate more formulas to openssl 1.1 (H)

### DIFF
--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -3,6 +3,7 @@ class H2o < Formula
   homepage "https://github.com/h2o/h2o/"
   url "https://github.com/h2o/h2o/archive/v2.2.6.tar.gz"
   sha256 "f8cbc1b530d85ff098f6efc2c3fdbc5e29baffb30614caac59d5c710f7bda201"
+  revision 1
 
   bottle do
     sha256 "214df20969a0f0abd19a22cb946af49193cb86cada2d711ffa388a75d9d6d1dc" => :mojave
@@ -12,7 +13,7 @@ class H2o < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   uses_from_macos "zlib"
 
   def install
@@ -22,7 +23,7 @@ class H2o < Formula
 
     system "cmake", *std_cmake_args,
                     "-DWITH_BUNDLED_SSL=OFF",
-                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}"
+                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
 
     (etc/"h2o").mkpath

--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -3,6 +3,7 @@ class Haproxy < Formula
   homepage "https://www.haproxy.org/"
   url "https://www.haproxy.org/download/2.0/src/haproxy-2.0.5.tar.gz"
   sha256 "3f2e0d40af66dd6df1dc2f6055d3de106ba62836d77b4c2e497a82a4bdbc5422"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Haproxy < Formula
     sha256 "1d400d6708bdd052b2ffb08c0e56c64d635988b34dd15a55ed7724062b00f9b8" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
 
   def install

--- a/Formula/heimdal.rb
+++ b/Formula/heimdal.rb
@@ -3,6 +3,7 @@ class Heimdal < Formula
   homepage "https://www.h5l.org"
   url "https://github.com/heimdal/heimdal/releases/download/heimdal-7.6.0/heimdal-7.6.0.tar.gz"
   sha256 "afb996e27e722f51bf4d9e8d1d51e47cd10bfa1a41a84106af926e5639a52e4d"
+  revision 1
 
   bottle do
     sha256 "1897773e72a05fa2c8f22a81f90abb0775e5aa68d7468308bb9caffe80557b53" => :mojave
@@ -12,7 +13,7 @@ class Heimdal < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   resource "JSON" do
     url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz"

--- a/Formula/http_load.rb
+++ b/Formula/http_load.rb
@@ -4,7 +4,7 @@ class HttpLoad < Formula
   url "https://www.acme.com/software/http_load/http_load-09Mar2016.tar.gz"
   version "20160309"
   sha256 "5a7b00688680e3fca8726dc836fd3f94f403fde831c71d73d9a1537f215b4587"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class HttpLoad < Formula
     sha256 "f4702e82a17b0c972164f2bc8ba985edccf0f3dc840627d37d5307d9b914ba25" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     bin.mkpath
@@ -26,7 +26,7 @@ class HttpLoad < Formula
       LIBDIR=#{lib}
       MANDIR=#{man1}
       CC=#{ENV.cc}
-      SSL_TREE=#{Formula["openssl"].opt_prefix}
+      SSL_TREE=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     inreplace "Makefile", "#SSL_", "SSL_"

--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -3,7 +3,7 @@ class Httping < Formula
   homepage "https://www.vanheusden.com/httping/"
   url "https://www.vanheusden.com/httping/httping-2.5.tgz"
   sha256 "3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8"
-  revision 1
+  revision 2
   head "https://github.com/flok99/httping.git"
 
   bottle do
@@ -14,7 +14,7 @@ class Httping < Formula
   end
 
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Reported upstream, see: https://github.com/Homebrew/homebrew/pull/28653

--- a/Formula/httrack.rb
+++ b/Formula/httrack.rb
@@ -5,6 +5,7 @@ class Httrack < Formula
   # link to download.httrack.com will break on next HTTrack update.
   url "https://mirror.httrack.com/historical/httrack-3.49.2.tar.gz"
   sha256 "3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025"
+  revision 1
 
   bottle do
     sha256 "8542fa3b1a4badf7290315b4174d5026c81e79c5add75432176bb5385f6a1e5e" => :mojave
@@ -14,7 +15,7 @@ class Httrack < Formula
     sha256 "e07658fd32a00001eb85c18b159eea17e2014142e8e56c7d1e07ecbb5774be95" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
Formulas beginning with H, that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1