### PR TITLE
Update wtfutil to use appropriate flags

### DIFF
--- a/Formula/wtfutil.rb
+++ b/Formula/wtfutil.rb
@@ -4,6 +4,7 @@ class Wtfutil < Formula
   url "https://github.com/wtfutil/wtf.git",
     :tag      => "v0.21.0",
     :revision => "2612194f464b93dd06c17e299dfef54b8be45471"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -23,12 +24,15 @@ class Wtfutil < Formula
     dir.install buildpath.children
 
     cd dir do
-      system "go", "build", "-o", bin/"wtfutil"
+      commit = `git rev-parse HEAD`.chomp
+      system "go", "build", "-o", "wtfutil", "-ldflags", "-X main.version=#{version} -X main.commit=#{commit}"
+      bin.install "wtfutil"
       prefix.install_metafiles
     end
   end
 
   test do
+    assert_equal version, shell_output("#{bin}/wtfutil -v").strip
     testconfig = testpath/"config.yml"
     testconfig.write <<~EOS
       wtf:

--- a/Formula/wtfutil.rb
+++ b/Formula/wtfutil.rb
@@ -32,7 +32,7 @@ class Wtfutil < Formula
   end
 
   test do
-    assert_equal version, shell_output("#{bin}/wtfutil -v").strip
+    assert_equal version.to_s, shell_output("#{bin}/wtfutil -v").strip
     testconfig = testpath/"config.yml"
     testconfig.write <<~EOS
       wtf:

--- a/Formula/wtfutil.rb
+++ b/Formula/wtfutil.rb
@@ -4,7 +4,6 @@ class Wtfutil < Formula
   url "https://github.com/wtfutil/wtf.git",
     :tag      => "v0.21.0",
     :revision => "2612194f464b93dd06c17e299dfef54b8be45471"
-  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
This sets a few variables in the binary, so that the version flag works.
Previously, would always print `dev` as version.
Now, should print the appropriate version

- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
