### PR TITLE
infer: use system Python 2

### DIFF
--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -24,6 +24,7 @@ class Infer < Formula
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "sqlite"
+  uses_from_macos "python@2" # python@2 dependency will be removed in https://github.com/facebook/infer/issues/934
 
   # Remove camlp4 dependency, which is deprecated
   # Addressed in 0.18.x


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`infer` contains several Python scripts which point to `#!/usr/bin/env python2.7` (in `lib/infer/infer/lib/python/`). And since we're working on `python@2` removal, this PR adds missing system dependency.

There is an upstream issue for  Python 3 migration / rewriting scripts in `ocalm` https://github.com/facebook/infer/issues/934