### PR TITLE
shfmt 3.0.1

### DIFF
--- a/Formula/shfmt.rb
+++ b/Formula/shfmt.rb
@@ -3,6 +3,7 @@ class Shfmt < Formula
   homepage "https://github.com/mvdan/sh"
   url "https://github.com/mvdan/sh/archive/v3.0.1.tar.gz"
   sha256 "4cca3d8a40e5132a4764a3bf7bcf335288ebff8a4a74e130f9359605e6f07544"
+  revision 1
   head "https://github.com/mvdan/sh.git"
 
   bottle do
@@ -18,10 +19,12 @@ class Shfmt < Formula
     ENV["CGO_ENABLED"] = "0"
     (buildpath/"src/mvdan.cc").mkpath
     ln_sf buildpath, buildpath/"src/mvdan.cc/sh"
-    system "go", "build", "-a", "-tags", "production brew", "-ldflags", "-w -s -extldflags '-static'", "-o", "#{bin}/shfmt", "mvdan.cc/sh/cmd/shfmt"
+    system "go", "build", "-a", "-tags", "production brew", "-ldflags", "-w -s -extldflags '-static'", "-o", "#{bin}/shfmt", "./cmd/shfmt"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/shfmt  --version")
+
     (testpath/"test").write "\t\techo foo"
     system "#{bin}/shfmt", testpath/"test"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently the version of `shfmt` built by the formula is always 2.6.4, even though it's listed as 3.0.1, since it isn't built directly from the archive:

```
$ brew install shfmt
==> Downloading https://homebrew.bintray.com/bottles/shfmt-3.0.1.mojave.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/14/142441307ad8c014c3f46fcf9f4bbd8d708efc535ae7e98611cf3f332f4c6c86?__gda__=exp=157878451
######################################################################## 100.0%
==> Pouring shfmt-3.0.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/shfmt/3.0.1: 6 files, 3.2MB
==> `brew cleanup` has not been run in 30 days, running now...
$ /usr/local/Cellar/shfmt/3.0.1/bin/shfmt --version
v2.6.4
$ brew reinstall --build-from-source shfmt
==> Reinstalling shfmt 
==> Downloading https://github.com/mvdan/sh/archive/v3.0.1.tar.gz
==> Downloading from https://codeload.github.com/mvdan/sh/tar.gz/v3.0.1
######################################################################## 100.0%
==> go build -a -tags production brew -ldflags -w -s -extldflags '-static' -o /usr/local/Cellar/shfmt/3.0.1/bin/shfmt mvdan.cc/sh/cmd/shfmt
🍺  /usr/local/Cellar/shfmt/3.0.1: 6 files, 3.2MB, built in 14 seconds
$ /usr/local/Cellar/shfmt/3.0.1/bin/shfmt --version
v2.6.4
```