### PR TITLE
awscli 1.17.8

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -4,8 +4,8 @@ class Awscli < Formula
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
   # awscli should only be updated every 10 releases on multiples of 10
-  url "https://github.com/aws/aws-cli/archive/1.17.0.tar.gz"
-  sha256 "e5f91dccfb292ddcdd3e27d22c019918e7d506645fbafeacc83989aec768dbee"
+  url "https://github.com/aws/aws-cli/archive/1.17.7.tar.gz"
+  sha256 "1be7731192fa2be7f1e3bcaab94d9e7db1853f2d8c25ae7567fcf181466a1a2f"
   head "https://github.com/aws/aws-cli.git", :branch => "develop"
 
   bottle do

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -4,8 +4,8 @@ class Awscli < Formula
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
   # awscli should only be updated every 10 releases on multiples of 10
-  url "https://github.com/aws/aws-cli/archive/1.17.7.tar.gz"
-  sha256 "1be7731192fa2be7f1e3bcaab94d9e7db1853f2d8c25ae7567fcf181466a1a2f"
+  url "https://github.com/aws/aws-cli/archive/1.17.8.tar.gz"
+  sha256 "c81093cc8d2d7471f4a1bb9876f63b2468bf0f1caa8baea5a222f4ebd282f154"
   head "https://github.com/aws/aws-cli.git", :branch => "develop"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit --strict awscli` fails with:

```
awscli:
  * should only be updated every 10 releases on multiples of 10
Error: 1 problem in 1 formula detected
```

As described in #49095, the update is needed because awscli 1.17.0 generates multiple lines of output in the form of the following line whenever invoked:

```
/usr/local/Cellar/awscli/1.17.0/libexec/lib/python3.8/site-packages/jmespath/visitor.py:32: SyntaxWarning: "is" with a literal. Did you mean "=="? if x is 0 or x is 1:
```

Thanks!