### PR TITLE
bic 1.0.0 (new formula)

### DIFF
--- a/Formula/bic.rb
+++ b/Formula/bic.rb
@@ -1,0 +1,39 @@
+class Bic < Formula
+  desc "C interpreter and API explorer"
+  homepage "https://github.com/hexagonal-sun/bic"
+  url "https://github.com/hexagonal-sun/bic/releases/download/v1.0.0/bic-v1.0.0.tar.gz"
+  sha256 "553324e39d87df59930d093a264c14176d5e3aaa24cd8bff276531fb94775100"
+  head do
+    url "https://github.com/hexagonal-sun/bic.git"
+
+    depends_on "autoconf" => :build
+    depends_on "autoconf-archive" => :build
+    depends_on "automake" => :build
+    depends_on "bison" => :build # macOS bison is too outdated, build fails unless gnu bison is used
+    depends_on "libtool" => :build if build.head?
+
+    uses_from_macos "flex" => :build
+  end
+
+  depends_on "gmp"
+  uses_from_macos "readline"
+
+  def install
+    system "autoreconf", "-fi" if build.head?
+    system "./configure", "--disable-debug",
+           "--disable-dependency-tracking",
+          "--disable-silent-rules",
+           "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.c").write <<~EOS
+      #include <stdio.h>
+      int main () {
+        puts("Hello Homebrew!");
+      }
+    EOS
+    assert_equal "Hello Homebrew!", shell_output("#{bin}/bic -s hello.c").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

No, it doesn't pass `brew audit --strict bic` because a HEAD dependency on GNU bison exists. macOS/Xcode bison cannot be used because it is too out of date: The formula non-trivially fails to build with macOS bison. However I've added a comment indicating why this is required and the stable versions do not require this.

-----
