### PR TITLE
adguard-home v0.98.1 (new formula)

### DIFF
--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -10,8 +10,8 @@ class AdguardHome < Formula
   depends_on "node" => :build
 
   resource "packr" do
-    url "https://github.com/gobuffalo/packr/archive/v2.0.1.tar.gz"
-    sha256 "cc0488e99faeda4cf56631666175335e1cce021746972ce84b8a3083aa88622f"
+    url "https://github.com/gobuffalo/packr/archive/v2.7.1.tar.gz"
+    sha256 "842bc86dfb34c1ff8d1cc1c12fb46cf30ad279eec17ecef8b122c151cfc16b85"
   end
 
   def install

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -93,7 +93,15 @@ class AdguardHome < Formula
       EOS
 
       pid = fork do
-        exec bin/"AdGuardHome", "-w", "#{testpath}", "-c", "#{testpath}/AdGuardHome.yaml", "--pidfile", "#{testpath}/httpd.pid"
+        exec(
+          bin/"AdGuardHome",
+          "-w",
+          "#{testpath}",
+          "-c",
+          "#{testpath}/AdGuardHome.yaml",
+          "--pidfile",
+          "#{testpath}/httpd.pid",
+        )
       end
       sleep 3
 

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -35,21 +35,6 @@ class AdguardHome < Formula
     end
   end
 
-  def caveats; <<~EOS
-    On the first run, you have to go through the initial configuration
-    wizard. Open your web browser and go to:
-      http://127.0.0.1:3000
-
-    After starting and configuring AdGuardHome, you will need to point your
-    local DNS server to 127.0.0.1. You can do this by going to
-    System Preferences > "Network" and clicking the "Advanced..."
-    button for your interface. You will see a "DNS" tab where you
-    can click "+" and enter 127.0.0.1 in the "DNS Servers" section.
-    By default, AdGuardHome runs on localhost (127.0.0.1), port 53,
-    balancing traffic across a set of resolvers.
-  EOS
-  end
-
   plist_options :startup => true
 
   def plist; <<~EOS

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -9,11 +9,6 @@ class AdguardHome < Formula
   depends_on "go" => :build
   depends_on "node" => :build
 
-  resource "packr" do
-    url "https://github.com/gobuffalo/packr/archive/v2.7.1.tar.gz"
-    sha256 "842bc86dfb34c1ff8d1cc1c12fb46cf30ad279eec17ecef8b122c151cfc16b85"
-  end
-
   def install
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
@@ -22,8 +17,6 @@ class AdguardHome < Formula
 
     dir = buildpath/"src/github.com/AdguardTeam/AdGuardHome"
     dir.install buildpath.children
-
-    resource("packr").stage { system "go", "install", "./packr" }
 
     cd dir do
       system "make"

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -1,8 +1,9 @@
 class AdguardHome < Formula
   desc "Network-wide ads & trackers blocking DNS server"
   homepage "https://adguard.com/adguard-home.html"
-  url "https://github.com/AdguardTeam/AdGuardHome/archive/v0.98.1.tar.gz"
-  sha256 "37779d659bb9faa1b2273f70aba4db14a77b4467888953d055547f28e8afa707"
+  url "https://github.com/AdguardTeam/AdGuardHome.git",
+      :tag      => "v0.98.1",
+      :revision => "64d40bdc47081ed80e597e61e5c96953c1e35c30"
   head "https://github.com/AdguardTeam/AdGuardHome.git", :using => :git
 
   depends_on "go" => :build
@@ -23,11 +24,7 @@ class AdguardHome < Formula
     resource("packr").stage { system "go", "install", "./packr" }
 
     cd dir do
