### PR TITLE
dcos-cli: remove gopath

### DIFF
--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -14,22 +14,15 @@ class DcosCli < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
     ENV["NO_DOCKER"] = "1"
+    ENV["VERSION"] = version.to_s
 
-    ENV["VERSION"] = "1.1.0"
-
-    bin_path = buildpath/"src/github.com/dcos/dcos-cli"
-
-    bin_path.install Dir["*"]
-    cd bin_path do
-      system "make", "darwin"
-      bin.install "build/darwin/dcos"
-    end
+    system "make", "darwin"
+    bin.install "build/darwin/dcos"
   end
 
   test do
     run_output = shell_output("#{bin}/dcos --version 2>&1")
-    assert_match "dcoscli.version=1.1.0", run_output
+    assert_match "dcoscli.version=#{version}", run_output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.