### PR TITLE
gmp: work around Catalina bug

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -15,6 +15,10 @@ class Gmp < Formula
   end
 
   def install
+    # Work around macOS Catalina / Xcode 11 code generation bug
+    # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
+    ENV.append_to_cflags "-fno-stack-check"
+
     # Enable --with-pic to avoid linking issues with the static library
     args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
     args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"


### PR DESCRIPTION
`-fno-stack-check` fixes a bug in code generation