### PR TITLE
Updated bcel-6.3.1 url in ant.rb

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,7 +15,7 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3.1-bin.tar.gz"
+    url "http://archive.apache.org/dist/commons/bcel/binaries/bcel-6.3.1-bin.tar.gz"
     sha256 "ed1d281cb66dedb89611019168071fe22a50ff325253e2c453dc00423905cf9d"
   end
 


### PR DESCRIPTION
According to https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3.1-bin.tar.gz, the file is not in the mirrors.
Changed the link to download directly from the archive.