### PR TITLE
mrboom: improve test reliability

### DIFF
--- a/Formula/mrboom.rb
+++ b/Formula/mrboom.rb
@@ -25,12 +25,20 @@ class Mrboom < Formula
 
   test do
     require "pty"
-    PTY.spawn(bin/"mrboom", "-m") do |r, _w, pid|
+    require "expect"
+    require "timeout"
+    PTY.spawn(bin/"mrboom", "-m", "-f 0", "-z") do |r, _w, pid|
       sleep 1
       Process.kill "SIGINT", pid
-      assert_match "monster", r.read
+      assert_match "monster", r.expect(/monster/, 10)[0]
     ensure
-      Process.wait pid
+      begin
+        Timeout.timeout(10) do
+          Process.wait pid
+        end
+      rescue Timeout::Error
+        Process.kill "KILL", pid
+      end
     end
   end
 end


### PR DESCRIPTION
This should reduce the likelihood of a hang. It was consistently doing this on the High Sierra nodes so let's test that out.

The use of `expect` over `read` means it exits earlier when it finds what it needs - it previously may have waited until the application terminated. There's also a timeout value associated.

Now that we can get past `read` without hanging for long, I've added timeout functionality to the `Process.wait` as that that point we've got what we are looking for and don't care about much else. Give it a short 10 seconds and if it can't terminate itself, we'll force it.

I also muted the audio for the test.