### PR TITLE
exercism: add shell completion

### DIFF
--- a/Formula/exercism.rb
+++ b/Formula/exercism.rb
@@ -21,7 +21,7 @@ class Exercism < Formula
 
     bash_completion.install "shell/exercism_completion.bash"
     zsh_completion.install "shell/exercism_completion.zsh" => "_exercism"
-    fish_completion.install "shell/exercism.fish" => "exercism.fish"
+    fish_completion.install "shell/exercism.fish"
   end
 
   test do

--- a/Formula/exercism.rb
+++ b/Formula/exercism.rb
@@ -18,6 +18,10 @@ class Exercism < Formula
   def install
     system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"exercism", "exercism/main.go"
     prefix.install_metafiles
+
+    bash_completion.install "shell/exercism_completion.bash"
+    zsh_completion.install "shell/exercism_completion.zsh" => "_exercism"
+    fish_completion.install "shell/exercism.fish" => "exercism.fish"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds installation of Exercism's shell completion scripts: https://github.com/exercism/cli/tree/master/shell

**Note:** I was unable to get `brew audit --strict <formula>` to run locally. The problem seems to be related to a known bug described in Homebrew/brew#5561.

