### PR TITLE
go: depend on OS X El Capitan or later

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -28,7 +28,7 @@ class Go < Formula
     end
   end
 
-  depends_on :macos => :yosemite
+  depends_on :macos => :el_capitan
 
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do


### PR DESCRIPTION
Go as of version 1.13 depends on OS X El Capitan or later.
See https://golang.org/doc/go1.13#darwin.

