### PR TITLE
Switch to a Working Fork of AFSCTools

### DIFF
--- a/Formula/afsctool.rb
+++ b/Formula/afsctool.rb
@@ -1,58 +1,35 @@
 class Afsctool < Formula
-  desc "Utility for manipulating HFS+ compressed files"
-  homepage "https://brkirch.wordpress.com/afsctool/"
-  url "https://dl.bintray.com/homebrew/mirror/afsctool-1.6.4.zip"
-  mirror "https://docs.google.com/uc?export=download&id=0BwQlnXqL939ZQjBQNEhRQUo0aUk"
-  sha256 "bb6a84370526af6ec1cee2c1a7199134806e691d1093f4aef060df080cd3866d"
-  revision 2
-
+  desc "Control HFS+ and APFS transparent file compression"
+  homepage "https://github.com/RJVB/afsctool"
+  url "https://github.com/RJVB/afsctool/archive/1.7.0.tar.gz"
+  sha256 "4ae643ae43aca22e96cd6a2a471f5d975a3d08eafa937c1fc8e562691bcbfb1a"
   bottle do
     cellar :any_skip_relocation
-    rebuild 2
+    rebuild 3
     sha256 "f418e15be4bafdcb1a85e14c3148c8d4af1b300bd6ed3e4a30eca3725459ac48" => :catalina
     sha256 "15c264a828ed98a42cc5ac68869c16b8306f73effe108e50bb1f731574311c51" => :mojave
     sha256 "72e92414d524b82ec1d8381ad50f55bd330f1109a5e10bca4235300fee557caf" => :high_sierra
     sha256 "96437b04a2974c215979550d3d70b4c8e3f609e76954ca41059c6f246da452ee" => :sierra
   end
-
-  # Fixes Sierra "Unable to compress" issue; reported upstream on 24 July 2017
-  patch :p2 do
-    url "https://github.com/vfx01j/afsctool/commit/26293a3809c9ad1db5f9bff9dffaefb8e201a089.diff?full_index=1"
-    sha256 "a541526679eb5d2471b3f257dab6103300d950f7b2f9d49bbfeb9f27dfc48542"
-  end
-
-  # Fixes High Sierra "Expecting f_type of 17 or 23. f_type is 24" issue
-  # Acknowledged by upstream 12 Apr 2018:
-  # https://github.com/Homebrew/homebrew-core/pull/20898#issuecomment-380727547
-  patch :p2, :DATA
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "google-sparsehash"
 
   def install
-    system ENV.cc, ENV.cflags, "-lz", "afsctool.c",
-                   "-framework", "CoreServices", "-o", "afsctool"
-    bin.install "afsctool"
+    cd buildpath do
+      mkpath "afsctool/build"
+      cd "afsctool/build" do
+        system "cmake", "-Wno-dev", "../.."
+        system "make"
+        bin.install "afsctool"
+      end
+    end
   end
 
   test do
-    path = testpath/"foo"
+    path = testpath / "foo"
     path.write "some text here."
     system "#{bin}/afsctool", "-c", path
     system "#{bin}/afsctool", "-v", path
   end
 end
-
-__END__
-diff --git a/afsctool_34/afsctool.c b/afsctool_34/afsctool.c
-index 8713407fa673f216e69dfc36152c39bc1dea4fe7..7038859f43e035be44c9b8cfbb1bb76a93e26e0a 100644
---- a/afsctool_34/afsctool.c
-+++ b/afsctool_34/afsctool.c
-@@ -104,8 +104,8 @@ void compressFile(const char *inFile, struct stat *inFileInfo, long long int max
-
-	if (statfs(inFile, &fsInfo) < 0)
-		return;
--	if (fsInfo.f_type != 17 && fsInfo.f_type != 23) {
--		printf("Expecting f_type of 17 or 23. f_type is %i.\n", fsInfo.f_type);
-+	if (fsInfo.f_type != 17 && fsInfo.f_type != 23 && fsInfo.f_type != 24) {
-+		printf("Expecting f_type of 17, 23 or 24. f_type is %i.\n", fsInfo.f_type);
-		return;
-	}
-	if (!S_ISREG(inFileInfo->st_mode))


### PR DESCRIPTION
AFSCTool failed to build on Catalina (and possibly earlier as well), and did not support APFS. This switches to the fork at https://github.com/RJVB/afsctool which is maintained and current. It has a healthy number of stars and is being linked to on [StackExchange](https://apple.stackexchange.com/a/360124/182183). That link also demonstrates how the outdated version here is causing confusion.

There was a previous discussion of such a move at https://github.com/Homebrew/homebrew-core/issues/40041, with no clear outcome but the suggestion to file a PR. One should note that the version currently being distributed includes several patches, one of which is loaded from some random Github repository as well. It isn't entirely obvious which of these two approaches should be considered "cleaner" or more trustworthy.

While it is obviously debatable if the fork is established enough to be used, the alternative would be remove or deprecate afsctool altogether. 

-----
- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----