### PR TITLE
cargo-c: patch crash issue with v2 Cargo.lock

### DIFF
--- a/Formula/cargo-c.rb
+++ b/Formula/cargo-c.rb
@@ -3,6 +3,7 @@ class CargoC < Formula
   homepage "https://github.com/lu-zero/cargo-c"
   url "https://github.com/lu-zero/cargo-c/archive/v0.5.1.tar.gz"
   sha256 "e547f3604bb801914d5685c22b54776baf70686b9aeb191396866a6e55391591"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,6 +13,13 @@ class CargoC < Formula
   end
 
   depends_on "rust" => [:build, :test]
+
+  # Fixes crash issue with v2 Cargo.lock files - detected while building rav1e.
+  # Remove with the next version.
+  patch do
+    url "https://github.com/lu-zero/cargo-c/commit/0cb09ac3c1950a2c05758b344131ff7b7a38c42d.patch?full_index=1"
+    sha256 "746a6a9e6fc9a3b15afa9167011a2a06b9c70d7c9adbf7bb20b4e376fa0ab667"
+  end
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes the rav1e build issue - #50815. cargo-c was crashing while parsing the lockfile, which changed format somewhat recently.