### PR TITLE
git-fixup: remove bottle

### DIFF
--- a/Formula/git-fixup.rb
+++ b/Formula/git-fixup.rb
@@ -5,12 +5,7 @@ class GitFixup < Formula
   sha256 "29665151f82cac5f5807b8241392150e7c8ee8024ce37f23752c23c134516d57"
   head "https://github.com/keis/git-fixup.git", :branch => "master"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "adb91d6c86a8330a51394a03e20b5d7dc20144ee80426802b1b651766fc2462e" => :catalina
-    sha256 "adb91d6c86a8330a51394a03e20b5d7dc20144ee80426802b1b651766fc2462e" => :mojave
-    sha256 "adb91d6c86a8330a51394a03e20b5d7dc20144ee80426802b1b651766fc2462e" => :high_sierra
-  end
+  bottle :unneeded
 
   def install
     system "make", "PREFIX=#{prefix}", "install"


### PR DESCRIPTION
as I understand how brew works, the bottle is unneeded as this package is just a single bash script.

the `revision` is deliberately not bumped, as no need to update existing installations.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
