### PR TITLE
gcc: revision for new Xcode

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -4,7 +4,7 @@ class Gcc < Formula
   url "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
   sha256 "ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206"
-  revision 1
+  revision 2
   head "https://gcc.gnu.org/git/gcc.git"
 
   bottle do
@@ -90,7 +90,7 @@ class Gcc < Formula
       elsif MacOS.version >= :mojave
         # System headers are no longer located in /usr/include
         args << "--with-native-system-header-dir=/usr/include"
-        args << "--with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+        args << "--with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk"
       end
 
       system "../configure", *args

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -3,7 +3,7 @@ class Ipopt < Formula
   homepage "https://projects.coin-or.org/Ipopt/"
   url "https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.13.tgz"
   sha256 "aac9bb4d8a257fdfacc54ff3f1cbfdf6e2d61fb0cf395749e3b0c0664d3e7e96"
-  revision 2
+  revision 3
   head "https://github.com/coin-or/Ipopt.git"
 
   bottle do


### PR DESCRIPTION
Now that Mojave has Xcode 11 and the 10.15 SDK, we need to update GCC there so that it fixes the system headers. Since High Sierra also now has a new Xcode version, it seems appropriate to refresh our bottles, so users avoid a mismatched GCC / Xcode / SDK combination.