### PR TITLE
shared-mime-info: fix postinstall

### DIFF
--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -42,10 +42,18 @@ class SharedMimeInfo < Formula
   end
 
   def post_install
-    ln_sf HOMEBREW_PREFIX/"share/mime", share/"mime"
-    (HOMEBREW_PREFIX/"share/mime/packages").mkpath
-    cp (pkgshare/"packages").children, HOMEBREW_PREFIX/"share/mime/packages"
-    system bin/"update-mime-database", HOMEBREW_PREFIX/"share/mime"
+    global_mime = HOMEBREW_PREFIX/"share/mime"
+    cellar_mime = share/"mime"
+
+    if !cellar_mime.exist? || !cellar_mime.symlink?
+      rm_rf cellar_mime
+      ln_sf global_mime, cellar_mime
+    end
+
+    (global_mime/"packages").mkpath
+    cp (pkgshare/"packages").children, global_mime/"packages"
+
+    system bin/"update-mime-database", global_mime
   end
 
   test do


### PR DESCRIPTION
We have to do something about https://github.com/Homebrew/homebrew-core/issues/38213

I don't fully understand why that bug occurs, but one of the symptoms observed is the creation of a symlink `share/"mime/mime"`, because sometimes the `ln_sf` is run in circumstances where the symlink already exists (for reasons I do not understand).

If the symlink already exists, we don't need to try and create it again.

This should also fix the actual `postinstall` failure, which is when `postinstall` is run one more time, now since `share/"mime/mime"` already exists, the `ln_sf` will fail completely.