### PR TITLE
ansible: use lxml linker fix on older OS versions too.

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -592,7 +592,7 @@ class Ansible < Formula
     ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
 
     # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
+    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
 
     # Work around Xcode 11 clang bug
     # https://code.videolan.org/videolan/libbluray/issues/20


### PR DESCRIPTION
Update the ansible formula so that the existing SDKROOT fix for a linking issue with lxml is applied on El Capitan and older OS versions, as well as Sierra.
