### PR TITLE
ungit: fix test on Mojave

### DIFF
--- a/Formula/ungit.rb
+++ b/Formula/ungit.rb
@@ -21,8 +21,6 @@ class Ungit < Formula
   end
 
   test do
-    require "nokogiri"
-
     server = TCPServer.new(0)
     port = server.addr[1]
     server.close
@@ -31,7 +29,7 @@ class Ungit < Formula
       exec bin/"ungit", "--no-launchBrowser", "--port=#{port}", "--autoShutdownTimeout=6000"
     end
     sleep 5
-    assert_match "ungit", Nokogiri::HTML(shell_output("curl -s 127.0.0.1:#{port}/")).at_css("title").text
+    assert_includes shell_output("curl -s 127.0.0.1:#{port}/"), "<title>ungit</title>"
   ensure
     if ppid
       Process.kill("TERM", ppid)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, `ungit` test fails on Mojave with an error:
```
  LoadError: cannot load such file -- nokogiri
```

This PR replaces usage of nokogiri with a simple string inclusion check.