### PR TITLE
gr-osmosdr: fix warning in test

### DIFF
--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -43,11 +43,11 @@ class GrOsmosdr < Formula
     (testpath/"test.cpp").write <<~EOS
       #include <osmosdr/device.h>
       int main() {
-        osmosdr::device_t device();
+        osmosdr::device_t device;
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-L#{lib}", "-lgnuradio-osmosdr", "-o", "test"
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lgnuradio-osmosdr", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
