### PR TITLE
add new utf8proc dependency to neovim

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -3,12 +3,16 @@ class Neovim < Formula
   homepage "https://neovim.io/"
   url "https://github.com/neovim/neovim/archive/v0.4.2.tar.gz"
   sha256 "9f874d3d2a74f33b931db62adebe28f8d2ec116270d1e13998b58a73348b6e56"
-  head "https://github.com/neovim/neovim.git"
 
   bottle do
     sha256 "5436532a1574329e386cf29df04e7d528730a7bd95c073b6ea76a37499ececc0" => :mojave
     sha256 "7d839a0c108ea2a95b7a61bde2fb08f667938bcad2e4a5d908d51a35d899c85c" => :high_sierra
     sha256 "73bc96be3bccacb2c6c02e4c3aaf06ad0dc4f3b34569a46adda8ec7b41db2f52" => :sierra
+  end
+
+  head do
+    url "https://github.com/neovim/neovim.git"
+    depends_on "utf8proc"
   end
 
   depends_on "cmake" => :build
@@ -21,7 +25,6 @@ class Neovim < Formula
   depends_on "luajit"
   depends_on "msgpack"
   depends_on "unibilium"
-  depends_on "utf8proc"
 
   resource "mpack" do
     url "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz"

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -21,6 +21,7 @@ class Neovim < Formula
   depends_on "luajit"
   depends_on "msgpack"
   depends_on "unibilium"
+  depends_on "utf8proc"
 
   resource "mpack" do
     url "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz"


### PR DESCRIPTION
The `--HEAD` version of neovim has a new dependency: `utf8proc`. Without this dependency `--HEAD` builds fail.

Check https://github.com/neovim/neovim/issues/11125 for more info.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
