### PR TITLE
doctl: fix zsh completion

### DIFF
--- a/Formula/doctl.rb
+++ b/Formula/doctl.rb
@@ -3,6 +3,7 @@ class Doctl < Formula
   homepage "https://github.com/digitalocean/doctl"
   url "https://github.com/digitalocean/doctl/archive/v1.32.3.tar.gz"
   sha256 "e6e60c3bd6c3638a71e7be610c662344bca240194cc3de826e78a51739ca546d"
+  revision 1
   head "https://github.com/digitalocean/doctl.git"
 
   bottle do
@@ -33,7 +34,7 @@ class Doctl < Formula
     end
 
     (bash_completion/"doctl").write `#{bin}/doctl completion bash`
-    (zsh_completion/"doctl").write `#{bin}/doctl completion zsh`
+    (zsh_completion/"_doctl").write `#{bin}/doctl completion zsh`
   end
 
   test do


### PR DESCRIPTION
ZSH completion functions must start with `_`... e.g. the
completion function for `doctl` should be `_doctl`.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----