### PR TITLE
libevhtp: fix opportunistic linkage to oniguruma

### DIFF
--- a/Formula/libevhtp.rb
+++ b/Formula/libevhtp.rb
@@ -3,7 +3,7 @@ class Libevhtp < Formula
   homepage "https://criticalstack.com/"
   url "https://github.com/criticalstack/libevhtp/archive/1.2.18.tar.gz"
   sha256 "316ede0d672be3ae6fe489d4ac1c8c53a1db7d4fe05edaff3c7c853933e02795"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -20,6 +20,7 @@ class Libevhtp < Formula
   def install
     system "cmake", "-DEVHTP_BUILD_SHARED=ON",
                     "-DBUILD_SHARED_LIBS=ON",
+                    "-DEVHTP_DISABLE_REGEX=ON",
                     ".", *std_cmake_args
     system "make", "install"
     mkdir_p "./html/docs/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Unless you prefer to enable regex support and add oniguruma as a dependency.

Ref: #46728