### PR TITLE
emscripten: Fix setup related to binaryen

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -81,7 +81,7 @@ class Emscripten < Formula
     Manually set LLVM_ROOT to
       #{opt_libexec}/llvm/bin
     and BINARYEN_ROOT to
-      #{Formulary.factory("binaryen").opt_prefix}
+      #{Formula["binaryen"].opt_prefix}
     in ~/.emscripten after running `emcc` for the first time.
   EOS
   end

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -37,6 +37,7 @@ class Emscripten < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "binaryen"
   depends_on "node"
   depends_on "python"
   depends_on "yuicompressor"
@@ -79,7 +80,8 @@ class Emscripten < Formula
   def caveats; <<~EOS
     Manually set LLVM_ROOT to
       #{opt_libexec}/llvm/bin
-    and comment out BINARYEN_ROOT
+    and BINARYEN_ROOT to
+      #{Formulary.factory("binaryen").opt_prefix}
     in ~/.emscripten after running `emcc` for the first time.
   EOS
   end


### PR DESCRIPTION
Seems that since
https://github.com/emscripten-core/emscripten/pull/6523/files
BINARYEN_ROOT is required in ~/.emscripten. Therefore I am adding
dependency on binaryen and changing caveats so that it reflects proper
steps that need to be taken to get emscripten working.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
