### PR TITLE
aravis 0.6.4

### DIFF
--- a/Formula/aravis.rb
+++ b/Formula/aravis.rb
@@ -1,8 +1,8 @@
 class Aravis < Formula
   desc "Vision library for genicam based cameras"
   homepage "https://wiki.gnome.org/Projects/Aravis"
-  url "https://download.gnome.org/sources/aravis/0.6/aravis-0.6.3.tar.xz"
-  sha256 "961ef50d7cacc9306c100e9146164b9a397fe128a12fd7395840d5e937ade026"
+  url "https://download.gnome.org/sources/aravis/0.6/aravis-0.6.4.tar.xz"
+  sha256 "b595a4724da51d0fdb71f2b6e2f1e12f328e423155c3e84607ee2ce704f516bd"
 
   bottle do
     sha256 "f7ec81b740fa25fd7c0fbdf94b8abdadb3afccdda6225b209493d85efdfe3558" => :mojave

--- a/Formula/gst-plugins-good.rb
+++ b/Formula/gst-plugins-good.rb
@@ -1,7 +1,7 @@
 class GstPluginsGood < Formula
   desc "GStreamer plugins (well-supported, under the LGPL)"
   homepage "https://gstreamer.freedesktop.org/"
-  revision 5
+  revision 6
 
   stable do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.16.0.tar.xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

The gst-plugins-good revbump was necessary to fix the following warning when launching the aravis viewer:

```
(arv-viewer:82848): GLib-DEBUG: 16:59:16.670: posix_spawn avoided (fd close requested)

(gst-plugin-scanner:82849): GStreamer-WARNING **: 16:59:16.718: Failed to load plugin '/usr/local/lib/gstreamer-1.0/libgstgtk.so': dlopen(/usr/local/lib/gstreamer-1.0/libgstgtk.so, 2): Library not loaded: /usr/local/opt/gtk+3/lib/libgtk-3.0.dylib
  Referenced from: /usr/local/lib/gstreamer-1.0/libgstgtk.so
  Reason: Incompatible library version: libgstgtk.so requires version 2407.0.0 or later, but libgtk-3.0.dylib provides version 2405.0.0
(arv-viewer:82848): GLib-GIO-DEBUG: 16:59:16.919: _g_io_module_get_default: Found default implementation local (GLocalVfs) for ‘gio-vfs’
(arv-viewer:82848): GLib-DEBUG: 16:59:16.960: posix_spawn avoided (fd close requested)
```

-----