### PR TITLE
ccheck 1.0.1 (new formula)

### DIFF
--- a/Formula/ccheck.rb
+++ b/Formula/ccheck.rb
@@ -1,0 +1,18 @@
+class Ccheck < Formula
+  desc "Check X509 certificate expiration from the command-line, with TAP output"
+  homepage "https://github.com/nerdlem/ccheck"
+  url "https://github.com/nerdlem/ccheck/archive/v1.0.1.tar.gz"
+  sha256 "2325ea8476cce5111b8f848ca696409092b1d1d9c41bd46de7e3145374ed32cf"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"ccheck", "main.go"
+    prefix.install_metafiles
+  end
+
+  test do
+    assert_equal "brew-ccheck.libertad.link:443 TLS",
+    shell_output("#{bin}/ccheck brew-ccheck.libertad.link:443").strip
+  end
+end


### PR DESCRIPTION
Provide a formula to directly compile the ccheck tool for X.509
TLS certificate monitoring / review utility.

The formula compiles the upstream Go binary and dependencies as specified
via vendoring, in compliance with the automated audit as well as the advice
provided in the Formula Cookbook.

- [✔︎] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✔︎] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✔︎] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✔︎] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✔︎] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
