### PR TITLE
notmuch: Install shell completions and vim plugin files

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -29,6 +29,8 @@ class Notmuch < Formula
       --mandir=#{man}
       --emacslispdir=#{elisp}
       --emacsetcdir=#{elisp}
+      --bashcompletiondir=#{bash_completion}
+      --zshcompletiondir=#{zsh_completion}
       --without-ruby
     ]
 
@@ -36,6 +38,12 @@ class Notmuch < Formula
 
     system "./configure", *args
     system "make", "V=1", "install"
+
+    bash_completion.install "completion/notmuch-completion.bash"
+
+    (prefix/"vim/plugin").install "vim/notmuch.vim"
+    (prefix/"vim/doc").install "vim/notmuch.txt"
+    (prefix/"vim").install "vim/syntax"
 
     cd "bindings/python" do
       system "python3", *Language::Python.setup_install_args(prefix)


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow on to #50297. This modifies the `notmuch` formula to 1) provide bash and zsh completions and 2) install the included vim plugin files.

Note that I included both `--bashcompletiondir` as a `configure` argument as well as manually installing the bash completion file with `bash_completion.install`. The notmuch configure script looks for bash completion with pkg-config and does not install bash completion files if it can't find it, and the `bash-completion.pc` file is not on the default `PKG_CONFIG_PATH`. I figured it was easier and simpler to simply manually install the bash completion files rather than fiddle with pkg-config.