### PR TITLE
Update wsk Formula to version 1.0.0

### DIFF
--- a/Formula/wsk.rb
+++ b/Formula/wsk.rb
@@ -1,9 +1,9 @@
 class Wsk < Formula
   desc "OpenWhisk Command-Line Interface (CLI)"
   homepage "https://openwhisk.apache.org/"
-  url "https://github.com/apache/incubator-openwhisk-cli/archive/0.10.0-incubating.tar.gz"
-  version "0.10.0-incubating"
-  sha256 "0f0052ea85b10aea8902d4ccb9393fd523b96d5b2477b1c38d486366edc9535c"
+  url "https://github.com/apache/openwhisk-cli/archive/1.0.0.tar.gz"
+  version "1.0.0"
+  sha256 "31e6fceaa3ae51be7b93d308eb0b68c891277f904c17cf6496e51062f1655332"
 
   bottle do
     cellar :any_skip_relocation
@@ -18,7 +18,7 @@ class Wsk < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/apache/incubator-openwhisk-cli"
+    dir = buildpath/"src/github.com/apache/openwhisk-cli"
     dir.install buildpath.children
     cd dir do
       system "go-bindata", "-pkg", "wski18n", "-o",

--- a/Formula/wsk.rb
+++ b/Formula/wsk.rb
@@ -2,7 +2,6 @@ class Wsk < Formula
   desc "OpenWhisk Command-Line Interface (CLI)"
   homepage "https://openwhisk.apache.org/"
   url "https://github.com/apache/openwhisk-cli/archive/1.0.0.tar.gz"
-  version "1.0.0"
   sha256 "31e6fceaa3ae51be7b93d308eb0b68c891277f904c17cf6496e51062f1655332"
 
   bottle do


### PR DESCRIPTION
1. Update GitHub repository to remove incubator- since Apache OpenWhisk
   has graduated to a Top Level Project.
2. Bump wsk version to 1.0.0 (latest release of wsk cli)

- [ X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
 Unable to run `brew audit` due to known issue with installing `jaro_winkler` on Mojave.
-----
