### PR TITLE
Add 'whereis' command (new formula)

### DIFF
--- a/Formula/whereis.rb
+++ b/Formula/whereis.rb
@@ -1,0 +1,17 @@
+class Whereis < Formula
+  desc "Whereis that works! for macOS (and linux)"
+  homepage "https://github.com/WestleyR/whereis"
+  url "https://github.com/WestleyR/whereis/archive/v1.0.0.tar.gz"
+  sha256 "ea140364f939f96c1d5971d7a83f60bd0f6000f5a07f4a0efc5e4692cebf70f8"
+
+  # depends_on "cmake" => :build
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/whereis", "sh"
+  end
+end
+


### PR DESCRIPTION
This PR adds a `whereis` command, why? the default whereis that comes
with macOS sucks, it wont show a symlink, or sometimes wont print anything!

**Example:**

Old `whereis` command on macOS:

```
$ whereis tac
# no output
```

New `whereis` command:

```
$ whereis tac
/usr/local/bin/tac -> ../Cellar/coreutils/8.31/bin/tac
```

See! Much better!

Although the linux whereis command wont print symlinks, but I think its much nicer if it does. Imo.

<br>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [?] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
