### PR TITLE
Routine update of hledger to the latest release

### DIFF
--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -5,8 +5,8 @@ class Hledger < Formula
 
   desc "Command-line accounting tool"
   homepage "https://hledger.org/"
-  url "https://hackage.haskell.org/package/hledger-1.14.2/hledger-1.14.2.tar.gz"
-  sha256 "849a6e0683192ec504da9a631ddfc82e04973583f4a028fd39b8cdac2efe29ea"
+  url "https://hackage.haskell.org/package/hledger-1.15.1/hledger-1.15.1.tar.gz"
+  sha256 "c9be087b72735411554bc058178a4b084a48d5ab2a18bce259c40ead6d331866"
 
   bottle do
     cellar :any_skip_relocation
@@ -20,22 +20,17 @@ class Hledger < Formula
   uses_from_macos "ncurses"
 
   resource "hledger_web" do
-    url "https://hackage.haskell.org/package/hledger-web-1.14.1/hledger-web-1.14.1.tar.gz"
-    sha256 "a1eacde5b9d531df0875b65c8239e8351749610e1e6e46c847dd02594fb6a970"
+    url "https://hackage.haskell.org/package/hledger-web-1.15/hledger-web-1.15.tar.gz"
+    sha256 "837f527c7e611c1f2830a37314076825bd2c8f7364439860fe8a7e1736aaa4d4"
   end
 
   resource "hledger_ui" do
-    url "https://hackage.haskell.org/package/hledger-ui-1.14.2/hledger-ui-1.14.2.tar.gz"
-    sha256 "9951a8665c7a182d8008c92565272a6c4a8e12d363df4b169fa09dddffee112e"
-  end
-
-  resource "hledger_api" do
-    url "https://hackage.haskell.org/package/hledger-api-1.14/hledger-api-1.14.tar.gz"
-    sha256 "ad7a714201cf912a6c756e40a25116e2352b86a81b048599c15f403b2a65f7a3"
+    url "https://hackage.haskell.org/package/hledger-ui-1.15/hledger-ui-1.15.tar.gz"
+    sha256 "38e8c1ad6e7076345914dfc0df3f0801713550fa80343b6130b8dfd363d5fa10"
   end
 
   def install
-    install_cabal_package "hledger", "hledger-web", "hledger-ui", "hledger-api", :using => ["happy", "alex"]
+    install_cabal_package "hledger", "hledger-web", "hledger-ui", :using => ["happy", "alex"]
   end
 
   test do
@@ -43,6 +38,5 @@ class Hledger < Formula
     system "#{bin}/hledger", "test"
     system "#{bin}/hledger-web", "--version"
     system "#{bin}/hledger-ui", "--version"
-    system "#{bin}/hledger-api", "--version"
   end
 end


### PR DESCRIPTION
Update hledger to latest 1.15.1, drop obsolete hledger-api tool.