### PR TITLE
rav1e 0.1.0 (new formula)

### DIFF
--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -1,0 +1,28 @@
+class Rav1e < Formula
+  desc "The fastest and safest AV1 encoder"
+  homepage "https://github.com/xiph/rav1e"
+  url "https://github.com/xiph/rav1e/archive/0.1.0.tar.gz"
+  sha256 "00395087eaba4778d17878924e007716e2f399116b8011bf057fd54cc528a6cb"
+
+  depends_on "nasm" => :build
+  depends_on "rust" => :build
+
+  resource "bus_qcif_15fps.y4m" do
+    url "https://media.xiph.org/video/derf/y4m/bus_qcif_15fps.y4m"
+    sha256 "868fc3446d37d0c6959a48b68906486bd64788b2e795f0e29613cbb1fa73480e"
+  end
+
+  def install
+    system "cargo", "install", "--locked",
+                               "--root", prefix,
+                               "--path", "."
+  end
+
+  test do
+    resource("bus_qcif_15fps.y4m").stage do
+      system "#{bin}/rav1e", "--tile-rows=2",
+                                   "bus_qcif_15fps.y4m",
+                                   "--output=bus_qcif_15fps.ivf"
+    end
+  end
+end


### PR DESCRIPTION
rav1e is a new AV1 encoder written in rust targetted to safest and fastest AV1 encoder

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Hi Team, 

rav1e has now new 0.1 release and this PR is targetted to add rav1e into the homebrew package manager.

References
[1]: https://github.com/xiph/rav1e/issues/886
[2]: https://github.com/xiph/rav1e/releases/tag/0.1.0


Best, 
Vibhoothi