### PR TITLE
lcov & percona-toolkit: use system perl

### DIFF
--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -3,6 +3,7 @@ class PerconaToolkit < Formula
   homepage "https://www.percona.com/software/percona-toolkit/"
   url "https://www.percona.com/downloads/percona-toolkit/3.1.0/source/tarball/percona-toolkit-3.1.0.tar.gz"
   sha256 "722593773825efe7626ff0b74de6a2133483c9c89fd7812bfe440edaacaec9cc"
+  revision 1
   head "lp:percona-toolkit", :using => :bzr
 
   bottle do
@@ -37,6 +38,7 @@ class PerconaToolkit < Formula
 
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
     resources.each do |r|
       r.stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
@@ -47,6 +49,15 @@ class PerconaToolkit < Formula
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
     system "make", "install"
     share.install prefix/"man"
+
+    # Disable dynamic selection of perl which may cause segfault when an
+    # incompatible perl is picked up.
+    # https://github.com/Homebrew/homebrew-core/issues/4936
+    non_perl_files = %w[bin/pt-ioprofile bin/pt-mext bin/pt-mysql-summary
+                        bin/pt-pmp bin/pt-sift bin/pt-stalk bin/pt-summary]
+    perl_files = Dir["bin/*"] - non_perl_files
+    inreplace perl_files, "#!/usr/bin/env perl", "#!/usr/bin/perl"
+
     bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR forces `lcov` and `percona-toolkit` to use system Perl. Otherwise, if homebrew's Perl is installed it will crash. 

See https://github.com/Homebrew/homebrew-core/issues/48575 & https://github.com/Homebrew/homebrew-core/issues/4936