### PR TITLE
Remove Python 2 from dual-versioned formulas

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -1,8 +1,8 @@
 class Csound < Formula
   desc "Sound and music computing system"
   homepage "https://csound.com"
-  url "https://github.com/csound/csound/archive/6.13.tar.gz"
-  sha256 "6118ffc1ee04eaeffe7483afc3d48190d93d0e97b51e25f0f3d71e44293827d6"
+  url "https://github.com/csound/csound/archive/6.13.0.tar.gz"
+  sha256 "183beeb3b720bfeab6cc8af12fbec0bf9fef2727684ac79289fd12d0dfee728b"
 
   bottle do
     sha256 "5a2380000f04fa02589d37040c1771a0e07b7a7a944f8355c38b58cb9a06229f" => :mojave
@@ -12,7 +12,6 @@ class Csound < Formula
 
   depends_on "cmake" => :build
   depends_on "python" => [:build, :test]
-  depends_on "python@2" => [:build, :test]
   depends_on "fltk"
   depends_on "liblo"
   depends_on "libsamplerate"
@@ -47,12 +46,10 @@ class Csound < Formula
 
     libexec.install "#{buildpath}/interfaces/ctcsound.py"
 
-    ["python2", "python3"].each do |python|
-      version = Language::Python.major_minor_version python
-      (lib/"python#{version}/site-packages/homebrew-csound.pth").write <<~EOS
-        import site; site.addsitedir('#{libexec}')
-      EOS
-    end
+    version = Language::Python.major_minor_version "python3"
+    (lib/"python#{version}/site-packages/homebrew-csound.pth").write <<~EOS
+      import site; site.addsitedir('#{libexec}')
+    EOS
   end
 
   def caveats; <<~EOS
@@ -91,7 +88,6 @@ class Csound < Formula
 
     ENV["DYLD_FRAMEWORK_PATH"] = "#{opt_prefix}/Frameworks"
 
-    system "python2", "-c", "import ctcsound"
     system "python3", "-c", "import ctcsound"
   end
 end

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -3,6 +3,7 @@ class ProtobufAT36 < Formula
   homepage "https://github.com/protocolbuffers/protobuf/"
   url "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"
   sha256 "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,7 +19,6 @@ class ProtobufAT36 < Formula
   depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "python"
-  depends_on "python@2"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
@@ -56,20 +56,18 @@ class ProtobufAT36 < Formula
     ENV.append_to_cflags "-I#{include}"
     ENV.append_to_cflags "-L#{lib}"
 
