### PR TITLE
Allow pony related bottles to run on CPUs older than the build machine

### DIFF
--- a/Formula/corral.rb
+++ b/Formula/corral.rb
@@ -15,7 +15,7 @@ class Corral < Formula
   depends_on "ponyc"
 
   def install
-    system "make", "prefix=#{prefix}", "install"
+    system "make", "arch=x86-64", "prefix=#{prefix}", "install"
   end
 
   test do

--- a/Formula/pony-stable.rb
+++ b/Formula/pony-stable.rb
@@ -16,7 +16,7 @@ class PonyStable < Formula
   depends_on "ponyc"
 
   def install
-    system "make", "prefix=#{prefix}", "install"
+    system "make", "arch=x86-64", "prefix=#{prefix}", "install"
   end
 
   test do

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -27,7 +27,7 @@ class Ponyc < Formula
   def install
     ENV.cxx11
     ENV["LLVM_CONFIG"] = "#{Formula["llvm@7"].opt_bin}/llvm-config"
-    system "make", "install", "verbose=1", "config=release",
+    system "make", "install", "verbose=1", "config=release", "arch=x86-64",
            "ponydir=#{prefix}", "prefix="
   end
 


### PR DESCRIPTION
By default, all Pony project makefiles optimize for the CPU of the machine
being built on unless the `arch` option is provided. Today, we had a user
with an older machine report that the Homebrew bottles didn't work for them.
They were encountering an illegal instruction exception.

This patch fixes all 3 Pony related formulas to stick to a basic x86-64 instruction
set.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
