### PR TITLE
grex 0.2.0 (new formula)

### DIFF
--- a/Formula/grex.rb
+++ b/Formula/grex.rb
@@ -1,0 +1,17 @@
+class Grex < Formula
+  desc "Command-line tool for generating regular expressions"
+  homepage "https://github.com/pemistahl/grex"
+  url "https://github.com/pemistahl/grex/archive/v0.2.0.tar.gz"
+  sha256 "79eb86a1e27b3701527f8524a64f2c1a32edf9b7474a2c5cddc3e9e56f21567d"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--root", prefix, "--path", "."
+  end
+
+  test do
+    output = shell_output("#{bin}/grex a b c")
+    assert_match "^[a-c]$\n", output
+  end
+end


### PR DESCRIPTION
Hi, I would like my command-line tool [*grex*](https://github.com/pemistahl/grex) to be installable from Homebrew. It aims at helping people to create regular expressions by generating them from provided input strings.

Executing `brew audit --new-formula` has passed all tests except for saying `GitHub repository too new (<30 days old)`. Well, it is actually new, yes. However, it has already gained significant traction, so it is hard to comprehend why it should not be included in homebrew-core if there are no other reasons against it.

It would be great if you told me whether my tool can be merged, either now or after the 30 days are over. Otherwise, I will create a tap for it.

Thank you.