### PR TITLE
mpi4py 3.0.2 (new formula)

### DIFF
--- a/Formula/mpi4py.rb
+++ b/Formula/mpi4py.rb
@@ -1,0 +1,34 @@
+class Mpi4py < Formula
+  desc "Python bindings for MPI"
+  homepage "https://mpi4py.readthedocs.io"
+  url "https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-3.0.2.tar.gz"
+  sha256 "f8d629d1e3e3b7b89cb99d0e3bc5505e76cc42089829807950d5c56606ed48e0"
+
+  depends_on "cython" => :build
+  depends_on "open-mpi"
+  depends_on "python"
+
+  def install
+    system "#{Formula["python"].opt_bin}/python3",
+           *Language::Python.setup_install_args(libexec)
+
+    system "python3", "setup.py",
+      "build", "--mpicc=mpicc -shared", "--parallel=#{ENV.make_jobs}",
+      "install", "--prefix=#{prefix}",
+      "--single-version-externally-managed", "--record=installed.txt"
+  end
+
+  test do
+    system "#{Formula["python"].opt_bin}/python3",
+           "-c", "import mpi4py"
+    system "#{Formula["python"].opt_bin}/python3",
+           "-c", "import mpi4py.MPI"
+    system "#{Formula["python"].opt_bin}/python3",
+           "-c", "import mpi4py.futures"
+    system "mpiexec", "-n", "4", "#{Formula["python"].opt_bin}/python3",
+           "-m", "mpi4py.run", "-m", "mpi4py.bench", "helloworld"
+    system "mpiexec", "-n", "4", "#{Formula["python"].opt_bin}/python3",
+           "-m", "mpi4py.run", "-m", "mpi4py.bench", "ringtest",
+           "-l", "10", "-n", "1024"
+  end
+end


### PR DESCRIPTION
Adds `mpi4py` which are popular Cython bindings for MPI used in many Python projects (h5py, adios, adios2, ...).

Dependency for #45997

CC-ing upstream maintainer @dalcinl .

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
(`brew audit` install is broken since last update today)
-----
