### PR TITLE
stubby: disable logging in launch agent file

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -46,10 +46,6 @@ class Stubby < Formula
           <string>-C</string>
           <string>#{etc}/stubby/stubby.yml</string>
         </array>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/stubby/stubby.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/stubby/stubby.log</string>
       </dict>
     </plist>
   EOS


### PR DESCRIPTION
The log folder `/usr/local/var/stubby` created by launch agent is owned
by root with permission 744. The log file `stubby.log` seems unable to be
created under this folder and the service just failed to start.

A fix for this by disabling logging as what other DNS service
like dnsmasq and unbound do in homebrew-core.

---- 

In case I didn't make it clear in the commit message. The stubby daemon failed to start with

```shell
brew services start stubby
```

cause the log file `/usr/local/var/stubby/stubby.log` failed to be created. I just removed the logging output like what the other DNS servers (like dnsmasq, unbound) do in homebrew-core.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
