### PR TITLE
freeswitch 1.10.1

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -1,10 +1,10 @@
 class Freeswitch < Formula
   desc "Telephony platform to route various communication protocols"
   homepage "https://freeswitch.org"
-  url "https://freeswitch.org/stash/scm/fs/freeswitch.git",
-      :tag      => "v1.6.20",
-      :revision => "987c9b9a2a2e389becf4f390feb9eb14c77e2371"
-  head "https://freeswitch.org/stash/scm/fs/freeswitch.git"
+  url "https://github.com/signalwire/freeswitch.git",
+      :tag      => "v1.10.1",
+      :revision => "f9990221e6094886066ec2bf9685648135bd405a"
+  head "https://github.com/signalwire/freeswitch.git"
 
   bottle do
     rebuild 1
@@ -19,10 +19,14 @@ class Freeswitch < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "yasm" => :build
+  depends_on "ffmpeg"
   depends_on "jpeg"
+  depends_on "ldns"
+  depends_on "libpq"
   depends_on "libsndfile"
+  depends_on "libtiff"
   depends_on "lua"
-  depends_on "openssl" # no OpenSSL 1.1 support
+  depends_on "openssl@1.1"
   depends_on "opus"
   depends_on "pcre"
   depends_on "speex"
@@ -62,41 +66,36 @@ class Freeswitch < Formula
   #-----------
   # sounds-en
   #-----------
-  sounds_en_version = "1.0.51" # from build/sounds_version.txt
+  sounds_en_version = "1.0.52" # from build/sounds_version.txt
   resource "sounds-en-us-callie-8000" do
     url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-8000-#{sounds_en_version}.tar.gz"
     version sounds_en_version
-    sha256 "e48a63bd69e6253d294ce43a941d603b02467feb5d92ee57a536ccc5f849a4a8"
+    sha256 "fbe51296ba5282864a8f0269a968de0783b88b2a75dad710ee076138382a5151"
   end
   resource "sounds-en-us-callie-16000" do
     url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-16000-#{sounds_en_version}.tar.gz"
     version sounds_en_version
-    sha256 "324b1ab5ab754db5697963e9bf6a2f9c7aeb1463755e86bbb6dc4d6a77329da2"
+    sha256 "bf3ac7be99939f57ed4fab7b76d1e47ba78d1573cc72aa0cfe656c559eb097bd"
   end
   resource "sounds-en-us-callie-32000" do
     url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-32000-#{sounds_en_version}.tar.gz"
     version sounds_en_version
-    sha256 "06fd6b8aec937556bf5303ab19a212c60daf00546d395cf269dfe324ac9c6838"
+    sha256 "9091553934f7ee453646058ff54837f55c5b38be11c987148c63a1cccc88b741"
   end
   resource "sounds-en-us-callie-48000" do
     url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-48000-#{sounds_en_version}.tar.gz"
     version sounds_en_version
-    sha256 "cfc50f1d9b5d43cb87a9a2c0ce136c37ee85ac3b0e5be930d8dc2c913c4495aa"
+    sha256 "9df388d855996a04f6014999d59d4191e22b579f2e8df542834451a25ea3e1cf"
   end
 
   #------------------------ End sound file resources --------------------------
 
   def install
-    ENV["ac_cv_lib_lzma_lzma_code"] = "no" # prevent opportunistic linkage to xz
-
-    # avoid a dependency on ldns to prevent OpenSSL version conflicts
-    inreplace "build/modules.conf.in", "applications/mod_enum",
-                                       "#applications/mod_enum"
+    # avoid libks and signalwire-client-c dependencies
+    inreplace "build/modules.conf.in", "applications/mod_signalwire",
+                                       "#applications/mod_signalwire"
 
     system "./bootstrap.sh", "-j"
-
-    # tiff will fail to find OpenGL unless told not to use X
-    inreplace "libs/tiff-4.0.2/configure.gnu", "--with-pic", "--with-pic --without-x"
 
     system "./configure", "--disable-dependency-tracking",
                           "--enable-shared",
@@ -104,27 +103,27 @@ class Freeswitch < Formula
                           "--prefix=#{prefix}",
                           "--exec_prefix=#{prefix}"
 
-    system "make"
-    system "make", "install", "all"
+    system "make", "all"
+    system "make", "install"
 
     # Should be equivalent to: system "make", "cd-moh-install"
-    mkdir_p prefix/"sounds/music"
+    mkdir_p pkgshare/"sounds/music"
     [8, 16, 32, 48].each do |n|
       resource("sounds-music-#{n}000").stage do
-        cp_r ".", prefix/"sounds/music"
+        cp_r ".", pkgshare/"sounds/music"
       end
     end
 
     # Should be equivalent to: system "make", "cd-sounds-install"
-    mkdir_p prefix/"sounds/en"
+    mkdir_p pkgshare/"sounds/en"
     [8, 16, 32, 48].each do |n|
       resource("sounds-en-us-callie-#{n}000").stage do
-        cp_r ".", prefix/"sounds/en"
+        cp_r ".", pkgshare/"sounds/en"
       end
     end
   end
 
-  plist_options :manual => "freeswitch -nc --nonat"
+  plist_options :manual => "freeswitch -nc -nonat"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula hadn't been updated in a couple years.

There's two new formula that I had to add. libks used to ship with freeswitch but is now a separate (dynamically linked) dependency. signalwire-client-c was added in 1.8.3.

Now uses OpenSSL 1.1.

I fully expect there to be some build error from missing a dependency or something. I managed to get it to build locally so let's see.

This pull request should also fix source builds which were broken due to a change of URL.