### PR TITLE
mintest 5.1.0 with required patch

### DIFF
--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -3,12 +3,18 @@ class Minetest < Formula
   homepage "https://www.minetest.net/"
 
   stable do
-    url "https://github.com/minetest/minetest/archive/5.0.1.tar.gz"
-    sha256 "aa771cf178ad1b436d5723e5d6dd24e42b5d56f1cfe9c930f6426b7f24bb1635"
+    url "https://github.com/minetest/minetest/archive/5.1.0.tar.gz"
+    sha256 "ca53975eecf6a39383040658f41d697c8d7f8d5fe9176460f564979c73b53906"
+
+    # This patch is already merged in master and it should be removed when new version of mintest is released
+    patch do
+      url "https://patch-diff.githubusercontent.com/raw/minetest/minetest/pull/9064.diff"
+      sha256 "ec85ad198f1db811cde5b543ce741f219abdf6038dee7f72b426e3488632b5da"
+    end
 
     resource "minetest_game" do
-      url "https://github.com/minetest/minetest_game/archive/5.0.1.tar.gz"
-      sha256 "965d2cf3ac8c822bc9e60fb8f508182fb2f24dde46f46b000caf225ebe2ec519"
+      url "https://github.com/minetest/minetest_game/archive/5.1.0.tar.gz"
+      sha256 "f165fac0081bf4797cf9094282cc25034b2347b3ea94e6bb8d9329c5ee63f41b"
     end
   end
 

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -8,8 +8,8 @@ class Minetest < Formula
 
     # This patch is already merged in master and it should be removed when new version of mintest is released
     patch do
-      url "https://patch-diff.githubusercontent.com/raw/minetest/minetest/pull/9064.diff"
-      sha256 "ec85ad198f1db811cde5b543ce741f219abdf6038dee7f72b426e3488632b5da"
+      url "https://github.com/minetest/minetest/pull/9064.patch"
+      sha256 "251217d2c44f53c37419260bc329c5c09fe590342ff2c1c3a4c5cb7192cea550"
     end
 
     resource "minetest_game" do

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -8,8 +8,8 @@ class Minetest < Formula
 
     # This patch is already merged in master and it should be removed when new version of mintest is released
     patch do
-      url "https://github.com/minetest/minetest/pull/9064.patch"
-      sha256 "251217d2c44f53c37419260bc329c5c09fe590342ff2c1c3a4c5cb7192cea550"
+      url "https://github.com/minetest/minetest/pull/9064.patch?full_index=1"
+      sha256 "78c5148ae5260bf2220ca18849c698e92c93e1c92b8f287135b293457c9ab6cd"
     end
 
     resource "minetest_game" do


### PR DESCRIPTION
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

-----

This PR should fix build issue for minetest 5.1.0

There is already a failing pull request for minetest 5.1.0 - here: #47322. 
The patch is taken from accepted pull request on the official minetest repository - here [https://github.com/minetest/minetest/pull/9064](https://github.com/minetest/minetest/pull/9064).

