### PR TITLE
vit: increase test sleep time

### DIFF
--- a/Formula/vit.rb
+++ b/Formula/vit.rb
@@ -32,7 +32,7 @@ class Vit < Formula
 
     require "pty"
     PTY.spawn(bin/"vit") do |_stdout, _stdin, pid|
-      sleep 1
+      sleep 3
       Process.kill "TERM", pid
     end
     assert_predicate testpath/".task", :exist?


### PR DESCRIPTION
The test occasionally terminated the program too early (example in #46728).