### PR TITLE
v8 7.7.299.13

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -2,8 +2,8 @@ class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
   # Track V8 version from Chrome stable: https://omahaproxy.appspot.com
-  url "https://github.com/v8/v8/archive/7.7.299.11.tar.gz"
-  sha256 "03d8abac7b5cb427b1d29085d82bf3a9f8030cc39cbc6f8528518053075adbbc"
+  url "https://github.com/v8/v8/archive/7.7.299.13.tar.gz"
+  sha256 "1f5939fcd74464ba43e3445d3e3f82b5bbf2efe7314dde06b3fb12b65ba7d5f9"
 
   bottle do
     cellar :any
@@ -12,11 +12,10 @@ class V8 < Formula
     sha256 "3dc8186f25a9efd9b5aef9e69943053bb98d3600d8de3f536f8035a2c87e2c93" => :sierra
   end
 
+  depends_on "llvm" => :build if DevelopmentTools.clang_build_version < 1001 # 1100 with v8 7.9+
   depends_on "ninja" => :build
-  depends_on "llvm" if MacOS.version < :mojave
 
-  # https://bugs.chromium.org/p/chromium/issues/detail?id=620127
-  depends_on :macos => :el_capitan
+  depends_on :xcode => ["9.0", :build] # required by v8 (bump to 10.0 with v8 7.9+)
 
   # Look up the correct resource revisions in the DEP file of the specific releases tag
   # e.g. for CIPD dependency gn: https://github.com/v8/v8/blob/7.6.303.27/DEPS#L15
@@ -64,6 +63,11 @@ class V8 < Formula
     (buildpath/"base/trace_event/common").install resource("v8/base/trace_event/common")
     (buildpath/"third_party/icu").install resource("v8/third_party/icu")
 
+    # workaround for xcode-select --print-path pointing to CLT
+    inreplace buildpath/"build/config/mac/mac_sdk.gni",
+              "\"--print_bin_path\",",
+              "\"--print_bin_path\", \"--developer_dir\", \"#{MacOS::Xcode.bundle_path}\""
+
     # Build gn from source and add it to the PATH
     (buildpath/"gn").install resource("gn")
     cd "gn" do
@@ -82,8 +86,12 @@ class V8 < Formula
       :clang_use_chrome_plugins     => false,       # disable the usage of Google's custom clang plugins
       :use_custom_libcxx            => false,       # uses system libc++ instead of Google's custom one
     }
+
     # use clang from homebrew llvm formula on <= High Sierra, because the system clang is to old for V8
-    gn_args[:clang_base_path] = "\"#{Formula["llvm"].prefix}\"" if MacOS.version < :mojave
+    if DevelopmentTools.clang_build_version < 1001 # 1100 with v8 7.9+
+      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib # but link against system libc++
+      gn_args[:clang_base_path] = "\"#{Formula["llvm"].prefix}\""
+    end
 
     # Transform to args string
     gn_args_string = gn_args.map { |k, v| "#{k}=#{v}" }.join(" ")

--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -63,11 +63,6 @@ class V8 < Formula
     (buildpath/"base/trace_event/common").install resource("v8/base/trace_event/common")
     (buildpath/"third_party/icu").install resource("v8/third_party/icu")
 
-    # workaround for xcode-select --print-path pointing to CLT
-    inreplace buildpath/"build/config/mac/mac_sdk.gni",
-              "\"--print_bin_path\",",
-              "\"--print_bin_path\", \"--developer_dir\", \"#{MacOS::Xcode.bundle_path}\""
-
     # Build gn from source and add it to the PATH
     (buildpath/"gn").install resource("gn")
     cd "gn" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR makes a very minor version upgrade to `v8` 7.7.299.13 but more importantly it backports some improvement we did for the `deno` formula in #44361 and #44573:
* link against system `libc++` when build with `llvm`, so that we have no runtime dep on it
* properly `depend_on :xcode` (with the required minimum version)
* use `DevelopmentTools.clang_build_version` to determine if system `clang` is new enough to build `v8`
* *apply a workaround for `xcode-select --print-path` pointing to the CLT instead of XCode on the CI, blocking the Catalina bottle* (let's find out first, if this is still needed here)