### PR TITLE
thundersvm 0.3.3 (new formula)

### DIFF
--- a/Formula/thundersvm.rb
+++ b/Formula/thundersvm.rb
@@ -20,6 +20,9 @@ class Thundersvm < Formula
       args << "-DUSE_CUDA=OFF"
       args << "-DUSE_EIGEN=ON"
 
+      # keep same performance as when built manually
+      args << "-DCMAKE_CXX_FLAGS_RELEASE=-O3"
+
       libomp = Formula["libomp"]
       args << "-DOpenMP_C_FLAGS=\"-Xpreprocessor -fopenmp -I#{libomp.opt_include}\""
       args << "-DOpenMP_C_LIB_NAMES=omp"

--- a/Formula/thundersvm.rb
+++ b/Formula/thundersvm.rb
@@ -14,17 +14,16 @@ class Thundersvm < Formula
     mkdir "build" do
       args = std_cmake_args
 
-      args << "-DCMAKE_C_COMPILER=gcc-9"
-      args << "-DCMAKE_CXX_COMPILER=g++-9"
+      args << "-DUSE_CUDA=OFF"
+      args << "-DUSE_EIGEN=ON"
 
       # keep same performance as when built manually
       args << "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -O3"
 
-      args << "-DUSE_CUDA=OFF"
-      args << "-DUSE_EIGEN=ON"
-
-      system "cmake", "..", *args
-      system "make"
+      with_env("HOMEBREW_CC" => "gcc-9", "HOMEBREW_CXX" => "g++-9") do
+        system "cmake", "..", *args
+        system "make"
+      end
 
       bin.install "bin/thundersvm-predict"
       bin.install "bin/thundersvm-train"

--- a/Formula/thundersvm.rb
+++ b/Formula/thundersvm.rb
@@ -18,7 +18,7 @@ class Thundersvm < Formula
       args << "-DCMAKE_CXX_COMPILER=g++-9"
 
       # keep same performance as when built manually
-      args << "-DCMAKE_CXX_FLAGS_RELEASE=-O3"
+      args << "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -O3"
 
       args << "-DUSE_CUDA=OFF"
       args << "-DUSE_EIGEN=ON"

--- a/Formula/thundersvm.rb
+++ b/Formula/thundersvm.rb
@@ -14,16 +14,17 @@ class Thundersvm < Formula
     mkdir "build" do
       args = std_cmake_args
 
+      args << "-DCMAKE_C_COMPILER=gcc-9"
+      args << "-DCMAKE_CXX_COMPILER=g++-9"
+
+      # keep same performance as when built manually
+      args << "-DCMAKE_CXX_FLAGS_RELEASE=-O3"
+
       args << "-DUSE_CUDA=OFF"
       args << "-DUSE_EIGEN=ON"
 
-      # keep same performance as when built manually
-      args << "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -O3"
-
-      with_env("HOMEBREW_CC" => "gcc-9", "HOMEBREW_CXX" => "g++-9") do
-        system "cmake", "..", *args
-        system "make"
-      end
+      system "cmake", "..", *args
+      system "make"
 
       bin.install "bin/thundersvm-predict"
       bin.install "bin/thundersvm-train"

--- a/Formula/thundersvm.rb
+++ b/Formula/thundersvm.rb
@@ -1,0 +1,40 @@
+class Thundersvm < Formula
+  desc "Fast SVM Library on GPUs and CPUs"
+  homepage "https://github.com/Xtra-Computing/thundersvm"
+  url "https://github.com/Xtra-Computing/thundersvm/archive/0.3.3.tar.gz"
+  sha256 "0328511caa762ebbf5f7174c2a3cf7a05393b93fff51a6819bcdd5b25e5c54ae"
+
+  depends_on "cmake" => :build
+  depends_on "eigen" => :build
+  depends_on "gcc"
+
+  def install
+    inreplace "CMakeLists.txt", "${PROJECT_SOURCE_DIR}/eigen", "#{Formula["eigen"].opt_include}/eigen3"
+
+    mkdir "build" do
+      args = std_cmake_args
+
+      args << "-DCMAKE_C_COMPILER=gcc-9"
+      args << "-DCMAKE_CXX_COMPILER=g++-9"
+
+      # keep same performance as when built manually
+      args << "-DCMAKE_CXX_FLAGS_RELEASE=-O3"
+
+      args << "-DUSE_CUDA=OFF"
+      args << "-DUSE_EIGEN=ON"
+
+      system "cmake", "..", *args
+      system "make"
+
+      bin.install "bin/thundersvm-predict"
+      bin.install "bin/thundersvm-train"
+      lib.install "lib/libthundersvm.dylib"
+    end
+
+    pkgshare.install "dataset"
+  end
+
+  test do
+    system "#{bin}/thundersvm-train", "-c", "100", "-g", "0.5", "#{pkgshare}/dataset/test_dataset.txt"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A few notes:

- It currently requires `gcc` to build. I'm following up with the authors to see if they'll support Clang + `libomp`.
- Homebrew's `std_cmake_args` sets `DCMAKE_CXX_FLAGS_RELEASE` which causes `-O3` to be lost. This greatly reduces performance, which is why it is added back.
- There's no `make install`.