### PR TITLE
libcbor: bump to 0.6.1, change build options

### DIFF
--- a/Formula/libcbor.rb
+++ b/Formula/libcbor.rb
@@ -1,8 +1,8 @@
 class Libcbor < Formula
   desc "CBOR protocol implementation for C and others"
   homepage "http://libcbor.org/"
-  url "https://github.com/PJK/libcbor/archive/v0.6.0.tar.gz"
-  sha256 "ad97dfe6462a28956be38c924a5a557acf303d8454ca121e02150a5b87e03ee7"
+  url "https://github.com/PJK/libcbor/archive/v0.6.1.tar.gz"
+  sha256 "2f805f5fa2790c4fdd16046287f5814703229547da2b83009dd32357623aa182"
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class Libcbor < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "-G", "Unix Makefiles", "..", *std_cmake_args
+      system "cmake", "..", "-DWITH_EXAMPLES=OFF", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -3,7 +3,7 @@ class Libfido2 < Formula
   homepage "https://developers.yubico.com/libfido2/"
   url "https://github.com/Yubico/libfido2/archive/1.3.1.tar.gz"
   sha256 "ba35e22016b60c1e4be66dff3cd6a60c1fe4bfa0d91ec0b89ca9da25ebeaaf41"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any


### PR DESCRIPTION
The examples which require cJSON are part of the default build and a useful test step.

Additionally, `-G "Unix Makefiles"` should be unnecessary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
