### PR TITLE
okteto 1.6.1 (new formula)

### DIFF
--- a/Formula/okteto.rb
+++ b/Formula/okteto.rb
@@ -1,0 +1,28 @@
+class Okteto < Formula
+  desc "Build better apps by developing and testing code directly in Kubernetes"
+  homepage "https://okteto.com"
+  url "https://github.com/okteto/okteto/archive/1.6.1.tar.gz"
+  sha256 "10e8ac27ec8d2e8d37d2eb779d71dcda66e1f5751ba84ed9d197ddc1b2fe039b"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=#{version}"
+    tags = "osusergo netgo static_build"
+    system "go", "build", "-o", "#{bin}/#{name}", "-trimpath", "-ldflags", ldflags, "-tags", tags
+  end
+
+  test do
+    touch "test.rb"
+    system "echo | okteto init --overwrite --file test.yml"
+    expected = <<~EOS
+      name: #{Pathname.getwd.basename}
+      image: okteto/ruby:2
+      command:
+      - bash
+      workdir: /usr/src/app
+    EOS
+    got = File.read("test.yml")
+    assert_equal expected, got
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From upstream's README:
```
Kubernetes has made it very easy to deploy applications to the cloud at a higher scale than ever, but the development practices have not evolved at the same speed as application deployment patterns.

Today, most developers try to either run parts of the infrastructure locally, or just test these integrations directly in the cluster via CI jobs or the "docker build, docker push, kubectl apply" cycle. It works, but this workflow is painful and incredibly slow.

Okteto makes this cycle a lot faster by launching your development environment directly in your Kubernetes cluster.
```