### PR TITLE
skopeo: fix path to registries.conf

### DIFF
--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -35,7 +35,7 @@ class Skopeo < Formula
         "-X github.com/containers/skopeo/vendor/github.com/containers/image/docker.systemRegistriesDirPath=#{etc/"containers/registries.d"}",
         "-X github.com/containers/skopeo/vendor/github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=#{ENV["TEMPDIR"]}",
         "-X github.com/containers/skopeo/vendor/github.com/containers/image/signature.systemDefaultPolicyPath=#{etc/"containers/policy.json"}",
-        "-X github.com/containers/skopeo/vendor/github.com/containers/image/sysregistries.systemRegistriesConfPath=#{etc/"containers/registries.conf"}",
+        "-X github.com/containers/skopeo/vendor/github.com/containers/image/pkg/sysregistriesv2.systemRegistriesConfPath=#{etc/"containers/registries.conf"}",
       ].join(" ")
 
       system "go", "build", "-v", "-x", "-tags", buildtags, "-ldflags", ldflags, "-o", bin/"skopeo", "./cmd/skopeo"

--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -32,10 +32,10 @@ class Skopeo < Formula
 
       ldflags = [
         "-X main.gitCommit=",
-        "-X github.com/containers/skopeo/vendor/github.com/containers/image/docker.systemRegistriesDirPath=#{etc/"containers/registries.d"}",
-        "-X github.com/containers/skopeo/vendor/github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=#{ENV["TEMPDIR"]}",
-        "-X github.com/containers/skopeo/vendor/github.com/containers/image/signature.systemDefaultPolicyPath=#{etc/"containers/policy.json"}",
-        "-X github.com/containers/skopeo/vendor/github.com/containers/image/pkg/sysregistriesv2.systemRegistriesConfPath=#{etc/"containers/registries.conf"}",
+        "-X github.com/containers/image/docker.systemRegistriesDirPath=#{etc/"containers/registries.d"}",
+        "-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=#{ENV["TEMPDIR"]}",
+        "-X github.com/containers/image/signature.systemDefaultPolicyPath=#{etc/"containers/policy.json"}",
+        "-X github.com/containers/image/pkg/sysregistriesv2.systemRegistriesConfPath=#{etc/"containers/registries.conf"}",
       ].join(" ")
 
       system "go", "build", "-v", "-x", "-tags", buildtags, "-ldflags", ldflags, "-o", bin/"skopeo", "./cmd/skopeo"

--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -3,6 +3,7 @@ class Skopeo < Formula
   homepage "https://github.com/containers/skopeo"
   url "https://github.com/containers/skopeo/archive/v0.1.40.tar.gz"
   sha256 "ee1e33245938fcb622f5864fac860e2d8bfa2fa907af4b5ffc3704ed0db46bbf"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
This PR attempts to fix error:

```
$ skopeo copy docker://alpine bla
FATA[0000] Error loading trust policy: open /etc/containers/policy.json: no such file or directory
```

Originally added in https://github.com/Homebrew/homebrew-core/pull/42060, but one path is incorrect because source code mismatch:

```
$ git checkout v0.1.39
$ git grep '// -ldflags' -- '*.go'
vendor/github.com/containers/image/docker/lookaside.go:// -ldflags '-X github.com/containers/image/docker.systemRegistriesDirPath=$your_path'
vendor/github.com/containers/image/internal/tmpdir/tmpdir.go:// -ldflags '-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=$your_path'
vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go:// -ldflags '-X github.com/containers/image/sysregistries.systemRegistriesConfPath=$your_path'
vendor/github.com/containers/image/signature/policy_config.go:// -ldflags '-X github.com/containers/image/signature.systemDefaultPolicyPath=$your_path'
```

This got broken with v0.1.32 release:
- https://github.com/containers/skopeo/commit/72468d6817ddc2e568d9c66be9bf7202bd90ff27

cc @sj26

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
