### PR TITLE
buildifier: build with bazelisk

### DIFF
--- a/Formula/buildifier.rb
+++ b/Formula/buildifier.rb
@@ -12,10 +12,10 @@ class Buildifier < Formula
     sha256 "62f0325685b520d81ea00e5c59de99b1e9647a121808d60c0d6414fc6847db03" => :high_sierra
   end
 
-  depends_on "bazel" => :build
+  depends_on "bazelisk" => :build
 
   def install
-    system "bazel", "build", "--config=release", "buildifier:buildifier"
+    system "bazelisk", "build", "--config=release", "buildifier:buildifier"
     bin.install "bazel-bin/buildifier/darwin_amd64_stripped/buildifier"
   end
 


### PR DESCRIPTION
bazelisk is a wrapper around bazel and is invoked with exactly the
same semantics. For projects with a `.bazelversion` in the root of
their workspace, bazelisk will ensure that the correct version of
bazel is used, downloading it if necessary. When bazelisk is used,
bazel does not need to be explicitly installed.

Some users install bazelisk and then symlink it to `bazel` so that
it can be invoked transparently by any tools/scripts that are hard-
coded to use `bazel`. In this case, building buildifier from source
in homebrew will attempt to install bazel, but this step will fail
when it tries to symlink the `bazel` command.

Replacing the build tool with bazelisk should be transparent to
end users.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
