### PR TITLE
cmus: add --with-pulseaudio option

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -24,6 +24,7 @@ class Cmus < Formula
   depends_on "mad"
   depends_on "mp4v2"
   depends_on "opusfile"
+  depends_on "pulseaudio" => :optional
 
   def install
     system "./configure", "prefix=#{prefix}", "mandir=#{man}"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds the option to build cmus with pulseaudio support, for streaming audio to remote pulseaudio sinks.

The `brew audit` failure follows, however I'm unsure what alternate there is to resolve it without forcing all cmus users to  install/link pulseaudio by default (which is unnecessary in most use cases):
```
cmus:
  * Formulae in homebrew/core should not have optional or recommended dependencies
Error: 2 problems in 1 formula detected
```
