### PR TITLE
cvs 1.12.13 (catalina fix)

### DIFF
--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -41,6 +41,9 @@ class Cvs < Formula
     sha256 "affa485332f66bb182963680f90552937bf1455b855388f7c06ef6a3a25286e2"
   end
 
+  # Fixes "cvs [init aborted]: cannot get working directory: No such file or directory" on Catalina. Original patch idea by Jason White from stackoverflow
+  patch :DATA
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -71,3 +74,19 @@ class Cvs < Formula
     end
   end
 end
+
+__END__
+--- cvs-1.12.13/lib/xgetcwd.c.orig      2019-10-10 22:52:37.000000000 -0500
++++ cvs-1.12.13/lib/xgetcwd.c   2019-10-10 22:53:32.000000000 -0500
+@@ -25,8 +25,9 @@
+ #include "xgetcwd.h"
+
+ #include <errno.h>
++#include <unistd.h>
+
+-#include "getcwd.h"
++/* #include "getcwd.h" */
+ #include "xalloc.h"
+
+ /* Return the current directory, newly allocated.
+


### PR DESCRIPTION
Fixes `cvs [init aborted]: cannot get working directory: No such file or directory` on Catalina. Original patch idea by Jason White from stackoverflow

https://stackoverflow.com/questions/58329787/cvs-broken-on-macos-catalina-cannot-get-working-directory?fbclid=IwAR15wnJ4MT9RWEkM1FNE0_iqoLwERgEv3tkEBooDQsqe9RqEk8dKxqefjb8

I've tested it here on catalina and it works OK.

- [yes] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [yes] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [yes] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [yes] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [yes] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
