### PR TITLE
nef 0.5.2 (new formula)

### DIFF
--- a/Formula/nef.rb
+++ b/Formula/nef.rb
@@ -1,0 +1,62 @@
+class Nef < Formula
+  desc "💊 steroids for Xcode Playgrounds"
+  homepage "https://github.com/bow-swift/nef"
+  url "https://github.com/bow-swift/nef/archive/0.5.2.tar.gz"
+  sha256 "050181c1e541e54428f8214092b17a321fb1e4f2460ae2bd8115063637244b02"
+
+  depends_on :xcode => "11.0"
+
+  def version
+    "0.5.2"
+  end
+
+  def install
+    build_project
+
+    bin.install "./bin/nef"
+    bin.install "./bin/nef-common"
+    bin.install "./bin/nefc"
+    bin.install "./bin/nef-playground"
+    bin.install "./bin/nef-markdown-page"
+    bin.install "./bin/nef-markdown"
+    bin.install "./bin/nef-jekyll-page"
+    bin.install "./bin/nef-jekyll"
+    bin.install "./bin/nef-carbon-page"
+    bin.install "./bin/nef-carbon"
+    bin.install "./bin/nef-playground-book"
+  end
+
+  def build_project
+    system "swift", "build", "--disable-sandbox", "--package-path", "project", "--configuration", "release", "--build-path", "release"
+    cp "./release/x86_64-apple-macosx/release/nef-markdown-page", "./bin"
+    cp "./release/x86_64-apple-macosx/release/nef-jekyll-page", "./bin"
+    cp "./release/x86_64-apple-macosx/release/nef-carbon-page", "./bin"
+    cp "./release/x86_64-apple-macosx/release/nef-playground-book", "./bin"
+  end
+
+  test do
+    project = "#{project_path}"
+    chdir(project)
+
+    tests = shell_output("swift test --disable-sandbox --package-path #{project}/project --configuration debug --build-path tests 2>&1")
+    nef = shell_output("#{bin}/nef --version")
+    markdown = shell_output("#{bin}/nef markdown --project #{project}/Documentation.app --output #{HOMEBREW_TEMP}/nef-test-markdown")
+    jekyll = shell_output("#{bin}/nef jekyll --project #{project}/Documentation.app --main-page #{project}/Documentation.app/jekyll/Home.md --output #{HOMEBREW_TEMP}/nef-test-jekyll")
+
+    assert_match "'All tests' passed", tests
+    assert_match "#{version}", nef
+    assert_match "✅", markdown
+    assert_match "✅", jekyll
+  end
+
+  def project_path
+    chdir("#{HOMEBREW_TEMP}")
+    url = "https://github.com/bow-swift/nef/archive/#{version}.tar.gz"
+    cleanUp = shell_output("rm -rf #{HOMEBREW_TEMP}/nef*")
+    donwloadProject = shell_output("curl -L #{url} --output #{HOMEBREW_TEMP}/nef-#{version}.tar.gz")
+    unzipProject = shell_output("tar xzf #{HOMEBREW_TEMP}/nef-#{version}.tar.gz")
+
+    "#{HOMEBREW_TEMP}/nef-#{version}"
+  end
+
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`nef` is a toolset to ease the creation of documentation in the form of Xcode Playgrounds. It provides compile-time verification of documentation, exports it in Markdown format that can be consumed by Jekyll to generate websites, and export Carbon snippets for a given Xcode Playground.

### Features

💡 Eases the creation of Xcode Playgrounds with support for third party libraries.

💡 Compiles Xcode Playgrounds with support for 3rd-party libraries from the command line.

💡 Builds a Playground Book for iPad with external dependencies defined in a Swift Package.

💡 Generates Markdown project from Xcode Playground.

💡 Generates Markdown files that can be consumed from Jekyll to create a microsite.

💡 Export Carbon code snippets for given Xcode Playgrounds.

&nbsp;

We tried to add nef in the past to homebrew-core in a premature version; today (a half year later) we have reached out 100 stars and we have consolidated our tool in the Xcode Playground market. We think it is a great time to jump into the official repo.
