### PR TITLE
kubernetes-service-catalog-client: update git revision

### DIFF
--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -3,7 +3,7 @@ class KubernetesServiceCatalogClient < Formula
   homepage "https://svc-cat.io/"
   url "https://github.com/kubernetes-sigs/service-catalog.git",
       :tag      => "v0.2.2",
-      :revision => "f3e67cc3e70d266e643d391e43b1bdd31cdad448"
+      :revision => "33d0c09773b4a57b652b4e08b68921f402065f1d"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Relates to #45514

Updated to git revision from https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.2.2

It seems the git history was rewritten since kubernetes-sigs/service-catalog@f3e67cc3e70d266e643d391e43b1bdd31cdad448 and kubernetes-sigs/service-catalog@33d0c09773b4a57b652b4e08b68921f402065f1d are pretty much the same commit.