### PR TITLE
gettext: fix build on Catalina

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -20,6 +20,8 @@ class Gettext < Formula
                           "--disable-debug",
                           "--prefix=#{prefix}",
                           "--with-included-gettext",
+                          # Work around a gnulib issue with macOS Catalina
+                          "gl_cv_func_ftello_works=yes",
                           "--with-included-glib",
                           "--with-included-libcroco",
                           "--with-included-libunistring",


### PR DESCRIPTION
The `gnulib` configure detects a problem with Catalina's `ftell` function. This check was added to `gnulib` for a Solaris bug, and the substitution code for `ftell` is actually Solaris-specific — thus, it doesn't compile on Catalina. We set `gl_cv_func_ftello_works=yes` to bypass the check.

---

The root cause is a problem with standard C I/O in Catalina's libc. Take the following C code:

```
#include <stdio.h>

int main (void) {
  FILE *fp;
  int i;

  fp = fopen ("test", "w");
  fwrite ("foogarsh", 1, 8, fp);
  fclose (fp);

  fp = fopen ("test", "r+");
  fseek (fp, -1, SEEK_END);
  getc (fp); // 'h'
  getc (fp); // EOF
  putc ('!', fp);

  i = ftell (fp);
  printf("%d\n", i); // it should be 9
  fclose (fp);
}
```

- When compiled and run on Mojave, the output is `9`, as expected, and the `test` file contains `foogarsh!` when the program finishes.
- When compiled and run on Catalina beta 9, the output is `8`, and the `test` file contains `foogarsh`. This is incorrect, and was reported to Apple as FB7334099