### PR TITLE
Add extra unixodbc path to php formula

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -146,7 +146,7 @@ class Php < Formula
       --with-password-argon2=#{Formula["argon2"].opt_prefix}
       --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
       --with-pdo-mysql=mysqlnd
-      --with-pdo-odbc=unixODBC
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
       --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
       --with-pdo-sqlite
       --with-pgsql=#{Formula["libpq"].opt_prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request restores unixODBC directory path to PHP configure options in php formula, which existed in previous versions of formula.

By update of the php formula including upgrade PHP version to 7.4, `--with-unixODBC` configure option no longer has additional custom unixODBC directory path.

- https://github.com/Homebrew/homebrew-core/pull/47289/files#diff-4b08885c3dc65ec4ff4e37a1186a86a7R149
- https://github.com/Homebrew/homebrew-core/pull/47289#issuecomment-559541145

However, building the php fails on `configure` if you installed Homebrew in custom location instead of `/usr/local` because required header files only exist in custom location's  `include` directory.

I know installing Home-brew other than `/usr/local` is not recommended, since unixodbc is installed as a separate package, I think it is not bad idea to keep it work as previous versions.