### PR TITLE
vert.x 3.8.4

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://dl.bintray.com/vertx/downloads/vert.x-3.8.3-full.tar.gz"
-  sha256 "fe029a8d0f245b3bf5738f52ecfa3199b8076c2d19e869ea56bd6ae936169c31"
+  url "https://dl.bintray.com/vertx/downloads/vert.x-3.8.4-full.tar.gz"
+  sha256 "96e7d10763216796aa7d8f324822f4e6a4a9dff84758052c7719d7035e8ae14c"
 
   bottle :unneeded
   depends_on :java => "1.8+"


### PR DESCRIPTION
Update the vert.x formula to 3.8.4.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The https://vertx.io page is not yet updated with this version, as homebrew is part of the release process.