### PR TITLE
node_exporter: embed revision hash to binary

### DIFF
--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -1,9 +1,10 @@
 class NodeExporter < Formula
   desc "Prometheus exporter for machine metrics"
   homepage "https://prometheus.io/"
-  url "https://github.com/prometheus/node_exporter/archive/v0.18.1.tar.gz"
-  sha256 "9ddf187c462f2681ab4516410ada0e6f0f03097db6986686795559ea71a07694"
-  revision 1
+  url "https://github.com/prometheus/node_exporter.git",
+    :tag      => "v0.18.1",
+    :revision => "3db77732e925c08f675d7404a8c46466b2ece83e"
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -16,12 +17,8 @@ class NodeExporter < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = %W[
-      -X github.com/prometheus/common/version.Version=#{version}
-      -X github.com/prometheus/common/version.BuildUser=Homebrew
-    ]
-    system "go", "build", "-ldflags", ldflags.join(" "), "-trimpath",
-           "-o", bin/"node_exporter"
+    system "make", "build"
+    bin.install "node_exporter"
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Embed git revision hash to binary.
node_exporter will be able to display its revision.

Before
```
$ node_exporter --version
node_exporter, version 0.18.1 (branch: , revision: )
  build user:       Homebrew
  build date:
  go version:       go1.13.5
```

After
```
$  node_exporter --version
node_exporter, version 0.18.1 (branch: HEAD, revision: 3db77732e925c08f675d7404a8c46466b2ece83e)
  build user:       cazador@locus.local
  build date:       20200116-16:03:58
  go version:       go1.13.6
```

`brew audit --strict` failed due to 
```
prometheus:
* stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
```
But I believe source code is not changed because git tag is not changed.