### PR TITLE
perkeep: depend on go@1.10

### DIFF
--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -13,14 +13,14 @@ class Perkeep < Formula
     sha256 "e4e42c68017500af8a8aa7b542e89905849b09b398a547da818323f08a6e680a" => :el_capitan
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.10" => :build
   depends_on "pkg-config" => :build
 
   conflicts_with "hello", :because => "both install `hello` binaries"
 
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/perkeep.org").install buildpath.children
+    (buildpath/"src/perkeep.org").install buildpath.children - [buildpath/".brew_home"]
     cd "src/perkeep.org" do
       system "go", "run", "make.go"
       prefix.install_metafiles


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Also exclude moving `.brew_home`, so we get better errors.

> You're using go1.14 != go1.10, which GopherJS requires, and it was not found in /private/tmp/perkeep-20200325-3472-1e6w9i3/.brew_home. You need to specify a go1.10 root in CAMLI_GOPHERJS_GOROOT for building GopherJS.