### PR TITLE
libcapn: fix for OpenSSL 1.1

### DIFF
--- a/Formula/libcapn.rb
+++ b/Formula/libcapn.rb
@@ -1,6 +1,7 @@
 class Libcapn < Formula
   desc "C library to send push notifications to Apple devices"
   homepage "https://web.archive.org/web/20181220090839/libcapn.org/"
+  revision 1
   head "https://github.com/adobkin/libcapn.git"
 
   stable do
@@ -23,14 +24,20 @@ class Libcapn < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl" # no OpenSSL 1.1 support
+  depends_on "openssl@1.1"
+
+  # Compatibility with OpenSSL 1.1
+  patch do
+    url "https://github.com/adobkin/libcapn/pull/46.diff?full_index=1"
+    sha256 "9d90edd1c8e3fa479554f48fe9f92afd771e5852ced595e7f66f6174d805530b"
+  end
 
   def install
     # head gets jansson as a git submodule
     if build.stable?
       (buildpath/"src/third_party/jansson").install resource("jansson")
     end
-    system "cmake", ".", "-DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}",
+    system "cmake", ".", "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
                          *std_cmake_args
     system "make", "install"
     pkgshare.install "examples"
@@ -39,7 +46,7 @@ class Libcapn < Formula
   test do
     system ENV.cc, pkgshare/"examples/send_push_message.c",
                    "-o", "send_push_message",
-                   "-I#{Formula["openssl"].opt_include}",
+                   "-I#{Formula["openssl@1.1"].opt_include}",
                    "-L#{lib}/capn", "-lcapn"
     output = shell_output("./send_push_message", 255)
     assert_match "unable to use specified PKCS12 file (errno: 9012)", output


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/46454
Fix is trivial, I've opened a pull request upstream: https://github.com/adobkin/libcapn/pull/46