### PR TITLE
virtuoso: patches for OpenSSL 1.1

### DIFF
--- a/Formula/virtuoso.rb
+++ b/Formula/virtuoso.rb
@@ -6,6 +6,8 @@ class Virtuoso < Formula
   # This explicit version should be safe to remove next release.
   version "7.2.5.1"
   sha256 "826477d25a8493a68064919873fb4da4823ebe09537c04ff4d26ba49d9543d64"
+  revision 1
+  # HEAD is disabled as the below, required patches are not compatible.
 
   bottle do
     cellar :any
@@ -16,24 +18,33 @@ class Virtuoso < Formula
     sha256 "bb86d15d36d1affafc57ff612ea0a6c88425882bbf5e1bd4cabe5bc1f434a31e" => :sierra
   end
 
-  head do
-    url "https://github.com/openlink/virtuoso-opensource.git", :branch => "develop/7"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   # If gawk isn't found, make fails deep into the process.
   depends_on "gawk" => :build
-  depends_on "openssl" # no OpenSSL 1.1 support
+  depends_on "libtool" => :build
+  depends_on "openssl@1.1"
 
   conflicts_with "unixodbc", :because => "Both install `isql` binaries."
 
   skip_clean :la
 
+  # Support OpenSSL 1.1
+  patch do
+    url "https://sources.debian.org/data/main/v/virtuoso-opensource/7.2.5.1+dfsg-2/debian/patches/ssl1.1.patch"
+    sha256 "9fcaaff5394706fcc448e35e30f89c20fe83f5eb0fbe1411d4b2550d1ec37bf3"
+  end
+
+  # TLS 1.3 compile error patch.
+  # This also updates the default TLS protocols to allow TLS 1.3.
+  patch do
+    url "https://github.com/openlink/virtuoso-opensource/commit/67e09939cf62dc753feca8381396346f6d3d4a06.patch?full_index=1"
+    sha256 "485f54e4c79d4e1e8b30c4900e5c10ae77bded3928f187e7e2e960d345ca5378"
+  end
+
   def install
-    system "./autogen.sh" if build.head?
+    # We patched configure.ac on stable so need to rerun the autogen.
+    system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request removes `--HEAD` support for now as the patches are incompatible (but still required in part).