### PR TITLE
qt5-sqlcipher 1.0.10 (new formula).

### DIFF
--- a/Formula/qt5-sqlcipher.rb
+++ b/Formula/qt5-sqlcipher.rb
@@ -1,0 +1,29 @@
+class Qt5Sqlcipher < Formula
+  desc "Qt5 SQL driver plugin for SQLCipher"
+  homepage "https://github.com/blizzard4591/qt5-sqlcipher"
+  url "https://github.com/blizzard4591/qt5-sqlcipher/archive/v1.0.10.tar.gz"
+  sha256 "e60206becbe37dc9edcb9bfdc98d794fe612de68818cb81cef95e95193cbd089"
+  head "https://github.com/blizzard4591/qt5-sqlcipher.git", :using => :git, :shallow => false
+
+  depends_on "cmake" => [:build]
+  depends_on "pkg-config" => [:build]
+  depends_on "qt"
+  depends_on "sqlcipher"
+
+  def install
+    args = %w[
+      -DCMAKE_BUILD_TYPE=RELEASE
+      -DQSQLCIPHER_INSTALL_INTO_QT_PLUGIN_DIRECTORY=Off
+    ]
+
+    mktemp do
+      system "cmake", buildpath, *(std_cmake_args + args)
+      system "make", "install"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/qsqlcipher-test")
+    assert_match("Success! All tests completed.", output)
+  end
+end


### PR DESCRIPTION
This is required to be upstreamed for PR #50579 to be accepted.
Audit complains:

- GitHub fork (not canonical repository)
- GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Yes, I forked  this, because the original repo is not maintained anymore, and I have contributed several large changes since then.
As this is required for integrating openMittsu into homebrew (which is notable) enough, I hope this is fine, too.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
