### PR TITLE
yarn-completion 0.15.0

### DIFF
--- a/Formula/yarn-completion.rb
+++ b/Formula/yarn-completion.rb
@@ -1,8 +1,8 @@
 class YarnCompletion < Formula
   desc "Bash completion for Yarn"
   homepage "https://github.com/dsifford/yarn-completion"
-  url "https://github.com/dsifford/yarn-completion/archive/v0.8.0.tar.gz"
-  sha256 "f359dbfd4d9dd28e231e81da16f308e73662fd586546672569a0eac994f2bcd6"
+  url "https://github.com/dsifford/yarn-completion/archive/v0.15.0.tar.gz"
+  sha256 "4f350f50e85d4d47c67677a35b8a67950d0193a324b0c932c320831c7834f73a"
 
   bottle :unneeded
 

--- a/Formula/yarn-completion.rb
+++ b/Formula/yarn-completion.rb
@@ -6,6 +6,8 @@ class YarnCompletion < Formula
 
   bottle :unneeded
 
+  conflicts_with "bash-completion", :because => "Bash v4+ & bash completion v2 are required"
+
   def install
     bash_completion.install "yarn-completion.bash" => "yarn"
   end

--- a/Formula/yarn-completion.rb
+++ b/Formula/yarn-completion.rb
@@ -12,6 +12,6 @@ class YarnCompletion < Formula
 
   test do
     assert_match "complete -F _yarn yarn",
-      shell_output("source #{bash_completion}/yarn && complete -p yarn")
+      shell_output("bash -c 'source #{bash_completion}/yarn && complete -p yarn'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Update to 0.15

Adds conflicts with `bash-completion@1`. Technically this depends on `bash-completion@2` and bash v4+, but it was previously stated that a completion formula should not install another shell.
So this at least attempts to warn the user.

Attempts to fix the test by referencing the shell; probably won't work on build server.
