### PR TITLE
opencascade 7.4.0: add RapidJSON dependency required by glTF reader

### DIFF
--- a/Formula/opencascade.rb
+++ b/Formula/opencascade.rb
@@ -4,6 +4,7 @@ class Opencascade < Formula
   url "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_4_0;sf=tgz"
   version "7.4.0"
   sha256 "655da7717dac3460a22a6a7ee68860c1da56da2fec9c380d8ac0ac0349d67676"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,6 +16,7 @@ class Opencascade < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "rapidjson" => :build
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "tbb"
@@ -22,10 +24,13 @@ class Opencascade < Formula
   def install
     system "cmake", ".",
                     "-DUSE_FREEIMAGE=ON",
+                    "-DUSE_RAPIDJSON=ON",
                     "-DUSE_TBB=ON",
                     "-DINSTALL_DOC_Overview=ON",
                     "-D3RDPARTY_FREEIMAGE_DIR=#{Formula["freeimage"].opt_prefix}",
                     "-D3RDPARTY_FREETYPE_DIR=#{Formula["freetype"].opt_prefix}",
+                    "-D3RDPARTY_RAPIDJSON_DIR=#{Formula["rapidjson"].opt_prefix}",
+                    "-D3RDPARTY_RAPIDJSON_INCLUDE_DIR=#{Formula["rapidjson"].opt_include}",
                     "-D3RDPARTY_TBB_DIR=#{Formula["tbb"].opt_prefix}",
                     "-D3RDPARTY_TCL_DIR:PATH=#{MacOS.sdk_path_if_needed}/usr",
                     "-D3RDPARTY_TCL_INCLUDE_DIR=#{MacOS.sdk_path_if_needed}/usr/include",


### PR DESCRIPTION
Optional RapidJSON dependency introduced with OCCT 7.4.0 release.

Note that I haven't checked the formula - will do it later if there will be nobody else close to mac to check.