### PR TITLE
wal2json: use HOMEBREW_PREFIX instead of **

### DIFF
--- a/Formula/wal2json.rb
+++ b/Formula/wal2json.rb
@@ -16,7 +16,7 @@ class Wal2json < Formula
   def install
     mkdir "stage"
     system "make", "install", "USE_PGXS=1", "DESTDIR=#{buildpath}/stage"
-    lib.install Dir["stage/**/lib/*"]
+    lib.install Dir["stage/#{HOMEBREW_PREFIX}/lib/*"]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/linuxbrew-core/pull/16600