### PR TITLE
sk: add fish key bindings

### DIFF
--- a/Formula/sk.rb
+++ b/Formula/sk.rb
@@ -22,6 +22,7 @@ class Sk < Formula
     pkgshare.install "install"
     bash_completion.install "shell/key-bindings.bash"
     bash_completion.install "shell/completion.bash"
+    fish_completion.install "shell/key-bindings.fish" => "skim.fish"
     zsh_completion.install "shell/key-bindings.zsh"
     zsh_completion.install "shell/completion.zsh"
     man1.install "man/man1/sk.1", "man/man1/sk-tmux.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
Adds installation of skim's fish key bindings: [lotabout/skim:shell/key-bindings.fish@`master`](https://github.com/lotabout/skim/tree/master/shell/key-bindings.fish) [](/exercism/cli/tree/HEAD@{2020-01-21T03:25:40Z}/shell)