### PR TITLE
mosquitto 1.6.9

### DIFF
--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -1,9 +1,8 @@
 class Mosquitto < Formula
   desc "Message broker implementing the MQTT protocol"
   homepage "https://mosquitto.org/"
-  url "https://mosquitto.org/files/source/mosquitto-1.6.8.tar.gz"
-  sha256 "7df23c81ca37f0e070574fe74414403cf25183016433d07add6134366fb45df6"
-  revision 1
+  url "https://mosquitto.org/files/source/mosquitto-1.6.9.tar.gz"
+  sha256 "412979b2db0a0020bd02fa64f0a0de9e7000b84462586e32b67f29bb1f6c1685"
 
   bottle do
     cellar :any
@@ -18,7 +17,8 @@ class Mosquitto < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DWITH_WEBSOCKETS=ON"
+    system "cmake", ".", *std_cmake_args, "-DWITH_WEBSOCKETS=ON",
+      "-DWITH_BUNDLED_DEPS=ON"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A previous attempt to update `mosquitto` to version 1.6.9 can be found in #50855. After that PR was closed (without merging), [a fix for the build issue was proposed](https://github.com/Homebrew/homebrew-core/pull/50855#issuecomment-598226424) (adding `-DWITH_BUNDLED_DEPS=ON` to the `cmake` arguments). This change worked when I tested it locally (it previously failed without the argument), so here's another PR for the update.