### PR TITLE
mercury 20.01.1

### DIFF
--- a/Formula/mercury.rb
+++ b/Formula/mercury.rb
@@ -1,9 +1,8 @@
 class Mercury < Formula
   desc "Logic/functional programming language"
   homepage "https://mercurylang.org/"
-  url "https://dl.mercurylang.org/release/mercury-srcdist-14.01.1.tar.gz"
-  sha256 "98f7cbde7a7425365400feef3e69f1d6a848b25dc56ba959050523d546c4e88b"
-  revision 1
+  url "https://dl.mercurylang.org/release/mercury-srcdist-20.01.1.tar.gz"
+  sha256 "579cf00fa485d3918dbf9e50bb8057662b66fb82f69b3b824542e42a814bb76f"
 
   bottle do
     cellar :any
@@ -16,20 +15,16 @@ class Mercury < Formula
     sha256 "0e736ef6f5cc48bc9d6f7d50cb9df6fb52dba2b0b3bf2d83b378f83fcff4ecb9" => :mavericks
   end
 
+  depends_on "openjdk"
+
   def install
     args = ["--prefix=#{prefix}",
             "--mandir=#{man}",
-            "--infodir=#{info}",
-            "--disable-dependency-tracking",
-            "--enable-java-grade"]
+            "--infodir=#{info}"]
 
     system "./configure", *args
 
-    # The build system doesn't quite honour the mandir/infodir autoconf
-    # parameters.
-    system "make", "install", "PARALLEL=-j",
-                              "INSTALL_MAN_DIR=#{man}",
-                              "INSTALL_INFO_DIR=#{info}"
+    system "make", "install", "PARALLEL=-j"
 
     # Remove batch files for windows.
     rm Dir.glob("#{bin}/*.bat")
@@ -47,7 +42,13 @@ class Mercury < Formula
       main(IOState_in, IOState_out) :-
           io.write_string("#{test_string}", IOState_in, IOState_out).
     EOS
-    system "#{bin}/mmc", "--make", "hello"
+
+    system "#{bin}/mmc", "-o", "hello_c", "hello"
+    assert_predicate testpath/"hello_c", :exist?
+
+    assert_equal test_string, shell_output("#{testpath}/hello_c")
+
+    system "#{bin}/mmc", "--grade", "java", "hello"
     assert_predicate testpath/"hello", :exist?
 
     assert_equal test_string, shell_output("#{testpath}/hello")


### PR DESCRIPTION
Also:
* Added proper Java dependency
* Added test for Java grade
* Removed defunct configure flags
* Removed old build issue workaround

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
