### PR TITLE
flyway@5 5.2.4 (new formula)

### DIFF
--- a/Formula/flyway@5.rb
+++ b/Formula/flyway@5.rb
@@ -1,0 +1,20 @@
+class FlywayAT5 < Formula
+  desc "Database version control to control migrations"
+  homepage "https://flywaydb.org/"
+  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4.tar.gz"
+  sha256 "ac42a414e316d7592c7035cd7fa14050ed02c77972196367ab8f11b9a9352a9a"
+
+  bottle :unneeded
+
+  depends_on :java
+
+  def install
+    rm Dir["*.cmd"]
+    libexec.install Dir["*"]
+    bin.install_symlink Dir["#{libexec}/flyway"]
+  end
+
+  test do
+    system "#{bin}/flyway", "-url=jdbc:h2:mem:flywaydb", "validate"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Flyway 6 dropped support for MySQL5.6 in the community version. 

Given that many teams might still need to continue to use Flyway with MySQL5.6, this versioned formula should come in handy.