### PR TITLE
cminpack, libftdi, libgraphqlparser: fix linkage issues

### DIFF
--- a/Formula/cminpack.rb
+++ b/Formula/cminpack.rb
@@ -3,6 +3,7 @@ class Cminpack < Formula
   homepage "http://devernay.free.fr/hacks/cminpack/cminpack.html"
   url "https://github.com/devernay/cminpack/archive/v1.3.6.tar.gz"
   sha256 "3c07fd21308c96477a2c900032e21d937739c233ee273b4347a0d4a84a32d09f"
+  revision 1
   head "https://github.com/devernay/cminpack.git"
 
   bottle do
@@ -18,7 +19,9 @@ class Cminpack < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON",
+                         "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                         *std_cmake_args
     system "make", "install"
 
     man3.install Dir["doc/*.3"]

--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -20,7 +20,9 @@ class Libftdi < Formula
 
   def install
     mkdir "libftdi-build" do
-      system "cmake", "..", "-DPYTHON_BINDINGS=OFF", *std_cmake_args
+      system "cmake", "..", "-DPYTHON_BINDINGS=OFF",
+                            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                            *std_cmake_args
       system "make", "install"
       pkgshare.install "../examples"
       (pkgshare/"examples/bin").install Dir["examples/*"] \

--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -3,7 +3,7 @@ class Libftdi < Formula
   homepage "https://www.intra2net.com/en/developer/libftdi"
   url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.4.tar.bz2"
   sha256 "ec36fb49080f834690c24008328a5ef42d3cf584ef4060f3a35aa4681cb31b74"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -22,11 +22,13 @@ class Libftdi < Formula
     mkdir "libftdi-build" do
       system "cmake", "..", "-DPYTHON_BINDINGS=OFF", *std_cmake_args
       system "make", "install"
-      (libexec/"bin").install "examples/find_all"
+      pkgshare.install "../examples"
+      (pkgshare/"examples/bin").install Dir["examples/*"] \
+                                        - Dir["examples/{CMake*,Makefile,*.cmake}"]
     end
   end
 
   test do
-    system libexec/"bin/find_all"
+    system pkgshare/"examples/bin/find_all"
   end
 end

--- a/Formula/libgraphqlparser.rb
+++ b/Formula/libgraphqlparser.rb
@@ -3,6 +3,7 @@ class Libgraphqlparser < Formula
   homepage "https://github.com/graphql/libgraphqlparser"
   url "https://github.com/graphql/libgraphqlparser/archive/0.7.0.tar.gz"
   sha256 "63dae018f970dc2bdce431cbafbfa0bd3e6b10bba078bb997a3c1a40894aa35c"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,7 +17,8 @@ class Libgraphqlparser < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                         *std_cmake_args
     system "make"
     system "make", "install"
     libexec.install "dump_json_ast"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

What these have in common is that they all use CMake and they all have additional binaries (typically examples) which are manually installed since they aren't in `make install`.

CMake, by default, is designed to assume that what you build through it will also be installed through it. This assumption no longer holds as soon as you do a `dir.install "some_binary"`.

CMake handles rpaths and other `install_name_tool` handling for you, but does so in a two stage process:
* During building, CMake intentionally sets the rpaths etc to be the build directory. This is done so that you can run the binaries before/without installing them.
* During installation, CMake then modifies what it did to then point to the real install directory.

Since some of these additional installed binaries were built but not installed via CMake, the paths will still point to the build directory and hence we have broken linkage warnings.

The fix is to use `CMAKE_BUILD_WITH_INSTALL_RPATH`. This squashes the two stage process into one. On build, CMake will immediately set the rpath to be install directory instead of waiting until install. I think losing out on being able to run binaries from the build directory is a non-issue for Homebrew.

Additionally, I have modified libftdi to not install examples in `libexec/bin` but instead put them in `pkgshare`, like everything else does, and to install all of them, with source code, instead of just a single random binary. I can split this into a separate pull request if you prefer - I just wanted to avoid two rev bumps.