### PR TITLE
b3sum 0.1.0 (new formula)

### DIFF
--- a/Formula/b3sum.rb
+++ b/Formula/b3sum.rb
@@ -1,0 +1,21 @@
+class B3sum < Formula
+  desc "The BLAKE3 cryptographic hash function"
+  homepage "https://github.com/BLAKE3-team/BLAKE3"
+  url "https://github.com/BLAKE3-team/BLAKE3/archive/0.1.0.tar.gz"
+  sha256 "0a5d8900f63bfe875115398fa2935ec0d5d518fd3f860ef81d22d328cc832148"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "./b3sum/"
+  end
+
+  test do
+    (testpath/"test.txt").write <<~EOS
+      content
+    EOS
+
+    output = shell_output("#{bin}/b3sum test.txt")
+    assert_equal "df0c40684c6bda3958244ee330300fdcbc5a37fb7ae06fe886b786bc474be87e  test.txt", output.strip
+  end
+end


### PR DESCRIPTION
This commits adds the b3sum checsum utility based on the blake3 hash
function, see https://github.com/BLAKE3-team/BLAKE3 for more details.

> BLAKE3 is a cryptographic hash function that is:
>
> * Much faster than MD5, SHA-1, SHA-2, SHA-3, and BLAKE2.
> * Secure, unlike MD5 and SHA-1. And secure against length extension, unlike SHA-2.
> * Highly parallelizable across any number of threads and SIMD lanes, because it's a Merkle tree on the inside.
> * Capable of verified streaming and incremental updates, again because it's a Merkle tree.
> * A PRF, MAC, KDF, and XOF, as well as a regular hash.
> * One algorithm with no variants, which is fast on x86-64 and also on smaller architectures.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
