### PR TITLE
minipro 0.4 (new formula)

### DIFF
--- a/Formula/minipro.rb
+++ b/Formula/minipro.rb
@@ -1,0 +1,24 @@
+class Minipro < Formula
+  desc "Control MiniPRO TL866xx series of chip programmers"
+  homepage "https://gitlab.com/DavidGriffith/minipro"
+  url "https://gitlab.com/DavidGriffith/minipro/-/archive/0.4/minipro-0.4.tar.gz"
+  sha256 "029ecba6c2eecb86d9e137ac71bd93244bb53272230581520f29209edb825178"
+  head "https://gitlab.com/DavidGriffith/minipro.git"
+
+  depends_on "libusb"
+
+  def install
+    inreplace "Makefile" do |s|
+      s.remove_make_var! "CC"
+      s.change_make_var! "PREFIX", prefix
+      s.change_make_var! "MANDIR", share
+    end
+
+    system "make", "all"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/minipro", "-V"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Trying this again following advice from @dawidd6 in https://github.com/Homebrew/linuxbrew-core/pull/16636

New formula for minipro, a free and open source program for controlling the TL866xx line of chip burners.