### PR TITLE
dfix: remove build-time check

### DIFF
--- a/Formula/dfix.rb
+++ b/Formula/dfix.rb
@@ -18,7 +18,6 @@ class Dfix < Formula
 
   def install
     system "make"
-    system "make", "test"
     bin.install "bin/dfix"
     pkgshare.install "test/testfile_expected.d", "test/testfile_master.d"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes:

```
dfix:
  * C: 21: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
Error: 1 problem in 1 formula detected
```