### PR TITLE
Sync some `uses_from_macos` upstream from Homebrew/linuxbrew-core

### DIFF
--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -17,6 +17,8 @@ class AwsGoogleAuth < Formula
   depends_on "freetype"
   depends_on "jpeg"
   depends_on "python"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
 
   resource "soupsieve" do
     url "https://files.pythonhosted.org/packages/fb/9e/2e236603b058daa6820193d4d95f4dcfbbbd0d3c709bec8c6ef1b1902501/soupsieve-1.9.1.tar.gz#sha256=b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -22,6 +22,9 @@ class Fdroidserver < Formula
   depends_on "python"
   depends_on "s3cmd"
   depends_on "webp"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
 
   resource "androguard" do
     url "https://files.pythonhosted.org/packages/83/78/0f44e8f0fd10493b3118d79d60599c93e5a2cd378d83054014600a620cba/androguard-3.3.5.tar.gz"

--- a/Formula/howdoi.rb
+++ b/Formula/howdoi.rb
@@ -13,6 +13,8 @@ class Howdoi < Formula
   end
 
   depends_on "python"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/06/b8/d1ea38513c22e8c906275d135818fee16ad8495985956a9b7e2bb21942a1/certifi-2019.3.9.tar.gz"

--- a/Formula/latexml.rb
+++ b/Formula/latexml.rb
@@ -13,6 +13,10 @@ class Latexml < Formula
     sha256 "b911ac9897012edcc7c32d96785e4ca3830ce8cbddff78da0942263c7fb0d0bb" => :sierra
   end
 
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "perl"
+
   resource "Image::Size" do
     url "https://cpan.metacpan.org/authors/id/R/RJ/RJRAY/Image-Size-3.300.tar.gz"
     sha256 "53c9b1f86531cde060ee63709d1fda73cabc0cf2d581d29b22b014781b9f026b"

--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -25,6 +25,7 @@ class Libbluray < Formula
   depends_on "pkg-config" => :build
   depends_on "fontconfig"
   depends_on "freetype"
+  uses_from_macos "libxml2"
 
   def install
     # Need to set JAVA_HOME manually since ant overrides 1.8 with 1.8+

--- a/Formula/libcroco.rb
+++ b/Formula/libcroco.rb
@@ -16,6 +16,7 @@ class Libcroco < Formula
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libgsf.rb
+++ b/Formula/libgsf.rb
@@ -24,6 +24,7 @@ class Libgsf < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
+  uses_from_macos "libxml2"
 
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]

--- a/Formula/libical.rb
+++ b/Formula/libical.rb
@@ -15,6 +15,7 @@ class Libical < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "icu4c"
+  uses_from_macos "libxml2"
 
   def install
     system "cmake", ".", "-DBDB_LIBRARY=BDB_LIBRARY-NOTFOUND",

--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -26,6 +26,8 @@ class Liblwgeom < Formula
   depends_on "json-c"
   depends_on "proj"
 
+  uses_from_macos "libxml2"
+
   def install
     # See postgis.rb for comments about these settings
     ENV.deparallelize

--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -4,7 +4,7 @@ class Liblwgeom < Formula
   url "https://download.osgeo.org/postgis/source/postgis-2.5.2.tar.gz"
   sha256 "b6cb286c5016029d984f8c440947bf9178da72e1f6f840ed639270e1c451db5e"
   revision 1
-  head "https://svn.osgeo.org/postgis/trunk/"
+  head "https://git.osgeo.org/gitea/postgis/postgis"
 
   bottle do
     cellar :any

--- a/Formula/libstrophe.rb
+++ b/Formula/libstrophe.rb
@@ -18,6 +18,7 @@ class Libstrophe < Formula
   depends_on "pkg-config" => :build
   depends_on "check"
   depends_on "openssl@1.1"
+  uses_from_macos "libxml2"
 
   def install
     system "./bootstrap.sh"

--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -20,6 +20,7 @@ class Libsvg < Formula
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -15,6 +15,7 @@ class Libxmlxx < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glibmm"
+  uses_from_macos "libxml2"
 
   def install
     ENV.cxx11

--- a/Formula/raptor.rb
+++ b/Formula/raptor.rb
@@ -15,6 +15,8 @@ class Raptor < Formula
     sha256 "5e640e01d5cdd6899ca00704ba581358d254f7cfb9b81d62c901c825bb347681" => :mavericks
   end
 
+  uses_from_macos "libxml2"
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -23,6 +23,7 @@ class SharedMimeInfo < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
+  uses_from_macos "libxml2"
 
   def install
     # Disable the post-install update-mimedb due to crash

--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -14,6 +14,8 @@ class Sratoolkit < Formula
 
   depends_on "hdf5"
   depends_on "libmagic"
+  uses_from_macos "libxml2"
+  uses_from_macos "perl"
 
   resource "ngs-sdk" do
     url "https://github.com/ncbi/ngs/archive/2.10.0.tar.gz"

--- a/Formula/stoken.rb
+++ b/Formula/stoken.rb
@@ -15,6 +15,7 @@ class Stoken < Formula
 
   depends_on "pkg-config" => :build
   depends_on "nettle"
+  uses_from_macos "libxml2"
 
   def install
     args = %W[

--- a/Formula/uwsgi.rb
+++ b/Formula/uwsgi.rb
@@ -27,6 +27,8 @@ class Uwsgi < Formula
   depends_on "pcre"
   depends_on "python"
   depends_on "yajl"
+  uses_from_macos "curl"
+  uses_from_macos "libxml2"
 
   def install
     # Fix file not found errors for /usr/lib/system/libsystem_symptoms.dylib and

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -15,6 +15,7 @@ class Wimlib < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
+  uses_from_macos "libxml2"
 
   def install
     # fuse requires librt, unavailable on OSX

--- a/Formula/xml2.rb
+++ b/Formula/xml2.rb
@@ -16,6 +16,7 @@ class Xml2 < Formula
   end
 
   depends_on "pkg-config" => :build
+  uses_from_macos "libxml2"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -20,6 +20,7 @@ class Yaz < Formula
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
+  uses_from_macos "libxml2"
 
   def install
     system "./buildconf.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Over in Homebrew/linuxbrew-core, we fix builds frequently using `uses_from_macos` for macOS built-in dependencies like `libxml2`, `libxslt` and `curl`. Sometimes, we want to get changes in quickly so we don't raise PRs upstream and go through the merge cycle. I noticed some of these earlier and thought we should sync up so that we're as consistent as possible - given that's what the `uses_from_macos` DSL is designed for.

These should all be a no-op on macOS and therefore not require bottles. So this should be good to merge via the GitHub UI.