### PR TITLE
Remove 'conflicts_with "mysql-cluster"' from mysql.rb.

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -14,7 +14,7 @@ class Mariadb < Formula
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
 
-  conflicts_with "mysql", "mysql-cluster", "percona-server",
+  conflicts_with "mysql", "percona-server",
     :because => "mariadb, mysql, and percona install the same binaries"
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -23,7 +23,7 @@ class Mysql < Formula
 
   depends_on "openssl@1.1"
 
-  conflicts_with "mysql-cluster", "mariadb", "percona-server",
+  conflicts_with "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."
   conflicts_with "mysql-connector-c",
     :because => "both install MySQL client libraries"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It is the warning:

Warning: mysql: No available formula with the name "mysql-cluster"
'conflicts_with "mysql-cluster"' should be removed from mysql.rb.

So just removed 'conflicts_with "mysql-cluster"' from mysql.rb.
