### PR TITLE
git-delta 0.0.14

### DIFF
--- a/Formula/git-delta.rb
+++ b/Formula/git-delta.rb
@@ -1,9 +1,8 @@
 class GitDelta < Formula
   desc "Syntax-highlighting pager for git"
   homepage "https://github.com/dandavison/delta"
-  url "https://github.com/dandavison/delta.git",
-    :tag     => "0.0.13",
-    :revison => "c2360a90d75e2d574a5d89d3c608ee77748e6d37"
+  url "https://github.com/dandavison/delta/archive/0.0.14.tar.gz"
+  sha256 "777b90bb20c89b63eb158d238dfb38914c3bc4617d65f8a0e465227f9c6884f9"
   head "https://github.com/dandavison/delta.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed that a previous PR (#45328) seemed to mention git-delta 0.0.13 having build issues on macOS Catalina.  Version 0.0.14 built fine and passed audits/tests locally on macOS Catalina (10.15.1), so this update may have fixed the related issues.  Besides that, I hope it's fine that I switched the URL to the tar.gz archive from than the repo/tag, since it didn't seem necessary at this point.