### PR TITLE
bro: use brew caf

### DIFF
--- a/Formula/bro.rb
+++ b/Formula/bro.rb
@@ -3,6 +3,7 @@ class Bro < Formula
   homepage "https://www.bro.org"
   url "https://www.bro.org/downloads/bro-2.6.4.tar.gz"
   sha256 "a47a9cdcef0ea14d5f70c390ab266f0333063ff96f3869a5f1609581a1d1ceb7"
+  revision 1
   head "https://github.com/bro/bro.git"
 
   bottle do
@@ -14,12 +15,15 @@ class Bro < Formula
   depends_on "bison" => :build
   depends_on "cmake" => :build
   depends_on "swig" => :build
+  depends_on "caf"
   depends_on "geoip"
   depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}",
+                          "--with-caf=#{Formula["caf"].opt_prefix}",
                           "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--disable-broker-tests",
                           "--localstatedir=#{var}",
                           "--conf-files-dir=#{etc}"
     system "make", "install"

--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -4,6 +4,7 @@ class Caf < Formula
   homepage "https://actor-framework.org/"
   url "https://github.com/actor-framework/actor-framework/archive/0.17.3.tar.gz"
   sha256 "af235dbb5001a86d716c19f1b597be81bbcf172b87d42e2a38dc3ac97ea3863d"
+  revision 1
   head "https://github.com/actor-framework/actor-framework.git"
 
   bottle do
@@ -14,6 +15,7 @@ class Caf < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--no-examples",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`bro` contains a bundled version of `caf`. It installs the full set of `caf` headers and libraries, creating a conflict.

Instead, let's try depend on Homebrew's `caf`.

Note that in order to do this, I had to enable the OpenSSL module in `caf` and thus add a dependency there.