### PR TITLE
node_exporter: remove gopath

### DIFF
--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -15,19 +15,13 @@ class NodeExporter < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    (buildpath/"src/github.com/prometheus/node_exporter").install buildpath.children
-    cd "src/github.com/prometheus/node_exporter" do
-      ldflags = %W[
-        -X github.com/prometheus/common/version.Version=#{version}
-        -X github.com/prometheus/common/version.BuildUser=Homebrew
-      ]
-      system "go", "build", "-o", bin/"node_exporter",
-           "-ldflags", ldflags.join(" "),
-           "github.com/prometheus/node_exporter"
-      prefix.install_metafiles
-    end
+    ldflags = %W[
+      -X github.com/prometheus/common/version.Version=#{version}
+      -X github.com/prometheus/common/version.BuildUser=Homebrew
+    ]
+    system "go", "build", "-ldflags", ldflags.join(" "), "-trimpath",
+           "-o", bin/"node_exporter"
+    prefix.install_metafiles
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.