### PR TITLE
hopenpgp-tools: depend on ghc@8.6

### DIFF
--- a/Formula/hopenpgp-tools.rb
+++ b/Formula/hopenpgp-tools.rb
@@ -17,7 +17,7 @@ class HopenpgpTools < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.6" => :build
   depends_on "pkg-config" => :build
   depends_on "nettle"
 
@@ -27,7 +27,7 @@ class HopenpgpTools < Formula
   end
 
   def install
-    install_cabal_package :using => ["alex", "happy"]
+    install_cabal_package :using => ["alex", "happy", "c2hs"]
   end
 
   test do


### PR DESCRIPTION
hopenpgp-tools currently does not support GHC 8.8.