### PR TITLE
downgrade bash-completion@2 back to 2.8

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -1,14 +1,16 @@
 class BashCompletionAT2 < Formula
   desc "Programmable completion for Bash 4.1+"
   homepage "https://github.com/scop/bash-completion"
-  url "https://github.com/scop/bash-completion/releases/download/2.10/bash-completion-2.10.tar.xz"
-  sha256 "123c17998e34b937ce57bb1b111cd817bc369309e9a8047c0bcf06ead4a3ec92"
+  url "https://github.com/scop/bash-completion/releases/download/2.8/bash-completion-2.8.tar.xz"
+  sha256 "c01f5570f5698a0dda8dc9cfb2a83744daa1ec54758373a6e349bd903375f54d"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "457ae745fa3c9ad6cda7f497cd312bcc70f469a723e1a9b0d59af87234a9b3d3" => :catalina
-    sha256 "457ae745fa3c9ad6cda7f497cd312bcc70f469a723e1a9b0d59af87234a9b3d3" => :mojave
-    sha256 "457ae745fa3c9ad6cda7f497cd312bcc70f469a723e1a9b0d59af87234a9b3d3" => :high_sierra
+    rebuild 1
+    sha256 "2e9f92a4467a67597ae250f98bf9c6e10903acb94b22deb747253837283c4113" => :catalina
+    sha256 "4377303d2f57e4fd4887201a15c6ffe9e41e0636b8b83cf7a4a53ce76f85a5e7" => :mojave
+    sha256 "ae0fd1bc4b23207417f5d070eeedb4d3158cc170dcf9c84f04c23fe479c219dc" => :high_sierra
+    sha256 "ae0fd1bc4b23207417f5d070eeedb4d3158cc170dcf9c84f04c23fe479c219dc" => :sierra
   end
 
   head do


### PR DESCRIPTION
Revert "bash-completion@2: update 2.10 bottle."
This reverts commit 8687cbd065a559bb8ce2884dfc4b5ff9367cd94e.
Revert "bash-completion@2 2.10"
This reverts commit a386bbf30b68e4fd20daeeda9f691679443542db.

Some completions, such as git, and even Homebrew itself, are now
broken after 2.10 update.
See: https://github.com/Homebrew/homebrew-core/pull/47527#issuecomment-563289732

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
