### PR TITLE
python 3.8: migrate independent formulae

### DIFF
--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -5,6 +5,7 @@ class AwsElasticbeanstalk < Formula
   homepage "https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html"
   url "https://files.pythonhosted.org/packages/a6/26/e723d628db031a434466597f2310779a46d41e7548a83e04188c55aaa051/awsebcli-3.16.0.tar.gz"
   sha256 "03252f15f06f131e17644333cabe0221e446ff36fccad3d9434eeb7aef226c35"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class AwsElasticbeanstalk < Formula
     sha256 "31abd014c69a88ecf601a2afe0716de3e56c07f89709793bfa2d5b6ea21fdb1f" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "blessed" do
     url "https://files.pythonhosted.org/packages/51/c7/3af3ec267387d4a900a9e8f9a03a6c9068fb3c606c77bf2dd4558e1ea248/blessed-1.15.0.tar.gz"

--- a/Formula/awslogs.rb
+++ b/Formula/awslogs.rb
@@ -5,6 +5,7 @@ class Awslogs < Formula
   homepage "https://github.com/jorgebastida/awslogs"
   url "https://github.com/jorgebastida/awslogs/archive/0.11.0.tar.gz"
   sha256 "6258a121629cb872ee61fe78bf112753c8782c971524f0943a0e21f74d5e28bd"
+  revision 1
   head "https://github.com/jorgebastida/awslogs.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Awslogs < Formula
     sha256 "7abb54b867eaa110ef231718f22452cd663188037176de08ada4519835420282" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "boto3" do
     url "https://files.pythonhosted.org/packages/fd/50/3868735fae36e0f93216019551ca0f75b6cf9f933a55891244efefdcc3bd/boto3-1.9.62.tar.gz"

--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -6,7 +6,7 @@ class BandcampDl < Formula
   url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-12.tar.gz"
   version "0.0.8-12"
   sha256 "3252f52780f280ba18818d40cda1c89bdb99ee33d7911320ec2ce4c374df2d6b"
-  revision 1
+  revision 2
   head "https://github.com/iheanyi/bandcamp-dl.git"
 
   bottle do
@@ -18,7 +18,7 @@ class BandcampDl < Formula
     sha256 "d0ec20e1cdd9b41230d038ba8b93c4d09c185768bfc60c77a98c13a7f2465935" => :el_capitan
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "Unidecode" do
     url "https://files.pythonhosted.org/packages/9d/36/49d0ee152b6a1631f03a541532c6201942430060aa97fe011cf01a2cce64/Unidecode-1.0.22.tar.gz"

--- a/Formula/black.rb
+++ b/Formula/black.rb
@@ -5,6 +5,7 @@ class Black < Formula
   homepage "https://black.readthedocs.io/en/stable/"
   url "https://files.pythonhosted.org/packages/b0/dc/ecd83b973fb7b82c34d828aad621a6e5865764d52375b8ac1d7a45e23c8d/black-19.10b0.tar.gz"
   sha256 "c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Black < Formula
     sha256 "d26e50bbc697b595266542a1fc544e06057000537b11d17d1d1c6f9e158af0cd" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/48/69/d87c60746b393309ca30761f8e2b49473d43450b150cb08f3c6df5c11be5/appdirs-1.4.3.tar.gz"

--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -7,6 +7,7 @@ class Bumpversion < Formula
   # Ongoing maintenance discussion for the project, https://github.com/c4urself/bump2version/issues/86
   url "https://github.com/c4urself/bump2version/archive/v0.5.11.tar.gz"
   sha256 "f06c943b320033b3aa07958c99920474a54f1d0d76b12299fa67d59cdb17ab00"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,7 @@ class Bumpversion < Formula
     sha256 "5b40851a4fa852ef9b58c379aeba9ace20f6c3132c1caad41ce43307e79b68d9" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/bzt.rb
+++ b/Formula/bzt.rb
@@ -5,6 +5,7 @@ class Bzt < Formula
   homepage "https://gettaurus.org/"
   url "https://files.pythonhosted.org/packages/source/b/bzt/bzt-1.14.0.tar.gz"
   sha256 "849ff649d92bfc8077e5070036d801f6544d7189aaa1007d77e20a4aa4359ee9"
+  revision 1
   head "https://github.com/Blazemeter/taurus.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Bzt < Formula
     sha256 "c64cc21ad875a5e67879062af841dddac62f4787b1df560edd5752fe9d41e125" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "apiritif" do
     url "https://files.pythonhosted.org/packages/f6/25/acb55e688587b9d60a85713ba4d71ad5c4c85485fe4fb0af8e6792d181ae/apiritif-0.9.0.tar.gz"

--- a/Formula/cfn-lint.rb
+++ b/Formula/cfn-lint.rb
@@ -5,6 +5,7 @@ class CfnLint < Formula
   homepage "https://github.com/aws-cloudformation/cfn-python-lint/"
   url "https://github.com/aws-cloudformation/cfn-python-lint/archive/v0.26.2.tar.gz"
   sha256 "fff4b0a6f867308b5fa27b7e6cbd4e6bfa161b6a9edefc03835698c7c266a263"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class CfnLint < Formula
     sha256 "b1fadf87e056092b095e14d6a072e13df65f6b190b8392c17f4e9c9b1e66c76f" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/98/c3/2c227e66b5e896e15ccdae2e00bbc69aa46e9a8ce8869cc5fa96310bf612/attrs-19.3.0.tar.gz"

--- a/Formula/codespell.rb
+++ b/Formula/codespell.rb
@@ -5,6 +5,7 @@ class Codespell < Formula
   homepage "https://github.com/codespell-project/codespell"
   url "https://files.pythonhosted.org/packages/df/6f/764ca059e0eb06b69e1abed2c9a2cabe7dac72b336e2600615b38ea547a3/codespell-1.16.0.tar.gz"
   sha256 "bf3b7c83327aefd26fe718527baa9bd61016e86db91a8123c0ef9c150fa02de9"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Codespell < Formula
     sha256 "b77254f7aee7303a2edabb0a780a78407e7d8c55a44e6a5c75c9dd799beba12d" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/cookiecutter.rb
