### PR TITLE
mapnik: fix for Boost 1.72

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -26,6 +26,12 @@ class Mapnik < Formula
   depends_on "proj"
   depends_on "webp"
 
+  # Upstream fix for Boost 1.72
+  patch do
+    url "https://github.com/mapnik/mapnik/commit/f1cf712d.diff?full_index=1"
+    sha256 "129cded3c55c916565ba03b00429dde192b7fdface35ea425bcfa685697e7653"
+  end
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
Upstream fix from https://github.com/mapnik/mapnik/issues/4098