### PR TITLE
xrootd: `uses_from_macos` "libxml2" and "zlib"

### DIFF
--- a/Formula/xrootd.rb
+++ b/Formula/xrootd.rb
@@ -15,6 +15,8 @@ class Xrootd < Formula
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
   depends_on "readline"
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
 
   def install
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

(Built and tested on Linux.)

-----

This fixes the following build failure on Linux (Ubuntu 16.04.6 LTS):
```
/tmp/xrootd-20191222-2243-932lew/xrootd-4.11.1/src/XrdXml/XrdXmlRdrXml2.cc:36:30: fatal error: libxml/xmlreader.h: No such file or directory
compilation terminated.
src/CMakeFiles/XrdXml.dir/build.make:156: recipe for target 'src/CMakeFiles/XrdXml.dir/XrdXml/XrdXmlRdrXml2.cc.o' failed
make[2]: *** [src/CMakeFiles/XrdXml.dir/XrdXml/XrdXmlRdrXml2.cc.o] Error 1
```
Like #44269, #46891 and #47111, I used `uses_from_macos "libxml2"`. I also added `uses_from_macos "zlib"`, which is already in the current [xrootd.rb in linuxbrew-core](https://github.com/Homebrew/linuxbrew-core/blob/45c29a14f37fc8e23d9f12890dc578f0f14948b3/Formula/xrootd.rb).