### PR TITLE
ammonite-repl 1.8.2 (revision 1)

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -1,8 +1,9 @@
 class AmmoniteRepl < Formula
   desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
   homepage "https://lihaoyi.github.io/Ammonite/#Ammonite-REPL"
-  url "https://github.com/lihaoyi/Ammonite/releases/download/1.8.2/2.12-1.8.2"
-  sha256 "378d7a9fa1a8f44f8e27769259a465423cf540658ba42365213a3c00e4a8acc0"
+  url "https://github.com/lihaoyi/Ammonite/releases/download/1.8.2/2.13-1.8.2"
+  sha256 "2d13aee7a29366f6a56ec8c1f9b46d0fd586a8c0327c9bb7789042328400005c"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ammonite REPL releases are released for both Scala 2.12 and Scala 2.13. I think the default formula should be using the Scala 2.13 version. I don't know what should be done about this long term. Should the 2.12 line of releases be ammonite-repl@2.12? Then Scala 3 will come out and this is going to be a problem all over again.

So I don't know what to do with the version number. Adding the revision let me upgrade it locally but the audit complained that the hash was different but the versions were the same.

Apologies, I also didn't know what to do for the commit message either. I'll fix that up once I know what it should be.