### PR TITLE
Update MySQL formula default collation to `utf8mb4_0900_ai_ci`

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -42,8 +42,6 @@ class Mysql < Formula
     args = %W[
       -DFORCE_INSOURCE_BUILD=1
       -DCOMPILATION_COMMENT=Homebrew
-      -DDEFAULT_CHARSET=utf8mb4
-      -DDEFAULT_COLLATION=utf8mb4_general_ci
       -DINSTALL_DOCDIR=share/doc/#{name}
       -DINSTALL_INCLUDEDIR=include/mysql
       -DINSTALL_INFODIR=share/info


### PR DESCRIPTION
The `utf8mb4_general_ci` collation has been the MySQL 8.0 default before GA, however, on the GA release, it's been changed to utf8mb4_0900_ai_ci.

This commit changes it to the new standard, `utf8mb4_0900_ai_ci`, as `utf8mb4_general_ci` can cause problems when connecting to an 8.0 server with the standard defaults.

Closes #49411.