### PR TITLE
shairport-sync 3.3.2: update configuration flags to include the libdaemon library

### DIFF
--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -3,7 +3,7 @@ class ShairportSync < Formula
   homepage "https://github.com/mikebrady/shairport-sync"
   url "https://github.com/mikebrady/shairport-sync/archive/3.3.2.tar.gz"
   sha256 "a8f580fa8eb71172f6237c0cdbf23287b27f41f5399f5addf8cd0115a47a4b2b"
-  revision 1
+  revision 2
   head "https://github.com/mikebrady/shairport-sync.git", :branch => "development"
 
   bottle do

--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -27,6 +27,7 @@ class ShairportSync < Formula
     system "autoreconf", "-fvi"
     args = %W[
       --with-os=darwin
+      --with-libdaemon
       --with-ssl=openssl
       --with-dns_sd
       --with-ao
@@ -49,6 +50,6 @@ class ShairportSync < Formula
 
   test do
     output = shell_output("#{bin}/shairport-sync -V")
-    assert_match "OpenSSL-dns_sd-ao-pa-stdout-pipe-soxr-metadata", output
+    assert_match "libdaemon-OpenSSL-dns_sd-ao-pa-stdout-pipe-soxr-metadata", output
   end
 end


### PR DESCRIPTION
Include the `--with-libdaemon` configuration flag and also check for a version string that has `"libdaemon"` in it.