### PR TITLE
Migrate more formulas to openssl 1.1 (U/V)

### DIFF
--- a/Formula/uftp.rb
+++ b/Formula/uftp.rb
@@ -11,10 +11,10 @@ class Uftp < Formula
     sha256 "f07b4b2fef5ad1d292c7e54591ac2ba3a99625483621ad0154907c28ed79cf08" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
-    system "make", "OPENSSL=#{Formula["openssl"].opt_prefix}", "DESTDIR=#{prefix}", "install"
+    system "make", "OPENSSL=#{Formula["openssl@1.1"].opt_prefix}", "DESTDIR=#{prefix}", "install"
     # the makefile installs into DESTDIR/usr/..., move everything up one and remove usr
     # the project maintainer was contacted via sourceforge on 12-Feb, he responded WONTFIX on 13-Feb
     prefix.install Dir["#{prefix}/usr/*"]

--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -15,14 +15,14 @@ class Urweb < Formula
   depends_on "libtool" => :build
   depends_on "mlton" => :build
   depends_on "gmp"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --prefix=#{prefix}
       SITELISP=$prefix/share/emacs/site-lisp/urweb
     ]

--- a/Formula/virtuoso.rb
+++ b/Formula/virtuoso.rb
@@ -25,7 +25,7 @@ class Virtuoso < Formula
 
   # If gawk isn't found, make fails deep into the process.
   depends_on "gawk" => :build
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   conflicts_with "unixodbc", :because => "Both install `isql` binaries."
 


### PR DESCRIPTION
Formula beginning with U/V that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1