### PR TITLE
afflib: depend on python3 instead of python2

### DIFF
--- a/Formula/afflib.rb
+++ b/Formula/afflib.rb
@@ -3,6 +3,7 @@ class Afflib < Formula
   homepage "https://github.com/sshock/AFFLIBv3"
   url "https://github.com/sshock/AFFLIBv3/archive/v3.7.18.tar.gz"
   sha256 "5481cd5d8dbacd39d0c531a68ae8afcca3160c808770d66dcbf5e9b5be3e8199"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,8 +17,7 @@ class Afflib < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl"
-  # Python 3 error filed upstream: https://github.com/sshock/AFFLIBv3/issues/35
-  depends_on "python@2" # does not support Python 3
+  depends_on "python"
 
   def install
     args = %w[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[The noted AFFLIB issue](https://github.com/sshock/AFFLIBv3/issues/35) has been closed and fixed upstream; we can use Python 3 now.