### PR TITLE
sorbet 0.4.5085 (new formula)

### DIFF
--- a/Formula/sorbet.rb
+++ b/Formula/sorbet.rb
@@ -1,22 +1,24 @@
 class Sorbet < Formula
   desc "Fast, powerful type checker designed for Ruby"
   homepage "https://sorbet.org"
-  url "https://github.com/sorbet/sorbet/archive/0.4.5059.20191122150919-e82c71a19.tar.gz"
-  version "0.4.5059"
-  sha256 "6f7921c4689ced005f2ee5cf82c6470a876f3b70d32161e6dacbb4bf2fa10c32"
+  url "https://github.com/sorbet/sorbet/archive/0.4.5085.20191130175112-e9dddf67d.tar.gz"
+  version "0.4.5085"
+  sha256 "79d73af69ac393db244c62b3847a496669a4dbd9c9b1c3fcf55d9d2be382aec5"
 
   depends_on "autoconf" => :build
+  depends_on "bazel" => :build
   depends_on "coreutils" => :build
   uses_from_macos "llvm" => :build
   depends_on "parallel" => :build
   depends_on :xcode => :build
 
   def install
-    # 1. use the ./bazel script which installs a very specific bazel version and it loads the *.rc files
+    # 1. use the bazel homebrew dependency not the bazel script file local
     # 2. jemalloc is not set because it does not build on all platforms
     #    specifically on Mojave since it builds with Bazel, it does not get the correct header paths for the SDK.
     #    the headers are searched only /usr/include which have been removed in Mojave to a different path
-    system "./bazel", "build", "--define=release=true", "--compilation_mode=opt", "--config=debugsymbols",
+    # 3. D_LIBCPP_DISABLE_AVAILABILITY is to make it build on older compilers https://github.com/sorbet/sorbet/issues/1281#issuecomment-511543604
+    system "#{Formula["bazel"].opt_bin}/bazel", "build", "--define=release=true", "--compilation_mode=opt", "--copt=-D_LIBCPP_DISABLE_AVAILABILITY",
            "--config=static-libs", "--config=versioned", "--verbose_failures", "//main:sorbet"
     bin.install "bazel-bin/main/sorbet" => "sorbet"
   end

--- a/Formula/sorbet.rb
+++ b/Formula/sorbet.rb
@@ -7,6 +7,7 @@ class Sorbet < Formula
 
   depends_on "autoconf" => :build
   depends_on "coreutils" => :build
+  uses_from_macos "llvm" => :build
   depends_on "parallel" => :build
   depends_on :xcode => :build
 

--- a/Formula/sorbet.rb
+++ b/Formula/sorbet.rb
@@ -1,0 +1,26 @@
+class Sorbet < Formula
+  desc "Fast, powerful type checker designed for Ruby"
+  homepage "https://sorbet.org"
+  url "https://github.com/sorbet/sorbet/archive/0.4.5059.20191122150919-e82c71a19.tar.gz"
+  version "0.4.5059"
+  sha256 "6f7921c4689ced005f2ee5cf82c6470a876f3b70d32161e6dacbb4bf2fa10c32"
+
+  depends_on "autoconf" => :build
+  depends_on "coreutils" => :build
+  depends_on "parallel" => :build
+  depends_on :xcode => :build
+
+  def install
+    # 1. use the ./bazel script which installs a very specific bazel version and it loads the *.rc files
+    # 2. jemalloc is not set because it does not build on all platforms
+    #    specifically on Mojave since it builds with Bazel, it does not get the correct header paths for the SDK.
+    #    the headers are searched only /usr/include which have been removed in Mojave to a different path
+    system "./bazel", "build", "--define=release=true", "--compilation_mode=opt", "--config=debugsymbols",
+           "--config=static-libs", "--config=versioned", "--verbose_failures", "//main:sorbet"
+    bin.install "bazel-bin/main/sorbet" => "sorbet"
+  end
+
+  test do
+    assert_equal "", shell_output("#{bin}/sorbet -e '1 + 1'").chomp
+  end
+end


### PR DESCRIPTION
[sorbet](https://sorbet.org) is a fast ruby type checker open-sourced
by Stripe.

At the moment, it relies on Ruby's RubyGems to install sorbet however
that is impossible if using other Ruby platforms such as JRuby.

This formulae will help allow developers who would like to use Sorbet,
install it regardless of their ruby platform.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
