### PR TITLE
ghostscript 9.51 - apply patch to fix segfaults and other issues

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -3,6 +3,7 @@ class Ghostscript < Formula
   homepage "https://www.ghostscript.com/"
   url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs951/ghostpdl-9.51.tar.gz"
   sha256 "f0a6aab8c10f681f499b77dc2827978d2a0f93437f2b50f2b101a0eb9ee8bc28"
+  revision 1
 
   bottle do
     sha256 "27a0e1f41050d121dab550b75bd27770b41d774fa7da8ac9d709e75f83f07a1d" => :catalina
@@ -29,6 +30,18 @@ class Ghostscript < Formula
   end
 
   patch :DATA # Uncomment macOS-specific make vars
+
+  # This patch fixes a regression that seems to occur when Ghostscript is told
+  # to render a subset of PDF pages as images, such as with the arguments
+  # -dFirstPage and -dLastPage. Programs that use Ghostscript as a PDF backend
+  # often use these arguments. If not applied, there will be seg faults,
+  # floating point exceptions and other undefined behavior.
+  # This should be removed in Ghostscript 9.52, as we are cherrypicking this
+  # from the master branch of changes that will appear in 9.52.
+  patch do
+    url "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=aaf5edb15fceaae962569bae30eb4633480c1d15"
+    sha256 "bdf9741c7b8a069a523e9a7f2736af21469989b8332148a8bd3682085346c662"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
This cherry-picks an important patch to ghostscript 9.51 to fix a regression. If
unpatched there may be seg faults, floating point exceptions and other
issues as outlined in the patch.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I did not know if `+ revision 1` was a necessary change or what amount of commenting you prefer. Since the patch is merged upstream it will likely not be needed for gs 9.52.