### PR TITLE
Fix valgrind.rb --HEAD build

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -37,7 +37,7 @@ class Valgrind < Formula
     system "./autogen.sh" if build.head?
 
     # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
-    if build.stable? and not stableMacOS::CLT.installed?
+    if build.stable? && !MacOS::CLT.installed?
       inreplace "coregrind/Makefile.in", %r{(\s)(?=/usr/include/mach/)}, '\1'+MacOS.sdk_path.to_s
     end
 

--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -37,7 +37,7 @@ class Valgrind < Formula
     system "./autogen.sh" if build.head?
 
     # Look for headers in the SDK on Xcode-only systems: https://bugs.kde.org/show_bug.cgi?id=295084
-    unless MacOS::CLT.installed?
+    if build.stable? and not stableMacOS::CLT.installed?
       inreplace "coregrind/Makefile.in", %r{(\s)(?=/usr/include/mach/)}, '\1'+MacOS.sdk_path.to_s
     end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Path replacement with `inreplace` is not needed anymore in the current HEAD version.

https://sourceware.org/git/?p=valgrind.git;a=commit;h=5d687db28752f650fd77e34074975d3d107c24b3