### PR TITLE
Migrate more formulas to openssl 1.1 (Q/S)

### DIFF
--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -1,6 +1,7 @@
 class Qca < Formula
   desc "Qt Cryptographic Architecture (QCA)"
   homepage "https://userbase.kde.org/QCA"
+  revision 1
   head "https://anongit.kde.org/qca.git"
 
   stable do
@@ -23,7 +24,7 @@ class Qca < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl" # qca-ossl plugin
+  depends_on "openssl@1.1" # qca-ossl plugin
   depends_on "qt"
 
   def install

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -3,6 +3,7 @@ class QpidProton < Formula
   homepage "https://qpid.apache.org/proton/"
   url "https://www.apache.org/dyn/closer.lua?path=qpid/proton/0.29.0/qpid-proton-0.29.0.tar.gz"
   sha256 "7dfee950e40f3bd89edf1b1d41874fe129ba25ea3068300aa2578ddc67680bef"
+  revision 1
   head "https://gitbox.apache.org/repos/asf/qpid-proton.git"
 
   bottle do
@@ -14,7 +15,7 @@ class QpidProton < Formula
 
   depends_on "cmake" => :build
   depends_on "libuv"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     mkdir "build" do

--- a/Formula/s-nail.rb
+++ b/Formula/s-nail.rb
@@ -3,6 +3,7 @@ class SNail < Formula
   homepage "https://www.sdaoden.eu/code.html"
   url "https://www.sdaoden.eu/downloads/s-nail-14.9.15.tar.gz"
   sha256 "4c4bb1dae0fd6edabf1d268ac6a476de9aab3c15b4bbe2141549a11dbf2bae73"
+  revision 1
 
   bottle do
     sha256 "430e096643d36fb5a237c20e26969cc5d378b843ac9bc7fef327caa9668966d8" => :mojave
@@ -12,12 +13,12 @@ class SNail < Formula
 
   depends_on "awk" => :build
   depends_on "libidn"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "make", "CC=#{ENV.cc}",
-                   "C_INCLUDE_PATH=#{Formula["openssl"].opt_include}",
-                   "LDFLAGS=-L#{Formula["openssl"].opt_lib}",
+                   "C_INCLUDE_PATH=#{Formula["openssl@1.1"].opt_include}",
+                   "LDFLAGS=-L#{Formula["openssl@1.1"].opt_lib}",
                    "VAL_PREFIX=#{prefix}",
                    "OPT_DOTLOCK=no",
                    "config"

--- a/Formula/s2geometry.rb
+++ b/Formula/s2geometry.rb
@@ -3,6 +3,7 @@ class S2geometry < Formula
   homepage "https://github.com/google/s2geometry.git"
   url "https://github.com/google/s2geometry/archive/v0.9.0.tar.gz"
   sha256 "54c09b653f68929e8929bffa60ea568e26f3b4a51e1b1734f5c3c037f1d89062"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class S2geometry < Formula
 
   depends_on "cmake" => :build
   depends_on "glog" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   resource "gtest" do
     url "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
@@ -21,7 +22,7 @@ class S2geometry < Formula
   end
 
   def install
-    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     (buildpath/"gtest").install resource "gtest"
     (buildpath/"gtest/googletest").cd do

--- a/Formula/sagittarius-scheme.rb
+++ b/Formula/sagittarius-scheme.rb
@@ -1,8 +1,8 @@
 class SagittariusScheme < Formula
   desc "Free Scheme implementation supporting R6RS and R7RS"
   homepage "https://bitbucket.org/ktakashi/sagittarius-scheme/wiki/Home"
-  url "https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/sagittarius-0.9.4.tar.gz"
-  sha256 "0a8fd767c19c7d784448b68c03a241ebacba5bbcd177c0cbda0164807d9ef7f2"
+  url "https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/sagittarius-0.9.6.tar.gz"
+  sha256 "b946b168fca70f84d922bcfa2125e2e64ad5fb8cf67e4204deb43dd2dcdedb0e"
 
   bottle do
     cellar :any
@@ -14,7 +14,7 @@ class SagittariusScheme < Formula
   depends_on "cmake" => :build
   depends_on "bdw-gc"
   depends_on "libffi"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/sblim-sfcc.rb
+++ b/Formula/sblim-sfcc.rb
@@ -3,6 +3,7 @@ class SblimSfcc < Formula
   homepage "https://sourceforge.net/projects/sblim/"
   url "https://downloads.sourceforge.net/project/sblim/sblim-sfcc/sblim-sfcc-2.2.8.tar.bz2"
   sha256 "1b8f187583bc6c6b0a63aae0165ca37892a2a3bd4bb0682cd76b56268b42c3d6"
+  revision 1
 
   bottle do
     sha256 "e4f4705965c06672a0143381756c57445df47afb3873eafd1669b338796ba118" => :mojave
@@ -16,7 +17,7 @@ class SblimSfcc < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"

