### PR TITLE
manticoresearch: explicit version

### DIFF
--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -4,6 +4,7 @@ class Manticoresearch < Formula
   url "https://github.com/manticoresoftware/manticoresearch/releases/download/3.3.0/manticore-3.3.0-200204-01fc8ad-release.tar.gz"
   sha256 "f62801f6eb50bd08cb8fe976f0a3a43c7600b979a1ced8d14b8261ca06eaf22c"
   head "https://github.com/manticoresoftware/manticoresearch.git"
+  version "3.3.0"
 
   bottle do
     sha256 "1ca227dc0117b0dfcc68d1fca84c17c0b1ec40b7e14d354f2275045a4d8c218c" => :catalina

--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -2,9 +2,10 @@ class Manticoresearch < Formula
   desc "Open source text search engine"
   homepage "https://www.manticoresearch.com"
   url "https://github.com/manticoresoftware/manticoresearch/releases/download/3.3.0/manticore-3.3.0-200204-01fc8ad-release.tar.gz"
-  sha256 "f62801f6eb50bd08cb8fe976f0a3a43c7600b979a1ced8d14b8261ca06eaf22c"
-  head "https://github.com/manticoresoftware/manticoresearch.git"
   version "3.3.0"
+  sha256 "f62801f6eb50bd08cb8fe976f0a3a43c7600b979a1ced8d14b8261ca06eaf22c"
+  version_scheme 1
+  head "https://github.com/manticoresoftware/manticoresearch.git"
 
   bottle do
     sha256 "1ca227dc0117b0dfcc68d1fca84c17c0b1ec40b7e14d354f2275045a4d8c218c" => :catalina


### PR DESCRIPTION
Seems version is not extracted properly due to how we have the naming of the source gz file.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
