### PR TITLE
tomcat@8 8.5.50

### DIFF
--- a/Formula/tomcat@8.rb
+++ b/Formula/tomcat@8.rb
@@ -1,8 +1,8 @@
 class TomcatAT8 < Formula
   desc "Implementation of Java Servlet and JavaServer Pages"
   homepage "https://tomcat.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz"
-  sha256 "40f23e1d9a882b33bbc0029bc17405a231099437b2bf1fb60f55a620385831d4"
+  url "https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.5.50/bin/apache-tomcat-8.5.50.tar.gz"
+  sha256 "ea762293e889f85d40f5ec14ac4474e133a379522d623f4ba5993da6260bf06e"
 
   bottle :unneeded
 


### PR DESCRIPTION
There is no way to execute command `brew install tomcat@8` because it refers to version which was removed 12/12/2019
Error from terminal:
```
==> Downloading https://www.apache.org/dyn/closer.cgi?path=tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz
==> Downloading from http://apache.ip-connect.vn.ua/tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Trying a mirror...
==> Downloading https://www-eu.apache.org/dist/tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Trying a mirror...
==> Downloading https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz

curl: (22) The requested URL returned error: 404 Not Found
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "tomcat@8"
Download failed: https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.49/bin/apache-tomcat-8.5.49.tar.gz
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
