### PR TITLE
swift-sh 1.16.1 (new formula)

### DIFF
--- a/Formula/swift-sh.rb
+++ b/Formula/swift-sh.rb
@@ -1,0 +1,21 @@
+class SwiftSh < Formula
+  desc "Scripting with easy zero-conf dependency imports"
+  homepage "https://github.com/mxcl/swift-sh"
+  url "https://github.com/mxcl/swift-sh/archive/1.16.1.tar.gz"
+  sha256 "fb70b075101594b146d4120b52d6132f8b34d3337d4d55ed289c57e4d7808519"
+  head "https://github.com/mxcl/swift-sh.git"
+
+  depends_on :xcode => ["10.0", :build]
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/swift-sh"
+    bin.install ".build/release/swift-sh-edit"
+  end
+
+  test do
+    (testpath/"test.swift").write "#!/usr/bin/env swift sh"
+    system "#{bin}/swift-sh", "eject", "test.swift"
+    assert_predicate testpath/"Test"/"Package.swift", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I first wrote a simple test something like:

```ruby
test do
  (testpath/"test.swift").write "print(\"Hello, World\");"
  assert_equal "Hello, World", shell_output("#{bin}/swift-sh test.swift").strip
end
```

However, this resulted in a sandbox error as `swift-sh` tries to write cache files to `~/Library`.
I'm not sure if there is a better way to testing `swift-sh` other than the current approach (testing `--help`).