### PR TITLE
Remove old fails_with

### DIFF
--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -16,9 +16,6 @@ class Arangodb < Formula
   depends_on :macos => :mojave
   depends_on "openssl@1.1"
 
-  # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87665
-  fails_with :gcc => "7"
-
   # the ArangoStarter is in a separate github repository;
   # it is used to easily start single server and clusters
   # with a unified CLI

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -23,14 +23,6 @@ class Gdb < Formula
     EOS
   end
 
-  fails_with :clang do
-    build 600
-    cause <<~EOS
-      clang: error: unable to execute command: Segmentation fault: 11
-      Test done on: Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
-    EOS
-  end
-
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/libcds.rb
+++ b/Formula/libcds.rb
@@ -14,10 +14,6 @@ class Libcds < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
-  if DevelopmentTools.clang_build_version < 800
-    depends_on "gcc"
-    fails_with :clang
-  end
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/libkate.rb
+++ b/Formula/libkate.rb
@@ -21,11 +21,6 @@ class Libkate < Formula
   depends_on "libogg"
   depends_on "libpng"
 
-  fails_with :gcc do
-    build 5666
-    cause "Segfault during compilation"
-  end
-
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -22,20 +22,6 @@ class Mesos < Formula
   conflicts_with "nanopb-generator", :because => "they depend on an incompatible version of protobuf"
   conflicts_with "rapidjson", :because => "mesos installs a copy of rapidjson headers"
 
-  if DevelopmentTools.clang_build_version >= 802 # does not affect < Xcode 8.3
-    # _scheduler.so segfault when Mesos is built with Xcode 8.3.2
-    # Reported 29 May 2017 https://issues.apache.org/jira/browse/MESOS-7583
-    # The issue does not occur with Xcode 9 beta 3.
-    fails_with :clang do
-      build 802
-      cause "Segmentation fault in _scheduler.so"
-    end
-  end
-
-  # error: 'Megabytes(32).Megabytes::<anonymous>' is not a constant expression
-  # because it refers to an incompletely initialized variable
-  fails_with :gcc => "7"
-
   resource "protobuf" do
     url "https://files.pythonhosted.org/packages/1b/90/f531329e628ff34aee79b0b9523196eb7b5b6b398f112bb0c03b24ab1973/protobuf-3.6.1.tar.gz"
     sha256 "1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811"

--- a/Formula/nu.rb
+++ b/Formula/nu.rb
@@ -13,11 +13,6 @@ class Nu < Formula
 
   depends_on "pcre"
 
-  fails_with :gcc do
-    build 5666
-    cause "nu only builds with clang"
-  end
-
   def install
     ENV.delete("SDKROOT") if MacOS.version < :sierra
     ENV["PREFIX"] = prefix

--- a/Formula/osquery.rb
+++ b/Formula/osquery.rb
@@ -35,8 +35,6 @@ class Osquery < Formula
   depends_on "yara"
   depends_on "zstd"
 
-  fails_with :gcc => "6"
-
   resource "MarkupSafe" do
     url "https://files.pythonhosted.org/packages/c0/41/bae1254e0396c0cc8cf1751cb7d9afc90a602353695af5952530482c963f/MarkupSafe-0.23.tar.gz"
     sha256 "a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -18,11 +18,6 @@ class Pdnsrec < Formula
   depends_on "lua"
   depends_on "openssl@1.1"
 
-  fails_with :clang do
-    build 600
-    cause "incomplete C++11 support"
-  end
-
   def install
     ENV.cxx11
 


### PR DESCRIPTION
- Compiling with GCC is not exactly supported, in any case… especially older versions.
- Removing fails_with for ancient clang versions (Xcode 6)