### PR TITLE
piknik: fix test on high sierra

### DIFF
--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -70,6 +70,7 @@ class Piknik < Formula
       exec "#{bin}/piknik", "-server", "-config", conffile
     end
     begin
+      sleep 1
       IO.popen([{}, "#{bin}/piknik", "-config", conffile, "-copy"], "w+") do |p|
         p.write "test"
       end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the test on High Sierra with Go 1.13.5, tested locally, related to https://github.com/Homebrew/homebrew-core/pull/47510

Somehow piknik needs more time to start on High Sierra with go 1.13.5