### PR TITLE
workflows: upload from Jenkins builds

### DIFF
--- a/.github/workflows/dispatch-upload-bottles-jenkins.yml
+++ b/.github/workflows/dispatch-upload-bottles-jenkins.yml
@@ -1,0 +1,32 @@
+name: Upload bottles from Jenkins
+
+on: repository_dispatch
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew
+    env:
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
+      HOMEBREW_GIT_EMAIL: homebrew-test-bot@lists.sfconservancy.org
+      HOMEBREW_GIT_NAME: BrewTestBot
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Set up environment
+        run: |
+          echo "::set-env name=UPSTREAM_JOB_NAME::${{ github.event.client_payload.upstream_job_name }}"
+          echo "::set-env name=UPSTREAM_BUILD_ID::${{ github.event.client_payload.upstream_build_id }}"
+          echo "::set-env name=UPSTREAM_PULL_REQUEST::${{ github.event.client_payload.upstream_pull_request }}"
+          echo "::set-env name=UPSTREAM_BUILD_NUMBER::${{ github.event.client_payload.upstream_build_number }}"
+          echo "::set-env name=UPSTREAM_BOTTLE_KEEP_OLD::${{ github.event.client_payload.upstream_bottle_keep_old }}"
+          echo "::set-env name=UPSTREAM_GIT_URL::${{ github.event.client_payload.upstream_git_url }}"
+      - name: Upload bottles
+        env:
+          HOMEBREW_BINTRAY_USER: BrewTestBot
+          HOMEBREW_BINTRAY_KEY: ${{ secrets.HOMEBREW_BINTRAY_KEY }}
+        run: |
+          brew update-reset
+          brew test-bot --ci-upload


### PR DESCRIPTION
Part of https://github.com/Homebrew/brew/issues/6255

Suggested in https://github.com/Homebrew/brew/issues/6255#issuecomment-589948765

This workflow is intended to replace the Homebrew Bottles job on Jenkins, which is responsible for transferring bottles from Jenkins workers to Bintray. The intent is to merge this, then switch the Homebrew Core Pull Requests job on Jenkins to triggering this webhook.

Checklist:

* [ ] Add `HOMEBREW_BINTRAY_KEY` as a secret to this repository
* [ ] Generate webhook PAT for Jenkins
* [ ] Update Jenkins configuration to fire this dispatch job