### PR TITLE
STP and minisat (new formula)

### DIFF
--- a/Formula/minisat.rb
+++ b/Formula/minisat.rb
@@ -1,0 +1,33 @@
+class Minisat < Formula
+  desc "Boolean satisfiability (SAT) problem solver"
+  homepage "http://minisat.se"
+
+  head "https://github.com/stp/minisat.git", :branch => "master"
+
+  stable do
+    url "https://github.com/stp/minisat/archive/releases/2.2.1.tar.gz"
+    sha256 "432985833596653fcd698ab439588471cc0f2437617d0df2bb191a0252ba423d"
+  end
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "-DSTATIC_BINARIES=ON",
+                      "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+                      ".."
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    dimacs = <<~EOS
+      p cnf 3 2
+      1 -3 0
+      2 3 -1 0
+    EOS
+
+    assert_match(/^SATISFIABLE$/, pipe_output("#{bin}/minisat", dimacs, 10))
+  end
+end

--- a/Formula/stp.rb
+++ b/Formula/stp.rb
@@ -1,0 +1,35 @@
+class Stp < Formula
+  desc "Simple Theorem Prover"
+  homepage "https://stp.github.io"
+
+  head "https://github.com/stp/stp.git", :branch => "master"
+
+  stable do
+    url "https://github.com/stp/stp/archive/2.3.3.tar.gz"
+    sha256 "ea6115c0fc11312c797a4b7c4db8734afcfce4908d078f386616189e01b4fffa"
+  end
+
+  depends_on "bison" => :build  # requires >= 2.6
+  depends_on "cmake" => :build
+  depends_on "flex" => :build   # requires >= 2.6
+  depends_on "minisat"
+
+  def install
+    system "cmake", "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+                    "-DENABLE_PYTHON_INTERFACE:BOOL=OFF",
+                    "."
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    input = <<~EOS
+      (set-logic QF_BV)
+      (assert (= (bvsdiv (_ bv3 2) (_ bv2 2)) (_ bv0 2)))
+      (check-sat)
+      (exit)
+    EOS
+
+    assert_match(/^sat$/, pipe_output("#{bin}/stp_simple", input, 0))
+  end
+end


### PR DESCRIPTION
STP is a (boolean formula) SAT solver library from Stanford, and
minisat is a library it depends on.

Amongst other things, it's used by the Bluespec hardware description
language which is in the process of being open sourced, and which I'd
eventually like to package in Homebrew.

Formulae based on tidied up versions of https://github.com/klee/homebrew-klee/tree/master/Formula

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
