### PR TITLE
katago: new default networks

### DIFF
--- a/Formula/katago.rb
+++ b/Formula/katago.rb
@@ -3,6 +3,7 @@ class Katago < Formula
   homepage "https://github.com/lightvector/KataGo"
   url "https://github.com/lightvector/KataGo/archive/v1.3.3.tar.gz"
   sha256 "de346ea2e0e58f584df482c4ba28703d961dbdb6569bc4203d3edb98ca6c0b1a"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,18 +17,18 @@ class Katago < Formula
   depends_on "libzip"
 
   resource "20b-network" do
-    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3/g170e-b20c256x2-s2430231552-d525879064.bin.gz", :using => :nounzip
-    sha256 "770f65c5cfa6e7ebba1b972768406668afdfc2e65d61e45b8cb468677f5fea4d"
+    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3-nets/g170e-b20c256x2-s2971705856-d633407024.bin.gz", :using => :nounzip
+    sha256 "dba074142b9da4822ed9ad91c676372fd943c0c115b7975773dd292b9e96a899"
   end
 
   resource "30b-network" do
-    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3/g170-b30c320x2-s1287828224-d525929064.bin.gz", :using => :nounzip
-    sha256 "3c2864fda18d8bc595b1fb65ec25cc998ac90cd203a6269c56691e195297c325"
+    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3-nets/g170-b30c320x2-s1840604672-d633482024.bin.gz", :using => :nounzip
+    sha256 "2f066112e163de396f5bd56b94162419f16ff48e9fb9836c35a711122ecc9a32"
   end
 
   resource "40b-network" do
-    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3/g170-b40c256x2-s1349368064-d524332537.bin.gz", :using => :nounzip
-    sha256 "74ea1a4e9c0a461b9fb35a297d11f10e3fcfee32e5b710720784120fe52cbad0"
+    url "https://github.com/lightvector/KataGo/releases/download/v1.3.3-nets/g170-b40c256x2-s1929311744-d633132024.bin.gz", :using => :nounzip
+    sha256 "acbdd1aa883d7d8d60101cdcd0c75754ec25dba66b4d60d8d284427cf645124d"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updated default networks that come with katago. Syncs with release https://github.com/lightvector/KataGo/releases/tag/v1.3.3-nets