### PR TITLE
mtoc 927.0.2 (new formula)

### DIFF
--- a/Formula/mtoc.rb
+++ b/Formula/mtoc.rb
@@ -1,0 +1,36 @@
+class Mtoc < Formula
+  desc "Mach-O to PE/COFF binary converter"
+  homepage "https://opensource.apple.com/source/cctools/cctools-927.0.2/"
+  url "https://opensource.apple.com/tarballs/cctools/cctools-927.0.2.tar.gz"
+  sha256 "3d5d35e7120aac187de306019d4b53b3b08dd7ebf48764fcd5c8cefef40b3dbf"
+
+  depends_on "llvm" => :build
+
+  def install
+    # Conflicts with _structs.h in macOS 10.13 - 10.15 SDK
+    File.delete "include/mach/i386/_structs.h"
+
+    system "make", "-C", "libstuff", "EFITOOLS=efitools"
+    system "make", "-C", "efitools"
+
+    bin.install "efitools/mtoc.NEW" => "mtoc"
+    man1.install "man/mtoc.1"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      __attribute__((naked)) int start() {}
+    EOS
+
+    args = %W[
+      -nostdlib
+      -Wl,-preload
+      -Wl,-e,_start
+      -seg1addr 0x1000
+      -o #{testpath}/test
+      #{testpath}/test.c
+    ]
+    system "cc", *args
+    system "#{bin}/mtoc", "#{testpath}/test", "#{testpath}/test.pe"
+  end
+end


### PR DESCRIPTION
mtoc is a Mach-O to PE binary converter.
It enables Tianocore UEFI build on macOS.

- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The formula is based off #19922 made by @rickmark. Changelog:
* mtoc is updated to the latest available version (949.0.1 can't be downloaded);
* install routine is updated to match the new version;
* man page is installed and test was added.