### PR TITLE
openssh 8.2p1 (with FIDO support)

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -5,6 +5,7 @@ class Openssh < Formula
   mirror "https://mirror.vdms.io/pub/OpenBSD/OpenSSH/portable/openssh-8.2p1.tar.gz"
   version "8.2p1"
   sha256 "43925151e6cf6cee1450190c0e9af4dc36b41c12737619edff8bcebdff64e671"
+  revision 1
 
   bottle do
     sha256 "d4881d69f149e5b08f6a77c3320be4b8b5c92fba30cb05eb6e815845689c1413" => :catalina
@@ -17,6 +18,7 @@ class Openssh < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ldns"
+  depends_on "libfido2"
   depends_on "openssl@1.1"
 
   resource "com.openssh.sshd.sb" do
@@ -50,6 +52,7 @@ class Openssh < Formula
       --with-kerberos5
       --with-pam
       --with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}
+      --with-security-key-builtin
     ]
 
     system "./configure", *args


### PR DESCRIPTION
This uses libfido2 to add FIDO support to OpenSSH.
This is arguably the most prominent feature in the 8.2 release.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~~This is a draft because I'm still working on the formulae for the dependencies, which are not yet upstream. See #50305 for libcbor and #50326 for libfido2.~~ Deps are upstream. 🎉 

~~Would the maintainers also prefer if we devised some sort of test for the FIDO/U2F functionality?~~ It's difficult to test w/o a physical security key.