### PR TITLE
Fixes kubeseal wasn't reporting it's version

### DIFF
--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -5,6 +5,7 @@ class Kubeseal < Formula
       :tag      => "v0.8.3",
       :revision => "ec80fcecfe8b29cb13535c242337d79b18a14072"
   revision 1
+  sha256 "753f9084a0bf5dfccfe84dff036e87b899a3be921c1d33a497a4b44ac582f00d"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -4,8 +4,8 @@ class Kubeseal < Formula
   url "https://github.com/bitnami-labs/sealed-secrets.git",
       :tag      => "v0.8.3",
       :revision => "ec80fcecfe8b29cb13535c242337d79b18a14072"
-  revision 1
   sha256 "753f9084a0bf5dfccfe84dff036e87b899a3be921c1d33a497a4b44ac582f00d"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -1,8 +1,10 @@
 class Kubeseal < Formula
   desc "Kubernetes controller and tool for one-way encrypted Secrets"
   homepage "https://github.com/bitnami-labs/sealed-secrets"
-  url "https://github.com/bitnami-labs/sealed-secrets/archive/v0.8.3.tar.gz"
-  sha256 "753f9084a0bf5dfccfe84dff036e87b899a3be921c1d33a497a4b44ac582f00d"
+  url "https://github.com/bitnami-labs/sealed-secrets.git",
+      :tag      => "v0.8.3",
+      :revision => "ec80fcecfe8b29cb13535c242337d79b18a14072"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,14 +16,18 @@ class Kubeseal < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    kubesealpath = buildpath/"src/github.com/bitnami-labs/sealed-secrets"
-    kubesealpath.install Dir["*"]
-    system "make", "-C", kubesealpath, "kubeseal"
-    bin.install kubesealpath/"kubeseal"
+    cd buildpath do
+      system "make", "kubeseal"
+      bin.install "kubeseal"
+    end
   end
 
   test do
+    # ensure build reports the (git tag) version
+    output = shell_output("#{bin}/kubeseal --version")
+    assert_equal "kubeseal version: v0.8.3", output.strip
+
+    # ensure kubeseal can seal secrets
     secretyaml = [
       "apiVersion: v1",
       "kind: Secret",


### PR DESCRIPTION
Until now the binary produced by this formula didn't output correctly
the version :

    ~ brew install kubeseal
    ==> Installing kubeseal
    ==> Downloading https://homebrew.bintray.com/bottles/kubeseal-0.8.3.mojave.bottle.tar.gz
    Already downloaded: /Users/bric3/Library/Caches/Homebrew/downloads/84c2991367c12e749d7193133fed0cf15b8a8d6458f109f2d0f14f9f9acae47c--kubeseal-0.8.3.mojave.bottle.tar.gz
    ==> Pouring kubeseal-0.8.3.mojave.bottle.tar.gz
    🍺  /usr/local/Cellar/kubeseal/0.8.3: 3 files, 32MB

    ~ kubeseal --version
    kubeseal version:

Compared to the original kubeseal binary

    ~ wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.8.3/kubeseal-darwin-amd64 -O kubeseal
    ~ chmod +x kubeseal
    ~ ./kubeseal --version
    kubeseal version: v0.8.3


This is caused by two problems :

- The program was built from a git archive,
  unfortunatley the makefile uses git tags to compute a version

  https://github.com/bitnami-labs/sealed-secrets/blob/v0.8.3/Makefile#L24-L38
  ```
  COMMIT = $(shell git rev-parse HEAD)
  TAG = $(shell git describe --exact-match --abbrev=0 --tags '$(COMMIT)' 2> /dev/null || true)
  DIRTY = $(shell git diff --shortstat 2> /dev/null | tail -n1)

  # Use a tag if set, otherwise use the commit hash
  ifeq ($(TAG),)
  VERSION := $(COMMIT)
  else
  VERSION := $(TAG)
  endif

  # Check for changed files
  ifneq ($(DIRTY),)
  VERSION := $(VERSION)+dirty
  endif
  ```

  This is fixed changing the url to a git url and specifying the
  revision and tag.

- The build/install directive perform some changes in the files
  which cause the version to be _dirty_:

      ENV["GOPATH"] = buildpath
      kubesealpath = buildpath/"src/github.com/bitnami-labs/sealed-secrets"
      kubesealpath.install Dir["*"]
      system "make", "-C", kubesealpath, "kubeseal"
      bin.install kubesealpath/"kubeseal"

      results in this command (visible via `brew install --verbose kubeseal`)

      go build -o kubeseal -mod=vendor -ldflags "-X main.VERSION=v0.8.3+dirty" ./cmd/kubeseal

  This is fixed by using the `make` command directly, from within the
  right folder, just as other formula appears to be doing.

This commit also adds a test to make sure the version is right
(`kubeseal version: v0.8.3`) so this issue doesn't happen again.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The audit reports this problem, but I'm not sure how to fix the issue :

```
brew audit --strict kubeseal
kubeseal:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 1 problem in 1 formula detected
```
