### PR TITLE
cfr-decompiler 0.149

### DIFF
--- a/Formula/cfr-decompiler.rb
+++ b/Formula/cfr-decompiler.rb
@@ -1,27 +1,55 @@
 class CfrDecompiler < Formula
   desc "Yet Another Java Decompiler"
   homepage "https://www.benf.org/other/cfr/"
-  url "https://www.benf.org/other/cfr/cfr-0.148.jar"
-  sha256 "1407f91fe7f94ff700cc1c8d546986a3fc2554273f07bae664bd58b0d85fd012"
-  revision 1
+  url "https://github.com/leibnitz27/cfr/archive/0.149.tar.gz"
+  sha256 "6d1883710ed1585cc4b675bc0d56b87351aff14dfc74270790b7bb3ff8f79743"
+  head "https://github.com/leibnitz27/cfr.git"
 
-  bottle :unneeded
-
+  depends_on "maven" => :build
   depends_on "openjdk"
 
   def install
-    libexec.install "cfr-#{version}.jar"
-    (bin/"cfr-decompiler").write <<~EOS
-      #!/bin/bash
-      export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk"].opt_prefix}}"
-      exec "${JAVA_HOME}/bin/java" -jar "#{libexec}/cfr-#{version}.jar" "$@"
-    EOS
+    # Homebrew's OpenJDK no longer accepts Java 6 source, so:
+    inreplace "pom.xml", "<javaVersion>1.6</javaVersion>", "<javaVersion>1.7</javaVersion>"
+    inreplace "cfr.iml", 'LANGUAGE_LEVEL="JDK_1_6"', 'LANGUAGE_LEVEL="JDK_1_7"'
+
+    # build
+    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
+    system Formula["maven"].bin/"mvn", "package"
+
+    cd "target" do
+      # switch on jar names
+      if build.head?
+        lib_jar = Dir["cfr-*-SNAPSHOT.jar"]
+        doc_jar = Dir["cfr-*-SNAPSHOT-javadoc.jar"]
+        odie "Unexpected number of artifacts!" unless (lib_jar.length == 1) && (doc_jar.length == 1)
+        lib_jar = lib_jar[0]
+        doc_jar = doc_jar[0]
+      else
+        lib_jar = "cfr-#{version}.jar"
+        doc_jar = "cfr-#{version}-javadoc.jar"
+      end
+
+      # install library and binary
+      libexec.install lib_jar
+      (bin/"cfr-decompiler").write <<~EOS
+        #!/bin/bash
+        export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk"].opt_prefix}}"
+        exec "${JAVA_HOME}/bin/java" -jar "#{libexec/lib_jar}" "$@"
+      EOS
+
+      # install library docs
+      doc.install doc_jar
+      mkdir doc/"javadoc"
+      cd doc/"javadoc" do
+        system Formula["openjdk"].bin/"jar", "-xf", doc/doc_jar
+        rm_rf "META-INF"
+      end
+    end
   end
 
   test do
     fixture = <<~EOS
-      import java.io.PrintStream;
-
       class T {
           T() {
           }
@@ -32,8 +60,8 @@ class CfrDecompiler < Formula
       }
     EOS
     (testpath/"T.java").write fixture
-    system "#{Formula["openjdk"].bin}/javac", "T.java"
-    output = pipe_output("#{bin}/cfr-decompiler T.class")
+    system Formula["openjdk"].bin/"javac", "T.java"
+    output = pipe_output("#{bin}/cfr-decompiler --comments false T.class")
     assert_match fixture, output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Replaces and obviates #50833.

This almost completely rewrites the formula to build the JAR itself rather than relying on the prebuilt one, which in turn allows for the Javadoc to _also_ be built and also for the whole process to work on HEAD as well as stable.