### PR TITLE
mysql@5.6: dynamically link OpenSSL

### DIFF
--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -3,7 +3,7 @@ class MysqlAT56 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
   url "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.46.tar.gz"
   sha256 "12e1fbabf2086e6175359767ca89fa8a58f9274fcad40434aa6a56e582d65f49"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "110f70d90f42d346fba999930aae72b6e585d97f22c8774e00e62f6b959fad87" => :catalina
@@ -35,7 +35,7 @@ class MysqlAT56 < Formula
       -DINSTALL_DOCDIR=share/doc/#{name}
       -DINSTALL_INFODIR=share/info
       -DINSTALL_MYSQLSHAREDIR=share/mysql
-      -DWITH_SSL=system
+      -DWITH_SSL=yes
       -DDEFAULT_CHARSET=utf8
       -DDEFAULT_COLLATION=utf8_general_ci
       -DSYSCONFDIR=#{etc}


### PR DESCRIPTION
The upgrade to 5.6.46 a few weeks ago changed how OpenSSL worked. On the MySQL side, their primary goal was to add support for OpenSSL 1.1 (which we managed with success in #46355), but 5.6.46 seems to have changed how OpenSSL is linked (regardless of whether it is 1.0 or 1.1).

Originally we had:
* WITH_SSL=bundled - use bundled yaSSL
* WITH_SSL=system - use "system" OpenSSL (Homebrew's)
* WITH_SSL=yes - system with a fallback to bundled
* WITH_SSL=\<path\> - use custom path for OpenSSL

In 5.6.43, OpenSSL would be linked dynamically with "system" and "yes". I've not tested with custom paths on that version.

Now "bundled" is removed, you would think that "yes" and "system" are identical. And they are documented as being so.

However there is actually a difference now. "system" now statically links OpenSSL (and adds bogus `-limported_openssl -limported_crypto` to `mysql_config` - #45397), the custom path option also statically links (without any ssl/crypto links at all in `mysql_config` - since it's static), and "yes" does a dynamic link.

[The MySQL 5.7 formula already uses "yes"](https://github.com/Homebrew/homebrew-core/blob/37e7203b351fce859178ea351cb2c377a04cfbf5/Formula/mysql%405.7.rb#L39) so was not affected.

Things can be improved upstream no doubt, but we've found what works for us.

(Hopefully) fixes #45397.

---

5.6.43:
```
$ brew linkage mysql@5.6
System libraries:
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libedit.3.dylib
Homebrew libraries:
  /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (openssl)
  /usr/local/opt/openssl/lib/libssl.1.0.0.dylib (openssl)
```

5.6.46 (prior to this pull request):
```
$ brew linkage mysql@5.6
System libraries:
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libedit.3.dylib
```

After this pull request:
```
$ brew linkage mysql@5.6
System libraries:
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libedit.3.dylib
Homebrew libraries:
  /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (openssl@1.1)
  /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (openssl@1.1)
```