### PR TITLE
gitless: modify git config steps to fix test on CI

### DIFF
--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -57,9 +57,9 @@ class Gitless < Formula
   end
 
   test do
+    system "git", "config", "--global", "user.email", '"test@example.com"'
+    system "git", "config", "--global", "user.name", '"Test"'
     system bin/"gl", "init"
-    system "git", "config", "user.name", "Gitless Install"
-    system "git", "config", "user.email", "Gitless@Install"
     %w[haunted house].each { |f| touch testpath/f }
     system bin/"gl", "track", "haunted", "house"
     system bin/"gl", "commit", "-m", "Initial Commit"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This attempts to fix a test error on CI that was encountered in #49316:

```
        Testing gitless
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200201-19013-bx3tc6.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gitless.rb --verbose
==> /usr/local/Cellar/gitless/0.8.8_1/bin/gl init
✘ b'\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email "you@example.com"\n  git config --global user.name "Your Name"\n\nto set your account\'s default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: unable to auto-detect email address (got \'brew@Catalina.(none)\')\n'
Error: gitless: failed
```

The gitless test already had `git config` steps but the values weren't wrapped in quotes, so I'm seeing if that will fix the test failure on CI. Beyond that, there really wasn't any technical reason to modify the values themselves or rearrange them and that was just for aesthetics.