### PR TITLE
Sync `uses_from_macos` from Homebrew/linuxbrew-core

### DIFF
--- a/Formula/acpica.rb
+++ b/Formula/acpica.rb
@@ -12,6 +12,10 @@ class Acpica < Formula
     sha256 "19bde18f6e8eb1616c8ed61b6d12a813252463e1cecfd6b3a22e3c28c895020e" => :high_sierra
   end
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "m4" => :build
+
   def install
     ENV.deparallelize
     system "make", "PREFIX=#{prefix}"

--- a/Formula/advancecomp.rb
+++ b/Formula/advancecomp.rb
@@ -16,6 +16,7 @@ class Advancecomp < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 

--- a/Formula/advancemame.rb
+++ b/Formula/advancemame.rb
@@ -15,6 +15,9 @@ class Advancemame < Formula
   depends_on "freetype"
   depends_on "sdl"
 
+  uses_from_macos "expat"
+  uses_from_macos "ncurses"
+
   conflicts_with "advancemenu", :because => "both install `advmenu` binaries"
 
   def install

--- a/Formula/advancemenu.rb
+++ b/Formula/advancemenu.rb
@@ -13,7 +13,9 @@ class Advancemenu < Formula
   end
 
   depends_on "sdl"
+
   uses_from_macos "expat"
+  uses_from_macos "zlib"
 
   conflicts_with "advancemame", :because => "both install `advmenu` binaries"
 

--- a/Formula/advancescan.rb
+++ b/Formula/advancescan.rb
@@ -14,6 +14,8 @@ class Advancescan < Formula
     sha256 "f91cbe31c7c8072fffffcd0cc8766e20df6f728abc73f66140f97c0a49d6f6c8" => :yosemite
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "./configure", "--disable-silent-rules",
                           "--prefix=#{prefix}"

--- a/Formula/afflib.rb
+++ b/Formula/afflib.rb
@@ -20,6 +20,9 @@ class Afflib < Formula
   depends_on "openssl@1.1"
   depends_on "python"
 
