### PR TITLE
pandoc 2.9.1.1

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -5,8 +5,8 @@ class Pandoc < Formula
 
   desc "Swiss-army knife of markup format conversion"
   homepage "https://pandoc.org/"
-  url "https://hackage.haskell.org/package/pandoc-2.9.1/pandoc-2.9.1.tar.gz"
-  sha256 "0a543566be3468a0283d08cf6f3cda44c70de46b52755d902277273450d78bfb"
+  url "https://hackage.haskell.org/package/pandoc-2.9.1.1/pandoc-2.9.1.1.tar.gz"
+  sha256 "9d21c5efe2074f9b3097a20e0798de9d8b89a86a1ce04a307f476c7b4aa3816d"
   head "https://github.com/jgm/pandoc.git"
 
   bottle do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,570,248 bytes
- formula fetch time: 0.1 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.