### PR TITLE
rsync-time-backup: add head option

### DIFF
--- a/Formula/rsync-time-backup.rb
+++ b/Formula/rsync-time-backup.rb
@@ -3,6 +3,7 @@ class RsyncTimeBackup < Formula
   homepage "https://github.com/laurent22/rsync-time-backup"
   url "https://github.com/laurent22/rsync-time-backup/archive/v1.1.5.tar.gz"
   sha256 "567f42ddf2c365273252f15580bb64aa3b3a8abb4a375269aea9cf0278510657"
+  head "https://github.com/laurent22/rsync-time-backup.git"
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds --HEAD option to the formula rsync-time-backup.