### PR TITLE
glib: fix failing inreplace

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -56,7 +56,7 @@ class Glib < Formula
     # have a pkgconfig file, so we add gettext lib and include paths here.
     gettext = Formula["gettext"].opt_prefix
     inreplace lib+"pkgconfig/glib-2.0.pc" do |s|
-      s.gsub! "Libs: -lintl -L${libdir} -lglib-2.0",
+      s.gsub! "Libs: -L${libdir} -lglib-2.0 -lintl",
               "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib -lintl"
       s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
               "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR resolves the failing `inreplace` during the installation of `glib`:

```
==> meson --prefix=/usr/local/Cellar/glib/2.62.1 -Diconv=auto -Dgio_module_dir=/usr/local/lib/gio/modules -Dbsymbolic_functions=false -Ddtrace=false ..
==> ninja -v
==> ninja install -v
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
/usr/local/Cellar/glib/2.62.1/lib/pkgconfig/glib-2.0.pc:
  expected replacement of "Libs: -lintl -L${libdir} -lglib-2.0" with "Libs: -L${libdir} -lglib-2.0 -L/usr/local/opt/gettext/lib -lintl"
```

It seems that Meson 0.52.0 (#45089) generates the pkg-config file in a slightly different way.