### PR TITLE
yq 3.1.0

### DIFF
--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -1,8 +1,8 @@
 class Yq < Formula
   desc "Process YAML documents from the CLI"
   homepage "https://github.com/mikefarah/yq"
-  url "https://github.com/mikefarah/yq/archive/v3.1.0.tar.gz"
-  sha256 ""
+  url "https://github.com/mikefarah/yq/archive/3.1.0.tar.gz"
+  sha256 "dcb9c3d4f4acf5be29ae547b76a8ff67b6f994760d5adad22691132bae3ff490"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -1,8 +1,8 @@
 class Yq < Formula
   desc "Process YAML documents from the CLI"
   homepage "https://github.com/mikefarah/yq"
-  url "https://github.com/mikefarah/yq/archive/3.0.1.tar.gz"
-  sha256 "bb81bb9689014fcfb5247e7d49ccc1c9236f218889e991ad983180123d7c0030"
+  url "https://github.com/mikefarah/yq/archive/v3.1.0.tar.gz"
+  sha256 ""
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 0 bytes
- formula fetch time: 0.7 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.