### PR TITLE
Change to only install asdf bin file

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -16,14 +16,11 @@ class Asdf < Formula
   depends_on "readline"
   depends_on "unixodbc"
 
-  conflicts_with "homeshick",
-    :because => "asdf and homeshick both install files in lib/commands"
-
   def install
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"
     libexec.install "bin/private"
-    prefix.install Dir["*"]
+    bin.install "bin/asdf"
   end
 
   test do


### PR DESCRIPTION
In the upcoming asdf version the symlink issue has been resolved. 
This is preparation for it's release

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----