### PR TITLE
Update sile to v0.10.0, add new dependencies

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,11 +1,10 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
-  homepage "https://www.sile-typesetter.org/"
-  url "https://github.com/simoncozens/sile/releases/download/v0.9.5.1/sile-0.9.5.1.tar.bz2"
-  sha256 "60cdcc4509971973feab352dfc1a86217cc1fdb12d56823f04d863afef92003a"
-  revision 2
+  homepage "https://www.sile-typesetter.org"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.10.0/sile-0.10.0.tar.bz2"
+  sha256 "b0353b88793d68bf3e800f87bff51e8161ce39d250e22dff11385712caf332b6"
 
-  head "https://github.com/simoncozens/sile.git"
+  head "https://github.com/sile-typesetter/sile.git"
 
   bottle do
     sha256 "c2db86e0a1510c94d2d06365d2c31222948ea3b89b64c24ffc81451b0894ff71" => :catalina
@@ -31,10 +30,25 @@ class Sile < Formula
   depends_on "openssl@1.1"
   depends_on "zlib"
 
+  resource "cassowary" do
+    url "https://github.com/sile-typesetter/cassowary.lua/archive/v2.2.tar.gz"
+    sha256 "e2f7774b6883581491b8f2c9d1655b2136bc24d837a9e43f515590a766ec4afd"
+  end
+
+  resource "linenoise" do
+    url "https://github.com/hoelzro/lua-linenoise/archive/0.9.tar.gz"
+    sha256 "cc1cdb4047edd056a10dcdeec853dbaf5088e2202941d579e4592584d733f09c"
+  end
+
   resource "lpeg" do
     url "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.1.tar.gz"
     mirror "https://mirror.sobukus.de/files/grimoire/lua-forge/lpeg-1.0.1.tar.gz"
     sha256 "62d9f7a9ea3c1f215c77e0cadd8534c6ad9af0fb711c3f89188a8891c72f026b"
+  end
+
+  resource "lua_cliargs" do
+    url "https://github.com/amireh/lua_cliargs/archive/v3.0-2.tar.gz"
+    sha256 "971d6f1440a55bdf9db581d4b2bcbf472a301d76f696a0d0ed9423957c7d176e"
   end
 
   resource "lua-zlib" do
@@ -47,9 +61,19 @@ class Sile < Formula
     sha256 "d060397960d87b2c89cf490f330508b7def1a0677bdc120531c571609fc57dc3"
   end
 
+  resource "luaepnf" do
+    url "https://github.com/siffiejoe/lua-luaepnf/archive/v0.3.tar.gz"
+    sha256 "57c0ad1917e45c5677bfed0f6122da2baff98117aba05a5e987a0238600f85f9"
+  end
+
   resource "luafilesystem" do
     url "https://github.com/keplerproject/luafilesystem/archive/v1_7_0_2.tar.gz"
     sha256 "23b4883aeb4fb90b2d0f338659f33a631f9df7a7e67c54115775a77d4ac3cc59"
+  end
+
+  resource "luarepl" do
+    url "https://github.com/hoelzro/lua-repl/archive/0.9.tar.gz"
+    sha256 "3c88a3b102a4a4897c46fadb2cd12ee6760438e41e39ffc6cf353582d651b313"
   end
 
   resource "luasocket" do
@@ -62,9 +86,24 @@ class Sile < Formula
     sha256 "2176e95b1d2a72a3235ede5d2aa9838050feee55dade8fdbde4be7fdc66f3a31"
   end
 
+  resource "penlight" do
+    url "https://github.com/Tieske/Penlight/archive/1.7.0.tar.gz"
+    sha256 "5b793fc93fa7227190e191e5b24a8f0ce9dd5958ccebe7a53842a58b5d46057f"
+  end
+
+  resource "vstruct" do
+    url "https://github.com/ToxicFrog/vstruct/archive/v2.0.1.tar.gz"
+    sha256 "4529ab32691b5f6e3c798ddfac36013d24d7581715dc7a50a77f17bb2d575c13"
+  end
+
+  resource "stdlib" do
+    url "https://github.com/lua-stdlib/lua-stdlib/archive/release-v41.2.2.tar.gz"
+    sha256 "42ca25ddcde59f608694a3335d24919a4df4cf6f14ea46c75249561a16c84711"
+  end
+
   def install
     luapath = libexec/"vendor"
-    ENV["LUA_PATH"] = "#{luapath}/share/lua/5.3/?.lua;;#{luapath}/share/lua/5.3/lxp/?.lua"
+    ENV["LUA_PATH"] = "#{luapath}/share/lua/5.3/?.lua;#{luapath}/share/lua/5.3/?/init.lua;#{luapath}/share/lua/5.3/lxp/?.lua"
     ENV["LUA_CPATH"] = "#{luapath}/lib/lua/5.3/?.so"
 
     resources.each do |r|
@@ -87,6 +126,7 @@ class Sile < Formula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--with-system-luarocks",
                           "--with-lua=#{prefix}",
                           "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Question for anybody familiar with Lua issues in Homebrew:

As of this release SILE has a new build time option option `./configure --with-system-luarocks` (default is without) that will use Luarocks to download and bundle all the required libraries alongside the SILE install. This would make this Formula simpler, but I wasn't sure whether that is the preferred method. Would it be better to do that (which will fetch from Luarocks at build time) or use the current pattern? I added the new dependencies with the current pattern just in case, but I could also switch methods.

@simoncozens maybe you can test this, I don't actually have a Mac :wink: