### PR TITLE
libxml2: add readline history support

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -26,6 +26,7 @@ class Libxml2 < Formula
   keg_only :provided_by_macos
 
   depends_on "python"
+  depends_on "readline"
 
   # Fix crash when using Python 3 using Fedora's patch.
   # Reported upstream:
@@ -51,6 +52,7 @@ class Libxml2 < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--with-history",
                           "--without-python",
                           "--without-lzma"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Rational

As an assignment this week, we are dealing with XPath.  Having tried a quite few apps, I've landed on `xmllint`.  However, I became irritated with writing the same query over and over.  To my fortune, the `libxml2` has a configure flag (`--with-history`) that enables the support for readline history when using `xmllint --shell`.

I've tested it some, and it behaves just as a readline app.  No issue so far.

## Formula

If accepted, do I need to bump the revision, and should I add `readline` as a dependency?