### PR TITLE
libcaca: depend on imlib2

### DIFF
--- a/Formula/libcaca.rb
+++ b/Formula/libcaca.rb
@@ -6,6 +6,7 @@ class Libcaca < Formula
   mirror "https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz"
   version "0.99b19"
   sha256 "128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4"
+  revision 1
 
   bottle do
     cellar :any
@@ -27,6 +28,7 @@ class Libcaca < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "imlib2"
 
   def install
     system "./bootstrap" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libcaca is quite redundant as it stands, as in current master, it only supports BMP file formats. Depending on imlib2 allows it to decode a much wider range of formats.
