### PR TITLE
botan: Sync `uses_from_macos` from Homebrew/linuxbrew-core

### DIFF
--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -14,6 +14,10 @@ class Botan < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
 
+  uses_from_macos "python@2" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~- Over in Homebrew/linuxbrew-core, we fixed a failing build for this
  formula by specifying `uses_from_macos "python@2" => :build`. I
  was going to sync that here, as per usual, but on closer inspection
  the code itself looked to happily be in Python 3 syntax.~
~- I'm not sure I've done this right or if this is our approach to Python
  updates, so some eyes from other maintainers would be appreciated
  please!~

- We had more dependencies on Linux that are included in macOS, so sync them here.