### PR TITLE
grv: fix test

### DIFF
--- a/Formula/grv.rb
+++ b/Formula/grv.rb
@@ -35,6 +35,8 @@ class Grv < Formula
     ENV["TERM"] = "xterm"
 
     system "git", "init"
+    system "git", "config", "user.email", '"test@example.com"'
+    system "git", "config", "user.name", '"Test"'
     system "git", "commit", "--allow-empty", "-m", "test"
     pipe_output("#{bin}/grv -logLevel DEBUG", "'<grv-exit>'", 0)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As seen in #50120, the test for the `grv` formula is failing with the following error:

```
        Testing grv
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200214-34949-2rufeo.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/grv.rb --verbose
==> git init
Initialized empty Git repository in /private/tmp/grv-test-20200214-34950-1c2kuy7/.git/
==> git commit --allow-empty -m test

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'brew@Catalina.(none)')
Error: grv: failed
```

This adds `git config` steps to the test, which should fix the test on CI (though it will need the `--global` flag if it still fails with these changes).