--- a/Formula/scamper.rb
+++ b/Formula/scamper.rb
@@ -3,6 +3,7 @@ class Scamper < Formula
   homepage "https://www.caida.org/tools/measurement/scamper/"
   url "https://www.caida.org/tools/measurement/scamper/code/scamper-cvs-20181219.tar.gz"
   sha256 "fc80a079cd4db85860cf9b11118747bdbd2e33365e9b3456f7cf4403cc8241bc"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,7 +13,7 @@ class Scamper < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/scrypt.rb
+++ b/Formula/scrypt.rb
@@ -3,6 +3,7 @@ class Scrypt < Formula
   homepage "https://www.tarsnap.com/scrypt.html"
   url "https://www.tarsnap.com/scrypt/scrypt-1.2.1.tgz"
   sha256 "4621f5e7da2f802e20850436219370092e9fcda93bd598f6d4236cce33f4c577"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,7 +21,7 @@ class Scrypt < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "autoreconf", "-fvi" if build.head?

--- a/Formula/sdhash.rb
+++ b/Formula/sdhash.rb
@@ -3,7 +3,7 @@ class Sdhash < Formula
   homepage "http://roussev.net/sdhash/sdhash.html"
   url "http://roussev.net/sdhash/releases/packages/sdhash-3.1.tar.gz"
   sha256 "b991d38533d02ae56e0c7aeb230f844e45a39f2867f70fab30002cfa34ba449c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class Sdhash < Formula
     sha256 "bb4951185ede8233e4dccb48fa0da53a812e1af61dac9babbdf41e781b78a1e9" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     inreplace "Makefile" do |s|

--- a/Formula/shairport.rb
+++ b/Formula/shairport.rb
@@ -3,6 +3,7 @@ class Shairport < Formula
   homepage "https://github.com/abrasive/shairport"
   url "https://github.com/abrasive/shairport/archive/1.1.1.tar.gz"
   sha256 "1b60df6d40bab874c1220d7daecd68fcff3e47bda7c6d7f91db0a5b5c43c0c72"
+  revision 1
   head "https://github.com/abrasive/shairport.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Shairport < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure"

--- a/Formula/shellinabox.rb
+++ b/Formula/shellinabox.rb
@@ -16,7 +16,7 @@ class Shellinabox < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/sipsak.rb
+++ b/Formula/sipsak.rb
@@ -3,6 +3,7 @@ class Sipsak < Formula
   homepage "https://github.com/nils-ohlmeier/sipsak/"
   url "https://github.com/nils-ohlmeier/sipsak/releases/download/0.9.7/sipsak-0.9.7.tar.gz"
   sha256 "e07f32e692381d9db404d75868218b553e0aba414d35efc96d13024533a53f0f"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Sipsak < Formula
     sha256 "28b6d28bfdc537cea588ebe947a0e98833c052e0eaac31b2a672d23e121894ce" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.append "CFLAGS", "-std=gnu89"

--- a/Formula/skipfish.rb
+++ b/Formula/skipfish.rb
@@ -13,7 +13,7 @@ class Skipfish < Formula
   end
 
   depends_on "libidn"
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
   depends_on "pcre"
 
   def install

--- a/Formula/slowhttptest.rb
+++ b/Formula/slowhttptest.rb
@@ -15,7 +15,7 @@ class Slowhttptest < Formula
     sha256 "45bad60bd26ee4d81a0888658bbc86890331b76a2e8fa071f63e4da8062599fe" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/slrn.rb
+++ b/Formula/slrn.rb
@@ -3,6 +3,7 @@ class Slrn < Formula
   homepage "https://slrn.sourceforge.io/"
   url "https://jedsoft.org/releases/slrn/slrn-1.0.3a.tar.bz2"
   sha256 "3ba8a4d549201640f2b82d53fb1bec1250f908052a7983f0061c983c634c2dac"
+  revision 1
   head "git://git.jedsoft.org/git/slrn.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Slrn < Formula
     sha256 "06d71ffeb008854c63eeadf6f45633cf692e648490cb20c2ba5f3229cc3dc808" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "s-lang"
 
   def install
@@ -23,7 +24,7 @@ class Slrn < Formula
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
                           "--with-slrnpull=#{var}/spool/news/slrnpull",
                           "--with-slang=#{HOMEBREW_PREFIX}"
     system "make", "all", "slrnpull"

--- a/Formula/sngrep.rb
+++ b/Formula/sngrep.rb
@@ -3,6 +3,7 @@ class Sngrep < Formula
   homepage "https://github.com/irontec/sngrep"
   url "https://github.com/irontec/sngrep/archive/v1.4.6.tar.gz"
   sha256 "638d6557dc68db401b07d73b2e7f8276800281f021fe0c942992566d6b59a48a"
+  revision 1
 
   bottle do
     sha256 "3715ca732df699b3165f4410cc4939e7d13502204b76ae31e6d31acd29efcd91" => :mojave
