### PR TITLE
x264: update git urls

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -2,11 +2,11 @@ class X264 < Formula
   desc "H.264/AVC encoder"
   homepage "https://www.videolan.org/developers/x264.html"
   revision 1
-  head "https://git.videolan.org/git/x264.git"
+  head "https://code.videolan.org/videolan/x264.git"
 
   stable do
     # the latest commit on the stable branch
-    url "https://git.videolan.org/git/x264.git",
+    url "https://code.videolan.org/videolan/x264.git",
         :revision => "0a84d986e7020f8344f00752e3600b9769cc1e85"
     version "r2917"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing Git repo URL in the formula was redirecting, so this updates it to the current URL. This change was also part of #49295 but that PR is having trouble moving forward and I wanted to get this into the formula in the interim time (especially if that PR ends up being closed).