### PR TITLE
go-md2man: remove gopath

### DIFF
--- a/Formula/go-md2man.rb
+++ b/Formula/go-md2man.rb
@@ -16,21 +16,10 @@ class GoMd2man < Formula
   depends_on "go" => :build
 
   def install
-    contents = Dir["*"]
-    gopath = buildpath/"gopath"
-    (gopath/"src/github.com/cpuguy83/go-md2man").install contents
-
-    ENV["GOPATH"] = buildpath
-    ENV["GO111MODULES"] = "enabled"
-
-    cd gopath/"src/github.com/cpuguy83/go-md2man" do
-      system "go", "build", "-o", "go-md2man"
-      system "./go-md2man", "-in=go-md2man.1.md", "-out=go-md2man.1"
-
-      bin.install "go-md2man"
-      man1.install "go-md2man.1"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"go-md2man"
+    system bin/"go-md2man", "-in=go-md2man.1.md", "-out=go-md2man.1"
+    man1.install "go-md2man.1"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.