### PR TITLE
newrelic-cli 0.2.3 (new formula)

### DIFF
--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -1,0 +1,22 @@
+class NewrelicCli < Formula
+  desc "The New Relic Command-line Interface"
+  homepage "https://github.com/newrelic/newrelic-cli"
+  url "https://github.com/newrelic/newrelic-cli/archive/v0.2.3.tar.gz"
+  sha256 "f09d7e1705731578da79f0d9c204a6875edbd1d78cc6e69bd9f7d00dd9919986"
+  head "https://github.com/newrelic/newrelic-cli.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["PROJECT_VER"] = version
+    system "make", "compile-only"
+    bin.install "bin/darwin/newrelic"
+  end
+
+  test do
+    assert_match /pluginDir/, shell_output("#{bin}/newrelic config list")
+    assert_match /logLevel/, shell_output("#{bin}/newrelic config list")
+    assert_match /sendUsageData/, shell_output("#{bin}/newrelic config list")
+    assert_match version.to_s, shell_output("#{bin}/newrelic version 2>&1")
+  end
+end


### PR DESCRIPTION
New Relic is in the process of developing a CLI to interact with New Relic SaaS
infrastructure.  Here we include a new formula that will download and install
the pre-release version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
