### PR TITLE
arangodb 3.6.2

### DIFF
--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -2,7 +2,8 @@ class Arangodb < Formula
   desc "The Multi-Model NoSQL Database"
   homepage "https://www.arangodb.com/"
   url "https://github.com/arangodb/arangodb/archive/v3.6.2.tar.gz"
-  sha256 "fcfc575affb89471b62f7fdf8dfb04ef7d8329ab43fc1c22617fe1f0d9c9f17d"
+  sha256 "2bfc406e4985eb432a5f83f2f3ca1ebee61792dad972024183408c2f8b148dbe"
+  revision 1
   head "https://github.com/arangodb/arangodb.git", :branch => "devel"
 
   bottle do

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -13,7 +13,7 @@ class Arangodb < Formula
 
   depends_on "ccache" => :build
   depends_on "cmake" => :build
-  depends_on "go" => :build
+  depends_on "go@1.13" => :build
   depends_on :macos => :mojave
   depends_on "openssl@1.1"
 

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -21,7 +21,7 @@ class Arangodb < Formula
   # with a unified CLI
   resource "starter" do
     url "https://github.com/arangodb-helper/arangodb.git",
-      :revision => "bbe29730e70dba609b57c469e8f863f032fabf3e"
+      :revision => "598e7d7794ad4a98024548dd9061e03782542ecd"
   end
 
   def install
@@ -29,10 +29,11 @@ class Arangodb < Formula
 
     resource("starter").stage do
       ENV.append "GOPATH", Dir.pwd + "/.gobuild"
+      ENV.append "DOCKERCLI", ""
       system "make", "deps"
       # use commit-id as projectBuild
       commit = `git rev-parse HEAD`.chomp
-      system "go", "build", "-ldflags", "-X main.projectVersion=0.14.12 -X main.projectBuild=#{commit}",
+      system "go", "build", "-ldflags", "-X main.projectVersion=0.14.14 -X main.projectBuild=#{commit}",
                             "-o", "arangodb",
                             "github.com/arangodb-helper/arangodb"
       bin.install "arangodb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@MikeMcQuaid can you please help here? By some mistake or bad will the following things were added into Homebrew recently:
- https://github.com/Homebrew/homebrew-core/pull/50925
- https://github.com/Homebrew/homebrew-core/commit/a8e095ad0a82f1effeaa594f086238526fb4162d#diff-271e832fd581b39f66010ee8f8e18438

That gave wrong absolutely non-official and non-supportable from ArangoDB side version which is being distributed now. It's strange that the following fork was accepted https://github.com/shwang53/homebrew-core/ instead of officially supported by ArangoDB members and community: https://github.com/arangodb-helper/homebrew-core.

We weren't able to produce ArangoDB 3.6.1 before because of dockerless policy violation (https://github.com/Homebrew/homebrew-core/pull/49567), but we did improve things and want to be in good connection with Homebrew!