### PR TITLE
nzbget: use brew binaries for helpers like unrar and 7z

### DIFF
--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -52,6 +52,11 @@ class Nzbget < Formula
     <dict>
       <key>Label</key>
       <string>#{plist_name}</string>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>PATH</key>
+        <string>#{HOMEBREW_PREFIX}/bin:$PATH</string>
+      </dict>
       <key>ProgramArguments</key>
       <array>
         <string>#{opt_bin}/nzbget</string>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
