### PR TITLE
cfssl shows version instead of "dev"

### DIFF
--- a/Formula/cfssl.rb
+++ b/Formula/cfssl.rb
@@ -19,9 +19,10 @@ class Cfssl < Formula
     ENV["GOPATH"] = buildpath
     cfsslpath = buildpath/"src/github.com/cloudflare/cfssl"
     cfsslpath.install Dir["{*,.git}"]
+    ldflags = "-X github.com/cloudflare/cfssl/cli/version.version=#{version}"
     cd "src/github.com/cloudflare/cfssl" do
-      system "go", "build", "-o", "#{bin}/cfssl", "cmd/cfssl/cfssl.go"
-      system "go", "build", "-o", "#{bin}/cfssljson", "cmd/cfssljson/cfssljson.go"
+      system "go", "build", "-o", "#{bin}/cfssl", "-ldflags", ldflags, "cmd/cfssl/cfssl.go"
+      system "go", "build", "-o", "#{bin}/cfssljson", "-ldflags", ldflags, "cmd/cfssljson/cfssljson.go"
       system "go", "build", "-o", "#{bin}/cfsslmkbundle", "cmd/mkbundle/mkbundle.go"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I'm not sure if it passes the `brew audit --strict cfssl` command. It installed a bunch of ruby gems and exited with a 0 return code when I ran it , but it didn't report anything, so I'm unsure.

I opened an issue against the CloudFlare repo, assuming it was their team that managed this formula, but I was wrong, and it was closed. This PR is meant to close https://github.com/cloudflare/cfssl/issues/1056 according to the instructions they offered here: https://github.com/cloudflare/cfssl/issues/1049#issuecomment-549526192

I tried to base my changes on other golang formulae that used `ldflags`, but if it can be improved, please let me know, and I'll do my best 🙏 

Best,
Arthur