### PR TITLE
Restore original urls to Apache projects

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -1,7 +1,7 @@
 class Ant < Formula
   desc "Java build tool"
   homepage "https://ant.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=ant/binaries/apache-ant-1.10.7-bin.tar.xz"
+  url "https://www.apache.org/dyn/closer.lua?path=ant/binaries/apache-ant-1.10.7-bin.tar.xz"
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.xz"
   sha256 "925fa954d82b6edf5cfd51fc66659d6e02cf1a6a082c3c41fe83f604c2d17c02"
   revision 1
@@ -12,12 +12,14 @@ class Ant < Formula
   depends_on "openjdk"
 
   resource "ivy" do
-    url "https://www.apache.org/dyn/closer.cgi?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
     sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
   end
 
   resource "bcel" do
-    url "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.lua?path=commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.4.0-bin.tar.gz"
     sha256 "2e7d3c24fabc5a24c482ddc77c031d9f5978c5aa918bae68ad7adcf3e9167d04"
   end
 

--- a/Formula/apache-flink.rb
+++ b/Formula/apache-flink.rb
@@ -1,7 +1,8 @@
 class ApacheFlink < Formula
   desc "Scalable batch and stream data processing"
   homepage "https://flink.apache.org/"
-  url "https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz"
+  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz"
+  mirror "https://archive.apache.org/dist/flink/flink-1.10.0/flink-1.10.0-bin-scala_2.11.tgz"
   version "1.10.0"
   sha256 "4d9e8e1a2de3cd7f221b73a9d266f0d260550272afd82041134b9032c84cceb3"
   head "https://github.com/apache/flink.git"

--- a/Formula/apollo.rb
+++ b/Formula/apollo.rb
@@ -1,7 +1,8 @@
 class Apollo < Formula
   desc "Multi-protocol messaging broker based on ActiveMQ"
   homepage "https://activemq.apache.org/apollo"
-  url "https://archive.apache.org/dist/activemq/activemq-apollo/1.7.1/apache-apollo-1.7.1-unix-distro.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=activemq/activemq-apollo/1.7.1/apache-apollo-1.7.1-unix-distro.tar.gz"
+  mirror "https://archive.apache.org/dist/activemq/activemq-apollo/1.7.1/apache-apollo-1.7.1-unix-distro.tar.gz"
   sha256 "74577339a1843995a5128d14c68b21fb8f229d80d8ce1341dd3134f250ab689d"
   revision 1
 

--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -1,7 +1,8 @@
 class Cassandra < Formula
   desc "Eventually consistent, distributed key-value store"
   homepage "https://cassandra.apache.org"
-  url "https://archive.apache.org/dist/cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz"
   sha256 "ce34edebd1b6bb35216ae97bd06d3efc338c05b273b78267556a99f85d30e45b"
 
   bottle do

--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -1,7 +1,8 @@
 class CassandraAT21 < Formula
   desc "Distributed key-value store"
   homepage "https://cassandra.apache.org"
-  url "https://archive.apache.org/dist/cassandra/2.1.21/apache-cassandra-2.1.21-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=cassandra/2.1.21/apache-cassandra-2.1.21-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/cassandra/2.1.21/apache-cassandra-2.1.21-bin.tar.gz"
   sha256 "992080ce42bb90173b1a910edffadc7f917b5a6e598db5154ff32ae8e2d00ad3"
   revision 1
 

--- a/Formula/fuseki.rb
+++ b/Formula/fuseki.rb
@@ -1,7 +1,8 @@
 class Fuseki < Formula
   desc "SPARQL server"
   homepage "https://jena.apache.org/documentation/fuseki2/"
-  url "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-3.14.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=jena/binaries/apache-jena-fuseki-3.14.0.tar.gz"
+  mirror "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-3.14.0.tar.gz"
   sha256 "11cdfc60c515281efeb392394d750f1847ee77a2b0a4728ab006f4faafee916a"
 
   bottle :unneeded

--- a/Formula/jena.rb
+++ b/Formula/jena.rb
@@ -1,7 +1,8 @@
 class Jena < Formula
   desc "Framework for building semantic web and linked data apps"
   homepage "https://jena.apache.org/"
