### PR TITLE
Fix PostGIS installation for Linuxbrew

### DIFF
--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -52,13 +52,13 @@ class Postgis < Formula
     mkdir "stage"
     system "make", "install", "DESTDIR=#{buildpath}/stage"
 
-    bin.install Dir["stage/**/bin/*"]
-    lib.install Dir["stage/**/lib/*"]
+    bin.install Dir["stage/#{HOMEBREW_PREFIX}/**/bin/*"]
+    lib.install Dir["stage/**/lib/*", "stage/#{HOMEBREW_PREFIX}/**/lib/*"]
     include.install Dir["stage/**/include/*"]
-    (doc/"postgresql/extension").install Dir["stage/**/share/doc/postgresql/extension/*"]
-    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
-    pkgshare.install Dir["stage/**/contrib/postgis-*/*"]
-    (share/"postgis_topology").install Dir["stage/**/contrib/postgis_topology-*/*"]
+    (doc/"postgresql/extension").install Dir["stage/#{HOMEBREW_PREFIX}/**/share/doc/postgresql/extension/*"]
+    (share/"postgresql/extension").install Dir["stage/#{HOMEBREW_PREFIX}/**/share/postgresql/extension/*"]
+    pkgshare.install Dir["stage/#{HOMEBREW_PREFIX}/**/contrib/postgis-*/*"]
+    (share/"postgis_topology").install Dir["stage/#{HOMEBREW_PREFIX}/**/contrib/postgis_topology-*/*"]
 
     # Extension scripts
     bin.install %w[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the installation of the PostGIS under Linuxbrew.

Currently, when running `$ brew install postgis` under Linux everything seems to work out fine except no files are copied from the temporary build directory:
```
==> Downloading https://download.osgeo.org/postgis/source/postgis-2.5.3.tar.gz
Already downloaded: /home/sandrasi/.cache/Homebrew/downloads/bb221060ce3d64d32854a7ca9a65cbbe770c0295584e7ac13082343149ced0eb--postgis-2.5.3.tar.gz
==> ./configure --with-projdir=/home/linuxbrew/.linuxbrew/opt/proj --with-jsondir=/home/linuxbrew/.linuxbrew/opt/json-c --with-pgconfig=/home/linuxbrew/.linuxbrew/
==> make
==> make install DESTDIR=/tmp/postgis-20190906-11061-10nmsqm/postgis-2.5.3/stage
Warning: tried to install empty array to /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3/bin
Warning: tried to install empty array to /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3/share/doc/postgis/postgresql/extension
Warning: tried to install empty array to /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3/share/postgresql/extension
Warning: tried to install empty array to /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3/share/postgis
Warning: tried to install empty array to /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3/share/postgis_topology
🍺  /home/linuxbrew/.linuxbrew/Cellar/postgis/2.5.3: 24 files, 3.8MB, built in 43 seconds
```
It is because the PostGIS formula uses Ruby's `Dir` class to find all the files that need to be installed, but that class - as it's currently used in the formula - doesn't match on dotfiles. Linuxbrew, by default, is installed into the _/home/linuxbrew/.linuxbrew_ hidden directory - a directory that has a dot in its name. This path also appears in the temporary build path so when the formula is about to install the built files, `Dir["some/**/path/*"]` silently ignores all of them. This results in an incomplete install and when later trying to install the PostGIS extension into a database the following error occurs:
```
$ psql postgis_test
psql (11.5)
Type "help" for help.

postgis_test=# CREATE EXTENSION postgis;
2019-09-06 23:00:48.149 PDT [29777] ERROR: could not open extension control file "/home/linuxbrew/.linuxbrew/share/postgresql/extension/postgis.control": No such file or directory
```
This PR attempts to fix it by replacing all the `Dir` instances with a custom `dir(pattern)` method that matches on all files - including those whose name contains a dot. It also filters out the current (`.`) and the parent (`..`) directories.

Additional notes:
- A global fix would be preferable, in my opinion, so that hidden directories are never a problem when trying to find files with `Dir`, but I can't say for sure that every single formula could benefit from this. It works for the PostGIS formula, though.
- This is most likely never an issue in Homebrew as on a MacBook it's installed into the _/usr/local_ directory (so no dotfiles are on the path). This fix should not affect the Homebrew installations of PostGIS since the new `dir(pattern)` method returns the regular files the same way as before.
- While this PR fixes the PostGIS installation, as of [this](https://github.com/Homebrew/linuxbrew-core/commit/aaf4e4e5d15b5d2718f8cab5f8007e175292db2c) very recent version upgrade of _Boost_ PostGIS errors out with a different runtime error (it works with Boost 1.70.0).

For more details see: https://github.com/Homebrew/linuxbrew-core/issues/15275