### PR TITLE
solr: include contrib and dist in prefix

### DIFF
--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -14,7 +14,7 @@ class Solr < Formula
     bin.install %w[bin/solr bin/post bin/oom_solr.sh]
     pkgshare.install "bin/solr.in.sh"
     (var/"lib/solr").install "server/solr/README.txt", "server/solr/solr.xml", "server/solr/zoo.cfg"
-    prefix.install %w[example server]
+    prefix.install %w[contrib dist example server]
     libexec.install Dir["*"]
 
     # Fix the classpath for the post tool


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These directories include jar files which are part of a standard solr installation. Since the files are referred to relative to the prefix, there shouldn't be any conflicts with other jars.