### PR TITLE
volatility: use system Python 2

### DIFF
--- a/Formula/volatility.rb
+++ b/Formula/volatility.rb
@@ -5,7 +5,7 @@ class Volatility < Formula
   homepage "https://github.com/volatilityfoundation/volatility"
   url "https://github.com/volatilityfoundation/volatility/archive/2.6.1.tar.gz"
   sha256 "a8dfdbdb2aaa0885387b709b821bb8250e698086fb32015bc2896ea55f359058"
-  revision 1
+  revision 2
   head "https://github.com/volatilityfoundation/volatility.git"
 
   bottle do
@@ -17,8 +17,10 @@ class Volatility < Formula
 
   depends_on "freetype"
   depends_on "jpeg"
-  depends_on "python@2" # does not support Python 3
   depends_on "yara"
+  # Python 3 support will come with volatility 3
+  # https://github.com/volatilityfoundation/volatility3
+  uses_from_macos "python@2"
 
   resource "distorm3" do
     url "https://files.pythonhosted.org/packages/2c/e3/84a3a99904c368daa1de5e85a6e9cc07189e7f66cb1338a9ebf93fa051bd/distorm3-3.4.1.tar.gz"


### PR DESCRIPTION
Because we will remove the python@2 formula end of 2019.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
