### PR TITLE
boost: patch for library search issues

### DIFF
--- a/Formula/azure-storage-cpp.rb
+++ b/Formula/azure-storage-cpp.rb
@@ -21,7 +21,6 @@ class AzureStorageCpp < Formula
     system "cmake", "Microsoft.WindowsAzure.Storage",
                     "-DBUILD_SAMPLES=OFF",
                     "-DBUILD_TESTS=OFF",
-                    "-DBoost_USE_MULTITHREADED=ON",
                     *std_cmake_args
     system "make", "install"
   end

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -3,6 +3,7 @@ class Boost < Formula
   homepage "https://www.boost.org/"
   url "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2"
   sha256 "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722"
+  revision 1
   head "https://github.com/boostorg/boost.git"
 
   bottle do
@@ -16,6 +17,15 @@ class Boost < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
+
+  # Fixes significant library search issues in the CMake scripts
+  # where it mixes single-threaded and multithreaded libraries.
+  # Remove with Boost 1.73.0.
+  patch do
+    url "https://github.com/boostorg/boost_install/compare/52ab9149544bae82e54f600303f5d6d1dda9a4f5...a1b5a477470ff9dc2e00f30be4ec4285583b33b6.patch?full_index=1"
+    sha256 "fb168dd2ddfa20983b565ead86d4355c6d6e3e49bce9c2c6ab7f6e9cd9350bd4"
+    directory "tools/boost_install"
+  end
 
   def install
     # Force boost to compile with the desired compiler

--- a/Formula/innoextract.rb
+++ b/Formula/innoextract.rb
@@ -1,8 +1,8 @@
 class Innoextract < Formula
   desc "Tool to unpack installers created by Inno Setup"
   homepage "https://constexpr.org/innoextract/"
-  url "https://constexpr.org/innoextract/files/innoextract-1.7.tar.gz"
-  sha256 "c1efb732f2bc3a80065c5f51a0d4ea6027aebf528c609d3f336aea2055d2f0a4"
+  url "https://constexpr.org/innoextract/files/innoextract-1.8.tar.gz"
+  sha256 "5e78f6295119eeda08a54dcac75306a1a4a40d0cb812ff3cd405e9862c285269"
   head "https://github.com/dscharrer/innoextract.git"
 
   bottle do
@@ -16,6 +16,12 @@ class Innoextract < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "xz"
+
+  # Boost 1.70+ compatibility. Remove with next release.
+  patch do
+    url "https://github.com/dscharrer/innoextract/commit/b47f46102bccf1d813ca159230029b0cd820ceff.patch?full_index=1"
+    sha256 "92d321d552a65e16ae6df992a653839fb19de79aa77388c651bf57b3c582d546"
+  end
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We have a serious Boost problem.

#### Background

We currently install both the single-threaded and multithreadded version of the Boost libraries, and have done so for about 7 years. This gives the developer the choice of which one they want (e.g. via the CMake option `Boost_USE_MULTITHREADED`).

#### The Problem

Boost 1.70 incorporated their own CMake system. This had significant issues for us to begin with. Their system did not listen to `Boost_USE_MULTITHREADED` and prevented various updates until 1.71 shipped.

However, there is still major library searching problems (like those reported in #44093) which are blocking formulae from being updated. Notably, while 1.71 now listens to `Boost_USE_MULTITHREADED`, the default is to use whatever single-threaded or multithreaded libraries it can find, which is a recipe for disaster as this can result in a mixture of the two.

Pull requests that were blocked on this include #45473 and #45164.

I've included a couple of changes of other formulae in the pull request to test this.

I'll keep this open for a few days to allow feedback.