### PR TITLE
composer 1.10.1

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/1.10.0/composer.phar"
-  sha256 "8ced713bde2d89468c3385588daf27dc6fc7bc7619f95239068608d303700b09"
+  url "https://getcomposer.org/download/1.10.1/composer.phar"
+  sha256 "1831f266580f221189dc04d4b58d7fc50c934ffc3a0eca89ecb4a53aa44867e2"
 
   bottle :unneeded
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 1,969,526 bytes
- formula fetch time: 2.9 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.