### PR TITLE
sparkey: rename bench executable

### DIFF
--- a/Formula/sparkey.rb
+++ b/Formula/sparkey.rb
@@ -3,6 +3,7 @@ class Sparkey < Formula
   homepage "https://github.com/spotify/sparkey/"
   url "https://github.com/spotify/sparkey/archive/sparkey-1.0.0.tar.gz"
   sha256 "d607fb816d71d97badce6301dd56e2538ef2badb6530c0a564b1092788f8f774"
+  revision 1
 
   bottle do
     cellar :any
@@ -25,6 +26,7 @@ class Sparkey < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
+    mv bin/"bench", bin/"sparkey_bench"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

sparkey has a "bench" executable which, to no surprise, conflicts with the bench formula.

Since its sole purpose is to benchmark sparkey, I propose renaming it to sparkey_bench like I have or just removing it altogether.