### PR TITLE
zydis 3.0.0

### DIFF
--- a/Formula/zydis.rb
+++ b/Formula/zydis.rb
@@ -1,8 +1,10 @@
 class Zydis < Formula
   desc "Fast and lightweight x86/x86_64 disassembler library"
   homepage "https://zydis.re"
-  url "https://github.com/zyantific/zydis/archive/v2.0.3.tar.gz"
-  sha256 "9a49b179ee2c787e1887e789867ca5c3a6c5e1fc929548c0a64f81272990ab01"
+  url "https://github.com/zyantific/zydis.git",
+    :tag      => "v3.0.0",
+    :revision => "ce4a42ffaffe4a5ff615665e05177c4c69eb4683",
+    :shallow  => false
   head "https://github.com/zyantific/zydis.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Zydis now requires Zycore to build, which doesn't have release archives but is instead a Git submodule.  The alias for `zycore-c` is found in `/dependencies/zycore` in the `zydis` repo and the resource `:revision` will also need to be updated when the Zydis version is bumped in the future (I left a comment explaining this).

Usually the `zycore` submodule is also checked out when you run `git clone --recursive 'https://github.com/zyantific/zydis.git'` but I couldn't find any mention of formulae doing recursive clones.  If this is possible, someone please do let me know and I can update the formula so this is simpler.