### PR TITLE
Install VTK Python modules to correct location

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -69,16 +69,6 @@ class Vtk < Formula
               Formula["hdf5"].opt_prefix
   end
 
-  def caveats
-    xy = "#{Formula["python"].version.to_s.slice(/(3\.\d)/) || "3.7"}"
-    <<~EOS
-      In order import vtk using python, it will be necessary to append PYTHONPATH:
-
-         export PYTHONPATH=$PYTHONPATH:#{prefix}/lib/python#{xy}/site-packages
-
-    EOS
-  end
-
   test do
     vtk_include = Dir[opt_include/"vtk-*"].first
     major, minor = vtk_include.match(/.*-(.*)$/)[1].split(".")

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -3,7 +3,7 @@ class Vtk < Formula
   homepage "https://www.vtk.org/"
   url "https://www.vtk.org/files/release/8.2/VTK-8.2.0.tar.gz"
   sha256 "34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb"
-  revision 2
+  revision 3
   head "https://github.com/Kitware/VTK.git"
 
   bottle do
@@ -50,7 +50,7 @@ class Vtk < Formula
       -DPYTHON_EXECUTABLE=#{Formula["python"].opt_bin}/python3
       -DPYTHON_INCLUDE_DIR=#{py_prefix}/include/python#{pyver}m
       -DPYTHON_LIBRARY=#{py_prefix}/lib/libpython#{pyver}.dylib
-      -DVTK_PYTHON_SITE_PACKAGES_SUFFIX=#{lib}/python3/site-packages
+      -DVTK_INSTALL_PYTHON_MODULE_DIR=#{lib}/python#{pyver}/site-packages
       -DVTK_QT_VERSION:STRING=5
       -DVTK_Group_Qt=ON
       -DVTK_WRAP_PYTHON_SIP=ON
@@ -67,6 +67,16 @@ class Vtk < Formula
     inreplace Dir["#{lib}/cmake/**/vtkhdf5.cmake"].first,
               Formula["hdf5"].prefix.realpath,
               Formula["hdf5"].opt_prefix
+  end
+
+  def caveats
+    xy = "#{Formula["python"].version.to_s.slice(/(3\.\d)/) || "3.7"}"
+    <<~EOS
+      In order import vtk using python, it will be necessary to append PYTHONPATH:
+
+         export PYTHONPATH=$PYTHONPATH:#{prefix}/lib/python#{xy}/site-packages
+
+    EOS
   end
 
   test do


### PR DESCRIPTION
Install python site-packages to correct location.
Add caveat to assist the user with environment variables.

Closes #43953

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

The audit is failing at line 73. It does not like the slice command.

-----
