### PR TITLE
imgproxy 2.7.0 (new formula)

### DIFF
--- a/Formula/imgproxy.rb
+++ b/Formula/imgproxy.rb
@@ -1,0 +1,49 @@
+class Imgproxy < Formula
+  desc "Fast and secure server for resizing and converting remote images"
+  homepage "https://imgproxy.net"
+  url "https://github.com/imgproxy/imgproxy/archive/v2.7.0.tar.gz"
+  sha256 "9a97a4b184f67718f97a4b3d16cd98b61a825ba418e6e04139ed3a3a9d787fad"
+  head "https://github.com/imgproxy/imgproxy.git"
+
+  depends_on "go" => :build
+  depends_on "pkg-config" => :build
+  depends_on "vips"
+
+  def install
+    ENV["CGO_LDFLAGS_ALLOW"]="-s|-w"
+    ENV["CGO_CFLAGS_ALLOW"]="-Xpreprocessor"
+
+    system "go", "build", "-o", "#{bin}/#{name}"
+  end
+
+  test do
+    require "socket"
+
+    server = TCPServer.new(0)
+    port = server.addr[1]
+    server.close
+
+    cp(test_fixtures("test.jpg"), testpath/"test.jpg")
+
+    ENV["IMGPROXY_BIND"] = "127.0.0.1:#{port}"
+    ENV["IMGPROXY_LOCAL_FILESYSTEM_ROOT"] = testpath
+
+    pid = fork do
+      exec bin/"imgproxy"
+    end
+    sleep 3
+
+    output = testpath/"test-converted.png"
+
+    system("curl", "-s", "-o", output, "http://127.0.0.1:#{port}/insecure/fit/100/100/no/0/plain/local:///test.jpg@png")
+    assert_equal 0, $CHILD_STATUS
+    assert_predicate output, :exist?
+
+    file_output = shell_output("file #{output}")
+    assert_match "PNG image data", file_output
+    assert_match "1 x 1", file_output
+  ensure
+    Process.kill("TERM", pid)
+    Process.wait(pid)
+  end
+end


### PR DESCRIPTION
I used the install from source documentation as a template: https://docs.imgproxy.net/#/installation?id=from-the-source

ping @DarthSim (`imgproxy`'s author) if you want to have a look.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