-      system "npm", "--prefix", "client", "install"
-      system "npm", "--prefix", "client", "run", "build-prod"
-
-      system buildpath/"bin/packr", "-z"
-      system "go", "build", "-ldflags", "-s -w -X main.version=#{version}"
+      system "make"
       bin.install "AdGuardHome"
 
       (etc/"adguard-home").mkpath

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -96,7 +96,7 @@ class AdguardHome < Formula
         exec(
           bin/"AdGuardHome",
           "-w",
-          "#{testpath}",
+        testpath.to_s,
           "-c",
           "#{testpath}/AdGuardHome.yaml",
           "--pidfile",

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -106,7 +106,8 @@ class AdguardHome < Formula
       sleep 3
 
       shell_output("dig @127.0.0.1 -p #{dns_port} google.com NS +short")
-      .lines.each { |ns| assert_match expected_output_re, ns }
+      .lines
+      .each { |ns| assert_match expected_output_re, ns }
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -105,9 +105,8 @@ class AdguardHome < Formula
       end
       sleep 3
 
-      assert_block do
-        shell_output("dig @127.0.0.1 -p #{dns_port} google.com NS +short").split("\n").all? { |ns| ns =~ expected_output_re }
-      end
+      shell_output("dig @127.0.0.1 -p #{dns_port} google.com NS +short")
+      .lines.each { |ns| assert_match expected_output_re, ns }
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -59,9 +59,9 @@ class AdguardHome < Formula
         <key>UserName</key>
         <string>root</string>
         <key>StandardErrorPath</key>
-        <string>/dev/null</string>
+        <string>#{var}/log/adguard-home.log</string>
         <key>StandardOutPath</key>
-        <string>/dev/null</string>
+        <string>#{var}/log/consul.log</string>
       </dict>
     </plist>
   EOS

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -7,7 +7,7 @@ class AdguardHome < Formula
   head "https://github.com/AdguardTeam/AdGuardHome.git", :using => :git
 
   depends_on "go" => :build
-  depends_on "node@8" => :build
+  depends_on "node" => :build
 
   resource "packr" do
     url "https://github.com/gobuffalo/packr/archive/v2.0.1.tar.gz"
@@ -17,6 +17,8 @@ class AdguardHome < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
+
+    ENV.append_path "PATH", HOMEBREW_PREFIX/"bin"
 
     dir = buildpath/"src/github.com/AdguardTeam/AdGuardHome"
     dir.install buildpath.children

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -95,7 +95,7 @@ class AdguardHome < Formula
       dns_port = server.addr[1]
       server.close
 
-      expected_output_re = /ns\d{1,}\.google\.com\./
+      expected_output_re = /ns\d+\.google\.com\./
 
       (testpath/"AdGuardHome.yaml").write <<~EOS
         bind_host: localhost

--- a/Formula/adguard-home.rb
+++ b/Formula/adguard-home.rb
@@ -1,0 +1,90 @@
+class AdguardHome < Formula
+  desc "Network-wide ads & trackers blocking DNS server"
+  homepage "https://adguard.com/adguard-home.html"
+  url "https://github.com/AdguardTeam/AdGuardHome/archive/v0.98.1.tar.gz"
+  sha256 "37779d659bb9faa1b2273f70aba4db14a77b4467888953d055547f28e8afa707"
+  head "https://github.com/AdguardTeam/AdGuardHome.git", :using => :git
+
+  depends_on "go" => :build
+  depends_on "node@8" => :build
+
+  resource "packr" do
+    url "https://github.com/gobuffalo/packr/archive/v2.0.1.tar.gz"
+    sha256 "cc0488e99faeda4cf56631666175335e1cce021746972ce84b8a3083aa88622f"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["CGO_ENABLED"] = "0"
+
+    dir = buildpath/"src/github.com/AdguardTeam/AdGuardHome"
+    dir.install buildpath.children
+
+    resource("packr").stage { system "go", "install", "./packr" }
+
+    cd dir do
+      system "npm", "--prefix", "client", "install"
+      system "npm", "--prefix", "client", "run", "build-prod"
+
+      system buildpath/"bin/packr", "-z"
+      system "go", "build", "-ldflags", "-s -w -X main.version=#{version}"
+      bin.install "AdGuardHome"
+
+      (etc/"adguard-home").mkpath
+      prefix.install_metafiles
+    end
+  end
+
+  def caveats; <<~EOS
+    On the first run, you have to go through the initial configuration
+    wizard. Open your web browser and go to:
+      http://127.0.0.1:3000
+
+    After starting and configuring AdGuardHome, you will need to point your
+    local DNS server to 127.0.0.1. You can do this by going to
+    System Preferences > "Network" and clicking the "Advanced..."
+    button for your interface. You will see a "DNS" tab where you
+    can click "+" and enter 127.0.0.1 in the "DNS Servers" section.
+    By default, AdGuardHome runs on localhost (127.0.0.1), port 53,
+    balancing traffic across a set of resolvers.
+  EOS
+  end
+
+  plist_options :startup => true
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>KeepAlive</key>
+        <true/>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{bin}/AdGuardHome</string>
+          <string>-c</string>
+          <string>#{etc}/adguard-home/AdGuardHome.yaml</string>
+          <string>-w</string>
+          <string>#{etc}/adguard-home</string>
+          <string>--no-check-update</string>
+        </array>
+        <key>UserName</key>
+        <string>root</string>
+        <key>StandardErrorPath</key>
+        <string>/dev/null</string>
+        <key>StandardOutPath</key>
+        <string>/dev/null</string>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    output = shell_output("echo \"no\" | #{bin}/AdGuardHome 2>&1", 1)
+    assert_match "AdGuard Home, version #{version}, channel release", output
+  end
+end


### PR DESCRIPTION
Formula for [AdGuardHome](https://github.com/AdguardTeam/AdGuardHome) ads & trackers blocking DNS server. It's like a Pi-hole with some extras.

Disclaimer: I'm not related to the AdGuard Team in any way.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
