### PR TITLE
Added perl-build dependency because plenv can't be used without it.

### DIFF
--- a/Formula/plenv.rb
+++ b/Formula/plenv.rb
@@ -7,6 +7,8 @@ class Plenv < Formula
 
   bottle :unneeded
 
+  depends_on "perl-build"
+
   def install
     prefix.install "bin", "plenv.d", "completions", "libexec"
 


### PR DESCRIPTION
This is exactly the same as rbenv as well.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
Yes

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
Yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

Yes

- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

Yes

- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Yes
-----
