### PR TITLE
curl-openssl: build without libpsl explicitly

### DIFF
--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -41,8 +41,8 @@ class CurlOpenssl < Formula
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-ares=#{Formula["c-ares"].opt_prefix}
-      --with-ca-bundle=#{etc}/openssl/cert.pem
-      --with-ca-path=#{etc}/openssl/certs
+      --with-ca-bundle=#{etc}/openssl@1.1/cert.pem
+      --with-ca-path=#{etc}/openssl@1.1/certs
       --with-gssapi
       --with-libidn2
       --with-libmetalink

--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -49,6 +49,7 @@ class CurlOpenssl < Formula
       --with-librtmp
       --with-libssh2
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --without-libpsl
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix the installation err of `php`.

```
==> Downloading from https://akamai.bintray.com/8f/8f77f9e4c05467a0464d41ecb5c47f4bd135ac95f320d59426710088615c9bc5?__gda__=exp=1568023321~hmac=b83444dfead07d17aa785aec1901
######################################################################## 100.0%
==> Pouring php-7.3.9_1.high_sierra.bottle.tar.gz
==> /usr/local/Cellar/php/7.3.9_1/bin/pear config-set php_ini /usr/local/etc/php/7.3/php.ini system
Last 15 lines from /Users/wyh/Library/Logs/Homebrew/php/post_install.01.pear:
2019-09-09 17:50:14 +0800

/usr/local/Cellar/php/7.3.9_1/bin/pear
config-set
php_ini
/usr/local/etc/php/7.3/php.ini
system

dyld: Library not loaded: /usr/local/opt/libpsl/lib/libpsl.5.dylib
  Referenced from: /usr/local/opt/curl-openssl/lib/libcurl.4.dylib
  Reason: image not found
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall php`
```
