### PR TITLE
Migrate more formulas to openssl 1.1 (N)

### DIFF
--- a/Formula/nagios-plugins.rb
+++ b/Formula/nagios-plugins.rb
@@ -3,6 +3,7 @@ class NagiosPlugins < Formula
   homepage "https://www.nagios-plugins.org/"
   url "https://www.nagios-plugins.org/download/nagios-plugins-2.2.1.tar.gz"
   sha256 "647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18"
+  revision 1
 
   bottle do
     sha256 "27cfda8fe9e205ff63eda487821e13d93b19900838b4ad0ebd73a86fc8c7224b" => :mojave
@@ -12,7 +13,7 @@ class NagiosPlugins < Formula
     sha256 "1fcf4d4934fe7f7793fb78d13f17f948d46a19600e02881b22695f736f327e65" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "monitoring-plugins", :because => "monitoring-plugins ships their plugins to the same folder."
 
@@ -21,7 +22,7 @@ class NagiosPlugins < Formula
       --disable-dependency-tracking
       --prefix=#{libexec}
       --libexecdir=#{libexec}/sbin
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/ngircd.rb
+++ b/Formula/ngircd.rb
@@ -4,6 +4,7 @@ class Ngircd < Formula
   url "https://ngircd.barton.de/pub/ngircd/ngircd-25.tar.gz"
   mirror "https://ngircd.sourceforge.io/pub/ngircd/ngircd-25.tar.gz"
   sha256 "51915780519bae43da3798807e3bed60d887e4eaa728354aa6bb61cdbcda49ba"
+  revision 1
 
   bottle do
     sha256 "d73567d2f8a5282f0043b9ae86bc3742f3a31769c6659b05f5e689648f9f7c53" => :mojave
@@ -12,7 +13,7 @@ class Ngircd < Formula
   end
 
   depends_on "libident"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/nmap.rb
+++ b/Formula/nmap.rb
@@ -3,6 +3,7 @@ class Nmap < Formula
   homepage "https://nmap.org/"
   url "https://nmap.org/dist/nmap-7.80.tar.bz2"
   sha256 "fcfa5a0e42099e12e4bf7a68ebe6fde05553383a682e816a7ec9256ab4773faa"
+  revision 1
   head "https://svn.nmap.org/nmap/"
 
   bottle do
@@ -11,7 +12,7 @@ class Nmap < Formula
     sha256 "e06900a582cdbacfb201d38d72b906f882871bcf30d776f0192cc540a6902f5a" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   conflicts_with "ndiff", :because => "both install `ndiff` binaries"
 
@@ -22,7 +23,7 @@ class Nmap < Formula
       --prefix=#{prefix}
       --with-libpcre=included
       --with-liblua=included
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --without-nmap-update
       --disable-universal
       --without-zenmap

--- a/Formula/nmh.rb
+++ b/Formula/nmh.rb
@@ -3,6 +3,7 @@ class Nmh < Formula
   homepage "https://www.nongnu.org/nmh/"
   url "https://download.savannah.gnu.org/releases/nmh/nmh-1.7.1.tar.gz"
   sha256 "f1fb94bbf7d95fcd43277c7cfda55633a047187f57afc6c1bb9321852bd07c11"
+  revision 1
 
   bottle do
     sha256 "b0d273ecd1a67ddf6504e5aac8771bbc1b60bdea653c0635067e059eb4881507" => :mojave
@@ -17,7 +18,7 @@ class Nmh < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "w3m"
 
   def install

--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -4,6 +4,7 @@ class Nopoll < Formula
   url "https://www.aspl.es/nopoll/downloads/nopoll-0.4.6.b400.tar.gz"
   version "0.4.6.b400"
   sha256 "7f1b20f1d0525f30cdd2a4fc386d328b4cf98c6d11cef51fe62cd9491ba19ad9"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class Nopoll < Formula
     sha256 "266e0d329c27be6a5c9a202b0dd7c6745d7962be606321b9172c0a57b77b91b8" => :el_capitan
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/nrpe.rb
+++ b/Formula/nrpe.rb
@@ -3,6 +3,7 @@ class Nrpe < Formula
   homepage "https://www.nagios.org/"
   url "https://downloads.sourceforge.net/project/nagios/nrpe-3.x/nrpe-3.2.1.tar.gz"
   sha256 "8ad2d1846ab9011fdd2942b8fc0c99dfad9a97e57f4a3e6e394a4ead99c0f1f0"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class Nrpe < Formula
   end
 
   depends_on "nagios-plugins"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     user  = `id -un`.chomp
@@ -27,9 +28,9 @@ class Nrpe < Formula
                           "--with-nrpe-group=#{group}",
                           "--with-nagios-user=#{user}",
                           "--with-nagios-group=#{group}",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
                           # Set both or it still looks for /usr/lib
-                          "--with-ssl-lib=#{Formula["openssl"].opt_lib}",
+                          "--with-ssl-lib=#{Formula["openssl@1.1"].opt_lib}",
                           "--enable-ssl",
                           "--enable-command-args"
 

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -4,6 +4,7 @@ class Ntp < Formula
   url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p13.tar.gz"
   version "4.2.8p13"
   sha256 "288772cecfcd9a53694ffab108d1825a31ba77f3a8466b0401baeca3bc232a38"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,7 +13,7 @@ class Ntp < Formula
     sha256 "48c96f99d19135f055b15066a49a44a1e1560c1da0aa1cfaa8c81df782d86d77" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[
@@ -20,8 +21,8 @@ class Ntp < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-openssl-libdir=#{Formula["openssl"].lib}
-      --with-openssl-incdir=#{Formula["openssl"].include}
+      --with-openssl-libdir=#{Formula["openssl@1.1"].lib}
+      --with-openssl-incdir=#{Formula["openssl@1.1"].include}
       --with-net-snmp-config=no
     ]
 

--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -3,6 +3,7 @@ class Nushell < Formula
   homepage "https://www.nushell.sh"
   url "https://github.com/nushell/nushell/archive/0.2.0.tar.gz"
   sha256 "5bce8cdb33a6580ff15214322bc66945c0b4d93375056865ad30e0415fece3de"
+  revision 1
   head "https://github.com/nushell/nushell.git"
 
   bottle do
@@ -12,7 +13,7 @@ class Nushell < Formula
     sha256 "1741fd6332cf1125c1d5eecc9076545041d4ec64ccced6a394fbdf2679bf28b0" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # Nu requires features from Rust 1.39 to build, so we can't use Homebrew's
   # Rust; picking a known-good Rust nightly release to use instead.

--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -23,7 +23,7 @@ class Nut < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libusb-compat"
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   conflicts_with "rhino", :because => "both install `rhino` binaries"
 

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -3,6 +3,7 @@ class Nzbget < Formula
   homepage "https://nzbget.net/"
   url "https://github.com/nzbget/nzbget/releases/download/v21.0/nzbget-21.0-src.tar.gz"
   sha256 "65a5d58eb8f301e62cf086b72212cbf91de72316ffc19182ae45119ddd058d53"
+  revision 1
   head "https://github.com/nzbget/nzbget.git", :branch => "develop"
 
   bottle do
@@ -13,7 +14,7 @@ class Nzbget < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gcc" if MacOS.version == :mavericks
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
Formula beginning with N, that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1