### PR TITLE
shairport-sync: added support for pulseaudio

### DIFF
--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -3,6 +3,7 @@ class ShairportSync < Formula
   homepage "https://github.com/mikebrady/shairport-sync"
   url "https://github.com/mikebrady/shairport-sync/archive/3.3.2.tar.gz"
   sha256 "a8f580fa8eb71172f6237c0cdbf23287b27f41f5399f5addf8cd0115a47a4b2b"
+  revision 1
   head "https://github.com/mikebrady/shairport-sync.git", :branch => "development"
 
   bottle do
@@ -20,6 +21,7 @@ class ShairportSync < Formula
   depends_on "libsoxr"
   depends_on "openssl@1.1"
   depends_on "popt"
+  depends_on "pulseaudio"
 
   def install
     system "autoreconf", "-fvi"
@@ -29,6 +31,7 @@ class ShairportSync < Formula
       --with-dns_sd
       --with-ao
       --with-stdout
+      --with-pa
       --with-pipe
       --with-soxr
       --with-metadata
@@ -46,6 +49,6 @@ class ShairportSync < Formula
 
   test do
     output = shell_output("#{bin}/shairport-sync -V")
-    assert_match "OpenSSL-dns_sd-ao-stdout-pipe-soxr-metadata", output
+    assert_match "OpenSSL-dns_sd-ao-pa-stdout-pipe-soxr-metadata", output
   end
 end


### PR DESCRIPTION
Dear Homebrew team,

This fix for **shairport-sync** adds support for the **pulseaudio** audio backend, following the guideline to enable as much non-exclusive Formula functionality as possible per default (https://github.com/Homebrew/homebrew-core/issues/31510).

It adds the `pulseaudio`dependency and the `--with-pa` configure option.

The extended now test covers the addition of the `pa` audio backend.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
