### PR TITLE
katago 1.3.2 (new formula)

### DIFF
--- a/Formula/katago.rb
+++ b/Formula/katago.rb
@@ -1,0 +1,36 @@
+class Katago < Formula
+  desc "Neural Network Go engine with no human-provided knowledge"
+  homepage "https://github.com/lightvector/KataGo"
+  url "https://github.com/lightvector/KataGo/archive/v1.3.2.tar.gz"
+  sha256 "75e783cd2db6180f2cc694703df809e5c04ba24c09546a9c24aad575e18ef2d8"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "libzip"
+
+  resource "15b-network" do
+    url "https://github.com/lightvector/KataGo/releases/download/v1.3.2/g170e-b15c192-s1672170752-d466197061.txt.gz", :using => :nounzip
+    sha256 "09456899f1b9155217f4ca059cf8a68f79b7eba22cf6b7c00ffb7f17ce067967"
+  end
+
+  resource "20b-network" do
+    url "https://github.com/lightvector/KataGo/releases/download/v1.3.2/g170-b20c256x2-s1913382912-d435450331.txt.gz", :using => :nounzip
+    sha256 "c309c0361ca1109084dd026235c9fa0254ffe22eecf096b6c5988a9d902a75ca"
+  end
+
+  def install
+    cd "cpp" do
+      system "cmake", ".", "-DBUILD_MCTS=1", "-DUSE_BACKEND=OPENCL", "-DNO_GIT_REVISION=1", "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}", *std_cmake_args
+      system "make"
+      bin.install "katago"
+      pkgshare.install "configs"
+    end
+    pkgshare.install resource("15b-network")
+    pkgshare.install resource("20b-network")
+  end
+
+  test do
+    system "#{bin}/katago", "version"
+    assert_match /All tests passed$/, shell_output("#{bin}/katago runtests").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

KataGo is one of the major entities in the AlphaZero-based neural network AIs for the game of Go, and a huge asset to both the AI research communities and the Go-playing community. On roughly equal footing with the already-packaged [leela-zero](https://github.com/Homebrew/homebrew-core/blob/master/Formula/leela-zero.rb) package, and integrates nicely with the [Sabaki](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/sabaki.rb) Cask out-of-the-box.