### PR TITLE
Update flyway db to the latest version: v6.1.4

### DIFF
--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -1,8 +1,8 @@
 class Flyway < Formula
   desc "Database version control to control migrations"
   homepage "https://flywaydb.org/"
-  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/6.0.8/flyway-commandline-6.0.8.tar.gz"
-  sha256 "636d5ab5a3b226cad38b2e0bb56c0063b74a6f029ff887158948cbf962e46a2d"
+  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/6.1.4/flyway-commandline-6.1.4.tar.gz"
+  sha256 "899d506c1004566810a924389e379ecaa92460928bc223dbc1e604ffc4a387d8"
 
   bottle :unneeded
 


### PR DESCRIPTION
Bumping this to the new version released on 2019-12-20: https://flywaydb.org/blog/flyway-6.1.4#highlights

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
