### PR TITLE
liquidctl 1.3.2 (new formula)

### DIFF
--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -1,0 +1,46 @@
+class Liquidctl < Formula
+  include Language::Python::Virtualenv
+
+  desc "Cross-platform tool and drivers for liquid coolers and other devices"
+  homepage "https://github.com/jonasmalacofilho/liquidctl"
+  url "https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-1.3.2.tar.gz"
+  sha256 "bb742947c15f4a3987685641c0dd73184c4a40add5ad818ced68e5ace3631b6b"
+
+  head "https://github.com/jonasmalacofilho/liquidctl.git"
+
+  depends_on "libusb"
+  depends_on "python"
+
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/source/d/docopt/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+
+  resource "hidapi" do
+    url "https://files.pythonhosted.org/packages/source/h/hidapi/hidapi-0.7.99.post21.tar.gz"
+    sha256 "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97"
+  end
+
+  resource "pyusb" do
+    url "https://files.pythonhosted.org/packages/source/p/pyusb/pyusb-1.0.2.tar.gz"
+    sha256 "4e9b72cc4a4205ca64fbf1f3fff39a335512166c151ad103e55c8223ac147362"
+  end
+
+  def install
+    # customize liquidctl --version
+    ENV["DIST_NAME"] = "homebrew"
+    ENV["DIST_PACKAGE"] = "liquidctl #{version}"
+
+    virtualenv_install_with_resources
+
+    man_page = buildpath/"liquidctl.8"
+    # setting the is_macos register to 1 adjusts the man page for macOS
+    inreplace man_page, ".nr is_macos 0", ".nr is_macos 1"
+    man.mkpath
+    man8.install man_page
+  end
+
+  test do
+    shell_output "#{bin}/liquidctl list --verbose --debug"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I would like to submit `liquidctl` for inclusion in the `homebrew-core` tap. As a moderator on the [TonyMac forum](https://www.tonymacx86.com/threads/success-gigabyte-designare-z390-thunderbolt-3-i7-9700k-amd-rx-580.267551/), I have run into a fair number of people who are interested in installing and running this tool to monitor and control their PC power supplies, liquid coolers, fans, and RGB LEDs. The PC enthusiast community is still vibrant, and they're looking for solutions such as `liquidctl` to provide -- for the first time -- the ability to perform these functions on their custom builds. 

I have found `liquidctl` to be exceptionally well written and well maintained. It has grown over the past year to provide support for an expanded number of devices, and is proving itself to be an increasingly valuable tool for the enthusiast community.

Please consider adding it to `homebrew-core` so an even greater number of people will use homebrew for the first time, and be able to install `liquidctl` with a single `brew install liquidctl` command. Thank you.