### PR TITLE
imagemagick@6 6.9.10-83

### DIFF
--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -4,9 +4,9 @@ class ImagemagickAT6 < Formula
   # Please always keep the Homebrew mirror as the primary URL as the
   # ImageMagick site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
-  url "https://dl.bintray.com/homebrew/mirror/imagemagick%406-6.9.10-81.tar.xz"
-  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.10-81.tar.xz"
-  sha256 "9b3129f0453d1fbe2f4b89fb29f163df1a7c0bfc6ed6131951d93f06baa884b0"
+  url "https://dl.bintray.com/homebrew/mirror/imagemagick%406-6.9.10-83.tar.xz"
+  mirror "https://www.imagemagick.org/download/releases/ImageMagick-6.9.10-83.tar.xz"
+  sha256 "71b7db8384446a93af799b5ee5b50c787864566ad944d7f1edd6ffe2d6ac435c"
   head "https://github.com/imagemagick/imagemagick6.git"
 
   bottle do


### PR DESCRIPTION
The directory at `https://www.imagemagick.org/download/releases/` contains the latest few releases, so URLs won't become obsolete as fast.