### PR TITLE
ruby-build: force use of homebrew openssl

### DIFF
--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -16,6 +16,16 @@ class RubyBuild < Formula
     system "./install.sh"
   end
 
+  def caveats; <<~EOS
+    Warning: without further action ruby-build will download and install OpenSSL outside of Homebrew, and never update it.
+
+    To avoid this, set the following environment variable in your shell:
+      export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl)"
+
+    However, note that if you do this, it will interfere with building end of life rubies that still use OpenSSL 1.0.
+  EOS
+  end
+
   test do
     assert_match "2.0.0", shell_output("#{bin}/ruby-build --definitions")
   end

--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -17,12 +17,12 @@ class RubyBuild < Formula
   end
 
   def caveats; <<~EOS
-    Warning: without further action ruby-build will download and install OpenSSL outside of Homebrew, and never update it.
+    Warning: By default, ruby-build installs additional copies of OpenSSL outside of Homebrew, for each individual Ruby version installed, and such instances of OpenSSL are never updated.
 
-    To avoid this, set the following environment variable in your shell:
-      export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl)"
+    To have all Ruby versions link to Homebrew's OpenSSL, which is upgraded over time, you can place this in your shell initialization file:
+      export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
 
-    However, note that if you do this, it will interfere with building end of life rubies that still use OpenSSL 1.0.
+    Note that this might interfere with building end of life versions of Ruby, such as those older than Ruby 2.4, that still use OpenSSL 1.0.
   EOS
   end
 

--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -16,14 +16,17 @@ class RubyBuild < Formula
     system "./install.sh"
   end
 
-  def caveats; <<~EOS
-    Warning: By default, ruby-build installs additional copies of OpenSSL outside of Homebrew, for each individual Ruby version installed, and such instances of OpenSSL are never updated.
+  def caveats
+    <<~EOS
+      ruby-build installs a non-Homebrew OpenSSL for each Ruby version installed and these are never upgraded.
 
-    To have all Ruby versions link to Homebrew's OpenSSL, which is upgraded over time, you can place this in your shell initialization file:
-      export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
+      To link Rubies to Homebrew's OpenSSL 1.1 (which is upgraded) add the following
+      to your #{shell_profile}:
+        export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
 
-    Note that this might interfere with building end of life versions of Ruby, such as those older than Ruby 2.4, that still use OpenSSL 1.0.
-  EOS
+      Note: this may interfere with building old versions of Ruby (e.g <2.4) that use
+      OpenSSL <1.1.
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I know that https://github.com/Homebrew/homebrew-core/pull/46637 exists, however I'd like to suggest that this is a better approach to the problem. 

As is ruby-build will vendor a specific openssl version, per ruby installed, at install time, and then never update it. 

Some of the consequences of ruby-build's approach are:

- When openssl 1.1.1e or w/e the next security update is for openssl is called, none of your rbenv installed rubies will be updated.
- You have n extra copies of openssl lying around.
- In order to use self signed certs with your ruby's openssl, you need to add them to every single openssl and regenerate the cert bundle.

Some consequences of making this change:

- Some rubies won't build
- The ruby-build maintainers might get annoyed

Some alternatives I considered:

- just revert commit https://github.com/rbenv/ruby-build/commit/a0dcf52834ed76ee6baba3a03ffbd7d9399c2c79 as a patch in the formula, but that seems fragile
- do nothing, but that seems irresponsible
- add a scary warning to the ruby-build caveats warning users about the issue, this seems like it could be a reasonable compromise