### PR TITLE
pygtk: fix for recent Pango

### DIFF
--- a/Formula/pygtk.rb
+++ b/Formula/pygtk.rb
@@ -19,6 +19,9 @@ class Pygtk < Formula
   depends_on "py2cairo"
   depends_on "pygobject"
 
+  # Allow building with recent Pango, where some symbols were removed
+  patch :DATA
+
   def install
     ENV.append "CFLAGS", "-ObjC"
     system "./configure", "--disable-dependency-tracking",
@@ -37,3 +40,57 @@ class Pygtk < Formula
     system "#{bin}/pygtk-codegen-2.0", "codegen.def"
   end
 end
+__END__
+diff -pur a/pango-types.defs b/pango-types.defs
+--- a/pango-types.defs	2011-04-01 12:37:25.000000000 +0200
++++ b/pango-types.defs	2019-10-19 14:44:23.000000000 +0200
+@@ -176,13 +176,6 @@
+   (gtype-id "PANGO_TYPE_FONTSET")
+ )
+ 
+-(define-object FontsetSimple
+-  (in-module "Pango")
+-  (parent "PangoFontset")
+-  (c-name "PangoFontsetSimple")
+-  (gtype-id "PANGO_TYPE_FONTSET_SIMPLE")
+-)
+-
+ (define-object Layout
+   (in-module "Pango")
+   (parent "GObject")
+diff -pur a/pango.defs b/pango.defs
+--- a/pango.defs	2011-04-01 12:37:25.000000000 +0200
++++ b/pango.defs	2019-10-19 14:40:13.000000000 +0200
+@@ -1303,16 +1303,6 @@
+   )
+ )
+ 
+-(define-method find_shaper
+-  (of-object "PangoFont")
+-  (c-name "pango_font_find_shaper")
+-  (return-type "PangoEngineShape*")
+-  (parameters
+-    '("PangoLanguage*" "language")
+-    '("guint32" "ch")
+-  )
+-)
+-
+ (define-method get_metrics
+   (of-object "PangoFont")
+   (c-name "pango_font_get_metrics")
+@@ -1391,15 +1381,6 @@
+   )
+ )
+ 
+-(define-virtual find_shaper
+-  (of-object "PangoFont")
+-  (return-type "PangoEngineShape*")
+-  (parameters
+-    '("PangoLanguage*" "lang")
+-    '("guint32" "ch")
+-  )
+-)
+-
+ (define-virtual get_glyph_extents
+   (of-object "PangoFont")
+   (return-type "none")


### PR DESCRIPTION
It appears `pygtk` is not maintained anymore, and does not build with latest versions of Pango. Yet we have many users, so I'm reluctant to simply drop it. 

cc @tschoonj how does that simple patch feel to you?