### PR TITLE
terraform-provider-libvirt 0.6.1 (new formula)

### DIFF
--- a/Formula/terraform-provider-libvirt.rb
+++ b/Formula/terraform-provider-libvirt.rb
@@ -1,0 +1,20 @@
+class TerraformProviderLibvirt < Formula
+  desc "Terraform provisioning with Linux KVM using libvirt"
+  homepage "https://github.com/dmacvicar/terraform-provider-libvirt"
+  url "https://github.com/dmacvicar/terraform-provider-libvirt/archive/v0.6.1.tar.gz"
+  sha256 "3562070c22bda0f38c44fbef88f345e08a22a567bccc56f7a25eaecc6400ee36"
+
+  depends_on "go" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "libvirt"
+  depends_on "terraform"
+
+  def install
+    system "go", "build", "-mod=vendor", "-trimpath", "-ldflags", "-X main.version=#{version}", "-o", bin/name
+  end
+
+  test do
+    assert_match(/This binary is a plugin/, shell_output("#{bin}/terraform-provider-libvirt 2>&1", 1))
+  end
+end


### PR DESCRIPTION
* Terraform provider to provision infrastructure with Linux's KVM using libvirt

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
