### PR TITLE
github action: only run in the main repo

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate:
+    if: github.repository == 'Homebrew/homebrew-core'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This prevents the action being run in the fork, which will generate errors due to missing token.
