### PR TITLE
futhark: use frozen dependencies

### DIFF
--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -5,8 +5,8 @@ class Futhark < Formula
 
   desc "Data-parallel functional programming language"
   homepage "https://futhark-lang.org/"
-  url "https://github.com/diku-dk/futhark/archive/v0.13.1.tar.gz"
-  sha256 "a0f33d7605fad80998c9b8dae6678eb8932316235a4ac6e5993f3f2858987719"
+  url "https://github.com/diku-dk/futhark/archive/v0.13.2.tar.gz"
+  sha256 "51b1c4bf3cac469dabbf66955049480273411cf5eb50da235f0a4c96cffe2b8e"
   head "https://github.com/diku-dk/futhark.git"
 
   bottle do
@@ -22,6 +22,12 @@ class Futhark < Formula
 
   def install
     cabal_sandbox do
+      # Futhark provides a cabal.project.freeze for pinning Cabal
+      # dependencies, but this is only picked up by "v2" builds, and
+      # as of this writing, Homebrew still does sandboxed "v1" builds.
+      # Fortunately, the file formats seem to be compatible.
+      mv "cabal.project.freeze", "cabal.config"
+
       cabal_install "hpack"
       system "./.cabal-sandbox/bin/hpack"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Futhark provides a cabal.project.freeze for pinning Cabal dependencies, but this is only picked up by "v2" builds, and as of this writing, Homebrew still does sandboxed "v1" builds. Fortunately, the file formats seem to be compatible, so just copy `cabal.project.freeze` to `cabal.config` before the build.

With this fix, #47942 should work (after rebasing).