### PR TITLE
sonarqube 7.9.1 depends on java 11

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -6,7 +6,7 @@ class Sonarqube < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "11+"
 
   conflicts_with "sonarqube-lts", :because => "both install the same binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As of version 7.9 sonarqube requires Java 11 as a minimum.
See: https://docs.sonarqube.org/7.9/requirements/requirements/