### PR TITLE
piknik: listen to 127.0.0.1 instead of 0.0.0.0 in the test

### DIFF
--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -64,7 +64,7 @@ class Piknik < Formula
     conffile = testpath/"testconfig.toml"
 
     genkeys = shell_output("#{bin}/piknik -genkeys")
-    lines = genkeys.lines.grep(/\s+=\s+/).map { |x| x.gsub(/\s+/, " ").gsub(/#.*/, "") }.uniq
+    lines = genkeys.lines.grep(/\s+=\s+/).map { |x| x.gsub(/\s+/, " ").gsub(/#.*/, "").gsub("0.0.0.0", "127.0.0.1") }.uniq
     conffile.write lines.join("\n")
     pid = fork do
       exec "#{bin}/piknik", "-server", "-config", conffile


### PR DESCRIPTION
The test for the `piknik` formula starts a server listening to `0.0.0.0`, which is an issue on a machine with the firewall being activated.

This change simply uses `127.0.0.1` instead.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
