### PR TITLE
ghc@8.6: remove make check and fix Catalina compatibility

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -119,6 +119,6 @@ class Ghc < Formula
 
   test do
     (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')
-    system "#{bin}/runghc", testpath/"hello.hs"
+    assert_match "Hello Homebrew", shell_output("#{bin}/runghc hello.hs")
   end
 end

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -7,6 +7,7 @@ class GhcAT86 < Formula
   homepage "https://haskell.org/ghc/"
   url "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-src.tar.xz"
   sha256 "4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361"
+  revision 1
 
   bottle do
     sha256 "0aaed7d9ff0734d21611b8987796238e60288c87435eac3a834464471f3c14e0" => :mojave
@@ -33,6 +34,9 @@ class GhcAT86 < Formula
     sha256 "dfc1bdb1d303a87a8552aa17f5b080e61351f2823c2b99071ec23d0837422169"
   end
 
+  # Fix for Catalina compatibility https://gitlab.haskell.org/ghc/ghc/issues/17353
+  patch :DATA
+
   def install
     ENV["CC"] = ENV.cc
     ENV["LD"] = "ld"
@@ -47,7 +51,6 @@ class GhcAT86 < Formula
       system "./configure", "--prefix=#{gmp}", "--with-pic", "--disable-shared",
                             "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
       system "make"
-      system "make", "check"
       system "make", "install"
     end
 
@@ -110,3 +113,25 @@ class GhcAT86 < Formula
     system "#{bin}/runghc", testpath/"hello.hs"
   end
 end
+__END__
+diff -pur a/rts/Linker.c b/rts/Linker.c
+--- a/rts/Linker.c	2019-08-25 21:03:36.000000000 +0900
++++ b/rts/Linker.c	2019-11-05 11:09:06.000000000 +0900
+@@ -192,7 +192,7 @@ int ocTryLoad( ObjectCode* oc );
+  *
+  * MAP_32BIT not available on OpenBSD/amd64
+  */
+-#if defined(x86_64_HOST_ARCH) && defined(MAP_32BIT)
++#if defined(x86_64_HOST_ARCH) && defined(MAP_32BIT) && !defined(__APPLE__)
+ #define TRY_MAP_32BIT MAP_32BIT
+ #else
+ #define TRY_MAP_32BIT 0
+@@ -214,7 +214,7 @@ int ocTryLoad( ObjectCode* oc );
+  */
+ #if !defined(ALWAYS_PIC) && defined(x86_64_HOST_ARCH)
+
+-#if defined(MAP_32BIT)
++#if defined(MAP_32BIT) && !defined(__APPLE__)
+ // Try to use MAP_32BIT
+ #define MMAP_32BIT_BASE_DEFAULT 0
+ #else

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -109,7 +109,7 @@ class GhcAT86 < Formula
   end
 
   test do
-    (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')\
+    (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')
     assert_match "Hello Homebrew", shell_output("#{bin}/runghc hello.hs")
   end
 end

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -109,8 +109,8 @@ class GhcAT86 < Formula
   end
 
   test do
-    (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')
-    system "#{bin}/runghc", testpath/"hello.hs"
+    (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')\
+    assert_match "Hello Homebrew", shell_output("#{bin}/runghc hello.hs")
   end
 end
 __END__


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Audit failure due to [binary URL](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ghc@8.6.rb#L29-L34) is fixed in Homebrew/brew#7072

Note: the Catalina compatibility patch is the same one that was removed in e905cac when `ghc` was updated to version 8.8.2. This pull request backports that patch to 8.6.