### PR TITLE
libtensorflow: add tensorflow tools

### DIFF
--- a/Formula/libtensorflow.rb
+++ b/Formula/libtensorflow.rb
@@ -5,6 +5,7 @@ class Libtensorflow < Formula
   homepage "https://www.tensorflow.org/"
   url "https://github.com/tensorflow/tensorflow/archive/v2.0.0.tar.gz"
   sha256 "49b5f0495cd681cbcb5296a4476853d4aea19a43bdd9f179c928a977308a0617"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,11 @@ class Libtensorflow < Formula
   depends_on "bazel" => :build
   depends_on :java => ["1.8", :build]
   depends_on "python" => :build
+
+  resource "test-model" do
+    url "https://github.com/tensorflow/models/raw/v1.13.0/samples/languages/java/training/model/graph.pb"
+    sha256 "147fab50ddc945972818516418942157de5e7053d4b67e7fca0b0ada16733ecb"
+  end
 
   def install
     venv_root = "#{buildpath}/venv"
@@ -47,7 +53,24 @@ class Libtensorflow < Formula
     ENV["TF_CONFIGURE_IOS"] = "0"
     system "./configure"
 
-    system "bazel", "build", "--jobs", ENV.make_jobs, "--compilation_mode=opt", "--copt=-march=native", "tensorflow:libtensorflow.so"
+    targets = %w[
+      tensorflow:libtensorflow.so
+      tensorflow/tools/benchmark:benchmark_model
+      tensorflow/tools/graph_transforms:summarize_graph
+      tensorflow/tools/graph_transforms:transform_graph
+    ]
+
+    bazel_args = [
+      "--jobs=#{ENV.make_jobs}",
+      "--compilation_mode=opt",
+      "--copt=-march=native",
+      "--noincompatible_disable_nocopts", # fixes build of TensorFlow 2.0 on Bazel >= 1.0
+      "--noincompatible_remove_legacy_whole_archive", # fixes build of TensorFlow 2.0 on Bazel >= 1.0
+    ]
+    # Work around Xcode 11 clang bug
+    bazel_args << "--copt=-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
+
+    system "bazel", "build", *bazel_args, *targets
     lib.install Dir["bazel-bin/tensorflow/*.so*", "bazel-bin/tensorflow/*.dylib*"]
     (include/"tensorflow/c").install %w[
       tensorflow/c/c_api.h
@@ -56,6 +79,12 @@ class Libtensorflow < Formula
       tensorflow/c/tf_datatype.h
       tensorflow/c/tf_status.h
       tensorflow/c/tf_tensor.h
+    ]
+
+    bin.install %w[
+      bazel-bin/tensorflow/tools/benchmark/benchmark_model
+      bazel-bin/tensorflow/tools/graph_transforms/summarize_graph
+      bazel-bin/tensorflow/tools/graph_transforms/transform_graph
     ]
 
     (lib/"pkgconfig/tensorflow.pc").write <<~EOS
@@ -77,5 +106,49 @@ class Libtensorflow < Formula
     EOS
     system ENV.cc, "-L#{lib}", "-ltensorflow", "-o", "test_tf", "test.c"
     assert_equal version, shell_output("./test_tf")
+
+    resource("test-model").stage(testpath)
+
+    summarize_graph_output = shell_output("#{bin}/summarize_graph --in_graph=#{testpath}/graph.pb 2>&1")
+    variables_match = /Found \d+ variables:.+$/.match(summarize_graph_output)
+    assert_not_nil variables_match, "Unexpected stdout from summarize_graph for graph.pb (no found variables)"
+    variables_names = variables_match[0].scan(/name=([^,]+)/).flatten.sort
+
+    transform_command = %W[
+      #{bin}/transform_graph
+      --in_graph=#{testpath}/graph.pb
+      --out_graph=#{testpath}/graph-new.pb
+      --inputs=n/a
+      --outputs=n/a
+      --transforms="obfuscate_names"
+      2>&1
+    ].join(" ")
+    shell_output(transform_command)
+
+    assert_predicate testpath/"graph-new.pb", :exist?, "transform_graph did not create an output graph"
+
+    new_summarize_graph_output = shell_output("#{bin}/summarize_graph --in_graph=#{testpath}/graph-new.pb 2>&1")
+    new_variables_match = /Found \d+ variables:.+$/.match(new_summarize_graph_output)
+    assert_not_nil new_variables_match, "Unexpected summarize_graph output for graph-new.pb (no found variables)"
+    new_variables_names = new_variables_match[0].scan(/name=([^,]+)/).flatten.sort
+
+    assert_not_equal variables_names, new_variables_names, "transform_graph didn't obfuscate variable names"
+
+    benchmark_model_match = /benchmark_model -- (.+)$/.match(new_summarize_graph_output)
+    assert_not_nil benchmark_model_match, "Unexpected summarize_graph output for graph-new.pb (no benchmark_model example)"
+
+    benchmark_model_args = benchmark_model_match[1].split(" ")
+    benchmark_model_args.delete("--show_flops")
+
+    benchmark_model_command = [
+      "#{bin}/benchmark_model",
+      "--time_limit=10",
+      "--num_threads=1",
+      *benchmark_model_args,
+      "2>&1",
+    ].join(" ")
+
+    benchmark_model_output = shell_output(benchmark_model_command)
+    assert_includes benchmark_model_output, "Timings (microseconds):", "Unexpected benchmark_model output (no timings)"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
TensorFlow has a set of useful tools for work with graphs ([the first](https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/tools/graph_transforms/README.md) and [the second](https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/tools/benchmark/README.md)). This PR adds `summarize_graph`, `transform_graph`, and `benchmark_model` tools.

Since build process doesn't require (and does not install) any additional python packages I have switched virualenv python to a system (brew's) one.