### PR TITLE
anime-downloader: update test

### DIFF
--- a/Formula/anime-downloader.rb
+++ b/Formula/anime-downloader.rb
@@ -114,9 +114,6 @@ class AnimeDownloader < Formula
   end
 
   test do
-    assert_match "anime, version 4.0.1", shell_output("#{bin}/anime --version")
-    system "sh", "-c", "echo 1 | #{bin}/anime watch -n Kaguya-sama --provider twist.moe; echo 1 | #{bin}/anime watch -l | grep 0/12 > out"
-    assert_match "    1 | kaguya-sama-wa-kokurasetai-tensai-t |    0/12  |", (testpath/"out").read
-    system "sh", "-c", "echo y | anime watch -r Kaguya-sama"
+    assert_match "anime, version #{version}", shell_output("#{bin}/anime --version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This addresses a test error that was encountered in #49316 and discussed in #49339:

```
        Testing anime-downloader
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200201-70685-gcxfkf.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/anime-downloader.rb --verbose
==> /usr/local/Cellar/anime-downloader/4.0.1/bin/anime --version
==> sh -c echo 1 | /usr/local/Cellar/anime-downloader/4.0.1/bin/anime watch -n Kaguya-sama --provider twist.moe; echo 1 | /usr/local/Cellar/anime-downloader/4.0.1/bin/anime watch -l | grep 0/12 > out
�[32manime�[0m: anime-downloader 4.0.1
ERROR: 'NoneType' object has no attribute 'select'
�[32manime�[0m: anime-downloader 4.0.1
�[32manime�[0m: Add something to watch list first.
Error: anime-downloader: failed
```

Basically, this type of error will periodically occur when there are issues with anime-downloader's providers.  I personally wasn't able to get any of the current providers to work and, looking at the anime-downloader repo's issues, it appears that it's not uncommon for providers to come and go.

The current test interacts with external providers, which makes it inherently unstable.  It seems that the only way to test the executable without interacting with a provider is to check the version, so I've pared the test down to that.