### PR TITLE
numpy@1.16: use system Python 2

### DIFF
--- a/Formula/numpy@1.16.rb
+++ b/Formula/numpy@1.16.rb
@@ -3,6 +3,7 @@ class NumpyAT116 < Formula
   homepage "https://www.numpy.org/"
   url "https://files.pythonhosted.org/packages/d3/4b/f9f4b96c0b1ba43d28a5bdc4b64f0b9d3fbcf31313a51bc766942866a7c7/numpy-1.16.4.zip"
   sha256 "7242be12a58fec245ee9734e625964b97cf7e3f2f7d016603f9e56660ce479c7"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class NumpyAT116 < Formula
 
   depends_on "gcc" => :build # for gfortran
   depends_on "openblas"
-  depends_on "python@2"
+  uses_from_macos "python@2"
 
   resource "Cython" do
     url "https://files.pythonhosted.org/packages/a5/1f/c7c5450c60a90ce058b47ecf60bb5be2bfe46f952ed1d3b95d1d677588be/Cython-0.29.13.tar.gz"
@@ -39,22 +40,22 @@ class NumpyAT116 < Formula
 
     Pathname("site.cfg").write config
 
-    version = Language::Python.major_minor_version "python2"
+    version = Language::Python.major_minor_version "python"
     dest_path = lib/"python#{version}/site-packages"
     dest_path.mkpath
 
     nose_path = libexec/"nose/lib/python#{version}/site-packages"
     resource("nose").stage do
-      system "python2", *Language::Python.setup_install_args(libexec/"nose")
+      system "python", *Language::Python.setup_install_args(libexec/"nose")
       (dest_path/"homebrew-numpy-nose.pth").write "#{nose_path}\n"
     end
 
     ENV.prepend_create_path "PYTHONPATH", buildpath/"tools/lib/python#{version}/site-packages"
     resource("Cython").stage do
-      system "python2", *Language::Python.setup_install_args(buildpath/"tools")
+      system "python", *Language::Python.setup_install_args(buildpath/"tools")
     end
 
-    system "python2", "setup.py",
+    system "python", "setup.py",
       "build", "--fcompiler=gnu95", "--parallel=#{ENV.make_jobs}",
       "install", "--prefix=#{prefix}",
       "--single-version-externally-managed", "--record=installed.txt"
@@ -63,7 +64,7 @@ class NumpyAT116 < Formula
   end
 
   test do
-    system "python2", "-c", <<~EOS
+    system "python", "-c", <<~EOS
       import numpy as np
       t = np.ones((3,3), int)
       assert t.sum() == 9


### PR DESCRIPTION
because we will remove the python@2 formula.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
