### PR TITLE
new recipe - kubernetes-helm@3 to install latest v3 rc

### DIFF
--- a/Formula/kubernetes-helm@3.rb
+++ b/Formula/kubernetes-helm@3.rb
@@ -1,0 +1,51 @@
+class KubernetesHelmAT3 < Formula
+  desc "The Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/helm/helm.git",
+      :tag      => "v3.0.0-beta.5",
+      :revision => "509a8819b7e8dba86b7982c006fce22628aeea28"
+  head "https://github.com/helm/helm.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "f055d13d28b5f76e19718cb93bd5e64f34e27c1602de39fb6ade3449756153cc" => :catalina
+    sha256 "245bdf17ac134d98f7e022ddd36678ae62c0aa02116d3a61229f5fc1c5de5665" => :mojave
+    sha256 "859c2dd730bf2e6c593ca19bbc18a9e155470193770a7824ff1ad74f906ed7b9" => :high_sierra
+  end
+
+  depends_on "glide" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    ENV["TARGETS"] = "darwin/amd64"
+    dir = buildpath/"src/k8s.io/helm"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      system "make", "build"
+
+      bin.install "bin/helm"
+      man1.install Dir["docs/man/man1/*"]
+
+      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      (bash_completion/"helm").write output
+
+      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      (zsh_completion/"_helm").write output
+
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/helm", "create", "foo"
+    assert File.directory? "#{testpath}/foo/charts"
+
+    version_output = shell_output("#{bin}/helm version 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    assert_match stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision], version_output if build.stable?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Relates to https://github.com/helm/helm/issues/6787

Allows easy installation of `helm` v3 release candidates, prior to the `kubernetes-helm` recipe being migrated to v3 in future.