### PR TITLE
Fix prometheus service

### DIFF
--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -22,12 +22,29 @@ class Prometheus < Formula
     libexec.install %w[consoles console_libraries]
   end
 
+  def post_install
+    (etc/"prometheus.args").write <<~EOS
+      --config.file #{etc}/prometheus.yml
+      --web.listen-address=127.0.0.1:9090
+      --storage.tsdb.path #{var}/prometheus
+    EOS
+
+    (etc/"prometheus.yml").write <<~EOS
+      global:
+        scrape_interval: 15s
+
+      scrape_configs:
+        - job_name: "prometheus"
+          static_configs:
+          - targets: ["localhost:9090"]
+    EOS
+  end
+
   def caveats; <<~EOS
     When used with `brew services`, prometheus' configuration is stored as command line flags in
       #{etc}/prometheus.args
 
-    Example configuration:
-      echo "--config.file ~/.config/prometheus.yml" > #{etc}/prometheus.args
+    Configuration for prometheus is located in the #{etc}/prometheus.yml file.
 
   EOS
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```shell
$ brew install --build-from-source --debug --verbose Formula/prometheus.rb
Updating Homebrew...
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FromPathLoader): loading /Users/teochenglim/homebrew-core/Formula/prometheus.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/go.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/prometheus.rb
/usr/bin/sandbox-exec -f /private/tmp/homebrew20191111-68318-102r137.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/build.rb /Users/teochenglim/homebrew-core/Formula/prometheus.rb --verbose --debug
/usr/local/Homebrew/Library/Homebrew/build.rb (Formulary::FromPathLoader): loading /Users/teochenglim/homebrew-core/Formula/prometheus.rb
/usr/local/Homebrew/Library/Homebrew/build.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/go.rb
==> Downloading https://github.com/prometheus/prometheus/archive/v2.13.1.tar.gz
/usr/bin/curl -q --globoff --show-error --user-agent Homebrew/2.1.16-38-ge2c76cc\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.15.1\)\ curl/7.64.1 --location --silent --head --request GET https://github.com/prometheus/prometheus/archive/v2.13.1.tar.gz
Already downloaded: /Users/teochenglim/Library/Caches/Homebrew/downloads/3b968a8dc1e632bfaa45e1d701b30be5c621530090ba398074d0ee5e83169ad9--prometheus-2.13.1.tar.gz
==> Verifying 3b968a8dc1e632bfaa45e1d701b30be5c621530090ba398074d0ee5e83169ad9--prometheus-2.13.1.tar.gz checksum
tar xof /Users/teochenglim/Library/Caches/Homebrew/downloads/3b968a8dc1e632bfaa45e1d701b30be5c621530090ba398074d0ee5e83169ad9--prometheus-2.13.1.tar.gz -C /private/tmp/d20191111-68319-ajh6km
cp -pR /private/tmp/d20191111-68319-ajh6km/prometheus-2.13.1/. /private/tmp/prometheus-20191111-68319-1ktt95u/prometheus-2.13.1
chmod -Rf +w /private/tmp/d20191111-68319-ajh6km
==> make build
curl -s -L https://github.com/prometheus/promu/releases/download/v0.5.0/promu-0.5.0.darwin-amd64.tar.gz | tar -xvzf - -C /var/folders/dp/qtmghhxn2d7d4xfcfk0qwl300000gp/T/tmp.lihovtj2
x promu-0.5.0.darwin-amd64/
x promu-0.5.0.darwin-amd64/promu
x promu-0.5.0.darwin-amd64/NOTICE
x promu-0.5.0.darwin-amd64/LICENSE
mkdir -p /private/tmp/prometheus-20191111-68319-1ktt95u/prometheus-2.13.1/.brew_home/go/bin
cp /var/folders/dp/qtmghhxn2d7d4xfcfk0qwl300000gp/T/tmp.lihovtj2/promu-0.5.0.darwin-amd64/promu /private/tmp/prometheus-20191111-68319-1ktt95u/prometheus-2.13.1/.brew_home/go/bin/promu
rm -r /var/folders/dp/qtmghhxn2d7d4xfcfk0qwl300000gp/T/tmp.lihovtj2
>> building binaries
GO111MODULE=on /private/tmp/prometheus-20191111-68319-1ktt95u/prometheus-2.13.1/.brew_home/go/bin/promu build --prefix /private/tmp/prometheus-20191111-68319-1ktt95u/prometheus-2.13.1
 >   prometheus
 >   promtool
 >   tsdb
==> Cleaning
Fixing /usr/local/Cellar/prometheus/2.13.1/bin/prometheus permissions from 755 to 555
Fixing /usr/local/Cellar/prometheus/2.13.1/bin/promtool permissions from 755 to 555
==> Finishing up
ln -s ../Cellar/prometheus/2.13.1/bin/prometheus prometheus
ln -s ../Cellar/prometheus/2.13.1/bin/promtool promtool
/usr/bin/sandbox-exec -f /private/tmp/homebrew20191111-70325-1sey3vu.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/postinstall.rb /Users/teochenglim/homebrew-core/Formula/prometheus.rb --build-from-source --debug --verbose
/usr/local/Homebrew/Library/Homebrew/postinstall.rb (Formulary::FromPathLoader): loading /Users/teochenglim/homebrew-core/Formula/prometheus.rb
==> echo '--config.file $(brew --prefix)/etc/prometheus.yml        --web.listen-address=127.0.0.1:9090       --storage.tsdb.path $(brew --prefix)/var/prometheus'       > $(brew --prefix)/etc/prometheus.args
==> Caveats
When used with `brew services`, prometheus' configuration is stored as command line flags in
  /usr/local/etc/prometheus.args

Example configuration:
  echo '--config.file $(brew --prefix)/etc/prometheus.yml    --web.listen-address=127.0.0.1:9090   --storage.tsdb.path $(brew --prefix)/var/prometheus'   > $(brew --prefix)/etc/prometheus.args


To have launchd start prometheus now and restart at login:
  brew services start prometheus
Or, if you don't want/need a background service you can just run:
  prometheus
==> Summary
🍺  /usr/local/Cellar/prometheus/2.13.1: 18 files, 119.3MB, built in 4 minutes 39 seconds



$ brew test prometheus
Testing prometheus
==> /usr/local/Cellar/prometheus/2.13.1/bin/promtool check rules /private/tmp/prometheus-test-20191111-70716-14gfvb9/rules.example


$ brew audit --strict prometheus
Fetching gem metadata from https://rubygems.org/.........
Fetching concurrent-ruby 1.1.5
Fetching thread_safe 0.3.6
Fetching minitest 5.13.0
Installing thread_safe 0.3.6
Installing minitest 5.13.0
Installing concurrent-ruby 1.1.5
Fetching zeitwerk 2.2.1
Installing zeitwerk 2.2.1
Fetching ast 2.4.0
Installing ast 2.4.0
Using bundler 1.17.2
Fetching connection_pool 2.2.2
Installing connection_pool 2.2.2
Fetching json 2.2.0
Fetching docile 1.3.2
Installing json 2.2.0 with native extensions
Installing docile 1.3.2
Fetching simplecov-html 0.10.2
Installing simplecov-html 0.10.2
Fetching tins 1.22.0
Installing tins 1.22.0
Fetching thor 0.20.3
Installing thor 0.20.3
Fetching diff-lcs 1.3
Installing diff-lcs 1.3
Fetching unf_ext 0.0.7.6
Installing unf_ext 0.0.7.6 with native extensions
Fetching hpricot 0.8.6
Installing hpricot 0.8.6 with native extensions
Fetching jaro_winkler 1.5.4
Installing jaro_winkler 1.5.4 with native extensions
Fetching mime-types-data 3.2019.1009
Installing mime-types-data 3.2019.1009
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching mini_portile2 2.4.0
Fetching ntlm-http 0.1.1
Installing mini_portile2 2.4.0
Installing ntlm-http 0.1.1
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching mustache 1.1.0
Fetching parallel 1.18.0
Installing mustache 1.1.0
Installing parallel 1.18.0
Fetching plist 3.5.0
Installing plist 3.5.0
Fetching rainbow 3.0.0
Installing rainbow 3.0.0
Fetching rdiscount 2.2.0.1
Fetching rspec-support 3.9.0
Installing rdiscount 2.2.0.1 with native extensions
Installing rspec-support 3.9.0
Fetching ruby-progressbar 1.10.1
Installing ruby-progressbar 1.10.1
Fetching unicode-display_width 1.6.0
Installing unicode-display_width 1.6.0
Fetching ruby-macho 2.2.0
Installing ruby-macho 2.2.0
Fetching tzinfo 1.2.5
Installing tzinfo 1.2.5
Fetching parser 2.6.5.0
Installing parser 2.6.5.0
Fetching net-http-persistent 3.1.0
Installing net-http-persistent 3.1.0
Fetching i18n 1.7.0
Installing i18n 1.7.0
Fetching term-ansicolor 1.7.1
Installing term-ansicolor 1.7.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching mime-types 3.3
Installing mime-types 3.3
Fetching simplecov 0.16.1
Installing simplecov 0.16.1
Fetching nokogiri 1.10.5
Installing nokogiri 1.10.5 with native extensions
Fetching parallel_tests 2.29.2
Installing parallel_tests 2.29.2
Fetching rspec-core 3.9.0
Installing rspec-core 3.9.0
Fetching rspec-expectations 3.9.0
Installing rspec-expectations 3.9.0
Fetching rspec-mocks 3.9.0
Installing rspec-mocks 3.9.0
Fetching rubocop 0.76.0
Installing rubocop 0.76.0
Fetching activesupport 6.0.1
Installing activesupport 6.0.1
Fetching domain_name 0.5.20190701
Installing domain_name 0.5.20190701
Fetching coveralls 0.8.23
Installing coveralls 0.8.23
Fetching rspec-retry 0.6.1
Installing rspec-retry 0.6.1
Fetching rspec-its 1.3.0
Installing rspec-its 1.3.0
Fetching rspec 3.9.0
Installing rspec 3.9.0
Fetching rubocop-performance 1.5.0
Installing rubocop-performance 1.5.0
Fetching rubocop-rspec 1.36.0
Installing rubocop-rspec 1.36.0
Fetching http-cookie 1.0.3
Installing http-cookie 1.0.3
Fetching rspec-wait 0.0.9
Fetching ronn 0.7.3
Installing rspec-wait 0.0.9
Installing ronn 0.7.3
Fetching mechanize 2.7.6
Installing mechanize 2.7.6
Bundle complete! 16 Gemfile dependencies, 56 gems now installed.
Bundled gems are installed into `../../../usr/local/Homebrew/Library/Homebrew/vendor/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

```