### PR TITLE
git-req v2.1 (new formula)

### DIFF
--- a/Formula/git-req.rb
+++ b/Formula/git-req.rb
@@ -1,5 +1,5 @@
 class GitReq < Formula
-  desc "Check out merge requests from your GitLab/GitHub hosted repositories with ease!"
+  desc "Check out merge requests from GitLab/GitHub repositories with ease!"
   homepage "https://arusahni.github.io/git-req/"
   url "https://github.com/arusahni/git-req/archive/v2.1.0.tar.gz"
   sha256 "a7bc8f90230762e93d348dcb22dee93b7c47d07678012976a229950a752a72ff"

--- a/Formula/git-req.rb
+++ b/Formula/git-req.rb
@@ -1,0 +1,16 @@
+class GitReq < Formula
+  desc "Check out merge requests from your GitLab/GitHub hosted repositories with ease!"
+  homepage "https://arusahni.github.io/git-req/"
+  url "https://github.com/arusahni/git-req/archive/v2.1.0.tar.gz"
+  sha256 "a7bc8f90230762e93d348dcb22dee93b7c47d07678012976a229950a752a72ff"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix, "--path", "."
+  end
+
+  test do
+    assert_match /git-req 2.1.0/, shell_output("#{bin}/git-req --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds git-req v2.1 as a new formula. Tracked in arusahni/git-req#16.