### PR TITLE
nuget: use correct case for nuget.exe filename and fix test

### DIFF
--- a/Formula/nuget.rb
+++ b/Formula/nuget.rb
@@ -1,7 +1,7 @@
 class Nuget < Formula
   desc "Package manager for Microsoft development platform including .NET"
   homepage "https://www.nuget.org/"
-  url "https://dist.nuget.org/win-x86-commandline/v5.2.0/nuget.exe"
+  url "https://dist.nuget.org/win-x86-commandline/v5.2.0/nuget.exe" # make sure libexec.install below matches case
   sha256 "2865714c6588ef0770b4a04bdd20dac59bcb56756d001c040664c9966f1b835a"
 
   bottle :unneeded
@@ -9,7 +9,7 @@ class Nuget < Formula
   depends_on "mono"
 
   def install
-    libexec.install "NuGet.exe" => "nuget.exe"
+    libexec.install "nuget.exe" => "nuget.exe"
     (bin/"nuget").write <<~EOS
       #!/bin/bash
       mono #{libexec}/nuget.exe "$@"
@@ -17,6 +17,6 @@ class Nuget < Formula
   end
 
   test do
-    assert_match "NuGet.Protocol.Core.v3", shell_output("#{bin}/nuget list NuGet.Protocol.Core.v3")
+    assert_match "NuGet.Protocol.Core.v3", shell_output("#{bin}/nuget list packageid:NuGet.Protocol.Core.v3")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
Yes -- and nuget works fine afterwards.
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
>Test fixed so it no longer times out. (Old test seemed affected by <https://github.com/NuGet/Home/issues/8622>)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this fix `brew upgrade` failed on my case-sensitive macOS install:
````
==> Downloading https://dist.nuget.org/win-x86-commandline/v5.2.0/nuget.exe
######################################################################## 100.0%
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - NuGet.exe
````
