### PR TITLE
coq: remove camlp5 dependency

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -3,6 +3,7 @@ class Coq < Formula
   homepage "https://coq.inria.fr/"
   url "https://github.com/coq/coq/archive/V8.10.2.tar.gz"
   sha256 "693c188f045d21f83114239dbb8af8def01b42a157c7d828087d055c32ec6e86"
+  revision 1
   head "https://github.com/coq/coq.git"
 
   bottle do
@@ -12,7 +13,6 @@ class Coq < Formula
   end
 
   depends_on "ocaml-findlib" => :build
-  depends_on "camlp5"
   depends_on "ocaml"
   depends_on "ocaml-num"
 


### PR DESCRIPTION
Coq 8.10 doesn't depend on camlp5 for builds anymore; see
https://coq.github.io/doc/master/refman/changes.html#id96.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
