### PR TITLE
cassandra: mark cython as build dependency

### DIFF
--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -1,7 +1,7 @@
 class Cassandra < Formula
   desc "Eventually consistent, distributed key-value store"
   homepage "https://cassandra.apache.org"
-  url "https://www.apache.org/dyn/closer.cgi?path=cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz"
+  url "https://archive.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz"
   sha256 "5d598e23c3ffc4db0301ec2b313061e3208fae0f9763d4b47888237dd9069987"
 
   bottle do
@@ -12,7 +12,7 @@ class Cassandra < Formula
     sha256 "11de972c00c4b627e7c58de7b0645c4ef76ded64a31a88ccb8e3fc0b4c0da833" => :sierra
   end
 
-  depends_on "cython"
+  depends_on "cython" => :build
   depends_on "python"
 
   # Only >=Yosemite has new enough setuptools for successful compile of the below deps.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I believe `cython` is a build dependency for `cassandra` (also it is already marked that way for [`cassandra@2.2.rb`](https://github.com/Homebrew/homebrew-core/blob/2723ec740b1c223abb56431dbc42efd0dfb9d939/Formula/cassandra@2.2.rb)).

Not sure about bumping the revision for this case, probably it's not necessary.

Also, current url is unavailable anymore, so fixed it as well