### PR TITLE
Sync more `uses_from_macos` from Homebrew/linuxbrew-core

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -18,6 +18,8 @@ class Ansible < Formula
   depends_on "libyaml"
   depends_on "openssl@1.1"
   depends_on "python"
+  uses_from_macos "libffi"
+  uses_from_macos "libxslt"
 
   # Collect requirements from:
   #   ansible

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -17,6 +17,7 @@ class AwsGoogleAuth < Formula
   depends_on "freetype"
   depends_on "jpeg"
   depends_on "python"
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -26,6 +26,7 @@ class Poppler < Formula
   depends_on "nss"
   depends_on "openjpeg"
   depends_on "qt"
+  uses_from_macos "curl"
 
   conflicts_with "pdftohtml", "pdf2image", "xpdf",
     :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -15,6 +15,9 @@ class Postgresql < Formula
   depends_on "icu4c"
   depends_on "openssl@1.1"
   depends_on "readline"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "perl"
 
   def install
     # avoid adding the SDK library directory to the linker search path

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -16,6 +16,9 @@ class PostgresqlAT11 < Formula
   depends_on "icu4c"
   depends_on "openssl@1.1"
   depends_on "readline"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "perl"
 
   def install
     # avoid adding the SDK library directory to the linker search path

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -11,6 +11,7 @@ class Travis < Formula
   end
 
   depends_on "ruby" if MacOS.version <= :sierra
+  uses_from_macos "libffi"
 
   resource "addressable" do
     url "https://rubygems.org/gems/addressable-2.4.0.gem"

--- a/Formula/zurl.rb
+++ b/Formula/zurl.rb
@@ -17,6 +17,7 @@ class Zurl < Formula
   depends_on "python" => :test
   depends_on "qt"
   depends_on "zeromq"
+  uses_from_macos "curl"
 
   resource "pyzmq" do
     url "https://files.pythonhosted.org/packages/7a/d2/1eb3a994374802b352d4911f3317313a5b4ea786bc830cc5e343dad9b06d/pyzmq-18.1.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This syncs a load of `uses_from_macos` between Linuxbrew and Homebrew.
Sometimes we don't have time to add them here first and do another
merge. These should all do nothing to change the functionality of
formulae on macOS, as they're all system dependencies.