### PR TITLE
ruby: disable opportunistic linkage to gmp

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -3,7 +3,7 @@ class Ruby < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.xz"
   sha256 "df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "994a7b53cb210d2c8ad9901beb6acec803fab41e9d99ff2814714e5e484a3322" => :mojave
@@ -53,6 +53,7 @@ class Ruby < Formula
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
       --with-opt-dir=#{paths.join(":")}
+      --without-gmp
     ]
     args << "--disable-dtrace" unless MacOS::CLT.installed?
 

--- a/Formula/ruby@2.4.rb
+++ b/Formula/ruby@2.4.rb
@@ -38,6 +38,7 @@ class RubyAT24 < Formula
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
       --with-opt-dir=#{paths.join(":")}
+      --without-gmp
     ]
     args << "--disable-dtrace" unless MacOS::CLT.installed?
 

--- a/Formula/ruby@2.5.rb
+++ b/Formula/ruby@2.5.rb
@@ -38,6 +38,7 @@ class RubyAT25 < Formula
       --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
       --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
       --with-opt-dir=#{paths.join(":")}
+      --without-gmp
     ]
     args << "--disable-dtrace" unless MacOS::CLT.installed?
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This has bit us a number of times; let's just disable `gmp` support explicitly so this doesn't keep happening.

- https://discourse.brew.sh/t/problem-during-update-ruby-libgmp-10-dylib-not-loaded/5636
- https://github.com/Homebrew/homebrew-core/issues/35956
- https://github.com/Homebrew/homebrew-core/issues/36612
- https://github.com/Homebrew/homebrew-core/issues/43839