### PR TITLE
Update Zola 0.9.0 checksum

### DIFF
--- a/Formula/zola.rb
+++ b/Formula/zola.rb
@@ -2,7 +2,7 @@ class Zola < Formula
   desc "Fast static site generator in a single binary with everything built-in"
   homepage "https://www.getzola.org/"
   url "https://github.com/getzola/zola/archive/v0.9.0.tar.gz"
-  sha256 "a5b7658c9c56bd53613cd40254536ccdd6937444b935458c45416b8fb78bbcad"
+  sha256 "8d226ec764f2bc06de8e49e2e22ccf37811bc478bbcaa83c2c841b222ef4fc4e"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The sha256 checksum for Zola 0.9.0 has changed since this formula was originally updated and this commit brings the formula up to date with the current checksum.

In response to an Ubuntu Linux user reporting [an issue installing Zola with Homebrew](https://github.com/getzola/zola/issues/823), the creator of Zola said this was because "There were some issues with the new CI pipeline for the 0.9.0 release which required rebuilding it a couple of times" ([source](https://github.com/getzola/zola/issues/823#issuecomment-546115310)).