### PR TITLE
sops: remove gopath and improve tests

### DIFF
--- a/Formula/sops.rb
+++ b/Formula/sops.rb
@@ -3,6 +3,7 @@ class Sops < Formula
   homepage "https://github.com/mozilla/sops"
   url "https://github.com/mozilla/sops/archive/v3.5.0.tar.gz"
   sha256 "a9c257dc5ddaab736dce08b8c5b1f00e6ca1e3171909b6d7385689044ebe759b"
+  revision 1
   head "https://github.com/mozilla/sops.git"
 
   bottle do
@@ -12,22 +13,16 @@ class Sops < Formula
     sha256 "c2ce8bb370f5b3888de5696707c69627178aabdc6063ff35cce075c3df502a51" => :high_sierra
   end
 
-  depends_on "go@1.12" => :build
+  depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GOBIN"] = bin
-
-    dir = buildpath/"src/github.com/mozilla/sops"
-    dir.install buildpath.children
-
-    cd dir do
-      system "make", "install"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-o", bin/"sops", "go.mozilla.org/sops/v3/cmd/sops"
+    pkgshare.install "example.yaml"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/sops --version 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/sops --version")
+
+    assert_match "Recovery failed because no master key was able to decrypt the file.", shell_output("#{bin}/sops #{pkgshare}/example.yaml 2>&1", 128)
   end
 end


### PR DESCRIPTION
- Use go v1.13 and remove go path
- Improve the tests

Relates to https://github.com/mozilla/sops/pull/566