### PR TITLE
Update pygments homepage url and head url

### DIFF
--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -2,11 +2,12 @@ class Pygments < Formula
   include Language::Python::Virtualenv
 
   desc "Generic syntax highlighter"
-  homepage "http://pygments.org/"
+  homepage "https://pygments.org/"
   url "https://files.pythonhosted.org/packages/7e/ae/26808275fc76bf2832deb10d3a3ed3107bc4de01b85dcccbe525f2cd6d1e/Pygments-2.4.2.tar.gz"
   sha256 "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+  revision 1
 
-  head "https://bitbucket.org/birkenfeld/pygments-main", :using => :hg
+  head "https://github.com/pygments/pygments.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -5,7 +5,6 @@ class Pygments < Formula
   homepage "https://pygments.org/"
   url "https://files.pythonhosted.org/packages/7e/ae/26808275fc76bf2832deb10d3a3ed3107bc4de01b85dcccbe525f2cd6d1e/Pygments-2.4.2.tar.gz"
   sha256 "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
-  revision 1
 
   head "https://github.com/pygments/pygments.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Because pygments has been migrated from BitBucket to GitHub.

See pygments/pygments#1022, pygments/pygments#1240