-    ["python2", "python3"].each do |python|
-      resource("six").stage do
-        system python, *Language::Python.setup_install_args(libexec)
-      end
-      chdir "python" do
-        system python, *Language::Python.setup_install_args(libexec),
-                       "--cpp_implementation"
-      end
-
-      version = Language::Python.major_minor_version python
-      site_packages = "lib/python#{version}/site-packages"
-      pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-      (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
+    resource("six").stage do
+      system "python3", *Language::Python.setup_install_args(libexec)
     end
+    chdir "python" do
+      system "python3", *Language::Python.setup_install_args(libexec),
+                        "--cpp_implementation"
+    end
+
+    version = Language::Python.major_minor_version "python3"
+    site_packages = "lib/python#{version}/site-packages"
+    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
+    (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
   end
 
   test do

--- a/Formula/pyqt.rb
+++ b/Formula/pyqt.rb
@@ -4,7 +4,7 @@ class Pyqt < Formula
   url "https://dl.bintray.com/homebrew/mirror/pyqt-5.10.1.tar.gz"
   mirror "https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.10.1/PyQt5_gpl-5.10.1.tar.gz"
   sha256 "9932e971e825ece4ea08f84ad95017837fa8f3f29c6b0496985fa1093661e9ef"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,6 @@ class Pyqt < Formula
   end
 
   depends_on "python"
-  depends_on "python@2"
   depends_on "qt"
   depends_on "sip"
 
@@ -27,45 +26,41 @@ class Pyqt < Formula
   end
 
   def install
-    ["python2", "python3"].each do |python|
-      version = Language::Python.major_minor_version python
-      args = ["--confirm-license",
-              "--bindir=#{bin}",
-              "--destdir=#{lib}/python#{version}/site-packages",
-              "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
-              "--sipdir=#{share}/sip/Qt5",
-              # sip.h could not be found automatically
-              "--sip-incdir=#{Formula["sip"].opt_include}",
-              "--qmake=#{Formula["qt"].bin}/qmake",
-              # Force deployment target to avoid libc++ issues
-              "QMAKE_MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
-              "--qml-plugindir=#{pkgshare}/plugins",
-              "--verbose"]
+    version = Language::Python.major_minor_version "python3"
+    args = ["--confirm-license",
+            "--bindir=#{bin}",
+            "--destdir=#{lib}/python#{version}/site-packages",
+            "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
+            "--sipdir=#{share}/sip/Qt5",
+            # sip.h could not be found automatically
+            "--sip-incdir=#{Formula["sip"].opt_include}",
+            "--qmake=#{Formula["qt"].bin}/qmake",
+            # Force deployment target to avoid libc++ issues
+            "QMAKE_MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
+            "--qml-plugindir=#{pkgshare}/plugins",
+            "--verbose"]
 
-      system python, "configure.py", *args
-      system "make"
-      system "make", "install"
-      system "make", "clean"
-    end
+    system "python3", "configure.py", *args
+    system "make"
+    system "make", "install"
+    system "make", "clean"
   end
 
   test do
     system "#{bin}/pyuic5", "--version"
     system "#{bin}/pylupdate5", "-version"
 
-    ["python2", "python3"].each do |python|
-      system python, "-c", "import PyQt5"
-      %w[
-        Gui
-        Location
-        Multimedia
-        Network
-        Quick
-        Svg
-        WebEngineWidgets
-        Widgets
-        Xml
-      ].each { |mod| system python, "-c", "import PyQt5.Qt#{mod}" }
-    end
+    system "python3", "-c", "import PyQt5"
+    %w[
+      Gui
+      Location
+      Multimedia
+      Network
+      Quick
+      Svg
+      WebEngineWidgets
+      Widgets
+      Xml
+    ].each { |mod| system "python3", "-c", "import PyQt5.Qt#{mod}" }
   end
 end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -3,6 +3,7 @@ class Pyside < Formula
   homepage "https://wiki.qt.io/Qt_for_Python"
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.13.0-src/pyside-setup-everywhere-src-5.13.0.tar.xz"
   sha256 "8e47e778a6c8ee86e9bc7dbf56371cf607e9f3c1a03a7d6df9e34f8dba555782"
+  revision 1
 
   bottle do
     sha256 "33fe98a04017c78cd5bb34f9fc4a2286cbfd8b601e1e3eb90bdba1f844dbdab1" => :mojave
@@ -13,7 +14,6 @@ class Pyside < Formula
   depends_on "cmake" => :build
   depends_on "llvm" => :build
   depends_on "python"
-  depends_on "python@2"
   depends_on "qt"
 
   def install
@@ -37,34 +37,21 @@ class Pyside < Formula
 
     lib.install_symlink Dir.glob(lib/"python#{xy}/site-packages/PySide2/*.dylib")
     lib.install_symlink Dir.glob(lib/"python#{xy}/site-packages/shiboken2/*.dylib")
-
-    system "python2", *Language::Python.setup_install_args(prefix),
-           "--install-lib", lib/"python2.7/site-packages", *args,
-           "--build-type=shiboken2"
-
-    system "python2", *Language::Python.setup_install_args(prefix),
-           "--install-lib", lib/"python2.7/site-packages", *args,
-           "--build-type=pyside2"
-
-    lib.install_symlink Dir.glob(lib/"python2.7/site-packages/PySide2/*.dylib")
-    lib.install_symlink Dir.glob(lib/"python2.7/site-packages/shiboken2/*.dylib")
   end
 
   test do
-    ["python3", "python2"].each do |python|
-      system python, "-c", "import PySide2"
-      %w[
-        Core
-        Gui
-        Location
-        Multimedia
-        Network
-        Quick
-        Svg
-        WebEngineWidgets
-        Widgets
-        Xml
-      ].each { |mod| system python, "-c", "import PySide2.Qt#{mod}" }
-    end
+    system "python3", "-c", "import PySide2"
+    %w[
+      Core
+      Gui
+      Location
+      Multimedia
+      Network
+      Quick
+      Svg
+      WebEngineWidgets
+      Widgets
+      Xml
+    ].each { |mod| system "python3", "-c", "import PySide2.Qt#{mod}" }
   end
 end

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -3,7 +3,7 @@ class Qscintilla2 < Formula
   homepage "https://www.riverbankcomputing.com/software/qscintilla/intro"
   url "https://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.10.4/QScintilla_gpl-2.10.4.tar.gz"
   sha256 "0353e694a67081e2ecdd7c80e1a848cf79a36dbba78b2afa36009482149b022d"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,6 @@ class Qscintilla2 < Formula
 
   depends_on "pyqt"
   depends_on "python"
-  depends_on "python@2"
   depends_on "qt"
   depends_on "sip"
 
@@ -46,23 +45,23 @@ class Qscintilla2 < Formula
     ENV["QMAKEFEATURES"] = prefix/"data/mkspecs/features"
 
     cd "Python" do
-      Language::Python.each_python(build) do |python, version|
-        (share/"sip").mkpath
-        system python, "configure.py", "-o", lib, "-n", include,
-                       "--apidir=#{prefix}/qsci",
-                       "--destdir=#{lib}/python#{version}/site-packages/PyQt5",
-                       "--stubsdir=#{lib}/python#{version}/site-packages/PyQt5",
-                       "--qsci-sipdir=#{share}/sip",
-                       "--qsci-incdir=#{include}",
-                       "--qsci-libdir=#{lib}",
-                       "--pyqt=PyQt5",
-                       "--pyqt-sipdir=#{Formula["pyqt"].opt_share}/sip/Qt5",
-                       "--sip-incdir=#{Formula["sip"].opt_include}",
-                       "--spec=#{spec}"
-        system "make"
-        system "make", "install"
-        system "make", "clean"
-      end
+      (share/"sip").mkpath
+      version = Language::Python.major_minor_version "python3"
+      pydir = "#{lib}/python#{version}/site-packages/PyQt5"
+      system "python3", "configure.py", "-o", lib, "-n", include,
+                        "--apidir=#{prefix}/qsci",
+                        "--destdir=#{pydir}",
+                        "--stubsdir=#{pydir}",
+                        "--qsci-sipdir=#{share}/sip",
+                        "--qsci-incdir=#{include}",
+                        "--qsci-libdir=#{lib}",
+                        "--pyqt=PyQt5",
+                        "--pyqt-sipdir=#{Formula["pyqt"].opt_share}/sip/Qt5",
+                        "--sip-incdir=#{Formula["sip"].opt_include}",
+                        "--spec=#{spec}"
+      system "make"
+      system "make", "install"
+      system "make", "clean"
     end
   end
 
@@ -71,8 +70,7 @@ class Qscintilla2 < Formula
       import PyQt5.Qsci
       assert("QsciLexer" in dir(PyQt5.Qsci))
     EOS
-    Language::Python.each_python(build) do |python, _version|
-      system python, "test.py"
-    end
+
+    system "python3", "test.py"
   end
 end

--- a/Formula/sip.rb
+++ b/Formula/sip.rb
@@ -4,7 +4,7 @@ class Sip < Formula
   url "https://dl.bintray.com/homebrew/mirror/sip-4.19.8.tar.gz"
   mirror "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.19.8/sip-4.19.8.tar.gz"
   sha256 "7eaf7a2ea7d4d38a56dd6d2506574464bddf7cf284c960801679942377c297bc"
-  revision 12
+  revision 13
   head "https://www.riverbankcomputing.com/hg/sip", :using => :hg
 
   bottle do
@@ -15,7 +15,6 @@ class Sip < Formula
   end
 
   depends_on "python"
-  depends_on "python@2"
 
   def install
     ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
@@ -29,18 +28,16 @@ class Sip < Formula
       system "python", "build.py", "prepare"
     end
 
-    ["python2", "python3"].each do |python|
-      version = Language::Python.major_minor_version python
-      system python, "configure.py",
-                     "--deployment-target=#{MacOS.version}",
-                     "--destdir=#{lib}/python#{version}/site-packages",
-                     "--bindir=#{bin}",
-                     "--incdir=#{include}",
-                     "--sipdir=#{HOMEBREW_PREFIX}/share/sip"
-      system "make"
-      system "make", "install"
-      system "make", "clean"
-    end
+    version = Language::Python.major_minor_version "python3"
+    system "python3", "configure.py",
+                      "--deployment-target=#{MacOS.version}",
+                      "--destdir=#{lib}/python#{version}/site-packages",
+                      "--bindir=#{bin}",
+                      "--incdir=#{include}",
+                      "--sipdir=#{HOMEBREW_PREFIX}/share/sip"
+    system "make"
+    system "make", "install"
+    system "make", "clean"
   end
 
   def post_install
@@ -97,12 +94,10 @@ class Sip < Formula
                     "-o", "libtest.dylib", "test.cpp"
     system bin/"sip", "-b", "test.build", "-c", ".", "test.sip"
 
-    ["python2", "python3"].each do |python|
-      version = Language::Python.major_minor_version python
-      ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"
-      system python, "generate.py"
-      system "make", "-j1", "clean", "all"
-      system python, "run.py"
-    end
+    version = Language::Python.major_minor_version "python3"
+    ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"
+    system "python3", "generate.py"
+    system "make", "-j1", "clean", "all"
+    system "python3", "run.py"
   end
 end


### PR DESCRIPTION
These are dual-versioned formulas, shipping support for Python 2 and 3. Nothing in core uses them for their Python 2 bindings, so removing them ahead of the Python 2 EOL.

poke @alebcay @MikeMcQuaid 