### PR TITLE
crystal: keep llvm@8

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,6 +1,7 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
+  revision 1
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.31.0.tar.gz"
@@ -34,7 +35,7 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "llvm"
+  depends_on "llvm@8"
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 


### PR DESCRIPTION
Crystal was not updated yet for `llvm@9`.
I _think_ this change requires a bump in the revision.