### PR TITLE
libpq: enable auth drivers

### DIFF
--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -3,6 +3,7 @@ class Libpq < Formula
   homepage "https://www.postgresql.org/docs/12/libpq.html"
   url "https://ftp.postgresql.org/pub/source/v12.1/postgresql-12.1.tar.bz2"
   sha256 "a09bf3abbaf6763980d0f8acbb943b7629a8b20073de18d867aecdb7988483ed"
+  revision 1
 
   bottle do
     sha256 "e38eeb2551409bd6f85fac83f04fe73a794a040c155a75dafe56d6f8ce031494" => :catalina
@@ -17,6 +18,7 @@ class Libpq < Formula
   def install
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
+                          "--with-gssapi",
                           "--with-openssl",
                           "--libdir=#{opt_lib}",
                           "--includedir=#{opt_include}"
@@ -31,6 +33,8 @@ class Libpq < Formula
     system "make", "-C", "src/bin", "install", *dirs
     system "make", "-C", "src/include", "install", *dirs
     system "make", "-C", "src/interfaces", "install", *dirs
+    system "make", "-C", "src/common", "install", *dirs
+    system "make", "-C", "src/port", "install", *dirs
     system "make", "-C", "doc", "install", *dirs
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Users found that our bindings based on libpq didn't support all auth methods. This PR enables the same drivers as used in the [postgresql server formula](https://github.com/homebrew/homebrew-core/blob/master/Formula/postgresql.rb#L36-L43).

The relevant source file is [fe-auth.c](https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-auth.c) where the `ENABLE_GSS` macro switches on most of the auth methods.

Also added `libpgcommon.a` and `libpgport.a` to the installation because `libpq.a` depends on symbols in those libraries.