### PR TITLE
securefs 0.9.0

### DIFF
--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -1,8 +1,9 @@
 class Securefs < Formula
   desc "Filesystem with transparent authenticated encryption"
   homepage "https://github.com/netheril96/securefs"
-  url "https://github.com/netheril96/securefs/archive/0.8.3.tar.gz"
-  sha256 "04b0aa78108addcdeef64a4333ac75dff2833b7a48797b7c9060e325520db706"
+  url "https://github.com/netheril96/securefs.git",
+    :tag      => "0.9.0",
+    :revision => "cf84306e616f04aa3845db25e446df0f7c21416a"
   head "https://github.com/netheril96/securefs.git"
 
   bottle do


### PR DESCRIPTION
It now requires git to build.

------

I generated this PR by hand rather with `brew bump-formula-pr`, because the formula is changing from a URL+SHA256 to git+revision style.

------

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
