### PR TITLE
icecream: backport fix for icecc-create-env regression

### DIFF
--- a/Formula/icecream.rb
+++ b/Formula/icecream.rb
@@ -3,6 +3,7 @@ class Icecream < Formula
   homepage "https://en.opensuse.org/Icecream"
   url "https://github.com/icecc/icecream/archive/1.3.tar.gz"
   sha256 "5e147544dcc557ae6f0b13246aa1445f0f244f010de8e137053078275613bd00"
+  revision 1
 
   bottle do
     sha256 "72eaf1c15d341a9ecf8445111ebda07da0135fb919a93be1d485d616baba58cc" => :catalina
@@ -18,6 +19,13 @@ class Icecream < Formula
   depends_on "libarchive"
   depends_on "lzo"
   depends_on "zstd"
+
+  # Backport https://github.com/icecc/icecream/pull/511
+  # icecc-create-env was broken on darwin. Remove in next stable release
+  patch do
+    url "https://github.com/icecc/icecream/commit/10b9468f5bd30a0fdb058901e91e7a29f1bfbd42.patch?full_index=1"
+    sha256 "dcf817be4549b2a732935e5bb6e310c135324929578a59ec3e55514b2b580360"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

backport fix for upstream bug:
https://github.com/icecc/icecream/pull/509
https://github.com/icecc/icecream/pull/511