### PR TITLE
komposition 0.2.0 (new formula)

### DIFF
--- a/Formula/komposition.rb
+++ b/Formula/komposition.rb
@@ -1,0 +1,37 @@
+require "language/haskell"
+
+class Komposition < Formula
+  include Language::Haskell::Cabal
+
+  desc "Video editor built for screencasters"
+  homepage "https://github.com/owickstrom/komposition"
+  url "https://github.com/owickstrom/komposition/archive/v0.2.0.tar.gz"
+  sha256 "cedb41c68866f8d6a87579f566909fcd32697b03f66c0e2a700a94b6a9263b88"
+  head "https://github.com/owickstrom/komposition.git"
+
+  depends_on "cabal-install" => :build
+  depends_on "ghc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "ffmpeg"
+  depends_on "gobject-introspection"
+  depends_on "gst-libav"
+  depends_on "gst-plugins-base"
+  depends_on "gst-plugins-good"
+  depends_on "gstreamer"
+  depends_on "gstreamer"
+  depends_on "gtk+3"
+  depends_on "sox"
+  uses_from_macos "libffi"
+
+  def install
+    # The --allow-newer=base may be removed when the ffmpeg-light
+    # bound on base is relaxed, or when Homebrew moves to Cabal 3
+    # builds.
+    install_cabal_package "--allow-newer=base", :using => ["alex", "happy"]
+  end
+
+  test do
+    output = shell_output "#{bin}/komposition doesnotexist 2>&1"
+    assert_match "[ERROR] Opening existing project failed: ProjectDirectoryDoesNotExist \"doesnotexist\"", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[komposition](https://github.com/owickstrom/komposition) is a video editor with a rather peculiar GUI optimised for editing screencasts.  It has over 350 stars on GitHub, so it does have some popularity (and some people who are having trouble installing it on macOS, hence this PR).  The only problem I had with writing the formula is that komposition has almost no non-GUI functionality.  There's not even `--version` or `--help`!  Hence, the test is a little shoddy, but I think it's the best that can be done.  It does at least verify that all the dynamic dependencies are in place and linkable at run-time, and that komposition gets to running its own application code.