### PR TITLE
grafana 6.4.3

### DIFF
--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -1,8 +1,8 @@
 class Grafana < Formula
   desc "Gorgeous metric visualizations and dashboards for timeseries databases"
   homepage "https://grafana.com"
-  url "https://github.com/grafana/grafana/archive/v6.4.2.tar.gz"
-  sha256 "28f961f7b2c68e5961561fca99dd02a03382503a6179df9b62487df2501e171f"
+  url "https://github.com/grafana/grafana/archive/v6.4.3.tar.gz"
+  sha256 "2ed2bbaae731c0d168800ed41af2bd18e3df50abb6c9852347d4488a5cc8d63b"
   head "https://github.com/grafana/grafana.git"
 
   bottle do


### PR DESCRIPTION
Upgrade grafana to 6.4.3
This version fixes the following error on MacOS Catalina:
/usr/local/opt/grafana/bin/grafana-server: /usr/local/opt/grafana/bin/grafana-server: cannot execute binary file
Passes tests:
Testing grafana
==> /usr/local/Cellar/grafana/6.4.3/bin/grafana-server -v
Closes #45407
Fixes https://github.com/grafana/grafana/issues/19887

- [-] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
Yes.
- [-] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
For some reason #45407 does not pass the test step.
Mine did.
- [-] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
Yes.
- [-] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
Yes.

-----
