### PR TITLE
maxima 5.43.2

### DIFF
--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -1,8 +1,8 @@
 class Maxima < Formula
   desc "Computer algebra system"
   homepage "https://maxima.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/maxima/Maxima-source/5.43.1-source/maxima-5.43.1.tar.gz"
-  sha256 "4ac6157fd9d8cb14d5fd1c6fb523ecce208fc184b46005b27f9babc097740738"
+  url "https://downloads.sourceforge.net/project/maxima/Maxima-source/5.43.2-source/maxima-5.43.2.tar.gz"
+  sha256 "ea78ec8c674c9293621ab8af6e44fbc3d869d63ae594c105abdffedef2fb77bb"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,7 +11,11 @@ class Maxima < Formula
     sha256 "3b8a7c561dc3d11c0fd96fdef341f58a05a4b1d51f045b4e78a28bd9ef478383" => :high_sierra
   end
 
+  depends_on "gawk" => :build
+  depends_on "gnu-sed" => :build
+  depends_on "perl" => :build
   depends_on "sbcl" => :build
+  depends_on "texinfo" => :build
   depends_on "gettext"
   depends_on "gnuplot"
   depends_on "rlwrap"


### PR DESCRIPTION
In formula for Maxima, bump version to 5.43.2.

Also, declare dependencies on build tools so that up-to-date versions are available for build. Ensure that dependencies are put in an order which makes brew audit happy.

