### PR TITLE
groovy@2 2.5.9 (new formula)

### DIFF
--- a/Formula/groovy@2.rb
+++ b/Formula/groovy@2.rb
@@ -1,0 +1,32 @@
+class GroovyAT2 < Formula
+  desc "Java-based scripting language"
+  homepage "https://www.groovy-lang.org/"
+  url "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.5.9.zip"
+  sha256 "fea7dc321a3029c47ffa4aa165055d2bcc78bc280fac4e70ac131c717e45b89b"
+
+  bottle :unneeded
+
+  keg_only :versioned_formula
+
+  # Groovy 2.5 requires JDK8+ to build and JDK7 is the minimum version of the JRE that we support.
+  depends_on :java => "1.7+"
+
+  def install
+    # Don't need Windows files.
+    rm_f Dir["bin/*.bat"]
+
+    libexec.install "bin", "conf", "lib"
+    bin.install_symlink Dir["#{libexec}/bin/*"] - ["#{libexec}/bin/groovy.ico"]
+  end
+
+  def caveats
+    <<~EOS
+      You should set GROOVY_HOME:
+        export GROOVY_HOME=#{opt_libexec}
+    EOS
+  end
+
+  test do
+    system "#{bin}/grape", "install", "org.activiti", "activiti-engine", "5.16.4"
+  end
+end


### PR DESCRIPTION
Previous major stable version of groovy (2.5.9)

Why would we need 2.5.9 instead of 3.x.x?

Groovy 3 represents a major release with a new language parser and many subtle changes.
Changes are documented here: http://groovy-lang.org/changelogs/changelog-3.0.0.html

My use-case: groovy 3 breaks all of my SimpleTemplateEngine templates due to changes in the implementation. I will fix them eventually and migrate to groovy 3, but right now I just need a working code-base!

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
