### PR TITLE
pinboard-notes-backup: depend on ghc@8.6

### DIFF
--- a/Formula/pinboard-notes-backup.rb
+++ b/Formula/pinboard-notes-backup.rb
@@ -17,7 +17,7 @@ class PinboardNotesBackup < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.6" => :build
 
   def install
     install_cabal_package


### PR DESCRIPTION
Pinboard Notes Backup does not currently support GHC 8.8.