### PR TITLE
node: postinstall fix npm manpage symlinks

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -68,13 +68,13 @@ class Node < Formula
     ln_sf node_modules/"npm/bin/npm-cli.js", HOMEBREW_PREFIX/"bin/npm"
     ln_sf node_modules/"npm/bin/npx-cli.js", HOMEBREW_PREFIX/"bin/npx"
 
-    # Let's do the manpage dance. It's just a jump to the left.
-    # And then a step to the right, with your hand on rm_f.
+    # Create manpage symlinks (or overwrite the old ones)
     %w[man1 man5 man7].each do |man|
       # Dirs must exist first: https://github.com/Homebrew/legacy-homebrew/issues/35969
       mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      # still needed to migrate from copied file manpages to symlink manpages
       rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.,npx.}*"]
-      cp Dir[libexec/"lib/node_modules/npm/man/#{man}/{npm,package.json,npx}*"], HOMEBREW_PREFIX/"share/man/#{man}"
+      ln_sf Dir[node_modules/"npm/man/#{man}/{npm,package-,shrinkwrap-,npx}*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 
     (node_modules/"npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes: https://discourse.brew.sh/t/npm-upgrade-g-disables-npm-command/6715

`Npm` recently switched to installing symlinks to `share/man` instead of actually copying the files there. The fact that we still ship actually copied manpage files has broken `npm`'s ability to self upgrade (`npm i -g npm` without `--force`) because it expects symlinks there and tries to overwrite them with `ln -sf`. This unfortunately fails with our copied files over there, leaving `npm` in a broken state (see discourse thread). 

This PR fixes the issue my actually symlinking the manpages files to `share/man` as expected by `npm`. I can confirm, that you can now normally selfupdate npm again after running `postinstall` with this change.

Also is this change worth a revision bump to force a `postinstall` rerun, although there are no changes to the bottle content?