### PR TITLE
skopeo: do not use TEMPDIR

### DIFF
--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -34,7 +34,7 @@ class Skopeo < Formula
       ldflags = [
         "-X main.gitCommit=",
         "-X github.com/containers/image/docker.systemRegistriesDirPath=#{etc/"containers/registries.d"}",
-        "-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=#{ENV["TEMPDIR"]}",
+        "-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=/var/tmp",
         "-X github.com/containers/image/signature.systemDefaultPolicyPath=#{etc/"containers/policy.json"}",
         "-X github.com/containers/image/pkg/sysregistriesv2.systemRegistriesConfPath=#{etc/"containers/registries.conf"}",
       ].join(" ")


### PR DESCRIPTION
TEMPDIR injected at build time is wrong to use,
even if it's currently empty.

the default is /var/tmp, but keep it in formula to document paths that
can be customized

refs: https://github.com/Homebrew/homebrew-core/pull/45834#issuecomment-546530903

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
