### PR TITLE
minetest: Only download dependencies on build

### DIFF
--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -6,7 +6,7 @@ class Minetest < Formula
     url "https://github.com/minetest/minetest/archive/5.1.0.tar.gz"
     sha256 "ca53975eecf6a39383040658f41d697c8d7f8d5fe9176460f564979c73b53906"
 
-    # This patch is already merged in master and it should be removed when new version of mintest is released
+    # This patch is already merged in master and it should be removed when new version of minetest is released
     patch do
       url "https://github.com/minetest/minetest/pull/9064.patch?full_index=1"
       sha256 "78c5148ae5260bf2220ca18849c698e92c93e1c92b8f287135b293457c9ab6cd"
@@ -33,13 +33,13 @@ class Minetest < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "freetype"
-  depends_on "gettext"
-  depends_on "irrlicht"
-  depends_on "jpeg"
-  depends_on "libogg"
-  depends_on "libvorbis"
-  depends_on "luajit"
+  depends_on "freetype" => :build
+  depends_on "gettext" => :build
+  depends_on "irrlicht" => :build
+  depends_on "jpeg" => :build
+  depends_on "libogg" => :build
+  depends_on "libvorbis" => :build
+  depends_on "luajit" => :build
 
   def install
     (buildpath/"games/minetest_game").install resource("minetest_game")
@@ -62,7 +62,7 @@ class Minetest < Formula
       to create those folders first).
 
       If you would like to start the Minetest server from a terminal, run
-      "/Applications/minetest.app/Contents/MacOS/minetest --server".
+      "#{prefix}/minetest.app/Contents/MacOS/minetest --server".
     EOS
   end
 end

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -65,4 +65,8 @@ class Minetest < Formula
       "#{prefix}/minetest.app/Contents/MacOS/minetest --server".
     EOS
   end
+
+  test do
+    system "#{prefix}/minetest.app/Contents/MacOS/minetest", "--version"
+  end
 end

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -6,7 +6,7 @@ class Minetest < Formula
     url "https://github.com/minetest/minetest/archive/5.1.0.tar.gz"
     sha256 "ca53975eecf6a39383040658f41d697c8d7f8d5fe9176460f564979c73b53906"
 
-    # This patch is already merged in master and it should be removed when new version of minetest is released
+    # This patch is already merged in master and it should be removed when new version of mintest is released
     patch do
       url "https://github.com/minetest/minetest/pull/9064.patch?full_index=1"
       sha256 "78c5148ae5260bf2220ca18849c698e92c93e1c92b8f287135b293457c9ab6cd"
@@ -62,11 +62,7 @@ class Minetest < Formula
       to create those folders first).
 
       If you would like to start the Minetest server from a terminal, run
-      "#{prefix}/minetest.app/Contents/MacOS/minetest --server".
+      "/Applications/minetest.app/Contents/MacOS/minetest --server".
     EOS
-  end
-
-  test do
-    system "#{prefix}/minetest.app/Contents/MacOS/minetest", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
