### PR TITLE
monolith 2.0.16 (new formula)

### DIFF
--- a/Formula/monolith.rb
+++ b/Formula/monolith.rb
@@ -1,0 +1,18 @@
+class Monolith < Formula
+  desc "CLI tool for saving complete web pages as a single HTML file"
+  homepage "https://github.com/Y2Z/monolith"
+  url "https://github.com/Y2Z/monolith/archive/v2.0.16.tar.gz"
+  sha256 "b2f5cd1d95d4d2ccd06e7f44e88e43ff0f2ec5d73dabe93ca56bf22656b06a0e"
+
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@1.1"
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system bin/"monolith", "https://lyrics.github.io/db/p/portishead/dummy/roads"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> A data hoarder's dream come true: bundle any web page into a single HTML file.
You can finally replace that gazillion of open tabs with a gazillion of .html files stored somewhere on your precious little drive.
>
> Unlike the conventional "Save page as", monolith not only saves the target document, it embeds CSS, image, and JavaScript assets all at once, producing a single HTML5 document that is a joy to store and share.
>
> If compared to saving websites with wget -mpk, this tool embeds all assets as data URLs and therefore lets browsers render the saved page exactly the way it was on the Internet, even when no network connection is available.