### PR TITLE
kafkacat,libserdes: fix dependencies

### DIFF
--- a/Formula/kafkacat.rb
+++ b/Formula/kafkacat.rb
@@ -14,6 +14,7 @@ class Kafkacat < Formula
   end
 
   depends_on "avro-c"
+  depends_on "librdkafka"
   depends_on "libserdes"
   depends_on "yajl"
 

--- a/Formula/libserdes.rb
+++ b/Formula/libserdes.rb
@@ -2,8 +2,9 @@ class Libserdes < Formula
   desc "Schema ser/deserializer lib for Avro + Confluent Schema Registry"
   homepage "https://github.com/confluentinc/libserdes"
   url "https://github.com/confluentinc/libserdes.git",
-  :tag      => "v5.3.1",
-  :revision => "b259d15f68dce65591700b0ccccb73311db1de3d"
+    :tag      => "v5.3.1",
+    :revision => "b259d15f68dce65591700b0ccccb73311db1de3d"
+  head "https://github.com/confluentinc/libserdes.git"
 
   bottle do
     cellar :any

--- a/Formula/libserdes.rb
+++ b/Formula/libserdes.rb
@@ -13,7 +13,8 @@ class Libserdes < Formula
   end
 
   depends_on "avro-c"
-  depends_on "librdkafka"
+  depends_on "jansson"
+  uses_from_macos "curl"
 
   def install
     system "./configure", "--prefix=#{prefix}"
@@ -23,22 +24,24 @@ class Libserdes < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <stdio.h>
-      #include <stdlib.h>
-      #include <unistd.h>
-      #include <signal.h>
-      #include <librdkafka/rdkafka.h>
-      #include <serdes-avro.h>
-      #include <serdes.h>
+      #include <err.h>
+      #include <stddef.h>
+      #include <sys/types.h>
+      #include <libserdes/serdes.h>
 
       int main()
       {
-        rd_kafka_conf_t *rk_conf;
-        rk_conf = rd_kafka_conf_new();
+        char errstr[512];
+        serdes_conf_t *sconf = serdes_conf_new(NULL, 0, NULL);
+        serdes_t *serdes = serdes_new(sconf, errstr, sizeof(errstr));
+        if (serdes == NULL) {
+          errx(1, "constructing serdes: %s", errstr);
+        }
+        serdes_destroy(serdes);
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{include}/libserdes", "-L/usr/local/lib/", "-L#{lib}", "-lrdkafka", "-lserdes", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lserdes", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This patch series the dependency sets of kafkacat and libserdes. See individual commits for details. The gist is that libserdes *should not* depend on librdkafka while kafkacat *should*, and libserdes should declare its direct dependency on jansson, rather than relying on avro-c to transitively depend on jansson.