### PR TITLE
x264 r2991

### DIFF
--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -3,7 +3,7 @@ class Caffe < Formula
   homepage "https://caffe.berkeleyvision.org/"
   url "https://github.com/BVLC/caffe/archive/1.0.tar.gz"
   sha256 "71d3c9eb8a183150f965a465824d01fe82826c22505f7aa314f700ace03fa77f"
-  revision 17
+  revision 18
 
   bottle do
     sha256 "fa3f364b905f6ea568188c3c6788f7fe0e602469f89e9d48b1ff9701f1d2270f" => :catalina

--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -3,7 +3,7 @@ class Chromaprint < Formula
   homepage "https://acoustid.org/chromaprint"
   url "https://github.com/acoustid/chromaprint/releases/download/v1.4.3/chromaprint-1.4.3.tar.gz"
   sha256 "ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,6 +3,7 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.2.2.tar.xz"
   sha256 "cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c"
+  revision 1
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do

--- a/Formula/ffmpeg2theora.rb
+++ b/Formula/ffmpeg2theora.rb
@@ -3,7 +3,7 @@ class Ffmpeg2theora < Formula
   homepage "https://v2v.cc/~j/ffmpeg2theora/"
   url "https://v2v.cc/~j/ffmpeg2theora/downloads/ffmpeg2theora-0.30.tar.bz2"
   sha256 "4f6464b444acab5d778e0a3359d836e0867a3dcec4ad8f1cdcf87cb711ccc6df"
-  revision 4
+  revision 5
   head "https://git.xiph.org/ffmpeg2theora.git"
 
   bottle do

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -3,7 +3,7 @@ class FfmpegAT28 < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-2.8.15.tar.bz2"
   sha256 "35647f6c1f6d4a1719bc20b76bf4c26e4ccd665f46b5676c0e91c5a04622ee21"
-  revision 8
+  revision 9
 
   bottle do
     sha256 "74065f85e29e7e9c2e19e31145855e7a123e24ea700499378722d0ae008bccac" => :catalina

--- a/Formula/ffmpegthumbnailer.rb
+++ b/Formula/ffmpegthumbnailer.rb
@@ -3,6 +3,7 @@ class Ffmpegthumbnailer < Formula
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
   url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.2.2.tar.gz"
   sha256 "8c4c42ab68144a9e2349710d42c0248407a87e7dc0ba4366891905322b331f92"
+  revision 1
   head "https://github.com/dirkvdb/ffmpegthumbnailer.git"
 
   bottle do

--- a/Formula/ffms2.rb
+++ b/Formula/ffms2.rb
@@ -4,7 +4,7 @@ class Ffms2 < Formula
   url "https://github.com/FFMS/ffms2/archive/2.23.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/f/ffms2/ffms2_2.23.orig.tar.gz"
   sha256 "b09b2aa2b1c6f87f94a0a0dd8284b3c791cbe77f0f3df57af99ddebcd15273ed"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/gst-plugins-ugly.rb
+++ b/Formula/gst-plugins-ugly.rb
@@ -3,6 +3,7 @@ class GstPluginsUgly < Formula
   homepage "https://gstreamer.freedesktop.org/"
   url "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.16.2.tar.xz"
   sha256 "5500415b865e8b62775d4742cbb9f37146a50caecfc0e7a6fc0160d3c560fbca"
+  revision 1
 
   bottle do
     sha256 "768c76d71554bdd72c865ac0111dd19d0afe62734fa03dcd21a2494dd0010aea" => :catalina

--- a/Formula/komposition.rb
+++ b/Formula/komposition.rb
@@ -7,6 +7,7 @@ class Komposition < Formula
   homepage "https://github.com/owickstrom/komposition"
   url "https://github.com/owickstrom/komposition/archive/v0.2.0.tar.gz"
   sha256 "cedb41c68866f8d6a87579f566909fcd32697b03f66c0e2a700a94b6a9263b88"
+  revision 1
   head "https://github.com/owickstrom/komposition.git"
 
   bottle do

--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -3,7 +3,7 @@ class Libav < Formula
   homepage "https://libav.org/"
   url "https://libav.org/releases/libav-12.3.tar.xz"
   sha256 "6893cdbd7bc4b62f5d8fd6593c8e0a62babb53e323fbc7124db3658d04ab443b"
-  revision 2
+  revision 3
   head "https://git.libav.org/libav.git"
 
   bottle do

