### PR TITLE
urbit: revision for OpenSSL 1.1

### DIFF
--- a/Formula/urbit.rb
+++ b/Formula/urbit.rb
@@ -5,6 +5,7 @@ class Urbit < Formula
   url "https://github.com/urbit/urbit.git",
       :tag      => "v0.7.4",
       :revision => "e8416596fb7c47e343b49ea5ec12c2a095873c2f"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
This revision was missed in the move.

Note however that this formula is outdated as the latest version is v0.9.2. Unfortunately, v0.8.0 onwards _require_ the Nix package manager. The move has meant that no other repository (that is known about on [Repology](https://repology.org/project/urbit/versions)) ship these newer versions, except Arch Linux who ultimately [gave up trying to build from souce and are downloading a binary](https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=urbit&id=3a8033a9d108d5e7a7eebdbb32df42b24f45415f).