### PR TITLE
alpine - adjust to use keychain for macos

### DIFF
--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -4,7 +4,7 @@ class Alpine < Formula
   url "https://ftp.osuosl.org/pub/blfs/conglomeration/alpine/alpine-2.21.tar.xz"
   mirror "https://fossies.org/linux/misc/alpine-2.21.tar.xz"
   sha256 "6030b6881b8168546756ab3a5e43628d8d564539b0476578e287775573a77438"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "73d6ba0c5623c94d2434fbb7d64e232faff22ad4a2d0352f32bcf6e1c2b33d5b" => :catalina
@@ -23,7 +23,6 @@ class Alpine < Formula
       --with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}
       --with-ssl-certs-dir=#{etc}/openssl@1.1
       --prefix=#{prefix}
-      --with-passfile=.pine-passfile
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR effectively reverts #14239 .  The `--with-passfile` configure option is a binary choice.  You can either use the macOS keychain (no passfile) or you can use a passfile.  The packge does not support both at the same time.  I believe that use of the keychain should be the more canonical option and should be the behavior in homebrew-core.