### PR TITLE
glooctl: update version template and command

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -32,8 +32,11 @@ class Glooctl < Formula
     run_output = shell_output("#{bin}/glooctl 2>&1")
     assert_match "glooctl is the unified CLI for Gloo.", run_output
 
-    version_output = shell_output("#{bin}/glooctl --version 2>&1")
-    assert_match "glooctl community edition version #{version}", version_output
+    version_output = shell_output("#{bin}/glooctl version 2>&1")
+    assert_match "Client: {\"version\":\"#{version}\"}", version_output
+
+    version_output = shell_output("#{bin}/glooctl version 2>&1")
+    assert_match "Server: version undefined", version_output
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly
     status_output = shell_output("#{bin}/glooctl get proxy 2>&1", 1)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Context
`glooctl` is a cli largely built on `kubectl` used to install and manage Gloo installations. Learn more on our open-source GitHub [page](https://github.com/solo-io/gloo) or [website](https://www.solo.io/glooe).

### Goal
`glooctl` has been updated in the likeness of `kubectl`; we added the `glooctl version` command (which reports client & server version) which is meant to replace the deprecated `glooctl --version` command.

This PR updates our tests to use the new `glooctl version` command so we can safely remove the `glooctl --version` command (which only reports client version) without breaking our formula.