### PR TITLE
stgit: python3.8, man pages, and completions

### DIFF
--- a/Formula/stgit.rb
+++ b/Formula/stgit.rb
@@ -3,6 +3,7 @@ class Stgit < Formula
   homepage "https://github.com/ctmarinas/stgit"
   url "https://github.com/ctmarinas/stgit/releases/download/v0.21/stgit-0.21.tar.gz"
   sha256 "0f67a3c0ed3e0408aa8e9be6ff6c7be0a2981ca43639bc94bda7b6124717e71f"
+  revision 1
   head "https://github.com/ctmarinas/stgit.git"
 
   bottle do
@@ -12,18 +13,33 @@ class Stgit < Formula
     sha256 "a8c5a52941bb5c524f97bddf295dbf65b79ec74b4ec5a0d0ebcdb25429e1e03d" => :high_sierra
   end
 
+  depends_on "asciidoc" => :build
+  depends_on "xmlto" => :build
+  depends_on "python@3.8"
+
   def install
-    ENV["PYTHON"] = "python" # overrides 'python2' built into makefile
+    ENV["PYTHON"] = Formula["python@3.8"].opt_bin/"python3"
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     system "make", "prefix=#{prefix}", "all"
     system "make", "prefix=#{prefix}", "install"
+    system "make", "prefix=#{prefix}", "install-doc"
+    bash_completion.install "completion/stgit.bash"
+    fish_completion.install "completion/stg.fish"
+    zsh_completion.install "completion/stgit.zsh" => "_stgit"
   end
 
   test do
     system "git", "init"
+    system "git", "config", "user.name", "BrewTestBot"
+    system "git", "config", "user.email", "brew@test.bot"
     (testpath/"test").write "test"
     system "git", "add", "test"
     system "git", "commit", "--message", "Initial commit", "test"
+    system "#{bin}/stg", "--version"
     system "#{bin}/stg", "init"
+    system "#{bin}/stg", "new", "-m", "patch0"
+    (testpath/"test").append_lines "a change"
+    system "#{bin}/stg", "refresh"
     system "#{bin}/stg", "log"
   end
 end


### PR DESCRIPTION
Depend on python@3.8 instead of using the MacOS default python2.7. Upstream
StGit is dropping support for Python 2.x, so this needed to be done
eventually.

Also install the StGit man pages and completions for bash, fish, and zsh.

The test is updated to be slightly more robust.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
