### PR TITLE
liblzf: update source hash

### DIFF
--- a/Formula/liblzf.rb
+++ b/Formula/liblzf.rb
@@ -3,7 +3,7 @@ class Liblzf < Formula
   homepage "http://oldhome.schmorp.de/marc/liblzf.html"
   url "http://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
   mirror "http://download.openpkg.org/components/cache/liblzf/liblzf-3.6.tar.gz"
-  sha256 "41ed86a1bd3a9485612f7a7c1d3c9962d2fe771e55dc30fcf45bd419c39aab8d"
+  sha256 "9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Relates to #45514

From http://dist.schmorp.de/liblzf/ it says liblzf-3.6.tar.gz was last modified on 2019-10-04, which might explain the hash change.