### PR TITLE
dsvpn 0.1.4

### DIFF
--- a/Formula/dsvpn.rb
+++ b/Formula/dsvpn.rb
@@ -1,0 +1,24 @@
+class Dsvpn < Formula
+  desc "Dead Simple VPN"
+  homepage "https://github.com/jedisct1/dsvpn"
+  url "https://github.com/jedisct1/dsvpn/archive/0.1.4.tar.gz"
+  sha256 "b98604e1ca2ffa7a909bf07ca7cf0597e3baa73c116fbd257f93a4249ac9c0c5"
+  head "https://github.com/jedisct1/dsvpn.git"
+
+  def install
+    sbin.mkpath
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  def caveats; <<~EOS
+    dsvpn requires root privileges so you will need to run `sudo #{HOMEBREW_PREFIX}/sbin/dsvpn`.
+    You should be certain that you trust any software you grant root privileges.
+  EOS
+  end
+
+  test do
+    expected = "tun device creation: Operation not permitted"
+    assert_match expected, shell_output("#{sbin}/dsvpn client /dev/zero 127.0.0.1 0 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Dsvpn (Dead Simple VPN) is as the name describes a tool to create a VPN
server with minimal fuss. Ditto for the client.

It is designed around the "cafe Internet hotspot" use case where only
TCP/80 or TCP/443 is open and there is no deep packet inspection to
thwart your escape attempts.

Dsvpn on Mac currently supports client mode for the time being.
It is unclear whether server mode will ever be supported.

It is so dead simple that everything about its usage is described
in the usage screen.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----