### PR TITLE
libideviceactivation HEAD (new formula)

### DIFF
--- a/Formula/libideviceactivation.rb
+++ b/Formula/libideviceactivation.rb
@@ -1,0 +1,26 @@
+class Libideviceactivation < Formula
+  desc "Library to handle the activation process of iOS devices"
+  homepage "https://www.libimobiledevice.org/"
+  head "https://github.com/libimobiledevice/libideviceactivation.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libimobiledevice"
+  depends_on "libplist"
+  uses_from_macos "libxml2"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--enable-debug-code"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/ideviceactivation", "--help"
+  end
+end


### PR DESCRIPTION
This adds a formula to install libideviceactivation from
libimobiledevice.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    - No because it's HEAD only
-----
