### PR TITLE
boot-clj: fix shebang boot scripts

### DIFF
--- a/Formula/boot-clj.rb
+++ b/Formula/boot-clj.rb
@@ -10,7 +10,7 @@ class BootClj < Formula
 
   def install
     libexec.install "boot.jar"
-    bin.write_jar_script libexec/"boot.jar", "boot"
+    bin.write_jar_script libexec/"boot.jar", "boot", %Q(-Dboot.app.path="#{bin}/boot")
   end
 
   test do


### PR DESCRIPTION
PR #46494 changed the way the boot.jar is called to be a jar script generated by Homebrew. Previous versions of the formula used the wrapper from the boot project.

When running "shebang" scripts with boot, (i.e. Clojure scripts to be run like shell scripts), boot requires a Java property `boot.app.path` to be the path to the wrapper itself.

This patch adds th`boot.app.path`  java property.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
