### PR TITLE
fastlane: fix export PATH

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -3,6 +3,7 @@ class Fastlane < Formula
   homepage "https://fastlane.tools"
   url "https://github.com/fastlane/fastlane/archive/2.140.0.tar.gz"
   sha256 "06f6c3f348d1892d53ffc2055293b1d7fe0898c43e183811bce6055da8536be6"
+  revision 1
   head "https://github.com/fastlane/fastlane.git"
 
   bottle do
@@ -23,7 +24,7 @@ class Fastlane < Formula
 
     (bin/"fastlane").write <<~EOS
       #!/bin/bash
-      export PATH="#{Formula["ruby@2.5"].opt_bin}:$PATH}"
+      export PATH="#{Formula["ruby@2.5"].opt_bin}:#{libexec}/bin:$PATH"
       GEM_HOME="#{libexec}" GEM_PATH="#{libexec}" \\
         exec "#{libexec}/bin/fastlane" "$@"
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request fixes `fastlane` bin shell script .

- Added `#{libexec}/bin` to `PATH` so `fastlane` can see its dependencies (such as `xcprety`) correctly.
  - Without `#{libexec}/bin`, commands of `fastlane` (such as `gym`) that has dependencies organically fails.
- Removed typo `}`.