### PR TITLE
yaml-cpp: Fix CMake Variable Name & Do Not Build Test Code

### DIFF
--- a/Formula/skafos.rb
+++ b/Formula/skafos.rb
@@ -3,7 +3,7 @@ class Skafos < Formula
   homepage "https://skafos.ai/"
   url "https://github.com/MetisMachine/skafos/archive/1.7.7.tar.gz"
   sha256 "42eecd6094126f1e4febf94541c4b640f2b4ed39829af2686cd83a60fafcd994"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -14,7 +14,7 @@ class YamlCpp < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
+    system "cmake", ".", *std_cmake_args, "-DYAML_BUILD_SHARED_LIBS=ON"
     system "make", "install"
   end
 

--- a/Formula/yaml-cpp.rb
+++ b/Formula/yaml-cpp.rb
@@ -3,6 +3,7 @@ class YamlCpp < Formula
   homepage "https://github.com/jbeder/yaml-cpp"
   url "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.tar.gz"
   sha256 "77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,8 @@ class YamlCpp < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DYAML_BUILD_SHARED_LIBS=ON"
+    system "cmake", ".", *std_cmake_args, "-DYAML_BUILD_SHARED_LIBS=ON",
+                                          "-DYAML_CPP_BUILD_TESTS=OFF"
     system "make", "install"
   end
 


### PR DESCRIPTION
👋 Hi,

after this pull request `brew` will build the shared version of the library `yaml-cpp` instead of the static version. I don’t know if the formula for yaml-cpp 0.6.2 included both a static and shared library. However, as far as I can tell the options to build a shared and a static library [now exclude each other](https://github.com/jbeder/yaml-cpp/blob/yaml-cpp-0.6.3/CMakeLists.txt#L255-L259). 

I am not sure if you prefers static or shared libraries for `homebrew-core`? Personally I favor the shared library, since linking the static version of the library introduces strange parsing errors in a project I am working on. That of course might be my fault 😊. Anyway, if you prefer static libraries, I think it would make sense to remove 
`"-DBUILD_SHARED_LIBS=ON"`, since `yaml-cpp` does not use the variable `BUILD_SHARED_LIBS` any more.

----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
