### PR TITLE
jack: Fix source tarball URL and depends_on/uses_from_macos ordering

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -8,9 +8,12 @@
 class Jack < Formula
   desc "Audio Connection Kit"
   homepage "https://jackaudio.org/"
-  url "https://github.com/jackaudio/jack1/archive/0.125.0.tar.gz"
-  sha256 "fa2021ccb7e076881a699f17218b5a23705a0215a363e077ad8fd80bfcd76187"
+  # pull from git tag to get submodules
+  url "https://github.com/jackaudio/jack1.git",
+      :tag      => "0.125.0",
+      :revision => "f5e00e485e7aa4c5baa20355b27e3b84a6912790"
   revision 3
+  head "https://github.com/jackaudio/jack1.git"
 
   bottle do
     rebuild 1
@@ -21,6 +24,9 @@ class Jack < Formula
     sha256 "ee93da9885f06dde0f305fca2d5af6d6213c2133466ca93857a87ffb731ce43f" => :el_capitan
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "libsamplerate"
@@ -37,9 +43,10 @@ class Jack < Formula
       "#{sdk}/System/Library/Frameworks/Carbon.framework/Headers/Carbon.h"
 
     # https://github.com/jackaudio/jack1/issues/81
-    inreplace "configure", "-mmacosx-version-min=10.4",
-                           "-mmacosx-version-min=#{MacOS.version}"
+    inreplace "configure.ac", "-mmacosx-version-min=10.4",
+                              "-mmacosx-version-min=#{MacOS.version}"
 
+    system "./autogen.sh"
     ENV["LINKFLAGS"] = ENV.ldflags
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -12,7 +12,7 @@ class Jack < Formula
   url "https://github.com/jackaudio/jack1.git",
       :tag      => "0.125.0",
       :revision => "f5e00e485e7aa4c5baa20355b27e3b84a6912790"
-  revision 3
+  revision 4
   head "https://github.com/jackaudio/jack1.git"
 
   bottle do

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -8,8 +8,8 @@
 class Jack < Formula
   desc "Audio Connection Kit"
   homepage "https://jackaudio.org/"
-  url "https://jackaudio.org/downloads/jack-audio-connection-kit-0.125.0.tar.gz"
-  sha256 "3517b5bff82139a76b2b66fe2fd9a3b34b6e594c184f95a988524c575b11d444"
+  url "https://github.com/jackaudio/jack1/archive/0.125.0.tar.gz"
+  sha256 "fa2021ccb7e076881a699f17218b5a23705a0215a363e077ad8fd80bfcd76187"
   revision 3
 
   bottle do
@@ -21,12 +21,12 @@ class Jack < Formula
     sha256 "ee93da9885f06dde0f305fca2d5af6d6213c2133466ca93857a87ffb731ce43f" => :el_capitan
   end
 
-  uses_from_macos "util-linux"
-
   depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "libsamplerate"
   depends_on "libsndfile"
+
+  uses_from_macos "util-linux"
 
   def install
     sdk = MacOS.sdk_path_if_needed ? MacOS.sdk_path : ""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This was originally submitted as just the depends_on/uses_from_macos
  reordering in PR 49962, but the download URL had been moved in
  https://github.com/jackaudio/jackaudio.github.com/commit/5fd24b271c3aa3f3a879721cbe13840ed789836d