### PR TITLE
Update URLs for ios-deploy

### DIFF
--- a/Formula/ios-deploy.rb
+++ b/Formula/ios-deploy.rb
@@ -1,9 +1,9 @@
 class IosDeploy < Formula
   desc "Install and debug iPhone apps from the command-line"
-  homepage "https://github.com/phonegap/ios-deploy"
+  homepage "https://github.com/ios-control/ios-deploy"
   url "https://github.com/ios-control/ios-deploy/archive/1.10.0.tar.gz"
   sha256 "619176b0a78f631be169970a5afc9ec94b206d48ec7cb367bb5bf9d56b098290"
-  head "https://github.com/phonegap/ios-deploy.git"
+  head "https://github.com/ios-control/ios-deploy.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The project is now under https://github.com/ios-control/ios-deploy rather than under https://github.com/phonegap/ios-deploy. This is so that https://formulae.brew.sh/formula/ios-deploy will show the correct URL, but is just a cosmetic change since https://github.com/phonegap/ios-deploy redirects to the correct URL already.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
