### PR TITLE
http-server, ungit: make test more robust (by using a custom port)

### DIFF
--- a/Formula/http-server.rb
+++ b/Formula/http-server.rb
@@ -24,11 +24,15 @@ class HttpServer < Formula
   end
 
   test do
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    server.close
+
     pid = fork do
-      exec "#{bin}/http-server"
+      exec "#{bin}/http-server", "-p#{port}"
     end
     sleep 1
-    output = shell_output("curl -sI http://localhost:8080")
+    output = shell_output("curl -sI http://localhost:#{port}")
     assert_match /200 OK/m, output
   ensure
     Process.kill("HUP", pid)

--- a/Formula/ungit.rb
+++ b/Formula/ungit.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Ungit < Formula
   desc "The easiest way to use git. On any platform. Anywhere"
   homepage "https://github.com/FredrikNoren/ungit"
-  url "https://registry.npmjs.org/ungit/-/ungit-1.4.47.tgz"
-  sha256 "be09b1210dbd221e2df1545ba6f3f90607609dcd4f816acd10128f7b97142f24"
+  url "https://registry.npmjs.org/ungit/-/ungit-1.4.48.tgz"
+  sha256 "691447a39ac4729c2b0ee2705cc21b9d239063354b78583853d1c053347758b1"
 
   bottle do
     cellar :any_skip_relocation
@@ -36,7 +36,7 @@ class Ungit < Formula
   ensure
     Process.kill("TERM", ppid)
     # ensure that there are no spawned child processes left
-    child_p = shell_output("ps -o pid,ppid").scan(/^(\d+)\s+#{ppid}\s*$/).map {|p| p[0].to_i}
+    child_p = shell_output("ps -o pid,ppid").scan(/^(\d+)\s+#{ppid}\s*$/).map { |p| p[0].to_i }
     child_p.each { |pid| Process.kill("TERM", pid) }
     Process.wait(ppid)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **=> Includes #45677**
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a attempt to make the `http-server` and `ungit` tests more robust by using a custom port and in the case of `ungit` ensuring that no child processes are left over. This should hopefully resolve the test failures observed in #45725 and #45677 (later is included here).