### PR TITLE
pgbouncer 1.12.0

### DIFF
--- a/Formula/pgbouncer.rb
+++ b/Formula/pgbouncer.rb
@@ -1,9 +1,8 @@
 class Pgbouncer < Formula
   desc "Lightweight connection pooler for PostgreSQL"
-  homepage "https://pgbouncer.github.io/"
-  url "https://pgbouncer.github.io/downloads/files/1.10.0/pgbouncer-1.10.0.tar.gz"
-  sha256 "d8a01442fe14ce3bd712b9e2e12456694edbbb1baedb0d6ed1f915657dd71bd5"
-  revision 1
+  homepage "https://www.pgbouncer.org/"
+  url "https://www.pgbouncer.org/downloads/files/1.12.0/pgbouncer-1.12.0.tar.gz"
+  sha256 "1b3c6564376cafa0da98df3520f0e932bb2aebaf9a95ca5b9fa461e9eb7b273e"
 
   bottle do
     cellar :any
@@ -13,13 +12,13 @@ class Pgbouncer < Formula
     sha256 "ec357f9ba0bd22a1f34b0ce1d9174376ba4aedf43904318430cd109f076a4188" => :sierra
   end
 
+  depends_on "pkg-config" => :build
   depends_on "libevent"
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-debug",
-                          "--with-libevent=#{HOMEBREW_PREFIX}",
                           "--prefix=#{prefix}"
-    ln_s "../install-sh", "doc/install-sh"
     system "make", "install"
     bin.install "etc/mkauth.py"
     inreplace "etc/pgbouncer.ini" do |s|


### PR DESCRIPTION
Also now has an explicit dependency on OpenSSL 1.1. The previous bottle was broken as it had an opportunistic linkage with OpenSSL 1.0. Although it is optional, given the use case is for secure connections to the database server I think the dependency is reasonable to have.
