### PR TITLE
algernon: add version_scheme back

### DIFF
--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -3,6 +3,7 @@ class Algernon < Formula
   homepage "https://algernon.roboticoverlords.org/"
   url "https://github.com/xyproto/algernon/archive/1.12.7.tar.gz"
   sha256 "1e04be1274b875a90f3ca1b5685f0e2c2df79ae3b798a1c56395d0b5b5b686b3"
+  version_scheme 1
   head "https://github.com/xyproto/algernon.git"
 
   bottle do


### PR DESCRIPTION
This was removed by mistake in a0bf531eb6c47c7719ec700f48e394e3457e029b

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
