### PR TITLE
tmux: enable utf8proc and fix typo

### DIFF
--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -3,6 +3,7 @@ class Tmux < Formula
   homepage "https://tmux.github.io/"
   url "https://github.com/tmux/tmux/releases/download/3.0a/tmux-3.0a.tar.gz"
   sha256 "4ad1df28b4afa969e59c08061b45082fdc49ff512f30fc8e43217d7b0e5f8db9"
+  revision 1
 
   bottle do
     cellar :any
@@ -20,6 +21,7 @@ class Tmux < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "utf8proc"
   depends_on "libevent"
   depends_on "ncurses"
 
@@ -32,7 +34,8 @@ class Tmux < Formula
     system "sh", "autogen.sh" if build.head?
 
     args = %W[
-      --disable-Dependency-tracking
+      --enable-utf8proc
+      --disable-dependency-tracking
       --prefix=#{prefix}
       --sysconfdir=#{etc}
     ]

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -21,9 +21,9 @@ class Tmux < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "utf8proc"
   depends_on "libevent"
   depends_on "ncurses"
+  depends_on "utf8proc"
 
   resource "completion" do
     url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/homebrew_1.0.0/completions/tmux"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

1) Use `utf8proc`:
In newer mac osx, the Terminal use Unicode9+ character wide.
This cause bugs like https://github.com/denysdovhan/spaceship-prompt/issues/651
Enable utf8proc fix thix

2) The option `--disable-dependency-tracking` should be in lowercase