### PR TITLE
liblzf: update checksum due to recompression

### DIFF
--- a/Formula/liblzf.rb
+++ b/Formula/liblzf.rb
@@ -3,7 +3,7 @@ class Liblzf < Formula
   homepage "http://oldhome.schmorp.de/marc/liblzf.html"
   url "http://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
   mirror "http://download.openpkg.org/components/cache/liblzf/liblzf-3.6.tar.gz"
-  sha256 "41ed86a1bd3a9485612f7a7c1d3c9962d2fe771e55dc30fcf45bd419c39aab8d"
+  sha256 "9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Redo of #49134

> On Mon, Feb 17, 2020 at 05:12:29PM +0000, Seeker <meaningseeking@protonmail.com> wrote:
> > Hi, I'm a contributor to [Homebrew](https://github.com/Homebrew) and I wanted to ask why the checksum for LibLZF 3.6 has changed. When LibLZF was added to [homebrew-core](https://github.com/Homebrew/homebrew-core) on April 20, 2016, the checksum for liblzf-3.6.tar.gz[1] was 41ed86a...[2]. Since then, [it seems to have changed](https://github.com/Homebrew/homebrew-core/pull/49134) to 9c5de01...[3].
> 
> It was recompressed - the contents are the same.
> 
> --
> ```
>                 The choice of a       Deliantra, the free code+content MORPG
>       -----==-     _GNU_              http://www.deliantra.net
>       ----==-- _       generation
>       ---==---(_)__  __ ____  __      Marc Lehmann
>       --==---/ / _ \/ // /\ \/ /      schmorp@schmorp.de
>       -=====/_/_//_/\_,_/ /_/\_\
> ```