### PR TITLE
Migrate more formulas to openssl 1.1

### DIFF
--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -3,6 +3,7 @@ class Asio < Formula
   homepage "https://think-async.com/Asio"
   url "https://downloads.sourceforge.net/project/asio/asio/1.12.2%20%28Stable%29/asio-1.12.2.tar.bz2"
   sha256 "4e27dcb37456ba707570334b91f4798721111ed67b69915685eac141895779aa"
+  revision 1
   head "https://github.com/chriskohlhoff/asio.git"
 
   bottle do
@@ -14,8 +15,7 @@ class Asio < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.cxx11

--- a/Formula/bro.rb
+++ b/Formula/bro.rb
@@ -3,6 +3,7 @@ class Bro < Formula
   homepage "https://www.bro.org"
   url "https://www.bro.org/downloads/bro-2.6.2.tar.gz"
   sha256 "6df6876f3f7b1dd8afeb3d5f88bfb9269f52d5d796258c4414bdd91aa2eac0a6"
+  revision 1
   head "https://github.com/bro/bro.git"
 
   bottle do
@@ -15,11 +16,11 @@ class Bro < Formula
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "geoip"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
                           "--localstatedir=#{var}",
                           "--conf-files-dir=#{etc}"
     system "make", "install"

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -2,7 +2,9 @@ class Clamav < Formula
   desc "Anti-virus software"
   homepage "https://www.clamav.net/"
   url "https://www.clamav.net/downloads/production/clamav-0.101.4.tar.gz"
+  mirror "https://fossies.org/linux/misc/clamav-0.101.4.tar.gz"
   sha256 "0bf094f0919d158a578421d66bc2569c8c8181233ba162bb51722f98c802bccd"
+  revision 1
 
   bottle do
     sha256 "f64dacdcdd643b5b0b1d1cd3ed65da7da2234c8166832d6824732ec8f82ec05a" => :mojave
@@ -20,7 +22,7 @@ class Clamav < Formula
 
   depends_on "pkg-config" => :build
   depends_on "json-c"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "pcre"
   depends_on "yara"
 
@@ -36,7 +38,7 @@ class Clamav < Formula
       --disable-zlib-vcheck
       --enable-llvm=no
       --with-libjson=#{Formula["json-c"].opt_prefix}
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --with-pcre=#{Formula["pcre"].opt_prefix}
       --with-zlib=#{MacOS.sdk_path_if_needed}/usr
     ]

--- a/Formula/gammu.rb
+++ b/Formula/gammu.rb
@@ -3,7 +3,7 @@ class Gammu < Formula
   homepage "https://wammu.eu/gammu/"
   url "https://dl.cihar.com/gammu/releases/gammu-1.40.0.tar.xz"
   sha256 "a760a3520d9f3a16a4ed73cefaabdbd86125bec73c6fa056ca3f0a4be8478dd6"
-  revision 2
+  revision 3
   head "https://github.com/gammu/gammu.git"
 
   bottle do
@@ -14,7 +14,7 @@ class Gammu < Formula
 
   depends_on "cmake" => :build
   depends_on "glib"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Disable opportunistic linking against Postgres

--- a/Formula/globus-toolkit.rb
+++ b/Formula/globus-toolkit.rb
@@ -4,6 +4,7 @@ class GlobusToolkit < Formula
   # Note: Stable distributions have an even minor version number (e.g. 5.0.3)
   url "https://downloads.globus.org/toolkit/gt6/stable/installers/src/globus_toolkit-6.0.1531931206.tar.gz"
   sha256 "ef7b127174016627e1e161a99a95a4558b1c47fc0d368c4c3e84320924f14081"
+  revision 1
 
   bottle do
     sha256 "c9640e4f0b1829702b05fa33971fdc7dca2aa433fd1808c3ebc378b420ad3e45" => :mojave
@@ -14,7 +15,7 @@ class GlobusToolkit < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libtool"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -17,7 +17,7 @@ class ImapUw < Formula
     sha256 "f91d54e0b6f2f5c0ba371e68298dafe178ecd4ac23222dd0de982ba95643ded4" => :mavericks
   end
 
-  depends_on "openssl"
+  depends_on "openssl" # no OpenSSL 1.1 support
 
   def install
     ENV.deparallelize

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -4,7 +4,7 @@ class Ipmitool < Formula
   url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.18/ipmitool-1.8.18.tar.bz2"
   mirror "https://deb.debian.org/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class Ipmitool < Formula
     sha256 "5e9ad832c757416534a30df441ba41f83a4634bb80c224d4e42e7395b58cb9a6" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   # https://sourceforge.net/p/ipmitool/bugs/433/#89ea and
   # https://sourceforge.net/p/ipmitool/bugs/436/ (prematurely closed):
