### PR TITLE
prototool: remove gopath

### DIFF
--- a/Formula/prototool.rb
+++ b/Formula/prototool.rb
@@ -14,18 +14,13 @@ class Prototool < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/uber/prototool"
-    dir.install buildpath.children
-    cd dir do
-      system "make", "brewgen"
-      cd "brew" do
-        bin.install "bin/prototool"
-        bash_completion.install "etc/bash_completion.d/prototool"
-        zsh_completion.install "etc/zsh/site-functions/_prototool"
-        man1.install Dir["share/man/man1/*.1"]
-        prefix.install_metafiles
-      end
+    system "make", "brewgen"
+    cd "brew" do
+      bin.install "bin/prototool"
+      bash_completion.install "etc/bash_completion.d/prototool"
+      zsh_completion.install "etc/zsh/site-functions/_prototool"
+      man1.install Dir["share/man/man1/*.1"]
+      prefix.install_metafiles
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove `GOPATH` as formula supports Go modules.

Relates to #47627.