### PR TITLE
gdb: update head

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -5,7 +5,7 @@ class Gdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-9.1.tar.xz"
   sha256 "699e0ec832fdd2f21c8266171ea5bf44024bd05164fdf064e4d10cc4cf0d1737"
   revision 1
-  head "https://sourceware.org/git/binutils-gdb.git"
+  head "git://sourceware.org/git/binutils-gdb.git"
 
   bottle do
     sha256 "848a06573870a26ca89fe859fe8d2e159b1781db544841a55c0713f00b7c18bc" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --HEAD <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `gdb` formula's `head` repository responds with a `not found` error over HTTP(S). The [GDB website only references the repo using the `git` protocol](https://www.gnu.org/software/gdb/current/) , so this updates `head` to use `git://` instead.

With this change in place, installing with `--HEAD` works properly.