### PR TITLE
icecast: use proper etc dir and post_install block

### DIFF
--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -3,6 +3,7 @@ class Icecast < Formula
   homepage "https://icecast.org/"
   url "https://downloads.xiph.org/releases/icecast/icecast-2.4.4.tar.gz"
   sha256 "49b5979f9f614140b6a38046154203ee28218d8fc549888596a683ad604e4d44"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,9 +21,12 @@ class Icecast < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
                           "--localstatedir=#{var}"
     system "make", "install"
+  end
 
+  def post_install
     (var/"log/icecast").mkpath
     touch var/"log/icecast/access.log"
     touch var/"log/icecast/error.log"
@@ -30,7 +34,7 @@ class Icecast < Formula
 
   test do
     pid = fork do
-      exec "icecast", "-c", prefix/"etc/icecast.xml", "2>", "/dev/null"
+      exec "icecast", "-c", etc/"icecast.xml", "2>", "/dev/null"
     end
     sleep 3
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This commit moves the `icecast.xml` config file from `prefix/"etc/icecast.xml"` to `etc/"icecast.xml"`. The benefit is that the config file is no longer deleted when `icecast` is uninstalled. This is expected behavior (e.g. with `wgetrc` and `dmd.conf`).

The logic for creating the folder/file structure in `var` is also technically a `post_install` step, and as such has been moved into a `post_install` block.