### PR TITLE
fhir-validation-cli 4.1.40 (new formula)

### DIFF
--- a/Formula/fhir-validation-cli.rb
+++ b/Formula/fhir-validation-cli.rb
@@ -1,0 +1,21 @@
+class FhirValidationCli < Formula
+  desc "FHIR command-line validator"
+  homepage "https://wiki.hl7.org/Using_the_FHIR_Validator"
+  url "https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.validator.jar"
+  version "4.1.40-SNAPSHOT"
+  sha256 "350ac5a1b258946828fa5ad0bc3784bad427577336bab9a60c382b5470c60a1c"
+
+  bottle :unneeded
+
+  depends_on :java => "1.8+"
+
+  def install
+    inreplace "fhir-validation-cli", /SCRIPTDIR=(.*)/, "SCRIPTDIR=#{libexec}"
+    libexec.install "fhir-validation-cli.jar"
+    bin.install "fhir-validation-cli"
+  end
+
+  test do
+    system bin/"fhir-validation-cli"
+  end
+end


### PR DESCRIPTION
fhir-validation-cli is a the java based reference validator of the HL7 FHIR Spec. The validator enables the validation of FHIR instances against FHIR profiles.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
