### PR TITLE
mariadb-connector-odbc 3.1.5

### DIFF
--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,10 +1,8 @@
 class MariadbConnectorOdbc < Formula
   desc "Database driver using the industry standard ODBC API"
   homepage "https://downloads.mariadb.org/connector-odbc/"
-  url "https://downloads.mariadb.org/f/connector-odbc-3.0.2/mariadb-connector-odbc-3.0.2-ga-src.tar.gz"
-  mirror "http://archive.mariadb.org/connector-odbc-3.0.2/mariadb-connector-odbc-3.0.2-ga-src.tar.gz"
-  sha256 "eba4fbda21ae9d50c94d2cd152f0ec14dde3989522f41ef7d22aa0948882ff93"
-  revision 1
+  url "https://downloads.mariadb.org/f/connector-odbc-3.1.5/mariadb-connector-odbc-3.1.5-ga-src.tar.gz"
+  sha256 "c5a96fa166c8e7c93ceb86eeef2b4f726e076329f7686e36f7044e7b23b44ea9"
 
   bottle do
     sha256 "1c830919c8e1db83042f7cab13e21c8a09bdc754ae1acb2374eaa6ed75ce7267" => :catalina
@@ -19,11 +17,19 @@ class MariadbConnectorOdbc < Formula
   depends_on "unixodbc"
 
   def install
-    system "cmake", ".", "-DMARIADB_FOUND=1",
-                         "-DWITH_OPENSSL=1",
-                         "-DOPENSSL_INCLUDE_DIR=#{Formula["openssl@1.1"].opt_include}",
+    ENV.append_to_cflags "-I#{Formula["mariadb-connector-c"].opt_include}/mariadb"
+    ENV.append "LDFLAGS", "-L#{Formula["mariadb-connector-c"].opt_lib}/mariadb"
+    system "cmake", ".", "-DMARIADB_LINK_DYNAMIC=1",
+                         "-DWITH_SSL=OPENSSL",
+                         "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                         "-DWITH_IODBC=0",
                          *std_cmake_args
-    system "make", "install"
+
+    # By default, the installer pkg is built - we don't want that.
+    # maodbc limits the build to just the connector itself.
+    # install/fast prevents an "all" build being invoked that a regular "install" would do.
+    system "make", "maodbc"
+    system "make", "install/fast"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

And this (finally) concludes this round of MariaDB updates.

After this, all the MariaDB formulae will be now up-to-date. This ODBC driver was lagging behind a little more than the rest due to a combination of upstream issues and a quirky build system that requires a bit of Makefile inspection to work out.

Their build script does things like building an installer package, which I've avoided despite the lack of a CMake option, and their script fails to even try and look for MariaDB Connector/C in the system, despite it being a crucial requirement, which required me to supply some CFLAGS and LDFLAGS.

I may submit some patches upstream to improve the process for 3.1.6. I'll have a look at some point. Though a different patch I made in July hasn't even been looked at yet.