### PR TITLE
Fix boost cmake setup

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -46,6 +46,7 @@ class Boost < Formula
       -d2
       -j#{ENV.make_jobs}
       --layout=tagged-1.66
+      --no-cmake-config
       --user-config=user-config.jam
       -sNO_LZMA=1
       -sNO_ZSTD=1


### PR DESCRIPTION
Bring back `--no-cmake-setup` configuration flag in order
to fix setup inconsistencies.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    (Having setup issues with ruby `2.3` vs `2.6`, can debug this later)

Fixes #44093 