### PR TITLE
helm: use go@1.13

### DIFF
--- a/Formula/helm.rb
+++ b/Formula/helm.rb
@@ -4,6 +4,7 @@ class Helm < Formula
   url "https://github.com/helm/helm.git",
       :tag      => "v3.1.2",
       :revision => "d878d4d45863e42fd5cff6743294a11d28a9abce"
+  revision 1
   head "https://github.com/helm/helm.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Helm < Formula
     sha256 "90235f18ce7502aeb4a6d060161f53219eb825f8b529ec662fa9e97b2a730257" => :high_sierra
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.13" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Helm in combination with go 1.14 gives errors on templates. See https://github.com/helm/charts/issues/21446