### PR TITLE
prest: remove GOPATH, fix version under newer Go

### DIFF
--- a/Formula/prest.rb
+++ b/Formula/prest.rb
@@ -15,14 +15,11 @@ class Prest < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/prest/prest").install buildpath.children
-    cd "src/github.com/prest/prest" do
-      system "go", "build", "-ldflags",
-             "-X github.com/prest/prest/vendor/github.com/prest/helpers.PrestVersionNumber=#{version}",
-             "-o", bin/"prest"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-ldflags",
+           "-s -w -X github.com/prest/helpers.PrestVersionNumber=#{version}",
+           "-trimpath",
+           "-o", bin/"prest"
+    prefix.install_metafiles
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes a test failure when building from source. Existing bottles are not affected.