### PR TITLE
Python 3.8: glib

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -3,6 +3,7 @@ class Glib < Formula
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.62/glib-2.62.4.tar.xz"
   sha256 "4c84030d77fa9712135dfa8036ad663925655ae95b1d19399b6200e869925bbc"
+  revision 1
 
   bottle do
     sha256 "d5f0419ecc444b4d7b2e830d9ba880886fc683fcdcbbf2d0b791cdef51b67b07" => :catalina
@@ -16,7 +17,7 @@ class Glib < Formula
   depends_on "gettext"
   depends_on "libffi"
   depends_on "pcre"
-  depends_on "python"
+  depends_on "python@3.8"
   uses_from_macos "util-linux" # for libmount.so
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
@@ -40,7 +41,7 @@ class Glib < Formula
     ]
 
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", *args, ".."
+      system "meson", "--prefix=#{prefix}", "--bindir=#{libexec}/bin", *args, ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end
@@ -72,6 +73,11 @@ class Glib < Formula
     end
 
     bash_completion.install Dir["gio/completion/*"]
+
+    Dir[libexec/"bin/*"].each do |executable|
+      basename = File.basename(executable)
+      (bin/basename).write_env_script executable, :PATH => "#{Formula["python@3.8"].opt_bin}:$PATH"
+    end
   end
 
   def post_install

--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -3,6 +3,7 @@ class Meson < Formula
   homepage "https://mesonbuild.com/"
   url "https://github.com/mesonbuild/meson/releases/download/0.52.1/meson-0.52.1.tar.gz"
   sha256 "0c277472e49950a5537e3de3e60c57b80dbf425788470a1a8ed27446128fc035"
+  revision 1
   head "https://github.com/mesonbuild/meson.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Meson < Formula
   end
 
   depends_on "ninja"
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     version = Language::Python.major_minor_version("python3")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds `python@3.8` formula (as in https://github.com/Homebrew/homebrew-core/pull/47273 but with updated resources).

We need to migrate `glib` to `python@3.8` before https://github.com/Homebrew/homebrew-core/pull/47326 to avoid having `python` in dependencies.
As we find it out `glib` uses `python` only to run some scripts from `bin`, so I've added a patch to make sure it uses `python@3.8`.

Also, this PR migrates `meson` which is used by `glib` to `python@3.8`

Ref: https://github.com/Homebrew/homebrew-core/pull/47326#discussion_r353264009