### PR TITLE
spice-gtk: revision bump

### DIFF
--- a/Formula/spice-gtk.rb
+++ b/Formula/spice-gtk.rb
@@ -3,6 +3,7 @@ class SpiceGtk < Formula
   homepage "https://www.spice-space.org"
   url "https://www.spice-space.org/download/gtk/spice-gtk-0.37.tar.bz2"
   sha256 "1f28b706472ad391cda79a93fd7b4c7a03e84b88fc46ddb35dddbe323c923bb7"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It seems that the current bottle for `spice-gtk` did not pick up the latest gtk+3 (3.24.11). 
On my system, running `brew reinstall --build-from-source spice-gtk` corrects this.
I'm not sure if this pull request is the right way to request a bottle update. Thanks.
