### PR TITLE
deno 0.38.0

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -1,8 +1,8 @@
 class Deno < Formula
   desc "Command-line JavaScript / TypeScript engine"
   homepage "https://deno.land/"
-  url "https://github.com/denoland/deno/releases/download/v0.36.0/deno_src.tar.gz"
-  sha256 "23de3e13b87e40ac4cbd0d8f0362cf1afc50980f5226f381d3f44c67e603727e"
+  url "https://github.com/denoland/deno/releases/download/v0.38.0/deno_src.tar.gz"
+  sha256 "6973fafcedbd7c3aef26dd9f6afb9cbd64c623190f3ecf4a32eccc2311cb0ff6"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -24,7 +24,7 @@ class Deno < Formula
 
   resource "gn" do
     url "https://gn.googlesource.com/gn.git",
-      :revision => "a5bcbd726ac7bd342ca6ee3e3a006478fd1f00b5"
+      :revision => "fd3d768bcfd44a8d9639fe278581bd9851d0ce3a"
   end
 
   def install
@@ -37,6 +37,13 @@ class Deno < Formula
 
     # env args for building a release build with our clang, ninja and gn
     ENV["GN"] = buildpath/"gn/out/gn"
+    # Ensure build rust_v8 from the source
+    ENV["V8_FROM_SOURCE"] = "1"
+    # Chromium has decided to require the 10.15 sdk in their build config
+    ENV["FORCE_MAC_SDK_MIN"] = "10.13"
+    # Set no_inline_line_tables to false as required for custom (non-Chromium) `clang` builds.
+    ENV["GN_ARGS"] = "no_inline_line_tables=false"
+
     if DevelopmentTools.clang_build_version < 1100
       # build with llvm and link against system libc++ (no runtime dep)
       ENV["CLANG_BASE_PATH"] = Formula["llvm"].prefix


### PR DESCRIPTION
Created with:

    brew bump-formula-pr \
      --url=https://github.com/denoland/deno/releases/download/v0.37.1/deno_src.tar.gz \
      deno

Release notes:
- [deno@v0.37.0](https://github.com/denoland/deno/releases/tag/v0.37.0)
- [deno@v0.37.1](https://github.com/denoland/deno/releases/tag/v0.37.1)
- [deno@v0.38.0](https://github.com/denoland/deno/releases/tag/v0.38.1)
