### PR TITLE
eccodes: remove conflict_with deleted formula

### DIFF
--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -16,9 +16,6 @@ class Eccodes < Formula
   depends_on "libpng"
   depends_on "netcdf"
 
-  conflicts_with "grib-api",
-    :because => "eccodes and grib-api install the same binaries."
-
   def install
     inreplace "CMakeLists.txt", "find_package( OpenJPEG )", ""
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`grib-api` was deleted in https://github.com/Homebrew/homebrew-core/pull/46924