### PR TITLE
gsasl 1.8.1

### DIFF
--- a/Formula/gsasl.rb
+++ b/Formula/gsasl.rb
@@ -1,9 +1,9 @@
 class Gsasl < Formula
   desc "SASL library command-line interface"
   homepage "https://www.gnu.org/software/gsasl/"
-  url "https://ftp.gnu.org/gnu/gsasl/gsasl-1.8.0.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gsasl/gsasl-1.8.0.tar.gz"
-  sha256 "310262d1ded082d1ceefc52d6dad265c1decae8d84e12b5947d9b1dd193191e5"
+  url "https://ftp.gnu.org/gnu/gsasl/gsasl-1.8.1.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gsasl/gsasl-1.8.1.tar.gz"
+  sha256 "4dda162a511976bfef14ad1fecd7733719dfd9c361b5d09dc8414ea9d472d8d2"
 
   bottle do
     cellar :any
@@ -13,6 +13,8 @@ class Gsasl < Formula
     sha256 "9e6544e25c68eff0e352ba84355a9a6ea201b9b533cbb9420eee3bdfd1531eb3" => :high_sierra
     sha256 "22c6d1dd63deb2e26dd8e3b2b51b30735ada08b6972222eed3d1868fddf1ed3c" => :sierra
   end
+
+  depends_on "libgcrypt"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
now requires newer libgcrypt than is provided on macos:

```
checking for LIBGCRYPT - version >= 1.4.4... no
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
