### PR TITLE
bazel: Versioned symlink should bypass the wrapper script.

### DIFF
--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -37,7 +37,7 @@ class Bazel < Formula
              "scripts:bash_completion"
 
       bin.install "scripts/packages/bazel.sh" => "bazel"
-      ln_s bin/"bazel", bin/"bazel-#{version}"
+      ln_s libexec/"bin/bazel-real", bin/"bazel-#{version}"
       (libexec/"bin").install "output/bazel" => "bazel-real"
       bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
 
@@ -75,5 +75,18 @@ class Bazel < Formula
            "--javabase=@bazel_tools//tools/jdk:jdk",
            "//:bazel-test"
     assert_equal "Hi!\n", pipe_output("bazel-bin/bazel-test")
+
+    # Verify that `bazel` invokes Bazel's wrapper script, which delegates to
+    # project-specific `tools/bazel` if present. Invoking `bazel-VERSION`
+    # bypasses this behavior.
+    (testpath/"tools"/"bazel").write <<~EOS
+      #!/bin/bash
+      echo "stub-wrapper"
+      exit 1
+    EOS
+    (testpath/"tools/bazel").chmod 0755
+
+    assert_equal "stub-wrapper\n", shell_output("#{bin}/bazel --version", 1)
+    assert_equal "bazel #{version}-homebrew\n", shell_output("#{bin}/bazel-#{version} --version")
   end
 end

--- a/Formula/bazel.rb
+++ b/Formula/bazel.rb
@@ -3,6 +3,7 @@ class Bazel < Formula
   homepage "https://bazel.build/"
   url "https://github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-dist.zip"
   sha256 "9379878a834d105a47a87d3d7b981852dd9f64bc16620eacd564b48533e169a7"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

PR https://github.com/Homebrew/homebrew-core/pull/48237 added a new installation file to the `bazel` formula, a versioned symlink such that `bazel-2.2.0` would point to the Bazel installed by Homebrew at version v2.2.0. But there's a problem -- the symlink is pointing to Bazel's wrapper script, which does not guarantee any particular version will actually be used.

This causes two issues:
* First, running `bazel-2.2.0` can actually run any arbitrary Bazel version depending on the presence and contents of the Bazel workspace's `tools/bazel` file. This can be extremely confusing to users.
* Second, and worse, wrapper scripts that themselves try to pin a version can end up invoking something like `exec "bazel-${some_bazel_version}"`, which in the presence of these new symlinks will cause an infinite loop.

This PR fixes the issue by making the versioned symlink point to the `bazel-real` installed file, which is the actual Mach-O executable for that version. Well, technically it's a second wrapper script (Homebrew's for Java versioning) but close enough.

cc @bartle-stripe