### PR TITLE
sampler 1.1.0 (new formula)

### DIFF
--- a/Formula/sampler.rb
+++ b/Formula/sampler.rb
@@ -7,15 +7,10 @@ class Sampler < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/sqshq/sampler"
-    dir.install Dir["*"]
-    cd dir do
-      system "go", "build", "-o", bin/"sampler"
-    end
+    system "go", "build", "-o", bin/"sampler"
   end
 
   test do
-    system "#{bin}/sampler", "-v"
+    assert_includes "specify config file", shell_output("#{bin}/sampler")
   end
 end

--- a/Formula/sampler.rb
+++ b/Formula/sampler.rb
@@ -1,0 +1,21 @@
+class Sampler < Formula
+  desc "Tool for shell commands execution, visualization and alerting"
+  homepage "https://sampler.dev"
+  url "https://github.com/sqshq/sampler/archive/v1.1.0.tar.gz"
+  sha256 "8b60bc5c0f94ddd4291abc2b89c1792da424fa590733932871f7b5e07e7587f9"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/sqshq/sampler"
+    dir.install Dir["*"]
+    cd dir do
+      system "go", "build", "-o", bin/"sampler"
+    end
+  end
+
+  test do
+    system "#{bin}/sampler", "-v"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Please note that a previous version is available in `homebrew-cask`, see conversation here:
https://github.com/Homebrew/homebrew-cask/pull/67090

Now Sampler is licensed under an open-source license, and does not have any API interaction with  server side, so I'm ready to migrate it to `homebrew/core`.

I plan to submit MR to `homebrew-cask` to remove Sampler from there, once this one is merged.