### PR TITLE
cabal-install: move back to ghc@8.6

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -3,6 +3,7 @@ class CabalInstall < Formula
   homepage "https://www.haskell.org/cabal/"
   url "https://hackage.haskell.org/package/cabal-install-3.0.0.0/cabal-install-3.0.0.0.tar.gz"
   sha256 "a432a7853afe96c0fd80f434bd80274601331d8c46b628cd19a0d8e96212aaf1"
+  revision 1
   head "https://github.com/haskell/cabal.git", :branch => "2.4"
 
   bottle do
@@ -12,10 +13,16 @@ class CabalInstall < Formula
     sha256 "b134c0335ad5ef2acee9d11ec855e5b5e44cde3eda343a92a6ebfd2231bed329" => :sierra
   end
 
+  # Temporarily depend on older GHC for building cabal-install itself, due to
+  # https://github.com/Homebrew/homebrew-core/pull/46828
+  # https://github.com/haskell/cabal/issues/6327
+  depends_on "ghc@8.6" => :build
   depends_on "ghc"
   uses_from_macos "zlib"
 
   def install
+    ENV.prepend_path "PATH", Formula["ghc@8.6"].opt_bin
+
     cd "cabal-install" if build.head?
 
     system "sh", "bootstrap.sh", "--sandbox"


### PR DESCRIPTION
cabal-install currently does not build with latest GHC: https://github.com/haskell/cabal/issues/6327#issuecomment-554637005