### PR TITLE
kpt 0.4.0 (new formula)

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -13,11 +13,29 @@ class Kpt < Formula
   def install
     # ENV.deparallelize  # if your formula fails when building in parallel
     # Remove unrecognized options if warned by configure
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    # system "./configure", "--disable-debug",
+    #                       "--disable-dependency-tracking",
+    #                       "--disable-silent-rules",
+    #                       "--prefix=#{prefix}"
     # system "cmake", ".", *std_cmake_args
+    ENV["GO111MODULE"] = on
+    ENV["GOPATH"] = buildpath
+    ENV.prepend_create_path "PATH", buildpath/"bin"
+    dir = buildpath/"src/github.com/GoogleContainerTools/kpt"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+
+    cd dir do
+      #ENV.delete "AWS_ACCESS_KEY"
+      #ENV.delete "AWS_SECRET_KEY"
+
+      ENV["XC_OS"] = "darwin"
+      ENV["XC_ARCH"] = "amd64"
+      system "make", "build"
+
+      bin.install "pkg/darwin_amd64/kpt"
+      prefix.install_metafiles
+    end
+
   end
 
   test do

--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -1,8 +1,5 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook
-#                https://rubydoc.brew.sh/Formula
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class Kpt < Formula
-  desc "kpt is a toolkit to help you manage, manipulate, customize, and apply Kubernetes Resource configuration data files."
+  desc "Toolkit to manage,and apply Kubernetes Resource config data files"
   homepage "https://googlecontainertools.github.io/kpt"
   url "https://github.com/GoogleContainerTools/kpt/archive/v0.4.0.tar.gz"
   sha256 "63133d79cebfda47a281bee31bf10e1ec6f40556d6dac32546a54e91ee58ce9a"
@@ -10,21 +7,11 @@ class Kpt < Formula
   depends_on "go" => :build
 
   def install
-    # ENV.deparallelize  # if your formula fails when building in parallel
     ENV["GO111MODULE"] = "on"
     system "go", "build", "-ldflags", "-X main.version=#{version}", *std_go_args
   end
 
   test do
-    # `test do` will create, run in and delete a temporary directory.
-    #
-    # This test will fail and we won't accept that! For Homebrew/homebrew-core
-    # this will need to be a test that verifies the functionality of the
-    # software. Run the test with `brew test kpt`. Options passed
-    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
-    #
-    # The installed folder is not in the path, so use the entire path to any
-    # executables being tested: `system "#{bin}/program", "do", "something"`.
-    system "false"
+    assert_match version.to_s, shell_output("#{bin}/kpt version")
   end
 end

--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -4,38 +4,15 @@
 class Kpt < Formula
   desc "kpt is a toolkit to help you manage, manipulate, customize, and apply Kubernetes Resource configuration data files."
   homepage "https://googlecontainertools.github.io/kpt"
-  url "https://github.com/GoogleContainerTools/kpt/archive/v0.4.0.zip"
-  sha256 "9fa1d2a3d2ba38ee8c37ba5e01b3ecd77802d90748108ae7c96f4beb32af6cbf"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v0.4.0.tar.gz"
+  sha256 "63133d79cebfda47a281bee31bf10e1ec6f40556d6dac32546a54e91ee58ce9a"
 
-  # depends_on "cmake" => :build
   depends_on "go" => :build
 
   def install
     # ENV.deparallelize  # if your formula fails when building in parallel
-    # Remove unrecognized options if warned by configure
-    # system "./configure", "--disable-debug",
-    #                       "--disable-dependency-tracking",
-    #                       "--disable-silent-rules",
-    #                       "--prefix=#{prefix}"
-    # system "cmake", ".", *std_cmake_args
-    ENV["GO111MODULE"] = on
-    ENV["GOPATH"] = buildpath
-    ENV.prepend_create_path "PATH", buildpath/"bin"
-    dir = buildpath/"src/github.com/GoogleContainerTools/kpt"
-    dir.install buildpath.children - [buildpath/".brew_home"]
-
-    cd dir do
-      #ENV.delete "AWS_ACCESS_KEY"
-      #ENV.delete "AWS_SECRET_KEY"
-
-      ENV["XC_OS"] = "darwin"
-      ENV["XC_ARCH"] = "amd64"
-      system "make", "build"
-
-      bin.install "pkg/darwin_amd64/kpt"
-      prefix.install_metafiles
-    end
-
+    ENV["GO111MODULE"] = "on"
+    system "go", "build", "-ldflags", "-X main.version=#{version}", *std_go_args
   end
 
   test do

--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -1,0 +1,35 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+class Kpt < Formula
+  desc "kpt is a toolkit to help you manage, manipulate, customize, and apply Kubernetes Resource configuration data files."
+  homepage "https://googlecontainertools.github.io/kpt"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v0.4.0.zip"
+  sha256 "9fa1d2a3d2ba38ee8c37ba5e01b3ecd77802d90748108ae7c96f4beb32af6cbf"
+
+  # depends_on "cmake" => :build
+  depends_on "go" => :build
+
+  def install
+    # ENV.deparallelize  # if your formula fails when building in parallel
+    # Remove unrecognized options if warned by configure
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    # system "cmake", ".", *std_cmake_args
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test kpt`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello, I'm proposing this formula addition to brew for `kpt` (kept)  Kept is a new project that was recently released.  It is described from the docs page as: 
>  `kpt is a toolkit to help you manage, examine, manipulate, customize, validate, and apply Kubernetes resource configuration files, both manually and programmatically.` .

 Although this is a recently published project, and as such I do get this errer when running `brew audit` it is my expectation that this project will shortly meet the notability standards. 

```Shell
❯ brew audit --new-formula --strict kpt
kpt:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

kpt is installable through the Google Cloud SDK, however I thought it would be valuable to also have available via home brew.    