### PR TITLE
bind: build without lmdb explicitly

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -48,7 +48,8 @@ class Bind < Formula
                           "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
                           "--with-libjson=#{Formula["json-c"].opt_prefix}",
                           "--with-python=#{Formula["python"].opt_bin}/python3",
-                          "--with-python-install-dir=#{vendor_site_packages}"
+                          "--with-python-install-dir=#{vendor_site_packages}",
+                          "--without-lmdb"
 
     system "make"
     system "make", "install"


### PR DESCRIPTION
lmdb is required by command dig

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix the dependency missing err when `dig` is used.

```
$ dig @127.0.0.1 -p 5355 github.com
dyld: Library not loaded: /usr/local/opt/lmdb/lib/liblmdb.dylib
  Referenced from: /usr/local/bin/dig
  Reason: image not found
Abort trap: 6
```
