### PR TITLE
python: revision bump to get postinstall to run again

### DIFF
--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -5,7 +5,7 @@ class Certbot < Formula
   homepage "https://certbot.eff.org/"
   url "https://github.com/certbot/certbot/archive/v1.0.0.tar.gz"
   sha256 "cb853d4aeff1bd28c6a20bb4b26e782a791a28dfee5b6cf410ef2b6f4f580bd8"
-  revision 1
+  revision 2
   head "https://github.com/certbot/certbot.git"
 
   bottle do

--- a/Formula/doitlive.rb
+++ b/Formula/doitlive.rb
@@ -3,7 +3,7 @@ class Doitlive < Formula
   homepage "https://doitlive.readthedocs.io/en/latest/"
   url "https://files.pythonhosted.org/packages/e5/d9/4ce969d98f521c253ec3b15a0c759104a01061ac90fb9d8636b015bcb4ea/doitlive-4.3.0.tar.gz"
   sha256 "4cb1030e082d8649f10a61d599d3ff3bcad7f775e08f0e68ee06882e06d0190f"
-  revision 5
+  revision 6
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/python.rb
+++ b/Formula/python.rb
@@ -3,6 +3,7 @@ class Python < Formula
   homepage "https://www.python.org/"
   url "https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tar.xz"
   sha256 "55a2cce72049f0794e9a11a84862e9039af9183603b78bc60d89539f82cf533f"
+  revision 1
   head "https://github.com/python/cpython.git"
 
   bottle do


### PR DESCRIPTION
Second part of our fix for https://github.com/Homebrew/homebrew-core/issues/48368 is to get `python`'s `postinstall` to run again for all users (overwriting the bad symlinks that `python@3.8` may have created).