### PR TITLE
Use packaged hpack for futhark, purescript, and taskell.

### DIFF
--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -18,21 +18,19 @@ class Futhark < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
+  depends_on "hpack" => :build
   depends_on "sphinx-doc" => :build
 
   def install
-    cabal_sandbox do
-      # Futhark provides a cabal.project.freeze for pinning Cabal
-      # dependencies, but this is only picked up by "v2" builds, and
-      # as of this writing, Homebrew still does sandboxed "v1" builds.
-      # Fortunately, the file formats seem to be compatible.
-      mv "cabal.project.freeze", "cabal.config"
+    # Futhark provides a cabal.project.freeze for pinning Cabal
+    # dependencies, but this is only picked up by "v2" builds, and
+    # as of this writing, Homebrew still does sandboxed "v1" builds.
+    # Fortunately, the file formats seem to be compatible.
+    mv "cabal.project.freeze", "cabal.config"
 
-      cabal_install "hpack"
-      system "./.cabal-sandbox/bin/hpack"
+    system "hpack"
 
-      install_cabal_package :using => ["alex", "happy"]
-    end
+    install_cabal_package :using => ["alex", "happy"]
 
     system "make", "-C", "docs", "man"
     man1.install Dir["docs/_build/man/*.1"]

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -19,15 +19,16 @@ class Purescript < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc@8.6" => :build
 
-  def install
-    cabal_sandbox do
-      if build.head?
-        cabal_install "hpack"
-        system "./.cabal-sandbox/bin/hpack"
-      end
+  if build.head?
+    depends_on "hpack" => :build
+  end
 
-      install_cabal_package "-f", "release", :using => ["alex", "happy-1.19.9"]
+  def install
+    if build.head?
+      system "hpack"
     end
+
+    install_cabal_package "-f", "release", :using => ["alex", "happy-1.19.9"]
   end
 
   test do

--- a/Formula/taskell.rb
+++ b/Formula/taskell.rb
@@ -17,13 +17,11 @@ class Taskell < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
+  depends_on "hpack" => :build
 
   def install
-    cabal_sandbox do
-      cabal_install "hpack"
-      system "./.cabal-sandbox/bin/hpack"
-      install_cabal_package
-    end
+    system "hpack"
+    install_cabal_package
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Some Haskell packages manually install the `hpack` tool during building.  Now that `hpack` is in Homebrew, we can use the package instead.  The main short-term advantage is shorter build times.  Long time, I guess it's more structured this way.

Note that the `hadolint` package does not currently build, even without this change (which will likely cause the CI for this PR to fail).  This is because of the usual problem with Haskell packages not pinning their dependencies, in this case because a dependency of `hadolint` (ShellCheck on Hackage) demands a Cabal older than 3.0, and Homebrew provides 3.0.