### PR TITLE
curl: fix SecureTransport configuration

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -32,7 +32,7 @@ class Curl < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-darwinssl
+      --with-secure-transport
       --without-ca-bundle
       --without-ca-path
     ]


### PR DESCRIPTION
curl switched `--with-darwinssl` to `--with-secure-transport` recently, see https://github.com/curl/curl/pull/3619

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit --strict curl` fails with

```
Installing nokogiri 1.10.4 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension
...
```

so I don't know if `brew audit --strict curl` actually works.