### PR TITLE
wireguard-tools 1.0.20200102

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -1,8 +1,8 @@
 class WireguardTools < Formula
   desc "Tools for the WireGuard secure network tunnel"
   homepage "https://www.wireguard.com/"
-  url "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20200102.tar.xz"
-  sha256 "547cd1c2f8dca904faac9e8d3964f1ef956c24bb12e3498da88dde95243c7f08"
+  url "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20200121.tar.xz"
+  sha256 "15bfdbdbecbd3870ced9a7e68286c871bfcb2071d165f113808081f2e428faa3"
   head "https://git.zx2c4.com/wireguard-tools", :using => :git
 
   bottle do


### PR DESCRIPTION
```

  * Makefile: remove pwd from compile output
  * Makefile: add standard 'all' target
  * Makefile: evaluate git version lazily
  
  Quality of life improvements for packagers.
  
  * ipc: simplify inflatable buffer and add fuzzer
  * fuzz: add generic command argument fuzzer
  * fuzz: add set and setconf fuzzers
  
  More fuzzers and a slicker string list implementation. These fuzzers now find
  themselves configuring wireguard interfaces from scratch after several million
  mutations, which is fun to watch.
  
  * netlink: make sure to clear return value when trying again
  
  Prior, if a dump was interrupted by a concurrent set operation, we'd try
  again, but forget to reset an error flag, so we'd keep trying again forever.
  Now we do the right thing and succeed when we succeed.
  
  * Makefile: sort inputs to linker so that build is reproducible
  
  Earlier versions of make(1) passed GLOB_NOSORT to glob(3), resulting in the
  linker receiving its inputs in a filesystem-dependent order. This screwed up
  reproducible builds.
```

https://lists.zx2c4.com/pipermail/wireguard/2020-January/004869.html