### PR TITLE
shared-mime-info: repair old libheif postinstalls

### DIFF
--- a/Formula/shared-mime-info.rb
+++ b/Formula/shared-mime-info.rb
@@ -46,6 +46,9 @@ class SharedMimeInfo < Formula
     global_mime = HOMEBREW_PREFIX/"share/mime"
     cellar_mime = share/"mime"
 
+    # Remove bad links created by old libheif postinstall
+    rm_rf global_mime if global_mime.symlink?
+
     if !cellar_mime.exist? || !cellar_mime.symlink?
       rm_rf cellar_mime
       ln_sf global_mime, cellar_mime


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Repair old `libheif` postinstalls that created a bad `/usr/local/share/mime` link to libheif's Cellar.

Needed for https://github.com/Homebrew/homebrew-core/pull/47795