### PR TITLE
gdb/i386-elf-gdb: enable lzma support & switch to python@3.8

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -4,6 +4,7 @@ class Gdb < Formula
   url "https://ftp.gnu.org/gnu/gdb/gdb-9.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-9.1.tar.xz"
   sha256 "699e0ec832fdd2f21c8266171ea5bf44024bd05164fdf064e4d10cc4cf0d1737"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
   bottle do
@@ -11,6 +12,9 @@ class Gdb < Formula
     sha256 "e3159449ff06712174dae7c3f513196eb02439e83057e2779531ec94b422c278" => :mojave
     sha256 "4cde626aa5d32dde54d70bd531a06e65051e7ac7371f1970b6b9c838f565239c" => :high_sierra
   end
+
+  depends_on "python@3.8"
+  depends_on "xz" # required for lzma support
 
   conflicts_with "i386-elf-gdb", :because => "both install include/gdb, share/gdb and share/info"
 
@@ -24,11 +28,12 @@ class Gdb < Formula
 
   def install
     args = %W[
+      --enable-targets=all
       --prefix=#{prefix}
       --disable-debug
       --disable-dependency-tracking
-      --enable-targets=all
-      --with-python=/usr
+      --with-lzma
+      --with-python=#{Formula["python@3.8"].opt_bin}/python3
       --disable-binutils
     ]
 

--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -12,13 +12,24 @@ class I386ElfGdb < Formula
     sha256 "5a173cea39b163dabfd97db3ea26446344ff82bdc3792b3111414d7f5c9ee6de" => :high_sierra
   end
 
+  depends_on "python@3.8"
+  depends_on "xz" # required for lzma support
+
   conflicts_with "gdb", :because => "both install include/gdb, share/gdb and share/info"
 
   def install
+    args = %W[
+      --target=i386-elf
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-dependency-tracking
+      --with-lzma
+      --with-python=#{Formula["python@3.8"].opt_bin}/python3
+      --disable-binutils
+    ]
+
     mkdir "build" do
-      system "../configure", "--target=i386-elf",
-                             "--prefix=#{prefix}",
-                             "--disable-werror"
+      system "../configure", *args
       system "make"
 
       # Don't install bfd or opcodes, as they are provided by binutils


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR enables lzma support for `gdb`/`i386-elf-gdb` formulae, migrates them to `python@3.8` and unify installation process


Fixes https://github.com/Homebrew/homebrew-core/issues/50449