### PR TITLE
Remove boost as build dependency for assimp

### DIFF
--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -12,7 +12,6 @@ class Assimp < Formula
     sha256 "6dffc67ca984f5870bdc09a1c0adbb3c0d2209c7fb8169e2204c4c2d2d44aebe" => :high_sierra
   end
 
-  depends_on "boost" => :build
   depends_on "cmake" => :build
   uses_from_macos "zlib"
 


### PR DESCRIPTION
Boost was removed a while ago: https://github.com/assimp/assimp/issues/409

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