+++ b/Formula/cookiecutter.rb
@@ -5,6 +5,7 @@ class Cookiecutter < Formula
   homepage "https://github.com/audreyr/cookiecutter"
   url "https://github.com/audreyr/cookiecutter/archive/1.7.0.tar.gz"
   sha256 "975c578050a040e77c9a68a49ba420137d8da820d8ebf109342144f73a02722d"
+  revision 1
   revision 0
   head "https://github.com/audreyr/cookiecutter.git"
 
@@ -15,7 +16,7 @@ class Cookiecutter < Formula
     sha256 "1f60fbd7b821544830a73ec9fbbfd5a7d17e1d0a68b205f52b1f0c0f6481f74c" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "arrow" do
     url "https://files.pythonhosted.org/packages/a2/58/fd486f60594fe51afd1d2f2f0e8a80832d5b3d66c100caef24dadcdc95d7/arrow-0.15.4.tar.gz"

--- a/Formula/csvkit.rb
+++ b/Formula/csvkit.rb
@@ -5,6 +5,7 @@ class Csvkit < Formula
   homepage "https://csvkit.readthedocs.io/"
   url "https://files.pythonhosted.org/packages/66/d8/206e4da52bcf9cc29dfa3a93837b14b37ba42f58ccbd22a42a3b3ae0381a/csvkit-1.0.4.tar.gz"
   sha256 "1353a383531bee191820edfb88418c13dfe1cdfa9dd3dc46f431c05cd2a260a0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Csvkit < Formula
     sha256 "548d3e5d15d6b2f1cbb2043d9d83b8fff650fcea8875eff94f018f79432b607f" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "agate" do
     url "https://files.pythonhosted.org/packages/d4/1c/99fb34c81c68012c71e8d35a1f16a6b25952322e23c911c81327c8464be8/agate-1.6.1.tar.gz"

--- a/Formula/csvtomd.rb
+++ b/Formula/csvtomd.rb
@@ -5,7 +5,7 @@ class Csvtomd < Formula
   homepage "https://github.com/mplewis/csvtomd"
   url "https://files.pythonhosted.org/packages/2f/41/289bedde7fb32d817d5802eff68b99546842cb34df840665ec39b363f258/csvtomd-0.2.1.tar.gz"
   sha256 "d9fdf166c3c299ad5800b3cb1661f223b98237f38f22e9d253d45d321f70ec72"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,7 @@ class Csvtomd < Formula
     sha256 "d343b9087bbaf2b5a5be09f71d23ff9b07742cc262f5fd66b7b220d2db73b4b2" => :el_capitan
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/diceware.rb
+++ b/Formula/diceware.rb
@@ -5,6 +5,7 @@ class Diceware < Formula
   homepage "https://github.com/ulif/diceware"
   url "https://github.com/ulif/diceware/archive/v0.9.6.tar.gz"
   sha256 "ff55832e725abff212dec1a2cb6e1c3545ae782b5f49ec91ec870a2b50e1f0e8"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Diceware < Formula
     sha256 "7fd4218db14b490a0b2b0f5372c636dced0801829a16278f7751d3d831f79785" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/dxpy.rb
+++ b/Formula/dxpy.rb
@@ -5,6 +5,7 @@ class Dxpy < Formula
   homepage "https://github.com/dnanexus/dx-toolkit"
   url "https://files.pythonhosted.org/packages/fc/23/7eb806687ecb4d3795bce9d2cb294dd931a7536be319534b1818a7d32f65/dxpy-0.289.1.tar.gz"
   sha256 "6079f50557e67f24f2f86bb3c4324d29fce4c3ac257ffdd086a7d1149981f392"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,7 @@ class Dxpy < Formula
     sha256 "3de8cb5503f1e9a202e4c2bdaf0cfab36c9691b33a539c9783e6d6b7011d6e42" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "argcomplete" do
     url "https://files.pythonhosted.org/packages/58/88/5a8da671e087ef513a63519344b35d80c6979591eee24e06a5acd1cd11b9/argcomplete-1.10.2.tar.gz"

--- a/Formula/eg-examples.rb
+++ b/Formula/eg-examples.rb
@@ -5,6 +5,7 @@ class EgExamples < Formula
   homepage "https://github.com/srsudar/eg"
   url "https://files.pythonhosted.org/packages/a6/93/38075713a7968a9e8484e894f604f99a68e443e0f9db0ed48063b1241969/eg-1.1.1.tar.gz"
   sha256 "3faa5fb453d8ba113975a1f31e37ace94867539ba9d46a40af4cea90028a04e4"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class EgExamples < Formula
     sha256 "b97620b249f6b74425c157c068b415b4368245f7ce6d2a20d92b9a2db7230547" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/esptool.rb
+++ b/Formula/esptool.rb
@@ -5,6 +5,7 @@ class Esptool < Formula
   homepage "https://github.com/espressif/esptool"
   url "https://github.com/espressif/esptool/archive/v2.8.tar.gz"
   sha256 "f6187ab0467e05bff6ef4e777bde5ee8eb57a74154865d30491ebb42b228c617"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Esptool < Formula
     sha256 "c8f2ab169b860cd549b3fa1bf572adb29e77a76ebf0f3d5a62ba58af00f8173b" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "ecdsa" do
     url "https://files.pythonhosted.org/packages/f9/e5/99ebb176e47f150ac115ffeda5fedb6a3dbb3c00c74a59fd84ddf12f5857/ecdsa-0.13.tar.gz"

--- a/Formula/flintrock.rb
+++ b/Formula/flintrock.rb
@@ -5,7 +5,7 @@ class Flintrock < Formula
   homepage "https://github.com/nchammas/flintrock"
   url "https://files.pythonhosted.org/packages/82/2e/c2aa7e8a98b03632f789e15854ee9716d6b3aef31580950458285819be95/Flintrock-0.11.0.tar.gz"
   sha256 "f203a5558acc5fc7d8fd6efefaf6f0b90625c9d9c938521cdecc44bc684b3605"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -14,7 +14,7 @@ class Flintrock < Formula
     sha256 "4f84435e63cf37b5d02f36badd892ce90c5e71d685e1bc3d56f24e1403e3b159" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/c1/a9/86bfedaf41ca590747b4c9075bc470d0b2ec44fb5db5d378bc61447b3b6b/asn1crypto-1.2.0.tar.gz"