@@ -24,6 +24,13 @@ class Ipmitool < Formula
   patch do
     url "https://gist.githubusercontent.com/adaugherity/87f1466b3c93d5aed205a636169d1c58/raw/29880afac214c1821e34479dad50dca58a0951ef/ipmitool-getpass-segfault.patch"
     sha256 "fc1cff11aa4af974a3be191857baeaf5753d853024923b55c720eac56f424038"
+  end
+
+  # Upstream commit to fix OpenSSL 1.1 compatibility
+  # https://github.com/ipmitool/ipmitool/pull/47
+  patch do
+    url "https://github.com/ipmitool/ipmitool/commit/a8862d75.diff?full_index=1"
+    sha256 "c2c96aa5acdaa6b0fd5efc9fd5f6c6bc5eda55fa5fb9d9deab467cde4c494715"
   end
 
   def install

--- a/Formula/libre.rb
+++ b/Formula/libre.rb
@@ -3,6 +3,7 @@ class Libre < Formula
   homepage "http://www.creytiv.com"
   url "http://www.creytiv.com/pub/re-0.6.0.tar.gz"
   sha256 "0e97bcb5cc8f84d6920aa78de24c7d4bf271c5ddefbb650848e0db50afe98131"
+  revision 1
 
   bottle do
     cellar :any
@@ -11,7 +12,7 @@ class Libre < Formula
     sha256 "290fdbf6dd3a1b2064d00badb610ee1af38d1c070f38a72a54ec5a02ba3b4b2f" => :sierra
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "make", "SYSROOT=#{MacOS.sdk_path}/usr", "install", "PREFIX=#{prefix}"

--- a/Formula/libu2f-server.rb
+++ b/Formula/libu2f-server.rb
@@ -3,7 +3,7 @@ class Libu2fServer < Formula
   homepage "https://developers.yubico.com/libu2f-server/"
   url "https://developers.yubico.com/libu2f-server/Releases/libu2f-server-1.1.0.tar.xz"
   sha256 "8dcd3caeacebef6e36a42462039fd035e45fa85653dcb2013f45e15aad49a277"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -18,7 +18,7 @@ class Libu2fServer < Formula
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
   depends_on "json-c"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV["LIBSSL_LIBS"] = "-lssl -lcrypto -lz"

--- a/Formula/mktorrent.rb
+++ b/Formula/mktorrent.rb
@@ -3,6 +3,7 @@ class Mktorrent < Formula
   homepage "https://mktorrent.sourceforge.io/"
   url "https://github.com/Rudde/mktorrent/archive/v1.1.tar.gz"
   sha256 "d0f47500192605d01b5a2569c605e51ed319f557d24cfcbcb23a26d51d6138c9"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class Mktorrent < Formula
     sha256 "d0f3f1d677e34044abcd712163c01008b56391d665daad15911acd446255c88a" => :yosemite
   end
 
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "make", "USE_PTHREADS=1", "USE_OPENSSL=1", "USE_LONG_OPTIONS=1"

--- a/Formula/nordugrid-arc.rb
+++ b/Formula/nordugrid-arc.rb
@@ -3,7 +3,7 @@ class NordugridArc < Formula
   homepage "http://www.nordugrid.org/"
   url "https://download.nordugrid.org/packages/nordugrid-arc/releases/5.0.2/src/nordugrid-arc-5.0.2.tar.gz"
   sha256 "d7306d91b544eeba571ede341e43760997c46d4ccdacc8b785c64f594780a9d1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "f7f27bc22a9827be21f14f6e492278c948c553a47efcf5cefb5895af4bb05616" => :mojave

--- a/Formula/sofia-sip.rb
+++ b/Formula/sofia-sip.rb
@@ -3,7 +3,7 @@ class SofiaSip < Formula
   homepage "https://sofia-sip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
   sha256 "2b01bc2e1826e00d1f7f57d29a2854b15fd5fe24695e47a14a735d195dd37c81"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class SofiaSip < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -3,7 +3,7 @@ class Zbackup < Formula
   homepage "http://zbackup.org"
   url "https://github.com/zbackup/zbackup/archive/1.4.4.tar.gz"
   sha256 "efccccd2a045da91576c591968374379da1dc4ca2e3dec4d3f8f12628fa29a85"
-  revision 10
+  revision 11
 
   bottle do
     cellar :any
@@ -14,7 +14,7 @@ class Zbackup < Formula
 
   depends_on "cmake" => :build
   depends_on "lzo"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "protobuf"
   depends_on "xz" # get liblzma compression algorithm library from XZutils
 


### PR DESCRIPTION
_Note to self, and others:_

I’ve found that although `glib` technically has `openssl` as a dep (through `python`), it’s not actually linked to it in any way (it uses parts of Python that are unrelated to SSL). This means any recursive dependency to `openssl` through `glib` can actually be ignored, and can help us migrate more formulas independently.

(This is, e.g., the case of `gammu` in this pull request)