### PR TITLE
mkcert: update to v1.4.1 and set linker version

### DIFF
--- a/Formula/mkcert.rb
+++ b/Formula/mkcert.rb
@@ -2,7 +2,7 @@ class Mkcert < Formula
   desc "Simple tool to make locally trusted development certificates"
   homepage "https://github.com/FiloSottile/mkcert"
   url "https://github.com/FiloSottile/mkcert/archive/v1.4.1.tar.gz"
-  sha256 "8ad11055b4fb47955312b7b72e24057cc6dca1606d14838a1520ce87ed62cc89"
+  sha256 "b539e11ac0a06ff4831b76134b8d391610287cf8e56b002365b3786b96e0acbe"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/mkcert.rb
+++ b/Formula/mkcert.rb
@@ -19,7 +19,7 @@ class Mkcert < Formula
     (buildpath/"src/github.com/FiloSottile/mkcert").install buildpath.children
 
     cd "src/github.com/FiloSottile/mkcert" do
-      system "go", "build", "-o", bin/"mkcert", "-ldflags", "-X main.Version=#{version}"
+      system "go", "build", "-o", bin/"mkcert", "-ldflags", "-X main.Version=v#{version}"
       prefix.install_metafiles
     end
   end

--- a/Formula/mkcert.rb
+++ b/Formula/mkcert.rb
@@ -1,7 +1,7 @@
 class Mkcert < Formula
   desc "Simple tool to make locally trusted development certificates"
   homepage "https://github.com/FiloSottile/mkcert"
-  url "https://github.com/FiloSottile/mkcert/archive/v1.4.0.tar.gz"
+  url "https://github.com/FiloSottile/mkcert/archive/v1.4.1.tar.gz"
   sha256 "8ad11055b4fb47955312b7b72e24057cc6dca1606d14838a1520ce87ed62cc89"
 
   bottle do
@@ -19,7 +19,7 @@ class Mkcert < Formula
     (buildpath/"src/github.com/FiloSottile/mkcert").install buildpath.children
 
     cd "src/github.com/FiloSottile/mkcert" do
-      system "go", "build", "-o", bin/"mkcert"
+      system "go", "build", "-o", bin/"mkcert", "-ldflags", "-X main.Version=#{version}"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

BTW, why do formulas for Go modules still set up a directory structure that looks like GOPATH? Simply building in `buildpath` would also work.

```
    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
    system "go", "build", "-o", bin/"mkcert", "-ldflags", "-X main.Version=v#{version}"
    prefix.install_metafiles
```