### PR TITLE
pygobject3: remove py2cairo dependency

### DIFF
--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -16,7 +16,6 @@ class Pygobject3 < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "gobject-introspection"
-  depends_on "py2cairo"
   depends_on "py3cairo"
   depends_on "python"
 


### PR DESCRIPTION
This is not required when using Python 3. Remnant from 529126e320d4a85ca6a8d50326d2b97bf24c1e7a

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?