### PR TITLE
launch_socket_server 2.0.0

### DIFF
--- a/Formula/launch_socket_server.rb
+++ b/Formula/launch_socket_server.rb
@@ -1,0 +1,60 @@
+class LaunchSocketServer < Formula
+  desc "Bind to privileged ports without running a server as root"
+  homepage "https://github.com/mistydemeo/launch_socket_server"
+  url "https://github.com/mistydemeo/launch_socket_server/archive/v2.0.0.tar.gz"
+  sha256 "507184544d170dab63e6112198212033aaa84edf0e092c1dfe641087f092f365"
+  head "https://github.com/mistydemeo/launch_socket_server.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  plist_options :startup => true
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>KeepAlive</key>
+          <true/>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_sbin}/launch_socket_server</string>
+            <string>-</string>
+          </array>
+          <key>Sockets</key>
+          <dict>
+            <key>Socket</key>
+            <dict>
+              <key>SockNodeName</key>
+              <string>0.0.0.0</string>
+              <key>SockServiceName</key>
+              <string>80</string>
+            </dict>
+          </dict>
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>LAUNCH_PROGRAM_TCP_ADDRESS</key>
+            <string>127.0.0.1:8080</string>
+          </dict>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/launch_socket_server.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/launch_socket_server.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    assert_includes shell_output("#{opt_sbin}/launch_socket_server 2>&1; true"), "usage: #{opt_sbin}/launch_socket_server"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This restores `launch_socket_server`, which was deleted in #47838. In that PR, it was deleted because it was believed to be broken due to its test failing; in actuality, it turned out that its `brew test` block was buggy, but that the program itself works.

It turns out that our current sandbox implementation prevents the program from either loading new launch daemons or from binding to these ports; it's not quite clear which. The result is that the test, which once worked, now fails. We don't really have a way to fix the test, so I've gone for an alternate implementation similar to other server-based software we run. See some discussion here: https://github.com/Homebrew/homebrew-core/pull/47510#issuecomment-565776221

If there's concern over the source repo being archived, I'm happy to take over its maintenance burden. My company uses this software heavily so I'm very motivated to keep it working!

cc @iwittkau, @chenrui333 