### PR TITLE
pandoc 2.9.2.1

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -5,8 +5,8 @@ class Pandoc < Formula
 
   desc "Swiss-army knife of markup format conversion"
   homepage "https://pandoc.org/"
-  url "https://hackage.haskell.org/package/pandoc-2.9.2/pandoc-2.9.2.tar.gz"
-  sha256 "320d76bdaaafc88aa71167e527e79158b2184482cdc712aca66d30b33f5f3cb9"
+  url "https://hackage.haskell.org/package/pandoc-2.9.2.1/pandoc-2.9.2.1.tar.gz"
+  sha256 "c26d35372cf8b7d53062c9c495c0bca2ee370891c2349d3798a44f9ca33bdf57"
   head "https://github.com/jgm/pandoc.git"
 
   bottle do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,586,844 bytes
- formula fetch time: 1.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.