### PR TITLE
ginac: use Python 3 instead of Python 2

### DIFF
--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -13,8 +13,8 @@ class Ginac < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cln"
+  depends_on "python@3.8"
   depends_on "readline"
-  uses_from_macos "python@2"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [INSTALL](https://www.ginac.de/ginac.git/?p=ginac.git;a=blob_plain;f=INSTALL;hb=refs/tags/release_1-7-8) file of GiNaC 1.7.8 mentions Python 3 as a prerequisite.

See also https://discourse.brew.sh/t/ginac-dependency-of-python-2/6940.
