### PR TITLE
Add ldflags to wtfutil installation procedure

### DIFF
--- a/Formula/wtfutil.rb
+++ b/Formula/wtfutil.rb
@@ -16,7 +16,9 @@ class Wtfutil < Formula
 
   def install
     ENV["GOPROXY"] = "https://gocenter.io"
-    system "go", "build", "-o", bin/"wtfutil"
+    ldflags=["-s -w -X main.version=#{version}",
+             "-X main.date=#{Time.now.iso8601}"]
+    system "go", "build", "-ldflags", ldflags.join(" "), "-o", bin/"wtfutil"
   end
 
   test do


### PR DESCRIPTION
Add `ldflags` with version tag and build timestamp.  
Fixes https://github.com/wtfutil/wtf/issues/557.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----