### PR TITLE
gambit-scheme, gerbil-scheme: build fixes

### DIFF
--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -3,7 +3,7 @@ class GambitScheme < Formula
   homepage "https://github.com/gambit/gambit"
   url "https://github.com/gambit/gambit/archive/v4.9.3.tar.gz"
   sha256 "a5e4e5c66a99b6039fa7ee3741ac80f3f6c4cff47dc9e0ff1692ae73e13751ca"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -24,6 +24,13 @@ class GambitScheme < Formula
     ]
 
     system "./configure", *args
+
+    # Fixed in gambit HEAD, but they haven't cut a release
+    inreplace "config.status" do |s|
+      s.gsub! /\/usr\/local\/opt\/openssl(?!@1\.1)/, "/usr/local/opt/openssl@1.1"
+    end
+    system "./config.status"
+
     system "make"
     ENV.deparallelize
     system "make", "install"

--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -27,7 +27,7 @@ class GambitScheme < Formula
 
     # Fixed in gambit HEAD, but they haven't cut a release
     inreplace "config.status" do |s|
-      s.gsub! /\/usr\/local\/opt\/openssl(?!@1\.1)/, "/usr/local/opt/openssl@1.1"
+      s.gsub! %r{/usr/local/opt/openssl(?!@1\.1)}, "/usr/local/opt/openssl@1.1"
     end
     system "./config.status"
 

--- a/Formula/gerbil-scheme.rb
+++ b/Formula/gerbil-scheme.rb
@@ -3,7 +3,7 @@ class GerbilScheme < Formula
   homepage "https://cons.io"
   url "https://github.com/vyzo/gerbil/archive/v0.15.1.tar.gz"
   sha256 "3d29eecdaa845b073bf8413cd54e420b3f48c79c25e43fab5a379dde029d0cde"
-  revision 4
+  revision 5
 
   bottle do
     rebuild 1
@@ -28,6 +28,11 @@ class GerbilScheme < Formula
       gxtags
     ]
 
+    inreplace ["src/gerbil/gxi", "src/gerbil/gxi-build-script"] do |s|
+      s.gsub! /GERBIL_HOME=[^\n]*/, "GERBIL_HOME=#{libexec}"
+      s.gsub! /\bgsi\b/, "#{Formula["gambit-scheme"].opt_prefix}/current/bin/gsi"
+    end
+
     cd "src" do
       ENV.append_path "PATH", "#{Formula["gambit-scheme"].opt_prefix}/current/bin"
       ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
@@ -50,7 +55,6 @@ class GerbilScheme < Formula
   end
 
   test do
-    ENV.append_path "PATH", "#{Formula["gambit-scheme"].opt_prefix}/current/bin"
-    assert_equal "0123456789", shell_output("#{libexec}/bin/gxi -e \"(for-each write '(0 1 2 3 4 5 6 7 8 9))\"")
+    assert_equal "0123456789", shell_output("gxi -e \"(for-each write '(0 1 2 3 4 5 6 7 8 9))\"")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Gambit

`gambit-scheme` has an incorrectly hard-coded path for OpenSSL on Mac.  This has been fixed upstream, but they will not make a release for "about a month," so this patches `config.status`.  

This made it so that, even though Gambit would build, nothing could be built with it - it would use the 1.1 OpenSSL headers and link against 1.0, which has missing symbols.

### Gerbil

1. Gerbil attempted to find Gambit's `gsi` in the path, but it is not added to the path.  I patched the script to use the full path to `gsi`.
2. Gerbil attempts to find it's home directory from argv0 and got confused by Homebrew's symlinks, so `GERBIL_HOME` is now defaulted to `#{libexec}`.





