### PR TITLE
vale: 1.7.1 (new formula)

### DIFF
--- a/Formula/vale.rb
+++ b/Formula/vale.rb
@@ -1,0 +1,35 @@
+class Vale < Formula
+  desc "Syntax-aware linter for prose"
+  homepage "https://errata-ai.github.io/vale/"
+  url "https://github.com/errata-ai/vale/archive/v1.7.1.tar.gz"
+  sha256 "e1fee20d8fed7fc8819de310608b1ed584c0fad096cce95ecef727584ed9790f"
+
+  depends_on "go" => :build
+
+  def install
+    flags = "-X main.version=#{version} -s -w"
+    system "go", "build", "-ldflags=#{flags}", "-o", "#{bin}/#{name}"
+  end
+
+  test do
+    mkdir_p "styles/demo"
+    (testpath/"styles/demo/HeadingStartsWithCapital.yml").write <<~EOS
+      extends: capitalization
+      message: "'%s' should be in title case"
+      level: warning
+      scope: heading.h1
+      match: $title
+    EOS
+
+    (testpath/"vale.ini").write <<~EOS
+      StylesPath = styles
+      [*.md]
+      BasedOnStyles = demo
+    EOS
+
+    (testpath/"document.md").write("# heading is not capitalized")
+
+    output = shell_output("#{bin}/vale --config=#{testpath}/vale.ini #{testpath}/document.md 2>&1")
+    assert_match("✖ 0 errors, 1 warning and 0 suggestions in 1 file.", output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This is a source build of the [Vale linter](https://github.com/errata-ai/vale). It's [in a tap](https://github.com/ValeLint/homebrew-vale) in binary form at the moment, but it's widely used so I thought I'd give it a go in here.
- Versioning works, install and using it for linting works.
- I went to some effort to make a properly functional test here.

There's been [discussion in the Vale issues](https://github.com/errata-ai/vale/issues/150) about only maintaining in-project a subset of the existing packages, so it seemed like a good time to move this over. In a purely personal capacity as a Vale and Homebrew user. 😉
