### PR TITLE
nushell: Sets `rust` as a build-only dependency

### DIFF
--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -12,8 +12,9 @@ class Nushell < Formula
     sha256 "0a462f17a6f2c1fdab7fd605da8b24d1e30e83fdfd7834756f054d25460c1543" => :high_sierra
   end
 
+  depends_on "rust" => :build
+
   depends_on "openssl@1.1"
-  depends_on "rust"
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`rust` is not needed to run nushell, only build it, this PR sets `rust` as a build-only dependency.

I have also test running `brew install nushell`(without --build-from-source) as this is what this change is impacting