### PR TITLE
liquidctl 1.3.3

### DIFF
--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -3,8 +3,8 @@ class Liquidctl < Formula
 
   desc "Cross-platform tool and drivers for liquid coolers and other devices"
   homepage "https://github.com/jonasmalacofilho/liquidctl"
-  url "https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-1.3.2.tar.gz"
-  sha256 "bb742947c15f4a3987685641c0dd73184c4a40add5ad818ced68e5ace3631b6b"
+  url "https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-1.3.3.tar.gz"
+  sha256 "d13180867e07420c5890fe1110e8f45fe343794549a9ed7d5e8e76663bc10c24"
 
   head "https://github.com/jonasmalacofilho/liquidctl.git"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a maintenance update that contains the following changes:

- [HUE 2] Add missing identifiers for HUE+ accessories
- Forward hid option from UsbHidDriver.find_supported_devices
- Prevent reporting stale data during long lived connections to HIDs