### PR TITLE
python@3.8: Parallelise compilation

### DIFF
--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -111,7 +111,8 @@ class PythonAT38 < Formula
     args << "CPPFLAGS=#{cppflags.join(" ")}" unless cppflags.empty?
 
     system "./configure", *args
-    system "make"
+    ncpu = `sysctl -n hw.ncpu`.strip
+    system "make", "--jobs=#{ncpu}"
 
     ENV.deparallelize do
       # Tell Python not to install into /Applications (default for framework builds)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Let Python compilation use all available CPUs, which should speed up install time