@@ -13,7 +14,7 @@ class Sngrep < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./bootstrap.sh"
@@ -21,7 +22,7 @@ class Sngrep < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/snownews.rb
+++ b/Formula/snownews.rb
@@ -12,7 +12,7 @@ class Snownews < Formula
   end
 
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     # Fix file not found errors for /usr/lib/system/libsystem_symptoms.dylib and

--- a/Formula/softhsm.rb
+++ b/Formula/softhsm.rb
@@ -3,6 +3,7 @@ class Softhsm < Formula
   homepage "https://www.opendnssec.org/softhsm/"
   url "https://dist.opendnssec.org/source/softhsm-2.5.0.tar.gz"
   sha256 "92aa56cf45e25892326e98b851c44de9cac8559e208720e579bf8e2cd1c132b2"
+  revision 1
 
   bottle do
     sha256 "08706b58638ef1705eb815a68e98d1a7cb84881b947dec37fbcfedf3ed7e33c6" => :mojave
@@ -10,7 +11,7 @@ class Softhsm < Formula
     sha256 "5e69215d66ff6210d6c100e673194140c45d356bd810f5061d6e123cbba9a63c" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -19,7 +20,8 @@ class Softhsm < Formula
                           "--sysconfdir=#{etc}/softhsm",
                           "--localstatedir=#{var}",
                           "--with-crypto-backend=openssl",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--disable-gost"
     system "make", "install"
   end
 

--- a/Formula/spiped.rb
+++ b/Formula/spiped.rb
@@ -3,6 +3,7 @@ class Spiped < Formula
   homepage "https://www.tarsnap.com/spiped.html"
   url "https://www.tarsnap.com/spiped/spiped-1.6.0.tgz"
   sha256 "e6f7f8f912172c3ad55638af8346ae7c4ecaa92aed6d3fb60f2bda4359cba1e4"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,7 @@ class Spiped < Formula
   end
 
   depends_on "bsdmake" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     man1.mkpath

--- a/Formula/squid.rb
+++ b/Formula/squid.rb
@@ -3,6 +3,7 @@ class Squid < Formula
   homepage "http://www.squid-cache.org/"
   url "http://www.squid-cache.org/Versions/v4/squid-4.8.tar.xz"
   sha256 "78cdb324d93341d36d09d5f791060f6e8aaa5ff3179f7c949cd910d023a86210"
+  revision 1
 
   bottle do
     sha256 "ac56304ff9094551025952da4883eb7ea48ec4be7eb6cd6baa1033ad5b464587" => :mojave
@@ -18,7 +19,7 @@ class Squid < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # https://stackoverflow.com/questions/20910109/building-squid-cache-on-os-x-mavericks
@@ -37,7 +38,7 @@ class Squid < Formula
       --disable-eui
       --enable-pf-transparent
       --with-included-ltdl
-      --with-openssl
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --enable-delay-pools
       --enable-disk-io=yes
       --enable-removal-policies=yes

--- a/Formula/ssldump.rb
+++ b/Formula/ssldump.rb
@@ -3,6 +3,7 @@ class Ssldump < Formula
   homepage "https://ssldump.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
   sha256 "6422c16718d27c270bbcfcc1272c4f9bd3c0799c351f1d6dd54fdc162afdab1e"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,7 @@ class Ssldump < Formula
     sha256 "61b20e42893e904872f075064323366aa29e05fc3bab4a2d09265e6e05189532" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # reorder include files
   # https://sourceforge.net/p/ssldump/bugs/40/

--- a/Formula/strongswan.rb
+++ b/Formula/strongswan.rb
@@ -3,6 +3,7 @@ class Strongswan < Formula
   homepage "https://www.strongswan.org"
   url "https://download.strongswan.org/strongswan-5.8.0.tar.bz2"
   sha256 "15b1e10c7dd6253ab5d791fe9b9cb84624e24c118aecd9b90251b4e60daa0933"
+  revision 1
 
   bottle do
     sha256 "b7ecdc25dcb364981e83f6aed2d115f054d61321ebe6c7c61754456fe0744302" => :mojave
@@ -21,7 +22,7 @@ class Strongswan < Formula
     depends_on "pkg-config" => :build
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[

--- a/Formula/stuntman.rb
+++ b/Formula/stuntman.rb
@@ -3,6 +3,7 @@ class Stuntman < Formula
   homepage "http://www.stunprotocol.org/"
   url "http://www.stunprotocol.org/stunserver-1.2.15.tgz"
   sha256 "321f796a7cd4e4e56a0d344a53a6a96d9731df5966816e9b46f3aa6dcc26210f"
+  revision 1
   head "https://github.com/jselbie/stunserver.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Stuntman < Formula
   end
 
   depends_on "boost" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "make"


### PR DESCRIPTION
Formulas beginning with Q and S, that depend on openssl and are not part of more complex dependency chains. Let's see how many build with openssl 1.1