### PR TITLE
Add a caveat for git-gui when dark mode is enabled

### DIFF
--- a/Formula/git-gui.rb
+++ b/Formula/git-gui.rb
@@ -39,6 +39,15 @@ class GitGui < Formula
     system "make", "-C", "gitk-git", "install", *args
   end
 
+  def caveats
+    <<~EOS
+      When using Dark Mode, the UI for git-gui may be unusable. To work around
+      this you can force light mode for all Tcl/Tk applications by running:
+
+          defaults write com.tcltk.wish NSRequiresAquaSystemAppearance -bool Yes
+    EOS
+  end
+
   test do
     system bin/"git-gui", "--version"
   end


### PR DESCRIPTION
In dark mode the text cursor is (sometimes) invisible.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
