### PR TITLE
ripgrep-all 0.9.3 (new formula)

### DIFF
--- a/Aliases/rga
+++ b/Aliases/rga
@@ -1,0 +1,1 @@
+../Formula/ripgrep-all.rb

--- a/Formula/ripgrep-all.rb
+++ b/Formula/ripgrep-all.rb
@@ -1,0 +1,25 @@
+class RipgrepAll < Formula
+  desc "Wrapper around ripgrep that adds multiple rich file types"
+  homepage "https://github.com/phiresky/ripgrep-all"
+  url "https://github.com/phiresky/ripgrep-all/archive/0.9.3.tar.gz"
+  sha256 "06259e7c1734a9246c2d113bf5e914f4d418e53c201efc697bfc041a713fbef3"
+  head "https://github.com/phiresky/ripgrep-all.git"
+
+  depends_on "rust" => :build
+  depends_on "ripgrep"
+
+  def install
+    system "cargo", "install", "--root", prefix, "--path", "."
+  end
+
+  test do
+    tempfile = testpath / "file.txt"
+
+    tempfile.write("Hello World")
+    system "zip", "-r", "archive.zip", tempfile
+    tempfile.delete
+
+    assert_match /Hello World/,
+      shell_output("#{bin}/rga 'Hello World' #{testpath}")
+  end
+end

--- a/Formula/ripgrep-all.rb
+++ b/Formula/ripgrep-all.rb
@@ -13,13 +13,10 @@ class RipgrepAll < Formula
   end
 
   test do
-    tempfile = testpath / "file.txt"
+    (testpath/"file.txt").write("Hello World")
+    system "zip", "archive.zip", "file.txt"
 
-    tempfile.write("Hello World")
-    system "zip", "-r", "archive.zip", tempfile
-    tempfile.delete
-
-    assert_match /Hello World/,
-      shell_output("#{bin}/rga 'Hello World' #{testpath}")
+    output = shell_output("#{bin}/rga 'Hello World' #{testpath}")
+    assert_match "Hello World", output
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
What is the best way to enable plugins with external dependencies here? Maybe a "Caveats" section?
-----
Related to #42484. 