### PR TITLE
amdatu-bootstrap: update homepage

### DIFF
--- a/Formula/amdatu-bootstrap.rb
+++ b/Formula/amdatu-bootstrap.rb
@@ -1,6 +1,6 @@
 class AmdatuBootstrap < Formula
   desc "Bootstrapping OSGi development"
-  homepage "https://www.amdatu.com/bootstrap/intro.html"
+  homepage "https://bitbucket.org/amdatuadm/amdatu-bootstrap/"
   url "https://bitbucket.org/amdatuadm/amdatu-bootstrap/downloads/bootstrap-bin-r9.zip"
   sha256 "937ef932a740665439ea0118ed417ff7bdc9680b816b8b3c81ecfd6d0fc4773b"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current homepage doesn't resolve anymore (it was removed around March/April 2018), so I've switched to using the Bitbucket repo as the homepage.

For what it's worth, there hasn't been a commit since 2015-12-19 (current release was 2015-12-09), and there have only been 9 installs over the past 30 days (62 over the past 365).  The Amdatu website doesn't seem to reference Amdatu Bootstrap at all anymore, so it seems like they've moved on.  If you think it's better to just delete this formula, I can reformulate this PR to do that instead.