### PR TITLE
dvc: rebuild from source to get rid of openssl@1.0 dependency

### DIFF
--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -5,7 +5,7 @@ class Dvc < Formula
   homepage "https://dvc.org"
   url "https://github.com/iterative/dvc/archive/0.68.1.tar.gz"
   sha256 "a072ebf2151213c61ac7e580e51dc1cecefa4cd840e4f7ae1927d6710312cfe0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "a561c535faeb646e91b206f2f1ce2fa3f36ac806f35848542873eef56e7f7ccd" => :catalina
@@ -14,12 +14,23 @@ class Dvc < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "apache-arrow"
   depends_on "openssl@1.1"
   depends_on "python"
 
   def install
     venv = virtualenv_create(libexec, "python3")
-    system libexec/"bin/pip", "install", ".[all]"
+
+    system libexec/"bin/pip", "install",
+      "--no-binary", ":all:",
+      # NOTE: we will uninstall Pillow anyway, so there is no need to build it
+      # from source.
+      "--only-binary", "Pillow",
+      "--ignore-installed",
+      # NOTE: pyarrow is already installed as a part of apache-arrow package,
+      # so we don't need to specify `hdfs` option.
+      ".[gs,s3,azure,oss,ssh]"
+
     # NOTE: dvc depends on asciimatics, which depends on Pillow, which
     # uses liblcms2.2.dylib that causes troubles on mojave. See [1]
     # and [2] for more info. As a workaround, we need to simply


### PR DESCRIPTION
Per https://github.com/Homebrew/homebrew-core/pull/46829#issuecomment-554768866

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