--- a/Formula/fonttools.rb
+++ b/Formula/fonttools.rb
@@ -5,6 +5,7 @@ class Fonttools < Formula
   homepage "https://github.com/fonttools/fonttools"
   url "https://github.com/fonttools/fonttools/releases/download/4.2.2/fonttools-4.2.2.zip"
   sha256 "66bb3dfe7efe5972b0145339c063ffaf9539e973f7ff8791df84366eafc65804"
+  revision 1
   head "https://github.com/fonttools/fonttools.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Fonttools < Formula
     sha256 "4c259ab4c718c77c77bce6dbfaeb2aa2b6664f786b5b7a3bfc16f8699d47791f" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/gandi.cli.rb
+++ b/Formula/gandi.cli.rb
@@ -5,6 +5,7 @@ class GandiCli < Formula
   homepage "https://cli.gandi.net/"
   url "https://files.pythonhosted.org/packages/75/6d/ff2097a1b8f0142034394ca6832abade773a36efa0916500522b7d190264/gandi.cli-1.5.tar.gz"
   sha256 "a575be04fd373d4798ae16f6cbe03e8ed16255043788fb3de13bebfe7e621c84"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class GandiCli < Formula
     sha256 "f63f0c8c8a4d924f12589b8eb1c85e57ccd86ad09ee96c6d570191b07816a2e8" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/41/b6/4f0cefba47656583217acd6cd797bc2db1fede0d53090fdc28ad2c8e0716/certifi-2018.10.15.tar.gz"

--- a/Formula/git-revise.rb
+++ b/Formula/git-revise.rb
@@ -5,6 +5,7 @@ class GitRevise < Formula
   homepage "https://github.com/mystor/git-revise"
   url "https://github.com/mystor/git-revise/archive/0.5.1.tar.gz"
   sha256 "3f64521eb056ff097eb282811459820e1afd138cf2de113d609051060459d24d"
+  revision 1
   head "https://github.com/mystor/git-revise.git"
 
   bottle do
@@ -14,7 +15,7 @@ class GitRevise < Formula
     sha256 "5659d2d32986473c77135b28f52da15cd2a09a4dfdb8d959b640be765c9a5460" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/gitup.rb
+++ b/Formula/gitup.rb
@@ -6,6 +6,7 @@ class Gitup < Formula
   url "https://github.com/earwig/git-repo-updater.git",
       :tag      => "v0.5.1",
       :revision => "b502b2eaa46a6a10d9db228209f984bb235444a7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Gitup < Formula
     sha256 "b550170bcff2cb60d1af74abcea941c54f433003b084010ea2b73bd7d34f947e" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/e6/76/257b53926889e2835355d74fec73d82662100135293e17d382e2b74d1669/colorama-0.3.9.tar.gz"

--- a/Formula/homeassistant-cli.rb
+++ b/Formula/homeassistant-cli.rb
@@ -5,6 +5,7 @@ class HomeassistantCli < Formula
   homepage "https://github.com/home-assistant/home-assistant-cli"
   url "https://files.pythonhosted.org/packages/63/ad/e02ef2951ebeb871a1f7e13a1975683520a18c9dddfd9b94cc6fec6ff3ca/homeassistant-cli-0.8.0.tar.gz"
   sha256 "1610c91ce23fda460d95d2937f898360bfff8a9ef80fc7bbfa9966a0c4120463"
+  revision 1
   head "https://github.com/home-assistant/home-assistant-cli.git"
 
   bottle do
@@ -14,7 +15,7 @@ class HomeassistantCli < Formula
     sha256 "44d959f97d332c16c3a6fd455a03fe30471f7ddfb8e7e37c9704e1dbcd815047" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "aiohttp" do
     url "https://files.pythonhosted.org/packages/00/94/f9fa18e8d7124d7850a5715a0b9c0584f7b9375d331d35e157cee50f27cc/aiohttp-3.6.2.tar.gz"

--- a/Formula/httpie.rb
+++ b/Formula/httpie.rb
@@ -5,6 +5,7 @@ class Httpie < Formula
   homepage "https://httpie.org/"
   url "https://files.pythonhosted.org/packages/d5/a4/ab61c1dbfdef33c7b7f5f7df0d79eb5cd55a106601a4acc17f983f320b4a/httpie-1.0.3.tar.gz"
   sha256 "6d1b6e21da7d3ec030ae95536d4032c1129bdaf9de4adc72c596b87e5f646e80"
+  revision 1
   head "https://github.com/jakubroztocil/httpie.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Httpie < Formula
     sha256 "153ce88d4496d04fa1ba61641841b2c89254687af8c7e9aca7127b298e3ee0f1" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/7e/ae/26808275fc76bf2832deb10d3a3ed3107bc4de01b85dcccbe525f2cd6d1e/Pygments-2.4.2.tar.gz"

--- a/Formula/instalooter.rb
+++ b/Formula/instalooter.rb
@@ -5,6 +5,7 @@ class Instalooter < Formula
   homepage "https://github.com/althonos/instalooter"
   url "https://files.pythonhosted.org/packages/72/47/181d89914f9cd7cb066a32f5e21a49023bb4fec2d5e6aefa645f1874c972/instalooter-2.4.1.tar.gz"
   sha256 "aa65caaff3b43bd05288476765282165c7ca78e9de2e8ab9b796977b73d0320a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Instalooter < Formula
     sha256 "0b5da069f218433170d8520db0f4b8f12360c45d455014dc1f0188889ce839ef" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/48/69/d87c60746b393309ca30761f8e2b49473d43450b150cb08f3c6df5c11be5/appdirs-1.4.3.tar.gz"

--- a/Formula/internetarchive.rb
+++ b/Formula/internetarchive.rb
@@ -5,6 +5,7 @@ class Internetarchive < Formula
   homepage "https://github.com/jjjake/internetarchive"
   url "https://files.pythonhosted.org/packages/f8/08/4317a2a43b1c7d48683a36438c0c0f77044ed61d71df9e2cc95345ab4999/internetarchive-1.8.5.tar.gz"
   sha256 "2e7477ed3fe43f1d09853b281c8034deafacf7ebc614ba80788c90ecdbf0c3d3"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Internetarchive < Formula
     sha256 "ea342b66c28cd7b3b737891d3c02d03ff04afe8190fe67c96554d90cb2b8bdc0" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "args" do
     url "https://files.pythonhosted.org/packages/e5/1c/b701b3f4bd8d3667df8342f311b3efaeab86078a840fb826bd204118cc6b/args-0.1.0.tar.gz"

