### PR TITLE
php: add head

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -11,6 +11,13 @@ class Php < Formula
     sha256 "c0c2fa82be5609534d3fdf875515e0d98ea17ed4de4f27aece8e275c840e889b" => :high_sierra
   end
 
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -354,10 +361,16 @@ class Php < Formula
         DirectoryIndex index.php
       EOS
 
+      if head?
+        php_module = "LoadModule php_module #{lib}/httpd/modules/libphp.so"
+      else
+        php_module = "LoadModule php7_module #{lib}/httpd/modules/libphp7.so"
+      end
+
       (testpath/"httpd.conf").write <<~EOS
         #{main_config}
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
-        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        #{php_module}
         <FilesMatch \\.(php|phar)$>
           SetHandler application/x-httpd-php
         </FilesMatch>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I was in the process of modifying the livecheckable for PHP and noticed that the [upstream Git repo](https://www.php.net/git.php) wasn't anywhere in the formula. I could have just used the Git URL in the livecheckable but I thought I may as well add `--HEAD` support for the PHP formula instead.

This successfully installs, audits, and tests on macOS 10.15 but that's as far as I've tested it so far. If someone with more experience with this formula would like to kick the tires and let me know if there are any issues, that would be helpful.

Otherwise, if there isn't a compelling reason for including `--HEAD` support for PHP, I can just close this.