### PR TITLE
iproute2mac: catalina support

### DIFF
--- a/Formula/iproute2mac.rb
+++ b/Formula/iproute2mac.rb
@@ -1,12 +1,17 @@
 class Iproute2mac < Formula
   desc "CLI wrapper for basic network utilities on macOS - ip command"
-  homepage "https://github.com/brona/iproute2mac"
-  url "https://github.com/brona/iproute2mac/releases/download/v1.2.2/iproute2mac-1.2.2.tar.gz"
-  sha256 "37ea67da5bbcac5977877c4a3a1ea8c6149785d44c65ffdaf60f9e2ba689def3"
+  homepage "https://github.com/SpinlockLabs/iproute2mac"
+  url "https://github.com/SpinlockLabs/iproute2mac/releases/download/v1.2.4/iproute2mac-1.2.4.tar.gz"
+  sha256 "ae15aa4eb81be9cdec56e0005d806e8a1d2f9f2a91fafeb1eff67fe23e93e1fd"
+  head "https://github.com/SpinlockLabs/iproute2mac.git"
 
   bottle :unneeded
 
+  depends_on "python"
+
   def install
+    inreplace "src/ip.py", %r{^#!/usr/bin/python3$},
+                            "#!/usr/bin/env python3"
     bin.install "src/ip.py" => "ip"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This switches iproute2mac to a fork that is up-to-date and supports Catalina. Unfortunately the original upstream does not respond to PRs and is not actively updating the project. I have taken it over (as I use it at work a lot) and I plan to maintain it at https://github.com/SpinlockLabs/iproute2mac which is an organization open to good Open Source actors. This means it can live on past one maintainer.
