### PR TITLE
armor: remove gopath

### DIFF
--- a/Formula/armor.rb
+++ b/Formula/armor.rb
@@ -16,14 +16,8 @@ class Armor < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    armorpath = buildpath/"src/github.com/labstack/armor"
-    armorpath.install buildpath.children
-
-    cd armorpath do
-      system "go", "build", "-o", bin/"armor", "cmd/armor/main.go"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"armor", "cmd/armor/main.go"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.