### PR TITLE
add bpm-tag to bpm-tools

### DIFF
--- a/Formula/bpm-tools.rb
+++ b/Formula/bpm-tools.rb
@@ -16,5 +16,6 @@ class BpmTools < Formula
   def install
     system "make"
     bin.install "bpm"
+    bin.install "bpm-tag"
   end
 end


### PR DESCRIPTION
Hello,
I noticed that the bpm-tools formula doesn't install the `bpm-tag` binary despite building it.

I tested this locally and it worked fine :)

```
jojo at jojo-mini in ~/Library/Caches/Homebrew/bpm-tools--git (master)
$ ls
COPYING  Makefile  README  bpm-graph*  bpm-graph.1  bpm-tag*  bpm-tag.1  bpm.1  bpm.c
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
