### PR TITLE
kafkacat: enable support for deserializing Avro message 

### DIFF
--- a/Formula/kafkacat.rb
+++ b/Formula/kafkacat.rb
@@ -13,12 +13,15 @@ class Kafkacat < Formula
     sha256 "e09845976996cd838656e0065309e06f65e8446e1f0eb01f471bda2da36553ed" => :sierra
   end
 
+  depends_on "avro-c"
   depends_on "librdkafka"
+  depends_on "libserdes"
   depends_on "yajl"
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--enable-json"
+                          "--enable-json",
+                          "--enable-avro"
     system "make"
     system "make", "install"
   end

--- a/Formula/libserdes.rb
+++ b/Formula/libserdes.rb
@@ -1,0 +1,39 @@
+class Libserdes < Formula
+  desc "Avro serialization/deserialization library for C/C++"
+  homepage "https://github.com/confluentinc/libserdes"
+  url "http://packages.confluent.io/deb/5.3/pool/main/c/confluent-libserdes/confluent-libserdes_5.3.1.orig.tar.gz"
+  sha256 "06bcb4066f6f13d2f4ece7987188c1feb9510c36bb5828e3283c267267c3d470"
+
+  depends_on "avro-c"
+  depends_on "jansson"
+  uses_from_macos "curl"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <err.h>
+      #include <stddef.h>
+      #include <sys/types.h>
+      #include <libserdes/serdes.h>
+
+      int main()
+      {
+        char errstr[512];
+        serdes_conf_t *sconf = serdes_conf_new(NULL, 0, NULL);
+        serdes_t *serdes = serdes_new(sconf, errstr, sizeof(errstr));
+        if (serdes == NULL) {
+          errx(1, "constructing serdes: %s", errstr);
+        }
+        serdes_destroy(serdes);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lserdes", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

This required the addition of a new formula, libserdes, which is included in the first commit in this PR.