### PR TITLE
apache-zeppelin: fix depends_on :java

### DIFF
--- a/Formula/apache-zeppelin.rb
+++ b/Formula/apache-zeppelin.rb
@@ -7,7 +7,7 @@ class ApacheZeppelin < Formula
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.7"
 
   def install
     rm_f Dir["bin/*.cmd"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
