### PR TITLE
Update arduino-cli formula - version output

### DIFF
--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -16,13 +16,8 @@ class ArduinoCli < Formula
   depends_on "go" => :build
   
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/arduino/arduino-cli").install buildpath.children
-    cd "src/github.com/arduino/arduino-cli" do
     commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
     system "go", "build", "-ldflags", "-s -w -X github.com/arduino/arduino-cli/version.versionString=#{version} -X github.com/arduino/arduino-cli/version.commit=#{commit}", "-o", bin/"arduino-cli"
-    prefix.install_metafiles
-      end
   end
 
   test do

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -6,8 +6,15 @@ class ArduinoCli < Formula
      :revision => "3be22875e27f220350d8ab5b13403d804acfd20b"
   head "https://github.com/arduino/arduino-cli.git"
 
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "72c5f419d5c90eec86c00cd725219413ba20f8eadccfafc65fc5eb39d84c5c75" => :catalina
+    sha256 "cdcab9bbfeed3e305f1238e89daab615cab346e7ba40c7c40e2636f8baf9c5d0" => :mojave
+    sha256 "d30a97bb9f425ae34858b5cb79f9cedebf132eaa25f9044f5c159bbc5c4778e6" => :high_sierra
+  end
+  
   depends_on "go" => :build
-
+  
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/arduino/arduino-cli").install buildpath.children

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -1,20 +1,21 @@
 class ArduinoCli < Formula
   desc "Arduino command-line interface"
   homepage "https://github.com/arduino/arduino-cli"
-  url "https://github.com/arduino/arduino-cli/archive/0.5.0.tar.gz"
-  sha256 "17832841c36a46a8cdf1f03c29843ab805721a11df6f5f1bdd82e1df43304717"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "72c5f419d5c90eec86c00cd725219413ba20f8eadccfafc65fc5eb39d84c5c75" => :catalina
-    sha256 "cdcab9bbfeed3e305f1238e89daab615cab346e7ba40c7c40e2636f8baf9c5d0" => :mojave
-    sha256 "d30a97bb9f425ae34858b5cb79f9cedebf132eaa25f9044f5c159bbc5c4778e6" => :high_sierra
-  end
+  url "https://github.com/arduino/arduino-cli.git",
+     :tag      => "0.5.0",
+     :revision => "3be22875e27f220350d8ab5b13403d804acfd20b"
+  head "https://github.com/arduino/arduino-cli.git"
 
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-o", bin/"arduino-cli"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/arduino/arduino-cli").install buildpath.children
+    cd "src/github.com/arduino/arduino-cli" do
+    commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+    system "go", "build", "-ldflags", "-s -w -X github.com/arduino/arduino-cli/version.versionString=#{version} -X github.com/arduino/arduino-cli/version.commit=#{commit}", "-o", bin/"arduino-cli"
+    prefix.install_metafiles
+      end
   end
 
   test do


### PR DESCRIPTION
This commit fixes 'arduino-cli version' output by building it with the proper ldflags.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
