### PR TITLE
vert.x 3.8.2

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.8.1-full.tar.gz"
-  sha256 "940448e11d145791ae7c31a95992471790ab73dddfe5f79e3ed01ae58c7a2da3"
+  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.8.2-full.tar.gz"
+  sha256 "22b9ad3e4656112b55c911dcf777ef93b78af2517152f0a84dc8ceb0271ca58d"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the Eclipse Vert.x formula to 3.8.2.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As usual, the https://vertx.io does not yet mention this release as the Homebrew formula is part of the release process.
