### PR TITLE
libcbor 0.5.0 (new formula)

### DIFF
--- a/Formula/libcbor.rb
+++ b/Formula/libcbor.rb
@@ -1,0 +1,34 @@
+class Libcbor < Formula
+  desc "CBOR protocol implementation for C and others"
+  homepage "http://libcbor.org/"
+  url "https://github.com/PJK/libcbor/archive/v0.5.0.tar.gz"
+  sha256 "9bbec94bb385bad3cd2f65482e5d343ddb97e9ffe261123ea0faa3bfea51d320"
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "-G", "Unix Makefiles", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"example.c").write <<-EOS
+    #include "cbor.h"
+    #include <stdio.h>
+    int main(int argc, char * argv[])
+    {
+    printf("Hello from libcbor %s\\n", CBOR_VERSION);
+    printf("Custom allocation support: %s\\n", CBOR_CUSTOM_ALLOC ? "yes" : "no");
+    printf("Pretty-printer support: %s\\n", CBOR_PRETTY_PRINTER ? "yes" : "no");
+    printf("Buffer growth factor: %f\\n", (float) CBOR_BUFFER_GROWTH);
+    }
+    EOS
+
+    system ENV.cc, "-std=c99", "example.c", "-L#{lib}", "-lcbor", "-o", "example"
+    system "./example"
+    puts `./example`
+  end
+end


### PR DESCRIPTION
Maintainers: __DO NOT MERGE__ until we get the original author's sign-off in PJK/homebrew-libcbor#1.

---

This commit adds libcbor 0.5.0.
The tap containing the original version of this formula can be found at
https://github.com/PJK/homebrew-libcbor
which was authored by the libcbor maintainer.

(This PR is a slight edit of homebrew/homebrew-core#46071.)

Co-authored-by: Pavel Kalvoda <me@pavelkalvoda.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
