### PR TITLE
bibtex2html: Mark "hevea" and "ocaml" as build deps

### DIFF
--- a/Formula/bibtex2html.rb
+++ b/Formula/bibtex2html.rb
@@ -12,8 +12,8 @@ class Bibtex2html < Formula
     sha256 "ba8aa5695eed41c522c20396b8509add1c0a45abead9e32a079e6c4a22507602" => :el_capitan
   end
 
-  depends_on "hevea"
-  depends_on "ocaml"
+  depends_on "hevea" => :build
+  depends_on "ocaml" => :build
 
   def install
     ENV["OCAMLPARAM"] = "safe-string=0,_" # OCaml 4.06.0 compat

--- a/Formula/bibtex2html.rb
+++ b/Formula/bibtex2html.rb
@@ -12,7 +12,6 @@ class Bibtex2html < Formula
     sha256 "ba8aa5695eed41c522c20396b8509add1c0a45abead9e32a079e6c4a22507602" => :el_capitan
   end
 
-  depends_on "hevea" => :build
   depends_on "ocaml" => :build
 
   def install


### PR DESCRIPTION
I suspect that the two are only required for building the package.

```
$ otool -L /usr/local/bin/bibtex2html
/usr/local/bin/bibtex2html:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.200.5)
```
