### PR TITLE
Update bcel to 6.4.0

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,8 +15,8 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3.1-bin.tar.gz"
-    sha256 "ed1d281cb66dedb89611019168071fe22a50ff325253e2c453dc00423905cf9d"
+    url "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
+    sha256 "2e7d3c24fabc5a24c482ddc77c031d9f5978c5aa918bae68ad7adcf3e9167d04"
   end
 
   def install


### PR DESCRIPTION
The links to bcel 6.3.1 no longer work. This will keep going, so it might be worth finding a better location to get historical releases from.