### PR TITLE
Bump yubico-piv-tool to 2.0.0

### DIFF
--- a/Formula/yubico-piv-tool.rb
+++ b/Formula/yubico-piv-tool.rb
@@ -1,8 +1,8 @@
 class YubicoPivTool < Formula
   desc "Command-line tool for the YubiKey PIV application"
   homepage "https://developers.yubico.com/yubico-piv-tool/"
-  url "https://developers.yubico.com/yubico-piv-tool/Releases/yubico-piv-tool-1.7.0.tar.gz"
-  sha256 "b428527e4031453a637128077983e782e9fea25df98e95e0fc27819b2e82fd7f"
+  url "https://developers.yubico.com/yubico-piv-tool/Releases/yubico-piv-tool-2.0.0.tar.gz"
+  sha256 "dae510ea88922720019029c7f0296ddc74bb30573e40d9bc18fc155023859488"
 
   bottle do
     cellar :any


### PR DESCRIPTION
This commit bumps yubico-piv-tool to 2.0.0

- Official announcement: https://www.yubico.com/blog/whats-new-in-yubico-piv-tool-2-0/
- Release notes: https://developers.yubico.com/yubico-piv-tool/Release_Notes.html

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
