### PR TITLE
ktoblzcheck: depend on Python@3.8

### DIFF
--- a/Formula/ktoblzcheck.rb
+++ b/Formula/ktoblzcheck.rb
@@ -3,6 +3,7 @@ class Ktoblzcheck < Formula
   homepage "https://ktoblzcheck.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.52.tar.gz"
   sha256 "e433da63af7161a6ce8b1e0c9f0b25bd59ad6d81bc4069e9277c97c1320a3ac4"
+  revision 1
 
   bottle do
     sha256 "4deeacd897afde29f6c83c5567b0a7e840b17239ada9444bf443921b6a473077" => :catalina
@@ -11,6 +12,7 @@ class Ktoblzcheck < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "python@3.8"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Fixes:
```
-- Could NOT find Python3 (missing: Python3_LIBRARIES Python3_INCLUDE_DIRS Development) (found version "3.5.2")
-- Could NOT find Python2 (missing: Python2_EXECUTABLE Python2_LIBRARIES Python2_INCLUDE_DIRS Interpreter
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
