### PR TITLE
travis: fix test

### DIFF
--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -117,8 +117,6 @@ class Travis < Formula
     (testpath/".travis.yml").write <<~EOS
       language: ruby
 
-      sudo: true
-
       matrix:
         include:
           - os: osx


### PR DESCRIPTION
Currently the test fails, and outputs:

```
Warnings for /private/tmp/travis-test-20191117-87476-j3kac1/.travis.yml:
[x] [warn] on root: deprecated key: sudo (The key `sudo` has no effect anymore.)
```