### PR TITLE
efl: patch for building with 10.15 SDK

### DIFF
--- a/Formula/efl.rb
+++ b/Formula/efl.rb
@@ -33,6 +33,12 @@ class Efl < Formula
   depends_on "pulseaudio"
   depends_on "shared-mime-info"
 
+  # Fix build with 10.15+ SDK
+  patch do
+    url "https://github.com/Enlightenment/efl/commit/51e4bcc32c8b3d20980dd4f669e92e32a95a82fb.patch?full_index=1"
+    sha256 "173f15e9154f76898ce090211a7c87675d9198a79a32c7ef59df870cfafea02c"
+  end
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
~~This will be submitted upstream and is just a test to make sure it works across all three SDKs:~~
This has been accepted and has landed upstream. It's been tested on:

* 10.13
* 10.14 - where the internal variables that broke compile were deprecated but not removed
* 10.15 - where the internal variables were removed from public use in the SDK