### PR TITLE
Faust 2.15.11 (new formula)

### DIFF
--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,0 +1,26 @@
+class Faust < Formula
+  desc "Functional programming language for real time signal processing"
+  homepage "https://faust.grame.fr"
+  url "https://github.com/grame-cncm/faust/releases/download/2.15.11/faust-2.15.11.tar.gz"
+  sha256 "660816b7fa44da718868d895a82f18f4a441c347bc39afc20a651124f5711d5c"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libmicrohttpd"
+  depends_on "libsndfile"
+  depends_on "llvm"
+
+  def install
+    system "make", "world"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"noise.dsp").write <<~EOS
+      import("stdfaust.lib");
+      process = no.noise;
+    EOS
+
+    system "#{bin}/faust", "noise.dsp"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[Faust](https://github.com/grame-cncm/faust) is a functional programming language for signal processing.

There was an attempt to add this in https://github.com/Homebrew/homebrew-core/pull/16724, but it didn’t pan out.

A couple notes:

* This formula is getting the source tarball from https://github.com/grame-cncm/faust/releases/download/2.15.11/faust-2.15.11.tar.gz instead of the usual https://github.com/grame-cncm/faust/archive/2.15.11.tar.gz because the Faust repository uses a submodule, and this submodule isn’t contained in the usual tarball. Some discussion of this is at https://github.com/grame-cncm/faust/issues/109.

* This formula includes LLVM as a dependency. This is needed because Faust uses `llvm-config`, which I don’t believe is included in macOS’s built-in LLVM.