### PR TITLE
pijul: Add --locked flag to cargo install

### DIFF
--- a/Formula/pijul.rb
+++ b/Formula/pijul.rb
@@ -24,7 +24,7 @@ class Pijul < Formula
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
     cd "pijul" do
-      system "cargo", "install", "--root", prefix, "--path", "."
+      system "cargo", "install", "--locked", "--root", prefix, "--path", "."
     end
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in #44041 (and #46025), adding the `--locked` flag to `cargo install` will fix the build for Pijul v0.12.0 while we wait for them to add tar.gz files on their website for newer releases (open issue here: https://nest.pijul.com/pijul_org/pijul/discussions/425).