### PR TITLE
ctags: Remove caveat wording about installing emacs with options

### DIFF
--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -49,11 +49,6 @@ class Ctags < Formula
       emacs provides an executable `ctags` that would conflict with the
       executable of the same name that ctags provides. To prevent this,
       Homebrew removes the emacs `ctags` and its manpage before linking.
-
-      However, if you install emacs with the `--keep-ctags` option, then
-      the `ctags` emacs provides will not be removed. In that case, you
-      won't be able to install ctags successfully. It will build but not
-      link.
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Options were removed a while ago, so the instructions here (`brew
  install emacs --with-ctags`) no longer work with the `emacs` formula
  here.

EDIT: The documented option is `--keep-ctags`, not `--with-ctags` as I wrote, but neither of them work. :sweat_smile: 