### PR TITLE
atasm 1.07d (new formula)

### DIFF
--- a/Formula/atasm.rb
+++ b/Formula/atasm.rb
@@ -1,0 +1,23 @@
+class Atasm < Formula
+  desc "Atari MAC/65 compatible assembler for Unix"
+  homepage "https://atari.miribilist.com/atasm/"
+  url "https://atari.miribilist.com/atasm/atasm107d.zip"
+  version "1.07d"
+  sha256 "24a165506346029fbe05ed99b22900ae50f91f5a8c5d38ebad6a92a5c53f3d99"
+
+  def install
+    cd "src" do
+      system "make", "prog"
+      bin.install "atasm"
+      system "sed -e 's,%%DOCDIR%%,/usr/local/share/doc/atasm,g' < atasm.1.in > atasm.1"
+      man1.install "atasm.1"
+    end
+    doc.install "examples"
+  end
+
+  test do
+    cd "#{doc}/examples" do
+      system "#{bin}/atasm", "-v", "test.m65", "-o/tmp/test.bin"
+    end
+  end
+end


### PR DESCRIPTION
Formula brings another 6502 assembler, compatible with popular in '80s MAC/65
Atari macroassembler.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
