### PR TITLE
trader 7.13 (new formula)

### DIFF
--- a/Formula/trader.rb
+++ b/Formula/trader.rb
@@ -1,0 +1,29 @@
+class Trader < Formula
+  desc "Star Traders"
+  homepage "https://www.zap.org.au/projects/trader/"
+  url "https://ftp.zap.org.au/pub/trader/unix/trader-7.13.tar.xz"
+  sha256 "0d2b51134166b0f436dc6423e2ce378b1df929a9de141c002f3da86af18bb262"
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "ncurses" # The system version does not work correctly
+
+  def install
+    ENV.prepend_path "PKG_CONFIG_PATH",
+        Formula["ncurses"].opt_libexec/"lib/pkgconfig"
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-libintl-prefix=#{Formula["gettext"].opt_prefix}
+    ]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    # Star Traders is an interactive game, so the only option for testing
+    # is to run something like "trader --version"
+    system "#{bin}/trader", "--version"
+  end
+end


### PR DESCRIPTION
Add Star Traders, a simple text-based game of interstellar trading,
where the objective is to create companies, buy and sell shares,
borrow and repay money, in order to become the wealthiest player
(the winner).

Uses the Homebrew version of `ncurses` as the system version does not
handle multibyte strings correctly (according to the output of the
`./configure` script).

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
**No**: requires the Homebrew version of `ncurses` as described above.
-----