--- a/Formula/jinja2-cli.rb
+++ b/Formula/jinja2-cli.rb
@@ -5,6 +5,7 @@ class Jinja2Cli < Formula
   homepage "https://github.com/mattrobenolt/jinja2-cli"
   url "https://files.pythonhosted.org/packages/23/67/6f05f5f8a9fc108c58e4eac9b9b7876b400985d33149fe2faa87a9ca502b/jinja2-cli-0.7.0.tar.gz"
   sha256 "9ccd8d530dad5d031230afd968cf54637b49842a13ececa6e17c2f67f6e9336e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Jinja2Cli < Formula
     sha256 "bae549938d2954d8ffb3de7add885df8dbfcd020f65356fdc08cf2bd029c409e" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "jinja2" do
     url "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"

--- a/Formula/jrnl.rb
+++ b/Formula/jrnl.rb
@@ -5,7 +5,7 @@ class Jrnl < Formula
   homepage "https://jrnl.sh/"
   url "https://github.com/maebert/jrnl/archive/1.9.8.tar.gz"
   sha256 "ec9dcf01f67a2329218fcd090b56042379937b269ddbd8c0c64097636f012e63"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +15,7 @@ class Jrnl < Formula
     sha256 "0325b924a82ce0153d3e9d683fc55190d154d45ee9279fc6d136f50506417af3" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "entrypoints" do
     url "https://files.pythonhosted.org/packages/27/e8/607697e6ab8a961fc0b141a97ea4ce72cd9c9e264adeb0669f6d194aa626/entrypoints-0.2.3.tar.gz"

--- a/Formula/keepkey-agent.rb
+++ b/Formula/keepkey-agent.rb
@@ -5,7 +5,7 @@ class KeepkeyAgent < Formula
   homepage "https://github.com/romanz/trezor-agent"
   url "https://files.pythonhosted.org/packages/65/72/4bf47a7bc8dc93d2ac21672a0db4bc58a78ec5cee3c4bcebd0b4092a9110/keepkey_agent-0.9.0.tar.gz"
   sha256 "47c85de0c2ffb53c5d7bd2f4d2230146a416e82511259fad05119c4ef74be70c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,7 @@ class KeepkeyAgent < Formula
     sha256 "923d1471a0285a545de011f0628e36e02566bc422b7d5d86d20af82b3e301968" => :el_capitan
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "backports.shutil_which" do
     url "https://files.pythonhosted.org/packages/dd/ea/715dc80584207a0ff4a693a73b03c65f087d8ad30842832b9866fe18cb2f/backports.shutil_which-3.5.1.tar.gz"

--- a/Formula/khard.rb
+++ b/Formula/khard.rb
@@ -5,6 +5,7 @@ class Khard < Formula
   homepage "https://github.com/scheibler/khard/"
   url "https://files.pythonhosted.org/packages/38/41/e54a6ef446701a4ba723df8850189f62e9e9a320de9ff2b1accadd589cc6/khard-0.15.1.tar.gz"
   sha256 "5ca8e678133e08fa4861cc31aedf9f30b4f8e3958ed66ede025c23ec5e176aa1"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Khard < Formula
     sha256 "99aa1b845b5b35d5a08797344a4dabfb5a2055e1f415efb8dd5f1694846a2efb" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "atomicwrites" do
     url "https://files.pythonhosted.org/packages/ec/0f/cd484ac8820fed363b374af30049adc8fd13065720fd4f4c6be8a2309da7/atomicwrites-1.3.0.tar.gz"

--- a/Formula/legit.rb
+++ b/Formula/legit.rb
@@ -5,6 +5,7 @@ class Legit < Formula
   homepage "https://frostming.github.io/legit/"
   url "https://files.pythonhosted.org/packages/6b/65/819f84ef3caa4743c834122acb897df29167f6178c9c095d7896f2181387/legit-1.1.0.tar.gz"
   sha256 "25bd3809d657c9b0bd45a6a230dc7f58a56e6e068159d471ffeadb0cf4677b4d"
+  revision 1
   head "https://github.com/frostming/legit.git", :branch => "master"
 
   bottle do
@@ -14,7 +15,7 @@ class Legit < Formula
     sha256 "b2b05bde239b036eec589a445c27ada95aca2330b76113bba72c7ad20e482d10" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "args" do
     url "https://files.pythonhosted.org/packages/e5/1c/b701b3f4bd8d3667df8342f311b3efaeab86078a840fb826bd204118cc6b/args-0.1.0.tar.gz"

--- a/Formula/mackup.rb
+++ b/Formula/mackup.rb
@@ -5,6 +5,7 @@ class Mackup < Formula
   homepage "https://github.com/lra/mackup"
   url "https://github.com/lra/mackup/archive/0.8.27.tar.gz"
   sha256 "b7d84ea661de27b1d4664bb71e6ab52ef30c6ca180a67435c1d4dea073cb3e4c"
+  revision 1
   head "https://github.com/lra/mackup.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Mackup < Formula
     sha256 "c941c433ddcb1f6deee07ade71d4d3a9f910e229bb01601402377ebca43411fd" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"

--- a/Formula/mdv.rb
+++ b/Formula/mdv.rb
@@ -5,7 +5,7 @@ class Mdv < Formula
   homepage "https://github.com/axiros/terminal_markdown_viewer"
   url "https://github.com/axiros/terminal_markdown_viewer/archive/1.6.3.tar.gz"
   sha256 "58dbdf8c051a2d7f8c00e4dc13c655c335cbc2bc96851dd0388d73a21c4507b6"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +15,7 @@ class Mdv < Formula
     sha256 "d4a980db5be1cb783cb85c4f769b8e47f3ed09be8539ca7b02c8ea4c80e8e43d" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"

