### PR TITLE
Add Akku, a package manager for Scheme

### DIFF
--- a/Formula/akku.rb
+++ b/Formula/akku.rb
@@ -1,8 +1,8 @@
 class Akku < Formula
   desc "R6RS/R7RS Scheme language package manager"
   homepage "https://akkuscm.org"
-  url "https://github.com/weinholt/akku/releases/download/v1.0.0/akku-1.0.0.src.tar.xz"
-  sha256 "37ac149c19cce1219595d751f9d5b99ccaffe3892ba023148dc48aab89c4bf7d"
+  url "https://gitlab.com/akkuscm/akku/uploads/7f36e5a69b24c028d478fdc3c13e7c3d/akku-1.0.1.src.tar.xz"
+  sha256 "33d6ca54122bc565b91520006f97f611dc5f5ae2ebcf77953544b50f1b1bd7c7"
   head "https://gitlab.com/akkuscm/akku.git"
 
   # TODO: Akku supports both Guile and Chez, but the actual tarball to download is
@@ -34,7 +34,7 @@ class Akku < Formula
   end
 
   test do
-    expected = ",()´ Akku.scm 1.0.0 - Scheme package manager"
+    expected = ",()´ Akku.scm 1.0.1 - Scheme package manager"
     assert_match shell_output("#{bin}/akku --help"), expected
   end
 end

--- a/Formula/akku.rb
+++ b/Formula/akku.rb
@@ -1,0 +1,40 @@
+class Akku < Formula
+  desc "R6RS/R7RS Scheme language package manager"
+  homepage "https://akkuscm.org"
+  url "https://github.com/weinholt/akku/releases/download/v1.0.0/akku-1.0.0.src.tar.xz"
+  sha256 "37ac149c19cce1219595d751f9d5b99ccaffe3892ba023148dc48aab89c4bf7d"
+  head "https://gitlab.com/akkuscm/akku.git"
+
+  # TODO: Akku supports both Guile and Chez, but the actual tarball to download is
+  # different depending on which you choose for running Akku. I wasn't able to get
+  # the Guile version working, so this uses Chez.
+  depends_on "chezscheme"
+
+  # XXX: This is effectively a reimplementation of Akku's own install.sh, but running
+  # that script via Homebrew fails for me without an error.
+  def install
+    chez = Formula["chezscheme"].bin/"chez"
+    lib.mkpath
+    (lib/"akku/bin").mkpath
+    (lib/"akku/bin").install Dir["lib/akku/bin/*"]
+    (lib/"akku/lib").mkpath
+    (lib/"akku/lib").install Dir["lib/akku/lib/*"]
+    (lib/"akku/lib/akku.chezscheme").write <<~EOS
+      #!/bin/sh
+      export CHEZSCHEMELIBDIRS="#{lib}/akku/lib"
+      unset CHEZSCHEMELIBEXTS
+      exec #{chez} --program "#{lib}/akku/bin/akku.sps" "$@"
+    EOS
+    ENV["CHEZSCHEMELIBDIRS"] = lib/"akku/lib"
+    ENV.delete "CHEZSCHEMELIBEXTS"
+    system chez, "--compile-imported-libraries", "--program", lib/"akku/bin/akku.sps"
+    bin.mkpath
+    bin.install lib/"akku/lib/akku.chezscheme" => "akku"
+    man1.install "share/man/man1/akku.1"
+  end
+
+  test do
+    expected = ",()´ Akku.scm 1.0.0 - Scheme package manager"
+    assert_match shell_output("#{bin}/akku --help"), expected
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[Akku](https://akkuscm.org) is a package manager for R6RS/R7RS Scheme. Running the package manager itself requires either Chez or Guile, but I was only able to get things working with Chez, so that option is not provided in the formula; it unconditionally requires Chez.

cc @weinholt