### PR TITLE
aurora: remove gopath

### DIFF
--- a/Formula/aurora.rb
+++ b/Formula/aurora.rb
@@ -16,14 +16,8 @@ class Aurora < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    aurorapath = buildpath/"src/github.com/xuri/aurora"
-    aurorapath.install buildpath.children
-
-    cd aurorapath do
-      system "go", "build", "-o", bin/"aurora"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"aurora"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.