### PR TITLE
csound: remove open3 from test

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -109,13 +109,10 @@ class Csound < Formula
     ENV["OPCODE6DIR64"] = frameworks/"CsoundLib64.framework/Resources/Opcodes64"
     ENV["RAWWAVE_PATH"] = Formula["stk"].pkgshare/"rawwaves"
 
-    require "open3"
-    stdout, stderr, status = Open3.capture3("#{bin}/csound test.orc test.sco")
-
-    assert status.success?
-    assert_equal "hello, world\n", stdout
-    assert_match /^rtaudio:/, stderr
-    assert_match /^rtmidi:/, stderr
+    output = shell_output "#{bin}/csound test.orc test.sco 2>&1"
+    assert_match /^hello, world\n/, output
+    assert_match /^rtaudio:/, output
+    assert_match /^rtmidi:/, output
 
     assert_predicate testpath/"test.aif", :exist?
     assert_predicate testpath/"test.h5", :exist?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This replaces a use of `Open3.capture3` in a test with `shell_output`.