### PR TITLE
prometheus: embed revision hash to binary

### DIFF
--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -1,8 +1,10 @@
 class Prometheus < Formula
   desc "Service monitoring system and time series database"
   homepage "https://prometheus.io/"
-  url "https://github.com/prometheus/prometheus/archive/v2.15.2.tar.gz"
-  sha256 "2ba37bced3e90c5e7dd3248918f13f2f3444de748cfe413b0a09f82532c3c553"
+  url "https://github.com/prometheus/prometheus.git",
+    :tag      => "v2.15.2",
+    :revision => "d9613e5c466c6e9de548c4dae1b9aabf9aaf7c57"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,9 +18,6 @@ class Prometheus < Formula
   depends_on "yarn" => :build
 
   def install
-    mkdir_p buildpath/"src/github.com/prometheus"
-    ln_sf buildpath, buildpath/"src/github.com/prometheus/prometheus"
-
     system "make", "assets"
     system "make", "build"
     bin.install %w[promtool prometheus]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Embed git revision hash to prometheus binary.
Prometheus will be able to display its revision.

Before
```
$ prometheus --version
prometheus, version 2.15.2 (branch: non-git, revision: non-git)
  build user:       brew@Mojave.local
  build date:       20200106-16:32:25
  go version:       go1.13.5
```

After
```
$ prometheus --version
prometheus, version 2.15.2 (branch: HEAD, revision: d9613e5c466c6e9de548c4dae1b9aabf9aaf7c57)
  build user:       cazador@locus.local
  build date:       20200116-15:48:41
  go version:       go1.13.6
```

`brew audit --strict` failed due to 
```
prometheus:
* stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
```
But I believe source code is not changed because git tag is not changed.