### PR TITLE
pandoc: Build a relocatable executable

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -7,6 +7,7 @@ class Pandoc < Formula
   homepage "https://pandoc.org/"
   url "https://hackage.haskell.org/package/pandoc-2.9.1.1/pandoc-2.9.1.1.tar.gz"
   sha256 "9d21c5efe2074f9b3097a20e0798de9d8b89a86a1ce04a307f476c7b4aa3816d"
+  revision 1
   head "https://github.com/jgm/pandoc.git"
 
   bottle do
@@ -20,7 +21,7 @@ class Pandoc < Formula
 
   def install
     cabal_sandbox do
-      install_cabal_package
+      install_cabal_package :flags => ["embed_data_files"]
     end
     (bash_completion/"pandoc").write `#{bin}/pandoc --bash-completion`
     man1.install "man/pandoc.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> `embed_data_files`: embed all data files into the binary (default no). This is helpful if you want to create a relocatable binary.

See https://pandoc.org/installing.html#custom-cabal-method

The author of Pandoc recommends building with `embed_data_files` enabled.

See https://github.com/jgm/pandoc/issues/6143