### PR TITLE
platformio 4.2.1

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "An open-source ecosystem for embedded development"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/31/6b/6050e999bb94b7b0db86518a345fe118f8727e61f1d261df121d012878cf/platformio-4.2.0.tar.gz"
-  sha256 "bfe062fbe014ed4776f3e56491324bda9049de7a1338ea07972407e324623187"
+  url "https://files.pythonhosted.org/packages/f4/c8/8e472c22602ec6cdc6f93e35357ff5f3dff3434da6fc76cd3cd57c7eefb6/platformio-4.2.1.tar.gz"
+  sha256 "310fa8b624cf938ef95284ae3a40a9caa36aafef32ac30ad588b43df516945c3"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +13,7 @@ class Platformio < Formula
     sha256 "c6501bd561ee8d2b77037739484929eade3c4e15cb326b24b90634b32daecd32" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3"
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/d9/4f/57887a07944140dae0d039d8bc270c249fc7fc4a00744effd73ae2cde0a9/bottle-0.12.18.tar.gz"
@@ -81,6 +81,7 @@ class Platformio < Formula
   end
 
   def install
+    virtualenv_create(libexec, "python3")
     virtualenv_install_with_resources
   end
 

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -13,7 +13,7 @@ class Platformio < Formula
     sha256 "c6501bd561ee8d2b77037739484929eade3c4e15cb326b24b90634b32daecd32" => :high_sierra
   end
 
-  depends_on "python@3"
+  depends_on "python@3.8"
 
   resource "bottle" do
     url "https://files.pythonhosted.org/packages/d9/4f/57887a07944140dae0d039d8bc270c249fc7fc4a00744effd73ae2cde0a9/bottle-0.12.18.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

* Improved VSCode template with special ``forceInclude`` field for direct includes via ``-include`` flag ([issue #3379](https://github.com/platformio/platformio-core/issues/3379))
* Improved support of PIO Home on card-sized PC (Raspberry Pi, etc.) ([issue #3313](https://github.com/platformio/platformio-core/issues/3313))
* Froze "marshmallow" dependency to 2.X for Python 2 ([issue #3380](https://github.com/platformio/platformio-core/issues/3380))
* Fixed "TypeError: unsupported operand type(s)" when system environment variable is used by project configuration parser ([issue #3377](https://github.com/platformio/platformio-core/issues/3377))
* Fixed an issue when Library Dependency Finder (LDF) ignores custom "libLDFMode" and "libCompatMode" options in [library.json](http://docs.platformio.org/page/librarymanager/config.html)
* Fixed an issue when generating of compilation database "compile_commands.json" does not work with Python 2.7 ([issue #3378](https://github.com/platformio/platformio-core/issues/3378))
