### PR TITLE
node@12: move to Python 3

### DIFF
--- a/Formula/node@12.rb
+++ b/Formula/node@12.rb
@@ -14,11 +14,14 @@ class NodeAT12 < Formula
   keg_only :versioned_formula
 
   depends_on "pkg-config" => :build
-  depends_on "python@2" => :build # does not support Python 3
+  depends_on "python" => :build
   depends_on "icu4c"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--with-intl=system-icu"
+    # make sure subprocesses spawned by make are using our Python 3
+    ENV["PYTHON"] = Formula["python"].opt_bin/"python3"
+
+    system "python3", "configure.py", "--prefix=#{prefix}", "--with-intl=system-icu"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This switches `node@12` over to use our `python` 3 instead of the soon to be EOL `python@2`.

Side note: I've also tried to backport the Python 3 patches to `node@10` and got `configure` working with `python` 3, but I've given up fixing `make` for now, because there are still a lot of scrips called in the outdated `v8` in `node@10` which are not compatible with Python 3 (and backporting the complete `v8` upgrade isn't feasible obviously). Current progress so far: https://github.com/chrmoritz/homebrew-core/blob/7650508cdf4ffcc78666af3f473f098d0492b848/Formula/node%4010.rb