### PR TITLE
git-annex: add OBJC_DISABLE_INITIALIZE_FORK_SAFETY environment variable

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -45,6 +45,11 @@ class GitAnnex < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
+          <string>YES</string>
+        </dict>
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>


### PR DESCRIPTION
… work around an issue where ruby forks can trigger a security block on OSX 10.14 or higher

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
