### PR TITLE
percona-toolkit: fix segfault for system perl

### DIFF
--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -3,7 +3,7 @@ class PerconaToolkit < Formula
   homepage "https://www.percona.com/software/percona-toolkit/"
   url "https://www.percona.com/downloads/percona-toolkit/3.1.0/source/tarball/percona-toolkit-3.1.0.tar.gz"
   sha256 "722593773825efe7626ff0b74de6a2133483c9c89fd7812bfe440edaacaec9cc"
-  revision 1
+  revision 2
   head "lp:percona-toolkit", :using => :bzr
 
   bottle do
@@ -53,10 +53,12 @@ class PerconaToolkit < Formula
     # Disable dynamic selection of perl which may cause segfault when an
     # incompatible perl is picked up.
     # https://github.com/Homebrew/homebrew-core/issues/4936
-    non_perl_files = %w[bin/pt-ioprofile bin/pt-mext bin/pt-mysql-summary
-                        bin/pt-pmp bin/pt-sift bin/pt-stalk bin/pt-summary]
-    perl_files = Dir["bin/*"] - non_perl_files
-    inreplace perl_files, "#!/usr/bin/env perl", "#!/usr/bin/perl"
+    bin.find do |f|
+      next unless f.file?
+      next unless f.read("#!/usr/bin/env perl".length) == "#!/usr/bin/env perl"
+
+      inreplace f, "#!/usr/bin/env perl", "#!/usr/bin/perl"
+    end
 
     bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR contains a proper fix for system Perl segfault when homebrews Perl is installed.
The first attempt was made in https://github.com/Homebrew/homebrew-core/pull/51180, but I've made a mistake: 

https://github.com/Homebrew/homebrew-core/blob/6d9a2434df8120c4d5b9433c1c15349a424d3262/Formula/percona-toolkit.rb#L56-L58

It should be `Dir["#{bin}/*"]` instead of `Dir["bin/*"]`.

Also, this PR improves the logic of shebang rewrites.

Fixes https://github.com/Homebrew/homebrew-core/issues/52126