### PR TITLE
Migrate more formulas to openssl 1.1 (W)

### DIFF
--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -26,12 +26,12 @@ class W3m < Formula
 
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--disable-image",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/web100clt.rb
+++ b/Formula/web100clt.rb
@@ -16,7 +16,7 @@ class Web100clt < Formula
 
   depends_on "i2util"
   depends_on "jansson"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # fixes issue with new default secure strlcpy/strlcat functions in 10.9
   # https://github.com/ndt-project/ndt/issues/106
@@ -30,7 +30,7 @@ class Web100clt < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
 
     # we only want to build the web100clt client so we need
     # to change to the src directory before installing.

--- a/Formula/webfs.rb
+++ b/Formula/webfs.rb
@@ -1,6 +1,6 @@
 class Webfs < Formula
   desc "HTTP server for purely static content"
-  homepage "https://linux.bytesex.org/misc/webfs.html"
+  homepage "http://linux.bytesex.org/misc/webfs.html"
   url "https://www.kraxel.org/releases/webfs/webfs-1.21.tar.gz"
   sha256 "98c1cb93473df08e166e848e549f86402e94a2f727366925b1c54ab31064a62a"
   revision 1
@@ -15,7 +15,7 @@ class Webfs < Formula
     sha256 "79c670478aeb8f97d702a5112fde2dab07c92145ea836c12bfdf9a1acfca4232" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/0518a6d1/webfs/patch-ls.c"

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -22,14 +22,14 @@ class Wget < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libidn2"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./bootstrap", "--skip-po" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--with-ssl=openssl",
-                          "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}",
+                          "--with-libssl-prefix=#{Formula["openssl@1.1"].opt_prefix}",
                           "--disable-debug",
                           "--disable-pcre",
                           "--disable-pcre2",

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -12,7 +12,7 @@ class Wimlib < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # fuse requires librt, unavailable on OSX

--- a/Formula/wrk.rb
+++ b/Formula/wrk.rb
@@ -13,7 +13,7 @@ class Wrk < Formula
     sha256 "8aece2b0e05cfce8f9e1bc408bc043c8340e999cb175c2396ec94d9a8ead2221" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "wrk-trello", :because => "both install `wrk` binaries"
 


### PR DESCRIPTION
Formula beginning with W that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1