### PR TITLE
csound: update test

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -110,7 +110,7 @@ class Csound < Formula
     ENV["RAWWAVE_PATH"] = Formula["stk"].pkgshare/"rawwaves"
 
     output = shell_output "#{bin}/csound test.orc test.sco 2>&1"
-    assert_match /^hello, world\n/, output
+    assert_match /^hello, world$/, output
     assert_match /^rtaudio:/, output
     assert_match /^rtmidi:/, output
 
@@ -125,7 +125,7 @@ class Csound < Formula
           i_success wiiconnect 1, 1
       endin
     EOS
-    system bin/"csound", "wii.orc", "test.sco"
+    system bin/"csound", "--orc", "--syntax-check-only", "wii.orc"
 
     ENV["DYLD_FRAMEWORK_PATH"] = frameworks
     system "python3", "-c", "import ctcsound"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR is a minor change to a regex. It also changes the test of Wii opcodes to only check syntax; a Wiimote can’t actually be connected during CI, and this will probably result in an error in a future version of Csound (but the syntax check will still work).