### PR TITLE
libarchive: Add zstd libb2 and lz4 support by default

### DIFF
--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -3,6 +3,7 @@ class Libarchive < Formula
   homepage "https://www.libarchive.org"
   url "https://www.libarchive.org/downloads/libarchive-3.4.2.tar.xz"
   sha256 "d8e10494b4d3a15ae9d67a130d3ab869200cfd60b2ab533b391b0a0d5500ada1"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,10 +14,14 @@ class Libarchive < Formula
 
   keg_only :provided_by_macos
 
+  depends_on "libb2"
+  depends_on "lz4"
   depends_on "xz"
+  depends_on "zstd"
 
   uses_from_macos "bzip2"
   uses_from_macos "expat"
+  uses_from_macos "iconv"
   uses_from_macos "zlib"
 
   def install


### PR DESCRIPTION
* They would previously have appeared if you built from
  source and had them in brew anyway.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libarchive by default checks for libzstd, libb2 (blake2) and liblz4 support. These would have been enabled if you built from source. I have just gone ahead and added them, but we could also explicitly `--without-X` them? What is the 'done' thing here?

Also maybe I should bump the `revision`?