### PR TITLE
AntTweakBar: Add test

### DIFF
--- a/Formula/anttweakbar.rb
+++ b/Formula/anttweakbar.rb
@@ -32,6 +32,7 @@ class Anttweakbar < Formula
     if DevelopmentTools.clang_build_version >= 900 ||
        (MacOS.version == :el_capitan && MacOS::Xcode.version >= "8.0")
       ENV.delete("SDKROOT")
+      ENV.delete("HOMEBREW_SDKROOT")
     end
 
     system "make", "-C", "src", "-f", "Makefile.osx"

--- a/Formula/anttweakbar.rb
+++ b/Formula/anttweakbar.rb
@@ -38,4 +38,16 @@ class Anttweakbar < Formula
     lib.install "lib/libAntTweakBar.dylib", "lib/libAntTweakBar.a"
     include.install "include/AntTweakBar.h"
   end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <AntTweakBar.h>
+      int main() {
+        TwBar *bar; // TwBar is an internal structure of AntTweakBar
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-anttweakbar", "-o", "test"
+    system "./test"
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The AntTweakBar formula was missing the `test do` block, which came to my notice after running `brew audit --strict anttweakbar`.

AntTweakBar is a GUI-based library and I was unable to find a command-line only function call. Hence, I added a test to check if a C++ program links properly to the AntTweakBar library.

Please let me know if I can add other test cases as well! 

Thanks! 🚀 