### PR TITLE
mktorrent.rb: Homepage changed

### DIFF
--- a/Formula/mktorrent.rb
+++ b/Formula/mktorrent.rb
@@ -1,6 +1,6 @@
 class Mktorrent < Formula
   desc "Create BitTorrent metainfo files"
-  homepage "https://mktorrent.sourceforge.io/"
+  homepage "https://github.com/Rudde/mktorrent/wiki"
   url "https://github.com/Rudde/mktorrent/archive/v1.1.tar.gz"
   sha256 "d0f47500192605d01b5a2569c605e51ed319f557d24cfcbcb23a26d51d6138c9"
   revision 1


### PR DESCRIPTION
I visited the SourceForge page and got a 404 error. After poking around  github.com/Rudde/mktorrent, the root page of the wiki appears to be the homepagiest page available.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----