### PR TITLE
Build ffmpeg without stack check to fix segfault on Catalina

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -88,6 +88,7 @@ class Ffmpeg < Formula
       --enable-videotoolbox
       --disable-libjack
       --disable-indev=jack
+      --extra-cflags="-fno-stack-check"
     ]
 
     system "./configure", *args


### PR DESCRIPTION
ffmpeg fails with segmentation fault on Catalina. 

Discussion in the ffmpeg bug tracker suggests disabling stack check: 
https://trac.ffmpeg.org/ticket/8073.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
