### PR TITLE
Add test to frei0r

### DIFF
--- a/Formula/frei0r.rb
+++ b/Formula/frei0r.rb
@@ -23,4 +23,22 @@ class Frei0r < Formula
     system "cmake", ".", *cmake_args
     system "make", "install"
   end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <frei0r.h>
+
+      int main()
+      {
+        int mver = FREI0R_MAJOR_VERSION;
+        if (mver != 0) {
+          return 0;
+        } else {
+          return 1;
+        }
+      }
+    EOS
+    system ENV.cc, "-L#{lib}", "test.c", "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
This basically links against the library and checks includes. This omits
calling a function from the library as the test would then be bound to which
frei0r filters are included in a particular release, breaking the test if one were removed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
