### PR TITLE
Boost: fix missing cmake files

### DIFF
--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -3,6 +3,7 @@ class BoostMpi < Formula
   homepage "https://www.boost.org/"
   url "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2"
   sha256 "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
+  revision 1
   head "https://github.com/boostorg/boost.git"
 
   bottle do
@@ -16,16 +17,15 @@ class BoostMpi < Formula
 
   def install
     # "layout" should be synchronized with boost
-    args = ["--prefix=#{prefix}",
-            "--libdir=#{lib}",
-            "-d2",
-            "-j#{ENV.make_jobs}",
-            "--layout=tagged-1.66",
-            # --no-cmake-config should be dropped if possible in next version
-            "--no-cmake-config",
-            "--user-config=user-config.jam",
-            "threading=multi,single",
-            "link=shared,static"]
+    args = %W[
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged-1.66
+      --user-config=user-config.jam
+      install
+      threading=multi,single
+      link=shared,static
+    ]
 
     # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
     # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
@@ -41,9 +41,13 @@ class BoostMpi < Formula
 
     system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}", "--with-libraries=mpi"
 
-    system "./b2", *args
+    system "./b2",
+           "--prefix=install-mpi",
+           "--libdir=install-mpi/lib",
+           *args
 
-    lib.install Dir["stage/lib/*mpi*"]
+    lib.install Dir["install-mpi/lib/*mpi*"]
+    (lib/"cmake").install Dir["install-mpi/lib/cmake/*mpi*"]
 
     # libboost_mpi links to libboost_serialization, which comes from the main boost formula
     boost = Formula["boost"]

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -3,6 +3,7 @@ class BoostPython < Formula
   homepage "https://www.boost.org/"
   url "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2"
   sha256 "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
+  revision 1
   head "https://github.com/boostorg/boost.git"
 
   bottle do
@@ -18,11 +19,10 @@ class BoostPython < Formula
   def install
     # "layout" should be synchronized with boost
     args = %W[
-      --prefix=#{prefix}
-      --libdir=#{lib}
       -d2
       -j#{ENV.make_jobs}
       --layout=tagged-1.66
+      install
       threading=multi,single
       link=shared,static
     ]
@@ -39,11 +39,24 @@ class BoostPython < Formula
     system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}",
                              "--with-libraries=python", "--with-python=python"
 
-    system "./b2", "--build-dir=build-python", "--stagedir=stage-python",
-                   "python=#{pyver}", *args
+    system "./b2", "--build-dir=build-python",
+                   "--stagedir=stage-python",
+                   "--libdir=install-python/lib",
+                   "--prefix=install-python",
+                   "python=#{pyver}",
+                   *args
 
+    lib.install Dir["install-python/lib/*.*"]
     lib.install Dir["stage-python/lib/*py*"]
     doc.install Dir["libs/python/doc/*"]
+  end
+
+  def caveats; <<~EOS
+    This formula provides Boost.Python for Python 2. Due to a
+    collision with boost-python3, the CMake Config files are not
+    available. Please use -DBoost_NO_BOOST_CMAKE=ON when building
+    with CMake or switch to Python 3.
+  EOS
   end
 
   test do

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -39,8 +39,6 @@ class Boost < Formula
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
 
     # layout should be synchronized with boost-python and boost-mpi
-    #
-    # --no-cmake-config should be dropped if possible in next version
     args = %W[
       --prefix=#{prefix}
       --libdir=#{lib}

--- a/Formula/cucumber-cpp.rb
+++ b/Formula/cucumber-cpp.rb
@@ -24,10 +24,6 @@ class CucumberCpp < Formula
       -DCUKE_DISABLE_BOOST_TEST=on
     ]
 
-    # Temporary fix for bad boost 1.70.0 / cmake interaction
-    # https://github.com/Homebrew/homebrew-core/pull/38890
-    args << "-DBoost_NO_BOOST_CMAKE=ON"
-
     system "cmake", ".", *args
     system "cmake", "--build", "."
     system "make", "install"


### PR DESCRIPTION
Fix #44093 by installing to a staging area, then copying unique files to python or mpi. This adds the Cmake files that are currently missing. Drops workarounds in two formulas due to this bug. Also drops custom numpy download since the numpy formula now is python 3 only and can be used (only added numpy as a build requirement).

There still are warnings when using Boost's Cmake files due to an issue in upstream that should be fixed in 1.72 (I believe). It happens because we provide both MT and non-MT libraries; if we only provided one, the warnings would go away.