--- a/Formula/mgba.rb
+++ b/Formula/mgba.rb
@@ -3,7 +3,7 @@ class Mgba < Formula
   homepage "https://mgba.io/"
   url "https://github.com/mgba-emu/mgba/archive/0.7.3.tar.gz"
   sha256 "6d5e8ab6f87d3d9fa85af2543db838568dbdfcecd6797f8153f1b3a10b4a8bdd"
-  revision 1
+  revision 2
   head "https://github.com/mgba-emu/mgba.git"
 
   bottle do

--- a/Formula/minidlna.rb
+++ b/Formula/minidlna.rb
@@ -3,7 +3,7 @@ class Minidlna < Formula
   homepage "https://sourceforge.net/projects/minidlna/"
   url "https://downloads.sourceforge.net/project/minidlna/minidlna/1.2.1/minidlna-1.2.1.tar.gz"
   sha256 "67388ba23ab0c7033557a32084804f796aa2a796db7bb2b770fb76ac2a742eec"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -3,6 +3,7 @@ class Mpd < Formula
   homepage "https://www.musicpd.org/"
   url "https://www.musicpd.org/download/mpd/0.21/mpd-0.21.19.tar.xz"
   sha256 "d3275e11d85637adde250cadf3b4f5aec2144228f0d8085767493fc46c55b2f9"
+  revision 1
   head "https://github.com/MusicPlayerDaemon/MPD.git"
 
   bottle do

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,6 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.31.0.tar.gz"
   sha256 "805a3ac8cf51bfdea6087a6480c18835101da0355c8e469b6d488a1e290585a5"
+  revision 1
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -3,7 +3,7 @@ class Opencv < Formula
   homepage "https://opencv.org/"
   url "https://github.com/opencv/opencv/archive/4.2.0.tar.gz"
   sha256 "9ccb2192d7e8c03c58fee07051364d94ed7599363f3b0dce1c5e6cc11c1bb0ec"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "472eb704dd3314e66ae8d891d935a6d3064d7456f2a523bb4fdb6b0eff3abd09" => :catalina

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -3,7 +3,7 @@ class OpencvAT2 < Formula
   homepage "https://opencv.org/"
   url "https://github.com/opencv/opencv/archive/2.4.13.7.tar.gz"
   sha256 "192d903588ae2cdceab3d7dc5a5636b023132c8369f184ca89ccec0312ae33d0"
-  revision 7
+  revision 8
 
   bottle do
     sha256 "31719e8af1404aca919073f25576ff2dceb880aa0fc91d863f7a73ac0073f598" => :catalina

--- a/Formula/opencv@3.rb
+++ b/Formula/opencv@3.rb
@@ -3,7 +3,7 @@ class OpencvAT3 < Formula
   homepage "https://opencv.org/"
   url "https://github.com/opencv/opencv/archive/3.4.9.tar.gz"
   sha256 "b7ea364de7273cfb3b771a0d9c111b8b8dfb42ff2bcd2d84681902fb8f49892a"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "26cdf6eb9124f389db3eaf0df185096b1b225110e16df0b00650d8a3b3efebbc" => :catalina

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -4,6 +4,7 @@ class Openimageio < Formula
   url "https://github.com/OpenImageIO/oiio/archive/Release-2.1.10.0.tar.gz"
   version "2.1.10"
   sha256 "f1547f15e9af16792a4ca0881c9298704d56db3e5d1cf41ca7e855a6a7548e66"
+  revision 1
   head "https://github.com/OpenImageIO/oiio.git"
 
   bottle do

--- a/Formula/pdfsandwich.rb
+++ b/Formula/pdfsandwich.rb
@@ -3,6 +3,7 @@ class Pdfsandwich < Formula
   homepage "http://www.tobias-elze.de/pdfsandwich/"
   url "https://downloads.sourceforge.net/project/pdfsandwich/pdfsandwich%200.1.7/pdfsandwich-0.1.7.tar.bz2"
   sha256 "9795ffea84b9b6b501f38d49a4620cf0469ddf15aac31bac6dbdc9ec1716fa39"
+  revision 1
   head "https://svn.code.sf.net/p/pdfsandwich/code/trunk/src"
 
   bottle do

--- a/Formula/pianobar.rb
+++ b/Formula/pianobar.rb
@@ -3,6 +3,7 @@ class Pianobar < Formula
   homepage "https://github.com/PromyLOPh/pianobar/"
   url "https://6xq.net/pianobar/pianobar-2019.02.14.tar.bz2"
   sha256 "c0bd0313b31492ed266d1932d319cfe2a4be7024686492c458bb5e4ceb0ee21f"
