### PR TITLE
phpunit 7.5.2

### DIFF
--- a/Formula/phpunit@7.5.rb
+++ b/Formula/phpunit@7.5.rb
@@ -1,0 +1,110 @@
+class PhpunitAT75 < Formula
+  desc "Programmer-oriented testing framework for PHP"
+  homepage "https://phpunit.de"
+  url "https://phar.phpunit.de/phpunit-7.5.2.phar"
+  sha256 "64682015804129b83e5dcfe5d1b9810d39f161a25ca1207ca8befe31204297d2"
+
+  bottle :unneeded
+
+  depends_on "php" => :test
+
+  def install
+    bin.install "phpunit-#{version}.phar" => "phpunit"
+  end
+
+  test do
+    (testpath/"src/autoload.php").write <<~EOS
+      <?php
+      spl_autoload_register(
+          function($class) {
+              static $classes = null;
+              if ($classes === null) {
+                  $classes = array(
+                      'email' => '/Email.php'
+                  );
+              }
+              $cn = strtolower($class);
+              if (isset($classes[$cn])) {
+                  require __DIR__ . $classes[$cn];
+              }
+          },
+          true,
+          false
+      );
+    EOS
+
+    (testpath/"src/Email.php").write <<~EOS
+      <?php
+        declare(strict_types=1);
+
+        final class Email
+        {
+            private $email;
+
+            private function __construct(string $email)
+            {
+                $this->ensureIsValidEmail($email);
+
+                $this->email = $email;
+            }
+
+            public static function fromString(string $email): self
+            {
+                return new self($email);
+            }
+
+            public function __toString(): string
+            {
+                return $this->email;
+            }
+
+            private function ensureIsValidEmail(string $email): void
+            {
+                if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            '"%s" is not a valid email address',
+                            $email
+                        )
+                    );
+                }
+            }
+        }
+    EOS
+
+    (testpath/"tests/EmailTest.php").write <<~EOS
+      <?php
+      declare(strict_types=1);
+
+      use PHPUnit\\Framework\\TestCase;
+
+      final class EmailTest extends TestCase
+      {
+          public function testCanBeCreatedFromValidEmailAddress(): void
+          {
+              $this->assertInstanceOf(
+                  Email::class,
+                  Email::fromString('user@example.com')
+              );
+          }
+
+          public function testCannotBeCreatedFromInvalidEmailAddress(): void
+          {
+              $this->expectException(InvalidArgumentException::class);
+
+              Email::fromString('invalid');
+          }
+
+          public function testCanBeUsedAsString(): void
+          {
+              $this->assertEquals(
+                  'user@example.com',
+                  Email::fromString('user@example.com')
+              );
+          }
+      }
+
+    EOS
+    assert_match /^OK \(3 tests, 3 assertions\)$/, shell_output("#{bin}/phpunit --bootstrap src/autoload.php tests/EmailTest")
+  end
+end

--- a/Formula/phpunit@7.5.rb
+++ b/Formula/phpunit@7.5.rb
@@ -6,6 +6,8 @@ class PhpunitAT75 < Formula
 
   bottle :unneeded
 
+keg_only :versioned_formula
+
   depends_on "php" => :test
 
   def install

--- a/Formula/phpunit@7.5.rb
+++ b/Formula/phpunit@7.5.rb
@@ -6,7 +6,7 @@ class PhpunitAT75 < Formula
 
   bottle :unneeded
 
-keg_only :versioned_formula
+  keg_only :versioned_formula
 
   depends_on "php" => :test
 

--- a/Formula/phpunit@7.rb
+++ b/Formula/phpunit@7.rb
@@ -1,4 +1,4 @@
-class PhpunitAT75 < Formula
+class PhpunitAT7 < Formula
   desc "Programmer-oriented testing framework for PHP"
   homepage "https://phpunit.de"
   url "https://phar.phpunit.de/phpunit-7.5.2.phar"


### PR DESCRIPTION
This pull request proposes to add the formula for PHPUnit 7.x to Homebrew, which would allow for installing either the 8.x version or the 7.x version, both of which are [actively supported](https://phpunit.de/supported-versions.html) by the maintainer, Sebastian Bergmann.

> The currently supported versions are PHPUnit 8 and PHPUnit 7. PHPUnit 9 will be released in February 2020.

Presently only the formula for PHPUnit 8 is available in Homebrew Core, so this addition allows for installing PHPUnit 7, if needed.

_Note: PHPUnit is among the Top 3,000 most active formula according to [Homebrew Analytics](https://formulae.brew.sh/analytics/) data, so having this package available will serve the needs of many._