-  url "https://archive.apache.org/dist/jena/binaries/apache-jena-3.14.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=jena/binaries/apache-jena-3.14.0.tar.gz"
+  mirror "https://archive.apache.org/dist/jena/binaries/apache-jena-3.14.0.tar.gz"
   sha256 "6729c587a3a9020a464cbf54bbc016d1a9c14b4b223c35914f8b675633e2b39e"
 
   bottle :unneeded

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -1,7 +1,8 @@
 class Sqoop < Formula
   desc "Transfer bulk data between Hadoop and structured datastores"
   homepage "https://sqoop.apache.org/"
-  url "https://archive.apache.org/dist/sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
+  mirror "https://archive.apache.org/dist/sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
   version "1.4.7"
   sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
 

--- a/Formula/tomee-jax-rs.rb
+++ b/Formula/tomee-jax-rs.rb
@@ -1,7 +1,8 @@
 class TomeeJaxRs < Formula
   desc "TomeEE Web Profile plus JAX-RS"
   homepage "https://tomee.apache.org/"
-  url "https://archive.apache.org/dist/tomee/tomee-1.7.5/apache-tomee-1.7.5-jaxrs.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-1.7.5/apache-tomee-1.7.5-jaxrs.tar.gz"
+  mirror "https://archive.apache.org/dist/tomee/tomee-1.7.5/apache-tomee-1.7.5-jaxrs.tar.gz"
   sha256 "5c9241ca683db85c13a23234b206fe98011d734a661383bbc9027deb756c09da"
 
   bottle :unneeded

--- a/Formula/tomee-plume.rb
+++ b/Formula/tomee-plume.rb
@@ -1,7 +1,8 @@
 class TomeePlume < Formula
   desc "Apache TomEE Plume"
   homepage "https://tomee.apache.org/"
-  url "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-plume.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.0/apache-tomee-8.0.0-plume.tar.gz"
+  mirror "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-plume.tar.gz"
   sha256 "477ef236f0668c3bf8ee22d65588261ac046f0b982d4147accd5bd250250373e"
 
   bottle :unneeded

--- a/Formula/tomee-plus.rb
+++ b/Formula/tomee-plus.rb
@@ -1,7 +1,8 @@
 class TomeePlus < Formula
   desc "Everything in TomEE Web Profile and JAX-RS, plus more"
   homepage "https://tomee.apache.org/"
-  url "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-plus.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.0/apache-tomee-8.0.0-plus.tar.gz"
+  mirror "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-plus.tar.gz"
   sha256 "677d9db26a5d1d8fc23a348e29935133bdb995ae420623563bcfb0b6a6638da8"
 
   bottle :unneeded

--- a/Formula/tomee-webprofile.rb
+++ b/Formula/tomee-webprofile.rb
@@ -1,7 +1,8 @@
 class TomeeWebprofile < Formula
   desc "All-Apache Java EE 7 Web Profile stack"
   homepage "https://tomee.apache.org/"
-  url "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-webprofile.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.0/apache-tomee-8.0.0-webprofile.tar.gz"
+  mirror "https://archive.apache.org/dist/tomee/tomee-8.0.0/apache-tomee-8.0.0-webprofile.tar.gz"
   sha256 "5cdda0d0416700692f1e5282154f786f1fdb7015aa3909b0e44cdfe39720dedd"
 
   bottle :unneeded

--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -3,7 +3,8 @@ class Trafficserver < Formula
   homepage "https://trafficserver.apache.org/"
 
   stable do
-    url "https://archive.apache.org/dist/trafficserver/trafficserver-8.0.5.tar.bz2"
+    url "https://www.apache.org/dyn/closer.lua?path=trafficserver/trafficserver-8.0.5.tar.bz2"
+    mirror "https://archive.apache.org/dist/trafficserver/trafficserver-8.0.5.tar.bz2"
     sha256 "8ede46ef4b7961b0f53dc3418985f30569725c671ea9e6626dc8bbf0ca46544f"
   end
 

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -1,7 +1,8 @@
 class Zookeeper < Formula
   desc "Centralized server for distributed coordination of services"
   homepage "https://zookeeper.apache.org/"
-  url "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz"
+  mirror "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz"
   sha256 "b14f7a0fece8bd34c7fffa46039e563ac5367607c612517aa7bd37306afbd1cd"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR continues https://github.com/Homebrew/homebrew-core/pull/50404 and moves urls `https://archive.apache.org/dist/` to mirror and restores original urls to `https://www.apache.org/dyn/closer.lua?path=` (which points to the best mirror dynamically, if works)