### PR TITLE
ec2instanceconnect 1.0.0 (new formula)

### DIFF
--- a/Formula/ec2instanceconnect.rb
+++ b/Formula/ec2instanceconnect.rb
@@ -1,0 +1,74 @@
+class Ec2instanceconnect < Formula
+  include Language::Python::Virtualenv
+
+  desc "All-in-one client for EC2 Instance Connect"
+  homepage "https://github.com/aws/aws-ec2-instance-connect-cli"
+  url "https://files.pythonhosted.org/packages/0c/7b/2dbd14b2caf0d834f781ef982bb4b22884245c44af0ebb6ccc5a7019fd3a/ec2instanceconnectcli-1.0.0.tar.gz"
+  sha256 "dc818c78d51a475a97d502db0221962e3c42af66900a63d7da69d3d68af29de8"
+  revision 1
+  head "https://github.com/aws/aws-ec2-instance-connect-cli.git", :branch => "master"
+
+  depends_on "python"
+
+  resource "botocore" do
+    url "https://files.pythonhosted.org/packages/56/28/9ef10dca4aa0d48802765447e3f6371dc218567b0f3038bdb7664ae4f0e0/botocore-1.12.253.tar.gz"
+    sha256 "3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b"
+  end
+
+  resource "cffi" do
+    url "https://files.pythonhosted.org/packages/0d/aa/c5ac2f337d9a10ee95d160d47beb8d9400e1b2a46bb94990a0409fe6d133/cffi-1.13.1.tar.gz"
+    sha256 "558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b"
+  end
+
+  resource "cryptography" do
+    url "https://files.pythonhosted.org/packages/be/60/da377e1bed002716fb2d5d1d1cab720f298cb33ecff7bf7adea72788e4e4/cryptography-2.8.tar.gz"
+    sha256 "3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651"
+  end
+
+  resource "docutils" do
+    url "https://files.pythonhosted.org/packages/93/22/953e071b589b0b1fee420ab06a0d15e5aa0c7470eb9966d60393ce58ad61/docutils-0.15.2.tar.gz"
+    sha256 "a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+  end
+
+  resource "ec2instanceconnectcli" do
+    url "https://files.pythonhosted.org/packages/0c/7b/2dbd14b2caf0d834f781ef982bb4b22884245c44af0ebb6ccc5a7019fd3a/ec2instanceconnectcli-1.0.0.tar.gz"
+    sha256 "dc818c78d51a475a97d502db0221962e3c42af66900a63d7da69d3d68af29de8"
+  end
+
+  resource "jmespath" do
+    url "https://files.pythonhosted.org/packages/2c/30/f0162d3d83e398c7a3b70c91eef61d409dea205fb4dc2b47d335f429de32/jmespath-0.9.4.tar.gz"
+    sha256 "bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+  end
+
+  resource "pycparser" do
+    url "https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz"
+    sha256 "a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/ad/99/5b2e99737edeb28c71bcbec5b5dda19d0d9ef3ca3e92e3e925e7c0bb364c/python-dateutil-2.8.0.tar.gz"
+    sha256 "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/ff/44/29655168da441dff66de03952880c6e2d17b252836ff1aa4421fba556424/urllib3-1.25.6.tar.gz"
+    sha256 "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+  end
+
+  def install
+    virtualenv_install_with_resources
+
+    bin.install_symlink libexec/"bin/mssh"
+    bin.install_symlink libexec/"bin/msftp"
+  end
+
+  test do
+    system "mssh", "-h"
+    system "msftp", "-h"
+  end
+end


### PR DESCRIPTION
Adds a recipe for the mssh and msftp commands from the aws ec2 instance
connect cli.

https://github.com/aws/aws-ec2-instance-connect-cli

Does not conflict with standard ssh,sftp and can be used alongside
existing installs of those tools.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
