### PR TITLE
geographiclib-1.50

### DIFF
--- a/Formula/geographiclib.rb
+++ b/Formula/geographiclib.rb
@@ -1,8 +1,8 @@
 class Geographiclib < Formula
   desc "C++ geography library"
   homepage "https://geographiclib.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/geographiclib/distrib/GeographicLib-1.49.tar.gz"
-  sha256 "aec0ab52b6b9c9445d9d0a77e3af52257e21d6e74e94d8c2cb8fa6f11815ee2b"
+  url "https://downloads.sourceforge.net/project/geographiclib/distrib/GeographicLib-1.50.tar.gz"
+  sha256 "2ac8888094d21ba48adb433c4bb569937497b39733e96c080b5ce278e2587622"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The audit step fails.  Probably because of some stale brew stuff on my machine.  The specific complaint is:

    Using rubocop-performance 1.4.1
    Using rubocop-rspec 1.35.0
    Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory:
    /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/json-2.2.0/ext/json/ext/parser
    /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby -r
    ./siteconf20190924-75843-1lwxea2.rb extconf.rb
    checking for rb_enc_raise() in ruby.h... *** extconf.rb failed ***
    Could not create Makefile due to some reason, probably lack of necessary
    libraries and/or headers.  Check the mkmf.log file for more details.  You may
    need configuration options.

Any tips on cleaning up my environment so that the audit passes?