### PR TITLE
cheat: 3.6.0_1 Add bash and fish completion scripts

### DIFF
--- a/Formula/cheat.rb
+++ b/Formula/cheat.rb
@@ -4,6 +4,7 @@ class Cheat < Formula
   url "https://github.com/cheat/cheat.git",
     :tag      => "3.6.0",
     :revision => "b13246978ab7ebb254b49d58c625f94aa2e08ee7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,6 +17,9 @@ class Cheat < Formula
 
   def install
     system "go", "build", "-mod", "vendor", "-o", bin/"cheat", "./cmd/cheat"
+
+    bash_completion.install "scripts/cheat.bash"
+    fish_completion.install "scripts/cheat.fish"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add missing bash & fish shell completion from scripts existing in [cheat repo](https://github.com/cheat/cheat.git) `scripts` directory.