### PR TITLE
phpmyadmin 5.0.0

### DIFF
--- a/Formula/phpmyadmin.rb
+++ b/Formula/phpmyadmin.rb
@@ -1,8 +1,8 @@
 class Phpmyadmin < Formula
   desc "Web interface for MySQL and MariaDB"
   homepage "https://www.phpmyadmin.net"
-  url "https://files.phpmyadmin.net/phpMyAdmin/4.9.3/phpMyAdmin-4.9.3-all-languages.tar.gz"
-  sha256 "669b4c0a642684e6bc5cb053121435cfb4006600a5f69b3b3b4ac87b737be69c"
+  url "https://files.phpmyadmin.net/phpMyAdmin/5.0.0/phpMyAdmin-5.0.0-all-languages.tar.gz"
+  sha256 "56589e624236778b63cfb221f7752371e4e87192c342a8f2492818ae04e31298"
 
   bottle :unneeded
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.4
- formula new file size: 12,943,674 bytes
- formula fetch time: 22.4 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.