### PR TITLE
Remove resources that duplicates formula

### DIFF
--- a/Formula/smali.rb
+++ b/Formula/smali.rb
@@ -1,38 +1,21 @@
 class Smali < Formula
   desc "Assembler/disassembler for Android's Java VM implementation"
   homepage "https://github.com/JesusFreke/smali"
-  url "https://bitbucket.org/JesusFreke/smali/downloads/smali-2.3.4.jar"
-  sha256 "a7c3bedc9c2a82191a30cfd1a0191f984f7b9add5a75112a7c9686d01dd99d0b"
+  url "https://github.com/JesusFreke/smali/archive/v2.3.4.tar.gz"
+  sha256 "d364ebb60ac954cac7c974d72def897a373430fcd4e3349816743147fbaba375"
+  revision 1
 
-  bottle :unneeded
-
-  resource "baksmali-jar" do
-    url "https://bitbucket.org/JesusFreke/smali/downloads/baksmali-2.3.4.jar"
-    sha256 "4896337b63a48c318de35f1f861b2a374d0f1ad6b17b6067e16b7d788e8ce4ef"
-  end
-
-  resource "baksmali" do
-    url "https://bitbucket.org/JesusFreke/smali/downloads/baksmali"
-    sha256 "5d4b79776d401f2cbdb66c7c88e23cca773b9a939520fef4bf42e2856bbbfed4"
-  end
-
-  resource "smali" do
-    url "https://bitbucket.org/JesusFreke/smali/downloads/smali"
-    sha256 "910297fbeefb4590e6bffd185726c878382a0960fb6a7f0733f045b6faf60a30"
-  end
+  depends_on "gradle" => :build
+  depends_on :java => "1.8+"
 
   def install
-    resource("baksmali-jar").stage do
-      libexec.install "baksmali-#{version}.jar" => "baksmali.jar"
-    end
+    system "gradle", "build", "--no-daemon"
 
-    libexec.install "smali-#{version}.jar" => "smali.jar"
+    %w[smali baksmali].each do |name|
+      jarfile = "#{name}-#{version}-dev-fat.jar"
 
-    %w[smali baksmali].each do |r|
-      libexec.install resource(r)
-      inreplace libexec/r, /^libdir=.*$/, "libdir=\"#{libexec}\""
-      chmod 0755, libexec/r
-      bin.install_symlink libexec/r
+      libexec.install "#{name}/build/libs/#{jarfile}"
+      bin.write_jar_script libexec/jarfile, name, :java_version => "1.8+"
     end
   end
 

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -126,11 +126,6 @@ class VstsCli < Formula
     sha256 "1ece70729d616029f7fd1859524ee6b7d95ff07403af7bb4f963322ad28005f8"
   end
 
-  resource "vsts-cli" do
-    url "https://files.pythonhosted.org/packages/f9/c2/3ed698480ab30d2807fc961eef152099589aeaec3f1407945a4e07275de5/vsts-cli-0.1.4.tar.gz"
-    sha256 "27defe1d8aaa1fcbc3517274c0fdbd42b5ebe2c1c40edfc133d98fe4bb7114de"
-  end
-
   resource "vsts-cli-admin" do
     url "https://files.pythonhosted.org/packages/96/15/501240b53c6de9c81ba7c2c57e4a7227cc68eacb776a7b034178d7ffb56d/vsts-cli-admin-0.1.4.tar.gz"
     sha256 "d8a56dd57112a91818557043a8c1e98e26b8d9e793a448ceaa9df0439972cfd5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ref: https://github.com/Homebrew/brew/pull/6778

- `vsts-cli` — just remove a duplicated resource, I believe revision bump is not required
- `smali` — build formula instead of downloading jars

`brew audit` fails for `smali` on Catalina and High Sierra fails because I've switched link from jar to source code, so **it's ok**.