### PR TITLE
supervisor 4.1.0

### DIFF
--- a/Formula/supervisor.rb
+++ b/Formula/supervisor.rb
@@ -3,8 +3,8 @@ class Supervisor < Formula
 
   desc "Process Control System"
   homepage "http://supervisord.org/"
-  url "https://github.com/Supervisor/supervisor/archive/4.0.4.tar.gz"
-  sha256 "5087a99c008c8b4ca26c27a360cbcef03430589b8f60912715179ef19e16fa18"
+  url "https://github.com/Supervisor/supervisor/archive/4.1.0.tar.gz"
+  sha256 "e4e87a309d34c1356b77d1dfd300191b2a7c314e050d7b3853e5b91ef166c2f2"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,11 +15,6 @@ class Supervisor < Formula
   end
 
   depends_on "python"
-
-  resource "meld3" do
-    url "https://files.pythonhosted.org/packages/45/a0/317c6422b26c12fe0161e936fc35f36552069ba8e6f7ecbd99bbffe32a5f/meld3-1.0.2.tar.gz"
-    sha256 "f7b754a0fde7a4429b2ebe49409db240b5699385a572501bb0d5627d299f9558"
-  end
 
   def install
     inreplace buildpath/"supervisor/skel/sample.conf" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `meld3` dependency was removed from the formula because `supervisor` no longer uses `meld3` [since 4.1.0](https://github.com/Supervisor/supervisor/blame/4.1.0/CHANGES.rst#L11-L12).