### PR TITLE
add fdm and dependency tdb

### DIFF
--- a/Formula/fdm.rb
+++ b/Formula/fdm.rb
@@ -6,7 +6,6 @@ class Fdm < Formula
 
   depends_on "openssl@1.1"
   depends_on "pcre"
-  depends_on "pkg-config"
   depends_on "tdb"
 
   def install

--- a/Formula/fdm.rb
+++ b/Formula/fdm.rb
@@ -1,0 +1,21 @@
+class Fdm < Formula
+  desc "Fetch and deliver mail based on a ruleset"
+  homepage "https://github.com/nicm/fdm"
+  url "https://github.com/nicm/fdm/releases/download/2.0/fdm-2.0.tar.gz"
+  sha256 "06b28cb6b792570bc61d7e29b13d2af46b92fea77e058b2b17e11e8f7ed0cea4"
+
+  depends_on "openssl@1.1"
+  depends_on "pcre"
+  depends_on "pkg-config"
+  depends_on "tdb"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--enable-pcre",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+    doc.install "MANUAL"
+  end
+end

--- a/Formula/fdm.rb
+++ b/Formula/fdm.rb
@@ -26,6 +26,6 @@ class Fdm < Formula
     EOS
     system "cat", testpath/"fdm.conf"
     system bin/"fdm", "-f", testpath/"fdm.conf", "cache", "add", testpath/"fdm.cache", "test"
-    assert_match /#{testpath}\/fdm.cache: 1 keys/, shell_output("#{bin}/fdm cache list #{testpath}/fdm.cache")
+    assert_match /#{testpath}\/fdm.cache: 1 keys/, shell_output("#{bin}/fdm -f #{testpath}/fdm.conf cache list #{testpath}/fdm.cache")
   end
 end

--- a/Formula/fdm.rb
+++ b/Formula/fdm.rb
@@ -17,4 +17,15 @@ class Fdm < Formula
     system "make", "install"
     doc.install "MANUAL"
   end
+
+  test do
+    path = testpath/"fdm.conf"
+    path.write <<~EOS
+      account "stdin" stdin
+      cache "#{testpath}/fdm.cache"
+    EOS
+    system "cat", testpath/"fdm.conf"
+    system bin/"fdm", "-f", testpath/"fdm.conf", "cache", "add", testpath/"fdm.cache", "test"
+    assert_match /#{testpath}\/fdm.cache: 1 keys/, shell_output("#{bin}/fdm cache list #{testpath}/fdm.cache")
+  end
 end

--- a/Formula/tdb.rb
+++ b/Formula/tdb.rb
@@ -1,0 +1,18 @@
+class Tdb < Formula
+  desc "Trivial database library"
+  homepage "https://tdb.samba.org"
+  url "https://www.samba.org/ftp/tdb/tdb-1.4.2.tar.gz"
+  sha256 "9040b2cce4028e392f063f91bbe76b8b28fecc2b7c0c6071c67b5eb3168e004a"
+
+  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "python" => :build
+
+  def install
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    system "./configure", "--prefix=#{prefix}", "--disable-rpath"
+    system "make", "test"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a PR to add `fdm` (a `procmail` and `fetchmail` replacement) and its dependency (`tdb` from `samba`).

i have found https://github.com/Homebrew/legacy-homebrew/pull/36581/.  the dynamic library thing is fixed by `--disable-rpath`

`brew test`: `tdb` has an extensive test suite executed during build.  `fdm` could have a test later when i have actually started using it and learned the config language :}

as there are no `brew test`s, the audits do not pass.