### PR TITLE
asdf: add zsh completions

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -21,6 +21,16 @@ class Asdf < Formula
 
   def install
     bash_completion.install "completions/asdf.bash"
+    zsh_completion.mkpath
+    cp "#{bash_completion}/asdf.bash", zsh_completion
+    (zsh_completion/"_asdf").write <<~EOS
+      #compdef asdf
+      _asdf () {
+        local e
+        e=$(dirname ${funcsourcetrace[1]%:*})/asdf.bash
+        if [[ -f $e ]]; then source $e; fi
+      }
+    EOS
     fish_completion.install "completions/asdf.fish"
     libexec.install "bin/private"
     prefix.install Dir["*"]


### PR DESCRIPTION
I used the same technique as the AWS formula and copied the bash
completion and then created a small wrapper to allow it to autoload.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
