### PR TITLE
testssl 3.0

### DIFF
--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -1,10 +1,9 @@
 class Testssl < Formula
   desc "Tool which checks for the support of TLS/SSL ciphers and flaws"
   homepage "https://testssl.sh/"
-  url "https://github.com/drwetter/testssl.sh/archive/v2.9.5-8.tar.gz"
-  version "2.9.5-8"
-  sha256 "b236094a5360883bc8b1bb283c8a2c6f75230ca42e88bc04f0ab65074cd21e8a"
-  head "https://github.com/drwetter/testssl.sh.git", :branch => "2.9dev"
+  url "https://github.com/drwetter/testssl.sh/archive/3.0.tar.gz"
+  sha256 "ab3c9a000f0f6703e4fc94821e06f531de6d2799322bf534188ebf766365a9c1"
+  head "https://github.com/drwetter/testssl.sh.git", :branch => "3.1dev"
 
   bottle :unneeded
 


### PR DESCRIPTION
Update testssl formula to 3.0 including new dev branch

Removed version due to brew audit complaining it is redundant

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- `brew bump-formula-pr` did not work, said formula needs manually updated
- removed `version` line due to `brew audit` complaining it is redundant from `url`.
- updated dev branch to 3.1dev