### PR TITLE
uhd: remove build-time check

### DIFF
--- a/Formula/uhd.rb
+++ b/Formula/uhd.rb
@@ -38,7 +38,6 @@ class Uhd < Formula
     mkdir "host/build" do
       system "cmake", "..", *std_cmake_args, "-DENABLE_STATIC_LIBS=ON", "-DENABLE_TESTS=OFF"
       system "make"
-      system "make", "test"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes:

```
uhd:
  * C: 41: col 7: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
Error: 1 problem in 1 formula detected
```