### PR TITLE
newsboat: uses_from_macos "curl" and "libxslt"

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -18,7 +18,9 @@ class Newsboat < Formula
   depends_on "gettext"
   depends_on "json-c"
   depends_on "libstfl"
+  uses_from_macos "curl"
   uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
 
   def install
     gettext = Formula["gettext"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Over in [Homebrew/linuxbrew-core PR 15920](https://github.com/Homebrew/linuxbrew-core/pull/15920)
  we found that the latest version of newsboat wouldn't build without
  these.
- Rather than adding `depends_on` lines, follow prior art upstream
  (here) and add `uses_from_macos`.