### PR TITLE
pass: improve speed when calling gnu-getopt

### DIFF
--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -19,6 +19,7 @@ class Pass < Formula
   depends_on "tree"
 
   def install
+    inreplace "src/platform/darwin.sh", /^GETOPT=".*"$/, "GETOPT=\"#{HOMEBREW_PREFIX}/opt/gnu-getopt/bin/getopt\""
     system "make", "PREFIX=#{prefix}", "WITH_ALLCOMP=yes", "BASHCOMPDIR=#{bash_completion}", "ZSHCOMPDIR=#{zsh_completion}", "FISHCOMPDIR=#{fish_completion}", "install"
     inreplace "#{bin}/pass", /^SYSTEM_EXTENSION_DIR=.*$/, "SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\""
     elisp.install "contrib/emacs/password-store.el"


### PR DESCRIPTION
The `pass` tool requires `gnu-getopt` which on macOS is done by (amongst others) trying:

    brew --prefix gnu-getopt

This has two downsides:

1. It is slow, see e.g. Homebrew/brew#3097 (0.5-0.8s).
2. It can break, see e.g. https://lists.zx2c4.com/pipermail/password-store/2019-September/003774.html

For this reason `pass` should not use `brew` and this patch changes the relevant line to use an absolute path.

This can’t be fixed upstream, as the location of `gnu-getopt` depends on which package manager installed `pass`.

Question: Is there a different way to obtain the install path of `gnu-getopt`? Currently the patch assumes it’s installed into `#{HOMEBREW_PREFIX}/opt`.