### PR TITLE
cups 2.3.0 (new formula)

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -1,0 +1,32 @@
+class Cups < Formula
+  desc "Common UNIX Printing System"
+  homepage "https://www.cups.org"
+  url "https://github.com/apple/cups/releases/download/v2.3.0/cups-2.3.0-source.tar.gz"
+  sha256 "acaf0229cf008ea8f06353ffd1bbd62d71dbe88990dd3330650ef87edb95a1a5"
+
+  keg_only :provided_by_macos
+
+  uses_from_macos "zlib"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--with-components=core",
+                          "--without-bundledir",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    pid = fork do
+      exec "#{bin}/ippeveprinter", "Homebrew Test Printer"
+    end
+
+    begin
+      sleep 2
+      system "#{bin}/ippfind"
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`openjdk` needs this on Linux, and since macOS already provides CUPS this is `keg_only :provided_by_macos`.