### PR TITLE
testssl.sh 3.0rc6

### DIFF
--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -1,10 +1,10 @@
 class Testssl < Formula
   desc "Tool which checks for the support of TLS/SSL ciphers and flaws"
   homepage "https://testssl.sh/"
-  url "https://github.com/drwetter/testssl.sh/archive/v2.9.5-8.tar.gz"
-  version "2.9.5-8"
-  sha256 "b236094a5360883bc8b1bb283c8a2c6f75230ca42e88bc04f0ab65074cd21e8a"
-  head "https://github.com/drwetter/testssl.sh.git", :branch => "2.9dev"
+  url "https://github.com/drwetter/testssl.sh/archive/3.0rc6.tar.gz"
+  version "3.0rc6"
+  sha256 "fc5aee354e5350448ac48294dee04c34989a21517d2181ff83738b6858eb12f2"
+  head "https://github.com/drwetter/testssl.sh.git", :branch => "3.0"
 
   bottle :unneeded
 


### PR DESCRIPTION
Support for 2.9.5 has been dropped.
https://github.com/drwetter/testssl.sh#status

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
no
```
testssl:
  * Stable: version 3.0rc6 is redundant with version scanned from URL
  * Stable version URLs should not contain rc6
```
