### PR TITLE
Updated to 1.16.281 to have aws ecr container scanning capability

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -4,8 +4,8 @@ class Awscli < Formula
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
   # awscli should only be updated every 10 releases on multiples of 10
-  url "https://github.com/aws/aws-cli/archive/1.16.260.tar.gz"
-  sha256 "cf6f954eecf2bb17eebc2e74db15b9d55b4f106d92da16fad21a9f1cde06f2d3"
+  url "https://github.com/aws/aws-cli/archive/1.16.281.tar.gz"
+  sha256 "3d1c247c48fa1c1c7e51ba01e0398731be68ff60beafed40c3c304a30cfaac09"
   head "https://github.com/aws/aws-cli.git", :branch => "develop"
 
   bottle do


### PR DESCRIPTION
Pull Request to update version because newer version has ECR container security scanning and fetch result capabilities.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

$ brew test Formula/awscli.rb
Testing awscli
==> /usr/local/Cellar/awscli/1.16.281/bin/aws help
$ brew audit --strict Formula/awscli.rb
Fetching gem metadata from https://rubygems.org/.........
Using concurrent-ruby 1.1.5
Using minitest 5.13.0
Using thread_safe 0.3.6
Using zeitwerk 2.2.1
Using connection_pool 2.2.2
Using ast 2.4.0
Using json 2.2.0
Using docile 1.3.2
Using simplecov-html 0.10.2
Using thor 0.20.3
Using diff-lcs 1.3
Fetching tins 1.22.2
Using bundler 1.17.2
Using hpricot 0.8.6
Using jaro_winkler 1.5.4
Using mime-types-data 3.2019.1009
Using net-http-digest_auth 1.4.1
Using mini_portile2 2.4.0
Using ntlm-http 0.1.1
Using webrobots 0.1.2
Using mustache 1.1.0
Using unf_ext 0.0.7.6
Using plist 3.5.0
Using rainbow 3.0.0
Using rdiscount 2.2.0.1
Using rspec-support 3.9.0
Using ruby-progressbar 1.10.1
Using unicode-display_width 1.6.0
Using ruby-macho 2.2.0
Using i18n 1.7.0
Using tzinfo 1.2.5
Using simplecov 0.16.1
Using parser 2.6.5.0
Using net-http-persistent 3.1.0
Using mime-types 3.3
Fetching parallel 1.19.0
Using nokogiri 1.10.5
Using activesupport 6.0.1
Using unf 0.1.4
Using ronn 0.7.3
Using rspec-core 3.9.0
Using rspec-expectations 3.9.0
Using rspec-mocks 3.9.0
Using domain_name 0.5.20190701
Using rspec-retry 0.6.1
Using rspec-its 1.3.0
Using http-cookie 1.0.3
Using rspec 3.9.0
Using mechanize 2.7.6
Using rspec-wait 0.0.9
Installing parallel 1.19.0
Installing tins 1.22.2
Using parallel_tests 2.29.2
Using rubocop 0.76.0
Using rubocop-rspec 1.36.0
Fetching rubocop-performance 1.5.1
Installing rubocop-performance 1.5.1
Using term-ansicolor 1.7.1
Using coveralls 0.8.23
Bundle complete! 16 Gemfile dependencies, 56 gems now installed.
Bundled gems are installed into `../../../usr/local/Homebrew/Library/Homebrew/vendor/bundle`
Removing rubocop-performance (1.5.0)
Removing parallel (1.18.0)
Removing tins (1.22.0)
