### PR TITLE
assimp 5.0.0 - Add patch from upstream pull request to fix CMake builds.

### DIFF
--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -25,6 +25,14 @@ class Assimp < Formula
     end
   end
 
+  # Fix CMake error "The imported target "assimp::assimp" references the file
+  # "/usr/local/lib/libassimp.dylib.5""
+  # Upstream PR from 11 Nov 2019 "Fix shared lib name on macOS"
+  patch do
+    url "https://github.com/assimp/assimp/pull/2765.patch?full_index=1"
+    sha256 "4c8102fea4af720f65d420aa883d60e6ed0f9eb8309938793e82de69d11a23dc"
+  end
+
   def install
     args = std_cmake_args
     args << "-DASSIMP_BUILD_TESTS=OFF"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/assimp/assimp/pull/2765 has been merged upstream but is not yet part of a release.

According to fxcoudert ([1]) once the fix has been merged PRs applying the
patch directly will be considered.

[1]: https://github.com/Homebrew/homebrew-core/issues/47210#issuecomment-558734305