### PR TITLE
frotz 2.50

### DIFF
--- a/Formula/frotz.rb
+++ b/Formula/frotz.rb
@@ -1,9 +1,9 @@
 class Frotz < Formula
   desc "Infocom-style interactive fiction player"
-  homepage "https://github.com/DavidGriffith/frotz"
-  url "https://github.com/DavidGriffith/frotz/archive/2.44.tar.gz"
-  sha256 "dbb5eb3bc95275dcb984c4bdbaea58bc1f1b085b20092ce6e86d9f0bf3ba858f"
-  head "https://github.com/DavidGriffith/frotz.git"
+  homepage "https://gitlab.com/DavidGriffith/frotz"
+  url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.50/frotz-2.50.tar.gz"
+  sha256 "0352dfc458fb5cc7a932c568bd86aabdde943bee25ea0cce58c46f8c893f554f"
+  head "https://gitlab.com/DavidGriffith/frotz.git"
 
   bottle do
     sha256 "a47f879a4475b7ca3b35e481ae220a672023178536a8453b0a27cc34a705919b" => :catalina
@@ -16,13 +16,18 @@ class Frotz < Formula
 
   def install
     inreplace "Makefile" do |s|
-      s.remove_make_var! %w[CC OPTS]
       s.change_make_var! "PREFIX", prefix
-      s.change_make_var! "CONFIG_DIR", etc
-      s.change_make_var! "MAN_PREFIX", share
+      s.change_make_var! "MANDIR", man
+      s.change_make_var! "SYSCONFDIR", etc
+      s.change_make_var! "SOUND_TYPE", "none"
+      s.gsub! "        ", "	"
     end
 
     system "make", "frotz"
     system "make", "install"
+  end
+
+  test do
+    assert_match "FROTZ", shell_output("#{bin}/frotz --version").strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Frotz has moved from github to gitlab. Frotz enables sound support by default, and depends on several external libraries for this. I disabled it here to avoid these extra dependencies. Seems like this should be selectable as an option (along with sdl support) but homebrew-core doesn't allow options - this is the no sound, text (curses) version as with previous versions.