### PR TITLE
gcc: patch for Catalina SDK

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -4,6 +4,7 @@ class Gcc < Formula
   url "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
   sha256 "ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206"
+  revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
   bottle do
@@ -26,6 +27,15 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+
+  # Fix system headers for Catalina SDK
+  # (otherwise __OSX_AVAILABLE_STARTING ends up undefined)
+  if DevelopmentTools.clang_build_version >= 1100
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/b8b8e65e/gcc/9.2.0-catalina.patch"
+      sha256 "0b8d14a7f3c6a2f0d2498526e86e088926671b5da50a554ffa6b7f73ac4f132b"
+    end
+  end
 
   def version_suffix
     if build.head?


### PR DESCRIPTION
Catalina SDK bug reported as FB7338312. Basically, a faulty if/else logic leads to __OSX_AVAILABLE_STARTING not being defined at all with non-clang compilers (like GCC).

Using GCC's fixinclude mechanism to avoid it. Revision bumping, since this will also affect people using Mojave with Xcode 11 (tested locally).