### PR TITLE
Update notmuch formula

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -16,7 +16,6 @@ class Notmuch < Formula
   depends_on "libgpg-error" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "emacs"
   depends_on "glib"
   depends_on "gmime"
   depends_on "python"
@@ -28,7 +27,6 @@ class Notmuch < Formula
     args = %W[
       --prefix=#{prefix}
       --mandir=#{man}
-      --with-emacs
       --emacslispdir=#{elisp}
       --emacsetcdir=#{elisp}
       --without-ruby
@@ -36,6 +34,8 @@ class Notmuch < Formula
 
     # Emacs and parallel builds aren't friends
     ENV.deparallelize
+
+    ENV.append_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"lib/python3.7/site-packages"
 
     system "./configure", *args
     system "make", "V=1", "install"

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -32,9 +32,6 @@ class Notmuch < Formula
       --without-ruby
     ]
 
-    # Emacs and parallel builds aren't friends
-    ENV.deparallelize
-
     ENV.append_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"lib/python3.7/site-packages"
 
     system "./configure", *args

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -18,7 +18,7 @@ class Notmuch < Formula
   depends_on "sphinx-doc" => :build
   depends_on "glib"
   depends_on "gmime"
-  depends_on "python"
+  depends_on "python@3.8"
   depends_on "talloc"
   depends_on "xapian"
   depends_on "zlib"


### PR DESCRIPTION
* Remove emacs dependency
* Add sphinx-doc installation to PYTHONPATH so that man pages are
  properly built

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There is no reason that emacs should be a dependency of notmuch.

This is also fixes #47572 by prepending `sphinx-doc`'s `site-packages` directory to the `PYTHONPATH` during installation.