### PR TITLE
pwntools: use system python 2

### DIFF
--- a/Formula/pwntools.rb
+++ b/Formula/pwntools.rb
@@ -5,7 +5,7 @@ class Pwntools < Formula
   homepage "https://github.com/Gallopsled/pwntools"
   url "https://github.com/Gallopsled/pwntools/archive/3.12.2.tar.gz"
   sha256 "8e048b514ee449b4c76f4eba1b4fcd48fdefd1bf04ae4c62b44e984923d2e979"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,7 +16,8 @@ class Pwntools < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@2" # does not support Python 3
+  # Has a 4.0 beta release with Python 3 support
+  uses_from_macos "python@2"
 
   conflicts_with "moreutils", :because => "Both install `errno` binaries"
 


### PR DESCRIPTION
Because we will remove the python@2 formula end of 2019.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
