### PR TITLE
sigrok-firmware-fx2lafw 0.1.7 (new formula)

### DIFF
--- a/Formula/sigrok-firmware-fx2lafw.rb
+++ b/Formula/sigrok-firmware-fx2lafw.rb
@@ -1,0 +1,19 @@
+class SigrokFirmwareFx2lafw < Formula
+  desc "Open-source firmware for Cypress FX2 chips"
+  homepage "https://sigrok.org/wiki/Fx2lafw"
+  url "https://sigrok.org/download/source/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.7.tar.gz"
+  sha256 "a3f440d6a852a46e2c5d199fc1c8e4dacd006bc04e0d5576298ee55d056ace3b"
+
+  depends_on "make" => :build
+  depends_on "sdcc" => :build
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_equal "13", shell_output("ls -1 #{share}/sigrok-firmware/ | grep -v ^l | wc -l").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note that this is the first part of bringing [sigrok](https://sigrok.org)'s [sigrok-cli](https://sigrok.org/wiki/Sigrok-cli) to Homebrew. I have the following packages ready to go, and will submit PRs as soon as this is approved:
- libsigrok (depends on sigrok-firmware-fx2lafw) https://github.com/rob-deutsch/homebrew-core/commit/d83e45120a3a1a3970aed96922badaab0c4d8673
- libsigrokdecode (will be submitted in a seperate PR) https://github.com/rob-deutsch/homebrew-core/commit/5493f9a878ba509ef8dae9cdbdfee5cbc77e4878
- sigrock-cli (depends on libsigrok and libsigrokdecode) https://github.com/rob-deutsch/homebrew-core/commit/49ad246613fdb9f7fb48d74bfedf669cc7113ff3