### PR TITLE
ttyd: revision bump for OpenSSL 1.1

### DIFF
--- a/Formula/ttyd.rb
+++ b/Formula/ttyd.rb
@@ -3,7 +3,7 @@ class Ttyd < Formula
   homepage "https://tsl0922.github.io/ttyd/"
   url "https://github.com/tsl0922/ttyd/archive/1.5.2.tar.gz"
   sha256 "b5b62ec2ce08add0173e6d1dfdd879e55f02f9490043e89f389981a62e87d376"
-  revision 2
+  revision 3
   head "https://github.com/tsl0922/ttyd.git"
 
   bottle do


### PR DESCRIPTION
This still linked to OpenSSL 1.0. Not entirely sure how, but it shouldn't happen again now that 1.0 is gone.
