### PR TITLE
phpmyadmin 5.0.1

### DIFF
--- a/Formula/phpmyadmin.rb
+++ b/Formula/phpmyadmin.rb
@@ -1,8 +1,8 @@
 class Phpmyadmin < Formula
   desc "Web interface for MySQL and MariaDB"
   homepage "https://www.phpmyadmin.net"
-  url "https://files.phpmyadmin.net/phpMyAdmin/5.0.0/phpMyAdmin-5.0.0-all-languages.tar.gz"
-  sha256 "56589e624236778b63cfb221f7752371e4e87192c342a8f2492818ae04e31298"
+  url "https://files.phpmyadmin.net/phpMyAdmin/5.0.1/phpMyAdmin-5.0.1-all-languages.tar.gz"
+  sha256 "1bd82fdcf5375526c8b5124a20968b69981724307d878321ae29499c61bbf48e"
 
   bottle :unneeded
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,949,452 bytes
- formula fetch time: 4.2 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.