### PR TITLE
ghq: Add head

### DIFF
--- a/Formula/ghq.rb
+++ b/Formula/ghq.rb
@@ -4,6 +4,7 @@ class Ghq < Formula
   url "https://github.com/motemen/ghq.git",
       :tag      => "v0.12.7",
       :revision => "3a4306ec482248f6643a3b3dd6ae0d3ffe8d7a7e"
+  head "https://github.com/motemen/ghq.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds head target to `ghq` formula. I tested the formula as follows:
```
$ brew install ./Formula/ghq.rb --HEAD
==> Cloning https://github.com/motemen/ghq.git
Cloning into '/Users/ksuda/Library/Caches/Homebrew/ghq--git'...
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
==> make build
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/ghq/HEAD-787ce65: 7 files, 8.2MB, built in 7 seconds
```
