### PR TITLE
minikube 1.5.0 (new formula)

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -1,0 +1,36 @@
+class Minikube < Formula
+  desc "Run a Kubernetes cluster locally"
+  homepage "https://minikube.sigs.k8s.io/"
+  url "https://github.com/kubernetes/minikube.git",
+      :tag      => "v1.5.0",
+      :revision => "d1151d93385a70c5a03775e166e94067791fe2d9"
+  head "https://github.com/kubernetes/minikube.git"
+
+  depends_on "go" => :build
+  depends_on "go-bindata" => :build
+  depends_on "kubernetes-cli"
+
+  def install
+    system "make"
+    bin.install "out/minikube"
+
+    output = Utils.popen_read("#{bin}/minikube completion bash")
+    (bash_completion/"minikube").write output
+
+    output = Utils.popen_read("#{bin}/minikube completion zsh")
+    (zsh_completion/"_minikube").write output
+  end
+
+  test do
+    output = shell_output("#{bin}/minikube version")
+    assert_match "version: v#{version}", output
+
+    (testpath/".minikube/config/config.json").write <<~EOS
+      {
+        "vm-driver": "virtualbox"
+      }
+    EOS
+    output = shell_output("#{bin}/minikube config view")
+    assert_match "vm-driver: virtualbox", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula has been attempted a couple of times before: https://github.com/Homebrew/homebrew-core/pull/2417, https://github.com/Homebrew/homebrew-core/pull/12189, https://github.com/Homebrew/homebrew-core/pull/27468

The previous problems (docker was needed for macOS builds, running `go get` for build deps) have been resolved.

`minikube` already exists within Homebrew as a [linuxbrew only formula](https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/minikube.rb) and a [cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/minikube.rb).
