### PR TITLE
create awscli@1.rb because of breaking changes

### DIFF
--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -6,7 +6,6 @@ class AwscliAT1 < Formula
   # awscli should only be updated every 10 releases on multiples of 10
   url "https://github.com/aws/aws-cli/archive/1.17.10.tar.gz"
   sha256 "29fb03756ec56af1ab64de48f926440a7c9c3664b2f3382525e45fae6decb9f8"
-  head "https://github.com/aws/aws-cli.git", :branch => "develop"
   
   keg_only :versioned_formula
 

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -7,13 +7,6 @@ class AwscliAT1 < Formula
   url "https://github.com/aws/aws-cli/archive/1.17.10.tar.gz"
   sha256 "29fb03756ec56af1ab64de48f926440a7c9c3664b2f3382525e45fae6decb9f8"
   head "https://github.com/aws/aws-cli.git", :branch => "develop"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "ed66a81ad012426c49328d7d1ff6b49e871a9ff54e2dd22ad726c38f447d4fab" => :catalina
-    sha256 "250ff17d41717dcce1cac123eb286030c0c2b3290c7272fa2ffbd1bb8fe1d02f" => :mojave
-    sha256 "372c8e6b3a9b243ebddc2003730160ef9da3300ec029e2598b70d0f186365814" => :high_sierra
-  end
   
   keg_only :versioned_formula
 

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -6,7 +6,7 @@ class AwscliAT1 < Formula
   # awscli should only be updated every 10 releases on multiples of 10
   url "https://github.com/aws/aws-cli/archive/1.17.10.tar.gz"
   sha256 "29fb03756ec56af1ab64de48f926440a7c9c3664b2f3382525e45fae6decb9f8"
-  
+
   keg_only :versioned_formula
 
   # Some AWS APIs require TLS1.2, which system Python doesn't have before High

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -1,0 +1,52 @@
+class Awscli < Formula
+  include Language::Python::Virtualenv
+
+  desc "Official Amazon AWS command-line interface"
+  homepage "https://aws.amazon.com/cli/"
+  # awscli should only be updated every 10 releases on multiples of 10
+  url "https://github.com/aws/aws-cli/archive/1.17.10.tar.gz"
+  sha256 "29fb03756ec56af1ab64de48f926440a7c9c3664b2f3382525e45fae6decb9f8"
+  head "https://github.com/aws/aws-cli.git", :branch => "develop"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "ed66a81ad012426c49328d7d1ff6b49e871a9ff54e2dd22ad726c38f447d4fab" => :catalina
+    sha256 "250ff17d41717dcce1cac123eb286030c0c2b3290c7272fa2ffbd1bb8fe1d02f" => :mojave
+    sha256 "372c8e6b3a9b243ebddc2003730160ef9da3300ec029e2598b70d0f186365814" => :high_sierra
+  end
+
+  # Some AWS APIs require TLS1.2, which system Python doesn't have before High
+  # Sierra
+  depends_on "python@3.8"
+
+  def install
+    venv = virtualenv_create(libexec, "python3")
+    system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
+                              "--ignore-installed", buildpath
+    system libexec/"bin/pip", "uninstall", "-y", "awscli"
+    venv.pip_install_and_link buildpath
+    pkgshare.install "awscli/examples"
+
+    rm Dir["#{bin}/{aws.cmd,aws_bash_completer,aws_zsh_completer.sh}"]
+    bash_completion.install "bin/aws_bash_completer"
+    zsh_completion.install "bin/aws_zsh_completer.sh"
+    (zsh_completion/"_aws").write <<~EOS
+      #compdef aws
+      _aws () {
+        local e
+        e=$(dirname ${funcsourcetrace[1]%:*})/aws_zsh_completer.sh
+        if [[ -f $e ]]; then source $e; fi
+      }
+    EOS
+  end
+
+  def caveats; <<~EOS
+    The "examples" directory has been installed to:
+      #{HOMEBREW_PREFIX}/share/awscli/examples
+  EOS
+  end
+
+  test do
+    assert_match "topics", shell_output("#{bin}/aws help")
+  end
+end

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -14,6 +14,8 @@ class AwscliAT1 < Formula
     sha256 "250ff17d41717dcce1cac123eb286030c0c2b3290c7272fa2ffbd1bb8fe1d02f" => :mojave
     sha256 "372c8e6b3a9b243ebddc2003730160ef9da3300ec029e2598b70d0f186365814" => :high_sierra
   end
+  
+  keg_only :versioned_formula
 
   # Some AWS APIs require TLS1.2, which system Python doesn't have before High
   # Sierra

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -1,4 +1,4 @@
-class Awscli < Formula
+class AwscliAT1 < Formula
   include Language::Python::Virtualenv
 
   desc "Official Amazon AWS command-line interface"


### PR DESCRIPTION
because v2 has major breaking changes we need to allow the installation of awscli v1 just as we do node@10. aws is still supporting aws v1

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
