### PR TITLE
noti: simplify and install man pages

### DIFF
--- a/Formula/noti.rb
+++ b/Formula/noti.rb
@@ -14,18 +14,9 @@ class Noti < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GO111MODULE"] = "on"
-    ENV["GOFLAGS"] = "-mod=vendor"
-    ENV["GOPATH"] = buildpath
-
-    src = buildpath/"src/github.com/variadico/noti"
-    src.install buildpath.children
-
-    cd src.join("cmd/noti") do
-      system "go", "build"
-      bin.install "noti"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-mod=vendor", "-o", "#{bin}/noti", "cmd/noti/main.go"
+    man1.install "docs/man/noti.1"
+    man5.install "docs/man/noti.yaml.5"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR aims on simplifying the build process + adds installation of man pages provided by upstream.

Closes: https://github.com/variadico/noti/issues/92

Also, should I add `revision 1` so the bottle with man pages would be built?