### PR TITLE
inlets 2.6.1

### DIFF
--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -1,9 +1,9 @@
 class Inlets < Formula
   desc "Expose your local endpoints to the Internet"
-  homepage "https://github.com/alexellis/inlets"
-  url "https://github.com/alexellis/inlets.git",
-      :tag      => "2.5.0",
-      :revision => "9744ca87b0b0e4c32ce22aa102827d684f5ef792"
+  homepage "https://github.com/inlets/inlets"
+  url "https://github.com/inlets/inlets.git",
+      :tag      => "2.6.1",
+      :revision => "5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,8 +16,8 @@ class Inlets < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/alexellis/inlets").install buildpath.children
-    cd "src/github.com/alexellis/inlets" do
+    (buildpath/"src/github.com/inlets/inlets").install buildpath.children
+    cd "src/github.com/inlets/inlets" do
       commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-ldflags",
              "-s -w -X main.GitCommit=#{commit} -X main.Version=#{version}",
@@ -34,6 +34,7 @@ class Inlets < Formula
   end
 
   MOCK_RESPONSE = "INLETS OK".freeze
+  SECRET_TOKEN = "itsasecret-sssshhhhh".freeze
 
   test do
     upstream_server = TCPServer.new(0)
@@ -64,6 +65,7 @@ class Inlets < Formula
         end
 
         socket.print "HTTP/1.1 200 OK\\r\\n" +
+                    "Host: localhost:#{upstream_port}\\r\\n" +
                     "Content-Type: text/plain\\r\\n" +
                     "Content-Length: \#\{response.bytesize\}\\r\\n" +
                     "Connection: close\\r\\n"
@@ -103,12 +105,12 @@ class Inlets < Formula
       sleep 3
       server_pid = fork do
         puts "Starting inlets server with port #{remote_port}"
-        exec "#{bin}/inlets server --port #{remote_port}"
+        exec "#{bin}/inlets server --port #{remote_port} --token #{SECRET_TOKEN}"
       end
 
       client_pid = fork do
-        puts "Starting inlets client with remote localhost:#{remote_port}, upstream localhost:#{upstream_port}"
-        exec "#{bin}/inlets client --remote localhost:#{remote_port} --upstream localhost:#{upstream_port}"
+        puts "Starting inlets client with remote localhost:#{remote_port}, upstream localhost:#{upstream_port}, token: #{SECRET_TOKEN}"
+        exec "#{bin}/inlets client --remote localhost:#{remote_port} --upstream localhost:#{upstream_port} --token #{SECRET_TOKEN}"
       end
 
       puts "Waiting for inlets websocket tunnel"


### PR DESCRIPTION
* Project moved from alexellis personal org to inlets org
* Supply token to establish test connection

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Test Output
Test passed, success exit code
```
brew test inlets
Testing inlets
Starting mock server on: localhost:61695
==> /usr/local/Cellar/inlets/2.6.1/bin/inlets version
Waiting for mock server
Waiting for inlets websocket tunnel
Starting inlets server with port 61696
Starting inlets client with remote localhost:61696, upstream localhost:61695, token: itsasecret-sssshhhhh
2019/11/04 17:44:45 Welcome to inlets.dev! Find out more at https://github.com/inlets/inlets
2019/11/04 17:44:45 Welcome to inlets.dev! Find out more at https://github.com/inlets/inlets
2019/11/04 17:44:45 Starting server - version 2.6.1
2019/11/04 17:44:45 Starting client - version 2.6.1
2019/11/04 17:44:45 Upstream:  => localhost:61695
2019/11/04 17:44:45 Server token: "itsasecret-sssshhhhh"
2019/11/04 17:44:45 Token: "itsasecret-sssshhhhh"
INFO[0000] Connecting to proxy                           url="ws://localhost:61696/tunnel"
2019/11/04 17:44:45 Control Plane Listening on :61696
2019/11/04 17:44:45 Data Plane Listening on :61696
INFO[0000] Handling backend connection request [67e80cee043741e59e1de3cbb1d1e4dc] 
Querying upstream endpoint via inlets remote: http://localhost:61696/inlets-test
2019/11/04 17:44:48 [b1fc6bcbc5a740c5a823420a597c3d41] proxy localhost:61696 GET /inlets-test
GET /inlets-test HTTP/1.1
Exiting test server
Tearing down Mock Server on PID 54116
Tearing down Inlets Server on PID 54255
Tearing down Inlets Client on PID 54256
```

### Audit Output
No output, success exit code.
```
brew audit --strict inlets
```