### PR TITLE
Remove dead references to mysql-cluster

### DIFF
--- a/Formula/memcached.rb
+++ b/Formula/memcached.rb
@@ -13,8 +13,6 @@ class Memcached < Formula
 
   depends_on "libevent"
 
-  conflicts_with "mysql-cluster", :because => "both install `bin/memcached`"
-
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-coverage"
     system "make", "install"

--- a/Formula/mysql-connector-c.rb
+++ b/Formula/mysql-connector-c.rb
@@ -17,8 +17,6 @@ class MysqlConnectorC < Formula
 
   conflicts_with "mysql", "mariadb", "percona-server",
     :because => "both install MySQL client libraries"
-  conflicts_with "mysql-cluster",
-    :because => "both install `bin/my_print_defaults`"
 
   def install
     system "cmake", ".", "-DWITH_SSL=system", *std_cmake_args

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -23,7 +23,7 @@ class Mysql < Formula
 
   depends_on "openssl@1.1"
 
-  conflicts_with "mysql-cluster", "mariadb", "percona-server",
+  conflicts_with "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -24,7 +24,7 @@ class PerconaServer < Formula
   depends_on :macos => :yosemite
   depends_on "openssl@1.1"
 
-  conflicts_with "mariadb", "mysql", "mysql-cluster",
+  conflicts_with "mariadb", "mysql",
     :because => "percona, mariadb, and mysql install the same binaries."
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

mysql-cluster was deleted in b969722f5b3d978ce41fa1961d4c6e7e9c6e3051, but several `conflicts_with` still pointed to it.