### PR TITLE
euler-py: update test

### DIFF
--- a/Formula/euler-py.rb
+++ b/Formula/euler-py.rb
@@ -39,11 +39,10 @@ class EulerPy < Formula
 
   test do
     require "open3"
-    Open3.popen3("#{bin}/euler") do |stdin, stdout, _|
-      stdin.write("\n")
-      stdin.close
-      assert_match 'Successfully created "001.py".', stdout.read
-    end
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    output = Open3.capture2("#{bin}/euler", :stdin_data => "\n")
+    # output[0] is the stdout text, output[1] is the exit code
+    assert_match 'Successfully created "001.py".', output[0]
+    assert_equal 0, output[1]
+    assert_predicate testpath/"001.py", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes a test error that was encountered in #49316.  The error was as follows when testing locally on macOS 10.15.3:

```
Testing euler-py
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200201-10883-1wnlkm2.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/euler-py.rb --verbose
Error: euler-py: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <0> expected but was
<127>.
```

I reworked the test a bit to accomplish the same thing in a slightly different manner, while also adding a check for the existence of the `001.py` file.