--- a/Formula/mkdocs.rb
+++ b/Formula/mkdocs.rb
@@ -5,7 +5,7 @@ class Mkdocs < Formula
   homepage "https://www.mkdocs.org/"
   url "https://github.com/mkdocs/mkdocs/archive/1.0.4.tar.gz"
   sha256 "c9a0e1637c1e92b663d290a74ed1370ee7d50c6af165f49215df3a0c10b5bafa"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +15,7 @@ class Mkdocs < Formula
     sha256 "ec14bfa77ebb331e8d24e345825f3eff934709ed46f2a3f30f990dfd63654969" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"

--- a/Formula/mongo-orchestration.rb
+++ b/Formula/mongo-orchestration.rb
@@ -5,7 +5,7 @@ class MongoOrchestration < Formula
   homepage "https://github.com/10gen/mongo-orchestration"
   url "https://files.pythonhosted.org/packages/6d/b5/624a02d5f6cbfa8eb3c6554f5387c4739ad283bac7efb27ee99434a4d314/mongo-orchestration-0.6.11.tar.gz"
   sha256 "7a09706d36e94ae767e90646fed98a52b426a4d14b0f4f724b185e292ac8f425"
-  revision 1
+  revision 2
   head "https://github.com/10gen/mongo-orchestration.git"
 
   bottle do
@@ -16,7 +16,7 @@ class MongoOrchestration < Formula
     sha256 "8a463e718a50549325ae910fa944f4fa1761cbc4050d271c16d285b22402685e" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/bd/99/04dc59ced52a8261ee0f965a8968717a255ea84a36013e527944dbf3468c/bottle-0.12.13.tar.gz"

--- a/Formula/nbdime.rb
+++ b/Formula/nbdime.rb
@@ -5,6 +5,7 @@ class Nbdime < Formula
   homepage "https://nbdime.readthedocs.io"
   url "https://files.pythonhosted.org/packages/1d/49/f173b8697f9868059739055c27f4263dcbcc2060669249b5e4d62765b3e5/nbdime-1.1.0.tar.gz"
   sha256 "80032f75d2a9a4b23bb1a0cd6411a68ced8c33b8a63d9ab7cfbb9c47ab3dde61"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Nbdime < Formula
     sha256 "87c8cd36eaa6632b2c35f27e210cfea8867da1cafb333f85c3afb73850495921" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "appnope" do
     url "https://files.pythonhosted.org/packages/26/34/0f3a5efac31f27fabce64645f8c609de9d925fe2915304d1a40f544cff0e/appnope-0.1.0.tar.gz"

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -5,6 +5,7 @@ class Platformio < Formula
   homepage "https://platformio.org/"
   url "https://files.pythonhosted.org/packages/b5/b6/832b92113764feae278376dd0f39f0a3d4321c24b9ff1ff9c9777ba23b8d/platformio-4.1.0.tar.gz"
   sha256 "4552086d82fb4d7022abeb620499314249548d084b37ddf446a7ee3099b13c21"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Platformio < Formula
     sha256 "1313c81f8906aa6c6646c3175c05089afbcc0260a18ccb957f2ae37d666d9fbe" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/c4/a5/6bf41779860e9b526772e1b3b31a65a22bd97535572988d16028c5ab617d/bottle-0.12.17.tar.gz"

--- a/Formula/proselint.rb
+++ b/Formula/proselint.rb
@@ -5,7 +5,7 @@ class Proselint < Formula
   homepage "http://proselint.com"
   url "https://files.pythonhosted.org/packages/42/ff/8e7ad0108b8faffdf2ec7d170b4a8a3c9bc91f5077debf5381ef14702588/proselint-0.10.2.tar.gz"
   sha256 "3a87eb393056d1bc77d898e4bcf8998f50e9ad84f7b9ff7cf2720509ac8ef904"
-  revision 1
+  revision 2
   head "https://github.com/amperser/proselint.git"
 
   bottle do
@@ -16,7 +16,7 @@ class Proselint < Formula
     sha256 "7834267f43950c5d637d354c584a5e3093b3bce26b8b5869773745a60b7a0b29" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"

--- a/Formula/pssh.rb
+++ b/Formula/pssh.rb
@@ -4,6 +4,7 @@ class Pssh < Formula
   homepage "https://code.google.com/archive/p/parallel-ssh/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/parallel-ssh/pssh-2.3.1.tar.gz"
   sha256 "539f8d8363b722712310f3296f189d1ae8c690898eca93627fc89a9cb311f6b4"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Pssh < Formula
     sha256 "73f994d5f4b9e8df301351b552108cdc2cf5a99c2899c8f5c929c9111b69187c" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   conflicts_with "putty", :because => "both install `pscp` binaries"
 

--- a/Formula/pygitup.rb
+++ b/Formula/pygitup.rb
@@ -5,6 +5,7 @@ class Pygitup < Formula
   homepage "https://github.com/msiemens/PyGitUp"
   url "https://files.pythonhosted.org/packages/46/45/32dc0bf07c620644a8ed899e381309f4f25b50f20a91e555285522592833/git-up-1.6.1.tar.gz"
   sha256 "ea83441e7ab05011624e2e7333ef875c263124db5eed74507acd32b07c48473f"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Pygitup < Formula
     sha256 "3ca5dc9d6443ec789e54686ee3d71662e69db2da877749bbb1e5ba7b562279ff" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"

--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -5,6 +5,7 @@ class Pygments < Formula
   homepage "https://pygments.org/"
   url "https://files.pythonhosted.org/packages/7e/ae/26808275fc76bf2832deb10d3a3ed3107bc4de01b85dcccbe525f2cd6d1e/Pygments-2.4.2.tar.gz"
   sha256 "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+  revision 1
 
   head "https://github.com/pygments/pygments.git"
 
@@ -16,7 +17,7 @@ class Pygments < Formula
     sha256 "931c35edfec89042b2fc1c97256055060dd92fc60c699a883a204caf66930bae" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     bash_completion.install "external/pygments.bashcomp" => "pygmentize"

