### PR TITLE
Aliases: add openssl

### DIFF
--- a/Aliases/openssl
+++ b/Aliases/openssl
@@ -1,0 +1,1 @@
+../Formula/openssl@1.1.rb


### PR DESCRIPTION
Following https://github.com/Homebrew/homebrew-core/pull/46876, should we make `openssl` an alias for `openssl@1.1`? Is this breaking things for people who have the older formula installed?

**Edit:** the technical question is not “is this desirable?”, but “would this break things for some users?”. Input needed from experts in how `brew` code itself will handle this situation.