### PR TITLE
nethack: `uses_from_macos` and robustness fix

### DIFF
--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -15,6 +15,8 @@ class Nethack < Formula
     sha256 "4ee79f011195859ee87569c6d7080d438d9e7d23e4a096a437187da8479cc126" => :high_sierra
   end
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
   uses_from_macos "ncurses"
 
   def install
@@ -37,6 +39,8 @@ class Nethack < Formula
       # Setting VAR_PLAYGROUND preserves saves across upgrades
       inreplace "hints/#{hintfile}" do |s|
         s.change_make_var! "HACKDIR", libexec
+        s.change_make_var! "CHOWN", "true"
+        s.change_make_var! "CHGRP", "true"
         s.gsub! "#WANT_WIN_CURSES=1", "WANT_WIN_CURSES=1\nCFLAGS+=-DVAR_PLAYGROUND='\"#{HOMEBREW_PREFIX}/share/nethack\"'"
       end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sync `uses_from_macos` and also ensure `true` is used instead of `/usr/bin/true` (which also doesn't seem to exist on macOS).

This can be merged with the github ui.