### PR TITLE
various formulae: ensure consistent use of std_cmake_args

### DIFF
--- a/Formula/editorconfig.rb
+++ b/Formula/editorconfig.rb
@@ -17,7 +17,7 @@ class Editorconfig < Formula
   depends_on "pcre2"
 
   def install
-    system "cmake", ".", "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}"
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
   end
 

--- a/Formula/freeglut.rb
+++ b/Formula/freeglut.rb
@@ -18,7 +18,7 @@ class Freeglut < Formula
 
   def install
     inreplace "src/x11/fg_main_x11.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH" if MacOS.version < :sierra
-    system "cmake", "-DFREEGLUT_BUILD_DEMOS=OFF", "-DCMAKE_INSTALL_PREFIX=#{prefix}", "."
+    system "cmake", *std_cmake_args, "-DFREEGLUT_BUILD_DEMOS=OFF", "."
     system "make", "all"
     system "make", "install"
   end

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -39,7 +39,7 @@ class Haxe < Formula
 
     # Rebuild haxelib as a valid binary
     cd "extra/haxelib_src" do
-      system "cmake", "."
+      system "cmake", ".", *std_cmake_args
       system "make"
     end
     rm "haxelib"

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -34,7 +34,7 @@ class Ledger < Formula
       -DBUILD_WEB_DOCS=1
       -DBoost_NO_BOOST_CMAKE=ON
       -DPython_FIND_VERSION_MAJOR=3
-    ]
+    ] + std_cmake_args
     system "./acprep", "opt", "make", *args
     system "./acprep", "opt", "make", "doc", *args
     system "./acprep", "opt", "make", "install", *args

--- a/Formula/leela-zero.rb
+++ b/Formula/leela-zero.rb
@@ -25,7 +25,7 @@ class LeelaZero < Formula
   def install
     mkdir "build"
     cd "build" do
-      system "cmake", ".."
+      system "cmake", "..", *std_cmake_args
       system "cmake", "--build", "."
       bin.install "leelaz"
     end

--- a/Formula/lolcode.rb
+++ b/Formula/lolcode.rb
@@ -23,7 +23,7 @@ class Lolcode < Formula
   conflicts_with "lci", :because => "both install `lci` binaries"
 
   def install
-    system "cmake", "."
+    system "cmake", ".", *std_cmake_args
     system "make"
     # Don't use `make install` for this one file
     bin.install "lci"

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -15,10 +15,9 @@ class Mavsdk < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-Bbuild/default",
+    system "cmake", *std_cmake_args,
+                    "-Bbuild/default",
                     "-DBUILD_BACKEND=ON",
-                    "-DCMAKE_BUILD_TYPE=Release",
-                    "-DCMAKE_INSTALL_PREFIX=#{prefix}",
                     "-H."
     system "cmake", "--build", "build/default", "--target", "install"
   end

--- a/Formula/multimarkdown.rb
+++ b/Formula/multimarkdown.rb
@@ -19,9 +19,8 @@ class Multimarkdown < Formula
   conflicts_with "discount", :because => "both install `markdown` binaries"
 
   def install
-    system "make", "release"
-
-    cd "build" do
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
       system "make"
       bin.install "multimarkdown"
     end

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -34,7 +34,7 @@ class ProtobufAT36 < Formula
   def install
     (buildpath/"gtest").install resource "gtest"
     (buildpath/"gtest/googletest").cd do
-      system "cmake", "."
+      system "cmake", ".", *std_cmake_args
       system "make"
     end
     ENV["CXXFLAGS"] = "-I../gtest/googletest/include"

--- a/Formula/rp.rb
+++ b/Formula/rp.rb
@@ -24,7 +24,7 @@ class Rp < Formula
 
   def install
     mkdir "build" do
-      system "cmake", ".."
+      system "cmake", "..", *std_cmake_args
       system "make"
     end
     bin.install "bin/rp-osx"

--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -32,7 +32,8 @@ class Tbb < Formula
       system "python3", *Language::Python.setup_install_args(prefix)
     end
 
-    system "cmake", "-DINSTALL_DIR=lib/cmake/TBB",
+    system "cmake", *std_cmake_args,
+                    "-DINSTALL_DIR=lib/cmake/TBB",
                     "-DSYSTEM_NAME=Darwin",
                     "-DTBB_VERSION_FILE=#{include}/tbb/tbb_stddef.h",
                     "-P", "cmake/tbb_config_installer.cmake"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We usually use `std_cmake_args`, but there's some cases where we don't. Lets try fix some of them to ensure we are building things consistently.