### PR TITLE
syck: update homepage url

### DIFF
--- a/Formula/syck.rb
+++ b/Formula/syck.rb
@@ -1,6 +1,6 @@
 class Syck < Formula
   desc "Extension for reading and writing YAML"
-  homepage "https://wiki.github.com/indeyets/syck/"
+  homepage "https://github.com/indeyets/syck"
   url "https://github.s3.amazonaws.com/downloads/indeyets/syck/syck-0.70.tar.gz"
   sha256 "4c94c472ee8314e0d76eb2cca84f6029dc8fc58bfbc47748d50dcb289fda094e"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current homepage gives a 403 and the wiki on the GitHub page hasn't been updated since 2013, so this simply updates the homepage to use the GitHub repo instead.

This will still fail `brew audit -strict --online syck` due to not having a test block.