### PR TITLE
hadoop@2.8 2.8.5 (new formula)

### DIFF
--- a/Aliases/hadoop@3.2
+++ b/Aliases/hadoop@3.2
@@ -1,0 +1,1 @@
+../Formula/hadoop.rb

--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -9,7 +9,6 @@ class Hadoop < Formula
   depends_on :java => "1.8+"
 
   conflicts_with "yarn", :because => "both install `yarn` binaries"
-  conflicts_with "hadoop@2.8", :because => "both install `hadoop` binaries"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]

--- a/Formula/hadoop@2.8.rb
+++ b/Formula/hadoop@2.8.rb
@@ -10,8 +10,6 @@ class HadoopAT28 < Formula
 
   depends_on :java => "1.8+"
 
-  conflicts_with "yarn", :because => "both install `yarn` binaries"
-
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
     libexec.install %w[bin sbin libexec share etc]

--- a/Formula/hadoop@2.8.rb
+++ b/Formula/hadoop@2.8.rb
@@ -11,7 +11,6 @@ class HadoopAT28 < Formula
   depends_on :java => "1.8+"
 
   conflicts_with "yarn", :because => "both install `yarn` binaries"
-  conflicts_with "hadoop", :because => "both install `hadoop` binaries"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]

--- a/Formula/hadoop@2.8.rb
+++ b/Formula/hadoop@2.8.rb
@@ -6,6 +6,8 @@ class HadoopAT28 < Formula
 
   bottle :unneeded
 
+  keg_only :versioned_formula
+
   depends_on :java => "1.8+"
 
   conflicts_with "yarn", :because => "both install `yarn` binaries"

--- a/Formula/hadoop@2.8.rb
+++ b/Formula/hadoop@2.8.rb
@@ -1,15 +1,15 @@
-class Hadoop < Formula
+class HadoopAT28 < Formula
   desc "Framework for distributed processing of large data sets"
   homepage "https://hadoop.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-3.2.1/hadoop-3.2.1.tar.gz"
-  sha256 "f66a3a4115b8f16c1077d1a198a06854dbef0e4233291712ed08d0a10629ed37"
+  url "https://www.apache.org/dyn/closer.cgi?path=hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz"
+  sha256 "f9c726df693ce2daa4107886f603270d66e7257f77a92c9886502d6cd4a884a4"
 
   bottle :unneeded
 
   depends_on :java => "1.8+"
 
   conflicts_with "yarn", :because => "both install `yarn` binaries"
-  conflicts_with "hadoop@2.8", :because => "both install `hadoop` binaries"
+  conflicts_with "hadoop", :because => "both install `hadoop` binaries"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There are major differences between the various minor (and major) revisions of Hadoop. Hadoop 2.8 in particular is useful to have because it makes several large improvements to the S3A interface, which open source Apache Spark users commonly use.

Spark is not compatible (yet) with Hadoop 3, which is what the existing `hadoop` formula provides.