### PR TITLE
telegram-cli: replace inline patch

### DIFF
--- a/Formula/telegram-cli.rb
+++ b/Formula/telegram-cli.rb
@@ -28,7 +28,10 @@ class TelegramCli < Formula
   end
 
   # Patch for OpenSSL 1.1 compatibility
-  patch :DATA
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/129507e4ee3dc314156e179902ac375abd00c7fa/telegram-cli/openssl-1.1.diff"
+    sha256 "eb6243e1861c0b1595e8bdee705d1acdd2678e854f0919699d4b26c159e30b5e"
+  end
 
   def install
     args = %W[
@@ -50,105 +53,3 @@ class TelegramCli < Formula
     assert_match "telegram-cli", (shell_output "#{bin}/telegram -h", 1)
   end
 end
-__END__
-diff -pur a/tgl/mtproto-client.c b/tgl/mtproto-client.c
---- a/tgl/mtproto-client.c	2019-09-07 14:58:12.000000000 +0200
-+++ b/tgl/mtproto-client.c	2019-09-07 15:04:34.000000000 +0200
-@@ -143,7 +143,9 @@ static int decrypt_buffer[ENCRYPT_BUFFER
-
- static int encrypt_packet_buffer (struct tgl_state *TLS, struct tgl_dc *DC) {
-   RSA *key = TLS->rsa_key_loaded[DC->rsa_key_idx];
--  return tgl_pad_rsa_encrypt (TLS, (char *) packet_buffer, (packet_ptr - packet_buffer) * 4, (char *) encrypt_buffer, ENCRYPT_BUFFER_INTS * 4, key->n, key->e);
-+  const BIGNUM *n, *e;
-+  RSA_get0_key(key, &n, &e, NULL);
-+  return tgl_pad_rsa_encrypt (TLS, (char *) packet_buffer, (packet_ptr - packet_buffer) * 4, (char *) encrypt_buffer, ENCRYPT_BUFFER_INTS * 4, n, e);
- }
-
- static int encrypt_packet_buffer_aes_unauth (const char server_nonce[16], const char hidden_client_nonce[32]) {
-diff -pur a/tgl/mtproto-common.c b/tgl/mtproto-common.c
---- a/tgl/mtproto-common.c	2019-09-07 14:58:12.000000000 +0200
-+++ b/tgl/mtproto-common.c	2019-09-07 15:10:53.000000000 +0200
-@@ -178,10 +178,12 @@ int tgl_serialize_bignum (BIGNUM *b, cha
- long long tgl_do_compute_rsa_key_fingerprint (RSA *key) {
-   static char tempbuff[4096];
-   static unsigned char sha[20];
--  assert (key->n && key->e);
--  int l1 = tgl_serialize_bignum (key->n, tempbuff, 4096);
-+  const BIGNUM *n, *e;
-+  RSA_get0_key(key, &n, &e, NULL);
-+  assert (n && e);
-+  int l1 = tgl_serialize_bignum (n, tempbuff, 4096);
-   assert (l1 > 0);
--  int l2 = tgl_serialize_bignum (key->e, tempbuff + l1, 4096 - l1);
-+  int l2 = tgl_serialize_bignum (e, tempbuff + l1, 4096 - l1);
-   assert (l2 > 0 && l1 + l2 <= 4096);
-   SHA1 ((unsigned char *)tempbuff, l1 + l2, sha);
-   return *(long long *)(sha + 12);
-@@ -258,21 +260,21 @@ int tgl_pad_rsa_encrypt (struct tgl_stat
-   assert (size >= chunks * 256);
-   assert (RAND_pseudo_bytes ((unsigned char *) from + from_len, pad) >= 0);
-   int i;
--  BIGNUM x, y;
--  BN_init (&x);
--  BN_init (&y);
-+  BIGNUM *x, *y;
-+  x = BN_new();
-+  y = BN_new();
-   rsa_encrypted_chunks += chunks;
-   for (i = 0; i < chunks; i++) {
--    BN_bin2bn ((unsigned char *) from, 255, &x);
--    assert (BN_mod_exp (&y, &x, E, N, TLS->BN_ctx) == 1);
--    unsigned l = 256 - BN_num_bytes (&y);
-+    BN_bin2bn ((unsigned char *) from, 255, x);
-+    assert (BN_mod_exp (y, x, E, N, TLS->BN_ctx) == 1);
-+    unsigned l = 256 - BN_num_bytes (y);
-     assert (l <= 256);
-     memset (to, 0, l);
--    BN_bn2bin (&y, (unsigned char *) to + l);
-+    BN_bn2bin (y, (unsigned char *) to + l);
-     to += 256;
-   }
--  BN_free (&x);
--  BN_free (&y);
-+  BN_free (x);
-+  BN_free (y);
-   return chunks * 256;
- }
-
-@@ -285,26 +287,26 @@ int tgl_pad_rsa_decrypt (struct tgl_stat
-   assert (bits >= 2041 && bits <= 2048);
-   assert (size >= chunks * 255);
-   int i;
--  BIGNUM x, y;
--  BN_init (&x);
--  BN_init (&y);
-+  BIGNUM *x, *y;
-+  x = BN_new();
-+  y = BN_new();
-   for (i = 0; i < chunks; i++) {
-     ++rsa_decrypted_chunks;
--    BN_bin2bn ((unsigned char *) from, 256, &x);
--    assert (BN_mod_exp (&y, &x, D, N, TLS->BN_ctx) == 1);
--    int l = BN_num_bytes (&y);
-+    BN_bin2bn ((unsigned char *) from, 256, x);
-+    assert (BN_mod_exp (y, x, D, N, TLS->BN_ctx) == 1);
-+    int l = BN_num_bytes (y);
-     if (l > 255) {
--      BN_free (&x);
--      BN_free (&y);
-+      BN_free (x);
-+      BN_free (y);
-       return -1;
-     }
-     assert (l >= 0 && l <= 255);
-     memset (to, 0, 255 - l);
--    BN_bn2bin (&y, (unsigned char *) to + 255 - l);
-+    BN_bn2bin (y, (unsigned char *) to + 255 - l);
-     to += 255;
-   }
--  BN_free (&x);
--  BN_free (&y);
-+  BN_free (x);
-+  BN_free (y);
-   return chunks * 255;
- }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As per @fxcoudert request. Replacing inline patch that had issues with indentation.