### PR TITLE
WIP: Add KnightOS SDK

### DIFF
--- a/Formula/genkfs.rb
+++ b/Formula/genkfs.rb
@@ -1,0 +1,42 @@
+class Genkfs < Formula
+  desc "Writes a KFS filesystem into a ROM file"
+  homepage "https://github.com/KnightOS/genkfs"
+  url "https://github.com/KnightOS/genkfs/archive/1.2.2.tar.gz"
+
+  depends_on "asciidoc" => :build
+  depends_on "cmake" => :build
+
+  patch :DATA
+
+  def install
+    system "cmake", ".", *std_cmake_args, "-DCMAKE_INSTALL_MANDIR:PATH=#{man}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"genkfs", "--help"
+    system "man", "genkfs"
+    system "wget", "https://github.com/KnightOS/kernel/releases/download/0.6.11/kernel-TI83p.rom"
+    mkdir "model-directory"
+    touch "model-directory/file.txt"
+    system bin/"genkfs", "kernel-TI83p.rom", "model-directory"
+    system "echo", "a32bc31e965e1d0f43a4ea064126576b67059e77219ccb359941a1b30b95f341", "kernel-TI83p.rom", "|", "sha256sum", "-c", "--"
+  end
+end
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68c67e0..65c3277 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,10 @@ ADD_CUSTOM_COMMAND(
+   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/genkfs.1
+ )
+ 
++if (NOT DEFINED CMAKE_INSTALL_MANDIR)
++    set(CMAKE_INSTALL_MANDIR ${CMAKE_INSTALL_PREFIX}/man)
++endif()
+ INSTALL(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/genkfs.1
+-    DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man1
++    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+ )

--- a/Formula/genkfs.rb
+++ b/Formula/genkfs.rb
@@ -2,6 +2,7 @@ class Genkfs < Formula
   desc "Writes a KFS filesystem into a ROM file"
   homepage "https://github.com/KnightOS/genkfs"
   url "https://github.com/KnightOS/genkfs/archive/1.2.2.tar.gz"
+  sha256 "93690989819ee93dd5130b2761879deaa3d70c706b050bd31eb8d5997cb683e8"
 
   depends_on "asciidoc" => :build
   depends_on "cmake" => :build
@@ -16,7 +17,7 @@ class Genkfs < Formula
   test do
     system bin/"genkfs", "--help"
     system "man", "genkfs"
-    system "wget", "https://github.com/KnightOS/kernel/releases/download/0.6.11/kernel-TI83p.rom"
+    curl "https://github.com/KnightOS/kernel/releases/download/0.6.11/kernel-TI83p.rom", "-O"
     mkdir "model-directory"
     touch "model-directory/file.txt"
     system bin/"genkfs", "kernel-TI83p.rom", "model-directory"

--- a/Formula/knightos-sdk.rb
+++ b/Formula/knightos-sdk.rb
@@ -1,0 +1,58 @@
+class KnightosSdk < Formula
+  include Language::Python::Virtualenv
+
+  desc "The KnightOS SDK"
+  homepage "https://KnightOS.org"
+  url "https://github.com/KnightOS/sdk/archive/2.0.9.tar.gz"
+  sha256 "0fd7d1322aa925e06fa595bf52e4a1d04f7661b975d37bb9b78ff481d8ad63bc"
+
+  depends_on "genkfs"
+  depends_on "kpack"
+  depends_on "python"
+  # depends_on "kimg" => :test
+  # depends_on "mktiupgrade" => :test
+
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/source/d/docopt/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+  resource "pystache" do
+    url "https://files.pythonhosted.org/packages/source/p/pystache/pystache-0.5.4.tar.gz"
+    sha256 "f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a"
+  end
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/source/P/PyYAML/PyYAML-5.3.tar.gz"
+    sha256 "e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
+  end
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/source/r/requests/requests-2.22.0.tar.gz"
+    sha256 "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
+  end
+  # Requests dependencies
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/source/c/certifi/certifi-2019.11.28.tar.gz"
+    sha256 "25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+  end
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/source/c/chardet/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+  end
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/source/u/urllib3/urllib3-1.25.8.tar.gz"
+    sha256 "87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+  end
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/source/i/idna/idna-2.8.tar.gz"
+    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # TODO: Fix this
+    system bin/"knightos", "--help"
+    system "false"
+  end
+end

--- a/Formula/kpack.rb
+++ b/Formula/kpack.rb
@@ -1,0 +1,23 @@
+class Kpack < Formula
+  desc "Manipulates KnightOS packages on POSIX systems"
+  homepage "https://github.com/KnightOS/kpack"
+  url "https://github.com/KnightOS/kpack/archive/1.0.12.tar.gz"
+  sha256 "f63e53a390ef9300caaa9042ec030154d4825ebaa360ffb96720df11a591af4f"
+
+  depends_on "asciidoc" => :build
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "git", "clone", "-b", "0.5.1", "https://github.com/KnightOS/castle"
+    system bin/"kpack", testpath/"castle.pkg", "castle", "-c", "castle/package.config"
+    mkdir testpath/"castle2"
+    system bin/"kpack", "-e", testpath/"castle.pkg", testpath/"castle2"
+    system bin/"kpack", testpath/"castle2.pkg", testpath/"castle2", "-c", testpath/"castle2/package.config"
+    assert_equal (testpath/"castle.pkg").sha256, (testpath/"castle2.pkg").sha256
+  end
+end


### PR DESCRIPTION
This PR aims to add the essential utilities for building a [KnightOS](https://knightos.org) image that you can install on your very own TI-84!

Several packages will be required before you can build your own .8xu file to load through [TI Connect CE](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/ti-connect-ce.rb), so this merge request may grow... The goal is to be able to build the [standard KnightOS distribution](https://github.com/KnightOS/KnightOS) after installing recommended software.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

[genkfs](https://github.com/KnightOS/genkfs/) (SDK dependency)
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

[kpack](https://github.com/KnightOS/kpack/) (SDK Dependency)
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

[knightos-sdk](https://github.com/KnightOS/sdk)
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Assembler ([sass](https://github.com/KnightOS/sass) or [scas](https://github.com/KnightOS/scas))
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

[kimg](https://github.com/KnightOS/kimg) (required to convert the [copyright](https://github.com/KnightOS/KnightOS/blob/master/config/copyright.png) image in the standard KnightOS distribution.
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

[mktiupgrade](https://github.com/KnightOS/mktiupgrade) - This builds the 8xu file that you load onto your calculator.
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This PR will not attempt to add
* the [z80e](https://github.com/KnightOS/z80e) emulator
* The KnightOS C compiler [kcc](https://github.com/KnightOS/kcc) - I don't think it's necessary to build the OS.