### PR TITLE
geckodriver 0.26.0

### DIFF
--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -1,8 +1,10 @@
 class Geckodriver < Formula
   desc "WebDriver <-> Marionette proxy"
   homepage "https://github.com/mozilla/geckodriver"
-  url "https://github.com/mozilla/geckodriver/archive/v0.25.0.tar.gz"
-  sha256 "9ba9b1be1a2e47ddd11216ce863903853975a4805e72b9ed5da8bcbcaebbcea9"
+  # Get the commit id for stable releases from https://github.com/mozilla/geckodriver/releases
+  url "https://hg.mozilla.org/mozilla-central/archive/e9783a644016aa9b317887076618425586730d73.tar.gz"
+  version "0.26.0"
+  sha256 "034f525b6163ffd473ac61191107d104244b5ac7d3f89259b9c2915812654099"
   head "https://hg.mozilla.org/mozilla-central/", :using => :hg
 
   bottle do
@@ -16,8 +18,9 @@ class Geckodriver < Formula
   depends_on "rust" => :build
 
   def install
-    dir = build.head? ? "testing/geckodriver" : "."
-    cd(dir) { system "cargo", "install", "--root", prefix, "--path", "." }
+    cd "testing/geckodriver" do
+      system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    end
     bin.install_symlink bin/"geckodriver" => "wires"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Continuation of #45217. See https://github.com/Homebrew/homebrew-core/pull/45217#issuecomment-542316075 for why the switch to the full `mozilla-central` source code is necessary here. Also Refs #45839 for adding `--locked` to `cargo install`.

@andreastt I'm seeing this warning during `cargo install`:

```
warning: Patch `coreaudio-sys v0.2.2 (/private/tmp/geckodriver-20191028-33664-4v1ucp/mozilla-central-e9783a644016aa9b317887076618425586730d73/third_party/rust/coreaudio-sys)` was not used in the crate graph.
Patch `cranelift-codegen v0.44.0 (https://github.com/CraneStation/Cranelift?rev=182414f15c18538dfebbe040469ec8001e93ecc5#182414f1)` was not used in the crate graph.
Patch `cranelift-wasm v0.44.0 (https://github.com/CraneStation/Cranelift?rev=182414f15c18538dfebbe040469ec8001e93ecc5#182414f1)` was not used in the crate graph.
Patch `libudev-sys v0.1.3 (/private/tmp/geckodriver-20191028-33664-4v1ucp/mozilla-central-e9783a644016aa9b317887076618425586730d73/dom/webauthn/libudev-sys)` was not used in the crate graph.
Patch `packed_simd v0.3.3 (https://github.com/hsivonen/packed_simd?branch=rust_1_32#3541e381)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
```

Is this something we should worry about or can this be safely ignored.

ToDo: 
* [x] test this more carefully
