### PR TITLE
Squashfs 4.4

### DIFF
--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -1,9 +1,9 @@
 class Squashfs < Formula
   desc "Compressed read-only file system for Linux"
-  homepage "https://squashfs.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
-  sha256 "0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6"
-  revision 2
+  homepage "https://github.com/plougher/squashfs-tools"
+  url "https://github.com/plougher/squashfs-tools/archive/4.4.tar.gz"
+  sha256 "a7fa4845e9908523c38d4acf92f8a41fdfcd19def41bd5090d7ad767a6dc75c3"
+  head "https://github.com/plougher/squashfs-tools", :using => :git, :commit => "52eb4c279cd283ed9802dd1ceb686560b22ffb67"
 
   bottle do
     cellar :any
@@ -15,35 +15,58 @@ class Squashfs < Formula
   depends_on "lz4"
   depends_on "lzo"
   depends_on "xz"
+  depends_on "zstd"
 
-  # Patch necessary to emulate the sigtimedwait process otherwise we get build failures
+  # Patch necessary to emulate the sigtimedwait process otherwise we get build failures.
   # Also clang fixes, extra endianness knowledge and a bundle of other macOS fixes.
-  # Originally from https://github.com/plougher/squashfs-tools/pull/3
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/05ae0eb1/squashfs/squashfs-osx-bundle.diff"
-    sha256 "276763d01ec675793ddb0ae293fbe82cbf96235ade0258d767b6a225a84bc75f"
+    url "https://github.com/plougher/squashfs-tools/pull/69.patch?full_index=1"
+    sha256 "eb399705d259346473ebe5d43b886b278abc66d822ee4193b7c65b4a2ca903da"
   end
 
   def install
     args = %W[
       EXTRA_CFLAGS=-std=gnu89
+      LZ4_DIR=#{Formula["lz4"].opt_prefix}
       LZ4_SUPPORT=1
-      LZMA_XZ_SUPPORT=1
       LZO_DIR=#{Formula["lzo"].opt_prefix}
       LZO_SUPPORT=1
-      XATTR_SUPPORT=0
       XZ_DIR=#{Formula["xz"].opt_prefix}
       XZ_SUPPORT=1
+      LZMA_XZ_SUPPORT=1
+      ZSTD_DIR=#{Formula["zstd"].opt_prefix}
+      ZSTD_SUPPORT=1
+      XATTR_SUPPORT=1
     ]
 
     cd "squashfs-tools" do
       system "make", *args
       bin.install %w[mksquashfs unsquashfs]
     end
-    doc.install %w[ACKNOWLEDGEMENTS INSTALL OLD-READMEs PERFORMANCE.README README-4.3]
+
+    doc.install %w[README-4.4 RELEASE-READMEs USAGE COPYING]
   end
 
   test do
+    # Check binaries execute
+    assert_match version.to_s, shell_output("#{bin}/mksquashfs -version")
     assert_match version.to_s, shell_output("#{bin}/unsquashfs -v", 1)
+
+    (testpath/"in/test1").write "G'day!"
+    (testpath/"in/test2").write "Bonjour!"
+    (testpath/"in/test3").write "Moien!"
+
+    # Test mksquashfs can make a valid squashimg.
+    #   (Also tests that `xz` support is properly linked.)
+    system "#{bin}/mksquashfs", "in/test1", "in/test2", "in/test3", "test.xz.sqsh", "-quiet", "-comp", "xz"
+    assert_predicate testpath/"test.xz.sqsh", :exist?
+    assert_match "Found a valid SQUASHFS 4:0 superblock on test.xz.sqsh.", shell_output("#{bin}/unsquashfs -s test.xz.sqsh")
+
+    # Test unsquashfs can extract files verbatim.
+    system "#{bin}/unsquashfs", "-d", "out", "test.xz.sqsh"
+    assert_predicate testpath/"out/test1", :exist?
+    assert_predicate testpath/"out/test2", :exist?
+    assert_predicate testpath/"out/test3", :exist?
+    assert shell_output("diff -r in/ out/")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
1. Source has moved from SourceForge to GitHub (latest release on SourceForge is 4 years old).
   The upstream author has released v4.4 on GitHub (plougher/squashfs-tools#54).
   Update homepage, url, head to reflect this.
2. Add patch to work with v4.4: the existing patch works with the SourceForge 4.3 release, but fails to match on the GitHub 4.4 release.
   The existing patch is a long-standing PR (plougher/squashfs-tools#3) onto the 4.3 release. (See https://github.com/plougher/squashfs-tools/compare/ac9504...vasi:mac43).
   The updated patch is a rebase of these commits onto the 4.4 tag, solving conflicts. (See https://github.com/plougher/squashfs-tools/compare/master...blake-riley:mac44).
3. Update doc.install targets (some of the old ones have disappeared).
4. Enable zstd compression (this is a major feature of v4.4, and adding it to the Homebrew formula here addresses the intention of #32818 and #43253).