### PR TITLE
mandoc uses zlib

### DIFF
--- a/Formula/mandoc.rb
+++ b/Formula/mandoc.rb
@@ -12,6 +12,8 @@ class Mandoc < Formula
     sha256 "6176fcab59057d2188db3047849f96170bcb2133bfbe1f8c94845895d6a89bec" => :sierra
   end
 
+  uses_from_macos "zlib"
+
   def install
     localconfig = [
 


### PR DESCRIPTION
This fixes a build failure on Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
