### PR TITLE
mage: remove gopath

### DIFF
--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -17,13 +17,9 @@ class Mage < Formula
   depends_on "go"
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/magefile/mage").install buildpath.children
-    cd "src/github.com/magefile/mage" do
-      system "go", "run", "bootstrap.go"
-      bin.install buildpath/"bin/mage"
-      prefix.install_metafiles
-    end
+    system "go", "run", "bootstrap.go"
+    bin.install buildpath/"bin/mage"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.