### PR TITLE
miniserve: add --locked flag to cargo install

### DIFF
--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -24,7 +24,7 @@ class Miniserve < Formula
       system "./install.sh", "--prefix=#{buildpath}/rust-nightly"
       ENV.prepend_path "PATH", "#{buildpath}/rust-nightly/bin"
     end
-    system "cargo", "install", "--root", prefix, "--path", "."
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 
   test do


### PR DESCRIPTION
 - [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
 - [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 - [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

 -----
 Relates to #46025