### PR TITLE
Move rust-built formulas to OpenSSL 1.1

### DIFF
--- a/Formula/badtouch.rb
+++ b/Formula/badtouch.rb
@@ -3,6 +3,7 @@ class Badtouch < Formula
   homepage "https://github.com/kpcyrd/badtouch"
   url "https://github.com/kpcyrd/badtouch/archive/v0.7.0.tar.gz"
   sha256 "d49eb11825ab56245f82f0958a89ea69edf558c1bd142afba2d4408dc9d20fbb"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,12 +13,12 @@ class Badtouch < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     system "cargo", "install", "--root", prefix, "--path", "."
     man1.install "docs/badtouch.1"

--- a/Formula/ffsend.rb
+++ b/Formula/ffsend.rb
@@ -3,6 +3,7 @@ class Ffsend < Formula
   homepage "https://gitlab.com/timvisee/ffsend"
   url "https://github.com/timvisee/ffsend/archive/v0.2.50.tar.gz"
   sha256 "1fe6ea615f116060c9d4147250a3c5774527e98e3dadc089afdec51a0883163e"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,12 +14,12 @@ class Ffsend < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://docs.rs/openssl/0.10.19/openssl/#manual
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     system "cargo", "install", "--root", prefix, "--path", "."
 

--- a/Formula/pijul.rb
+++ b/Formula/pijul.rb
@@ -3,6 +3,7 @@ class Pijul < Formula
   homepage "https://pijul.org"
   url "https://pijul.org/releases/pijul-0.12.0.tar.gz"
   sha256 "987820fa2a6fe92a9f516f5e9b41ad59a597973e72cb0c7a44ca0f38e741a7e6"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,12 +16,12 @@ class Pijul < Formula
   depends_on "rust" => :build
   depends_on "libsodium"
   depends_on "nettle"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     cd "pijul" do
       system "cargo", "install", "--root", prefix, "--path", "."

--- a/Formula/sccache.rb
+++ b/Formula/sccache.rb
@@ -3,6 +3,7 @@ class Sccache < Formula
   homepage "https://github.com/mozilla/sccache"
   url "https://github.com/mozilla/sccache/archive/0.2.10.tar.gz"
   sha256 "e55813d2ca01ebf5704973bb5765a6b3bdf2d6f563be34441a278599579bb5e0"
+  revision 1
   head "https://github.com/mozilla/sccache.git"
 
   bottle do
@@ -13,12 +14,12 @@ class Sccache < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     system "cargo", "install", "--root", prefix, "--path", ".",
                                "--features", "all"

--- a/Formula/ssh-permit-a38.rb
+++ b/Formula/ssh-permit-a38.rb
@@ -3,6 +3,7 @@ class SshPermitA38 < Formula
   homepage "https://github.com/ierror/ssh-permit-a38"
   url "https://github.com/ierror/ssh-permit-a38/archive/v0.2.0.tar.gz"
   sha256 "cb8d94954c0e68eb86e3009d6f067b92464f9c095b6a7754459cfce329576bd9"
+  revision 1
 
   bottle do
     sha256 "79aa6e33c91a8cb2dd5c2f30277bc17b26b877010cf07a49ca212e2882085c2b" => :mojave
@@ -13,12 +14,12 @@ class SshPermitA38 < Formula
 
   depends_on "cmake" => :build
   depends_on "rust" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     system "cargo", "install", "--root", prefix, "--path", "."
   end

--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -3,6 +3,7 @@ class Starship < Formula
   homepage "https://starship.rs"
   url "https://github.com/starship/starship/archive/v0.13.1.tar.gz"
   sha256 "990b0e418224900824179bc6c8fca89566696be79d68b8af191da107b7414f46"
+  revision 1
   head "https://github.com/starship/starship.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Starship < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     system "cargo", "install", "--root", prefix, "--path", "."

--- a/Formula/tectonic.rb
+++ b/Formula/tectonic.rb
@@ -3,7 +3,7 @@ class Tectonic < Formula
   homepage "https://tectonic-typesetting.github.io/"
   url "https://github.com/tectonic-typesetting/tectonic/archive/v0.1.11.tar.gz"
   sha256 "e700dc691dfd092adfe098b716992136343ddfac5eaabb1e8cfae4e63f8454c7"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -20,7 +20,7 @@ class Tectonic < Formula
   depends_on "harfbuzz"
   depends_on "icu4c"
   depends_on "libpng"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
 
   def install
     ENV.cxx11
@@ -28,7 +28,7 @@ class Tectonic < Formula
 
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     system "cargo", "install", "--root", prefix, "--path", "."
   end


### PR DESCRIPTION
After checking, the `rust` dependency on `openssl` is only used to link `cargo`, which means formulas built with `rust` can be used with OpenSSL 1.1, even if `rust` is not.

So here we go…