### PR TITLE
git: include native prompt for zsh as well

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -125,6 +125,7 @@ class Git < Formula
     bash_completion.install "contrib/completion/git-completion.bash"
     bash_completion.install "contrib/completion/git-prompt.sh"
     zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
+    zsh_completion.install "contrib/completion/git-prompt.sh"
     cp "#{bash_completion}/git-completion.bash", zsh_completion
 
     elisp.install Dir["contrib/emacs/*.el"]


### PR DESCRIPTION
File supports both bash and zsh: https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh#L1

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
