### PR TITLE
ode: create shared library to avoid linking errors, default to double precision

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -3,6 +3,7 @@ class Ode < Formula
   homepage "https://www.ode.org/"
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.16.tar.gz"
   sha256 "4ba3b76f9c1314160de483b3db92b0569242a07452cbb25b368e75deb3cabf27"
+  revision 1
   head "https://bitbucket.org/odedevs/ode/", :using => :hg
 
   bottle do
@@ -23,7 +24,7 @@ class Ode < Formula
     inreplace "bootstrap", "libtoolize", "glibtoolize"
     system "./bootstrap"
 
-    system "./configure", "--prefix=#{prefix}", "--enable-libccd"
+    system "./configure", "--prefix=#{prefix}", "--enable-libccd", "--enable-shared", "--disable-static", "--enable-double-precision"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
`pkg-config --libs` doesn't list `-lccd` even though this library is needed at link time / run time. By building shared libraries, this problems goes away. Shared libraries are also usually the default choice.

ODE on Ubuntu and with MacPorts is compiled with double precision as the default. This PR switches the default to double precision for HomeBrew as well.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
