### PR TITLE
sysdig: add comment about using "latest" version

### DIFF
--- a/Formula/sysdig.rb
+++ b/Formula/sysdig.rb
@@ -1,6 +1,8 @@
 class Sysdig < Formula
   desc "System-level exploration and troubleshooting tool"
   homepage "https://sysdig.com/"
+  # The version used here should be the latest stable version from:
+  # https://github.com/draios/sysdig/releases/latest
   url "https://github.com/draios/sysdig/archive/0.26.5.tar.gz"
   sha256 "3a251eca408e71df9582eac93632d8927c5abcc8d09b25aa32ef6d9c99a07bd4"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While working on livecheck, I noticed that the `sysdig` livecheckable was set up to only report the version marked as "latest" on GitHub. The formula is currently using version 0.26.5 (updated in #50025), which is marked as "pre-release" on GitHub, instead of the ["latest" version](https://github.com/draios/sysdig/releases/latest) of 0.26.4.

This PR adds a comment above the URL to note that it shouldn't be upgraded past the "latest" version. However, if it's appropriate to use versions that are "pre-release" rather than "latest", I can update the livecheckable to match these as well.

If someone who's familiar with this situation can provide feedback on how to proceed, that would be helpful.