### PR TITLE
ffsend: Bump version and add --locked flag to cargo install

### DIFF
--- a/Formula/ffsend.rb
+++ b/Formula/ffsend.rb
@@ -1,8 +1,8 @@
 class Ffsend < Formula
   desc "Fully featured Firefox Send client"
   homepage "https://gitlab.com/timvisee/ffsend"
-  url "https://github.com/timvisee/ffsend/archive/v0.2.52.tar.gz"
-  sha256 "b5fd937604eeccd85d7b30d8510784d95497c2412da29c586430275db55043ef"
+  url "https://github.com/timvisee/ffsend/archive/v0.2.55.tar.gz"
+  sha256 "dbcf0891e0ebe3929dbe7e063bd185344d53c9d3ebde6b62d6e82297e85ed8ad"
 
   bottle do
     cellar :any
@@ -19,7 +19,7 @@ class Ffsend < Formula
     # https://docs.rs/openssl/0.10.19/openssl/#manual
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
 
-    system "cargo", "install", "--root", prefix, "--path", "."
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
     bash_completion.install "contrib/completions/ffsend.bash"
     fish_completion.install "contrib/completions/ffsend.fish"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related to #46025 but I also bumped the version to v0.2.55 in the process of adding the `--locked` flag to `cargo install`.