### PR TITLE
composer 1.9.3

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/1.9.2/composer.phar"
-  sha256 "58753998712ae435915a452d701ae28a9389653bbf36b3b6adf24e03d90a9467"
+  url "https://getcomposer.org/download/1.9.3/composer.phar"
+  sha256 "551655c2fc81f4106508f42bbc4b24eabd34b022b13bc1e7d9642bf483d0a7d4"
 
   bottle :unneeded
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 1,936,645 bytes
- formula fetch time: 2.8 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.