### PR TITLE
Zola: Add --locked flag to cargo install command, update sha256 checksum

### DIFF
--- a/Formula/zola.rb
+++ b/Formula/zola.rb
@@ -2,7 +2,8 @@ class Zola < Formula
   desc "Fast static site generator in a single binary with everything built-in"
   homepage "https://www.getzola.org/"
   url "https://github.com/getzola/zola/archive/v0.9.0.tar.gz"
-  sha256 "a5b7658c9c56bd53613cd40254536ccdd6937444b935458c45416b8fb78bbcad"
+  sha256 "8d226ec764f2bc06de8e49e2e22ccf37811bc478bbcaa83c2c841b222ef4fc4e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/zola.rb
+++ b/Formula/zola.rb
@@ -15,7 +15,7 @@ class Zola < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--root", prefix, "--path", "."
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     bash_completion.install "completions/zola.bash"
     zsh_completion.install "completions/_zola"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Building Zola from source currently fails since `cargo install` doesn't use the dependency versions specified in the `Cargo.lock` file by default.  A dependency released a breaking change between the time Zola 0.9.0 was released and now, so the build now fails with errors.  This commit adds the `--locked` flag to `cargo install` to ensure that the `Cargo.lock` file is used when building from source.

At least to me, it makes sense to use the `--locked` flag anyway, as it ensures that the build is predictable/reproducible and won't vary over time due to dependency updates.  It looks like other formulas using `cargo install` don't use the `--locked` flag either, so this may be something to consider on a larger scale.

Past that, it's expected for the builds to fail here, since the sha256 checksum changed between release and the current tar.gz for Zola 0.9.0, as mentioned in #45819.