### PR TITLE
cloc: vendor all dependencies

### DIFF
--- a/Formula/cloc.rb
+++ b/Formula/cloc.rb
@@ -27,6 +27,26 @@ class Cloc < Formula
     sha256 "c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404"
   end
 
+  resource "Sub::Quote" do
+    url "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Sub-Quote-2.006006.tar.gz"
+    sha256 "6e4e2af42388fa6d2609e0e82417de7cc6be47223f576592c656c73c7524d89d"
+  end
+
+  resource "Moo::Role" do
+    url "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Moo-2.003006.tar.gz"
+    sha256 "bcb2092ab18a45005b5e2e84465ebf3a4999d8e82a43a09f5a94d859ae7f2472"
+  end
+
+  resource "Module::Runtime" do
+    url "https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz"
+    sha256 "68302ec646833547d410be28e09676db75006f4aa58a11f3bdb44ffe99f0f024"
+  end
+
+  resource "Role::Tiny" do
+    url "https://cpan.metacpan.org/authors/id/H/HA/HAARG/Role-Tiny-2.001004.tar.gz"
+    sha256 "92ba5712850a74102c93c942eb6e7f62f7a4f8f483734ed289d08b324c281687"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 


### PR DESCRIPTION
In case when Homebrew Perl is installed on my system and is found in
PATH first, cloc fails to work due to missing dependencies. This adds
those dependencies in the same manner as ones already specified as
resources.
 
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

On my system without this patch installing cloc with perl 5.30 installed with homebrew in PATH leads to cloc not working properly without installing additional dependencies by hand.

```
Can't locate Moo/Role.pm in @INC (you may need to install the Moo::Role module) (@INC contains: /usr/local/Cellar/cloc/1.84/libexec/lib/perl5/darwin-thread-multi-2level /usr/local/Cellar/cloc/1.84/libexec/lib/perl5 /usr/local/Cellar/perl/5.30.1/lib/perl5/site_perl/5.30.1/darwin-thread-multi-2level /usr/local/Cellar/perl/5.30.1/lib/perl5/site_perl/5.30.1 /usr/local/Cellar/perl/5.30.1/lib/perl5/5.30.1/darwin-thread-multi-2level /usr/local/Cellar/perl/5.30.1/lib/perl5/5.30.1 /usr/local/lib/perl5/site_perl/5.30.1/darwin-thread-multi-2level /usr/local/lib/perl5/site_perl/5.30.1) at /usr/local/Cellar/cloc/1.84/libexec/lib/perl5/Parallel/ForkManager/Child.pm line 12.
BEGIN failed--compilation aborted at /usr/local/Cellar/cloc/1.84/libexec/lib/perl5/Parallel/ForkManager/Child.pm line 12.
Compilation failed in require at /usr/local/Cellar/cloc/1.84/libexec/lib/perl5/Parallel/ForkManager.pm line 12.
BEGIN failed--compilation aborted at /usr/local/Cellar/cloc/1.84/libexec/lib/perl5/Parallel/ForkManager.pm line 12.
Compilation failed in require at /usr/local/Cellar/cloc/1.84/libexec/bin/cloc line 879.
BEGIN failed--compilation aborted at /usr/local/Cellar/cloc/1.84/libexec/bin/cloc line 879.
```