### PR TITLE
phpmyadmin 5.0.2

### DIFF
--- a/Formula/phpmyadmin.rb
+++ b/Formula/phpmyadmin.rb
@@ -1,8 +1,8 @@
 class Phpmyadmin < Formula
   desc "Web interface for MySQL and MariaDB"
   homepage "https://www.phpmyadmin.net"
-  url "https://files.phpmyadmin.net/phpMyAdmin/5.0.1/phpMyAdmin-5.0.1-all-languages.tar.gz"
-  sha256 "1bd82fdcf5375526c8b5124a20968b69981724307d878321ae29499c61bbf48e"
+  url "https://files.phpmyadmin.net/phpMyAdmin/5.0.2/phpMyAdmin-5.0.2-all-languages.tar.gz"
+  sha256 "8d5cb67de154262b6e51e6ac6967d0931d28ef39cdc7fbec44011d374eb432ae"
 
   bottle :unneeded
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,795,023 bytes
- formula fetch time: 12.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.