### PR TITLE
Updates libsodium homepage and url.

### DIFF
--- a/Formula/libsodium.rb
+++ b/Formula/libsodium.rb
@@ -1,9 +1,9 @@
 class Libsodium < Formula
   desc "NaCl networking and cryptography library"
-  homepage "https://github.com/jedisct1/libsodium/"
-  url "https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz"
-  version "1.0.18"
-  sha256 "b7292dd1da67a049c8e78415cd498ec138d194cfdb302e716b08d26b80fecc10"
+  homepage "https://libsodium.org/"
+  url "https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz"
+  sha256 "6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It is recommended to use `stable` releases of `libsodium` - https://download.libsodium.org/doc/installation#stable-branch

Currently release is fetched via release tarball from GitHub. This PR changes that as well as updates libsodium homepage url.

I've added `revision 1` to formula for bottles to be rebuilt and redistributed.

Unfortunately `brew audit --strict libsodium` is showing:

```
libsodium:
  * Stable: version 1.0.18 is redundant with version scanned from URL
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 2 problems in 1 formula detected
```

Not sure how I can fix that.