### PR TITLE
libplist 2.1.0

### DIFF
--- a/Formula/libplist.rb
+++ b/Formula/libplist.rb
@@ -1,9 +1,8 @@
 class Libplist < Formula
   desc "Library for Apple Binary- and XML-Property Lists"
   homepage "https://www.libimobiledevice.org/"
-  url "https://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2"
-  sha256 "3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602"
-  revision 1
+  url "https://github.com/libimobiledevice/libplist/archive/2.1.0.tar.gz"
+  sha256 "4b33f9af3f9208d54a3c3e1a8c149932513f451c98d1dd696fe42c06e30b7f03"
 
   bottle do
     cellar :any
@@ -15,12 +14,11 @@ class Libplist < Formula
 
   head do
     url "https://git.sukimashita.com/libplist.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
   def install
@@ -33,8 +31,8 @@ class Libplist < Formula
       --without-cython
     ]
 
-    system "./autogen.sh" if build.head?
-    system "./configure", *args
+    system "./autogen.sh", *args
+    system "make"
     system "make", "install", "PYTHON_LDFLAGS=-undefined dynamic_lookup"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It seems like the Git repo gets updated but the website may not, so the 2.1.0 release archive is available on the Github mirror but not from the libimobiledevice.org website.

The archive from Github is in line with the Git repo in the `head` block (https://git.sukimashita.com/libplist.git), as you would expect.  As a result, we now have to build release archives in the same way as the `head` Git repo, so I've moved the `autoconf`, `automake`, and `libtool` dependencies out of that block.  I also updated the build commands to bring them in line with the [installation instructions in the README](https://github.com/libimobiledevice/libplist#installation).

Please do check my work and let me know if anything needs to be changed.