### PR TITLE
curl: build with HTTP/2 support

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -22,8 +22,9 @@ class Curl < Formula
   keg_only :provided_by_macos
 
   depends_on "pkg-config" => :build
+  depends_on "nghttp2"
+  depends_on "openssl@1.1"
 
-  uses_from_macos "openssl"
   uses_from_macos "zlib"
 
   def install
@@ -35,6 +36,7 @@ class Curl < Formula
       --disable-silent-rules
       --prefix=#{prefix}
       --with-secure-transport
+      --with-nghttp2
       --without-ca-bundle
       --without-ca-path
     ]


### PR DESCRIPTION
`curl(1)` installed by homebrew does not support HTTP/2, whereas the macOS-bundled version does. I think there is no reason not to support HTTP/2 in 2020, so I'd like to add `--with-nghttp2` to enable HTTP/2 support for curl.

This PR also uses `openssl@1.1` installed by homebrew, because nghttp2 does so:

https://github.com/Homebrew/homebrew-core/blob/2fab2c02eddeca06fa59e1fa9f38c9947bf5389c/Formula/nghttp2.rb#L29


---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

