### PR TITLE
Add conflict for gdb and i386-elf-gdb

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -12,6 +12,8 @@ class Gdb < Formula
     sha256 "4cde626aa5d32dde54d70bd531a06e65051e7ac7371f1970b6b9c838f565239c" => :high_sierra
   end
 
+  conflicts_with "i386-elf-gdb", :because => "both install include/gdb, share/gdb and share/info"
+
   fails_with :clang do
     build 800
     cause <<~EOS

--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -12,6 +12,8 @@ class I386ElfGdb < Formula
     sha256 "5a173cea39b163dabfd97db3ea26446344ff82bdc3792b3111414d7f5c9ee6de" => :high_sierra
   end
 
+  conflicts_with "gdb", :because => "both install include/gdb, share/gdb and share/info"
+
   def install
     mkdir "build" do
       system "../configure", "--target=i386-elf",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Found in https://github.com/Homebrew/homebrew-core/pull/49950 / https://github.com/Homebrew/homebrew-core/pull/49961:
```
The formula built, but is not symlinked into /usr/local
Could not symlink include/gdb/jit-reader.h
Target /usr/local/include/gdb/jit-reader.h
is a symlink belonging to gdb. You can unlink it:
  brew unlink gdb

To force the link and overwrite all conflicting files:
  brew link --overwrite i386-elf-gdb

To list all files that would be deleted:
  brew link --overwrite --dry-run i386-elf-gdb

Possible conflicting files are:
/usr/local/include/gdb/jit-reader.h -> /usr/local/Cellar/gdb/9.1/include/gdb/jit-reader.h
/usr/local/share/gdb/python/gdb/FrameDecorator.py
/usr/local/share/gdb/python/gdb/FrameIterator.py
/usr/local/share/gdb/python/gdb/__init__.py
/usr/local/share/gdb/python/gdb/command/__init__.py
/usr/local/share/gdb/python/gdb/command/explore.py
/usr/local/share/gdb/python/gdb/command/frame_filters.py
/usr/local/share/gdb/python/gdb/command/pretty_printers.py
/usr/local/share/gdb/python/gdb/command/prompt.py
/usr/local/share/gdb/python/gdb/command/type_printers.py
/usr/local/share/gdb/python/gdb/command/unwinders.py
/usr/local/share/gdb/python/gdb/command/xmethods.py
/usr/local/share/gdb/python/gdb/frames.py
/usr/local/share/gdb/python/gdb/function/__init__.py
/usr/local/share/gdb/python/gdb/function/as_string.py
/usr/local/share/gdb/python/gdb/function/caller_is.py
/usr/local/share/gdb/python/gdb/function/strfns.py
/usr/local/share/gdb/python/gdb/printer/__init__.py
/usr/local/share/gdb/python/gdb/printer/bound_registers.py
/usr/local/share/gdb/python/gdb/printing.py
/usr/local/share/gdb/python/gdb/prompt.py
/usr/local/share/gdb/python/gdb/types.py
/usr/local/share/gdb/python/gdb/unwinder.py
/usr/local/share/gdb/python/gdb/xmethod.py
/usr/local/share/gdb/syscalls/aarch64-linux.xml
/usr/local/share/gdb/syscalls/amd64-linux.xml
/usr/local/share/gdb/syscalls/arm-linux.xml
/usr/local/share/gdb/syscalls/freebsd.xml
/usr/local/share/gdb/syscalls/gdb-syscalls.dtd
/usr/local/share/gdb/syscalls/i386-linux.xml
/usr/local/share/gdb/syscalls/mips-n32-linux.xml
/usr/local/share/gdb/syscalls/mips-n64-linux.xml
/usr/local/share/gdb/syscalls/mips-o32-linux.xml
/usr/local/share/gdb/syscalls/ppc-linux.xml
/usr/local/share/gdb/syscalls/ppc64-linux.xml
/usr/local/share/gdb/syscalls/s390-linux.xml
/usr/local/share/gdb/syscalls/s390x-linux.xml
/usr/local/share/gdb/syscalls/sparc-linux.xml
/usr/local/share/gdb/syscalls/sparc64-linux.xml
/usr/local/share/gdb/system-gdbinit/elinos.py
/usr/local/share/gdb/system-gdbinit/wrs-linux.py
/usr/local/share/gdb/python/gdb/FrameDecorator.py
/usr/local/share/gdb/python/gdb/FrameIterator.py
/usr/local/share/gdb/python/gdb/__init__.py
/usr/local/share/gdb/python/gdb/command/__init__.py
/usr/local/share/gdb/python/gdb/command/explore.py
/usr/local/share/gdb/python/gdb/command/frame_filters.py
/usr/local/share/gdb/python/gdb/command/pretty_printers.py
/usr/local/share/gdb/python/gdb/command/prompt.py
/usr/local/share/gdb/python/gdb/command/type_printers.py
/usr/local/share/gdb/python/gdb/command/unwinders.py
/usr/local/share/gdb/python/gdb/command/xmethods.py
/usr/local/share/gdb/python/gdb/frames.py
/usr/local/share/gdb/python/gdb/function/__init__.py
/usr/local/share/gdb/python/gdb/function/as_string.py
/usr/local/share/gdb/python/gdb/function/caller_is.py
/usr/local/share/gdb/python/gdb/function/strfns.py
/usr/local/share/gdb/python/gdb/printer/__init__.py
/usr/local/share/gdb/python/gdb/printer/bound_registers.py
/usr/local/share/gdb/python/gdb/printing.py
/usr/local/share/gdb/python/gdb/prompt.py
/usr/local/share/gdb/python/gdb/types.py
/usr/local/share/gdb/python/gdb/unwinder.py
/usr/local/share/gdb/python/gdb/xmethod.py
/usr/local/share/gdb/syscalls/aarch64-linux.xml
/usr/local/share/gdb/syscalls/amd64-linux.xml
/usr/local/share/gdb/syscalls/arm-linux.xml
/usr/local/share/gdb/syscalls/freebsd.xml
/usr/local/share/gdb/syscalls/gdb-syscalls.dtd
/usr/local/share/gdb/syscalls/i386-linux.xml
/usr/local/share/gdb/syscalls/mips-n32-linux.xml
/usr/local/share/gdb/syscalls/mips-n64-linux.xml
/usr/local/share/gdb/syscalls/mips-o32-linux.xml
/usr/local/share/gdb/syscalls/ppc-linux.xml
/usr/local/share/gdb/syscalls/ppc64-linux.xml
/usr/local/share/gdb/syscalls/s390-linux.xml
/usr/local/share/gdb/syscalls/s390x-linux.xml
/usr/local/share/gdb/syscalls/sparc-linux.xml
/usr/local/share/gdb/syscalls/sparc64-linux.xml
/usr/local/share/gdb/system-gdbinit/elinos.py
/usr/local/share/gdb/system-gdbinit/wrs-linux.py
/usr/local/share/info/annotate.info -> /usr/local/Cellar/gdb/9.1/share/info/annotate.info
info /usr/local/share/info/annotate.info
/usr/local/share/info/gdb.info -> /usr/local/Cellar/gdb/9.1/share/info/gdb.info
info /usr/local/share/info/gdb.info
/usr/local/share/info/stabs.info -> /usr/local/Cellar/gdb/9.1/share/info/stabs.info
info /usr/local/share/info/stabs.info
```