### PR TITLE
Update arduino-cli.rb - remove Catalina bottle

### DIFF
--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -9,7 +9,6 @@ class ArduinoCli < Formula
   bottle do
     cellar :any_skip_relocation
     rebuild 1
-    sha256 "e65612c215ea053f4b19fae9d243f5a28cbd467549eef4a3fb3f11c66b7e977a" => :catalina
     sha256 "485320b786380d4a7fc18fe0d3251b5541f51ea79f65438596749fd0478f87ec" => :mojave
     sha256 "afa5030f20097880956596e04d76bb4efab028b67a6cd5f19d7b89a01039bc14" => :high_sierra
   end


### PR DESCRIPTION
Until the tar bug gets fixed, I'd like to request the Catalina bottle of arduino-cli to be removed as well, as per https://github.com/Homebrew/homebrew-core/commit/28e52448bb35ada73d0548d661fbb2229892f309