--- a/Formula/pyinstaller.rb
+++ b/Formula/pyinstaller.rb
@@ -5,6 +5,7 @@ class Pyinstaller < Formula
   homepage "https://www.pyinstaller.org"
   url "https://files.pythonhosted.org/packages/e2/c9/0b44b2ea87ba36395483a672fddd07e6a9cb2b8d3c4a28d7ae76c7e7e1e5/PyInstaller-3.5.tar.gz"
   sha256 "ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96"
+  revision 1
 
   head "https://github.com/pyinstaller/pyinstaller.git", :branch => "develop"
 
@@ -16,7 +17,7 @@ class Pyinstaller < Formula
     sha256 "4112b5a32d0b465156e207d08f8c97512625df9e2ee3596cd27dbf8ae7a63ffd" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "altgraph" do
     url "https://files.pythonhosted.org/packages/da/a4/6c508ac94d7a65859a7a47e6fbde4aa6b81d0f0863aa45861241e782391c/altgraph-0.16.1.tar.gz"
@@ -41,6 +42,12 @@ class Pyinstaller < Formula
   resource "pefile" do
     url "https://files.pythonhosted.org/packages/ed/cc/157f20038a80b6a9988abc06c11a4959be8305a0d33b6d21a134127092d4/pefile-2018.8.8.tar.gz"
     sha256 "4c5b7e2de0c8cb6c504592167acf83115cbbde01fe4a507c16a1422850e86cd6"
+  end
+
+  # Python 3.8 compatibility
+  patch do
+    url "https://github.com/pyinstaller/pyinstaller/pull/4440.patch?full_index=1"
+    sha256 "e7e21ba338e7245af063b13ee2f6e82fe064b831e81b524e0d28277084eaf211"
   end
 
   def install

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -5,6 +5,7 @@ class Pyinvoke < Formula
   homepage "https://www.pyinvoke.org/"
   url "https://github.com/pyinvoke/invoke/archive/1.3.0.tar.gz"
   sha256 "f95915dfbadc0a5526946950160334bf476b282de285af0e7defdb712bb25d8b"
+  revision 1
   head "https://github.com/pyinvoke/invoke.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Pyinvoke < Formula
     sha256 "385bb92f31b81c09dbc329d2f5fcab8fbcfc8608a65cdf924eef23ed9ef38ed0" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/pylint.rb
+++ b/Formula/pylint.rb
@@ -5,6 +5,7 @@ class Pylint < Formula
   homepage "https://github.com/PyCQA/pylint"
   url "https://files.pythonhosted.org/packages/93/eb/851ab1d1ca6b37babd326dfa517b432963c54eda26c730353306aa0cdf4d/pylint-2.4.4.tar.gz"
   sha256 "3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Pylint < Formula
     sha256 "420c9f77bef5437252fd291f4f182d269f3f67eb8168dbb65cebd18958a782b5" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "astroid" do
     url "https://files.pythonhosted.org/packages/40/df/70dfe3eed7352dd3f5c7cc74518ceed78230b2ca9d7d60dbabd81d5390ba/astroid-2.3.3.tar.gz"

--- a/Formula/pyvim.rb
+++ b/Formula/pyvim.rb
@@ -5,7 +5,7 @@ class Pyvim < Formula
   homepage "https://github.com/jonathanslenders/pyvim"
   url "https://files.pythonhosted.org/packages/6e/85/47543120e478ddc5d31e447a7fed1fe4ac81cbb066ca623a2cc54f685dff/pyvim-2.0.24.tar.gz"
   sha256 "27b8f244bebc49cf375b10d16046df24438798208d7eaf199e3d04babf08cc6f"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +14,7 @@ class Pyvim < Formula
     sha256 "b8626e91ddbbf8abaf02755765dc0228160e0a65faabb963a60352a03e9a6ac8" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"

--- a/Formula/remarshal.rb
+++ b/Formula/remarshal.rb
@@ -5,7 +5,7 @@ class Remarshal < Formula
   homepage "https://github.com/dbohdan/remarshal"
   url "https://github.com/dbohdan/remarshal/archive/v0.11.2.tar.gz"
   sha256 "3f383e48f59722a4d93ef2b5e417b6a8c152f382a1faad416099ffcde5c87a66"
-  revision 1
+  revision 2
   head "https://github.com/dbohdan/remarshal.git"
 
   bottle do
@@ -15,7 +15,7 @@ class Remarshal < Formula
     sha256 "5ed4e3a38f981f042acf5f85414341e1fd21a1780fd57297c4b4195a692f6b9f" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   conflicts_with "msgpack-tools", :because => "both install 'json2msgpack' binary"
 

--- a/Formula/rst-lint.rb
+++ b/Formula/rst-lint.rb
@@ -5,6 +5,7 @@ class RstLint < Formula
   homepage "https://github.com/twolfson/restructuredtext-lint"
   url "https://github.com/twolfson/restructuredtext-lint/archive/1.3.0.tar.gz"
   sha256 "4bf9d4724f59bc05ebe1cd5192c03d4597ee95c4bbf60bd5644422e1a2558da3"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class RstLint < Formula
     sha256 "46da54ff6e6f96663327291d0f51380107c377705d9eaccc7461c9156916799b" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "docutils" do
     url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"

--- a/Formula/sceptre.rb
+++ b/Formula/sceptre.rb
@@ -5,6 +5,7 @@ class Sceptre < Formula
   homepage "https://sceptre.cloudreach.com"
   url "https://github.com/cloudreach/sceptre/archive/v2.2.1.tar.gz"
   sha256 "86a2630d46f37adcd36b692e0788006777d130872d4de84a3e0ff36c29fa4dbe"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Sceptre < Formula
     sha256 "445841f4807d0d76606a7dcc6fd90d279f9aca66f410e78c8be09ea838f970ae" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "boto3" do
     url "https://files.pythonhosted.org/packages/36/d0/271327b50232d2e746b7a17b265be857f2fd086d40653b93415fc32e2a4f/boto3-1.10.39.tar.gz"

--- a/Formula/scour.rb
+++ b/Formula/scour.rb
@@ -5,7 +5,7 @@ class Scour < Formula
   homepage "https://www.codedread.com/scour/"
   url "https://github.com/scour-project/scour/archive/v0.37.tar.gz"
   sha256 "4fcb961586d8a6d98ac9343ca5647421b98fdc79b51d81a1d3d18576b7908823"
