### PR TITLE
chromaprint: build fpcalc

### DIFF
--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -3,6 +3,7 @@ class Chromaprint < Formula
   homepage "https://acoustid.org/chromaprint"
   url "https://github.com/acoustid/chromaprint/releases/download/v1.4.3/chromaprint-1.4.3.tar.gz"
   sha256 "ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,9 +15,15 @@ class Chromaprint < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ffmpeg"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_TOOLS=ON", ".", *std_cmake_args
     system "make", "install"
+  end
+
+  test do
+    out = shell_output("#{bin}/fpcalc -json -format s16le -rate 44100 -channels 2 -length 10 /dev/zero")
+    assert_equal "AQAAO0mUaEkSRZEGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", JSON.parse(out)["fingerprint"]
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request changes the chromaprint formula to build the `fpcalc` utility for acoustic fingerprinting.

This change was proposed before, but was not able to be merged due to a circular dependency with ffmpeg (#14235).  Since the `with-chromaprint` option was removed from the ffmpeg formula in f75cb092032c2eb921ba0bcdcf6a45af5cf86714, it is now safe to include ffmpeg as a dependency of chromaprint.

Thanks to @kolen for the inspiration and the test.
