### PR TITLE
rustup-init: add --locked flag to cargo install

### DIFF
--- a/Formula/rustup-init.rb
+++ b/Formula/rustup-init.rb
@@ -18,7 +18,7 @@ class RustupInit < Formula
     cargo_home.mkpath
     ENV["CARGO_HOME"] = cargo_home
 
-    system "cargo", "install", "--root", prefix, "--path", ".",
+    system "cargo", "install", "--locked", "--root", prefix, "--path", ".",
                     "--features", "no-self-update"
   end
 


### PR DESCRIPTION
 - [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
 - [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 - [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

 -----
 Relates to #46025