### PR TITLE
stellar-core: depend on libpq

### DIFF
--- a/Formula/stellar-core.rb
+++ b/Formula/stellar-core.rb
@@ -4,6 +4,7 @@ class StellarCore < Formula
   url "https://github.com/stellar/stellar-core.git",
       :tag      => "v12.1.0",
       :revision => "8afe57913a08deffa247d7b5f837e0b28a54b864"
+  revision 1
   head "https://github.com/stellar/stellar-core.git"
 
   bottle do
@@ -19,6 +20,7 @@ class StellarCore < Formula
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :build
   depends_on "parallel" => :test
+  depends_on "libpq"
   depends_on "libpqxx"
   depends_on "libsodium"
 


### PR DESCRIPTION
stellar-core links directly with libpq. Previously it managed to build because libpqxx depended on postgresql (now libpq). However, since it didn't depend directly in the formula file, it would be missed for revision bumping when libpq updates.
