### PR TITLE
sshfs: fix issue preventing use of global I/O size on macOS

### DIFF
--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -3,7 +3,7 @@ class Sshfs < Formula
   homepage "https://osxfuse.github.io/"
   url "https://github.com/libfuse/sshfs/releases/download/sshfs-2.10/sshfs-2.10.tar.gz"
   sha256 "70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -18,6 +18,16 @@ class Sshfs < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on :osxfuse
+
+  # Apply patch that clears one remaining roadblock that prevented setting
+  # a custom I/O buffer size on macOS. With this patch in place, it's
+  # recommended to use e.g. `-o iosize=1048576` (or other, reasonable value)
+  # when lauching `sshfs`, for improved performance.
+  # See also: https://github.com/libfuse/sshfs/issues/11
+  patch do
+    url "https://github.com/libfuse/sshfs/commit/667cf34622e2e873db776791df275c7a582d6295.diff?full_index=1"
+    sha256 "6a121d58a94cf0efebbfa217d62aa4d9915a8e6573ae2c086170ff9d9fc09456"
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
Following-up on this [sshfs commit](https://github.com/osxfuse/sshfs/commit/5c0dbfe3eb40100f9277e863926f2e7d7c9a5a4c), there was another instance where blksize was set to a non-zero value, thus making it impossible to configure global I/O size on macOS, and [using](https://github.com/libfuse/sshfs/blob/4c21d696e9d46bebae0a936e2aec72326c5954ea/sshfs.c#L812) the hard-wired value of 4096 bytes instead, resulting in uniformly [poor performance](https://github.com/libfuse/sshfs/issues/11#issuecomment-339407557).

With this patch, setting [I/O size](https://github.com/osxfuse/osxfuse/wiki/Mount-options#iosize) to a reasonable large value, will result in much improved performance, e.g.: `-o iosize=1048576`

Upstream PR: https://github.com/libfuse/sshfs/pull/185 [MERGED]

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've been testing/using this patch on my own system for the last 2 years. Brought speeds close to SMB levels. (Tested mostly with larger files.)