### PR TITLE
git-annex-remote-rclone 0.6 (new formula)

### DIFF
--- a/Formula/git-annex-remote-rclone.rb
+++ b/Formula/git-annex-remote-rclone.rb
@@ -1,0 +1,48 @@
+class GitAnnexRemoteRclone < Formula
+  desc "Use rclone supported cloud storage with git-annex"
+  homepage "https://github.com/DanielDent/git-annex-remote-rclone"
+  url "https://github.com/DanielDent/git-annex-remote-rclone/archive/v0.6.tar.gz"
+  sha256 "fb9bb77c6dd30dad4966926af87f63be92ef442cfeabcfd02202c657f40439d0"
+
+  bottle :unneeded
+
+  depends_on "git-annex"
+  depends_on "rclone"
+
+  def install
+    bin.install "git-annex-remote-rclone"
+  end
+
+  test do
+    # try a test modeled after git-annex.rb's test (copy some lines
+    # from there)
+
+    # make sure git can find git-annex
+    ENV.prepend_path "PATH", bin
+    # We don't want this here or it gets "caught" by git-annex.
+    rm_r "Library/Python/2.7/lib/python/site-packages/homebrew.pth"
+
+    system "git", "init"
+    system "git", "annex", "init"
+
+    (testpath/"Hello.txt").write "Hello!"
+    assert !File.symlink?("Hello.txt")
+    assert_match /^add Hello.txt.*ok.*\(recording state in git\.\.\.\)/m, shell_output("git annex add .")
+    system "git", "commit", "-a", "-m", "Initial Commit"
+    assert File.symlink?("Hello.txt")
+
+    ENV["RCLONE_CONFIG_TMPLOCAL_TYPE"]="local"
+    system "git", "annex", "initremote", "testremote", "type=external", "externaltype=rclone", "target=tmplocal", "encryption=none", "rclone_layout=lower"
+
+    system "git", "annex", "copy", "Hello.txt", "--to=testremote"
+
+    # The steps below are necessary to ensure the directory cleanly deletes.
+    # git-annex guards files in a way that isn't entirely friendly of automatically
+    # wiping temporary directories in the way `brew test` does at end of execution.
+    system "git", "rm", "Hello.txt", "-f"
+    system "git", "commit", "-a", "-m", "Farewell!"
+    system "git", "annex", "unused"
+    assert_match "dropunused 1 ok", shell_output("git annex dropunused 1 --force")
+    system "git", "annex", "uninit"
+  end
+end


### PR DESCRIPTION
First time contributing to homebrew-core. I've tried very hard to review all of your (very well-written) guidelines, but I apologize in advance if I've overlooked anything

Add formula for git-annex-remote-rclone. This tool enables git-annex
to use any of the providers supported by rclone as a special remote
when using git-annex. This is available for debian via apt, but is not
currently in homebrew. Installation is as simple as copying a bash
script onto the path. Writing a test was tricky, since using
git-annex-remote-rclone requires creating a new special remote using
an extant rclone target, so following the guidance in the formula
cookbook, I've tried to initialize a remote using target
testtest123123, which hopefully nobody uses as a name for a remote in
rclone. If git-annex-remote-rclone is correctly installed, it will
generate a specific error message which the test checks.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
