### PR TITLE
root: depend on zstd

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -4,7 +4,7 @@ class Root < Formula
   url "https://root.cern.ch/download/root_v6.20.00.source.tar.gz"
   version "6.20.00"
   sha256 "68421eb0434b38b66346fa8ea6053a0fdc9a6d254e4a72019f4e3633ae118bf0"
-  revision 2
+  revision 3
   head "https://github.com/root-project/root.git"
 
   bottle do
@@ -43,6 +43,7 @@ class Root < Formula
   depends_on "tbb"
   depends_on "xrootd"
   depends_on "xz" # for LZMA
+  depends_on "zstd"
 
   skip_clean "bin"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

ROOT implements a new compression algorithm (zstd) in version 6.20.00.
cf. https://root.cern/doc/v620/release-notes.html#compression-algorithms

ROOT seems to install successfully without zstd but later complains of missing libraries when trying to run ROOT:
`dyld: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: /usr/local/Cellar/root/6.20.00_2/lib/root/libCore.so
  Reason: image not found`