### PR TITLE
protobuf 3.11.4

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -2,8 +2,8 @@ class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/protocolbuffers/protobuf/"
   url "https://github.com/protocolbuffers/protobuf.git",
-      :tag      => "v3.11.3",
-      :revision => "498de9f761bef56a032815ee44b6e6dbe0892cc4"
+      :tag      => "v3.11.4",
+      :revision => "d0bfd5221182da1a7cc280f3337b5e41a89539cf"
   head "https://github.com/protocolbuffers/protobuf.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As before, it's expected that protobuf will fail `brew audit --strict protobuf`:

```
protobuf:
  * C: 37: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
Error: 1 problem in 1 formula detected
```
