### PR TITLE
mmseqs2: fix OpenMP linkage

### DIFF
--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -4,6 +4,7 @@ class Mmseqs2 < Formula
   url "https://github.com/soedinglab/MMseqs2/archive/11-e1a1c.tar.gz"
   version "11-e1a1c"
   sha256 "ffe1ae300dbe1a0e3d72fc9e947356a4807f07951cb56316f36974d8d5875cbb"
+  revision 1
   head "https://github.com/soedinglab/MMseqs2.git"
 
   bottle do
@@ -32,9 +33,9 @@ class Mmseqs2 < Formula
     args << "-DHAVE_SSE4_1=1"
 
     libomp = Formula["libomp"]
-    args << "-DOpenMP_C_FLAGS=\"-Xpreprocessor -fopenmp -I#{libomp.opt_include}\""
+    args << "-DOpenMP_C_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp.opt_include}"
     args << "-DOpenMP_C_LIB_NAMES=omp"
-    args << "-DOpenMP_CXX_FLAGS=\"-Xpreprocessor -fopenmp -I#{libomp.opt_include}\""
+    args << "-DOpenMP_CXX_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp.opt_include}"
     args << "-DOpenMP_CXX_LIB_NAMES=omp"
     args << "-DOpenMP_omp_LIBRARY=#{libomp.opt_lib}/libomp.a"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A user [reported](https://github.com/soedinglab/MMseqs2/issues/289) that our brew build of MMseqs2 is not actually parallelized. After some investigation I found that the compiler in the end sees something like (note the `"`):

```
clang++ ... "-Xpreprocessor -fopenmp -Ipath/to/libomp.a" ...
```

instead of 

```
clang++ ... -Xpreprocessor -fopenmp -Ipath/to/libomp.a ...
```

Running `grep Xpreprocessor -R .` inside the `Formula` directory reveals that `spades.rb` `lightgbm.rb` and maybe `cryfs.rb`might also be affected. I originally copied the OpenMP code for MMseq2 from `lightgbm.rb`.  Depending on how `ENV.append_to_cflags` works, `siril.rb` might also be affected.