### PR TITLE
container-structure-test 1.8.0 (new formula)

### DIFF
--- a/Formula/container-structure-test.rb
+++ b/Formula/container-structure-test.rb
@@ -1,0 +1,52 @@
+class ContainerStructureTest < Formula
+  desc "Validate the structure of your container images"
+  homepage "https://github.com/GoogleContainerTools/container-structure-test"
+  url "https://github.com/GoogleContainerTools/container-structure-test.git",
+      :tag      => "v1.8.0",
+      :revision => "19abf36d1451cb27f8e0f5ec8260815c73184bd4"
+  head "https://github.com/GoogleContainerTools/container-structure-test.git"
+
+  depends_on "go" => :build
+
+  # Small Docker image to run tests against
+  resource "busybox-image-tar" do
+    url "https://gist.github.com/AndiDog/1fab301b2dbc812b1544cd45db939e94/raw/5160ab30de17833fdfe183fc38e4e5f69f7bbae0/busybox-1.31.1.tar",
+      :using => :nounzip
+    sha256 "ab5088c314316f39ff1d1a452b486141db40813351731ec8d5300db3eb35a316"
+  end
+
+  def install
+    ENV["GOPATH"] = buildpath
+    dir = buildpath/"src/github.com/GoogleContainerTools/container-structure-test"
+    dir.install buildpath.children - [buildpath/".brew_home"]
+    cd dir do
+      system "make"
+      bin.install "out/container-structure-test"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    (testpath/"test.yml").write <<~EOF
+      schemaVersion: "2.0.0"
+
+      fileContentTests:
+        - name: root user
+          path: "/etc/passwd"
+          expectedContents:
+            - "root:x:0:0:root:/root:/bin/sh\\n.*"
+
+      fileExistenceTests:
+        - name: Basic executable
+          path: /bin/test
+          shouldExist: yes
+          permissions: '-rwxr-xr-x'
+    EOF
+
+    resource("busybox-image-tar").stage testpath
+    json_text = shell_output("#{bin}/container-structure-test test --driver tar --json --image busybox-1.31.1.tar --config test.yml")
+    res = JSON.parse(json_text)
+    assert_equal res["Pass"], 2
+    assert_equal res["Fail"], 0
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[container-structure-test](https://github.com/GoogleContainerTools/container-structure-test) is a container-related tool that helps with automated container image testing. For instance, it relates to the already existing skaffold formula which supports this tool out of the box.

@nkubala as container-structure-test maintainer: this might be interesting for you.