### PR TITLE
bash-completion@2: update caveat for v1

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -36,7 +36,7 @@ class BashCompletionAT2 < Formula
       [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
 
     If you'd like to use existing homebrew v1 completions, add the following before the previous line:
-      export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
+      export BASH_COMPLETION_COMPAT_DIR="#{etc}/bash_completion.d"
   EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As you can see, old caveat caused some sort of confusion among users, all because of hardcoded path:
https://github.com/Homebrew/homebrew-core/pull/47527
https://github.com/scop/bash-completion/issues/374

That should fix it.