### PR TITLE
z 1.9

### DIFF
--- a/Formula/z.rb
+++ b/Formula/z.rb
@@ -1,8 +1,8 @@
 class Z < Formula
   desc "Tracks most-used directories to make cd smarter"
   homepage "https://github.com/rupa/z"
-  url "https://github.com/rupa/z/archive/v1.11.tar.gz"
-  sha256 "873761c2eaf283c526b87ef272c8c35f70e94ea079fbbc985ba32070638ff963"
+  url "https://github.com/rupa/z/archive/v1.9.tar.gz"
+  sha256 "e2860e4f65770e02297ca4ca08ec1ee623a658bd9cc1acddbbe5ad22e1de70a7"
   head "https://github.com/rupa/z.git"
 
   bottle :unneeded


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#50983

The stable release should still be 1.9, hence, reverting the previous merge. (like what happened previously, https://github.com/Homebrew/homebrew-core/pull/32283)