### PR TITLE
ampl-mp: fix conflict with google-benchmark

### DIFF
--- a/Formula/ampl-mp.rb
+++ b/Formula/ampl-mp.rb
@@ -3,7 +3,7 @@ class AmplMp < Formula
   homepage "https://www.ampl.com/"
   url "https://github.com/ampl/mp/archive/3.1.0.tar.gz"
   sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -20,6 +20,13 @@ class AmplMp < Formula
   resource "miniampl" do
     url "https://github.com/dpo/miniampl/archive/v1.0.tar.gz"
     sha256 "b836dbf1208426f4bd93d6d79d632c6f5619054279ac33453825e036a915c675"
+  end
+
+  # Removes Google Benchmark - as already done so upstream
+  # All it did was conflict with the google-benchmark formula
+  patch do
+    url "https://github.com/ampl/mp/commit/96e332bb8cb7ba925e3ac947d6df515496027eed.patch?full_index=1"
+    sha256 "1a4ef4cd1f4e8b959c20518f8f00994ef577e74e05824b2d1b241b1c3c1f84eb"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This applies upstream commit https://github.com/ampl/mp/commit/96e332bb8cb7ba925e3ac947d6df515496027eed, which removes Google Benchmark from their sources.

It wasn't actually used for anything - all it did was conflict with the google-benchmark formula since installing ampl-mp would install Google Benchmark. Zero functionality is lost from this, unless you for some reason installed ampl-mp to use Google Benchmark.