### PR TITLE
glooctl: Fix homepage

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -1,6 +1,6 @@
 class Glooctl < Formula
   desc "Envoy-Powered API Gateway"
-  homepage "https://gloo.solo.io"
+  homepage "https://docs.solo.io/gloo/latest/"
   url "https://github.com/solo-io/gloo.git",
       :tag      => "v1.1.0",
       :revision => "c0dd0a2ff00f62664f73b6e7a8eeff9bfd9c5e64"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- For some reason, `brew audit --online` wasn't following this redirect
  (it appears as a standard 301 when checked via cURL) on the Homebrew on
  Linux side (https://github.com/Homebrew/linuxbrew-core/pull/17596). And if we can reduce extra hops then that's good, I guess.
