### PR TITLE
thrift@0.9 0.9.3.1

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -1,8 +1,8 @@
 class ThriftAT09 < Formula
   desc "Framework for scalable cross-language services development"
   homepage "https://thrift.apache.org"
-  url "https://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz"
-  sha256 "b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e"
+  url "https://github.com/apache/thrift/archive/0.9.3.1.tar.gz"
+  sha256 "1f7ca02d88a603f2845b2c7abcab74f8107dd7285056284d65241eb7965e143c"
 
   bottle do
     cellar :any
@@ -21,7 +21,19 @@ class ThriftAT09 < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "openssl" # no OpenSSL 1.1 support
+  depends_on "openssl@1.1"
+
+  # Fix CRYPTO_num_locks compile error
+  patch do
+    url "https://github.com/apache/thrift/commit/4bbfe6120e71b81df7f23dcc246990c29eb27859.patch?full_index=1"
+    sha256 "23b29d50cd606b88863153ec8ae1c7b3e1ef0fceca7ec59088b8135f40b99ce6"
+  end
+
+  # Fix compile when SSLv3 is disabled (OpenSSL 1.1)
+  patch do
+    url "https://github.com/apache/thrift/commit/b819260c653f6fd9602419ee2541060ecb930c4c.patch?full_index=1"
+    sha256 "5934555674b67fb7a9fad04ffe0bd46fdbe3eca5e8f98dd072efa4bb342c9bfa"
+  end
 
   def install
     args = %w[
@@ -40,6 +52,13 @@ class ThriftAT09 < Formula
 
     # Don't install extensions to /usr
     ENV["JAVA_PREFIX"] = pkgshare/"java"
+
+    # 0.9.3.1 shipped with a syntax error...
+    inreplace "configure.ac", "if test \"$have_cpp\" = \"yes\" ; then\nAC_TYPE_INT16_T",
+                              "AC_TYPE_INT16_T"
+
+    # We need to regenerate the configure script since it doesn't have all the changes.
+    system "./bootstrap.sh"
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Also some OpenSSL 1.1 patches.

Note that we are downloading from GitHub as the archive on apache.org contains an old, broken configure script (it does not work with openssl@1.1's install directory) and does not have any of the bootstrap scripts to generate a new one.