### PR TITLE
hydra: fix linkage issues

### DIFF
--- a/Formula/hydra.rb
+++ b/Formula/hydra.rb
@@ -3,7 +3,7 @@ class Hydra < Formula
   homepage "https://github.com/vanhauser-thc/thc-hydra"
   url "https://github.com/vanhauser-thc/thc-hydra/archive/v9.0.tar.gz"
   sha256 "56672e253c128abaa6fb19e77f6f59ba6a93762a9ba435505a009ef6d58e8d0e"
-  revision 2
+  revision 3
   head "https://github.com/vanhauser-thc/thc-hydra.git"
 
   bottle do
@@ -25,8 +25,19 @@ class Hydra < Formula
       s.gsub! "/opt/local/lib", Formula["openssl@1.1"].opt_lib
       s.gsub! "/opt/local/*ssl", Formula["openssl@1.1"].opt_lib
       s.gsub! "/opt/*ssl/include", Formula["openssl@1.1"].opt_include
-      # Avoid opportunistic linking of subversion
-      s.gsub! "libsvn", "oh_no_you_dont"
+      # Avoid opportunistic linking of everything
+      %w[
+        gtk+-2.0
+        libfreerdp2
+        libgcrypt
+        libidn
+        libmemcached
+        libmongoc
+        libpq
+        libsvn
+      ].each do |lib| 
+        s.gsub! lib, "oh_no_you_dont"
+      end
     end
 
     # Having our gcc in the PATH first can cause issues. Monitor this.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hydra had broken linkage on libgcrypt:

```
$ brew linkage --test hydra
Broken dependencies:
  /usr/local/opt/libgcrypt/lib/libgcrypt.20.dylib (libgcrypt)
```

The problem was this linkage was opportunistic. The whole configure file is full of opportunistic linking with no option to disable.

Not only have I disabled libgcrypt linking, I took the safe route and disabled linking with anything that configure file attempts to look for that we weren't linking before.