### PR TITLE
bash-completion@2: automatically read Homebrew's v1 completions

### DIFF
--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -3,6 +3,7 @@ class BashCompletionAT2 < Formula
   homepage "https://github.com/scop/bash-completion"
   url "https://github.com/scop/bash-completion/releases/download/2.10/bash-completion-2.10.tar.xz"
   sha256 "123c17998e34b937ce57bb1b111cd817bc369309e9a8047c0bcf06ead4a3ec92"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -23,7 +24,11 @@ class BashCompletionAT2 < Formula
   conflicts_with "bash-completion", :because => "Differing version of same formula"
 
   def install
-    inreplace "bash_completion", "readlink -f", "readlink"
+    inreplace "bash_completion" do |s|
+      s.gsub! "readlink -f", "readlink"
+      # Automatically read Homebrew's existing v1 completions
+      s.gsub! ":-/etc/bash_completion.d", ":-#{etc}/bash_completion.d"
+    end
 
     system "autoreconf", "-i" if build.head?
     system "./configure", "--prefix=#{prefix}"
@@ -33,11 +38,8 @@ class BashCompletionAT2 < Formula
 
   def caveats
     <<~EOS
-      Add the following to your ~/.bash_profile:
+      Add the following line to your ~/.bash_profile:
         [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
-
-      If you'd like to use existing homebrew v1 completions, add the following before the previous line:
-        export BASH_COMPLETION_COMPAT_DIR="#{etc}/bash_completion.d"
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove need to set `BASH_COMPLETION_COMPAT_DIR` for reading Homebrew's completions from `/usr/local/etc/bash_completion.d` by setting the value for `compat_dir` directly, which was being set to a [non-existent path](https://discourse.brew.sh/t/bash-completions-broken-reference/6689/6) anyway.