### PR TITLE
ledger: uses_from_macos "python@2"

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -16,6 +16,7 @@ class Ledger < Formula
   depends_on "boost"
   depends_on "gmp"
   depends_on "mpfr"
+  uses_from_macos "python@2"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- In #47053, we removed `depends_on python` etc because "building without
  Python" was a success. Turns out, [installing this formula still uses
  Python 2](https://github.com/ledger/ledger/blob/cd7297ed44671ea6c6a8eda93c94e5fbfa794243/acprep#L1).
- This makes the system Python 2 dependency explicit on macOS, so we
  don't make [mistakes](https://github.com/Homebrew/linuxbrew-core/pull/17943) on Linux.