### PR TITLE
Update restic.rb for mdns support

### DIFF
--- a/Formula/restic.rb
+++ b/Formula/restic.rb
@@ -4,6 +4,7 @@ class Restic < Formula
   url "https://github.com/restic/restic/archive/v0.9.5.tar.gz"
   sha256 "e22208e946ede07f56ef60c1c89de817b453967663ce4867628dff77761bd429"
   head "https://github.com/restic/restic.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,8 +17,9 @@ class Restic < Formula
 
   def install
     ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
+    ENV["CGO_ENABLED"] = "1"
 
-    system "go", "run", "build.go"
+    system "go", "run", "build.go", "--enable-cgo"
 
     mkdir "completions"
     system "./restic", "generate", "--bash-completion", "completions/restic"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update rustic with cgo enabled for mdns support (accessing local machines by dns names like `foo.local`).

https://github.com/restic/restic/issues/2335