### PR TITLE
Revert "carthage: update 0.33.0 bottle."

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -9,9 +9,7 @@ class Carthage < Formula
 
   bottle do
     cellar :any_skip_relocation
-    rebuild 1
-    sha256 "2d1dfd8accb374b3e14b71feb6ff531ff19936832e41581852a763ec84b7c278" => :catalina
-    sha256 "7183b69c0a12b7c4126751f4c6d5483717ae495aa0aa67fb9825fe6c00357013" => :mojave
+    sha256 "7f88034cfbd51439cd45467745ea3b1a21e6eec2cdd8a7eb2a8945382404b5f0" => :high_sierra
   end
 
   depends_on :xcode => ["10.0", :build]


### PR DESCRIPTION
This reverts commit 0245954d586225fb8f32ed4ef2df017c9342b8bc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Having a bottle for High Sierra is very desirable for Carthage as it is a crucial part of many people's CI workflows.

This PR restores the previous High Sierra bottle for 0.33.0 (which is unfortunately, un-re-buildable due to [a severe SwiftPM bug](https://github.com/Carthage/Carthage/commit/9b009cb408afb08e3b32d234adb7a8ee5f1be627)).

**Notes**:
Previously — as of https://github.com/Homebrew/homebrew-core/pull/38656 — only a High Sierra bottle was made available, in an effort to facilitate sub-10.14.4-Mojave and to match the `.pkg` installer on Carthage’s GitHub Releases page. That desire still (somewhat) remains.