### PR TITLE
libalac 0.0.7 (new formula)

### DIFF
--- a/Formula/libalac.rb
+++ b/Formula/libalac.rb
@@ -1,0 +1,53 @@
+class Libalac < Formula
+  desc "Apple Lossless Audio Codec (ALAC) Library"
+  homepage "https://github.com/mikebrady/alac"
+  url "https://github.com/mikebrady/alac/archive/0.0.7.tar.gz"
+  sha256 "5a2b059869f0d0404aa29cbde44a533ae337979c11234041ec5b5318f790458e"
+  head "https://github.com/mikebrady/alac.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <assert.h>
+      #include <alac/ALACEncoder.h>
+      #include <alac/ALACDecoder.h>
+
+      int main() {
+        uint32_t   frameSize = kALACDefaultFramesPerPacket;
+        uint8_t    *magicCookie = (uint8_t *)calloc(1337, 1);
+
+        ALACEncoder *theEncoder = new ALACEncoder;
+        theEncoder->SetFrameSize(frameSize);
+        assert(theEncoder != NULL);
+
+        ALACDecoder *theDecoder = new ALACDecoder;
+        theDecoder->Init(magicCookie, 1337);
+        assert(theDecoder != NULL);
+
+        return 0;
+      }
+    EOS
+    flags = %W[
+      -I#{include}
+      -L#{lib}
+      -lalac
+    ]
+    system ENV.cxx, testpath/"test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
Dear Homebrew team,

this PR adds the `libalac` library for the ALAC audio codec, whose executable is already available on Homebrew (the `alac` Formula).

The sourced repository is 8+ years old and maintained by the author of the `shairport-sync` Formula.

The test has been adapted from the original test suite of the ALAC codec.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