-  revision 1
+  revision 2
   head "https://github.com/scour-project/scour.git"
 
   bottle do
@@ -16,7 +16,7 @@ class Scour < Formula
     sha256 "034447e6f32a3c4925682911e97a89d62ca418347ad0be425a64d299db1f7f20" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz"

--- a/Formula/sqlparse.rb
+++ b/Formula/sqlparse.rb
@@ -5,7 +5,7 @@ class Sqlparse < Formula
   homepage "https://github.com/andialbrecht/sqlparse"
   url "https://files.pythonhosted.org/packages/79/3c/2ad76ba49f9e3d88d2b58e135b7821d93741856d1fe49970171f73529303/sqlparse-0.2.4.tar.gz"
   sha256 "ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +15,7 @@ class Sqlparse < Formula
     sha256 "9c77ae1a2ca8a0cfe79197762b9c60be451b827cf72f616542547ec280b3acb3" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/sshuttle.rb
+++ b/Formula/sshuttle.rb
@@ -6,6 +6,7 @@ class Sshuttle < Formula
   url "https://github.com/sshuttle/sshuttle.git",
       :tag      => "v0.78.5",
       :revision => "752a95310198886515577463a4a7e36d7f218018"
+  revision 1
   head "https://github.com/sshuttle/sshuttle.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Sshuttle < Formula
     sha256 "04e8f60acb5131f58a0fbe66d7c8d847c4d423db3edb2671ff1319fc499a2c5f" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     # Building the docs requires installing

--- a/Formula/supervisor.rb
+++ b/Formula/supervisor.rb
@@ -5,6 +5,7 @@ class Supervisor < Formula
   homepage "http://supervisord.org/"
   url "https://github.com/Supervisor/supervisor/archive/4.1.0.tar.gz"
   sha256 "e4e87a309d34c1356b77d1dfd300191b2a7c314e050d7b3853e5b91ef166c2f2"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Supervisor < Formula
     sha256 "41fd027c40c5e5da953fc007999db6248046f45ea68e9b1c5a4525834e98f130" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     inreplace buildpath/"supervisor/skel/sample.conf" do |s|

--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -5,6 +5,7 @@ class Thefuck < Formula
   homepage "https://github.com/nvbn/thefuck"
   url "https://files.pythonhosted.org/packages/19/b0/5a563805cd59ad99b46a82fad0008ff6d9b55b61db88d8839b448c45b63c/thefuck-3.29.tar.gz"
   sha256 "7b907b6ef6863cc0d3e9bb3e573054547a60f89572250b767ccadb317d3c8297"
+  revision 1
   head "https://github.com/nvbn/thefuck.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Thefuck < Formula
     sha256 "dbac00409d1662ad5c566f0936c296fba3dc42ce59cfa49b3bd5eb6fb9972cf5" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/76/53/e785891dce0e2f2b9f4b4ff5bc6062a53332ed28833c7afede841f46a5db/colorama-0.4.1.tar.gz"

--- a/Formula/todoman.rb
+++ b/Formula/todoman.rb
@@ -5,6 +5,7 @@ class Todoman < Formula
   homepage "https://todoman.readthedocs.io/"
   url "https://files.pythonhosted.org/packages/42/5a/b11c0df8bb9bfd4404d596a9ed1966aece1510a07b89499074080334297c/todoman-3.7.0.tar.gz"
   sha256 "1eb65c05ec82db501065d1a90d885a4352d92958121b1b9dab6a970abfe07999"
+  revision 1
   head "https://github.com/pimutils/todoman.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Todoman < Formula
     sha256 "ad43b0d360649e4e96d98c97cd218a2fcba3e66260e50d8e9da5de93b0d4a050" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   conflicts_with "devtodo", :because => "both install a `todo` binary"
 

--- a/Formula/tox.rb
+++ b/Formula/tox.rb
@@ -5,6 +5,7 @@ class Tox < Formula
   homepage "https://tox.readthedocs.org/"
   url "https://files.pythonhosted.org/packages/77/de/a0cd7de91f362a59ec689808ed2993b0578642247418840ae240cfdc4c66/tox-3.14.1.tar.gz"
   sha256 "bcfa3e40abc1e9b70607b56adfd976fe7dc8286ad56aab44e3151daca7d2d0d0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Tox < Formula
     sha256 "33aabd63d92c7af31e243ed0a5e3e09dd0dd6ea5978d5b6d189cccdcd8d0745e" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "filelock" do
     url "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz"
@@ -84,13 +85,11 @@ class Tox < Formula
       rm f
       ln_s realpath, f
     end
-    inreplace lib_python_path/"orig-prefix.txt",
-              Formula["python"].opt_prefix, Formula["python"].prefix.realpath
   end
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
-    pyver = Language::Python.major_minor_version("python3").to_s.delete(".")
+    pyver = Language::Python.major_minor_version("python3.8").to_s.delete(".")
     (testpath/"tox.ini").write <<~EOS
       [tox]
       envlist=py#{pyver}

--- a/Formula/translate-toolkit.rb
+++ b/Formula/translate-toolkit.rb
@@ -5,6 +5,7 @@ class TranslateToolkit < Formula
   homepage "https://toolkit.translatehouse.org/"
   url "https://github.com/translate/translate/archive/2.4.0.tar.gz"
   sha256 "7f1d6a9566bb512fd88d51bd8bc920f42e379c91a4686761dbe89762f8a3a51d"
+  revision 1
   head "https://github.com/translate/translate.git"
 
   bottle do
@@ -15,7 +16,7 @@ class TranslateToolkit < Formula
     sha256 "b22388e34bf4e0abdc73502967d6d6242f7c7d17e10f6b6cd55d3561ff696ee6" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "argparse" do
     url "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz"

--- a/Formula/trash-cli.rb
+++ b/Formula/trash-cli.rb
@@ -5,7 +5,7 @@ class TrashCli < Formula
   homepage "https://github.com/andreafrancia/trash-cli"
   url "https://github.com/andreafrancia/trash-cli/archive/0.17.1.14.tar.gz"
   sha256 "8fdd20e5e9c55ea4e24677e602a06a94a93f1155f9970c55b25dede5e037b974"
