### PR TITLE
unbound: enable TCP FastOpen (TFO)

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -19,6 +19,8 @@ class Unbound < Formula
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
+      --enable-tfo-client
+      --enable-tfo-server
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
       --enable-event-api


### PR DESCRIPTION
macOS supports TFO which is dynamically controlled with

	sysctl net.inet.tcp.fastopen

Unbound also supports TFO but this currently requires specifying a few
configure options at compile time.