### PR TITLE
Fix stack protect bugs with Xcode 11

### DIFF
--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -33,6 +33,10 @@ class Libbluray < Formula
     # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
     ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
 
+    # Work around Xcode 11 clang bug
+    # https://code.videolan.org/videolan/libbluray/issues/20
+    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
+
     args = %W[--prefix=#{prefix} --disable-dependency-tracking]
 
     system "./bootstrap" if build.head?

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -16,6 +16,10 @@ class X265 < Formula
   depends_on "nasm" => :build
 
   def install
+    # Work around Xcode 11 clang bug
+    # https://bitbucket.org/multicoreware/x265/issues/514/wrong-code-generated-on-macos-1015
+    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
+
     # Build based off the script at ./build/linux/multilib.sh
     args = std_cmake_args + %w[
       -DLINKED_10BIT=ON


### PR DESCRIPTION
libbluray and x265 have bugs when compiled with Xcode 11, unless `-fno-stack-protect` is used.