### PR TITLE
ruby-build: depend on readline

### DIFF
--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -10,6 +10,7 @@ class RubyBuild < Formula
   depends_on "autoconf"
   depends_on "openssl@1.1"
   depends_on "pkg-config"
+  depends_on "readline"
 
   def install
     ENV["PREFIX"] = prefix


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The various ruby formulae depend on readline; [ruby-build looks for homebrew readline](https://github.com/rbenv/ruby-build/blob/master/bin/ruby-build#L1003) as part of its build script; let's make it official & ensure that ruby built with ruby-build doesn't use the broken libedit.