### PR TITLE
gtk-doc: fix project url

### DIFF
--- a/Formula/gtk-doc.rb
+++ b/Formula/gtk-doc.rb
@@ -1,6 +1,6 @@
 class GtkDoc < Formula
   desc "GTK+ documentation tool"
-  homepage "https://www.gtk.org/gtk-doc/"
+  homepage "https://gitlab.gnome.org/GNOME/gtk-doc"
   url "https://download.gnome.org/sources/gtk-doc/1.32/gtk-doc-1.32.tar.xz"
   sha256 "de0ef034fb17cb21ab0c635ec730d19746bce52984a6706e7bbec6fb5e0b907c"
 


### PR DESCRIPTION
https://www.gtk.org/gtk-doc/ is gone

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
