### PR TITLE
git-annex: demote xdot to optional dep

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -22,7 +22,6 @@ class GitAnnex < Formula
   depends_on "gsasl"
   depends_on "libmagic"
   depends_on "quvi"
-  depends_on "xdot"
 
   def install
     install_cabal_package "--constraint", "http-conduit>=2.3",


### PR DESCRIPTION
`xdot` depends on `gtk+3`, which pulls in all of the core X libraries. And it's used only by a utility command, [`git-annex-map`](https://git-annex.branchable.com/git-annex-map/).

This change brings the xdot dependency in line with upstream's [Debian package dependencies](http://source.git-annex.branchable.com/?p=source.git;a=blob;f=debian/control;h=06d9f9f044d3bcbb66ab094f5fbb7ae4b92c66a6;hb=HEAD#l115).

This PR does not address the other inconsistencies in the dependencies (e.g., upstream is now using `youtube-dl` instead of `quvi`).
