### PR TITLE
[Actions] Only use Formula/*.rb files from PRs

### DIFF
--- a/.github/workflows/scripts/add-labels.rb
+++ b/.github/workflows/scripts/add-labels.rb
@@ -24,6 +24,4 @@ end
 if pr_files.count == pr_labels[:no_bottles]
   puts "Adding the 'no-bottles' label."
   client.add_labels_to_an_issue(repo, pr_number, ["no-bottles"])
-else
-  puts "Not labelling this PR as there's a mixture of bottled and unbottled formulae."
 end

--- a/.github/workflows/scripts/add-labels.rb
+++ b/.github/workflows/scripts/add-labels.rb
@@ -5,7 +5,9 @@ client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 repo = ENV["GITHUB_REPOSITORY"]
 pr_number = ENV["GITHUB_REF"].split("/")[2]
 
-pr_files = client.pull_request_files(repo, pr_number)
+pr_files = client.pull_request_files(repo, pr_number).select do |file|
+  file[:filename].start_with?("Formula")
+end
 
 pr_labels = {
   no_bottles: 0


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- Sometimes, we update a formula and its alias at the same time. In that
  case, the updated formula could have `bottle :unneeded`, but the number
  of files in the PR and the number of labels wouldn't match. However we
  still want the "no bottles" label, because there's only one _formula_ in
  the PR.
- To avoid this, only operate on files in the PR that are in the
  `Formula` dir.
- Fixes https://github.com/Homebrew/homebrew-core/pull/48911#discussion_r365583859.