### PR TITLE
selenium-server-standalone & frege: migrate to openjdk

### DIFF
--- a/Formula/frege.rb
+++ b/Formula/frege.rb
@@ -3,15 +3,18 @@ class Frege < Formula
   homepage "https://github.com/Frege/frege/"
   url "https://github.com/Frege/frege/releases/download/3.24public/frege3.24.405.jar"
   sha256 "f5a6e40d1438a676de85620e3304ada4760878879e02dbb7c723164bd6087fc4"
-  revision 1
+  revision 2
 
   bottle :unneeded
 
   depends_on "openjdk"
 
   def install
-    libexec.install Dir["*"]
-    bin.write_jar_script libexec/"frege#{version}.jar", "fregec", "-Xss1m"
+    libexec.install "frege#{version}.jar"
+    (bin/"fregec").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["openjdk"].opt_bin}/java" -jar "#{libexec}/frege#{version}.jar" "$@"
+    EOS
   end
 
   test do
@@ -24,6 +27,7 @@ class Frege < Formula
           println (greeting "World")
     EOS
     system bin/"fregec", "-d", testpath, "test.fr"
-    system "#{Formula["openjdk"].bin}/java", "-Xss1m", "-cp", "#{testpath}:#{libexec}/frege#{version}.jar", "Hello"
+    output = shell_output "#{Formula["openjdk"].bin}/java -Xss1m -cp #{testpath}:#{libexec}/frege#{version}.jar Hello"
+    assert_equal "Hello, World!\n", output
   end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -3,12 +3,18 @@ class SeleniumServerStandalone < Formula
   homepage "https://www.seleniumhq.org/"
   url "https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar"
   sha256 "acf71b77d1b66b55db6fb0bed6d8bae2bbd481311bcbedfeff472c0d15e8f3cb"
+  revision 1
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install "selenium-server-standalone-#{version}.jar"
-    bin.write_jar_script libexec/"selenium-server-standalone-#{version}.jar", "selenium-server"
+    (bin/"selenium-server").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["openjdk"].opt_bin}/java" -jar "#{libexec}/selenium-server-standalone-#{version}.jar" "$@"
+    EOS
   end
 
   plist_options :manual => "selenium-server -port 4444"
@@ -44,9 +50,22 @@ class SeleniumServerStandalone < Formula
   end
 
   test do
-    selenium_version =
-      shell_output("unzip -p #{libexec}/selenium-server-standalone-#{version}.jar META-INF/MANIFEST.MF " \
-                   "| sed -nEe '/Selenium-Version:/p'")
-    assert_equal "Selenium-Version: #{version}", selenium_version.strip
+    port = 4444
+    pid = fork do
+      exec "#{bin}/selenium-server -port #{port}"
+    end
+    sleep 3
+
+    begin
+      output = shell_output("curl --silent localhost:4444/wd/hub/status")
+      output = JSON.parse(output)
+
+      assert_equal 0, output["status"]
+      assert_true output["value"]["ready"]
+      assert_equal version, output["value"]["build"]["version"]
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`frege` already depends on `openjdk` but there was a possibility that system java is being used.
Also, improve tests a bit.