### PR TITLE
pnetcdf 1.11.2 (new formula)

### DIFF
--- a/Formula/pnetcdf.rb
+++ b/Formula/pnetcdf.rb
@@ -1,0 +1,60 @@
+class Pnetcdf < Formula
+  desc "Parallel netCDF library for scientific data using the OpenMPI library"
+  homepage "https://parallel-netcdf.github.io/index.html"
+  url "https://parallel-netcdf.github.io/Release/pnetcdf-1.11.2.tar.gz"
+  sha256 "d2c18601b364c35b5acb0a0b46cd6e14cae456e0eb854e5c789cf65f3cd6a2a7"
+
+  depends_on "gcc"
+  depends_on "open-mpi"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--enable-shared"
+    system "make", "install"
+  end
+
+  # These tests were converted from the netcdf formula.
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include "pnetcdf.h"
+      int main()
+      {
+        printf(PNETCDF_VERSION);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lpnetcdf",
+                   "-o", "test"
+    assert_equal `./test`, version.to_s
+
+    (testpath/"test.f90").write <<~EOS
+      program test
+        use mpi
+        use pnetcdf
+        integer :: ncid, varid, dimids(2), ierr
+        integer :: dat(2,2) = reshape([1, 2, 3, 4], [2, 2])
+        call mpi_init(ierr)
+        call check( nfmpi_create(MPI_COMM_WORLD, "test.nc", NF_CLOBBER, MPI_INFO_NULL, ncid) )
+        call check( nfmpi_def_dim(ncid, "x", 2_MPI_OFFSET_KIND, dimids(2)) )
+        call check( nfmpi_def_dim(ncid, "y", 2_MPI_OFFSET_KIND, dimids(1)) )
+        call check( nfmpi_def_var(ncid, "data", NF_INT, 2, dimids, varid) )
+        call check( nfmpi_enddef(ncid) )
+        call check( nfmpi_put_var_int_all(ncid, varid, dat) )
+        call check( nfmpi_close(ncid) )
+        call mpi_finalize(ierr)
+      contains
+        subroutine check(status)
+          integer, intent(in) :: status
+          if (status /= nf_noerr) call abort
+        end subroutine check
+      end program test
+    EOS
+    system "mpif90", "test.f90", "-L#{lib}", "-I#{include}", "-lpnetcdf",
+                       "-o", "testf"
+    system "./testf"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is my first contribution to Homebrew. I hope this package meets the criteria. I am happy to fix things.
For the uninitiated, pnetCDF is completely independent from netCDF, which is already in the repository. Some scientific software uses it to write netCDF files in parallel.
I adapted the tests from the netcdf formula for this.