### PR TITLE
Update ponyc to use LLVM 9

### DIFF
--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -2,8 +2,9 @@ class Ponyc < Formula
   desc "Object-oriented, actor-model, capabilities-secure programming language"
   homepage "https://www.ponylang.org/"
   url "https://github.com/ponylang/ponyc/archive/0.33.2.tar.gz"
-  sha256 "5917903e17af77b54ae692e832e11078569cecbc24811c03940257a6e9e61f93"
+  sha256 "41ba573f16b4aecbcc39ec6d5b794185bf50e570b4a8f2cceef0a276e7fb50a3"
   head "https://github.com/ponylang/ponyc.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/ponyc.rb
+++ b/Formula/ponyc.rb
@@ -21,12 +21,12 @@ class Ponyc < Formula
     satisfy { DevelopmentTools.clang_build_version >= 800 }
   end
 
-  depends_on "llvm@7"
+  depends_on "llvm@9"
   depends_on :macos => :yosemite
 
   def install
     ENV.cxx11
-    ENV["LLVM_CONFIG"] = "#{Formula["llvm@7"].opt_bin}/llvm-config"
+    ENV["LLVM_CONFIG"] = "#{Formula["llvm@9"].opt_bin}/llvm-config"
     system "make", "install", "verbose=1", "config=release",
            "ponydir=#{prefix}", "prefix="
   end


### PR DESCRIPTION
We now support LLVM 9 as the default ponyc LLVM of choice. This commit updates
Homebrew version of ponyc to use LLVM 9.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
