### PR TITLE
[Actions] Label PRs where the formula is `bottle :unneeded`

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,19 @@
+name: Label PRs according to criteria
+
+on:
+  pull_request:
+    paths:
+    - 'Formula/*.rb'
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6.3'
+      - run: gem install octokit
+      - run: ruby .github/workflows/scripts/add-labels.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/add-labels.rb
+++ b/.github/workflows/scripts/add-labels.rb
@@ -1,0 +1,27 @@
+require "octokit"
+
+client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+
+repo = ENV["GITHUB_REPOSITORY"]
+pr_number = ENV["GITHUB_REF"].split("/")[2]
+
+pr_files = client.pull_request_files(repo, pr_number)
+
+pr_labels = {
+  no_bottles: 0
+}
+
+pr_files.each do |file|
+  formula = file[:filename]
+
+  if File.exist?(formula) && File.read(formula).match(/bottle :unneeded/)
+    pr_labels[:no_bottles] += 1
+  end
+end
+
+if pr_files.count == pr_labels[:no_bottles]
+  puts "Adding the 'no-bottles' label."
+  client.add_labels_to_an_issue(repo, pr_number, ["no-bottles"])
+else
+  puts "Not labelling this PR as there's a mixture of bottled and unbottled formulae."
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- The vast majority of formulae here have bottles, but there are some that we can merge through the GitHub web UI buttons.
- Yes, we'll still check the diff of submitted formulae, but for those short on time, it might be good to know that we can review submissions and merge them on GitHub without having to be near a computer to pull the bottles.
- This was also a nice look into how we can potentially in future auto-label other conditions for formulae (new formula, test failure, etc).