### PR TITLE
amap: update homepage and url

### DIFF
--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -1,7 +1,7 @@
 class Amap < Formula
   desc "Perform application protocol detection"
-  homepage "https://www.thc.org/thc-amap/"
-  url "https://www.thc.org/releases/amap-5.4.tar.gz"
+  homepage "https://github.com/vanhauser-thc/THC-Archive"
+  url "https://github.com/vanhauser-thc/THC-Archive/raw/master/Tools/amap-5.4.tar.gz"
   mirror "https://downloads.sourceforge.net/project/slackbuildsdirectlinks/amap/amap-5.4.tar.gz"
   sha256 "a75ea58de75034de6b10b0de0065ec88e32f9e9af11c7d69edbffc4da9a5b059"
   revision 3


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current homepage now redirects to the [THC-Archive GitHub repo](https://github.com/vanhauser-thc/THC-Archive/), found in this commit.  The release archive is located in the `Tools` folder of that repo, so I've updated the archive URL to use that.