### PR TITLE
Add protobuf 3.9.2 as protobuf@3.9

### DIFF
--- a/Formula/protobuf@3.9.rb
+++ b/Formula/protobuf@3.9.rb
@@ -4,7 +4,7 @@ class ProtobufAT39 < Formula
   url "https://github.com/protocolbuffers/protobuf.git",
       :tag      => "v3.9.2",
       :revision => "52b2447247f535663ac1c292e088b4b27d2910ef"
-  head "https://github.com/protocolbuffers/protobuf.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,6 +12,8 @@ class ProtobufAT39 < Formula
     sha256 "9220693213ecdf0e22c9d965715509cbebfe34289f07d511468c69045b3f33a0" => :high_sierra
     sha256 "a3b58b755c7a238b8b9525d1c91ef4233c9f031a7236d7a9c7d8e8da86d178a3" => :sierra
   end
+
+  keg_only :versioned_formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/protobuf@3.9.rb
+++ b/Formula/protobuf@3.9.rb
@@ -4,18 +4,20 @@ class ProtobufAT39 < Formula
   url "https://github.com/protocolbuffers/protobuf.git",
       :tag      => "v3.9.2",
       :revision => "52b2447247f535663ac1c292e088b4b27d2910ef"
+  revision 1
+
+  bottle do
+    cellar :any
+    sha256 "c1be8ddc974a93cdf6bdeeac56ca03635397d0280adb4388cf228f0fb611ce12" => :mojave
+    sha256 "9220693213ecdf0e22c9d965715509cbebfe34289f07d511468c69045b3f33a0" => :high_sierra
+    sha256 "a3b58b755c7a238b8b9525d1c91ef4233c9f031a7236d7a9c7d8e8da86d178a3" => :sierra
+  end
 
   keg_only :versioned_formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "python" => [:build, :test]
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
-    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
-  end
 
   def install
     # Don't build in debug mode. See:
@@ -33,22 +35,6 @@ class ProtobufAT39 < Formula
 
     # Install editor support and examples
     doc.install "editors", "examples"
-
-    ENV.append_to_cflags "-I#{include}"
-    ENV.append_to_cflags "-L#{lib}"
-
-    resource("six").stage do
-      system "python3", *Language::Python.setup_install_args(libexec)
-    end
-    chdir "python" do
-      system "python3", *Language::Python.setup_install_args(libexec),
-                        "--cpp_implementation"
-    end
-
-    version = Language::Python.major_minor_version "python3"
-    site_packages = "lib/python#{version}/site-packages"
-    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-    (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
   end
 
   test do
@@ -64,6 +50,5 @@ class ProtobufAT39 < Formula
     EOS
     (testpath/"test.proto").write testdata
     system bin/"protoc", "test.proto", "--cpp_out=."
-    system "python3", "-c", "import google.protobuf"
   end
 end

--- a/Formula/protobuf@3.9.rb
+++ b/Formula/protobuf@3.9.rb
@@ -1,4 +1,4 @@
-class Protobuf < Formula
+class ProtobufAT39 < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/protocolbuffers/protobuf/"
   url "https://github.com/protocolbuffers/protobuf.git",
@@ -65,7 +65,7 @@ class Protobuf < Formula
         string name = 4;
       }
       message Test {
-        repeated TestCase case = 1;
+        repeated TestCase cases = 1;
       }
     EOS
     (testpath/"test.proto").write testdata

--- a/Formula/protobuf@3.9.rb
+++ b/Formula/protobuf@3.9.rb
@@ -4,14 +4,6 @@ class ProtobufAT39 < Formula
   url "https://github.com/protocolbuffers/protobuf.git",
       :tag      => "v3.9.2",
       :revision => "52b2447247f535663ac1c292e088b4b27d2910ef"
-  revision 1
-
-  bottle do
-    cellar :any
-    sha256 "c1be8ddc974a93cdf6bdeeac56ca03635397d0280adb4388cf228f0fb611ce12" => :mojave
-    sha256 "9220693213ecdf0e22c9d965715509cbebfe34289f07d511468c69045b3f33a0" => :high_sierra
-    sha256 "a3b58b755c7a238b8b9525d1c91ef4233c9f031a7236d7a9c7d8e8da86d178a3" => :sierra
-  end
 
   keg_only :versioned_formula
 

--- a/Formula/protobuf@3.9.rb
+++ b/Formula/protobuf@3.9.rb
@@ -1,0 +1,75 @@
+class Protobuf < Formula
+  desc "Protocol buffers (Google's data interchange format)"
+  homepage "https://github.com/protocolbuffers/protobuf/"
+  url "https://github.com/protocolbuffers/protobuf.git",
+      :tag      => "v3.9.2",
+      :revision => "52b2447247f535663ac1c292e088b4b27d2910ef"
+  head "https://github.com/protocolbuffers/protobuf.git"
+
+  bottle do
+    cellar :any
+    sha256 "c1be8ddc974a93cdf6bdeeac56ca03635397d0280adb4388cf228f0fb611ce12" => :mojave
+    sha256 "9220693213ecdf0e22c9d965715509cbebfe34289f07d511468c69045b3f33a0" => :high_sierra
+    sha256 "a3b58b755c7a238b8b9525d1c91ef4233c9f031a7236d7a9c7d8e8da86d178a3" => :sierra
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "python" => [:build, :test]
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  def install
+    # Don't build in debug mode. See:
+    # https://github.com/Homebrew/homebrew/issues/9279
+    # https://github.com/protocolbuffers/protobuf/blob/5c24564811c08772d090305be36fae82d8f12bbe/configure.ac#L61
+    ENV.prepend "CXXFLAGS", "-DNDEBUG"
+    ENV.cxx11
+
+    system "./autogen.sh"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}", "--with-zlib"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+
+    # Install editor support and examples
+    doc.install "editors", "examples"
+
+    ENV.append_to_cflags "-I#{include}"
+    ENV.append_to_cflags "-L#{lib}"
+
+    resource("six").stage do
+      system "python3", *Language::Python.setup_install_args(libexec)
+    end
+    chdir "python" do
+      system "python3", *Language::Python.setup_install_args(libexec),
+                        "--cpp_implementation"
+    end
+
+    version = Language::Python.major_minor_version "python3"
+    site_packages = "lib/python#{version}/site-packages"
+    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
+    (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
+  end
+
+  test do
+    testdata = <<~EOS
+      syntax = "proto3";
+      package test;
+      message TestCase {
+        string name = 4;
+      }
+      message Test {
+        repeated TestCase case = 1;
+      }
+    EOS
+    (testpath/"test.proto").write testdata
+    system bin/"protoc", "test.proto", "--cpp_out=."
+    system "python3", "-c", "import google.protobuf"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This just adds the explicit `protobuf@3.9` name, which went away with the [update to protobuf 3.10](https://github.com/Homebrew/homebrew-core/commit/6fbb6c073785ae14809240681df63b1d4995b16b).