### PR TITLE
glib: Make sure gobject-2.0.pc points to libffi's opt path

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -3,6 +3,7 @@ class Glib < Formula
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.62/glib-2.62.0.tar.xz"
   sha256 "6c257205a0a343b662c9961a58bb4ba1f1e31c82f5c6b909ec741194abc3da10"
+  revision 1
 
   bottle do
     sha256 "de1bacf18d547a429b058ce9fd3e98befe04158ac757d5e6de46a2589ab8b74f" => :mojave
@@ -62,6 +63,15 @@ class Glib < Formula
               "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib -lintl"
       s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
               "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
+    end
+
+    # `pkg-config --print-requires-private gobject-2.0` includes libffi,
+    # but that package is keg-only so it needs to look for the pkgconfig file
+    # in libffi's opt path.
+    libffi = Formula["libffi"].opt_prefix
+    inreplace lib+"pkgconfig/gobject-2.0.pc" do |s|
+      s.gsub! "Requires.private: libffi",
+              "Requires.private: #{libffi}/lib/pkgconfig/libffi.pc"
     end
   end
 

--- a/Formula/sofia-sip.rb
+++ b/Formula/sofia-sip.rb
@@ -3,7 +3,7 @@ class SofiaSip < Formula
   homepage "https://sofia-sip.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
   sha256 "2b01bc2e1826e00d1f7f57d29a2854b15fd5fe24695e47a14a735d195dd37c81"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any


### PR DESCRIPTION
Fixes #40179.

There is some precedent in other formulas to do that, either for libffi, or for gettext in glib's own formula.