### PR TITLE
gitlab-runner: use --short=8 bytes for commit hash

### DIFF
--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -4,6 +4,7 @@ class GitlabRunner < Formula
   url "https://gitlab.com/gitlab-org/gitlab-runner.git",
       :tag      => "v12.4.1",
       :revision => "05161b14c906e862455a2a9a8c3e549379af6bba"
+  revision 1
   head "https://gitlab.com/gitlab-org/gitlab-runner.git"
 
   bottle do
@@ -22,7 +23,7 @@ class GitlabRunner < Formula
 
     cd dir do
       proj = "gitlab.com/gitlab-org/gitlab-runner"
-      commit = Utils.popen_read("git", "rev-parse", "--short", "HEAD").chomp
+      commit = Utils.popen_read("git", "rev-parse", "--short=8", "HEAD").chomp
       branch = version.to_s.split(".")[0..1].join("-") + "-stable"
       built = Time.new.strftime("%Y-%m-%dT%H:%M:%S%:z")
       system "go", "build", "-ldflags", <<~EOS


### PR DESCRIPTION
the docker image published by gitlab team is with 8 byte hash
and currently git provides 9 bytes hash for that repository

this is now in sync with gitlab-runner source:
- https://gitlab.com/gitlab-org/gitlab-runner/blob/v12.4.1/Makefile#L4

refs:
- https://gitlab.com/gitlab-org/gitlab-runner/issues/3441#note_242426665

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
