### PR TITLE
lfe: Catalina removed emacs

### DIFF
--- a/Formula/lfe.rb
+++ b/Formula/lfe.rb
@@ -13,6 +13,7 @@ class Lfe < Formula
     sha256 "aab3e33761e9db3c4e5cceb8769edca70f2eb618e0bed5e3658ab2fdc3bae2ac" => :yosemite
   end
 
+  depends_on "emacs" if MacOS.version >= :catalina
   depends_on "erlang"
 
   def install


### PR DESCRIPTION
emacs is not present on Catalina anymore, so depend on Homebrew's emacs