### PR TITLE
pyenv: re-add `version_scheme`

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -3,6 +3,8 @@ class Pyenv < Formula
   homepage "https://github.com/pyenv/pyenv"
   url "https://github.com/pyenv/pyenv/archive/v1.2.14.tar.gz"
   sha256 "3062c104b200d8c572d185b54e73a94bf66d5d46cc789717c372d2941c314a93"
+  revision 1
+  version_scheme 1
   head "https://github.com/pyenv/pyenv.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`version_scheme 1` was removed in https://github.com/Homebrew/homebrew-core/pull/45365 which prevents users from upgrading to the current version.

https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/49954/version=catalina/testReport/junit/brew-test-bot/catalina/audit_pyenv___online/
![Screen Shot 2019-10-17 at 06 26 53](https://user-images.githubusercontent.com/26216252/66956231-63700080-f0a7-11e9-930d-aff75d377a90.png)

Should fix https://github.com/pyenv/pyenv/issues/1422#issuecomment-542863294.
