### PR TITLE
libpq and postgresql@x: link against MIT Kerberos

### DIFF
--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -14,6 +14,10 @@ class Libpq < Formula
 
   depends_on "openssl@1.1"
 
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   def install
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",

--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -3,6 +3,7 @@ class Libpq < Formula
   homepage "https://www.postgresql.org/docs/12/libpq.html"
   url "https://ftp.postgresql.org/pub/source/v12.2/postgresql-12.2.tar.bz2"
   sha256 "ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de"
+  revision 1
 
   bottle do
     sha256 "64bab543c341a2e26246aa434c8ef27c48985f397996a975751f2c5ea91cd3c3" => :catalina

--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -13,11 +13,11 @@ class Libpq < Formula
 
   keg_only "conflicts with postgres formula"
 
-  depends_on "openssl@1.1"
-
   # GSSAPI provided by Kerberos.framework crashes when forked.
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
+
+  depends_on "openssl@1.1"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -17,6 +17,10 @@ class PostgresqlAT10 < Formula
   depends_on "openssl@1.1"
   depends_on "readline"
 
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -3,6 +3,7 @@ class PostgresqlAT10 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v10.12/postgresql-10.12.tar.bz2"
   sha256 "388f7f888c4fbcbdf424ec2bce52535195b426010b720af7bea767e23e594ae7"
+  revision 1
 
   bottle do
     sha256 "6c7e4109f75dca307760c611678de01145967128a7e16e4407bc43473dbc1d9a" => :catalina

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -15,12 +15,13 @@ class PostgresqlAT10 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
-  depends_on "openssl@1.1"
-  depends_on "readline"
 
   # GSSAPI provided by Kerberos.framework crashes when forked.
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
+
+  depends_on "openssl@1.1"
+  depends_on "readline"
 
   uses_from_macos "libxslt"
   uses_from_macos "perl"

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -13,12 +13,12 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "openssl@1.1"
-  depends_on "readline"
-
   # GSSAPI provided by Kerberos.framework crashes when forked.
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
+
+  depends_on "openssl@1.1"
+  depends_on "readline"
 
   uses_from_macos "libxslt"
   uses_from_macos "perl"

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -3,6 +3,7 @@ class PostgresqlAT94 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v9.4.26/postgresql-9.4.26.tar.bz2"
   sha256 "f5c014fc4a5c94e8cf11314cbadcade4d84213cfcc82081c9123e1b8847a20b9"
+  revision 1
 
   bottle do
     sha256 "708f31b60651088de5c546f3c5f893d4f1a5b77716b9faeb362a3ce457dc408c" => :catalina

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -15,6 +15,10 @@ class PostgresqlAT94 < Formula
   depends_on "openssl@1.1"
   depends_on "readline"
 
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -13,12 +13,12 @@ class PostgresqlAT95 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "openssl@1.1"
-  depends_on "readline"
-
   # GSSAPI provided by Kerberos.framework crashes when forked.
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
+
+  depends_on "openssl@1.1"
+  depends_on "readline"
 
   uses_from_macos "libxslt"
   uses_from_macos "perl"

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -3,6 +3,7 @@ class PostgresqlAT95 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v9.5.21/postgresql-9.5.21.tar.bz2"
   sha256 "7eb56e4fa877243c2df78adc5a0ef02f851060c282682b4bb97b854100fb732c"
+  revision 1
 
   bottle do
     sha256 "6bf4e2ebeeba9aed6717e6f5db24c618573c63d7d1d090bb28a9f9ecf3a3b0e2" => :catalina

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -15,6 +15,10 @@ class PostgresqlAT95 < Formula
   depends_on "openssl@1.1"
   depends_on "readline"
 
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -13,12 +13,12 @@ class PostgresqlAT96 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "openssl@1.1"
-  depends_on "readline"
-
   # GSSAPI provided by Kerberos.framework crashes when forked.
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
+
+  depends_on "openssl@1.1"
+  depends_on "readline"
 
   uses_from_macos "libxslt"
   uses_from_macos "perl"

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -3,6 +3,7 @@ class PostgresqlAT96 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v9.6.17/postgresql-9.6.17.tar.bz2"
   sha256 "f6e1e32d32545f97c066f3c19f4d58dfab1205c01252cf85c5c92294ace1a0c2"
+  revision 1
 
   bottle do
     sha256 "c658b98448c42f82cbd1f26346284b47f409c915390f8fcb1f64d396adceb4fe" => :catalina

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -15,6 +15,10 @@ class PostgresqlAT96 < Formula
   depends_on "openssl@1.1"
   depends_on "readline"
 
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Today I noticed that the `pg` gem was crashing in my ruby app. I am building the `pg` gem with the `libpq` formula and not the `postgresql` formula like most people (I don't need the full server since I run that in docker). Building `pg` with `libpq` is possible with the following bundle config:

```
$ bundle config --global build.pg --with-pg-config=/usr/local/opt/libpq/bin/pg_config
```

I found this PR: https://github.com/Homebrew/homebrew-core/pull/47494 which would explain the problem. The PR stated:

> The `libpq` formula is unaffected because it does not use `--with-gssapi`.

However, `--with-gssapi` was added to `libpq` in https://github.com/Homebrew/homebrew-core/pull/47954.

I tested this change with:
```
# confirmed here that my app is crashing
$ gem uninstall pg
$ brew edit libpq
$ brew reinstall -s libpq
$ bundle install  # this installs the pg gem again
# confirmed here that my app is working fine
```

So I did my tests against the libpq formula only, but I think we may want to add this to all of them. If not, let me know and I can remove it from the other formulas. Also let me know if you want me to remove `revision`.

Thanks!