### PR TITLE
youtube-dl: add atomicparsley dependency

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -11,6 +11,8 @@ class YoutubeDl < Formula
 
   bottle :unneeded
 
+  depends_on "atomicparsley"
+
   def install
     system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Embedding youtube thumbnails into downloaded videos requires `atomicparsley`. Even though it's in essence an optional dependency (and thus can't be added as such), atomicparsley's pretty lightweight.

There's a couple of other optional youtube-dl dependencies that have not been added:
* `ffmpeg` (post-processor) -- Too heavy to include by default?
* `mpv`, `mplayer`, `rtmpdump` (custom downloaders) -- Mutually exclusive dependencies.
* `phantomjs` -- Only required for a small fraction of supported sites.

but I can amend the PR.

No tests added - Thumbnail embedding is a post-processing option and thus requires actually downloading a video.