### PR TITLE
hfstospell 0.5.1

### DIFF
--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -1,9 +1,8 @@
 class Hfstospell < Formula
   desc "Helsinki Finite-State Technology ospell"
   homepage "https://hfst.github.io/"
-  url "https://github.com/hfst/hfst-ospell/releases/download/v0.5.0/hfstospell-0.5.0.tar.gz"
-  sha256 "0fd2ad367f8a694c60742deaee9fcf1225e4921dd75549ef0aceca671ddfe1cd"
-  revision 6
+  url "https://github.com/hfst/hfst-ospell/releases/download/v0.5.1/hfstospell-0.5.1.tar.gz"
+  sha256 "ccf5f3b06bcdc5636365e753b9f7fad9c11dfe483272061700a905b3d65ac750"
 
   bottle do
     cellar :any
@@ -16,24 +15,12 @@ class Hfstospell < Formula
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "libarchive"
-  depends_on "libxml++"
-  uses_from_macos "libxml2"
-
-  # Fix "error: no template named 'auto_ptr' in namespace 'std'"
-  # Upstream PR 20 Jun 2018 "C++14 (C++1y) should be the highest supported standard."
-  # See https://github.com/hfst/hfst-ospell/pull/41
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/674a62d/hfstospell/no-cxx17.diff"
-    sha256 "0a3146e871ac0e3c71248b8671d09f6d8a8a69713b6f4857eab7bdb684709083"
-  end
 
   def install
-    # icu4c 61.1 compatability
-    ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"
-
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--without-libxmlpp",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/libvoikko.rb
+++ b/Formula/libvoikko.rb
@@ -3,6 +3,7 @@ class Libvoikko < Formula
   homepage "https://voikko.puimula.org/"
   url "https://www.puimula.org/voikko-sources/libvoikko/libvoikko-4.3.tar.gz"
   sha256 "e843df002fcea2a90609d87e4d6c28f8a0e23332d3b42979ab1793e18f839307"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
According to discussion at https://github.com/hfst/hfst-ospell/issues/48, the package isn't really supposed to be buildable without disabling libxml++.