### PR TITLE
cmake 3.17.0

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -1,8 +1,8 @@
 class Cmake < Formula
   desc "Cross-platform make"
   homepage "https://www.cmake.org/"
-  url "https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5.tar.gz"
-  sha256 "5f760b50b8ecc9c0c37135fae5fbf00a2fef617059aa9d61c1bb91653e5a8bfc"
+  url "https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0.tar.gz"
+  sha256 "b74c05b55115eacc4fa2b77a814981dbda05cdc95a53e279fe16b7b272f00847"
   head "https://gitlab.kitware.com/cmake/cmake.git"
 
   bottle do
@@ -40,7 +40,7 @@ class Cmake < Formula
     # See https://bugs.python.org/issue18378#msg215215 for explanation
     ENV["LC_ALL"] = "en_US.UTF-8"
 
-    system "./bootstrap", *args, "--", "-DCMAKE_BUILD_TYPE=Release"
+    system "./bootstrap", *args, "--", *std_cmake_args
     system "make"
     system "make", "install"
 


### PR DESCRIPTION
Created with brew-bump-formula-pr, but manually committed due to bug https://discourse.brew.sh/t/error-unable-to-fork-not-found-encountered-with-bump-formula-pr/6469/10 on two separate computers (including one that used to work).