### PR TITLE
conan: fix bottle issue

### DIFF
--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -5,6 +5,7 @@ class Conan < Formula
   homepage "https://github.com/conan-io/conan"
   url "https://github.com/conan-io/conan/archive/1.19.2.tar.gz"
   sha256 "1b824f14584a5da4deace6154ee49487faea99ddce3a2993f6a79f9a35b43d64"
+  revision 1
   head "https://github.com/conan-io/conan.git"
 
   bottle do


### PR DESCRIPTION
Relates to #45410

Failed to publish the bottles:

```
==> Fetching patch
Patch: https://github.com/Homebrew/homebrew-core/pull/45410.patch
######################################################################## 100.0%
==> Applying patch
Applying: conan 1.19.2
==> Patch closes issue #45410
==> Fetching patch (bottle commit)
Patch: https://github.com/BrewTestBot/homebrew-core/compare/Homebrew:master...pr-45410.patch

curl: (22) The requested URL returned error: 404 Not Found
Error: Failure while executing; `/usr/bin/curl -q --globoff --show-error --user-agent Homebrew/2.1.14-44-g2bf8015\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.14.6\)\ curl/7.54.0 --fail --progress-bar --location --remote-time --continue-at 0 --output /Users/rchen/Library/Caches/Homebrew/Homebrew:master...pr-45410.patch https://github.com/BrewTestBot/homebrew-core/compare/Homebrew:master...pr-45410.patch` exited with 22. Here's the output:

curl: (22) The requested URL returned error: 404 Not Found
```

And somehow did not do reset and republish. Fixing the bottle in this PR.