### PR TITLE
Update profanity.rb

### DIFF
--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -1,10 +1,9 @@
 class Profanity < Formula
   desc "Console based XMPP client"
   homepage "http://www.profanity.im/"
-  url "http://www.profanity.im/profanity-0.6.0.tar.gz"
+  url "https://profanity-im.github.io/profanity-0.7.0.tar.gz"
   # checksum change reported upstream at https://github.com/profanity-im/profanity/issues/1094
-  sha256 "f1b2773b79eb294297686f3913e9489c20effae5e3a335c8956db18f6ee2f660"
-  revision 2
+  sha256 "f1eb99be01683d41b891b0f997f4c873c9bb87b0b6b8400b7fccb8e553d514bb"
 
   bottle do
     sha256 "57d4299cc773dedb5a01221b414e97be579f025f50d8355bc965ae1750f9726b" => :mojave

--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -2,7 +2,6 @@ class Profanity < Formula
   desc "Console based XMPP client"
   homepage "http://www.profanity.im/"
   url "https://profanity-im.github.io/profanity-0.7.0.tar.gz"
-  # checksum change reported upstream at https://github.com/profanity-im/profanity/issues/1094
   sha256 "f1eb99be01683d41b891b0f997f4c873c9bb87b0b6b8400b7fccb8e553d514bb"
 
   bottle do


### PR DESCRIPTION
Update formula for profanity 0.7.0 as homebrew-core formula for profanity is still at 0.6.0

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
yes

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
yes

- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

Not working yet for path/ruby? reasons I have not been able to fix as of yet
```
Error: failed to install the 'bundler' gem.
Error: brew audit failed!
```

- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
WIP

- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
See Above 

-----