### PR TITLE
revision bumps for giflib

### DIFF
--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -3,6 +3,7 @@ class Imlib2 < Formula
   homepage "https://sourceforge.net/projects/enlightenment/"
   url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.5.1/imlib2-1.5.1.tar.bz2"
   sha256 "fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae"
+  revision 1
 
   bottle do
     rebuild 1

--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -3,6 +3,7 @@ class MonoLibgdiplus < Formula
   homepage "https://www.mono-project.com/docs/gui/libgdiplus/"
   url "https://github.com/mono/libgdiplus/archive/6.0.4.tar.gz"
   sha256 "9a5e3f98018116f99361520348e9713cd05680c231d689a83d87acfaf237d3a8"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -3,7 +3,7 @@ class Vice < Formula
   homepage "https://vice-emu.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/vice-emu/releases/vice-3.3.tar.gz"
   sha256 "1a55b38cc988165b077808c07c52a779d181270b28c14b5c9abf4e569137431d"
-  revision 2
+  revision 3
   head "https://svn.code.sf.net/p/vice-emu/code/trunk/vice"
 
   bottle do


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/46991#issuecomment-557941476

I've verified from the bottles that all of these had at least one file linking to giflib compatibility version 8.0.0.