### PR TITLE
k3d: match upstream version syntax

### DIFF
--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -14,7 +14,7 @@ class K3d < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "BINDIR='#{bin}'", "GIT_TAG='#{version}'", "build"
+    system "make", "BINDIR='#{bin}'", "GIT_TAG='v#{version}'", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I am automating the install of `k3d` on different systems by checking the version reported by `k3d --version`. The version reported by the formula differs from that reported by the upstream release.

The upstream binary version is `v1.3.1`:
```
➜ curl -LOs 'https://github.com/rancher/k3d/releases/download/v1.3.1/k3d-darwin-amd64'
➜ shasum -a 256 k3d-darwin-amd64
846b4f47ef7cb794dd2ecdedda66cfe72bf0a7345c51f16afe3f5e7c9b3e5ad9  k3d-darwin-amd64
➜ chmod +x k3d-darwin-amd64
➜ ./k3d-darwin-amd64 --version
k3d version v1.3.1
```

The formula-installed version is `1.3.1`:
```
➜ which k3d
k3d not found
➜ brew install k3d
==> Downloading https://homebrew.bintray.com/bottles/k3d-1.3.1.mojave.bottle.tar.gz
Already downloaded: /Users/cbandy/Library/Caches/Homebrew/downloads/39eca49a0c7434da60f4e91ba72e7e63456a427e9f74da40f3c86032a1971634--k3d-1.3.1.mojave.bottle.tar.gz
==> Pouring k3d-1.3.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/k3d/1.3.1: 5 files, 10.5MB
➜ which k3d
/usr/local/bin/k3d
➜ k3d --version
k3d version 1.3.1
```

With this change, the two match:
```
➜ which k3d
k3d not found
➜ brew install -s k3d
==> Downloading https://github.com/rancher/k3d/archive/v1.3.1.tar.gz
Already downloaded: /Users/cbandy/Library/Caches/Homebrew/downloads/ea608c0b41be14a59ccac332bdbdeee7a7ac15ca376f661ad1d41d6510236b08--k3d-1.3.1.tar.gz
==> make BINDIR='/usr/local/Cellar/k3d/1.3.1/bin' GIT_TAG='v1.3.1' build
🍺  /usr/local/Cellar/k3d/1.3.1: 5 files, 10.3MB, built in 15 seconds
➜ which k3d
/usr/local/bin/k3d
➜ k3d --version
k3d version v1.3.1
```