### PR TITLE
mongo-c-driver: fix HEAD version

### DIFF
--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -18,7 +18,11 @@ class MongoCDriver < Formula
   depends_on "sphinx-doc" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    cmake_args = std_cmake_args
+    if build.head?
+      cmake_args << "-DBUILD_VERSION=1.16.0-pre"
+    end
+    system "cmake", ".", *cmake_args
     system "make", "install"
     (pkgshare/"libbson").install "src/libbson/examples"
     (pkgshare/"libmongoc").install "src/libmongoc/examples"


### PR DESCRIPTION
Per https://jira.mongodb.org/browse/CDRIVER-2831 the calculated
release version for building libmongoc and libbson is computed
from git metadata, or retrieved from a VERSION_CURRENT file
distributed in release tarballs. Since the GitDownloadStrategy
does not copy refs (even if doing a non-shallow clone) the
version cannot be computed. This change explicitly sets the
version in the cmake command.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
