### PR TITLE
mongo-c-driver 1.16.0

### DIFF
--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -1,8 +1,8 @@
 class MongoCDriver < Formula
   desc "C driver for MongoDB"
   homepage "https://github.com/mongodb/mongo-c-driver"
-  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.15.3/mongo-c-driver-1.15.3.tar.gz"
-  sha256 "a09b871339ea15508baedd7777d7eaec13af962b4351e2fb2e19278d7313e049"
+  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.16.0/mongo-c-driver-1.16.0.tar.gz"
+  sha256 "a4e7ed92e3a2a28640987507b4b9da18c2ed225fe87af00ea9deec839cdd55e0"
   head "https://github.com/mongodb/mongo-c-driver.git"
 
   bottle do
@@ -19,7 +19,7 @@ class MongoCDriver < Formula
   def install
     cmake_args = std_cmake_args
     if build.head?
-      cmake_args << "-DBUILD_VERSION=1.16.0-pre"
+      cmake_args << "-DBUILD_VERSION=1.17.0-pre"
     end
     system "cmake", ".", *cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note: I'm getting an assertion error when running the tests, but I'm not sure if that's a genuine test failure or just my environment being messy:
```
==> ./test mongodb://0.0.0.0 2>&1
Error: mongo-c-driver: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <3> expected but was
<0>.
/Library/Ruby/Gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:55:in `block in assert_block'
/Library/Ruby/Gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:1636:in `_wrap_assertion'
/Library/Ruby/Gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:53:in `assert_block'
/Library/Ruby/Gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:240:in `assert_equal'
/usr/local/Homebrew/Library/Homebrew/formula_assertions.rb:12:in `shell_output'
/Users/alcaeus/Code/homebrew/homebrew-core/Formula/mongo-c-driver.rb:39:in `block in <class:MongoCDriver>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1745:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:478:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1744:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:865:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1743:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1982:in `block in mktemp'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1981:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1737:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:33:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:32:in `<main>'
```

The build will tell...