### PR TITLE
yaegi 0.7.2 (new formula)

### DIFF
--- a/Formula/yaegi.rb
+++ b/Formula/yaegi.rb
@@ -1,0 +1,18 @@
+class Yaegi < Formula
+  desc "Yet another elegant Go interpreter"
+  homepage "https://github.com/containous/yaegi"
+  url "https://github.com/containous/yaegi/archive/v0.7.2.tar.gz"
+  sha256 "1f2e63290614e26ffb82ef16af23d0ce5237c10a19a5c1191c22398adb62bc1e"
+  head "https://github.com/containous/yaegi.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"yaegi", "cmd/yaegi/yaegi.go"
+    prefix.install_metafiles
+  end
+
+  test do
+    assert_match "4", pipe_output("#{bin}/yaegi", "3 + 1", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the Go interpreter `yaegi`. [There was already a PR](https://github.com/Homebrew/homebrew-core/pull/42480) for this in July 2019 but all releases back then were tagged as pre-release versions and therefore not eligible to be added to `homebrew-core`