### PR TITLE
git-delta: Prevent segfault on MacOS Catalina

### DIFF
--- a/Formula/git-delta.rb
+++ b/Formula/git-delta.rb
@@ -18,6 +18,7 @@ class GitDelta < Formula
   conflicts_with "delta", :because => "both install a `delta` binary"
 
   def install
+    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 


### PR DESCRIPTION
This PR applies the same fix to `git-delta` as was recently applied to the bat formula. Both are Rust projects affected by a problem specific to MacOS Catalina.  See
- #46670 [bat homebrew formula PR]
- https://github.com/dandavison/delta/issues/24 [discussion of problem as it manifested for git-delta]

It has [been confirmed](https://github.com/dandavison/delta/issues/24#issuecomment-561915036) that this fix results in a functional binary on Catalina.
 
cc @uraimo @kevinnio @dawidd6 

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
