### PR TITLE
Convert elm-format, hpack, komposition, purescript, shellcheck to v2-build

### DIFF
--- a/Formula/elm-format.rb
+++ b/Formula/elm-format.rb
@@ -1,8 +1,4 @@
-require "language/haskell"
-
 class ElmFormat < Formula
-  include Language::Haskell::Cabal
-
   desc "Elm source code formatter, inspired by gofmt"
   homepage "https://github.com/avh4/elm-format"
   url "https://github.com/avh4/elm-format.git",
@@ -35,10 +31,9 @@ class ElmFormat < Formula
 
     (buildpath/"elm-format").install Dir["*"]
 
-    cabal_sandbox do
-      cabal_sandbox_add_source "elm-format"
-      cabal_install "--only-dependencies", "elm-format"
-      cabal_install "--prefix=#{prefix}", "elm-format"
+    cd "elm-format" do
+      system "cabal", "v2-update"
+      system "cabal", "v2-install", *std_cabal_v2_args
     end
   end
 

--- a/Formula/hpack.rb
+++ b/Formula/hpack.rb
@@ -1,8 +1,4 @@
-require "language/haskell"
-
 class Hpack < Formula
-  include Language::Haskell::Cabal
-
   desc "Modern format for Haskell packages"
   homepage "https://github.com/sol/hpack"
   url "https://github.com/sol/hpack/archive/0.33.0.tar.gz"
@@ -20,7 +16,8 @@ class Hpack < Formula
   depends_on "ghc" => :build
 
   def install
-    install_cabal_package
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
   end
 
   # Testing hpack is complicated by the fact that it is not guaranteed

--- a/Formula/komposition.rb
+++ b/Formula/komposition.rb
@@ -1,8 +1,4 @@
-require "language/haskell"
-
 class Komposition < Formula
-  include Language::Haskell::Cabal
-
   desc "Video editor built for screencasters"
   homepage "https://github.com/owickstrom/komposition"
   url "https://github.com/owickstrom/komposition/archive/v0.2.0.tar.gz"
@@ -31,10 +27,8 @@ class Komposition < Formula
   uses_from_macos "libffi"
 
   def install
-    # The --allow-newer=base may be removed when the ffmpeg-light
-    # bound on base is relaxed, or when Homebrew moves to Cabal 3
-    # builds.
-    install_cabal_package "--allow-newer=base", :using => ["alex", "happy"]
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
   end
 
   test do

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -1,8 +1,4 @@
-require "language/haskell"
-
 class Purescript < Formula
-  include Language::Haskell::Cabal
-
   desc "Strongly typed programming language that compiles to JavaScript"
   homepage "https://www.purescript.org/"
   url "https://hackage.haskell.org/package/purescript-0.13.6/purescript-0.13.6.tar.gz"
@@ -27,7 +23,8 @@ class Purescript < Formula
   def install
     system "hpack" if build.head?
 
-    install_cabal_package "-f", "release", :using => ["alex", "happy-1.19.9"]
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
   end
 
   test do

--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -1,8 +1,4 @@
-require "language/haskell"
-
 class Shellcheck < Formula
-  include Language::Haskell::Cabal
-
   desc "Static analysis and lint tool, for (ba)sh scripts"
   homepage "https://www.shellcheck.net/"
   url "https://github.com/koalaman/shellcheck/archive/v0.7.0.tar.gz"
@@ -27,7 +23,8 @@ class Shellcheck < Formula
   end
 
   def install
-    install_cabal_package
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
     system "pandoc", "-s", "-f", "markdown-smart", "-t", "man",
                      "shellcheck.1.md", "-o", "shellcheck.1"
     man1.install "shellcheck.1"


### PR DESCRIPTION
This is part of the move away from the old DSL-ish way of writing
Haskell formulae.  See https://github.com/Homebrew/brew/pull/6974 for the discussion leading up to this.  The point of this PR is mostly to exercise the cabal-v2 approach, hopefully eventually leading to a good fix of https://github.com/Homebrew/homebrew-core/issues/48604. 

This change does not actually change what is built in the formulae.  As I understand it, this means that new revisions are *not* necessary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
