### PR TITLE
mysql-client: depend on Xcode >= 9.0

### DIFF
--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -16,6 +16,8 @@ class MysqlClient < Formula
 
   depends_on "openssl@1.1"
 
+  depends_on :xcode => "9.0"
+
   def install
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[


### PR DESCRIPTION
CMake otherwise fails with the following error

    CMake Error at cmake/os/Darwin.cmake:36 (MESSAGE):
      XCode 9.0 or newer is required!