### PR TITLE
libsigrockdecode 0.5.3 (new formula)

### DIFF
--- a/Formula/libsigrokdecode.rb
+++ b/Formula/libsigrokdecode.rb
@@ -1,0 +1,53 @@
+class Libsigrokdecode < Formula
+  desc "Shared library providing protocol decoding functionality"
+  homepage "https://sigrok.org/wiki/Libsigrokdecode"
+  url "https://sigrok.org/download/source/libsigrokdecode/libsigrokdecode-0.5.3.tar.gz"
+  sha256 "c50814aa6743cd8c4e88c84a0cdd8889d883c3be122289be90c63d7d67883fc0"
+
+  depends_on "gettext" => [:build, :test]
+  depends_on "make" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "glib"
+  depends_on "python"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+    system "make", "install-decoders"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <libsigrokdecode/libsigrokdecode.h>
+      #include <glib.h>
+
+      int main(int argc, char **argv)
+      {
+        int ret;
+        if ((ret = srd_init(NULL)) != SRD_OK) {
+          printf("Error initializing libsigrokdecode (%s): %s.",
+                  srd_strerror_name(ret), srd_strerror(ret));
+          return 1;
+        }
+        srd_decoder_load_all();
+        const GSList* decoders = srd_decoder_list();
+        if (!decoders) {
+          printf("Error listing decoders");
+          return 1;
+        };
+        guint num_decoders = g_slist_length((GSList *)decoders);
+        if (num_decoders == 0) {
+          printf("No decoders listed");
+          return 1;
+        };
+        return 0;
+      }
+    EOS
+    pkg_config_flags = `pkg-config --cflags --libs glib-2.0`.chomp.split
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lsigrokdecode",
+                   *pkg_config_flags, "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note that this is the second part of bringing [sigrok](https://sigrok.org)'s [sigrok-cli](https://sigrok.org/wiki/Sigrok-cli) to Homebrew. I have the following packages ready to go, and will submit PRs as soon as this is approved:
- sigrok-firmware-fx2lafw (submitted in a seperate PR) https://github.com/Homebrew/homebrew-core/pull/49271
- libsigrok (depends on sigrok-firmware-fx2lafw) https://github.com/rob-deutsch/homebrew-core/commit/d83e45120a3a1a3970aed96922badaab0c4d8673
- sigrock-cli (depends on libsigrok and libsigrokdecode) https://github.com/rob-deutsch/homebrew-core/commit/49ad246613fdb9f7fb48d74bfedf669cc7113ff3