### PR TITLE
texlab: Fix test for case-insensitive filesystems

### DIFF
--- a/Formula/texlab.rb
+++ b/Formula/texlab.rb
@@ -19,7 +19,7 @@ class Texlab < Formula
   end
 
   test do
-    require "Open3"
+    require "open3"
 
     begin
       stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/texlab")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- On Linux, `require 'Open3'` failed, but `require 'open3'` succeeded.
- So, upstream this change just in case and to make merges easier.