### PR TITLE
docker-slim: also install docker-slim-sensor

### DIFF
--- a/Formula/docker-slim.rb
+++ b/Formula/docker-slim.rb
@@ -3,6 +3,7 @@ class DockerSlim < Formula
   homepage "https://dockersl.im"
   url "https://github.com/docker-slim/docker-slim/archive/1.26.1.tar.gz"
   sha256 "f3decf77b6a75cadd194085892469391cf39f7e54bf83d9ed9080308ec2d603a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,13 +14,22 @@ class DockerSlim < Formula
 
   depends_on "go" => :build
 
+  skip_clean "bin/docker-slim-sensor"
+
   def install
     ENV["CGO_ENABLED"] = "0"
     ldflags = "-s -w -X github.com/docker-slim/docker-slim/pkg/version.appVersionTag=#{version}"
-    system "go", "build", "-trimpath", "-ldflags=#{ldflags}", "-o", bin/name, "./cmd/docker-slim"
+    system "go", "build", "-trimpath", "-ldflags=#{ldflags}", "-o", bin/"docker-slim", "./cmd/docker-slim"
+
+    # docker-slim-sensor is a Linux binary that is used within Docker
+    # containers rather than directly on the macOS host.
+    ENV["GOOS"] = "linux"
+    system "go", "build", "-trimpath", "-ldflags=#{ldflags}", "-o", bin/"docker-slim-sensor", "./cmd/docker-slim-sensor"
+    (bin/"docker-slim-sensor").chmod 0555
   end
 
   test do
     assert_match version.to_s, shell_output("#{bin}/docker-slim --version")
+    system "test", "-x", bin/"docker-slim-sensor"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
    * ~~`stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.`~~
    * ~~`Non-executables were installed to "/usr/local/opt/docker-slim/bin"`~~
        - ~~`/usr/local/opt/docker-slim/bin/docker-slim-sensor` is a Linux binary file (This is the correct thing for docker-slim), so homebrew does `chmod 0444` forcibly.~~
-----

/fix #50646 