### PR TITLE
nushell: update to 0.7.0 and add stable features

### DIFF
--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -17,7 +17,7 @@ class Nushell < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    system "cargo", "install", "--features", "starship-prompt", "--locked", "--root", prefix, "--path", "."
   end
 
   test do

--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -1,8 +1,8 @@
 class Nushell < Formula
   desc "Modern shell for the GitHub era"
   homepage "https://www.nushell.sh"
-  url "https://github.com/nushell/nushell/archive/0.6.1.tar.gz"
-  sha256 "3f7878df7d77fe330e6840428845800d9eefc2ad8248617c42004030ecf527f0"
+  url "https://github.com/nushell/nushell/archive/0.7.0.tar.gz"
+  sha256 "9cfb6be335f7a06ccaf7cc2a06075a23ed6e2e2fdd6ea7fbc165a7d4a30990f9"
   head "https://github.com/nushell/nushell.git"
 
   bottle do
@@ -17,10 +17,10 @@ class Nushell < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "cargo", "install", "--features", "starship-prompt", "--locked", "--root", prefix, "--path", "."
+    system "cargo", "install", "--features", "stable", "--locked", "--root", prefix, "--path", "."
   end
 
   test do
-    assert_equal "#{Dir.pwd}> 2\n#{Dir.pwd}> ", pipe_output("#{bin}/nu", 'echo \'{"foo":1, "bar":2}\' | from-json | get bar | echo $it')
+    assert_equal "\n~ \n❯ 2\n\n~ \n❯ ", pipe_output("#{bin}/nu", 'echo \'{"foo":1, "bar":2}\' | from-json | get bar | echo $it')
   end
 end


### PR DESCRIPTION
This PR was originally created to add support for the [starship prompt](https://starship.rs/) feature, but soon after creating it I realized that 0.7.0 had been released, so I updated the PR to upgrade the formula and enable the stable features (which [include the starship prompt](https://github.com/nushell/nushell/blob/master@%7B2019-12-19T00:00:00Z%7D/Cargo.toml#L139)).

/cc @chenrui333 who has been involved in previous Nushell PRs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
