### PR TITLE
mypy: Compile with mypyc

### DIFF
--- a/Formula/mypy.rb
+++ b/Formula/mypy.rb
@@ -4,6 +4,7 @@ class Mypy < Formula
   url "https://github.com/python/mypy.git",
       :tag      => "v0.740",
       :revision => "0662772b5a6b9029da0cf4aec857b9b1e34057a9"
+  revision 1
   head "https://github.com/python/mypy.git"
 
   bottle do
@@ -67,6 +68,7 @@ class Mypy < Formula
     end
 
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
+    ENV["MYPY_USE_MYPYC"] = "1"
     system "python3", *Language::Python.setup_install_args(libexec)
 
     bin.install Dir[libexec/"bin/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/python/mypy#compiled-version-of-mypy
1. It is supposed to be a lot faster.
2. Implementing this change will bring the Homebrew version closer to the official binaries released via PyPI.