### PR TITLE
mysql: use brew protobuf

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -3,6 +3,7 @@ class Mysql < Formula
   homepage "https://dev.mysql.com/doc/refman/8.0/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.18.tar.gz"
   sha256 "0eccd9d79c04ba0ca661136bb29085e3833d9c48ed022d0b9aba12236994186b"
+  revision 1
 
   bottle do
     sha256 "e8aa0830817cd49a2155c7764650bc6bf46ee54d536af09f3b814d9b960065b2" => :catalina
@@ -21,6 +22,7 @@ class Mysql < Formula
   depends_on :macos => :yosemite
 
   depends_on "openssl@1.1"
+  depends_on "protobuf@3.7" # MySQL 8.0.19 will support the latest version
 
   conflicts_with "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."
@@ -58,8 +60,8 @@ class Mysql < Formula
       -DWITH_BOOST=boost
       -DWITH_EDITLINE=system
       -DWITH_SSL=yes
+      -DWITH_PROTOBUF=system
       -DWITH_UNIT_TESTS=OFF
-      -DWITH_EMBEDDED_SERVER=ON
       -DENABLED_LOCAL_INFILE=1
       -DWITH_INNODB_MEMCACHED=ON
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

MySQL and Protobuf currently conflict as they both install Protobuf libraries. I've changed MySQL so that it will instead depend on Homebrew's Protobuf rather than using the bundled version that MySQL ships. Note that 3.7 is currently the maximum supported version, but the next version of MySQL (8.0.19) will support the latest (3.10).

I could do the same for MySQL 5.7, but we would need to add an older version of Protobuf to do that (3.6 and later only support C++11 and MySQL only moved to C++11 in 8.0). It's not quite as important anyway since 5.7 is keg-only by default.

(I've also removed the `WITH_EMBEDDED_SERVER` option which had no effect as it has been removed as of 8.0.)