### PR TITLE
opensc: add pkcs11 caveats

### DIFF
--- a/Formula/opensc.rb
+++ b/Formula/opensc.rb
@@ -33,6 +33,13 @@ class Opensc < Formula
     system "make", "install"
   end
 
+  def caveats; <<~EOS
+    The OpenSSH PKCS11 smartcard integration will not work from High Sierra
+    onwards. If you need this functionality, unlink this formula, then install
+    the OpenSC cask.
+  EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/opensc-tool -i")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As per #44786, the formula for OpenSC installs the pkcs11 driver in a way that the OpenSSH agent won't accept:

```
refusing PKCS#11 add of "/usr/local/Cellar/opensc/0.20.0/lib/opensc-pkcs11.so": provider not whitelisted
```

The OpenSC **cask** installs the driver in a manner that works. Noting this in the caveats should help for future users, as the only other advice I've seen is to copy or hard-link the library from the OpenSC formula, and that causes issues on formula updates.

The OpenSC formula skips the linking step if the cask is already installed, so formula updates should not cause issues with this method:

```
==> opensc cask is installed, skipping link.
```