### PR TITLE
libusbmuxd: renamed from usbmuxd

### DIFF
--- a/Aliases/usb-multiplex-daemon
+++ b/Aliases/usb-multiplex-daemon
@@ -1,1 +1,1 @@
-../Formula/usbmuxd.rb
+../Formula/libusbmuxd.rb

--- a/Formula/ideviceinstaller.rb
+++ b/Formula/ideviceinstaller.rb
@@ -1,5 +1,5 @@
 class Ideviceinstaller < Formula
-  desc "Cross-platform library for communicating with iOS devices"
+  desc "Tool for managing apps on iOS devices"
   homepage "https://www.libimobiledevice.org/"
   url "https://www.libimobiledevice.org/downloads/ideviceinstaller-1.1.0.tar.bz2"
   sha256 "0821b8d3ca6153d9bf82ceba2706f7bd0e3f07b90a138d79c2448e42362e2f53"

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -1,5 +1,5 @@
 class Ifuse < Formula
-  desc "FUSE module for iPhone and iPod Touch devices"
+  desc "FUSE module for iOS devices"
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/ifuse/archive/1.1.3.tar.gz"
   sha256 "9b63afa6f2182da9e8c04b9e5a25c509f16f96f5439a271413956ecb67143089"

--- a/Formula/ios-webkit-debug-proxy.rb
+++ b/Formula/ios-webkit-debug-proxy.rb
@@ -3,7 +3,7 @@ class IosWebkitDebugProxy < Formula
   homepage "https://github.com/google/ios-webkit-debug-proxy"
   url "https://github.com/google/ios-webkit-debug-proxy/archive/v1.8.5.tar.gz"
   sha256 "5d3f71609b908910249a1bcdcb20c5e94f0cbea6418dc9f1d36ec2f41bed80a7"
-  revision 1
+  revision 2
   head "https://github.com/google/ios-webkit-debug-proxy.git"
 
   bottle do
@@ -20,7 +20,7 @@ class IosWebkitDebugProxy < Formula
   depends_on "pkg-config" => :build
   depends_on "libimobiledevice"
   depends_on "libplist"
-  depends_on "usbmuxd"
+  depends_on "libusbmuxd"
 
   def install
     system "./autogen.sh"

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -1,7 +1,7 @@
 class Libimobiledevice < Formula
   desc "Library to communicate with iOS devices natively"
   homepage "https://www.libimobiledevice.org/"
-  revision 4
+  revision 5
 
   stable do
     url "https://www.libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
@@ -39,8 +39,8 @@ class Libimobiledevice < Formula
   depends_on "pkg-config" => :build
   depends_on "libplist"
   depends_on "libtasn1"
+  depends_on "libusbmuxd"
   depends_on "openssl@1.1"
-  depends_on "usbmuxd"
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/libusbmuxd.rb
+++ b/Formula/libusbmuxd.rb
@@ -1,5 +1,5 @@
-class Usbmuxd < Formula
-  desc "USB multiplexor daemon for iPhone and iPod Touch devices"
+class Libusbmuxd < Formula
+  desc "USB multiplexor library for iOS devices"
   homepage "https://www.libimobiledevice.org/"
   revision 1
 
@@ -12,17 +12,6 @@ class Usbmuxd < Formula
       url "https://github.com/libimobiledevice/libusbmuxd/commit/4397b3376dc4.patch?full_index=1"
       sha256 "b28e17c82dc11320741d33cf68fd78e1baec9e4133f5265b944f167839cbe9bb"
     end
-  end
-
-  bottle do
-    cellar :any
-    sha256 "e3478a1fe9d403496347a8663e686d6499d4510bd4619567f9e9651001822125" => :catalina
-    sha256 "2305d6794314c64d0fb8c3339c2d75a8e01d218715bc871560e4fe9fcad486a8" => :mojave
-    sha256 "253be465f391159e278a0a9625775075503f75b0a404aa64b9f557486de3b82c" => :high_sierra
-    sha256 "37a70014ca7c861639b8dc0f280b66306c082091731dfc3a53d1ef709ab98d5e" => :sierra
-    sha256 "e7227fb7deaefc2990e23d9cfdb3aa4305fc7f31e902560fa46272168c85e151" => :el_capitan
-    sha256 "0aae53db481257e6ce5eed9be080b63b347f2e05d5dfecc55b0936a9ee5ab336" => :yosemite
-    sha256 "e36b16d09c26e83daf359216a9b66fd2515a10d7432fdcc724c7aba5224f19b1" => :mavericks
   end
 
   head do

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -191,6 +191,7 @@
   "transfig": "fig2dev",
   "transmission": "transmission-cli",
   "unison240": "unison@2.40",
+  "usbmuxd": "libusbmuxd",
   "v8-315": "v8@3.15",
   "varnish4": "varnish@4",
   "vim74": "vim@7.4",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Renames the `usbmuxd` formula to `libusbmuxd` to be consistent with how it's named [upstream](https://github.com/libimobiledevice/libusbmuxd) so as to avoid future confusion (#35872). Also bumps revisions of two formulae that depend on it and fixes descriptions on other formulae from the same developer.