### PR TITLE
rav1e: fix missing librav1e

### DIFF
--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -11,6 +11,7 @@ class Rav1e < Formula
     sha256 "d7677873a6ddb3c9818aadc04324727bd7d402ec930609dbbffff47cb931337a" => :high_sierra
   end
 
+  depends_on "cargo-c" => :build
   depends_on "nasm" => :build
   depends_on "rust" => :build
 
@@ -23,6 +24,7 @@ class Rav1e < Formula
     system "cargo", "install", "--locked",
                                "--root", prefix,
                                "--path", "."
+    system "cargo", "cinstall", "--prefix", prefix
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a dependency on the recently added cargo-c formula, which installs librav1e into the prefix.
As seen in FreeBSD ports, patches in the tag name which is not resolved when building from a tarball.