### PR TITLE
ephemeralpg: update homepage and stable url

### DIFF
--- a/Formula/ephemeralpg.rb
+++ b/Formula/ephemeralpg.rb
@@ -1,7 +1,7 @@
 class Ephemeralpg < Formula
   desc "Run tests on an isolated, temporary Postgres database"
-  homepage "http://ephemeralpg.org"
-  url "http://ephemeralpg.org/code/ephemeralpg-2.9.tar.gz"
+  homepage "https://eradman.com/ephemeralpg/"
+  url "https://eradman.com/ephemeralpg/code/ephemeralpg-2.9.tar.gz"
   sha256 "09314fe7d7ba2c26fb02864b9ddc92a538bc53674200363e77bb53a2fc1c17be"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing homepage for `ephemeralpg` (http://ephemeralpg.org) redirects (via JavaScript) to the current URL (https://eradman.com/ephemeralpg/), so I've updated the homepage to reflect this. The archive using the old domain still resolves but I've updated it to use the current URL for the archive from the aforementioned homepage. The new URLs support HTTPS, so this is an improvement.