### PR TITLE
Add "libvips" alias for "vips"

### DIFF
--- a/Aliases/libvips
+++ b/Aliases/libvips
@@ -1,0 +1,1 @@
+../Formula/vips.rb


### PR DESCRIPTION
The VIPS C library has been renamed to "libvips", and I can imagine many people trying to `brew install libvips` (I tried to run it myself recently). So, for convenience we add a "libvips" alias for the "vips" formula.