### PR TITLE
openjdk: replace `:provided_by_macos`

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -13,7 +13,7 @@ class Openjdk < Formula
     sha256 "358101f25201e4c942297223d854ef95003798fe5396ebc671efa359c27e3d22" => :high_sierra
   end
 
-  keg_only :provided_by_macos
+  keg_only "it shadows the macOS `java` wrapper"
 
   depends_on "autoconf" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Merely a wrapper is provided by macOS.