### PR TITLE
osrm-backend 5.22.0

### DIFF
--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -3,7 +3,7 @@ class OsrmBackend < Formula
   homepage "http://project-osrm.org/"
   url "https://github.com/Project-OSRM/osrm-backend/archive/v5.22.0.tar.gz"
   sha256 "df0987a04bcf65d74f9c4e18f34a01982bf3bb97aa47f9d86cfb8b35f17a6a55"
-  revision 2
+  revision 3
   head "https://github.com/Project-OSRM/osrm-backend.git"
 
   bottle do
@@ -28,7 +28,7 @@ class OsrmBackend < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DENABLE_CCACHE:BOOL=OFF", *std_cmake_args
+      system "cmake", "..", "-DENABLE_CCACHE:BOOL=OFF", "-DBoost_NO_BOOST_CMAKE=ON", *std_cmake_args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Issue

`osrm-backend` would build and I could use `osrm-extract` and `osrm-contract` with small US state-level files from Geofabrik. Larger state and regional files, however, would error. I believe the problem is related to recent issues between Cmake and Boost >= 1.70.0 (e.g., #44093) that prevent proper handling of single- vs multi-threading.

## Solution

Based on suggests in various forums (e.g., [here](https://gitlab.kitware.com/cmake/cmake/issues/19714)), it seems the current solution is to use `Boost_NO_BOOST_CMAKE=ON`. This may not be a long term solution, but it did allow me to build `osrm-backend` and use both `osrm-extract` and `osrm-contract` on an `*.osm.pbf` file that covered the entire continental United States.
