### PR TITLE
astartectl 0.10.2 (new formula)

### DIFF
--- a/Formula/astartectl.rb
+++ b/Formula/astartectl.rb
@@ -1,0 +1,17 @@
+class Astartectl < Formula
+  desc "Astarte command-line client utility"
+  homepage "https://astarte.cloud"
+  url "https://github.com/astarte-platform/astartectl/archive/v0.10.2.tar.gz"
+  sha256 "18c5a08274350866e814f777384dfabb4000469c29d45a5f7a2bfbea102b82c5"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build"
+    bin.install "astartectl" => "astartectl"
+  end
+
+  test do
+    system "#{bin}/astartectl", "help"
+  end
+end


### PR DESCRIPTION
This formula installs the astartectl binary, a tool used for managing Astarte clusters.
It leverages latest go + go modules to build.

Astartectl is hosted at https://github.com/astarte-platform/astartectl

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
```
% brew audit --strict --new-formula astartectl
astartectl:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected
```

Exception on last point - Astarte's umbrella repository is at https://github.com/astarte-platform/astarte, whereas the new repo for astartectl is quite new. I don't know if this is enough of an exception, otherwise I'll open the PR at a later time.

-----
