### PR TITLE
Migrate more formulas to openssl 1.1 (M)

### DIFF
--- a/Formula/makepkg.rb
+++ b/Formula/makepkg.rb
@@ -4,6 +4,7 @@ class Makepkg < Formula
   url "https://projects.archlinux.org/git/pacman.git",
       :tag      => "v5.0.2",
       :revision => "0c633c27eaeab2a9d30efb01199579896ccf63c9"
+  revision 1
   head "https://projects.archlinux.org/git/pacman.git"
 
   bottle do
@@ -28,7 +29,7 @@ class Makepkg < Formula
   # Regression due to https://git.archlinux.org/pacman.git/commit/?id=16718a21
   # Reported 19 Jun 2016: https://bugs.archlinux.org/task/49771
   depends_on :macos => :yosemite
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"

--- a/Formula/mfterm.rb
+++ b/Formula/mfterm.rb
@@ -3,6 +3,7 @@ class Mfterm < Formula
   homepage "https://github.com/4ZM/mfterm"
   url "https://github.com/4ZM/mfterm/releases/download/v1.0.7/mfterm-1.0.7.tar.gz"
   sha256 "b6bb74a7ec1f12314dee42973eb5f458055b66b1b41316ae0c5380292b86b248"
+  revision 1
 
   bottle do
     cellar :any
@@ -22,11 +23,11 @@ class Mfterm < Formula
 
   depends_on "libnfc"
   depends_on "libusb"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
-    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include}"
-    ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@1.1"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@1.1"].opt_lib}"
 
     if build.head?
       chmod 0755, "./autogen.sh"

--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -3,6 +3,7 @@ class Miniserve < Formula
   homepage "https://github.com/svenstaro/miniserve"
   url "https://github.com/svenstaro/miniserve/archive/v0.5.0.tar.gz"
   sha256 "5b7c91bdf35e1a17ca006efa0354712301886c5c50952a2162401aef77faced0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -11,7 +12,7 @@ class Miniserve < Formula
     sha256 "b21ba4b456e9f97d37c6fe667a6fdfb6d40c6b345c8f2a9baf0f85eb9cc39d98" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # Miniserve requires a known-good Rust nightly release to use.
   resource "rust-nightly" do

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -4,7 +4,7 @@ class MitScheme < Formula
   url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/9.2/mit-scheme-c-9.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/mit-scheme/stable.pkg/9.2/mit-scheme-c-9.2.tar.gz"
   sha256 "4f6a16f9c7d4b4b7bb3aa53ef523cad39b54ae1eaa3ab3205930b6a87759b170"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 2
@@ -19,7 +19,7 @@ class MitScheme < Formula
   # Dies on "configure: error: SIZEOF_CHAR is not 1" without Xcode.
   # https://github.com/Homebrew/homebrew-x11/issues/103#issuecomment-125014423
   depends_on :xcode => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Setting -march=native, which is what --build-from-source does, can fail

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -3,6 +3,7 @@ class Monetdb < Formula
   homepage "https://www.monetdb.org/"
   url "https://www.monetdb.org/downloads/sources/Apr2019/MonetDB-11.33.3.tar.xz"
   sha256 "f69e7312a77407bef2d970e6d8edfc0ca687d5b31c6b4714bd9132fa468a12e9"
+  revision 1
 
   bottle do
     sha256 "98754982eb7de2da55d57923901c2b4e888cba24045a63bdf362fb343dbdc8dc" => :mojave
@@ -21,7 +22,7 @@ class Monetdb < Formula
 
   depends_on "libatomic_ops" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
   depends_on "readline" # Compilation fails with libedit
 

--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -3,6 +3,7 @@ class Mongoose < Formula
   homepage "https://github.com/cesanta/mongoose"
   url "https://github.com/cesanta/mongoose/archive/6.15.tar.gz"
   sha256 "ed9b44690f9660d25562e45472d486c086bcc916bf49f39f22e0a90444d44454"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Mongoose < Formula
     sha256 "2df8b1fd42b06fab2579ba49bb82722a4cbbaf982b26bdbda428eca12ea26d1d" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "suite-sparse", :because => "suite-sparse vendors libmongoose.dylib"
 

--- a/Formula/monit.rb
+++ b/Formula/monit.rb
@@ -3,6 +3,7 @@ class Monit < Formula
   homepage "https://mmonit.com/monit/"
   url "https://mmonit.com/monit/dist/monit-5.26.0.tar.gz"
   sha256 "87fc4568a3af9a2be89040efb169e3a2e47b262f99e78d5ddde99dd89f02f3c2"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,13 +12,13 @@ class Monit < Formula
     sha256 "a4ec2fe5a66764c4135ad8332206a9f4eedf384f0f48aa8bccf8bbe4ec5713c7" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--localstatedir=#{var}/monit",
                           "--sysconfdir=#{etc}/monit",
