### PR TITLE
[Subversion] Depends on libmagic

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -34,6 +34,7 @@ class Subversion < Formula
   depends_on "perl"
   depends_on "sqlite"
   depends_on "utf8proc"
+  depends_on "libmagic"
 
   resource "serf" do
     url "https://www.apache.org/dyn/closer.cgi?path=serf/serf-1.3.9.tar.bz2"

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -25,6 +25,7 @@ class Subversion < Formula
   depends_on "swig@3" => :build # https://issues.apache.org/jira/browse/SVN-4818
   depends_on "apr"
   depends_on "apr-util"
+  depends_on "libmagic"
 
   # build against Homebrew versions of
   # gettext, lz4, perl, sqlite and utf8proc for consistency
@@ -34,7 +35,6 @@ class Subversion < Formula
   depends_on "perl"
   depends_on "sqlite"
   depends_on "utf8proc"
-  depends_on "libmagic"
 
   resource "serf" do
     url "https://www.apache.org/dyn/closer.cgi?path=serf/serf-1.3.9.tar.bz2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

After last update, Subversion is broken due to missing dependency, libmagic. After install that, it works great like before.

```
==> Summary
🍺  /usr/local/Cellar/subversion/1.12.2_1: 265 files, 36.2MB
➜  Code svn
dyld: Library not loaded: /usr/local/opt/libmagic/lib/libmagic.1.dylib
  Referenced from: /usr/local/bin/svn
  Reason: image not found
fish: 'svn' terminated by signal SIGABRT (Abort)
➜  Code brew install libmagic
==> Downloading https://homebrew.bintray.com/bottles/libmagic-5.37.mojave.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/d4/d4bef4ec5fd234cd4fdc0650d7a2dba51fa9e5d421669db9fa8d2d466e20c98c?__gd
######################################################################## 100.0%
==> Pouring libmagic-5.37.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libmagic/5.37: 315 files, 6.7MB
➜  Code svn
Entrer 'svn help' pour l'aide.
```
