### PR TITLE
newsboat: uses_from_macos "libxml2"

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -18,6 +18,7 @@ class Newsboat < Formula
   depends_on "gettext"
   depends_on "json-c"
   depends_on "libstfl"
+  uses_from_macos "libxml2"
 
   def install
     gettext = Formula["gettext"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This was failing to build on Linux -
  https://github.com/Homebrew/linuxbrew-core/issues/15586 - because of a
  missing `libxml2` dependency.
- Rather than `depends_on "libxml2" unless OS.mac?` in
  Homebrew/linuxbrew-core, uses `uses_from_macos` upstream here.