### PR TITLE
flint 2.5.2 (new formula)

### DIFF
--- a/Formula/flint.rb
+++ b/Formula/flint.rb
@@ -1,0 +1,49 @@
+class Flint < Formula
+  desc "C library for number theory"
+  homepage "http://flintlib.org"
+  url "http://flintlib.org/flint-2.5.2.tar.gz"
+  sha256 "cbf1fe0034533c53c5c41761017065f85207a1b770483e98b2392315f6575e87"
+  head "https://github.com/wbhart/flint2.git", :branch => "trunk"
+
+  depends_on "gmp"
+  depends_on "mpfr"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS
+      #include <stdlib.h>
+      #include <stdio.h>
+
+      #include <flint/flint.h>
+      #include <flint/fmpz_mod_poly.h>
+
+      int main(int argc, char* argv[])
+      {
+          fmpz_t n;
+          fmpz_mod_poly_t x, y;
+
+          fmpz_init_set_ui(n, 7);
+          fmpz_mod_poly_init(x, n);
+          fmpz_mod_poly_init(y, n);
+          fmpz_mod_poly_set_coeff_ui(x, 3, 5);
+          fmpz_mod_poly_set_coeff_ui(x, 0, 6);
+          fmpz_mod_poly_sqr(y, x);
+          fmpz_mod_poly_print(x); flint_printf("\\n");
+          fmpz_mod_poly_print(y); flint_printf("\\n");
+          fmpz_mod_poly_clear(x);
+          fmpz_mod_poly_clear(y);
+          fmpz_clear(n);
+
+          return EXIT_SUCCESS;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}/flint", "-L#{lib}", "-L#{Formula["gmp"].lib}",
+           "-lflint", "-lgmp", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

FLINT is an important library for computational number theory. The formula was lost during the homebrew/science merger; I'm reviving it ([homebrew/science formula](https://github.com/Homebrew/homebrew-science/blob/d2b0623922184c0e8e47828a73fdea3b1dc9c70e/flint.rb)) — fixed it up and added a caveat.

Curiously, there was another attempt to revive flint just a few months ago: #43425 (it was eventually closed due to lack of activity). CC @alebcay since I'm not sure about the point of setting `DYLD_LIBRARY_PATH`.