+  uses_from_macos "curl"
+  uses_from_macos "expat"
+
   def install
     args = %w[
       --enable-s3

--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -35,6 +35,7 @@ class Agda < Formula
   depends_on "cabal-install" => [:build, :test]
   depends_on "emacs"
   depends_on "ghc"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/aide.rb
+++ b/Formula/aide.rb
@@ -21,6 +21,8 @@ class Aide < Formula
   depends_on "libgcrypt"
   depends_on "libgpg-error"
   depends_on "pcre"
+
+  uses_from_macos "bison" => :build
   uses_from_macos "curl"
 
   def install

--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -13,6 +13,8 @@ class Alpine < Formula
 
   depends_on "openssl@1.1"
 
+  uses_from_macos "ncurses"
+
   def install
     ENV.deparallelize
 

--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -20,6 +20,7 @@ class Analog < Formula
   depends_on "gd"
   depends_on "jpeg"
   depends_on "libpng"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -19,6 +19,7 @@ class Ansible < Formula
   depends_on "libyaml"
   depends_on "openssl@1.1"
   depends_on "python@3.8"
+
   uses_from_macos "libffi"
   uses_from_macos "libxslt"
 

--- a/Formula/ansible@2.8.rb
+++ b/Formula/ansible@2.8.rb
@@ -20,6 +20,9 @@ class AnsibleAT28 < Formula
   depends_on "openssl@1.1"
   depends_on "python"
 
+  uses_from_macos "libffi"
+  uses_from_macos "libxslt"
+
   # Collect requirements from:
   #   ansible
   #   docker-py

--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -16,8 +16,10 @@ class AppscaleTools < Formula
   depends_on "libyaml"
   depends_on "openssl@1.1"
   depends_on "ssh-copy-id"
+  
   # Uses SOAPPy, which does not support Python 3
   uses_from_macos "python@2" # does not support Python 3
+  uses_from_macos "libffi"
 
   resource "retrying" do
     url "https://files.pythonhosted.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz"

--- a/Formula/apt-dater.rb
+++ b/Formula/apt-dater.rb
@@ -19,6 +19,7 @@ class AptDater < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "popt"
+
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -21,6 +21,7 @@ class Arabica < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "boost"
+
   uses_from_macos "expat"
 
   def install

--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -13,6 +13,7 @@ class Aria2 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libssh2"
+
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/arping.rb
+++ b/Formula/arping.rb
@@ -15,6 +15,7 @@ class Arping < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libnet"
+
   uses_from_macos "libpcap"
 
   def install

--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -20,6 +20,9 @@ class Asciidoc < Formula
   depends_on "docbook"
   depends_on "source-highlight"
 
+  uses_from_macos "libxml2" => :build
+  uses_from_macos "libxslt" => :build
+
   def install
     ENV.prepend_path "PATH", "/System/Library/Frameworks/Python.framework/Versions/2.7/bin"
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"

--- a/Formula/aspell.rb
+++ b/Formula/aspell.rb
@@ -11,6 +11,8 @@ class Aspell < Formula
     sha256 "9bbb8be505d953395bcccde4712cf85792c6bf03af535cc553783361476ddddb" => :high_sierra
   end
 
+  uses_from_macos "ncurses"
+
   resource "en" do
     url "https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2018.04.16-0.tar.bz2"
     mirror "https://ftpmirror.gnu.org/aspell/dict/en/aspell6-en-2018.04.16-0.tar.bz2"

--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -13,6 +13,7 @@ class Assimp < Formula
   end
 
   depends_on "cmake" => :build
+
   uses_from_macos "zlib"
 
   # Fix "unzip.c:150:11: error: unknown type name 'z_crc_t'"

--- a/Formula/atasm.rb
+++ b/Formula/atasm.rb
@@ -12,6 +12,8 @@ class Atasm < Formula
     sha256 "b9eb26201949590ab8fce80ee3feabe7f0be2f611e7c60b6b456c8d78480680c" => :high_sierra
   end
 
+  uses_from_macos "zlib"
+
   def install
     cd "src" do
       system "make", "prog"

--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -18,6 +18,7 @@ class Atomicparsley < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+
   uses_from_macos "zlib"
 
   # Fix Xcode 9 pointer warnings

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -51,6 +51,7 @@ class Audacious < Formula
   depends_on "qt"
   depends_on "sdl2"
   depends_on "wavpack"
+
   uses_from_macos "python@2"
 
   def install

--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -14,6 +14,7 @@ class Auditbeat < Formula
   end
 
   depends_on "go" => :build
+
   # https://github.com/elastic/beats/pull/14798
   uses_from_macos "python@2" => :build # does not support Python 3
 

--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -22,6 +22,7 @@ class Augeas < Formula
 
   depends_on "pkg-config" => :build
   depends_on "readline"
+
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -17,6 +17,9 @@ class Autoconf < Formula
     sha256 "d153b3318754731ff5e91b45b2518c75880993fa9d1f312a03696e2c1de0c9d5" => :mavericks
   end
 
+  uses_from_macos "m4"
+  uses_from_macos "perl"
+
   def install
     ENV["PERL"] = "/usr/bin/perl"
 

--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -15,6 +15,7 @@ class Autogen < Formula
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "guile"
+
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/avian.rb
+++ b/Formula/avian.rb
@@ -17,6 +17,7 @@ class Avian < Formula
   end
 
   depends_on :java => "1.8"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -16,6 +16,7 @@ class AvroC < Formula
   depends_on "jansson"
   depends_on "snappy"
   depends_on "xz"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -17,6 +17,7 @@ class AwsGoogleAuth < Formula
   depends_on "freetype"
   depends_on "jpeg"
   depends_on "python"
+
   uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -13,6 +13,7 @@ class AwsSdkCpp < Formula
   end
 
   depends_on "cmake" => :build
+
   uses_from_macos "curl"
 
   def install

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -18,6 +18,9 @@ class Awscli < Formula
   # Sierra
   depends_on "python@3.8"
 
+  uses_from_macos "groff"
+  uses_from_macos "libyaml"
+
   def install
     venv = virtualenv_create(libexec, "python3")
     system libexec/"bin/pip", "install", "-v", "-r", "requirements.txt",

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -20,6 +20,8 @@ class AwscliAT1 < Formula
   # Sierra
   depends_on "python@3.8"
 
+  uses_from_macos "groff"
+
   def install
     venv = virtualenv_create(libexec, "python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",

--- a/Formula/awslogs.rb
+++ b/Formula/awslogs.rb
@@ -17,6 +17,8 @@ class Awslogs < Formula
 
   depends_on "python@3.8"
 
+  uses_from_macos "zlib"
+
   resource "boto3" do
     url "https://files.pythonhosted.org/packages/fd/50/3868735fae36e0f93216019551ca0f75b6cf9f933a55891244efefdcc3bd/boto3-1.9.62.tar.gz"
     sha256 "e9e93029b0d4f91ff342ffd953048c5a64e6a1522c2362c4521864bcc88cc365"

--- a/Formula/bacula-fd.rb
+++ b/Formula/bacula-fd.rb
@@ -15,6 +15,8 @@ class BaculaFd < Formula
   depends_on "openssl@1.1"
   depends_on "readline"
 
+  uses_from_macos "zlib"
+
   conflicts_with "bareos-client",
     :because => "Both install a `bconsole` executable."
 

--- a/Formula/badtouch.rb
+++ b/Formula/badtouch.rb
@@ -14,6 +14,8 @@ class Badtouch < Formula
   depends_on "rust" => :build
   depends_on "openssl@1.1"
 
+  uses_from_macos "zlib"
+
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -13,6 +13,7 @@ class Bat < Formula
   end
 
   depends_on "rust" => :build
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -16,6 +16,8 @@ class Bazel < Formula
   depends_on :java => "1.8"
   depends_on :macos => :yosemite
 
+  uses_from_macos "zip"
+
   def install
     ENV["EMBED_LABEL"] = "#{version}-homebrew"
     # Force Bazel ./compile.sh to put its temporary files in the buildpath

--- a/Formula/bc.rb
+++ b/Formula/bc.rb
@@ -17,6 +17,9 @@ class Bc < Formula
 
   keg_only :provided_by_macos
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex"
+
   def install
     # prevent user BC_ENV_ARGS from interfering with or influencing the
     # bootstrap phase of the build, particularly

--- a/Formula/bettercap.rb
+++ b/Formula/bettercap.rb
@@ -16,6 +16,8 @@ class Bettercap < Formula
   depends_on "pkg-config" => :build
   depends_on "libusb"
 
+  uses_from_macos "libpcap"
+
   def install
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/bettercap/bettercap").install buildpath.children

--- a/Formula/bibtexconv.rb
+++ b/Formula/bibtexconv.rb
@@ -15,6 +15,10 @@ class Bibtexconv < Formula
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "curl"
+
   def install
     system "cmake", *std_cmake_args,
                     "-DCRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_lib}/libcrypto.dylib"

--- a/Formula/bic.rb
+++ b/Formula/bic.rb
@@ -23,6 +23,7 @@ class Bic < Formula
   end
 
   depends_on "gmp"
+
   uses_from_macos "readline"
 
   def install

--- a/Formula/bioawk.rb
+++ b/Formula/bioawk.rb
@@ -13,6 +13,9 @@ class Bioawk < Formula
     sha256 "df0810bc087f924cdddcdb73f00faf9772de9475e0e698c7af8a7d036b3a4c91" => :el_capitan
   end
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "zlib"
+
   def install
     # Fix make: *** No rule to make target `ytab.h', needed by `b.o'.
     ENV.deparallelize

--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -14,6 +14,9 @@ class Blast < Formula
 
   depends_on "lmdb"
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   conflicts_with "proj", :because => "both install a `libproj.a` library"
 
   def install

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -14,6 +14,8 @@ class BoostPython < Formula
 
   depends_on "boost"
 
+  uses_from_macos "python@2"
+
   def install
     # "layout" should be synchronized with boost
     args = %W[

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -14,6 +14,9 @@ class Boost < Formula
 
   depends_on "icu4c"
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|

--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -16,6 +16,9 @@ class BoostAT160 < Formula
 
   keg_only :versioned_formula
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   # Handle compile failure with boost/graph/adjacency_matrix.hpp
   # https://github.com/Homebrew/homebrew/pull/48262
   # https://svn.boost.org/trac/boost/ticket/11880

--- a/Formula/buku.rb
+++ b/Formula/buku.rb
@@ -16,6 +16,9 @@ class Buku < Formula
   depends_on "openssl@1.1"
   depends_on "python"
 
+  uses_from_macos "libffi"
+  uses_from_macos "expect" => :test
+
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/9f/3d/8beae739ed8c1c8f00ceac0ab6b0e97299b42da869e24cf82851b27a9123/asn1crypto-1.3.0.tar.gz"
     sha256 "5a215cb8dc12f892244e3a113fe05397ee23c5c4ca7a69cd6e69811755efc42d"

--- a/Formula/ccze.rb
+++ b/Formula/ccze.rb
@@ -15,6 +15,8 @@ class Ccze < Formula
 
   depends_on "pcre"
 
+  uses_from_macos "ncurses"
+
   def install
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=823334
     inreplace "src/ccze-compat.c", "#if HAVE_SUBOPTARg", "#if HAVE_SUBOPTARG"

--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -19,6 +19,8 @@ class Certbot < Formula
   depends_on "openssl@1.1"
   depends_on "python@3.8"
 
+  uses_from_macos "libffi"
+
   resource "acme" do
     url "https://files.pythonhosted.org/packages/40/0c/eeac8a14019d6f297fbd3b2bacfa57d38e60147cc03542214662253a694c/acme-1.2.0.tar.gz"
     sha256 "0630c740d49bda945e97bd35fc8d6f02d082c8cb9e18f8fec0dbb3d395ac26ab"

--- a/Formula/cgdb.rb
+++ b/Formula/cgdb.rb
@@ -21,6 +21,8 @@ class Cgdb < Formula
   depends_on "help2man" => :build
   depends_on "readline"
 
+  uses_from_macos "flex" => :build
+
   def install
     system "sh", "autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/cgns.rb
+++ b/Formula/cgns.rb
@@ -14,6 +14,7 @@ class Cgns < Formula
   depends_on "gcc"
   depends_on "hdf5"
   depends_on "szip"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/check.rb
+++ b/Formula/check.rb
@@ -11,6 +11,8 @@ class Check < Formula
     sha256 "b61bb914f053c31a8dcb86394d10d3e3b77b2d71ebe2c4f21585f05f15594d8e" => :high_sierra
   end
 
+  uses_from_macos "gawk"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -25,6 +25,9 @@ class Clamav < Formula
   depends_on "pcre"
   depends_on "yara"
 
+  uses_from_macos "curl"
+  uses_from_macos "zlib"
+
   skip_clean "share/clamav"
 
   def install

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -39,6 +39,10 @@ class ClangFormat < Formula
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def install
     (buildpath/"projects/libcxx").install resource("libcxx")
     (buildpath/"tools/clang").install resource("clang")

--- a/Formula/click.rb
+++ b/Formula/click.rb
@@ -14,6 +14,8 @@ class Click < Formula
 
   depends_on "rust" => :build
 
+  uses_from_macos "expect" => :test
+
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -10,6 +10,8 @@ class Clojure < Formula
   depends_on "openjdk"
   depends_on "rlwrap"
 
+  uses_from_macos "ruby" => :build
+
   def install
     system "./install.sh", prefix
     bin.env_script_all_files libexec/"bin", :JAVA_HOME => "${JAVA_HOME:-#{Formula["openjdk"].opt_prefix}}"

--- a/Formula/cmatrix.rb
+++ b/Formula/cmatrix.rb
@@ -14,6 +14,8 @@ class Cmatrix < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
+  uses_from_macos "ncurses"
+
   def install
     system "autoreconf", "-i"
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"

--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -22,6 +22,9 @@ class Collectd < Formula
   depends_on "libtool"
   depends_on "net-snmp"
   depends_on "riemann-client"
+
+  uses_from_macos "bison"
+  uses_from_macos "flex"
   uses_from_macos "perl"
 
   def install

--- a/Formula/comby.rb
+++ b/Formula/comby.rb
@@ -15,6 +15,9 @@ class Comby < Formula
   depends_on "opam" => :build
   depends_on "pcre"
   depends_on "pkg-config"
+
+  uses_from_macos "m4"
+  uses_from_macos "unzip"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -23,6 +23,8 @@ class ConjureUp < Formula
   depends_on "python@3.8"
   depends_on "redis"
 
+  uses_from_macos "libffi"
+
   # list generated from the 'requirements.txt' file in the repository root
   resource "aiofiles" do
     url "https://files.pythonhosted.org/packages/94/c2/e3cb60c1b7d9478203d4514e2d33ea424ad9bb98e45b21d6225db93f25c9/aiofiles-0.4.0.tar.gz"

--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -19,6 +19,7 @@ class Cryptol < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "z3"
+
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -32,6 +32,7 @@ class Csound < Formula
   depends_on "portmidi"
   depends_on "stk"
   depends_on "wiiuse"
+
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "curl"

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -22,7 +22,9 @@ class Curl < Formula
   keg_only :provided_by_macos
 
   depends_on "pkg-config" => :build
+
   uses_from_macos "openssl"
+  uses_from_macos "zlib"
 
   def install
     system "./buildconf" if build.head?

--- a/Formula/daq.rb
+++ b/Formula/daq.rb
@@ -16,6 +16,10 @@ class Daq < Formula
     sha256 "8ce4fbbbb9f6189f6ee51d3223a81ebc7ea76069353bd284822989d6ccc364a5" => :mavericks
   end
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "libpcap"
+
   # libpcap on >= 10.12 has pcap_lib_version() instead of pcap_version
   # Reported 8 Oct 2017 to bugs AT snort DOT org
   if MacOS.version >= :sierra

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -15,6 +15,7 @@ class Dcmtk < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "openssl@1.1"
+
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/deja-gnu.rb
+++ b/Formula/deja-gnu.rb
@@ -19,6 +19,8 @@ class DejaGnu < Formula
     depends_on "automake" => :build
   end
 
+  uses_from_macos "expect"
+
   def install
     ENV.deparallelize # Or fails on Mac Pro
     system "autoreconf", "-iv" if build.head?

--- a/Formula/dhall-json.rb
+++ b/Formula/dhall-json.rb
@@ -19,6 +19,9 @@ class DhallJson < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc@8.6" => :build
 
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def install
     install_cabal_package
   end

--- a/Formula/diamond.rb
+++ b/Formula/diamond.rb
@@ -12,6 +12,7 @@ class Diamond < Formula
   end
 
   depends_on "cmake" => :build
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/diesel.rb
+++ b/Formula/diesel.rb
@@ -16,6 +16,7 @@ class Diesel < Formula
   depends_on "rust" => [:build, :test]
   depends_on "libpq"
   depends_on "mysql-client"
+
   uses_from_macos "sqlite"
 
   def install

--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -44,6 +44,9 @@ class Dmd < Formula
     end
   end
 
+  uses_from_macos "unzip" => :build
+  uses_from_macos "xz" => :build
+
   def install
     # DMD defaults to v2.088.0 to bootstrap as of DMD 2.090.0
     # On MacOS Catalina, a version < 2.087.1 would not work due to TLS related symbols missing

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -16,7 +16,9 @@ class Docbook2x < Formula
   end
 
   depends_on "docbook"
+
   uses_from_macos "libxslt"
+  uses_from_macos "perl"
 
   def install
     inreplace "perl/db2x_xsltproc.pl", "http://docbook2x.sf.net/latest/xslt", "#{share}/docbook2X/xslt"

--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -17,6 +17,8 @@ class DockerCompose < Formula
   depends_on "libyaml"
   depends_on "python@3.8"
 
+  uses_from_macos "libffi"
+
   def install
     system "./script/build/write-git-sha" if build.head?
     venv = virtualenv_create(libexec, "python3")

--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -11,6 +11,8 @@ class Dovecot < Formula
   end
 
   depends_on "openssl@1.1"
+  uses_from_macos "bzip2"
+  uses_from_macos "sqlite"
 
   resource "pigeonhole" do
     url "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-0.5.9.tar.gz"

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -21,6 +21,9 @@ class Dpkg < Formula
   depends_on "perl"
   depends_on "xz" # For LZMA
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   def install
     # We need to specify a recent gnutar, otherwise various dpkg C programs will
     # use the system "tar", which will fail because it lacks certain switches.

--- a/Formula/dps8m.rb
+++ b/Formula/dps8m.rb
@@ -17,6 +17,8 @@ class Dps8m < Formula
 
   depends_on "libuv"
 
+  uses_from_macos "expect" => :test
+
   def install
     # Reported 23 Jul 2017 "make dosn't create bin directory"
     # See https://sourceforge.net/p/dps8m/mailman/message/35960505/

--- a/Formula/dub.rb
+++ b/Formula/dub.rb
@@ -14,6 +14,7 @@ class Dub < Formula
 
   depends_on "dmd" => :build
   depends_on "pkg-config"
+
   uses_from_macos "curl"
 
   def install

--- a/Formula/dwarf.rb
+++ b/Formula/dwarf.rb
@@ -15,6 +15,7 @@ class Dwarf < Formula
 
   depends_on "flex"
   depends_on "readline"
+
   uses_from_macos "bison"
 
   def install

--- a/Formula/dwarfutils.rb
+++ b/Formula/dwarfutils.rb
@@ -13,6 +13,8 @@ class Dwarfutils < Formula
 
   depends_on "libelf" => :build
 
+  uses_from_macos "zlib"
+
   def install
     system "./configure"
     system "make"

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -22,6 +22,8 @@ class Elinks < Formula
 
   depends_on "openssl@1.1"
 
+  uses_from_macos "zlib"
+
   # Two patches for compatibility with OpenSSL 1.1, from FreeBSD:
   # https://www.freshports.org/www/elinks/
   patch :p0 do

--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -18,6 +18,9 @@ class Elm < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc@8.6" => :build
 
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def install
     # elm-compiler needs to be staged in a subdirectory for the build process to succeed
     (buildpath/"elm-compiler").install Dir["*"]

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -23,6 +23,9 @@ class Emacs < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
 
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+
   def install
     args = %W[
       --disable-dependency-tracking

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -19,6 +19,8 @@ class Erlang < Formula
   depends_on "openssl@1.1"
   depends_on "wxmac" # for GUI apps like observer
 
+  uses_from_macos "m4" => :build
+
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_22.2.tar.gz"
     mirror "https://fossies.org/linux/misc/otp_doc_man_22.2.tar.gz"

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -20,6 +20,8 @@ class ErlangAT20 < Formula
   depends_on "openssl@1.1"
   depends_on "wxmac"
 
+  uses_from_macos "m4" => :build
+
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_20.3.tar.gz"
     mirror "https://fossies.org/linux/misc/legacy/otp_doc_man_20.3.tar.gz"

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -20,6 +20,8 @@ class ErlangAT21 < Formula
   depends_on "openssl@1.1"
   depends_on "wxmac" # for GUI apps like observer
 
+  uses_from_macos "m4" => :build
+
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_21.3.tar.gz"
     mirror "https://fossies.org/linux/misc/otp_doc_man_21.3.tar.gz"

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -16,6 +16,8 @@ class Exa < Formula
   depends_on "cmake" => :build
   depends_on "rust" => :build
 
+  uses_from_macos "zlib"
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
 

--- a/Formula/exempi.rb
+++ b/Formula/exempi.rb
@@ -13,6 +13,7 @@ class Exempi < Formula
   end
 
   depends_on "boost"
+
   uses_from_macos "expat"
 
   def install

--- a/Formula/exiv2.rb
+++ b/Formula/exiv2.rb
@@ -17,6 +17,10 @@ class Exiv2 < Formula
   depends_on "gettext"
   depends_on "libssh"
 
+  uses_from_macos "curl"
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
+
   def install
     args = std_cmake_args
     args += %W[

--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -21,6 +21,8 @@ class Expat < Formula
 
   keg_only :provided_by_macos
 
+  uses_from_macos "libbsd"
+
   def install
     cd "expat" if build.head?
     system "autoreconf", "-fiv" if build.head?

--- a/Formula/fdclone.rb
+++ b/Formula/fdclone.rb
@@ -11,6 +11,7 @@ class Fdclone < Formula
   end
 
   depends_on "nkf" => :build
+
   uses_from_macos "ncurses"
 
   patch do

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -21,6 +21,7 @@ class Fdroidserver < Formula
   depends_on "python@3.8"
   depends_on "s3cmd"
   depends_on "webp"
+
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -15,7 +15,6 @@ class Ffmpeg < Formula
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
   depends_on "texi2html" => :build
-
   depends_on "aom"
   depends_on "fontconfig"
   depends_on "freetype"
@@ -43,6 +42,9 @@ class Ffmpeg < Formula
   depends_on "x265"
   depends_on "xvid"
   depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
     args = %W[

--- a/Formula/fio.rb
+++ b/Formula/fio.rb
@@ -11,6 +11,8 @@ class Fio < Formula
     sha256 "1be63b9cabc31f619226bf5d7e653366f05ff3bc9beba15731654e9fe5e77579" => :high_sierra
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "./configure"
     # fio's CFLAGS passes vital stuff around, and crushing it will break the build

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -19,6 +19,7 @@ class Fish < Formula
 
   depends_on "cmake" => :build
   depends_on "pcre2"
+
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -7,6 +7,7 @@ class Fits < Formula
   bottle :unneeded
 
   depends_on :java => "1.7+"
+
   uses_from_macos "zlib"
 
   def install

--- a/Formula/flex.rb
+++ b/Formula/flex.rb
@@ -29,6 +29,9 @@ class Flex < Formula
   depends_on "help2man" => :build
   depends_on "gettext"
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "m4"
+
   def install
     if build.head?
       ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -21,10 +21,8 @@ class Folly < Formula
   depends_on "glog"
   depends_on "libevent"
   depends_on "lz4"
-
   # https://github.com/facebook/folly/issues/966
   depends_on :macos => :high_sierra
-
   depends_on "openssl@1.1"
   depends_on "snappy"
   depends_on "xz"

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -30,6 +30,9 @@ class Fontconfig < Formula
   depends_on "pkg-config" => :build
   depends_on "freetype"
 
+  uses_from_macos "bzip2"
+  uses_from_macos "expat"
+
   def install
     font_dirs = %w[
       /System/Library/Fonts

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -13,7 +13,10 @@ class FreeradiusServer < Formula
 
   depends_on "openssl@1.1"
   depends_on "talloc"
+
   uses_from_macos "perl"
+  uses_from_macos "readline"
+  uses_from_macos "sqlite"
 
   def install
     ENV.deparallelize

--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -22,6 +22,7 @@ class Freetds < Formula
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
   depends_on "unixodbc"
+
   uses_from_macos "readline"
 
   def install

--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -15,6 +15,9 @@ class Freetype < Formula
 
   depends_on "libpng"
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--enable-freetype-config",

--- a/Formula/frobtads.rb
+++ b/Formula/frobtads.rb
@@ -12,6 +12,8 @@ class Frobtads < Formula
     sha256 "cff84f9389281d4ca9c9aae8ece93384aec506ea9601e1c3d637df82776afce3" => :el_capitan
   end
 
+  uses_from_macos "curl" => :build
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -21,6 +21,9 @@ class Futhark < Formula
   depends_on "hpack" => :build
   depends_on "sphinx-doc" => :build
 
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def install
     system "hpack"
 

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -13,6 +13,7 @@ class Fzf < Formula
   end
 
   depends_on "go" => :build
+
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -14,6 +14,11 @@ class Wpscan < Formula
 
   depends_on "ruby"
 
+  uses_from_macos "curl"
+  uses_from_macos "unzip"
+  uses_from_macos "xz" # for liblxma
+  uses_from_macos "zlib"
+
   # Fixes the --no-update commandline option
   # https://github.com/wpscanteam/wpscan/pull/1455
   patch do

--- a/Formula/yaf.rb
+++ b/Formula/yaf.rb
@@ -21,6 +21,8 @@ class Yaf < Formula
   depends_on "libtool"
   depends_on "pcre"
 
+  uses_from_macos "libpcap"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -13,6 +13,8 @@ class Zstd < Formula
 
   depends_on "cmake" => :build
 
+  uses_from_macos "zlib"
+
   def install
     system "make", "install", "PREFIX=#{prefix}/"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Over in Homebrew/linuxbrew-core, we've been switching `depends_on ... unless OS.mac?` dependencies to `uses_from_macos`. This is an effort to sync all of those upstream to reduce the diff.
- I've probably missed some, but this is a good start for "all in one go" rather than piecemeal over time per-formula or per-dependency.

----

This is draft as there's only so many of these I can do before I start dreaming about `uses_from_macos`. So it'll be a slow-burning PR. But as of this PR's opening (2020-02-23, 1630 UTC), I've got to formulae starting with G. :+1:
