### PR TITLE
hwloc: Missing dependency on libxml2

### DIFF
--- a/Formula/hwloc.rb
+++ b/Formula/hwloc.rb
@@ -19,6 +19,7 @@ class Hwloc < Formula
   end
 
   depends_on "pkg-config" => :build
+  uses_from_macos "libxml2"
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
