### PR TITLE
darcs: depend on ghc@8.6

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -16,7 +16,7 @@ class Darcs < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.6" => :build
   depends_on "gmp"
 
   def install


### PR DESCRIPTION
Darcs does not currently support building using GHC 8.8.