### PR TITLE
Add a separate git-gui formula for the Tcl/Tk git UIs

### DIFF
--- a/Formula/git-gui.rb
+++ b/Formula/git-gui.rb
@@ -1,0 +1,50 @@
+class GitGui < Formula
+  desc "Tcl/Tk UI for the git revision control system"
+  homepage "https://git-scm.com"
+  # Note: Please keep these values in sync with git.rb when updating.
+  url "https://www.kernel.org/pub/software/scm/git/git-2.25.0.tar.xz"
+  sha256 "c060291a3ffb43d7c99f4aa5c4d37d3751cf6bca683e7344ea407ea504d9a8d0"
+  head "https://github.com/git/git.git", :shallow => false
+
+  depends_on "git"
+  depends_on "tcl-tk"
+
+  def install
+    ENV["V"] = "1" # build verbosely
+    tcl_bin = Formula["tcl-tk"].opt_bin
+    # By setting TKFRAMEWORK to a non-existent directory we ensure that
+    # the git makefiles don't install a .app for git-gui
+    # We also tell git to use the homebrew-installed wish binary from tcl-tk.
+    # See https://github.com/Homebrew/homebrew-core/issues/36390
+    args = %W[
+      TKFRAMEWORK=/dev/null
+      prefix=#{prefix}
+      gitexecdir=#{libexec}/git-core
+      sysconfdir=#{etc}
+      CC=#{ENV.cc}
+      CFLAGS=#{ENV.cflags}
+      LDFLAGS=#{ENV.ldflags}
+      TCL_PATH=#{tcl_bin}/tclsh
+      TCLTK_PATH=#{tcl_bin}/wish
+    ]
+    system "make", "-C", "git-gui", "install", *args
+    system "make", "-C", "gitk-git", "install", *args
+    # Git looks for git-foo binaries in $(git --exec-path), i.e.
+    # $CELLAR/git/$VERSION/libexec/git-core and in $PATH.
+    # If we only keep them in the cellar directory they will not be found.
+    # The easiest solution to this problem is to move the binaries
+    # from libexec to bin to ensure that git finds them when running e.g.
+    # `git gui` from the command line.
+    bin.install libexec/"git-core/git-gui"
+    bin.install libexec/"git-core/git-gui--askpass"
+    bin.install libexec/"git-core/git-citool"
+    # Check that the libexec directories are empty so that we don't
+    # forget to correctly install any newly added tools.
+    (libexec/"git-core").rmdir
+    libexec.rmdir
+  end
+
+  test do
+    system bin/"git-gui", "--version"
+  end
+end

--- a/Formula/git-gui.rb
+++ b/Formula/git-gui.rb
@@ -6,20 +6,21 @@ class GitGui < Formula
   sha256 "c060291a3ffb43d7c99f4aa5c4d37d3751cf6bca683e7344ea407ea504d9a8d0"
   head "https://github.com/git/git.git", :shallow => false
 
-  depends_on "git"
   depends_on "tcl-tk"
 
   def install
-    ENV["V"] = "1" # build verbosely
-    tcl_bin = Formula["tcl-tk"].opt_bin
+    # build verbosely
+    ENV["V"] = "1"
+
     # By setting TKFRAMEWORK to a non-existent directory we ensure that
     # the git makefiles don't install a .app for git-gui
     # We also tell git to use the homebrew-installed wish binary from tcl-tk.
     # See https://github.com/Homebrew/homebrew-core/issues/36390
+    tcl_bin = Formula["tcl-tk"].opt_bin
     args = %W[
       TKFRAMEWORK=/dev/null
       prefix=#{prefix}
-      gitexecdir=#{libexec}/git-core
+      gitexecdir=#{bin}
       sysconfdir=#{etc}
       CC=#{ENV.cc}
       CFLAGS=#{ENV.cflags}
@@ -29,22 +30,10 @@ class GitGui < Formula
     ]
     system "make", "-C", "git-gui", "install", *args
     system "make", "-C", "gitk-git", "install", *args
-    # Git looks for git-foo binaries in $(git --exec-path), i.e.
-    # $CELLAR/git/$VERSION/libexec/git-core and in $PATH.
-    # If we only keep them in the cellar directory they will not be found.
-    # The easiest solution to this problem is to move the binaries
-    # from libexec to bin to ensure that git finds them when running e.g.
-    # `git gui` from the command line.
-    bin.install libexec/"git-core/git-gui"
-    bin.install libexec/"git-core/git-gui--askpass"
-    bin.install libexec/"git-core/git-citool"
-    # Check that the libexec directories are empty so that we don't
-    # forget to correctly install any newly added tools.
-    (libexec/"git-core").rmdir
-    libexec.rmdir
   end
 
   test do
     system bin/"git-gui", "--version"
+    system bin/"gitk", "--version"
   end
 end

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -1,8 +1,10 @@
 class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
+  # Note: Please keep these values in sync with git-gui.rb when updating.
   url "https://www.kernel.org/pub/software/scm/git/git-2.25.0.tar.xz"
   sha256 "c060291a3ffb43d7c99f4aa5c4d37d3751cf6bca683e7344ea407ea504d9a8d0"
+  revision 1
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do
@@ -67,12 +69,17 @@ class Git < Formula
       ENV["HOMEBREW_SDKROOT"] = MacOS::CLT.sdk_path(MacOS.version)
     end
 
+    # The git-gui and gitk tools are installed by a separate formula (git-gui)
+    # to avoid a dependency on tcl-tk and to avoid using the broken system
+    # tcl-tk (see https://github.com/Homebrew/homebrew-core/issues/36390)
+    # This is done by setting the NO_TCLTK make variable.
     args = %W[
       prefix=#{prefix}
       sysconfdir=#{etc}
       CC=#{ENV.cc}
       CFLAGS=#{ENV.cflags}
       LDFLAGS=#{ENV.ldflags}
+      NO_TCLTK=1
     ]
 
     if MacOS.version < :yosemite
@@ -155,6 +162,13 @@ class Git < Formula
       \thelper = osxkeychain
     EOS
     etc.install "gitconfig"
+  end
+
+
+  def caveats; <<~EOS
+    The Tcl/Tk GUIs gitk and git-gui are no longer included in this formula.
+      To continue using them please install the git-gui formula.
+  EOS
   end
 
   test do

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -165,10 +165,10 @@ class Git < Formula
   end
 
 
-  def caveats; <<~EOS
-    The Tcl/Tk GUIs gitk and git-gui are no longer included in this formula.
-      To continue using them please install the git-gui formula.
-  EOS
+  def caveats
+    <<~EOS
+      The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.
+    EOS
   end
 
   test do


### PR DESCRIPTION
As a tcl-tk dependency for git is not considered acceptable, this change
moves the gitk and git-gui tools to a new formula and sets the NO_TCLTK
flag when building git.

Additionally, this change ensures that we no longer install a .app for
git-gui. Instead, we use the homebrew-installed tcl-tk wish binary to run
git-gui and gitk.

Without this change, all dialogs that are shown by git-gui are blank
windows and can only be closed by memorizing the location of the buttons.

This fixes #36390 and #39987

This is yet another alternative approach to #42788 and #42789.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
