### PR TITLE
frotz 2.51

### DIFF
--- a/Formula/frotz.rb
+++ b/Formula/frotz.rb
@@ -1,8 +1,8 @@
 class Frotz < Formula
   desc "Infocom-style interactive fiction player"
-  homepage "https://gitlab.com/DavidGriffith/frotz"
-  url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.50/frotz-2.50.tar.gz"
-  sha256 "0352dfc458fb5cc7a932c568bd86aabdde943bee25ea0cce58c46f8c893f554f"
+  homepage "https://661.org/proj/if/frotz/"
+  url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.51/frotz-2.51.tar.gz"
+  sha256 "7916f17061e845e4fa5047c841306c4be2614e9c941753f9739c5d39c7e9f05b"
   head "https://gitlab.com/DavidGriffith/frotz.git"
 
   bottle do
@@ -17,7 +17,6 @@ class Frotz < Formula
       s.change_make_var! "MANDIR", man
       s.change_make_var! "SYSCONFDIR", etc
       s.change_make_var! "SOUND_TYPE", "none"
-      s.gsub! "        ", "	"
     end
 
     system "make", "frotz"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The frotz url (gitlab) overview states: "The Frotz homepage is at https://661.org/proj/if/frotz/," hence the homepage change. The `Makefile` tab/space issue was also fixed in this version.

* `brew tests` fails for me (https://github.com/Homebrew/brew/issues/5561, https://github.com/Homebrew/homebrew-core/issues/35647), but everything else (formula test and audit) worked, hope this is ok.

Thanks.
