### PR TITLE
aspell: explicitly depend on ncurses

### DIFF
--- a/Formula/aspell.rb
+++ b/Formula/aspell.rb
@@ -545,6 +545,8 @@ class Aspell < Formula
     sha256 "3fa255cd0b20e6229a53df972fd3c5ed8481db11cfd0347dd3da629bbb7a6796"
   end
 
+  uses_from_macos "ncurses"
+
   # const problems with llvm: https://www.freebsd.org/cgi/query-pr.cgi?pr=180565&cat=
   patch :DATA
 


### PR DESCRIPTION
Required for linuxbrew, otherwise won't link to ncurses

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
It works on linuxbrew, but on OSX it fails as follows - help on how to resolve would be awesome: 

```
➜  Formula git:(master) brew audit --strict aspell                                                                            <<<
Traceback (most recent call last):
        2: from /Users/idvorkin/.gem/ruby/2.6.0/bin/bundle:23:in `<main>'
        1: from /usr/local/Cellar/ruby/2.6.3/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
/usr/local/Cellar/ruby/2.6.3/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by
your /usr/local/Homebrew/Library/Homebrew/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.2`
Error: failed to run `/Users/idvorkin/.gem/ruby/2.6.0/bin/bundle install`!
```
-----
