### PR TITLE
mongodb: add caveat about new versions of mongodb

### DIFF
--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -102,6 +102,17 @@ class Mongodb < Formula
   EOS
   end
 
+  def caveats; <<~EOS
+    This is an outdated version of MongoDB and newer versions will not
+    be added to Homebrew as the Server Side Pulic License is not
+    considered an open source license by Homebrew.
+
+    MongoDB maintains an official Homebrew tap with updated versions
+    of that can be found here:
+      https://github.com/mongodb/homebrew-brew
+  EOS
+  end
+
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 
   def plist; <<~EOS

--- a/Formula/mongodb@3.0.rb
+++ b/Formula/mongodb@3.0.rb
@@ -71,6 +71,17 @@ class MongodbAT30 < Formula
   EOS
   end
 
+  def caveats; <<~EOS
+    This is an outdated version of MongoDB and newer versions will not
+    be added to Homebrew as the Server Side Pulic License is not
+    considered an open source license by Homebrew.
+
+    MongoDB maintains an official Homebrew tap with updated versions
+    of that can be found here:
+      https://github.com/mongodb/homebrew-brew
+  EOS
+  end
+
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mongodb@3.0/bin/mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 
   def plist; <<~EOS

--- a/Formula/mongodb@3.2.rb
+++ b/Formula/mongodb@3.2.rb
@@ -80,6 +80,17 @@ class MongodbAT32 < Formula
   EOS
   end
 
+  def caveats; <<~EOS
+    This is an outdated version of MongoDB and newer versions will not
+    be added to Homebrew as the Server Side Pulic License is not
+    considered an open source license by Homebrew.
+
+    MongoDB maintains an official Homebrew tap with updated versions
+    of that can be found here:
+      https://github.com/mongodb/homebrew-brew
+  EOS
+  end
+
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mongodb@3.2/bin/mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 
   def plist; <<~EOS

--- a/Formula/mongodb@3.4.rb
+++ b/Formula/mongodb@3.4.rb
@@ -81,6 +81,17 @@ class MongodbAT34 < Formula
       bindIp: 127.0.0.1
   EOS
   end
+  
+  def caveats; <<~EOS
+    This is an outdated version of MongoDB and newer versions will not
+    be added to Homebrew as the Server Side Pulic License is not
+    considered an open source license by Homebrew.
+
+    MongoDB maintains an official Homebrew tap with updated versions
+    of that can be found here:
+      https://github.com/mongodb/homebrew-brew
+  EOS
+  end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mongodb@3.4/bin/mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 

--- a/Formula/mongodb@3.6.rb
+++ b/Formula/mongodb@3.6.rb
@@ -106,6 +106,17 @@ class MongodbAT36 < Formula
       bindIp: 127.0.0.1
   EOS
   end
+  
+  def caveats; <<~EOS
+    This is an outdated version of MongoDB and newer versions will not
+    be added to Homebrew as the Server Side Pulic License is not
+    considered an open source license by Homebrew.
+
+    MongoDB maintains an official Homebrew tap with updated versions
+    of that can be found here:
+      https://github.com/mongodb/homebrew-brew
+  EOS
+  end
 
   plist_options :manual => "#{HOMEBREW_PREFIX}/opt/mongodb@3.6/bin/mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed [on this discourse thread](https://discourse.brew.sh/t/mongodb-sspl-license/4058/12) this adds a caveat explaning that MongoDB is no longer considered open source by Homebrew and links users to our official Homebrew tap
