### PR TITLE
PyPy development is now on Heptapod.

### DIFF
--- a/Formula/pypy.rb
+++ b/Formula/pypy.rb
@@ -3,7 +3,7 @@ class Pypy < Formula
   homepage "https://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.0-src.tar.bz2"
   sha256 "b0b25c7f8938ab0fedd8dedf26b9e73c490913b002b484c1b2f19d5844a518de"
-  head "https://bitbucket.org/pypy/pypy", :using => :hg
+  head "https://foss.heptapod.net/pypy/pypy", :using => :hg
 
   bottle do
     cellar :any

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -3,6 +3,7 @@ class Pypy3 < Formula
   homepage "https://pypy.org/"
   url "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.0-src.tar.bz2"
   sha256 "48d12c15fbcbcf4a32882a883195e1f922997cde78e7a16d4342b9b521eefcfa"
+  head "https://foss.heptapod.net/pypy/pypy", :using => :hg, :branch => "py3.7"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Update the HEAD URL for PyPy, which has now moved from Bitbucket to [Heptapod](https://foss.heptapod.net/pypy/pypy).