### PR TITLE
crystal: 0.31.1

### DIFF
--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -24,8 +24,8 @@ class BdwGc < Formula
 
   patch do
     # Required for v8.0.4. Support for green threads.
-    url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch"
-    sha256 "784ade9fe1c2668db77a3c08cd195cd7701331bdf8c9d160038cfce099b77e37"
+    url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch?full_index=1"
+    sha256 "5c42d4b37cf4997bb6af3f9b00f5513644e1287c322607dc980a1955a09246e3"
   end
 
   def install

--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -3,6 +3,7 @@ class BdwGc < Formula
   homepage "https://www.hboehm.info/gc/"
   url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
   sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,6 +21,12 @@ class BdwGc < Formula
 
   depends_on "libatomic_ops" => :build
   depends_on "pkg-config" => :build
+
+  patch do
+    # Required for v8.0.4. Support for green threads.
+    url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch"
+    sha256 "784ade9fe1c2668db77a3c08cd195cd7701331bdf8c9d160038cfce099b77e37"
+  end
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/bdw-gc.rb
+++ b/Formula/bdw-gc.rb
@@ -3,7 +3,6 @@ class BdwGc < Formula
   homepage "https://www.hboehm.info/gc/"
   url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
   sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
-  revision 1
 
   bottle do
     cellar :any
@@ -21,12 +20,6 @@ class BdwGc < Formula
 
   depends_on "libatomic_ops" => :build
   depends_on "pkg-config" => :build
-
-  patch do
-    # Required for v8.0.4. Support for green threads.
-    url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch?full_index=1"
-    sha256 "5c42d4b37cf4997bb6af3f9b00f5513644e1287c322607dc980a1955a09246e3"
-  end
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -26,13 +26,29 @@ class Crystal < Formula
     end
   end
 
-  depends_on "bdw-gc"
+  depends_on "autoconf"      => :build # for building bdw-gc
+  depends_on "automake"      => :build # for building bdw-gc
+  depends_on "libatomic_ops" => :build # for building bdw-gc
+  depends_on "libtool"       => :build # for building bdw-gc
+
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
   depends_on "llvm@8"
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
+
+  # Crystal uses an extended version of bdw-gc to handle multi-threading
+  resource "bdw-gc" do
+    url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
+    sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
+
+    # extension to handle multi-threading
+    patch :p1 do
+      url "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch?full_index=1"
+      sha256 "5c42d4b37cf4997bb6af3f9b00f5513644e1287c322607dc980a1955a09246e3"
+    end
+  end
 
   resource "boot" do
     url "https://github.com/crystal-lang/crystal/releases/download/0.30.1/crystal-0.30.1-1-darwin-x86_64.tar.gz"
@@ -48,7 +64,19 @@ class Crystal < Formula
     end
 
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
+    ENV["CRYSTAL_CONFIG_LIBRARY_PATH"] = prefix/"embedded/lib"
     ENV.append_path "PATH", "boot/bin"
+
+    resource("bdw-gc").stage(buildpath/"gc")
+    cd(buildpath/"gc") do
+      system "./configure", "--disable-debug",
+                            "--disable-dependency-tracking",
+                            "--disable-shared",
+                            "--enable-large-config"
+      system "make"
+    end
+
+    ENV.prepend_path "CRYSTAL_LIBRARY_PATH", buildpath/"gc/.libs"
 
     # Build crystal
     (buildpath/".build").mkpath
@@ -75,6 +103,7 @@ class Crystal < Formula
     bin.install ".build/shards"
     bin.install ".build/crystal"
     prefix.install "src"
+    (prefix/"embedded/lib").install "#{buildpath/"gc"}/.libs/libgc.a"
 
     bash_completion.install "etc/completion.bash" => "crystal"
     zsh_completion.install "etc/completion.zsh" => "_crystal"

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,11 +1,10 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
-  revision 1
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.31.0.tar.gz"
-    sha256 "483ffcdce30b98f89b8c6cf6e48c62652cd0450205f609e04721a37997c32486"
+    url "https://github.com/crystal-lang/crystal/archive/0.31.1.tar.gz"
+    sha256 "b4a51164763b891572492e2445d3a69b462675184ea0ccf06fcc57a070f07b80"
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz"
@@ -27,29 +26,13 @@ class Crystal < Formula
     end
   end
 
-  depends_on "autoconf"      => :build # for building bdw-gc
-  depends_on "automake"      => :build # for building bdw-gc
-  depends_on "libatomic_ops" => :build # for building bdw-gc
-  depends_on "libtool"       => :build # for building bdw-gc
-
+  depends_on "bdw-gc"
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
   depends_on "llvm@8"
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
-
-  # Crystal uses an extended version of bdw-gc to handle multi-threading
-  resource "bdw-gc" do
-    url "https://github.com/ivmai/bdwgc/releases/download/v8.0.4/gc-8.0.4.tar.gz"
-    sha256 "436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
-
-    # extension to handle multi-threading
-    patch :p1 do
-      url "https://raw.githubusercontent.com/crystal-lang/distribution-scripts/ab683792f34c60159f0e697adf792ff5b0fcbf91/linux/files/feature-thread-stackbottom.patch"
-      sha256 "acbae8cfe10e3efac403a629490cfd05e809554d23e9c3a88acddbb66f8ef7e0"
-    end
-  end
 
   resource "boot" do
     url "https://github.com/crystal-lang/crystal/releases/download/0.30.1/crystal-0.30.1-1-darwin-x86_64.tar.gz"
@@ -65,19 +48,7 @@ class Crystal < Formula
     end
 
     ENV["CRYSTAL_CONFIG_PATH"] = prefix/"src:lib"
-    ENV["CRYSTAL_CONFIG_LIBRARY_PATH"] = prefix/"embedded/lib"
     ENV.append_path "PATH", "boot/bin"
-
-    resource("bdw-gc").stage(buildpath/"gc")
-    cd(buildpath/"gc") do
-      system "./configure", "--disable-debug",
-                            "--disable-dependency-tracking",
-                            "--disable-shared",
-                            "--enable-large-config"
-      system "make"
-    end
-
-    ENV.prepend_path "CRYSTAL_LIBRARY_PATH", buildpath/"gc/.libs"
 
     # Build crystal
     (buildpath/".build").mkpath
@@ -104,7 +75,6 @@ class Crystal < Formula
     bin.install ".build/shards"
     bin.install ".build/crystal"
     prefix.install "src"
-    (prefix/"embedded/lib").install "#{buildpath/"gc"}/.libs/libgc.a"
 
     bash_completion.install "etc/completion.bash" => "crystal"
     zsh_completion.install "etc/completion.zsh" => "_crystal"


### PR DESCRIPTION
There is a new patch release of Crystal.
This release allows moving to the upstream patch of an upcoming feature of bdw-gc.

So in order to remove the custom build of gc for Crystal instroduced in #39026, an update to the bdw-gc formula is needed.

The bdw-gc patch was merged in https://github.com/ivmai/bdwgc/pull/277 and [it should be released in 8.2.x](https://github.com/ivmai/bdwgc/issues/274#issuecomment-489634982)

---

`brew audit --strict crystal` is complaining locally about llvm@8 been an alias, but it's no longer an alias.