### PR TITLE
Ensure Sphinx uses MySQL 5.7.

### DIFF
--- a/Formula/sphinx.rb
+++ b/Formula/sphinx.rb
@@ -12,7 +12,7 @@ class Sphinx < Formula
     sha256 "848eb3db1c267231d5bff8bd8e6cc5b24fcef37acd977dd9be93c0716c6fdde2" => :sierra
   end
 
-  depends_on "mysql"
+  depends_on "mysql@5.7"
   depends_on "openssl@1.1"
 
   resource "stemmer" do


### PR DESCRIPTION
Sphinx 2.2.11 does not work with MySQL v8 (this support was added in Sphinx v3.1.1, but the source for that release is not open, hence I'm guessing this formula shouldn't change to that?).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
