### PR TITLE
csound: include commit hash, fix caveats

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -1,9 +1,10 @@
 class Csound < Formula
   desc "Sound and music computing system"
   homepage "https://csound.com"
-  url "https://github.com/csound/csound/archive/6.14.0.tar.gz"
-  sha256 "bef349c5304b2d3431ef417933b4c9e9469c0a408a4fa4a98acf0070af360a22"
-  revision 3
+  url "https://github.com/csound/csound.git",
+    :tag      => "6.14.0",
+    :revision => "1073b4d1bc2304a1e06defd266781a9c441a5be0"
+  revision 4
   head "https://github.com/csound/csound.git", :branch => "develop"
 
   bottle do
@@ -94,10 +95,10 @@ class Csound < Formula
         export DYLD_FRAMEWORK_PATH="$DYLD_FRAMEWORK_PATH:#{opt_frameworks}"
 
       To use the Java bindings, you may need to add to #{shell_profile}:
-        export CLASSPATH='#{opt_libexec}/csnd6.jar:.'
+        export CLASSPATH="#{opt_libexec}/csnd6.jar:."
       and link the native shared library into your Java Extensions folder:
         mkdir -p ~/Library/Java/Extensions
-        ln -s '#{opt_libexec}/lib_jcsound6.jnilib' ~/Library/Java/Extensions
+        ln -s "#{opt_libexec}/lib_jcsound6.jnilib" ~/Library/Java/Extensions
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request gets Csound from its repository instead of a tarball so that a commit hash can be included in its version.

**Before**

```
% csound --version          
⋮
--Csound version 6.14 (double samples) Jan 27 2020
[commit: none]
⋮
```

**After**

```
% csound --version          
⋮
--Csound version 6.14 (double samples) Feb  5 2020
[commit: 1073b4d1bc2304a1e06defd266781a9c441a5be0]
⋮
```

Because of this, `brew audit --strict csound` fails because of a changed SHA-256 hash, but this is because the repository is downloaded rather than the tarball.

This pull request also replaces single quotes with double quotes in the caveats. This allows the commands in the caveats to be used as they appear at https://formulae.brew.sh/formula/csound (`$(brew --prefix)` doesn’t expand in single-quoted strings).