### PR TITLE
entr: update head

### DIFF
--- a/Formula/entr.rb
+++ b/Formula/entr.rb
@@ -3,17 +3,13 @@ class Entr < Formula
   homepage "http://entrproject.org/"
   url "http://entrproject.org/code/entr-4.4.tar.gz"
   sha256 "54566c64f360afd43f6a6065bc6d849472337edf2189b1ce34bf15b611f350f4"
+  head "https://github.com/eradman/entr.git"
 
   bottle do
     cellar :any_skip_relocation
     sha256 "98f508565c8dd087b780fda140099fca3afb457ca27fcf3864bb508c87c403cc" => :catalina
     sha256 "d18935ecc0bf78504d6acd00b2adb889389af2586cafc2602e38599f2590183f" => :mojave
     sha256 "25fba36721d2857ca91efc7b82a8cbe15ff0a83f20e9febe57648fc173377629" => :high_sierra
-  end
-
-  head do
-    url "https://bitbucket.org/eradman/entr", :using => :hg
-    depends_on "mercurial" => :build
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --HEAD <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `entr` repository has moved from Bitbucket (where it was a Mercurial repo) to GitHub, as seen in the [last commit to the Bitbucket repo](https://bitbucket.org/eradman/entr/commits/33816756113b98eebba918e68e340447a4fa59de). The `entr` repo is now found at https://github.com/eradman/entr and this updates the HEAD repo accordingly.