### PR TITLE
itk: update homepage and head urls

### DIFF
--- a/Formula/itk.rb
+++ b/Formula/itk.rb
@@ -1,9 +1,9 @@
 class Itk < Formula
   desc "Insight Toolkit is a toolkit for performing registration and segmentation"
-  homepage "https://www.itk.org/"
+  homepage "https://itk.org"
   url "https://github.com/InsightSoftwareConsortium/ITK/releases/download/v5.0.1/InsightToolkit-5.0.1.tar.gz"
   sha256 "613b125cbf58481e8d1e36bdeacf7e21aba4b129b4e524b112f70c4d4e6d15a6"
-  head "https://itk.org/ITK.git"
+  head "https://github.com/InsightSoftwareConsortium/ITK.git"
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current homepage URL redirects, so this updates it accordingly.

The current `head` URL doesn't work (it redirects, redirects, and ends in a 403 for me) and the upstream homepage references the GitHub repo instead. The formula also uses the GitHub repo, so using this as `head` seems like the logical decision.