-  revision 1
+  revision 2
   head "https://github.com/andreafrancia/trash-cli.git"
 
   bottle do
@@ -16,7 +16,7 @@ class TrashCli < Formula
     sha256 "5cb6346603e9ba432c92d46bc20f8612dad0dfa4e32e1996e2c0cc1aaab87990" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   conflicts_with "trash", :because => "both install a `trash` binary"
 

--- a/Formula/twine-pypi.rb
+++ b/Formula/twine-pypi.rb
@@ -5,6 +5,7 @@ class TwinePypi < Formula
   homepage "https://github.com/pypa/twine"
   url "https://files.pythonhosted.org/packages/7e/2f/e2a91a8ab97e8c9830ce297132631aef5dcd599f076123d1ebb26f1941b6/twine-3.1.1.tar.gz"
   sha256 "d561a5e511f70275e5a485a6275ff61851c16ffcb3a95a602189161112d9f160"
+  revision 1
   head "https://github.com/pypa/twine.git"
 
   bottle do
@@ -14,7 +15,7 @@ class TwinePypi < Formula
     sha256 "ea2b15ce123653d0b5174b8ed00c6fb4718c9815385bada71d1aded4f99b55c9" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "bleach" do
     url "https://files.pythonhosted.org/packages/78/5a/0df03e8735cd9c75167528299c738702437589b9c71a849489d00ffa82e8/bleach-3.1.0.tar.gz"

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -5,6 +5,7 @@ class VstsCli < Formula
   homepage "https://docs.microsoft.com/en-us/cli/vsts"
   url "https://files.pythonhosted.org/packages/f9/c2/3ed698480ab30d2807fc961eef152099589aeaec3f1407945a4e07275de5/vsts-cli-0.1.4.tar.gz"
   sha256 "27defe1d8aaa1fcbc3517274c0fdbd42b5ebe2c1c40edfc133d98fe4bb7114de"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class VstsCli < Formula
     sha256 "ca77ac87f904bb3e88fb958f5d088d4740d93ea134a41c5bab3fb1218ef7c54d" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "argcomplete" do
     url "https://files.pythonhosted.org/packages/3c/21/9741e5e5e63245a8cdafb32ffc738bff6e7ef6253b65953e77933e56ce88/argcomplete-1.9.4.tar.gz"

--- a/Formula/watson.rb
+++ b/Formula/watson.rb
@@ -5,6 +5,7 @@ class Watson < Formula
   homepage "https://tailordev.github.io/Watson/"
   url "https://files.pythonhosted.org/packages/b2/ab/64c9eac8eb2032ce7bc51c41aa44c41bdbabf96d8f850aae2fcb28a67795/td-watson-1.8.0.tar.gz"
   sha256 "161870b9e398f2a25a08f0aed7b176676f503d7f16aead026f2e62b6a034e6c6"
+  revision 1
   head "https://github.com/TailorDev/Watson.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Watson < Formula
     sha256 "4d10018cf8a4cebde993145393c252ed2db81ff0adf4ae52a8dbfc2ed7f59109" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "arrow" do
     url "https://files.pythonhosted.org/packages/43/0e/47416c54ad7742981bf77fdfc405987551ab14b181a6140c8cd2a5823872/arrow-0.15.2.tar.gz"

--- a/Formula/xonsh.rb
+++ b/Formula/xonsh.rb
@@ -5,6 +5,7 @@ class Xonsh < Formula
   homepage "https://xon.sh/"
   url "https://github.com/xonsh/xonsh/archive/0.9.13.tar.gz"
   sha256 "21b9c81377c3be04bdf72f0eca2370a3c3ad7b050683362bc52ec84085cdebd2"
+  revision 1
   head "https://github.com/xonsh/xonsh.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Xonsh < Formula
     sha256 "245117ead07c8301e7ca7472e9c15542f001885101bb5b9013d9e8bf43e56d39" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   # Resources based on `pip3 install xonsh[ptk,pygments,proctitle]`
   # See https://xon.sh/osx.html#dependencies

--- a/Formula/yapf.rb
+++ b/Formula/yapf.rb
@@ -5,6 +5,7 @@ class Yapf < Formula
   homepage "https://github.com/google/yapf"
   url "https://files.pythonhosted.org/packages/8e/1e/730a64d83e1b6a64bb8efa5358fc8e9418e6c2d19862523dce22be1040ed/yapf-0.29.0.tar.gz"
   sha256 "712e23c468506bf12cadd10169f852572ecc61b266258422d45aaf4ad7ef43de"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class Yapf < Formula
     sha256 "326436e6bc974790bf36de06e7ea7070d3d0bcaf52b14e2067727c3e95ee47dc" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/ydcv.rb
+++ b/Formula/ydcv.rb
@@ -5,6 +5,7 @@ class Ydcv < Formula
   homepage "https://github.com/felixonmars/ydcv"
   url "https://github.com/felixonmars/ydcv/archive/0.7.tar.gz"
   sha256 "03dd5de36ea8fce3170e678e63fc3694e2718b22bc5e1526e3e07f5c36ec9aa0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class Ydcv < Formula
     sha256 "24bd213b43d60cf2ef49868c3419bf09bce242d82ce78c4cd4d793c01d45676c" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION"] = version

--- a/Formula/zabbix-cli.rb
+++ b/Formula/zabbix-cli.rb
@@ -5,6 +5,7 @@ class ZabbixCli < Formula
   homepage "https://github.com/usit-gd/zabbix-cli/"
   url "https://github.com/usit-gd/zabbix-cli/archive/2.1.1.tar.gz"
   sha256 "1f58b1374dc9e2711bab5d78740ab17fa81dc89aca14e7ea75c10631e6e81227"
+  revision 1
   head "https://github.com/usit-gd/zabbix-cli.git"
 
   bottle do
@@ -15,7 +16,7 @@ class ZabbixCli < Formula
     sha256 "f61ee16a471a92e786e4da862cdd9a510439db832719bef33a3962bd1ec8f003" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   ## direct dependencies
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR migrates to `python@3.8` independent formulae which:
- depends only on `python`
- doesn't have any depending formulae
- uses `virtualenv_install_with_resources` for installation
 
Ref: https://github.com/Homebrew/homebrew-core/issues/47274