### PR TITLE
oniguruma: Fixes to build

### DIFF
--- a/Formula/oniguruma.rb
+++ b/Formula/oniguruma.rb
@@ -3,6 +3,7 @@ class Oniguruma < Formula
   homepage "https://github.com/kkos/oniguruma/"
   url "https://github.com/kkos/oniguruma/releases/download/v6.9.3/onig-6.9.3.tar.gz"
   sha256 "ab5992a76b7ab2185b55f3aacc1b0df81132c947b3d594f82eb0b41cf219725f"
+  head "https://github.com/kkos/oniguruma.git"
 
   bottle do
     cellar :any
@@ -12,12 +13,18 @@ class Oniguruma < Formula
     sha256 "67a2105211f270ed618fdb3d29946ad89e2cb6e7bbb5cbb7dc7f48bc4e94e6db" => :sierra
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    system "autoreconf", "-vfi"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make"
     system "make", "install"
   end
 
   test do
-    assert_match /#{prefix}/, shell_output("#{bin}/onig-config --prefix")
+    assert_match(/#{prefix}/, shell_output("#{bin}/onig-config --prefix"))
   end
 end


### PR DESCRIPTION
The oniguruma forumula doesn't appear to actually allow building from
source as it is currently written.

This commit contains the following fixes:

* Adds "head" configuration
* Add missing build dependencies
* Adds required build steps

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
