### PR TITLE
predictionio: fix depends_on :java

### DIFF
--- a/Formula/predictionio.rb
+++ b/Formula/predictionio.rb
@@ -11,13 +11,13 @@ class Predictionio < Formula
   depends_on "elasticsearch"
   depends_on "hadoop"
   depends_on "hbase"
-  depends_on :java => "1.7+"
+  depends_on :java => "1.8"
 
   def install
     rm_f Dir["bin/*.bat"]
 
     libexec.install Dir["*"]
-    bin.write_exec_script libexec/"bin/pio"
+    (bin/"pio").write_env_script libexec/"bin/pio", Language::Java.java_home_env("1.8")
 
     inreplace libexec/"conf/pio-env.sh" do |s|
       s.gsub! /#\s*ES_CONF_DIR=.+$/, "ES_CONF_DIR=#{Formula["elasticsearch"].opt_prefix}/config"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
