### PR TITLE
Bump arduino-cli to 0.7.2

### DIFF
--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -2,8 +2,8 @@ class ArduinoCli < Formula
   desc "Arduino command-line interface"
   homepage "https://github.com/arduino/arduino-cli"
   url "https://github.com/arduino/arduino-cli.git",
-     :tag      => "0.7.1",
-     :revision => "7668c465dd0ed58059c51b1b1f0a06279d6f4714"
+     :tag      => "0.7.2",
+     :revision => "9c10e063435a813e6e9bdecc596b5d735aa8a4ec"
   head "https://github.com/arduino/arduino-cli.git"
 
   bottle do


### PR DESCRIPTION
This commit bumps arduino-cli to 0.7.2.

Changelog: https://github.com/arduino/arduino-cli/releases/tag/0.7.2

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
