### PR TITLE
gpgme: remove Python 2 test

### DIFF
--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -33,7 +33,6 @@ class Gpgme < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
-    system "python2.7", "-c", "import gpg; print gpg.version.versionstr"
     system "python3", "-c", "import gpg; print(gpg.version.versionstr)"
   end
 end


### PR DESCRIPTION
Because Python 2 is EOL and we do not care that much anymore.
Else we would have to add `uses_from_macos "python@2"`,
which we would like to actually get rid of.

The fact that gpgme uses python 2 is a side effect, and we should
not worry about this as Python 3 is the only supported way to use it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
