### PR TITLE
repo: use official GitHub mirror

### DIFF
--- a/Formula/repo.rb
+++ b/Formula/repo.rb
@@ -1,7 +1,7 @@
 class Repo < Formula
   desc "Repository tool for Android development"
   homepage "https://source.android.com/source/developing.html"
-  url "https://gerrit.googlesource.com/git-repo.git",
+  url "https://github.com/GerritCodeReview/git-repo.git",
       :tag      => "v2.4.1",
       :revision => "d957ec6a834e333a3812546911f786b0c20b808f"
   version_scheme 1


### PR DESCRIPTION
Using GitHub AOSP mirror to replace the original address is user-friendly to China.

- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
