### PR TITLE
Add tac Formula (new formula)

### DIFF
--- a/Formula/tac.rb
+++ b/Formula/tac.rb
@@ -1,0 +1,18 @@
+class Tac < Formula
+  desc "tac command for macOS (linux too)"
+  homepage "https://github.com/WestleyR/tac"
+  url "https://github.com/WestleyR/tac/archive/v1.0.1.tar.gz"
+  sha256 "e2458464709a0b027bb7834fe6362fb0ee25ac9bbe938050c1d9fbe0d9846387"
+
+  # depends_on "cmake" => :build
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "touch", "test-file"
+    system "#{bin}/tac", "test-file"
+  end
+end
+


### PR DESCRIPTION
This PR adds a new formula `tac`, since macOS dose not include this for
some reason, it will be really nice to have this here!

This is a quick little tac program I wrote up, should work as a
substitute for your Linux tac command.

_I'm very new to brew, (and I'm liking it!), never used ruby before,
hopfully I did everything correctly..._

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [?] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
