### PR TITLE
Fix manpage/completion installs for bat formula

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -3,6 +3,7 @@ class Bat < Formula
   homepage "https://github.com/sharkdp/bat"
   url "https://github.com/sharkdp/bat/archive/v0.13.0.tar.gz"
   sha256 "f4aee370013e2a3bc84c405738ed0ab6e334d3a9f22c18031a7ea008cd5abd2a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -19,8 +19,9 @@ class Bat < Formula
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
-    man1.install "target/release/build/bat-df82c97c3bd64ddc/out/assets/manual/bat.1"
-    fish_completion.install "target/release/build/bat-df82c97c3bd64ddc/out/assets/completions/bat.fish"
+    assets_dir = Dir["target/release/build/bat-*/out/assets"].first
+    man1.install "#{assets_dir}/manual/bat.1"
+    fish_completion.install "#{assets_dir}/completions/bat.fish"
   end
 
   test do

--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -19,13 +19,8 @@ class Bat < Formula
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
 
-    # In https://github.com/sharkdp/bat/pull/673,
-    # documentation and fish autocompletion got parameterized
-    inreplace "assets/manual/bat.1.in", "{{PROJECT_EXECUTABLE | upcase}}", "bat"
-    inreplace "assets/manual/bat.1.in", "{{PROJECT_EXECUTABLE}}", "bat"
-    inreplace "assets/completions/bat.fish.in", "{{PROJECT_EXECUTABLE}}", "bat"
-    man1.install "assets/manual/bat.1.in" => "bat.1"
-    fish_completion.install "assets/completions/bat.fish.in" => "bat.fish"
+    man1.install "target/release/build/bat-df82c97c3bd64ddc/out/assets/manual/bat.1"
+    fish_completion.install "target/release/build/bat-df82c97c3bd64ddc/out/assets/completions/bat.fish"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This picks up from where #52022 landed, and adjusts things to play more nicely.

This uses the manpage & fish completion that the install generates itself, instead of trying to hack a way to get the right files made.