### PR TITLE
xmount: use archive instead of git

### DIFF
--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -1,9 +1,8 @@
 class Xmount < Formula
   desc "Convert between multiple input & output disk image types"
   homepage "https://www.pinguin.lu/xmount/"
-  url "https://code.pinguin.lu/diffusion/XMOUNT/xmount.git",
-      :tag      => "v0.7.6",
-      :revision => "d0f67c46632a69ff1b608e90ed2fba8344ab7f3d"
+  url "https://files.pinguin.lu/xmount-0.7.6.tar.gz"
+  sha256 "76e544cd55edc2dae32c42a38a04e11336f4985e1d59cec9dd41e9f9af9b0008"
   revision 2
 
   bottle do
@@ -22,10 +21,8 @@ class Xmount < Formula
   def install
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@1.1"].opt_lib/"pkgconfig"
 
-    Dir.chdir "trunk" do
-      system "cmake", ".", *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

git clone seems to fail, so this PR switches to an archive. I've tried configuring git's http.postBuffer, but to no avail. Error output:

```
==> Cloning https://code.pinguin.lu/diffusion/XMOUNT/xmount.git
Cloning into '/Users/g/Library/Caches/Homebrew/xmount--git'...
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
fatal: the remote end hung up unexpectedly
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "xmount"
Failure while executing; `git clone --branch v0.7.6 https://code.pinguin.lu/diffusion/XMOUNT/xmount.git /Users/g/Library/Caches/Homebrew/xmount--git` exited with 128. Here's the output:
Cloning into '/Users/g/Library/Caches/Homebrew/xmount--git'...
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
fatal: the remote end hung up unexpectedly
```

Relates to #45514

Audit fails due to checksum changing?