### PR TITLE
geckodriver: fix broken url

### DIFF
--- a/Formula/geckodriver.rb
+++ b/Formula/geckodriver.rb
@@ -2,9 +2,9 @@ class Geckodriver < Formula
   desc "WebDriver <-> Marionette proxy"
   homepage "https://github.com/mozilla/geckodriver"
   # Get the commit id for stable releases from https://github.com/mozilla/geckodriver/releases
-  url "https://hg.mozilla.org/mozilla-central/archive/e9783a644016aa9b317887076618425586730d73.tar.gz"
+  url "https://hg.mozilla.org/mozilla-central/archive/e9783a644016aa9b317887076618425586730d73.zip/testing/"
   version "0.26.0"
-  sha256 "034f525b6163ffd473ac61191107d104244b5ac7d3f89259b9c2915812654099"
+  sha256 "89f20b2d492b44b40ee049d0f0d4d91c52758b74dd7b5c7acad89a88ca1f177e"
   head "https://hg.mozilla.org/mozilla-central/", :using => :hg
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
 => complains about `sha256` change here (see below)

-----

Fixes: https://github.com/Homebrew/homebrew-core/pull/45906#discussion_r346308034

The old `url` is starting to report an error: `Archive type not allowed: gz`. Looks like only `.zip` archives are allowed after a recent update to the `mozilla-central` web frontend. (This PR also uses a newly discovered feature to only check out the `testing` subdirectory, reducing the file size from 650mb to 110mb).

Obviously the `sha256` changed because of this, but we're still checkout out the same code from exactly the same upstream commit.