### PR TITLE
monero: drop cppzmq

### DIFF
--- a/Formula/monero.rb
+++ b/Formula/monero.rb
@@ -22,15 +22,8 @@ class Monero < Formula
   depends_on "unbound"
   depends_on "zeromq"
 
-  resource "cppzmq" do
-    url "https://github.com/zeromq/cppzmq/archive/v4.3.0.tar.gz"
-    sha256 "27d1f56406ba94ee779e639203218820975cf68174f92fbeae0f645df0fcada4"
-  end
-
   def install
-    (buildpath/"cppzmq").install resource("cppzmq")
-    system "cmake", ".", "-DZMQ_INCLUDE_PATH=#{buildpath}/cppzmq",
-                         "-DReadline_ROOT_DIR=#{Formula["readline"].opt_prefix}",
+    system "cmake", ".", "-DReadline_ROOT_DIR=#{Formula["readline"].opt_prefix}",
                          *std_cmake_args
     system "make", "install"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Has been dropped upstream: https://github.com/monero-project/monero/pull/5818