### PR TITLE
llvm (all versions): add missing versioned libLLVM symlink; fix Mojave sysroot

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -1,7 +1,7 @@
 class Llvm < Formula
   desc "Next-gen compiler infrastructure"
   homepage "https://llvm.org/"
-  revision 1
+  revision 2
 
   stable do
     url "https://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz"
@@ -159,7 +159,7 @@ class Llvm < Formula
 
     mkdir "build" do
       if MacOS.version >= :mojave
-        sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" : MacOS.sdk_path
+        sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk" : MacOS.sdk_path
         args << "-DDEFAULT_SYSROOT=#{sdk_path}"
       end
 
@@ -168,6 +168,9 @@ class Llvm < Formula
       system "make", "install"
       system "make", "install-xcode-toolchain"
     end
+
+    # llvm-config requires a versioned dylib
+    lib.install_symlink lib/"libLLVM.dylib" => "libLLVM-#{version.to_s[/\d+/]}.dylib"
 
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
     (share/"cmake").install "cmake/modules"
@@ -247,7 +250,7 @@ class Llvm < Formula
     # Testing Command Line Tools
     if MacOS::CLT.installed?
       toolchain_path = "/Library/Developer/CommandLineTools"
-      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk"
       system "#{bin}/clang++", "-v",
              "-isysroot", sdk_path,
              "-isystem", "#{toolchain_path}/usr/include/c++/v1",

--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -3,7 +3,7 @@ class LlvmAT6 < Formula
   homepage "https://llvm.org/"
   url "https://releases.llvm.org/6.0.1/llvm-6.0.1.src.tar.xz"
   sha256 "b6d6c324f9c71494c0ccaf3dac1f16236d970002b42bb24a6c9e1634f7d0f4e2"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -109,7 +109,7 @@ class LlvmAT6 < Formula
     ]
 
     if MacOS.version >= :mojave
-      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" : MacOS.sdk_path
+      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk" : MacOS.sdk_path
       args << "-DDEFAULT_SYSROOT=#{sdk_path}"
     end
 
@@ -119,6 +119,9 @@ class LlvmAT6 < Formula
       system "make", "install"
       system "make", "install-xcode-toolchain"
     end
+
+    # llvm-config requires a versioned dylib
+    lib.install_symlink lib/"libLLVM.dylib" => "libLLVM-6.0.dylib"
 
     (share/"cmake").install "cmake/modules"
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
@@ -205,7 +208,7 @@ class LlvmAT6 < Formula
     # Testing Command Line Tools
     if MacOS::CLT.installed?
       toolchain_path = "/Library/Developer/CommandLineTools"
-      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk"
       system "#{bin}/clang++", "-v",
              "-isysroot", sdk_path,
              "-isystem", "#{toolchain_path}/usr/include/c++/v1",

--- a/Formula/llvm@7.rb
+++ b/Formula/llvm@7.rb
@@ -3,7 +3,7 @@ class LlvmAT7 < Formula
   homepage "https://llvm.org/"
   url "https://releases.llvm.org/7.1.0/llvm-7.1.0.src.tar.xz"
   sha256 "1bcc9b285074ded87b88faaedddb88e6b5d6c331dfcfb57d7f3393dd622b3764"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -105,7 +105,7 @@ class LlvmAT7 < Formula
     ]
 
     if MacOS.version >= :mojave
-      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" : MacOS.sdk_path
+      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk" : MacOS.sdk_path
       args << "-DDEFAULT_SYSROOT=#{sdk_path}"
     end
 
@@ -115,6 +115,9 @@ class LlvmAT7 < Formula
       system "make", "install"
       system "make", "install-xcode-toolchain"
     end
+
+    # llvm-config requires a versioned dylib
+    lib.install_symlink lib/"libLLVM.dylib" => "libLLVM-#{version.to_s[/\d+/]}.dylib"
 
     (share/"cmake").install "cmake/modules"
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
@@ -198,7 +201,7 @@ class LlvmAT7 < Formula
     # Testing Command Line Tools
     if MacOS::CLT.installed?
       toolchain_path = "/Library/Developer/CommandLineTools"
-      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk"
       system "#{bin}/clang++", "-v",
              "-isysroot", sdk_path,
              "-isystem", "#{toolchain_path}/usr/include/c++/v1",

--- a/Formula/llvm@8.rb
+++ b/Formula/llvm@8.rb
@@ -3,7 +3,7 @@ class LlvmAT8 < Formula
   homepage "https://llvm.org/"
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz"
   sha256 "44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -115,7 +115,7 @@ class LlvmAT8 < Formula
     ]
 
     if MacOS.version >= :mojave
-      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" : MacOS.sdk_path
+      sdk_path = MacOS::CLT.installed? ? "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk" : MacOS.sdk_path
       args << "-DDEFAULT_SYSROOT=#{sdk_path}"
     end
 
@@ -125,6 +125,9 @@ class LlvmAT8 < Formula
       system "make", "install"
       system "make", "install-xcode-toolchain"
     end
+
+    # llvm-config requires a versioned dylib
+    lib.install_symlink lib/"libLLVM.dylib" => "libLLVM-#{version.to_s[/\d+/]}.dylib"
 
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]
     (share/"cmake").install "cmake/modules"
@@ -204,7 +207,7 @@ class LlvmAT8 < Formula
     # Testing Command Line Tools
     if MacOS::CLT.installed?
       toolchain_path = "/Library/Developer/CommandLineTools"
-      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      sdk_path = "/Library/Developer/CommandLineTools/SDKs/MacOSX#{MacOS.version}.sdk"
       system "#{bin}/clang++", "-v",
              "-isysroot", sdk_path,
              "-isystem", "#{toolchain_path}/usr/include/c++/v1",


### PR DESCRIPTION
`llvm-config` expects `libLLVM-9.dylib` (or the equivalent for LLVM 6-8) in order to properly function. It is however missing and I believe this to be the cause of #47142.

Since I was here revision bumping to include this fix, I've also taken the opportunity to fix the default sysroot for Mojave. We didn't get any reported issues about it AFAIK (only for GCC) - but now the behavior matches that of Xcode's LLVM build.