### PR TITLE
eventql: fix build in Xcode 10 and later

### DIFF
--- a/Formula/eventql.rb
+++ b/Formula/eventql.rb
@@ -21,6 +21,9 @@ class Eventql < Formula
   end
 
   def install
+    # SpiderMonkey sets the deployment target to 10.6, kicking in libstdc++ mode
+    # which no longer has headers as of Xcode 10.
+    ENV["_MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
     # the internal libzookeeper fails to build if we don't deparallelize
     # https://github.com/eventql/eventql/issues/180
     ENV.deparallelize


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

EventQL contains SpiderMonkey which forces a deployment target of 10.6 unless you pass a configure option.

The use of 10.6 as a deployment target is problematic on Xcode 10 and later. This deployment target kicks in libstdc++ mode (libc++ is 10.7 or later) which had its headers removed in Xcode 10. I've fixed the deployment target so that it now uses libc++ where available.

We can't directly pass the flag to change the deployment target into the configure script. The said configure script with the option is not the one we are calling - it is called internally with no option to pass in arguments. Instead, the next best thing is to exploit an internal environment variable used within that configure script to do the same thing (hence why it is `_MACOSX_DEPLOYMENT_TARGET` rather than `MACOSX_DEPLOYMENT_TARGET`, the latter is always overwritten by the former - or 10.6 if it's not set).