### PR TITLE
libfido2 1.2.0 (new formula)

### DIFF
--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -1,0 +1,27 @@
+class Libfido2 < Formula
+  desc "Provides library functionality for FIDO U2F and FIDO 2.0"
+  homepage "https://developers.yubico.com/libfido2/"
+  url "https://github.com/Yubico/libfido2/archive/1.2.0.tar.gz"
+  sha256 "db94b4970ac6f85881b8a8c38976e4f336a42c3d512d009aea6ffecc3ea474dd"
+  depends_on "cmake" => :build
+  depends_on "mandoc" => :build
+  depends_on "libcbor"
+  depends_on "openssl@1.1"
+
+  def install
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl@1.1"].opt_lib}/pkgconfig"
+    args = std_cmake_args - %w[-DCMAKE_BUILD_TYPE=None]
+    args << "-DCMAKE_BUILD_TYPE=None"
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
+      system "make", "man_symlink_html"
+      system "make", "install"
+    end
+  end
+
+  # Needs more comprehensive tests
+  test do
+    system "#{bin}/fido2-token", "-V"
+  end
+end


### PR DESCRIPTION
This PR adds libfido2-1.2.0 formula. 

libfido2 provides library functionality and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures. libfido2 supports the FIDO U2F (CTAP 1) and FIDO 2.0 (CTAP 2) protocols.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
