### PR TITLE
pandoc-crossref: Bump revision for pandoc

### DIFF
--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -7,6 +7,7 @@ class PandocCrossref < Formula
   homepage "https://github.com/lierdakil/pandoc-crossref"
   url "https://hackage.haskell.org/package/pandoc-crossref-0.3.5.0/pandoc-crossref-0.3.5.0.tar.gz"
   sha256 "646ea9b0d1564f894528036724d7a112d54e6946555602cd15c421b48fc301f4"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix the warning:
```
$ pandoc -Fpandoc-crossref -o document.pdf document.md
WARNING: pandoc-crossref was compiled with pandoc 2.8 but is being run
through 2.9.1.1. This is not supported. Strange things may (and likely
will) happen silently.
```