### PR TITLE
postgresql: link against MIT Kerberos

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -13,6 +13,11 @@ class Postgresql < Formula
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
+
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   depends_on "openssl@1.1"
   depends_on "readline"
   uses_from_macos "libxml2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The GSS libraries provided in macOS segfault when used in applications that fork(). This happens more often in languages like Ruby and Python. Notably, `rails console` breaks almost immediately.

Discussion: https://postgr.es/m/16041-b44f9931ad91fc3d%40postgresql.org
Related: https://github.com/ged/ruby-pg/issues/311

The `libpq` formula is unaffected because it does not use `--with-gssapi`.