### PR TITLE
osslsigncode: add dependency on libgsf to support msi

### DIFF
--- a/Formula/osslsigncode.rb
+++ b/Formula/osslsigncode.rb
@@ -3,6 +3,7 @@ class Osslsigncode < Formula
   homepage "https://github.com/mtrojnar/osslsigncode"
   url "https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz"
   sha256 "5a60e0a4b3e0b4d655317b2f12a810211c50242138322b16e7e01c6fbb89d92f"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,11 +16,12 @@ class Osslsigncode < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "libgsf"
   depends_on "openssl@1.1"
 
   def install
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--with-gsf", "--prefix=#{prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The optional dependency on `libgsf` was removed in a [recent commit](https://github.com/Homebrew/homebrew-core/commit/dabea97708333d84247c1d9ab1f269e38204f699) to remove options on osslsigncode. Nonetheless, the need to validate and sign .msi files does exist and I would like to be able to do this using osslsigncode, as do other people. See [Issue #42859](https://github.com/Homebrew/homebrew-core/issues/42859) for more detailed information on the usage of libgsf. This issue was closed after asking the issuer to open a PR. I'm not the issuer, but here is the PR!