### PR TITLE
ksh 2020.0.0

### DIFF
--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -1,11 +1,8 @@
 class Ksh < Formula
   desc "KornShell, ksh93"
   homepage "http://www.kornshell.com"
-  url "https://opensource.apple.com/source/ksh/ksh-23/ast-ksh.2012-08-01.tgz",
-    :using => :nounzip
-  mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/ast-ksh.2012-08-01.tgz"
-  version "93u+" # Versioning scheme: + means "+ patches", - means "beta/alpha".
-  sha256 "e6192cfa52a6a9fd20618cbaf3fa81f0cc9fd83525500757e83017275e962851"
+  url "https://github.com/att/ast/releases/download/2020.0.0/ksh-2020.0.0.tar.gz"
+  sha256 "8701c27211b0043ddd485e35f2ba7f4075fc8fc2818d0545e38b1dda4288b6f7"
 
   bottle do
     cellar :any_skip_relocation
@@ -19,29 +16,20 @@ class Ksh < Formula
     sha256 "7c665466fb323fc0cb6ffb87ec9fe1630d75afcd3b12864e2424677473db4924" => :mavericks
   end
 
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+
   resource "init" do
-    url "https://opensource.apple.com/source/ksh/ksh-23/INIT.2012-08-01.tgz"
-    mirror "https://www.mirrorservice.org/pub/pkgsrc/distfiles/INIT.2012-08-01.tgz"
-    sha256 "c40cf57e9b2186271a9c362a560aa4a6e25ba911a8258ab931d2bbdbce44cfe5"
+    url "https://github.com/att/ast/releases/download/2020.0.0/ksh-2020.0.0.tar.gz"
+    sha256 "8701c27211b0043ddd485e35f2ba7f4075fc8fc2818d0545e38b1dda4288b6f7"
   end
 
   def install
-    resource("init").stage buildpath
-    (buildpath/"lib/package/tgz").install Dir["*.tgz"]
-    system "/bin/ksh", "bin/package", "read"
-
-    # Needed due to unusal build system.
-    ENV.refurbish_args
-
-    # From Apple"s ksh makefile.
-    kshcppdefines = "-DSHOPT_SPAWN=0 -D_ast_int8_t=int64_t -D_lib_memccpy"
-    system "/bin/ksh", "bin/package", "make", "CCFLAGS=#{kshcppdefines}"
-
-    bin.install "arch/darwin.i386-64/bin/ksh" => "ksh93"
-    bin.install_symlink "ksh93" => "ksh"
-
-    man1.install "arch/darwin.i386-64/man/man1/sh.1" => "ksh93.1"
-    man1.install_symlink "ksh93.1" => "ksh.1"
+    mkdir "build" do
+      system "meson", "--prefix=#{prefix}", ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
   end
 
   def caveats

--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -19,24 +19,12 @@ class Ksh < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
 
-  resource "init" do
-    url "https://github.com/att/ast/releases/download/2020.0.0/ksh-2020.0.0.tar.gz"
-    sha256 "8701c27211b0043ddd485e35f2ba7f4075fc8fc2818d0545e38b1dda4288b6f7"
-  end
-
   def install
     mkdir "build" do
       system "meson", "--prefix=#{prefix}", ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end
-  end
-
-  def caveats
-    <<~EOS
-      We agreed to the Eclipse Public License 1.0 for you.
-      If this is unacceptable you should uninstall.
-    EOS
   end
 
   test do


### PR DESCRIPTION
New stable release of ksh primarily features:

- Switch to new and saner build system
- Hundreds of bug fixes
- Better test coverage

More details can be found at:

https://groups.google.com/d/msg/korn-shell/-tQkll8BxXU/X4ON61CHBwAJ

It is already rebased in Fedora, Debian, Gentoo, FreeBSD and several
other well known distros.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
