### PR TITLE
antlr4-cpp-runtime: install cmake package config files by default

### DIFF
--- a/Formula/antlr4-cpp-runtime.rb
+++ b/Formula/antlr4-cpp-runtime.rb
@@ -15,8 +15,8 @@ class Antlr4CppRuntime < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", ".", "-DANTLR4_INSTALL=ON", *std_cmake_args
+    system "cmake", "--build", ".", "--target", "install"
   end
 
   test do

--- a/Formula/antlr4-cpp-runtime.rb
+++ b/Formula/antlr4-cpp-runtime.rb
@@ -3,6 +3,7 @@ class Antlr4CppRuntime < Formula
   homepage "https://www.antlr.org/"
   url "https://www.antlr.org/download/antlr4-cpp-runtime-4.7.2-source.zip"
   sha256 "8631a39116684638168663d295a969ad544cead3e6089605a44fea34ec01f31a"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
As per https://github.com/antlr/antlr4/tree/master/runtime/Cpp#cmake-package-support
`ANTLR4_INSTALL` needs to be set to install the following cmake config files in addition to everything else:
```
/usr/local/Cellar/antlr4-cpp-runtime
└── 4.7.2
    ├── lib
    │   ├── cmake
    │   │   └── antlr4
    │   │       ├── antlr4-config-version.cmake
    │   │       ├── antlr4-generator-config.cmake
    │   │       ├── antlr4-runtime-config.cmake
    │   │       ├── antlr4-targets-release.cmake
    │   │       └── antlr4-targets.cmake

```
----------
Directory naming does not play well with cmake's default `add_package()` behavior, but that's a problem at `antlr4-cpp-runtime` packaging side:

This **works**:
```
find_package(antlr4-runtime REQUIRED PATH_SUFFIXES lib/cmake/antlr4)
find_package(antlr4-generator REQUIRED PATH_SUFFIXES lib/cmake/antlr4)
```

This **doesn't work**:
(strangely, cmake stops looking in `/usr/local/lib/cmake` as it does for other packages that don't provide `PATH_SUFFIXES`, seemingly)
```
find_package(antlr4-runtime REQUIRED PATH_SUFFIXES antlr4)
find_package(antlr4-generator REQUIRED PATH_SUFFIXES antlr4)
```
This **doesn't work** either:
(ideal approach)
```
find_package(antlr4-runtime REQUIRED)
find_package(antlr4-generator REQUIRED)
```
----------
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
