### PR TITLE
duplicacy-cli 2.4.0 (new formula)

### DIFF
--- a/Formula/duplicacy.rb
+++ b/Formula/duplicacy.rb
@@ -1,0 +1,28 @@
+class Duplicacy < Formula
+  desc "The only cross-platform encrypted/deduplicative cloud backup tool"
+  homepage "https://duplicacy.com"
+  url "https://github.com/gilbertchen/duplicacy.git",
+      :tag      => "v2.3.0",
+      :revision => "504d07bd5100b62473cd438738f8bc2507c67ff9"
+  head "https://github.com/gilbertchen/duplicacy.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    dir = buildpath/"src/github.com/gilbertchen/duplicacy"
+    dir.install buildpath.children
+
+    cd dir do
+      # https://forum.duplicacy.com/t/build-duplicacy-from-source/1091#build-on-macos
+      system "sed", "'s/github.com\/gilbertchen\/keyring/github.com\/twc\/keyring/'", "src/duplicacy_keyring.go"
+      system "go", "build", "duplicacy/duplicacy_main.go"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    system "#{bin}/duplicacy", "help"
+  end
+end

--- a/Formula/duplicacy.rb
+++ b/Formula/duplicacy.rb
@@ -2,8 +2,8 @@ class Duplicacy < Formula
   desc "The only cross-platform encrypted/deduplicative cloud backup tool"
   homepage "https://duplicacy.com"
   url "https://github.com/gilbertchen/duplicacy.git",
-      :tag      => "v2.3.0",
-      :revision => "504d07bd5100b62473cd438738f8bc2507c67ff9"
+      :tag      => "v2.4.0",
+      :revision => "b61906c99e17dca970f38c5b2c4ae88c9e170dd2"
   head "https://github.com/gilbertchen/duplicacy.git"
 
   depends_on "go" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

The installation documentation of building from source is by running `$ go get -u github.com/gilbertchen/duplicacy/...`. From what I read from the logs, `dir.install buildpath.children` seems not to provide the same functionality.

<details><summary>Failed Logs</summary>

```bash
$ brew install --build-from-source -vvv duplicacy
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Preferences or
https://developer.apple.com/download/more/.

/usr/bin/sandbox-exec -f /private/tmp/homebrew20200218-18267-12t8auo.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/duplicacy.rb --verbose
==> Cloning https://github.com/gilbertchen/duplicacy.git
Updating ~/Library/Caches/Homebrew/duplicacy--git
git config remote.origin.url https://github.com/gilbertchen/duplicacy.git
git config remote.origin.fetch \+refs/tags/v2.3.0:refs/tags/v2.3.0
git config remote.origin.tagOpt --no-tags
==> Checking out tag v2.3.0
git checkout -f v2.3.0 --
HEAD is now at 504d07b Bump version to 2.3.0
git reset --hard v2.3.0 --
HEAD is now at 504d07b Bump version to 2.3.0
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/Gopkg.toml /private/tmp/d20200218-18274-5ev9bw/Gopkg.toml
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/LICENSE.md /private/tmp/d20200218-18274-5ev9bw/LICENSE.md
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/duplicacy/. /private/tmp/d20200218-18274-5ev9bw/duplicacy
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/integration_tests/. /private/tmp/d20200218-18274-5ev9bw/integration_tests
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/images/. /private/tmp/d20200218-18274-5ev9bw/images
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/Gopkg.lock /private/tmp/d20200218-18274-5ev9bw/Gopkg.lock
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/README.md /private/tmp/d20200218-18274-5ev9bw/README.md
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/ACKNOWLEDGEMENTS.md /private/tmp/d20200218-18274-5ev9bw/ACKNOWLEDGEMENTS.md
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/GUIDE.md /private/tmp/d20200218-18274-5ev9bw/GUIDE.md
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/.github/. /private/tmp/d20200218-18274-5ev9bw/.github
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/DESIGN.md /private/tmp/d20200218-18274-5ev9bw/DESIGN.md
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/.git/. /private/tmp/d20200218-18274-5ev9bw/.git
cp -pR ~/Library/Caches/Homebrew/duplicacy--git/src/. /private/tmp/d20200218-18274-5ev9bw/src
cp -pR /private/tmp/d20200218-18274-5ev9bw/Gopkg.toml /private/tmp/duplicacy-20200218-18274-hnn59k/Gopkg.toml
cp -pR /private/tmp/d20200218-18274-5ev9bw/LICENSE.md /private/tmp/duplicacy-20200218-18274-hnn59k/LICENSE.md
cp -pR /private/tmp/d20200218-18274-5ev9bw/duplicacy/. /private/tmp/duplicacy-20200218-18274-hnn59k/duplicacy
cp -pR /private/tmp/d20200218-18274-5ev9bw/integration_tests/. /private/tmp/duplicacy-20200218-18274-hnn59k/integration_tests
cp -pR /private/tmp/d20200218-18274-5ev9bw/images/. /private/tmp/duplicacy-20200218-18274-hnn59k/images
cp -pR /private/tmp/d20200218-18274-5ev9bw/Gopkg.lock /private/tmp/duplicacy-20200218-18274-hnn59k/Gopkg.lock
cp -pR /private/tmp/d20200218-18274-5ev9bw/README.md /private/tmp/duplicacy-20200218-18274-hnn59k/README.md
cp -pR /private/tmp/d20200218-18274-5ev9bw/ACKNOWLEDGEMENTS.md /private/tmp/duplicacy-20200218-18274-hnn59k/ACKNOWLEDGEMENTS.md
cp -pR /private/tmp/d20200218-18274-5ev9bw/GUIDE.md /private/tmp/duplicacy-20200218-18274-hnn59k/GUIDE.md
cp -pR /private/tmp/d20200218-18274-5ev9bw/.github/. /private/tmp/duplicacy-20200218-18274-hnn59k/.github
cp -pR /private/tmp/d20200218-18274-5ev9bw/DESIGN.md /private/tmp/duplicacy-20200218-18274-hnn59k/DESIGN.md
cp -pR /private/tmp/d20200218-18274-5ev9bw/.git/. /private/tmp/duplicacy-20200218-18274-hnn59k/.git
cp -pR /private/tmp/d20200218-18274-5ev9bw/src/. /private/tmp/duplicacy-20200218-18274-hnn59k/src
chmod -Rf +w /private/tmp/d20200218-18274-5ev9bw
Error: An exception occurred within a child process:
  Errno::EINVAL: Invalid argument @ rb_file_s_rename - (/private/tmp/duplicacy-20200218-18274-hnn59k/src, /private/tmp/duplicacy-20200218-18274-hnn59k/src/github.com/gilbertchen/duplicacy/src)
```
</details>

- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

I've tried to add new Formula in Python/ Node.js, but new to Golang formula. I learned from existing Go formulas and is successful while making `$ brew install --interactive duplicacy`. Would you please help me with the seemingly Ruby renaming issue?

Related Casks:
- [Casks/duplicacy.rb](https://github.com/Homebrew/homebrew-cask/blob/masteer/Casks/duplicacy.rb)
- [Casks/duplicacy-web-edition.rb](https://github.com/Homebrew/homebrew-cask/blob/masteer/Casks/duplicacy-web-edition.rb)
