### PR TITLE
navi 2.0.2

### DIFF
--- a/Formula/navi.rb
+++ b/Formula/navi.rb
@@ -1,8 +1,8 @@
 class Navi < Formula
   desc "Interactive cheatsheet tool for the command-line"
   homepage "https://github.com/denisidoro/navi"
-  url "https://github.com/denisidoro/navi/archive/v0.18.3.tar.gz"
-  sha256 "2e65f6c8757dd5107c4ac7032e3cc1bfec785cfec84e33b2d1b365a31c8ee17b"
+  url "https://github.com/denisidoro/navi/archive/v2.0.2.tar.gz"
+  sha256 "f32cb110c1255d3b8f17a59fccc51aa92e842ff731c004c2cecf66234c1a8c3d"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,14 +11,18 @@ class Navi < Formula
     sha256 "64b6dac7d4c689ab6aa5c88ef58369249af2d9a6ac44f56769685569a673dd56" => :high_sierra
   end
 
+  depends_on "rust" => :build
   depends_on "fzf"
 
   def install
-    libexec.install Dir["*"]
-    bin.write_exec_script(libexec/"navi")
+    (libexec/"cheats").install Dir["cheats/*"]
+    (libexec/"shell").install Dir["shell/*"]
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 
   test do
-    assert_equal version, shell_output("#{bin}/navi --version")
+    assert_match "navi " + version, shell_output("#{bin}/navi --version")
+    (testpath/"cheats/test.cheat").write "% test\n\n# foo\necho bar\n\n# lorem\necho ipsum\n"
+    assert_match "bar", shell_output("export RUST_BACKTRACE=1; #{bin}/navi --path #{testpath}/cheats best foo")
   end
 end


### PR DESCRIPTION
### Why the change?

[navi](https://github.com/denisidoro/navi) was initially implemented in bash but it has been rewritten in Rust (cf https://github.com/denisidoro/navi/issues/201). 

The formula needs to be rewritten as well because we now need to compile a binary, in opposition to interpreting a bunch of `.sh` files.

### Previous attempt

This PR started as https://github.com/Homebrew/homebrew-core/pull/51124 but I made some confusion when updating with master + squashing. I'm sorry.