### PR TITLE
mpv.rb: always build with lua@5.1

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -14,6 +14,7 @@ class Mpv < Formula
   depends_on "docutils" => :build
   depends_on "pkg-config" => :build
   depends_on "python" => :build
+  depends_on :xcode => :build
 
   depends_on "ffmpeg"
   depends_on "jpeg"
@@ -46,6 +47,7 @@ class Mpv < Formula
       --mandir=#{man}
       --docdir=#{doc}
       --zshdir=#{zsh_completion}
+      --lua=51deb
     ]
 
     system "python3", "bootstrap.py"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Context:

- Since https://github.com/mpv-player/mpv/commit/d852ad2ae76c97fce710e41064c863842db87035 , `mpv` starts to prefer `luajit` than `lua@5.1`
- `mpv`'s own testing workflow is using `luajit` [link](https://github.com/mpv-player/mpv/blob/44f6e794390314656dc8b60bed5b3be6e1adb766/.travis.yml#L81)
-  The `MacOS.version < :catalina` part is added, since `luajit` 2.0 stable branch is broken on Catalina. 
I know @fxcoudert and other people have already tried to fix it, as  https://github.com/Homebrew/homebrew-core/pull/46928 and  https://github.com/LuaJIT/LuaJIT/issues/521 , but when I tried to make `luajit` works with Catalina, I ran into this issue https://github.com/mpv-player/mpv/issues/7512 . And mpv developers confirm `luajit` 2.0 is sort of broken on Catalina. 
Even `luajit`'s developer [recommends](https://github.com/LuaJIT/LuaJIT/issues/521#issuecomment-562999247) to use `2.1` branch, which is beta, can not add to homebrew due to the policy. 
I have already ask `luajit` whether it is possible to release a new stable version for Catalina. https://github.com/LuaJIT/LuaJIT/issues/563. but I am not sure when it will or will not happen
- if we could do something like `depends_on "luajit": HEAD` , that will fix the Catalina compatible issue, but I remember that depends_on version is not allowed, right? :(


updated:
One month later, no update from `luajit`, I hope they could release a new version in the future. For now, the better solution is always force build mpv with lua@5.1, no matter luajit is installed or not