### PR TITLE
argyll-cms 2.1.2

### DIFF
--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -1,9 +1,9 @@
 class ArgyllCms < Formula
   desc "ICC compatible color management system"
   homepage "https://www.argyllcms.com/"
-  url "https://www.argyllcms.com/Argyll_V2.1.1_src.zip"
-  version "2.1.1"
-  sha256 "51269bcafc4d95679354b796685c3f0a41b44b78443cbe360cda4a2d72f32acb"
+  url "https://www.argyllcms.com/Argyll_V2.1.2_src.zip"
+  version "2.1.2"
+  sha256 "be378ca836b17b8684db05e9feaab138d711835ef00a04a76ac0ceacd386a3e3"
 
   bottle do
     cellar :any
@@ -18,6 +18,16 @@ class ArgyllCms < Formula
   depends_on "libtiff"
 
   conflicts_with "num-utils", :because => "both install `average` binaries"
+
+  # Fixes calls to obj_msgSend, whose signature changed in macOS 10.15.
+  # Follows the advice in this blog post, which should be compatible
+  # with both older and newer versions of macOS.
+  # https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html
+  # Submitted upstream: https://www.freelists.org/post/argyllcms/Patch-Fix-macOS-build-failures-from-obj-msgSend-definition-change
+  patch do
+    url "https://www.freelists.org/archives/argyllcms/02-2020/bin7VecLntD2x.bin"
+    sha256 "fa86f5f21ed38bec6a20a79cefb78ef7254f6185ef33cac23e50bb1de87507a4"
+  end
 
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates https://github.com/Homebrew/homebrew-core/pull/49251 with a patch for the bug causing the build failure. This blog post has some more information - users are expected to cast the `obj_msgSend` function to a function with the appropriate arguments before calling it, and that works with both older and newer versions of macOS. https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html

I've submitted the patch upstream to the project's mailing list: https://www.freelists.org/post/argyllcms/Patch-Fix-macOS-build-failures-from-obj-msgSend-definition-change