### PR TITLE
ssldump: fix build

### DIFF
--- a/Formula/ssldump.rb
+++ b/Formula/ssldump.rb
@@ -3,7 +3,7 @@ class Ssldump < Formula
   homepage "https://ssldump.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
   sha256 "6422c16718d27c270bbcfcc1272c4f9bd3c0799c351f1d6dd54fdc162afdab1e"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -11,6 +11,7 @@ class Ssldump < Formula
     sha256 "b95746d7b8b7dea0d0a5dc5b043d75c5d072feaf2489b5b618f03e8d33e2eb39" => :sierra
   end
 
+  depends_on "libpcap"
   depends_on "openssl@1.1"
 
   # reorder include files
@@ -29,6 +30,7 @@ class Ssldump < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
+                          "--with-pcap=#{Formula["libpcap"].opt_prefix}",
                           "osx"
     system "make"
     # force install as make got confused by install target and INSTALL file.


### PR DESCRIPTION
With Xcode 11, pcap headers are not sufficient for building anymore.
Let's use our own libpcap everywhere.