### PR TITLE
hsd 2.1.3 (new formula)

### DIFF
--- a/Formula/hsd.rb
+++ b/Formula/hsd.rb
@@ -1,0 +1,35 @@
+require "language/node"
+
+class Hsd < Formula
+  desc "Handshake Daemon & Full Node"
+  homepage "https://handshake.org"
+  url "https://github.com/handshake-org/hsd/archive/v2.1.3.tar.gz"
+  sha256 "74d2aecada314d3479ba7dde8c100ddf1e546d4fd4a7bf78ffea4f4f240778dc"
+
+  depends_on "python" => :build
+  depends_on "node@10"
+  depends_on "unbound"
+
+  def install
+    system "#{Formula["node@10"].bin}/npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"hsd").write_env_script libexec/"bin/hsd", :PATH => "#{Formula["node@10"].opt_bin}:$PATH"
+  end
+
+  test do
+    (testpath/"script.js").write <<~EOS
+      const assert = require('assert');
+      const hsd = require('#{libexec}/lib/node_modules/hsd');
+      assert(hsd);
+
+      const node = new hsd.FullNode({
+        prefix: '#{testpath}/.hsd',
+        memory: false
+      });
+      (async () => {
+        await node.ensure();
+      })();
+    EOS
+    system "#{Formula["node@10"].opt_bin}/node", testpath/"script.js"
+    assert_true File.directory?("#{testpath}/.hsd")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This adds a formula for [hsd](https://github.com/handshake-org/hsd), an implementation of the [Handshake Protocol](https://handshake.org/). It also adds a formula for [hs-client](https://github.com/handshake-org/hs-client), the client library and command line toolkit for interacting with `hsd`.
