### PR TITLE
aria2: uses_from_macos "libxml2"

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -13,6 +13,7 @@ class Aria2 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libssh2"
+  uses_from_macos "libxml2"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This was failing to build on Linux:

```
FeatureConfig.cc:44:33: fatal error: libxml/xmlversion.h: No such file or directory
compilation terminated.
make[2]: *** [Makefile:2643: FeatureConfig.lo] Error 1
```