### PR TITLE
x264: disable opportunistic links

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -29,6 +29,8 @@ class X264 < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-lsmash
+      --disable-swscale
+      --disable-ffms
       --enable-shared
       --enable-static
       --enable-strip


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The old bottle (rebuild 0) for `x264` had an opportunistic link to `ffmpeg` and `ffms2`:

```console
$ brew reinstall https://homebrew.bintray.com/bottles/x264-r2917_1.catalina.bottle.tar.gz && brew linkage x264
==> Downloading https://homebrew.bintray.com/bottles/x264-r2917_1.catalina.bottle.tar.gz
Already downloaded: /Users/jonchang/Library/Caches/Homebrew/downloads/d19a5ed12d435e74f184f7831dc9fcf405015e6af33a4811b8387c32d9939230--x264-r2917_1.catalina.bottle.tar.gz
==> Pouring the cached bottle
==> Downloading https://homebrew.bintray.com/bottles/x264-r2917_1.catalina.bottle.tar.gz
Already downloaded: /Users/jonchang/Library/Caches/Homebrew/downloads/d19a5ed12d435e74f184f7831dc9fcf405015e6af33a4811b8387c32d9939230--x264-r2917_1.catalina.bottle.tar.gz
==> Pouring the cached bottle
==> Reinstalling x264 
Broken dependencies:
  /usr/local/opt/ffms2/lib/libffms2.4.dylib (ffms2)
Warning: x264 has broken dynamic library links:
  
Rebuild this from source with:
  brew reinstall --build-from-source x264
If that's successful, file an issue.
==> Summary
/usr/local/Cellar/x264/r2917_1: 11 files, 5.9MB
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/ffmpeg/lib/libavcodec.58.dylib (ffmpeg)
  /usr/local/opt/ffmpeg/lib/libavformat.58.dylib (ffmpeg)
  /usr/local/opt/ffmpeg/lib/libavresample.4.dylib (ffmpeg)
  /usr/local/opt/ffmpeg/lib/libavutil.56.dylib (ffmpeg)
  /usr/local/opt/ffmpeg/lib/libswresample.3.dylib (ffmpeg)
  /usr/local/opt/ffmpeg/lib/libswscale.5.dylib (ffmpeg)
Broken dependencies:
  /usr/local/opt/ffms2/lib/libffms2.4.dylib (ffms2)
Undeclared dependencies with linkage:
  ffmpeg
```

I identified this as causing a loop during `brew upgrade` (https://github.com/Homebrew/brew/issues/6671
). Although the `rebuild 1` bottle does not have this undeclared linkage, adding this configure flag should hopefully prevent a similar loop from happening again.

```console
$ brew install ffmpeg && brew reinstall -s x264 && brew linkage x264
Warning: ffmpeg 4.2.1_2 is already installed and up-to-date
To reinstall 4.2.1_2, run `brew reinstall ffmpeg`
==> Reinstalling x264
==> Cloning https://git.videolan.org/git/x264.git
Updating /Users/jonchang/Library/Caches/Homebrew/x264--git
==> Checking out revision 0a84d986e7020f8344f00752e3600b9769cc1e85
HEAD is now at 0a84d986 x86inc: Fix VEX -> EVEX instruction conversion
HEAD is now at 0a84d986 x86inc: Fix VEX -> EVEX instruction conversion
==> ./configure --prefix=/usr/local/Cellar/x264/r2917_1 --disable-lsmash --disable-lavf --disable-swscale --en
==> make install
/usr/local/Cellar/x264/r2917_1: 11 files, 5.9MB, built in 1 minute 17 seconds
System libraries:
  /usr/lib/libSystem.B.dylib
```