### PR TITLE
now-cli: Fix test

### DIFF
--- a/Formula/now-cli.rb
+++ b/Formula/now-cli.rb
@@ -24,8 +24,8 @@ class NowCli < Formula
   end
 
   test do
-    system "#{bin}/now", "init", "markdown"
-    assert_predicate testpath/"markdown/now.json", :exist?, "now.json must exist"
-    assert_predicate testpath/"markdown/README.md", :exist?, "README.md must exist"
+    system "#{bin}/now", "init", "jekyll"
+    assert_predicate testpath/"jekyll/_config.yml", :exist?, "_config.yml must exist"
+    assert_predicate testpath/"jekyll/README.md", :exist?, "README.md must exist"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- The examples [were moved](https://github.com/zeit/now-examples/commit/ec867ed3dc957b75ad44902d3d49e416f4c4f0b3), and the `markdown` example was somehow removed. (I can't find a reason why.)
- Replace `now init markdown` with `now init jekyll` as that was the easiest thing I could think of that did exist, as it's still based on Markdown files and isn't an entire JS thing.

EDIT: Force-pushed as it helps if I `git add` my most recent local changes to get actual working tests. 😴