### PR TITLE
nef 0.6.0 (new formula)

### DIFF
--- a/Formula/nef.rb
+++ b/Formula/nef.rb
@@ -1,0 +1,19 @@
+class Nef < Formula
+  desc "💊 steroids for Xcode Playgrounds"
+  homepage "https://nef.bow-swift.io"
+  url "https://github.com/bow-swift/nef/archive/0.6.0.tar.gz"
+  sha256 "a67bb4201739898832ec52e92d838ccfcae25a490df433cd7cf44f1fc6e0a786"
+
+  depends_on :xcode => "11.0"
+
+  def install
+    system "make", "install", "prefix=#{prefix}", "version=#{version}"
+  end
+
+  test do
+    system "#{bin}/nef", "markdown",
+           "--project", "#{share}/tests/Documentation.app",
+           "--output", "#{testpath}/nef"
+    assert_path_exist "#{testpath}/nef/resources.md", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

nef is a toolset to ease the creation of documentation using Xcode Playgrounds. It provides compile-time verification of documentation, exports it in Markdown format that can be consumed by Jekyll to generate websites, and export Carbon snippets for a given Xcode Playground. 

You can find more information in [GitHub main page](https://github.com/bow-swift/nef)

We tried to add nef in the past to homebrew-core in a premature version; and today, taking advantage of a new release, we have updated the formulae following the suggestions received in [previous conversations](https://github.com/Homebrew/homebrew-core/pull/47872) 

Thanks ^^