### PR TITLE
MySQL-client: fix improper includes

### DIFF
--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -19,6 +19,16 @@ class MysqlClient < Formula
 
   depends_on "openssl@1.1"
 
+  # Required to fix issue with angled includes
+  # https://bugs.gentoo.org/692644
+  # https://bugzilla.redhat.com/1623950
+  # https://bugs.mysql.com/92870
+  # We'll use Gentoo patch until PR Homebrew/formula-patches#282 lands.
+  patch :p1 do
+    url "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-db/mysql-connector-c/files/mysql-connector-c-8.0.17-use-relative-include-path-for-udf_registration_types-h.patch"
+    sha256 "606ab7ee0d1fe27a2638d917a47dd7763e97a635225ca44ece366f6613aea6b6"
+  end
+
   def install
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[


### PR DESCRIPTION
Recent MySQL client introduced a bug with includes. See these bugreports
for the details:

* https://bugs.gentoo.org/692644
* https://bugzilla.redhat.com/1623950
* https://bugs.mysql.com/92870

This patch fixes it.

See also Homebrew/formula-patches#282.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
