### PR TITLE
ruby-build: remove dependency on openssl

### DIFF
--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -8,7 +8,6 @@ class RubyBuild < Formula
   bottle :unneeded
 
   depends_on "autoconf"
-  depends_on "openssl@1.1"
   depends_on "pkg-config"
   depends_on "readline"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`ruby-build` stopped looking for any version of Homebrew `openssl` in the latest version b/c of various compatibility issues with the breadth of `ruby` versions that it can install. Let's stop depending on `openssl` in the formula so the user doesn't get something installed that isn't used.

PR: https://github.com/rbenv/ruby-build/pull/1375