### PR TITLE
jailkit: Use Python 3.8 instead of system Python 2

### DIFF
--- a/Formula/jailkit.rb
+++ b/Formula/jailkit.rb
@@ -10,7 +10,11 @@ class Jailkit < Formula
     sha256 "25e55b2cc8572ad043c97ad2b86e08f93ef1a69c6fb66d1bf1630c4c5092bdfc" => :high_sierra
   end
 
+  depends_on "python@3.8"
+
   def install
+    ENV["PYTHONINTERPRETER"] = Formula["python@3.8"].opt_bin/"python3"
+
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This formula has a relatively low number of installs (145 on macOS and 1 on Linux over the past 365 days), but it also didn't require very many hacks to make it work with Python 3.8, so I'm going for it.
- It doesn't have a test, so we won't know if it _actually_ works, but I don't know the software enough to write a test for it now.