### PR TITLE
protoc-gen-grpc-web 1.0.7 (new formula)

### DIFF
--- a/Formula/protoc-gen-grpc-web.rb
+++ b/Formula/protoc-gen-grpc-web.rb
@@ -1,0 +1,53 @@
+require "language/node"
+
+class ProtocGenGrpcWeb < Formula
+  desc "Protoc plugin that generates code for gRPC-Web clients"
+  homepage "https://github.com/grpc/grpc-web"
+  url "https://github.com/grpc/grpc-web/archive/1.0.7.tar.gz"
+  sha256 "04460e28ffa80bfc797a8758da10ba40107347ef0af8e9cc065ade10398da4bb"
+
+  depends_on "cmake" => :build
+  depends_on "node" => :test
+  depends_on "typescript" => :test
+  depends_on "protobuf"
+
+  def install
+    bin.mkpath
+    inreplace "javascript/net/grpc/web/Makefile", "/usr/local/bin/", "#{bin}/"
+    system "make", "install-plugin"
+  end
+
+  test do
+    # First use the plugin to generate the files.
+    testdata = <<~EOS
+      syntax = "proto3";
+      package test;
+      message TestCase {
+        string name = 4;
+      }
+      message Test {
+        repeated TestCase case = 1;
+      }
+      message TestResult {
+        bool passed = 1;
+      }
+      service TestService {
+        rpc RunTest(Test) returns (TestResult);
+      }
+    EOS
+    (testpath/"test.proto").write testdata
+    system "protoc", "test.proto", "--plugin=#{bin}/protoc-gen-grpc-web",
+      "--js_out=import_style=commonjs:.",
+      "--grpc-web_out=import_style=typescript,mode=grpcwebtext:."
+
+    # Now see if we can import them.
+    testts = <<~EOS
+      import * as grpcWeb from 'grpc-web';
+      import {TestServiceClient} from './TestServiceClientPb';
+      import {Test, TestResult} from './test_pb';
+    EOS
+    (testpath/"test.ts").write testts
+    system "npm", "install", *Language::Node.local_npm_install_args, "grpc-web", "@types/google-protobuf"
+    system "tsc", "test.ts"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds a new formula for installing the protoc plugin for https://github.com/grpc/grpc-web