### PR TITLE
git-filter-repo: new formula, version 2.24.0

### DIFF
--- a/Formula/git-filter-repo.rb
+++ b/Formula/git-filter-repo.rb
@@ -1,0 +1,43 @@
+class GitFilterRepo < Formula
+  desc "Quickly rewrite git repository history"
+  homepage "https://github.com/newren/git-filter-repo"
+  url "https://github.com/newren/git-filter-repo/releases/download/v2.24.0/git-filter-repo-2.24.0.tar.xz"
+  sha256 "92188d3c44b9ff0dd40dfeed72859e0a088f775c12fb24c4e3e27a8064cfcc84"
+
+  # ignore git dependency audit:
+  #  * Don't use git as a dependency (it's always available)
+  # But we require Git 2.22.0+
+  # https://github.com/Homebrew/homebrew-core/pull/46550#issuecomment-563229479
+  depends_on "git"
+
+  # Use any python3 version available
+  # https://github.com/Homebrew/homebrew-core/pull/46550/files#r363751231
+  if MacOS.version >= :catalina
+    uses_from_macos "python3"
+  else
+    depends_on "python3"
+  end
+
+  def install
+    bin.install "git-filter-repo"
+    man1.install "Documentation/man1/git-filter-repo.1"
+  end
+
+  test do
+    system "#{bin}/git-filter-repo", "--version"
+
+    system "git", "init"
+    system "git", "config", "user.name", "BrewTestBot"
+    system "git", "config", "user.email", "BrewTestBot@example.com"
+
+    touch "foo"
+    system "git", "add", "foo"
+    system "git", "commit", "-m", "foo"
+    # Use --force to accept non-fresh clone run:
+    # Aborting: Refusing to overwrite repo history since this does not look like a fresh clone.
+    # (expected freshly packed repo)
+    system "#{bin}/git-filter-repo", "--path-rename=foo:bar", "--force"
+
+    assert_predicate testpath/"bar", :exist?
+  end
+end


### PR DESCRIPTION
git started to emit this message when doing `git filter-branch`:

```

WARNING: git-filter-branch has a glut of gotchas generating mangled history
	 rewrites.  Hit Ctrl-C before proceeding to abort, then use an
	 alternative filtering tool such as 'git filter-repo'
	 (https://github.com/newren/git-filter-repo/) instead.  See the
	 filter-branch manual page for more details; to squelch this warning,
	 set FILTER_BRANCH_SQUELCH_WARNING=1.
```

So, as a fan of brew, I decided to create a formula for [git-filter-repo](https://github.com/newren/git-filter-repo)

Even `brew audit --new-formula` says it's notable enough, I think it's growing soon. Git 2.24.0 was released just on 2019-11-04. 
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

Created with:
```
$ brew create https://github.com/newren/git-filter-repo/releases/download/v2.24.0/git-filter-repo-2.24.0.tar.xz
```
Docs:
- https://docs.brew.sh/Formula-Cookbook

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
