### PR TITLE
glooctl: update to v1.3.1, build with go modules, fix test

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -2,8 +2,8 @@ class Glooctl < Formula
   desc "Envoy-Powered API Gateway"
   homepage "https://docs.solo.io/gloo/latest/"
   url "https://github.com/solo-io/gloo.git",
-      :tag      => "v1.3.0",
-      :revision => "6002921c48a901d6f4cca9ab801400b231088cfc"
+      :tag      => "v1.3.1",
+      :revision => "d3039276e4ece6cd9a93222d68456aae57f1b602"
   head "https://github.com/solo-io/gloo.git"
 
   bottle do
@@ -13,7 +13,6 @@ class Glooctl < Formula
     sha256 "ef4ef27f00830982defa16206543b14bda2a8ae991f41612b1c5d77ca9e6b936" => :high_sierra
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
@@ -22,7 +21,6 @@ class Glooctl < Formula
     dir.install buildpath.children - [buildpath/".brew_home"]
 
     cd dir do
-      system "dep", "ensure", "-vendor-only"
       system "make", "glooctl", "TAGGED_VERSION=v#{version}"
       bin.install "_output/glooctl"
     end
@@ -40,6 +38,6 @@ class Glooctl < Formula
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly
     status_output = shell_output("#{bin}/glooctl get proxy 2>&1", 1)
-    assert_match "failed to create proxy client", status_output
+    assert_match "failed to create kube client", status_output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
### Changes
- Updates formula from v1.3.0 to v1.3.1, superseding the automatically generated PR which failed to build here: https://github.com/Homebrew/homebrew-core/pull/48599
- We needed to remove the `dep` steps to successfully build as well.
- Updates a test string because we now attempt to create a `kube` client before a `proxy` client, and thus the `kube` client will fail first (as expected)

### Context
`glooctl` is a cli largely built on `kubectl` and `helm` used to install and manage Gloo installations. Learn more on our open-source GitHub [page](https://github.com/solo-io/gloo) or [website](https://www.solo.io/).

In version 1.3.1 we moved from `dep` as a package manager to go modules. In the move, we forgot to update the homebrew-core formula to use go modules as well to build `glooctl`. This PR rectifies that (and bumps to the new tag)

### Testing
- `brew reinstall --build-from-source ~/gomod/homebrew-core/Formula/glooctl.rb` was able to build and install v1.3.1
- `brew test  ~/gomod/homebrew-core/Formula/glooctl.rb` passes
- `brew audit --strict ~/gomod/homebrew-core/Formula/glooctl.rb` passes