### PR TITLE
libfido2 1.3.0 (new formula)

### DIFF
--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -1,0 +1,46 @@
+class Libfido2 < Formula
+  desc "Provides library functionality for FIDO U2F & FIDO 2.0, including USB"
+  homepage "https://developers.yubico.com/libfido2/"
+  url "https://github.com/Yubico/libfido2/archive/1.3.0.tar.gz"
+  sha256 "0b2e3671c4c5d42fd5604a08e45f89f49592b97cf66d7d3bfbc7e6a4d5a0fec7"
+  depends_on "cmake" => :build
+  depends_on "mandoc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libcbor"
+  depends_on "openssl@1.1"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "man_symlink_html"
+      system "make", "man_symlink"
+      system "make", "install"
+    end
+    mv prefix/"man", share/"man"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOF
+    #include <stddef.h>
+    #include <stdio.h>
+    #include <fido.h>
+    int main(void) {
+      fido_init(FIDO_DEBUG);
+      // Attempt to enumerate up to five FIDO/U2F devices. Five is an arbitrary number.
+      size_t max_devices = 5;
+      fido_dev_info_t *devlist;
+      if ((devlist = fido_dev_info_new(max_devices)) == NULL)
+        return 1;
+      size_t found_devices = 0;
+      int error;
+      if ((error = fido_dev_info_manifest(devlist, max_devices, &found_devices)) != FIDO_OK)
+        return 1;
+      printf("FIDO/U2F devices found: %s\\n", found_devices ? "Some" : "None");
+      fido_dev_info_free(&devlist, max_devices);
+    }
+    EOF
+    system ENV.cc, "-std=c99", "test.c", "-I#{include}", "-I#{Formula["openssl@1.1"].include}", "-o", "test", "-L#{lib}", "-lfido2"
+    system "./test"
+  end
+end


### PR DESCRIPTION
(This is a revival of PR #46072, which is now used by OpenSSH.)

Co-authored-by: Alexander Lent <git@xanderlent.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

There are multiple open issues with this PR, I'll take another look at it later this week:

- [x] ~~libcbor is not yet upstream (see #50305 for why)~~
- [x] Manual pages aren't installed in the correct location
- [x] There are probably additional ways to test this library.
- [x] Yubico's [official releases page](https://developers.yubico.com/libfido2/Releases/) gives different URLs than the GitHub URL we're using, but the artifacts are identical.
- [x] libudev is a Linux-only dependency
- [x] ~~Upstream prefers LibreSSL to OpenSSL. (Possibly true of OpenSSH-portable as well.)~~ We're using OpenSSL for OpenSSH portable, probably best to link dependencies against the same library.