### PR TITLE
kubebuilder: remove gopath

### DIFF
--- a/Formula/kubebuilder.rb
+++ b/Formula/kubebuilder.rb
@@ -17,16 +17,9 @@ class Kubebuilder < Formula
   depends_on "go"
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/sigs.k8s.io/kubebuilder"
-    dir.install buildpath.children - [buildpath/".brew_home"]
-
-    cd dir do
-      # Make binary
-      system "make", "build"
-      bin.install "bin/kubebuilder"
-      prefix.install_metafiles
-    end
+    system "make", "build"
+    bin.install "bin/kubebuilder"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.