### PR TITLE
pihelper 0.1.0 (new formula)

### DIFF
--- a/Formula/pihelper.rb
+++ b/Formula/pihelper.rb
@@ -1,0 +1,24 @@
+class Pihelper < Formula
+  desc "Unofficial command-line client for the Pi-hole"
+  homepage "https://git.wbrawner.com/cgit.cgi/Pi-Helper/pihelper.git/about/"
+  url "https://git.wbrawner.com/cgit.cgi/Pi-Helper/pihelper.git/snapshot/pihelper-0.1.0.tar.gz"
+  sha256 "110f16e1e8167c18ce7c11fd5a8d73f016f0e5a9c4e5898f3b24bbdd878bafcb"
+
+  depends_on "cmake" => :build
+  depends_on "json-c"
+  depends_on "openssl@1.1"
+  uses_from_macos "curl"
+
+  def install
+    system "cmake", ".", "-DPIHELPER_EXECUTABLE=ON", "-DPIHELPER_STATIC=OFF", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    require "open3"
+    File.write(Dir.pwd + "/tmp_file", "host=localhost\napi-key=test\n")
+    Open3.popen3("#{bin}/pihelper", "-f", Dir.pwd + "/tmp_file") do |_, _, stderr|
+      assert_equal "Failed to retrieve status for Pi-hole at localhost\n" + "\n", stderr.read
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
PiHelper is a small command-line utility I've put together to help with
managing a Pi-hole. It's a bit difficult to test without having a
Pi-hole set up, but you can get the gist of it by checking out their
website: https://pi-hole.net

If you want to test out pihelper manually, the quickest/easiest way is
probably to spin up an instance with docker:

    docker run -dp80:80 pihole/pihole

Then you can just run `pihelper` and follow the prompts to get
configured, using `localhost` for the host and the password output from
the logs for the pihole container.
