### PR TITLE
mercurial: move back to Python 2

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -5,7 +5,7 @@ class Mercurial < Formula
   homepage "https://mercurial-scm.org/"
   url "https://www.mercurial-scm.org/release/mercurial-5.1.1.tar.gz"
   sha256 "35fc8ba5e0379c1b3affa2757e83fb0509e8ac314cbd9f1fd133cf265d16e49f"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "5210f4a25ed713ea61c85dd969b3847cbfc39e5be6f69ecc2dae7b3f23272f10" => :mojave
@@ -13,12 +13,12 @@ class Mercurial < Formula
     sha256 "ee5a63ff8d2d121bdb69c56bddf49c2ec9cb08ae0d04f1043aec010e647261e6" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@2"
 
   def install
-    ENV["HGPYTHON3"] = "1"
+    ENV.prepend_path "PATH", Formula["python@2"].opt_libexec/"bin"
 
-    system "make", "PREFIX=#{prefix}", "PYTHON=python3", "install-bin"
+    system "make", "PREFIX=#{prefix}", "install-bin"
 
     # Install chg (see https://www.mercurial-scm.org/wiki/CHg)
     cd "contrib/chg" do


### PR DESCRIPTION
In https://github.com/Homebrew/homebrew-core/pull/44047 I moved `mercurial` to use Python 3. Some users requested it to move back to Python 2 for now, so this PR is opened to discuss the pros and cons, and gather other maintainers' opinion.

**Arguments for Python 2**
- Mercurial 5.0 [release notes](https://www.mercurial-scm.org/wiki/Release5.0) state: _“Mercurial 5.0 has beta level support for running on Python 3”_ and _“ If you package Mercurial or distribute it to users, we do not recommend making Python 3 the default at this time”_.
- It's not, however, clear if the above still applies to version 5.1.
- While mercurial itself works in Python 3, reports indicate many extensions do not: https://github.com/Homebrew/homebrew-core/pull/44047

**Arguments for Python 3**
- _“It is the project policy for Mercurial and its core extensions to be compatible with Python 3. Over 99% of tests pass with Python 3 and test regressions are treated seriously.”_ (https://www.mercurial-scm.org/wiki/Python3)
- Python 2 EOL is scheduled for 2019-12-31, so mercurial *will* have to move anyway.
- Upstream does not provide a clear schedule for migration or dropping Python 2 support, so it's not clear when they expect distributors to make the switch.

@Homebrew/core what do you think?