-                          "--with-ssl-dir=#{Formula["openssl"].opt_prefix}"
+                          "--with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
     pkgshare.install "monitrc"
   end

--- a/Formula/monitoring-plugins.rb
+++ b/Formula/monitoring-plugins.rb
@@ -3,6 +3,7 @@ class MonitoringPlugins < Formula
   homepage "https://www.monitoring-plugins.org"
   url "https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz"
   sha256 "296a538f00a9cbef7f528ff2d43af357a44b384dc98a32389a675b62a6dd3665"
+  revision 1
 
   bottle do
     sha256 "ad0ac72a226d385a990b6fba5836431136945aff4cc4b1a1d57c17457843f104" => :mojave
@@ -12,7 +13,7 @@ class MonitoringPlugins < Formula
     sha256 "b3d0549fc51c3948743b16eb5bc52a0a7f8af6cf6ad6c05b3056fa947661a6da" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "nagios-plugins", :because => "nagios-plugins ships their plugins to the same folder."
 
@@ -21,7 +22,7 @@ class MonitoringPlugins < Formula
       --disable-dependency-tracking
       --prefix=#{libexec}
       --libexecdir=#{libexec}/sbin
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -3,6 +3,7 @@ class Mupdf < Formula
   homepage "https://mupdf.com/"
   url "https://mupdf.com/downloads/archive/mupdf-1.15.0-source.tar.xz"
   sha256 "565036cf7f140139c3033f0934b72e1885ac7e881994b7919e15d7bee3f8ac4e"
+  revision 1
   head "https://git.ghostscript.com/mupdf.git"
 
   bottle do
@@ -12,7 +13,7 @@ class Mupdf < Formula
     sha256 "2ba0dee72242bc80ef22288dc6fe3df890d262cb4b36c808ee9a529111f098e5" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on :x11
 
   conflicts_with "mupdf-tools",

--- a/Formula/mysql-cluster.rb
+++ b/Formula/mysql-cluster.rb
@@ -14,7 +14,7 @@ class MysqlCluster < Formula
 
   depends_on "cmake" => :build
   depends_on :java => "1.8"
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   conflicts_with "memcached", :because => "both install `bin/memcached`"
   conflicts_with "mysql", "mariadb", "percona-server",

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -3,6 +3,7 @@ class Mysql < Formula
   homepage "https://dev.mysql.com/doc/refman/8.0/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.17.tar.gz"
   sha256 "d44231316ce30a1d1189125ceed86d3388409778e17d0e3b9a060f532463e29a"
+  revision 1
 
   bottle do
     sha256 "10cf5cf9a3d69d003df6d3e199077c86355a23bfbcec4a78c228a665bf138e02" => :mojave
@@ -20,7 +21,7 @@ class Mysql < Formula
   # Note: MySQL themselves don't support anything below Sierra.
   depends_on :macos => :yosemite
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "mysql-cluster", "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."

--- a/Formula/mysql@5.5.rb
+++ b/Formula/mysql@5.5.rb
@@ -14,7 +14,7 @@ class MysqlAT55 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def datadir
     var/"mysql"

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -13,7 +13,7 @@ class MysqlAT56 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def datadir
     var/"mysql"

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -3,6 +3,7 @@ class MysqlAT57 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-boost-5.7.27.tar.gz"
   sha256 "036ab46a8a1216cfc1e87374bd1cba12e2208c02cf328a31851be7e1c7f57a2b"
+  revision 1
 
   bottle do
     sha256 "e232cc9150f4f8d65ce5e24e010fa09ea3da90029bfd98036258d4370f75e798" => :mojave
@@ -14,7 +15,7 @@ class MysqlAT57 < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def datadir
     var/"mysql"

--- a/Formula/sphinx.rb
+++ b/Formula/sphinx.rb
@@ -3,7 +3,7 @@ class Sphinx < Formula
   homepage "https://sphinxsearch.com/"
   url "https://sphinxsearch.com/files/sphinx-2.2.11-release.tar.gz"
   sha256 "6662039f093314f896950519fa781bc87610f926f64b3d349229002f06ac41a9"
-  revision 2
+  revision 3
   head "https://github.com/sphinxsearch/sphinx.git"
 
   bottle do
@@ -13,7 +13,7 @@ class Sphinx < Formula
   end
 
   depends_on "mysql"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   resource "stemmer" do
     url "https://github.com/snowballstem/snowball.git",


### PR DESCRIPTION
Formula beginning with M, that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1