### PR TITLE
Fix postgresql@11 plist_options.manual

### DIFF
--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -77,7 +77,7 @@ class PostgresqlAT11 < Formula
   EOS
   end
 
-  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
+  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@11 start"
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently the info is not displaying properly.

See output below, with irrelevant sections redacted.

```
$ brew info postgresql@11
...
==> Caveats
...
Or, if you don't want/need a background service you can just run:
  pg_ctl -D /usr/local/var/Formulary::FormulaNamespacea6ceaa77ba5ad5656e6f12a514598ab0::PostgresqlAT11 start
```