### PR TITLE
csound: add more opcodes

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -3,7 +3,7 @@ class Csound < Formula
   homepage "https://csound.com"
   url "https://github.com/csound/csound/archive/6.13.0.tar.gz"
   sha256 "183beeb3b720bfeab6cc8af12fbec0bf9fef2727684ac79289fd12d0dfee728b"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "958c93d41713bb2fc943c22f22c1ad947a72336b27a1ee41afb9426e0696b565" => :mojave
@@ -11,11 +11,15 @@ class Csound < Formula
     sha256 "6a88a566ec1b7c713bea00065dd666445286f451c5709a58a0cdda461cb46fb7" => :sierra
   end
 
+  depends_on "asio" => :build
   depends_on "cmake" => :build
   depends_on "eigen" => :build
   depends_on "python" => [:build, :test]
+  depends_on "faust"
   depends_on "fltk"
   depends_on "fluid-synth"
+  depends_on "hdf5"
+  depends_on "jack"
   depends_on "liblo"
   depends_on "libsamplerate"
   depends_on "libsndfile"
@@ -23,17 +27,36 @@ class Csound < Formula
   depends_on "portaudio"
   depends_on "portmidi"
   depends_on "stk"
+  depends_on "wiiuse"
 
   conflicts_with "libextractor", :because => "both install `extract` binaries"
   conflicts_with "pkcrack", :because => "both install `extract` binaries"
 
+  resource "ableton-link" do
+    url "https://github.com/Ableton/link/archive/Link-3.0.2.tar.gz"
+    sha256 "2716e916a9dd9445b2a4de1f2325da818b7f097ec7004d453c83b10205167100"
+  end
+
+  resource "getfem" do
+    url "https://download.savannah.gnu.org/releases/getfem/stable/getfem-5.3.tar.gz"
+    sha256 "9d10a1379fca69b769c610c0ee93f97d3dcb236d25af9ae4cadd38adf2361749"
+  end
+
   def install
+    resource("ableton-link").stage { cp_r "include/ableton", buildpath }
+    resource("getfem").stage { cp_r "src/gmm", buildpath }
+
     args = std_cmake_args + %W[
+      -DABLETON_LINK_HOME=#{buildpath}/ableton
+      -DBUILD_ABLETON_LINK_OPCODES=ON
       -DBUILD_JAVA_INTERFACE=OFF
+      -DBUILD_LINEAR_ALGEBRA_OPCODES=ON
       -DBUILD_LUA_INTERFACE=OFF
       -DBUILD_PYTHON_INTERFACE=OFF
+      -DBUILD_WEBSOCKET_OPCODE=OFF
       -DCMAKE_INSTALL_RPATH=#{frameworks}
       -DCS_FRAMEWORK_DEST:PATH=#{frameworks}
+      -DGMM_INCLUDE_DIR=#{buildpath}/gmm
     ]
 
     mkdir "build" do
@@ -60,13 +83,17 @@ class Csound < Formula
   test do
     (testpath/"test.orc").write <<~EOS
       0dbfs = 1
+      gi_peer link_create
+      gi_programHandle faustcompile "process = _;", "--vectorize --loop-variant 1"
       FLrun
       gi_fluidEngineNumber fluidEngine
+      gi_realVector la_i_vr_create 1
       pyinit
       instr 1
           a_, a_, a_ chuap 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
           pyruni "from __future__ import print_function; print('hello, world')"
           a_signal STKPlucked 440, 1
+          hdf5write "test.h5", a_signal
           out a_signal
       endin
     EOS
@@ -87,8 +114,20 @@ class Csound < Formula
     assert_match /^rtaudio:/, stderr
     assert_match /^rtmidi:/, stderr
 
-    ENV["DYLD_FRAMEWORK_PATH"] = "#{opt_prefix}/Frameworks"
+    assert_predicate testpath/"test.aif", :exist?
+    assert_predicate testpath/"test.h5", :exist?
 
+    (testpath/"jacko.orc").write "JackoInfo"
+    system "#{bin}/csound", "--orc", "--syntax-check-only", "jacko.orc"
+
+    (testpath/"wii.orc").write <<~EOS
+      instr 1
+          i_success wiiconnect 1, 1
+      endin
+    EOS
+    system "#{bin}/csound", "wii.orc", "test.sco"
+
+    ENV["DYLD_FRAMEWORK_PATH"] = "#{opt_prefix}/Frameworks"
     system "python3", "-c", "import ctcsound"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request adds all Csound opcodes I’m aware of that are available on macOS (except for one that should be available but causes the build to fail).