### PR TITLE
sane-backends: Apply patch to make certain USB scanners work

### DIFF
--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -3,7 +3,7 @@ class SaneBackends < Formula
   homepage "http://www.sane-project.org/"
   url "https://gitlab.com/sane-project/backends/uploads/9e718daff347826f4cfe21126c8d5091/sane-backends-1.0.28.tar.gz"
   sha256 "31260f3f72d82ac1661c62c5a4468410b89fb2b4a811dabbfcc0350c1346de03"
-  revision 1
+  revision 2
   head "https://gitlab.com/sane-project/backends.git"
 
   bottle do
@@ -20,6 +20,15 @@ class SaneBackends < Formula
   depends_on "libusb"
   depends_on "net-snmp"
   depends_on "openssl@1.1"
+
+  # Some USB scanners, including Fujitsu ScanSnap, are not automatically configured on a USB
+  # level by OS X, and sanei_usb doesn't allow unconfigured USB devices to be used.
+  #
+  # It turns out that (in most/all? cases) this doesn't actually matter, and we can go ahead and
+  # use the device anyway. Applying this patch does that.
+  #
+  # Source/info: https://alioth-lists.debian.net/pipermail/sane-devel/2019-April/036715.html
+  patch :DATA
 
   def install
     # malloc lives in malloc/malloc.h instead of just malloc.h on macOS.
@@ -44,3 +53,26 @@ class SaneBackends < Formula
     assert_match prefix.to_s, shell_output("#{bin}/sane-config --prefix")
   end
 end
+__END__
+diff --git a/sanei/sanei_usb.c b/sanei/sanei_usb.c
+index e4b23dc..294c64b 100644
+--- a/sanei/sanei_usb.c
++++ b/sanei/sanei_usb.c
+@@ -936,7 +936,7 @@ static void libusb_scan_devices(void)
+ 	  DBG (1,
+ 	       "%s: device 0x%04x/0x%04x at %03d:%03d is not configured\n", __func__,
+ 	       vid, pid, busno, address);
+-	  continue;
++	  /* continue; */
+ 	}
+
+       ret = libusb_get_config_descriptor (dev, 0, &config0);
+@@ -1640,7 +1640,7 @@ sanei_usb_open (SANE_String_Const devname, SANE_Int * dn)
+       if (config == 0)
+ 	{
+ 	  DBG (1, "sanei_usb_open: device `%s' not configured?\n", devname);
+-	  return SANE_STATUS_INVAL;
++	  /*return SANE_STATUS_INVAL; */
+ 	}
+
+       result = libusb_get_device_descriptor (dev, &desc);


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

Some USB scanners, including Fujitsu ScanSnap models, are not automatically configured on a USB level by OS X, and sanei_usb doesn't allow unconfigured USB devices to be used.

This results in the scanner not being detected, and `sane-find-scanners -v` says `device 0xXXXX/0xXXXX at XXX:XXX is not configured`.

It turns out that (in most/all? cases) this doesn't actually matter, and we can go ahead and
use the device anyway. This PR applies a patch which does that.

* [Source of patch/more info](https://alioth-lists.debian.net/pipermail/sane-devel/2019-April/036715.html)
* [Related sane-project issue](https://gitlab.com/sane-project/backends/issues/38)