### PR TITLE
flyway@5 5.2.4 (new formula)

### DIFF
--- a/Formula/flyway@5.rb
+++ b/Formula/flyway@5.rb
@@ -1,0 +1,22 @@
+class FlywayAT5 < Formula
+  desc "Database version control to control migrations"
+  homepage "https://flywaydb.org/"
+  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-macosx-x64.tar.gz"
+  sha256 "3122916f45c95b2afd20b81126cbf687d1142e13e93d7434a06da642b99e2c4c"
+
+  bottle :unneeded
+
+  keg_only :versioned_formula
+
+  depends_on :java
+
+  def install
+    rm Dir["*.cmd"]
+    libexec.install Dir["*"]
+    bin.install_symlink Dir["#{libexec}/flyway"]
+  end
+
+  test do
+    system "#{bin}/flyway", "-url=jdbc:h2:mem:flywaydb", "validate"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Flyway 6 dropped support for MySQL < 5.7; this version still supports older MySQL versions.