### PR TITLE
tap_migrations: remove kdiff3

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -19,7 +19,6 @@
   "horndis": "homebrew/cask",
   "inkscape": "homebrew/cask",
   "jsl": "homebrew/cask",
-  "kdiff3": "homebrew/cask",
   "keybase": "homebrew/cask",
   "meld": "homebrew/cask",
   "osxfuse": "homebrew/cask",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`kdiff3` has stopped distributing binaries for newer versions, so it was also removed from HBC. The current messaging tells users to install something that doesn’t exist.