### PR TITLE
wiiuse 0.15.4 (new formula)

### DIFF
--- a/Formula/wiiuse.rb
+++ b/Formula/wiiuse.rb
@@ -1,0 +1,35 @@
+class Wiiuse < Formula
+  desc "Connect Nintendo Wii Remotes"
+  homepage "https://github.com/wiiuse/wiiuse"
+  url "https://github.com/wiiuse/wiiuse/archive/0.15.4.tar.gz"
+  sha256 "45be974acc418b8c8e248d960f3c0da143a513f6404a9c5cc5aa0072934b0cc4"
+
+  depends_on "cmake" => :build
+
+  def install
+    args = std_cmake_args + %w[
+      -DBUILD_EXAMPLE=NO
+      -DBUILD_EXAMPLE_SDL=NO
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <wiiuse.h>
+      int main()
+      {
+        int wiimoteCount = 1;
+        wiimote** wiimotes = wiiuse_init(wiimoteCount);
+        wiiuse_cleanup(wiimotes, wiimoteCount);
+      	return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-l", "wiiuse", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a formula for building a library to connect to Nintendo Wii Remotes.

The description of WiiUse at https://github.com/wiiuse/wiiuse describes it as a “Semi-Official Fork”. The original seems to be at https://sourceforge.net/projects/wiiuse/, but it hasn’t had a new release since 2008.