### PR TITLE
llvm: add installation of included elisp files

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -177,6 +177,13 @@ class Llvm < Formula
     # install llvm python bindings
     (lib/"python2.7/site-packages").install buildpath/"bindings/python/llvm"
     (lib/"python2.7/site-packages").install buildpath/"tools/clang/bindings/python/clang"
+
+    # install emacs modes
+    elisp.install Dir["utils/emacs/*.el"] + %w[
+      tools/clang/tools/clang-format/clang-format.el
+      tools/clang/tools/clang-rename/clang-rename.el
+      tools/clang/tools/extra/clang-include-fixer/tool/clang-include-fixer.el
+    ]
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not sure why these were overlooked.  They're especially useful now that most of them are no longer in MELPA for [stupid reasons](https://lists.llvm.org/pipermail/llvm-dev/2018-May/123171.html).