### PR TITLE
git-profile 0.1.0 (new formula)

### DIFF
--- a/Formula/git-profile.rb
+++ b/Formula/git-profile.rb
@@ -1,0 +1,19 @@
+class GitProfile < Formula
+  desc "Simple user profile manager for git"
+  homepage "https://github.com/bobbo/git-profile"
+  url "https://github.com/bobbo/git-profile/archive/v0.1.0.tar.gz"
+  sha256 "999404c4872d5af9b3fbb651337617fdc5ab075015267a64ae044cb14ff12ea1"
+  head "https://github.com/bobbo/git-profile.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    major, minor = version.to_s.split(".")
+    assert_match "git-profile #{major}.#{minor}",
+                 shell_output("#{bin}/git-profile --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Quoting `git-profile`'s [readme](https://github.com/bobbo/git-profile#readme):

>`git-profile` is a simple user profile manager for `git`. It lets you set-up multiple user profiles for git & switch between them, generate remote URLs and more. 

This is quite a new piece of software and a pretty niche one. I'm aware of previous attempts like [`gitcher`](https://github.com/bglezseoane/gitcher) (https://github.com/Homebrew/homebrew-core/pull/39412/files) but this one has at least two advantages compared to it:

1. it can be called as regular `git` command
2. FWIW it has more github stars even though the final number is still relatively small

If you think it is too early I'll move it to personal tap and wait for a better moment.