+  revision 1
   head "https://github.com/PromyLOPh/pianobar.git"
 
   bottle do

--- a/Formula/qcli.rb
+++ b/Formula/qcli.rb
@@ -3,6 +3,7 @@ class Qcli < Formula
   homepage "https://bavc.org/preserve-media/preservation-tools"
   url "https://github.com/bavc/qctools/archive/v1.0.tar.gz"
   sha256 "4b687eb9aedf29a8262393079669d3870c04b510669b9df406021243b8ebd918"
+  revision 1
   head "https://github.com/bavc/qctools.git"
 
   bottle do

--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -2,6 +2,7 @@ class Scrcpy < Formula
   desc "Display and control your Android device"
   homepage "https://github.com/Genymobile/scrcpy"
   url "https://github.com/Genymobile/scrcpy/archive/v1.12.1.tar.gz"
+  revision 1
   sha256 "7692664e1bd703421eb9659cc9956d9f0ac64eb14abddab7b2ade37625f0243d"
 
   bottle do

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -3,7 +3,7 @@ class Siril < Formula
   homepage "https://www.siril.org"
   url "https://free-astro.org/download/siril-0.9.12.tar.bz2"
   sha256 "9fb7f8a10630ea028137e8f213727519ae9916ea1d88cd8d0cc87f336d8d53b1"
-  revision 1
+  revision 2
   head "https://gitlab.com/free-astro/siril.git"
 
   bottle do

--- a/Formula/unpaper.rb
+++ b/Formula/unpaper.rb
@@ -3,7 +3,7 @@ class Unpaper < Formula
   homepage "https://www.flameeyes.eu/projects/unpaper"
   url "https://www.flameeyes.eu/files/unpaper-6.1.tar.xz"
   sha256 "237c84f5da544b3f7709827f9f12c37c346cdf029b1128fb4633f9bafa5cb930"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/vapoursynth-sub.rb
+++ b/Formula/vapoursynth-sub.rb
@@ -3,6 +3,7 @@ class VapoursynthSub < Formula
   homepage "http://www.vapoursynth.com"
   url "https://github.com/vapoursynth/vapoursynth/archive/R48.tar.gz"
   sha256 "3e98d134e16af894cf7040e4383e4ef753cafede34d5d77c42a2bb89790c50a8"
+  revision 1
   head "https://github.com/vapoursynth/vapoursynth.git"
 
   bottle do

--- a/Formula/vcs.rb
+++ b/Formula/vcs.rb
@@ -3,6 +3,7 @@ class Vcs < Formula
   homepage "https://p.outlyer.net/vcs/"
   url "https://p.outlyer.net/vcs/files/vcs-1.13.2.tar.gz"
   sha256 "fc2a2b3994d5ffb5d87fb3dceaa5f6855aca7a89c58533b12fd11b8fb5b623af"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -1,14 +1,13 @@
 class X264 < Formula
   desc "H.264/AVC encoder"
   homepage "https://www.videolan.org/developers/x264.html"
-  revision 1
-  head "https://git.videolan.org/git/x264.git"
+  head "https://code.videolan.org/videolan/x264.git"
 
   stable do
     # the latest commit on the stable branch
-    url "https://git.videolan.org/git/x264.git",
-        :revision => "0a84d986e7020f8344f00752e3600b9769cc1e85"
-    version "r2917"
+    url "https://code.videolan.org/videolan/x264.git",
+        :revision => "1771b556ee45207f8711744ccbd5d42a3949b14c"
+    version "r2991"
   end
 
   bottle do
@@ -22,10 +21,6 @@ class X264 < Formula
   depends_on "nasm" => :build
 
   def install
-    # Work around Xcode 11 clang bug
-    # https://bitbucket.org/multicoreware/x265/issues/514/wrong-code-generated-on-macos-1015
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
-
     args = %W[
       --prefix=#{prefix}
       --disable-lsmash


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`x264` builds and runs fine locally with the most recent version of Xcode 11 and macOS 10.15. As such I commented out the workaround for the Xcode 11 bug. Given that it might fail on the CI/CD, I haven't added any revisions for reverse dependencies to prevent unnecessary builds.

If this does build and run fine on all OS versions, I will completely remove the the workaround and push the necessary formula revisions.