### PR TITLE
Updates bcel binary location to github to resolve broken link

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,7 +15,7 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3.1-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
     sha256 "ed1d281cb66dedb89611019168071fe22a50ff325253e2c453dc00423905cf9d"
   end
 

--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -10,12 +10,12 @@ class Ant < Formula
   depends_on :java => "1.8+"
 
   resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    url "https://github.com/apache/ant-ivy/archive/2.4.0.tar.gz"
     sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
+    url "https://github.com/apache/commons-bcel/archive/commons-bcel-6.3.1.tar.gz"
     sha256 "ed1d281cb66dedb89611019168071fe22a50ff325253e2c453dc00423905cf9d"
   end
 


### PR DESCRIPTION
~~Updates [`bcel`](https://commons.apache.org/proper/commons-bcel/) binary from `6.3.1` to `6.4.0`.~~

REVISED: Updates binary link to use `github` sources instead. The current link / host does not persist old versions and presently leads to the following error:

```
DownloadError: Failed to download resource "ant--bcel"
Download failed: https://www-us.apache.org/dist/commons/bcel/binaries/bcel-6.3.1-bin.tar.gz
```

The pull request changes the package links to the `github` versions instead, as these appear to persist across version upgrades. For example:

`v6.3.1` - https://github.com/apache/commons-bcel/releases/tag/commons-bcel-6.3.1
`v6.4.0` - https://github.com/apache/commons-bcel/releases/tag/rel%2Fcommons-bcel-6.4.0