### PR TITLE
onfluent-platform: fix confluent-platform cli

### DIFF
--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -11,6 +11,8 @@ class ConfluentPlatform < Formula
 
   conflicts_with "kafka", :because => "kafka also ships with identically named Kafka related executables"
 
+  patch :DATA
+
   def install
     prefix.install "bin"
     rm_rf "#{bin}/windows"
@@ -27,3 +29,18 @@ class ConfluentPlatform < Formula
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
   end
 end
+__END__
+diff --git a/bin/confluent b/bin/confluent
+index 1247e4f..fadbb8d 100755
+--- a/bin/confluent
++++ b/bin/confluent
+@@ -184,7 +184,8 @@ BINARY=confluent
+ OS=$(uname_os)
+ ARCH=$(uname_arch)
+ PREFIX="${OWNER}/${REPO}"
+-EXE_PATH="${BASH_SOURCE%/*}/../libexec/cli"
++SELF=$(realpath "${BASH_SOURCE}")
++EXE_PATH="${SELF%/*}/../libexec/cli"
+ PLATFORM="${OS}/${ARCH}"
+
+ # use in logging routines

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -16,6 +16,11 @@ class ConfluentPlatform < Formula
     rm_rf "#{bin}/windows"
     prefix.install "etc"
     prefix.install "share"
+    prefix.install "libexec"
+    rm_rf "#{libexec}/cli/linux_386"
+    rm_rf "#{libexec}/cli/linux_amd64"
+    rm_rf "#{libexec}/cli/windows_386"
+    rm_rf "#{libexec}/cli/windows_amd64"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Confluent-platform install a `confluent` CLI that is not really working.
Two fixes are needed:
- install the `libexec` folder
- fix the `confluent` script to find the keg when run from `/usr/local/bin`