### PR TITLE
shadowsocks-libev: remove -u option

### DIFF
--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -51,7 +51,7 @@ class ShadowsocksLibev < Formula
     system "make", "install"
   end
 
-  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json -u"
+  plist_options :manual => "#{HOMEBREW_PREFIX}/opt/shadowsocks-libev/bin/ss-local -c #{HOMEBREW_PREFIX}/etc/shadowsocks-libev.json"
 
   def plist
     <<~EOS
@@ -66,7 +66,6 @@ class ShadowsocksLibev < Formula
             <string>#{opt_bin}/ss-local</string>
             <string>-c</string>
             <string>#{etc}/shadowsocks-libev.json</string>
-            <string>-u</string>
           </array>
           <key>RunAtLoad</key>
           <true/>


### PR DESCRIPTION
remove -u option, because user can enable UDP relay in config file (shadowsocks-libev.json).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

shadowsocks-libev allows users to enable UDP relay in `config.json`:

```
+------------------------------------+-----------------------------------------+
|                                    |                                         |
|-u                                  | "mode": "tcp_and_udp"                   |
+------------------------------------+-----------------------------------------+
|                                    |                                         |
|-U                                  | "mode": "udp_only"                      |
+------------------------------------+-----------------------------------------+
|                                    |                                         |
|no "-u" nor "-U" options (default)  | "mode": "tcp_only"                      |
+------------------------------------+-----------------------------------------+
```

So there is no need to special `-u` explicit anymore. By remove this option, freedom to choose whether to enable UDP relay or not can be given to users.

shadowsocks-libev also uses this strategy in their predefined systemd service: <https://github.com/shadowsocks/shadowsocks-libev/blob/f34b362af0ecf93c803b7fe0444ab547ac8afefc/debian/shadowsocks-libev-local%40.service#L21>.