### PR TITLE
libcouchbase3 3.0 (new formula)

### DIFF
--- a/Formula/libcouchbase3.rb
+++ b/Formula/libcouchbase3.rb
@@ -1,0 +1,28 @@
+class Libcouchbase3 < Formula
+  desc "C library for Couchbase"
+  homepage "https://docs.couchbase.com/c-sdk/3.0/hello-world/start-using-sdk.html"
+  url "https://packages.couchbase.com/clients/c/libcouchbase-3.0.0.tar.gz"
+  sha256 "7688aaeb5e5833ef4bfe9ab79da58b7291b2f1c1b49b28e6567b598698a9c026"
+  head "https://github.com/couchbase/libcouchbase.git"
+
+  depends_on "cmake" => :build
+  depends_on "libev"
+  depends_on "libevent"
+  depends_on "libuv"
+  depends_on "openssl@1.1"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args,
+                            "-DLCB_NO_TESTS=1",
+                            "-DLCB_BUILD_LIBEVENT=ON",
+                            "-DLCB_BUILD_LIBEV=ON",
+                            "-DLCB_BUILD_LIBUV=ON"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/cbc", "version"
+  end
+end


### PR DESCRIPTION
This is a clone of libcouchbase.rb. Libcouchbase 3 represent new version of the library with backwards incompatible API.

We still going to maintain and release fixes for libcouchbase 2.x, this is why I don't make changes in `Formula/libcouchbase.rb`