### PR TITLE
mongo-c-driver 1.15.1

### DIFF
--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -1,8 +1,8 @@
 class MongoCDriver < Formula
   desc "C driver for MongoDB"
   homepage "https://github.com/mongodb/mongo-c-driver"
-  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.14.0/mongo-c-driver-1.14.0.tar.gz"
-  sha256 "ebe9694f7fa6477e594f19507877bbaa0b72747682541cf0cf9a6c29187e97e8"
+  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.15.1/mongo-c-driver-1.15.1.tar.gz"
+  sha256 "4ee47c146ff0059d15ab547a0c2a87f7113f063e1c625e51f8c5174853b07765"
   head "https://github.com/mongodb/mongo-c-driver.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Unrelated note: bumping the version using `brew-formula-pr` did not work:
```
$ brew bump-formula-pr --url https://github.com/mongodb/mongo-c-driver/releases/download/1.15.1/mongo-c-driver-1.15.1.tar.gz --sha256 4ee47c146ff0059d15ab547a0c2a87f7113f063e1c625e51f8c5174853b07765
######################################################################## 100.0%
Error: mongo-c-driver-1.15.1.tar.gz: /Users/alcaeus/Library/Caches/Homebrew/Formula/mongo-c-driver-1.15.1.tar.gz:1: Invalid char `\x1F' in expression
/Users/alcaeus/Library/Caches/Homebrew/Formula/mongo-c-driver-1.15.1.tar.gz:1: invalid multibyte char (UTF-8)
```

I'm not sure if that's an error with `brew-formula-pr`, my local setup, or the binary package. I can create an issue if that's more appropriate, just thought I'd point it out. Updating manually worked just fine (see checklist above).