### PR TITLE
gdcm: set DGDCM_BUILD_APPLICATIONS=ON for cmake

### DIFF
--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -3,6 +3,7 @@ class Gdcm < Formula
   homepage "https://sourceforge.net/projects/gdcm/"
   url "https://github.com/malaterre/GDCM/archive/v3.0.1.tar.gz"
   sha256 "f1ee8ebda7a465281abada329b4dbca6e036a42ead6ad58070ff4f94da7819d9"
+  revision 1
 
   bottle do
     sha256 "02acc5b9d928de052b0a1ea8ce06c0184ad573d86797694f408d83c185d43624" => :mojave
@@ -28,7 +29,7 @@ class Gdcm < Formula
 
     args = std_cmake_args + %W[
       -GNinja
-      -DGDCM_BUILD_APPLICATIONS=OFF
+      -DGDCM_BUILD_APPLICATIONS=ON
       -DGDCM_BUILD_SHARED_LIBS=ON
       -DGDCM_BUILD_TESTING=OFF
       -DGDCM_BUILD_EXAMPLES=OFF


### PR DESCRIPTION
The current Homebrew formula for GDCM does not include command line tool functionality, although this functionality is critical for easy use of GDCM tools. It is notably nontrivial to figure out that this flag is necessary to be set to ON upon installation in order for command line tools to work (for Linux systems, running `apt-get install libgdcm-tools` is all that is necessary to get command line tools to work, but an equivalent does not exist for Macs). 

While it is possible for users to individually `brew edit` the `gdcm.rb` file to change this flag, I believe it should be included in the default installation since many users would expect it to be available anyway, and further may not be familiar with editing Homebrew formulae. 

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
