### PR TITLE
nushell: restore original test

### DIFF
--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -20,10 +20,6 @@ class Nushell < Formula
   end
 
   test do
-    # assert_equal "#{Dir.pwd}> 2\n#{Dir.pwd}> CTRL-D\n", pipe_output("#{bin}/nu", 'echo \'{"foo":1, "bar":2}\' | from-json | get bar | echo $it')
-
-    # Remove the test below and return to the better one above if/when Nushell
-    # reinstates the expected behavior for Ctrl+D (EOF)
-    assert_match version.to_s, shell_output("#{bin}/nu --version")
+    assert_equal "#{Dir.pwd}> 2\n#{Dir.pwd}> ", pipe_output("#{bin}/nu", 'echo \'{"foo":1, "bar":2}\' | from-json | get bar | echo $it')
   end
 end


### PR DESCRIPTION
As discussed in #46505, the test for this formula had to be changed due to the behavior of Ctrl+D being mapped to Ctrl+C. The behavior of Ctrl+D has been restored in Nushell v0.6.0, so the test can now be restored.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
