### PR TITLE
Add Tarantool new 1.10 release

### DIFF
--- a/Aliases/tarantool@2.1
+++ b/Aliases/tarantool@2.1
@@ -1,0 +1,1 @@
+../Formula/tarantool.rb

--- a/Formula/tarantool@1.10.rb
+++ b/Formula/tarantool@1.10.rb
@@ -1,0 +1,62 @@
+class TarantoolAT110 < Formula
+  desc "In-memory database and Lua application server"
+  homepage "https://tarantool.org/"
+  url "https://download.tarantool.org/tarantool/1.10/src/tarantool-1.10.4.1.tar.gz"
+  sha256 "dc99562840512151beca46d5618e6659b61e0749a99345750b14702f59a868fb"
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "autoconf"
+  depends_on "automake"
+  depends_on "icu4c"
+  depends_on "libtool"
+  depends_on "openssl"
+  depends_on "readline"
+
+  def install
+    sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
+
+    # Necessary for luajit to build on macOS Mojave (see luajit formula)
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+
+    args = std_cmake_args
+    args << "-DCMAKE_INSTALL_MANDIR=#{doc}"
+    args << "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}"
+    args << "-DCMAKE_INSTALL_LOCALSTATEDIR=#{var}"
+    args << "-DENABLE_DIST=ON"
+    args << "-DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}"
+    args << "-DREADLINE_ROOT=#{Formula["readline"].opt_prefix}"
+    args << "-DCURL_INCLUDE_DIR=#{sdk}/usr/include"
+    args << "-DCURL_LIBRARY=/usr/lib/libcurl.dylib"
+
+    system "cmake", ".", *args
+    system "make"
+    system "make", "install"
+  end
+
+  def post_install
+    local_user = ENV["USER"]
+    inreplace etc/"default/tarantool", /(username\s*=).*/, "\\1 '#{local_user}'"
+
+    (var/"lib/tarantool").mkpath
+    (var/"log/tarantool").mkpath
+    (var/"run/tarantool").mkpath
+  end
+
+  test do
+    (testpath/"test.lua").write <<~EOS
+      box.cfg{}
+      local s = box.schema.create_space("test")
+      s:create_index("primary")
+      local tup = {1, 2, 3, 4}
+      s:insert(tup)
+      local ret = s:get(tup[1])
+      if (ret[3] ~= tup[3]) then
+        os.exit(-1)
+      end
+      os.exit(0)
+    EOS
+    system bin/"tarantool", "#{testpath}/test.lua"
+  end
+end


### PR DESCRIPTION
Created additional formulas:
    tarantool@1.10: 1.10.4 LTS release with 1.10.4.1 package version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
