### PR TITLE
mpv: Ensure that installing uses Python 3

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -48,7 +48,7 @@ class Mpv < Formula
       --zshdir=#{zsh_completion}
     ]
 
-    system "./bootstrap.py"
+    system "python3", "bootstrap.py"
     system "python3", "waf", "configure", *args
     system "python3", "waf", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Over in https://github.com/Homebrew/linuxbrew-core/pull/17913, we thought we could remove `uses_from_macos "python@2"` given this looked to have macOS Python 3 dependencies.
- Turns out, `bootstrap.py`'s shebang line had `/usr/bin/env python`, which catches "Python 2" on macOS but nothing on Linux.
- To make this actually run wholly with Python 3 everywhere, run `bootstrap` with python3 like the rest of the file does.