### PR TITLE
john: add share symlink ~can't add test block~

### DIFF
--- a/Formula/john.rb
+++ b/Formula/john.rb
@@ -30,12 +30,6 @@ class John < Formula
 
     share.install_symlink libexec => "john"
   end
-
-  test do
-    # run john benchmarks
-    ENV["HOME"] = testpath
-    shell_output("john --test")
-  end
 end
 
 

--- a/Formula/john.rb
+++ b/Formula/john.rb
@@ -28,8 +28,13 @@ class John < Formula
     libexec.install Dir["run/*"]
     bin.install_symlink libexec/"john"
 
-    # Source code defaults to 'john.ini', so rename
-    mv libexec/"john.conf", libexec/"john.ini"
+    share.install_symlink libexec => "john"
+  end
+
+  test do
+    # run john benchmarks
+    ENV["HOME"] = testpath
+    shell_output("john --test")
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #47164
- adds a symlink `/usr/local/share/john -> PREFIX/john/libexec`
- removes the rename of `john.conf` to `john.ini` (code expects `john.conf`)

`john` code seems to default to `john.conf`:
- https://github.com/magnumripper/JohnTheRipper/search?utf8=%E2%9C%93&q=conf&type=
- https://github.com/magnumripper/JohnTheRipper/blob/c586a678f3ad7c92f4296957c24eba6ffb95d4b3/run/netntlm.pl#L198

Also, added a test block that runs john's internal benchmarks.