### PR TITLE
csound: depend on fluid-synth

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -3,6 +3,7 @@ class Csound < Formula
   homepage "https://csound.com"
   url "https://github.com/csound/csound/archive/6.13.0.tar.gz"
   sha256 "183beeb3b720bfeab6cc8af12fbec0bf9fef2727684ac79289fd12d0dfee728b"
+  revision 1
 
   bottle do
     rebuild 1
@@ -14,6 +15,7 @@ class Csound < Formula
   depends_on "cmake" => :build
   depends_on "python" => [:build, :test]
   depends_on "fltk"
+  depends_on "fluid-synth"
   depends_on "liblo"
   depends_on "libsamplerate"
   depends_on "libsndfile"
@@ -27,7 +29,6 @@ class Csound < Formula
 
   def install
     args = std_cmake_args + %W[
-      -DBUILD_FLUID_OPCODES=OFF
       -DBUILD_JAVA_INTERFACE=OFF
       -DBUILD_LUA_INTERFACE=OFF
       -DBUILD_PYTHON_INTERFACE=OFF
@@ -60,6 +61,7 @@ class Csound < Formula
     (testpath/"test.orc").write <<~EOS
       0dbfs = 1
       FLrun
+      giFluidEngineNumber fluidEngine
       pyinit
       instr 1
           pyruni "from __future__ import print_function; print('hello, world')"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds [fluid-synth](https://github.com/Homebrew/homebrew-core/blob/1550b3a65100564dfce352c5822291362a8bd0ca/Formula/fluid-synth.rb) as a dependency so [Csound’s FluidSynth opcodes](https://csound.com/docs/manual/fluidEngine.html) are usable.