### PR TITLE
caddy@2 2.0.0-beta.15 (new formula)

### DIFF
--- a/Formula/caddy@2.rb
+++ b/Formula/caddy@2.rb
@@ -1,0 +1,57 @@
+class CaddyAT2 < Formula
+  desc "Alternative general-purpose HTTP/2 web server"
+  homepage "https://caddyserver.com/"
+  url "https://github.com/caddyserver/caddy/archive/v2.0.0-beta.15.tar.gz"
+  sha256 "9d1992f80a7c8c4a6c3784396d5345e8cb64c412581eee14cce1921258e2cc9d"
+  head "https://github.com/caddyserver/caddy.git", :branch => "v2"
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOOS"] = "darwin"
+    ENV["GOARCH"] = "amd64"
+
+    Dir.chdir(buildpath/"cmd/caddy") do
+      system "go", "build", "-o", bin/"caddy"
+    end
+  end
+
+  plist_options :manual => "caddy run --config #{HOMEBREW_PREFIX}/etc/Caddyfile"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/caddy</string>
+          <string>run</string>
+          <string>--config</string>
+          <string>#{etc}/Caddyfile</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    begin
+      io = IO.popen("#{bin}/caddy run")
+      sleep 2
+    ensure
+      Process.kill("SIGINT", io.pid)
+      Process.wait(io.pid)
+    end
+
+    io.read =~ /0\.0\.0\.0:2019/
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The audit currently fails. I need guidance on how to fix it:

- Apparently the `head` directive is no longer supported? Or what exactly is the issue here?
- The URL contains `beta`, but that's intended as it's a versioned formula for the upcoming Caddy 2. Or are beta versions not acceptable at all (it's not in the list at https://docs.brew.sh/Versions)?

Thank you for your feedback!