### PR TITLE
lcov: fix gcc-9 compatibility, add perl dependency and improve test

### DIFF
--- a/Formula/lcov.rb
+++ b/Formula/lcov.rb
@@ -3,6 +3,7 @@ class Lcov < Formula
   homepage "https://github.com/linux-test-project/lcov"
   url "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz"
   sha256 "14995699187440e0ae4da57fe3a64adc0a3c5cf14feab971f8db38fb7d8f071a"
+  revision 1
   head "https://github.com/linux-test-project/lcov.git"
 
   bottle do
@@ -13,13 +14,71 @@ class Lcov < Formula
     sha256 "e6d2a1d121c878d81d051de0f9f7fbda37c438a620de9c99d0a0c7540b5f61d1" => :sierra
   end
 
+  depends_on "gcc" => :test
+
+  uses_from_macos "perl"
+
+  resource "JSON" do
+    url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz"
+    sha256 "444a88755a89ffa2a5424ab4ed1d11dca61808ebef57e81243424619a9e8627c"
+  end
+
+  resource "PerlIO::gzip" do
+    url "https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/PerlIO-gzip-0.20.tar.gz"
+    sha256 "4848679a3f201e3f3b0c5f6f9526e602af52923ffa471a2a3657db786bd3bdc5"
+  end
+
+  # The following 2 patches fix compatibiliry with gcc-9
+  # Remove in the next release
+  patch do
+    url "https://github.com/linux-test-project/lcov/commit/ebfeb3e179e450c69c3532f98cd5ea1fbf6ccba7.patch?full_index=1"
+    sha256 "83d380e753eda054d73da08774e9ca01aa642440ffb93a0f8f3d1ac81e35d006"
+  end
+
+  patch do
+    url "https://github.com/linux-test-project/lcov/commit/75fbae1cfc5027f818a0bb865bf6f96fab3202da.patch?full_index=1"
+    sha256 "72cf3f356a4ac0ff98a66ef7bc085b5be3b41f155decc9ef4eca8ec140840e7f"
+  end
+
   def install
+    ENV.prepend_create_path "PERL5LIB", libexec+"lib/perl5"
+
+    resource("JSON").stage do
+      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+      system "make"
+      system "make", "install"
+    end
+
+    resource("PerlIO::gzip").stage do
+      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+      system "make"
+      system "make", "install"
+    end
+
     inreplace %w[bin/genhtml bin/geninfo bin/lcov],
       "/etc/lcovrc", "#{prefix}/etc/lcovrc"
     system "make", "PREFIX=#{prefix}", "BIN_DIR=#{bin}", "MAN_DIR=#{man}", "install"
+    bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
   end
 
   test do
-    system "#{bin}/lcov", "--version"
+    gcc = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].version_suffix}"
+    gcov = Formula["gcc"].opt_bin/"gcov-#{Formula["gcc"].version_suffix}"
+
+    (testpath/"hello.c").write <<~EOS
+      #include <stdio.h>
+      int main(void)
+      {
+          puts("hello world");
+          return 0;
+      }
+    EOS
+
+    system gcc, "-g", "-O2", "--coverage", "-o", "hello", "hello.c"
+    system "./hello"
+    system "#{bin}/lcov", "--gcov-tool", gcov, "--directory", ".", "--capture", "--output-file", "all_coverage.info"
+
+    assert_predicate testpath/"all_coverage.info", :exist?
+    assert_include (testpath/"all_coverage.info").read, testpath/"hello.c"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/50043
