### PR TITLE
zdelta: don't run build time test

### DIFF
--- a/Formula/zdelta.rb
+++ b/Formula/zdelta.rb
@@ -17,7 +17,7 @@ class Zdelta < Formula
   end
 
   def install
-    system "make", "test", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
+    system "make"
     system "make", "install", "prefix=#{prefix}"
     bin.install "zdc", "zdu"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes:

```
==> brew audit zdelta --online
Error: 1 problem in 1 formula detected
zdelta:
  * C: 20: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
==> FAILED
```