### PR TITLE
ffmpeg: enable more build options

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,7 +3,7 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.2.1.tar.xz"
   sha256 "cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4"
-  revision 1
+  revision 2
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
@@ -17,6 +17,7 @@ class Ffmpeg < Formula
   depends_on "texi2html" => :build
 
   depends_on "aom"
+  depends_on "chromaprint"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "frei0r"
@@ -24,10 +25,13 @@ class Ffmpeg < Formula
   depends_on "lame"
   depends_on "libass"
   depends_on "libbluray"
+  depends_on "libcaca"
   depends_on "libsoxr"
+  depends_on "libssh"
   depends_on "libvidstab"
   depends_on "libvorbis"
   depends_on "libvpx"
+  depends_on "libxml2"
   depends_on "opencore-amr"
   depends_on "openjpeg"
   depends_on "opus"
@@ -38,10 +42,13 @@ class Ffmpeg < Formula
   depends_on "speex"
   depends_on "tesseract"
   depends_on "theora"
+  depends_on "webp"
   depends_on "x264"
   depends_on "x265"
   depends_on "xvid"
   depends_on "xz"
+  depends_on "zeromq"
+  depends_on "zimg"
 
   def install
     # Work around Xcode 11 clang bug
@@ -62,17 +69,21 @@ class Ffmpeg < Formula
       --enable-gpl
       --enable-libaom
       --enable-libbluray
+      --enable-libcaca
       --enable-libmp3lame
       --enable-libopus
       --enable-librubberband
       --enable-libsnappy
+      --enable-libssh
       --enable-libtesseract
       --enable-libtheora
       --enable-libvidstab
       --enable-libvorbis
       --enable-libvpx
+      --enable-libwebp
       --enable-libx264
       --enable-libx265
+      --enable-libxml2
       --enable-libxvid
       --enable-lzma
       --enable-libfontconfig
@@ -85,7 +96,10 @@ class Ffmpeg < Formula
       --enable-librtmp
       --enable-libspeex
       --enable-libsoxr
+      --enable-libzmq
+      --enable-libzimg
       --enable-videotoolbox
+      --enable-opencl
       --disable-libjack
       --disable-indev=jack
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

*NOTE*: All these options are up for discussion. I am not trying to enable every option, just those that I find provide a value-add and also use well-known libraries.

This adds various new build options to ffmpeg that add WEBP, Chromaprint audio fingerprinting, libcaca support, the awesome new ZeroMQ support (if any options should be enabled, it should be this one), zimg library support, and OpenCL acceleration support.

With the removal of --with options in core, it is my personal philosophy that formulae in homebrew-core should be a bit more "batteries included". This is an attempt at making ffmpeg more batteries included.
