### PR TITLE
rsyslog: ensure var/run is created

### DIFF
--- a/Formula/rsyslog.rb
+++ b/Formula/rsyslog.rb
@@ -41,6 +41,7 @@ class Rsyslog < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
+    mkdir_p var/"run"
   end
 
   plist_options :manual => "rsyslogd -f #{HOMEBREW_PREFIX}/etc/rsyslog.conf -i #{HOMEBREW_PREFIX}/var/run/rsyslogd.pid"

--- a/Formula/rsyslog.rb
+++ b/Formula/rsyslog.rb
@@ -41,6 +41,9 @@ class Rsyslog < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
+  end
+
+  def post_install
     mkdir_p var/"run"
   end
 


### PR DESCRIPTION
`brew services start rsyslog` may fail to run if ${HOMEBREW_PREFIX}/var/run does not exist.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
