### PR TITLE
Sync new `uses_from_macos` from Homebrew/linuxbrew-core

### DIFF
--- a/Formula/broot.rb
+++ b/Formula/broot.rb
@@ -14,6 +14,8 @@ class Broot < Formula
 
   depends_on "rust" => :build
 
+  uses_from_macos "zlib"
+
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end

--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -29,6 +29,7 @@ class Goffice < Formula
   depends_on "librsvg"
   depends_on "pango"
   depends_on "pcre"
+
   uses_from_macos "libxslt"
 
   def install

--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -21,6 +21,8 @@ class Gpredict < Formula
   depends_on "gtk+3"
   depends_on "hamlib"
 
+  uses_from_macos "curl"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/httpry.rb
+++ b/Formula/httpry.rb
@@ -17,6 +17,8 @@ class Httpry < Formula
     sha256 "ec016612be65aa5761213134d211f9bee121d8904dae9b9d73ebfc37d4de3cea" => :mavericks
   end
 
+  uses_from_macos "libpcap"
+
   def install
     system "make"
     bin.install "httpry"

--- a/Formula/lldpd.rb
+++ b/Formula/lldpd.rb
@@ -16,6 +16,8 @@ class Lldpd < Formula
   depends_on "libevent"
   depends_on "readline"
 
+  uses_from_macos "libxml2"
+
   def install
     readline = Formula["readline"]
     args = %W[

--- a/Formula/ophcrack.rb
+++ b/Formula/ophcrack.rb
@@ -16,6 +16,8 @@ class Ophcrack < Formula
 
   depends_on "openssl@1.1"
 
+  uses_from_macos "expat"
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-gui",

--- a/Formula/osslsigncode.rb
+++ b/Formula/osslsigncode.rb
@@ -19,6 +19,8 @@ class Osslsigncode < Formula
   depends_on "libgsf"
   depends_on "openssl@1.1"
 
+  uses_from_macos "curl"
+
   def install
     system "./autogen.sh"
     system "./configure", "--with-gsf", "--prefix=#{prefix}"

--- a/Formula/yetris.rb
+++ b/Formula/yetris.rb
@@ -14,6 +14,8 @@ class Yetris < Formula
     sha256 "a14c5327ab931d7394b3f617422916eafbc76a936ac77e81a959b38aa223dd5e" => :yosemite
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -17,6 +17,8 @@ class Zorba < Formula
   depends_on "icu4c"
   depends_on "xerces-c"
 
+  uses_from_macos "libxml2"
+
   conflicts_with "xqilla", :because => "Both supply xqc.h"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Over in Homebrew/linuxbrew-core we're attempting to bottle all formulae.
This is leading to lots of tiny dependency additions, most of which are
`uses_from_macos` so can be upstreamed here.