### PR TITLE
libmodplug: use ENV.cxx instead of ENV.cc for test

### DIFF
--- a/Formula/libmodplug.rb
+++ b/Formula/libmodplug.rb
@@ -70,7 +70,7 @@ class Libmodplug < Formula
         }
       }
     EOS
-    system ENV.cc, "test_mod.cpp", "-L#{lib}", "-lmodplug", "-lstdc++", "-o", "test_mod"
+    system ENV.cxx, "test_mod.cpp", "-L#{lib}", "-lmodplug", "-o", "test_mod"
     system "./test_mod"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`ENV.cxx` should be used to compile a C++ sources, instead of using `ENV.cc` with `-lstdc++`.