### PR TITLE
aptly: remove gopath

### DIFF
--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -2,7 +2,7 @@ class Aptly < Formula
   desc "Swiss army knife for Debian repository management"
   homepage "https://www.aptly.info/"
   url "https://github.com/aptly-dev/aptly/archive/v1.4.0.tar.gz"
-  sha256 "d124541c928ad35681b82e8554c4ca56bea04518c648ad44a995f319db53cdb2"
+  sha256 "4172d54613139f6c34d5a17396adc9675d7ed002e517db8381731d105351fbe5"
   head "https://github.com/aptly-dev/aptly.git"
 
   bottle do

--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -15,15 +15,11 @@ class Aptly < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GOBIN"] = bin
-    (buildpath/"src/github.com/aptly-dev/aptly").install buildpath.children
-    cd "src/github.com/aptly-dev/aptly" do
-      system "make", "VERSION=#{version}", "install"
-      prefix.install_metafiles
-      bash_completion.install "completion.d/aptly"
-      zsh_completion.install "completion.d/_aptly"
-    end
+    system "make", "VERSION=#{version}", "install"
+    prefix.install_metafiles
+
+    bash_completion.install "completion.d/aptly"
+    zsh_completion.install "completion.d/_aptly"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove gopath as formula has moved to go modules.

Relates to #47627