### PR TITLE
landscaper: use helm@2

### DIFF
--- a/Formula/landscaper.rb
+++ b/Formula/landscaper.rb
@@ -4,6 +4,7 @@ class Landscaper < Formula
   url "https://github.com/Eneco/landscaper.git",
       :tag      => "v1.0.24",
       :revision => "1199b098bcabc729c885007d868f38b2cf8d2370"
+  revision 1
   head "https://github.com/Eneco/landscaper.git"
 
   bottle do
@@ -16,8 +17,8 @@ class Landscaper < Formula
 
   depends_on "dep" => :build
   depends_on "go" => :build
+  depends_on "helm@2"
   depends_on "kubernetes-cli"
-  depends_on "kubernetes-helm"
 
   def install
     ENV["GOPATH"] = buildpath
@@ -30,11 +31,14 @@ class Landscaper < Formula
       system "make", "bootstrap"
       system "make", "build"
       bin.install "build/landscaper"
+      bin.env_script_all_files(libexec/"bin", :PATH => "#{Formula["helm@2"].opt_bin}:$PATH")
       prefix.install_metafiles
     end
   end
 
   test do
-    assert_match "This is Landscaper v#{version}", pipe_output("#{bin}/landscaper apply 2>&1")
+    output = shell_output("#{bin}/landscaper apply --dry-run 2>&1", 1)
+    assert_match "This is Landscaper v#{version}", output
+    assert_match "dryRun=true", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
One of two formula use `kubernetes-helm` and upstream repo is still using helm v2.