### PR TITLE
grapple 0.3.1 (new formula)

### DIFF
--- a/Formula/grapple.rb
+++ b/Formula/grapple.rb
@@ -1,0 +1,20 @@
+class Grapple < Formula
+  desc "Interruptible download accelerator, written in Rust"
+  homepage "https://github.com/daveallie/grapple"
+  url "https://github.com/daveallie/grapple/archive/v0.3.1.tar.gz"
+  sha256 "eda7ca1bc01ee42e63d2ea3d55f4d6ec0d7d66fd6825aad1481d08a38cb64ae7"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    output = shell_output("#{bin}/grapple --version")
+    assert_equal "Grapple #{version}", output.strip
+
+    shell_output("#{bin}/grapple -t2 http://i.imgur.com/z4d4kWk.jpg")
+    assert_predicate testpath/"z4d4kWk.jpg", :exist?
+  end
+end


### PR DESCRIPTION
This formula adds a great download accelerator written in rust.
More on the repo readme https://github.com/daveallie/grapple

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
