### PR TITLE
flow-tools: uses_from_macos zlib

### DIFF
--- a/Formula/flow-tools.rb
+++ b/Formula/flow-tools.rb
@@ -14,6 +14,8 @@ class FlowTools < Formula
     sha256 "dc15779397a7f60c67b20c314b4513133c0883a5eafb3e972e744b8a70ca1060" => :mavericks
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Over in Homebrew/linuxbrew-core we were seeing the following linkage error:

```
==> brew linkage --test flow-tools
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
  ==> FAILED
```