### PR TITLE
R: explicitly disable Tcl/Tk support

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -3,7 +3,7 @@ class R < Formula
   homepage "https://www.r-project.org/"
   url "https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz"
   sha256 "89302990d8e8add536e12125ec591d6951022cf8475861b3690bc8bf1cefaa8f"
-  revision 2
+  revision 1
 
   bottle do
     sha256 "87a9a56265163f342725418365989afbdab02abc997df0304e403034094f1117" => :catalina

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -3,7 +3,7 @@ class R < Formula
   homepage "https://www.r-project.org/"
   url "https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz"
   sha256 "89302990d8e8add536e12125ec591d6951022cf8475861b3690bc8bf1cefaa8f"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "87a9a56265163f342725418365989afbdab02abc997df0304e403034094f1117" => :catalina
@@ -41,6 +41,7 @@ class R < Formula
       "--prefix=#{prefix}",
       "--enable-memory-profiling",
       "--without-cairo",
+      "--without-tcltk",
       "--without-x",
       "--with-aqua",
       "--with-lapack",


### PR DESCRIPTION
Today, R is explicitly built without X11 support via `--without-x`. However, if Tcl/Tk is detected somewhere in the user's environment then R will try to build with Tcl/Tk support, yet X11 is required to build with Tcl/Tk support. This can cause build failures (see below).

As the intention seems to be to build R without Tcl/Tk support (the `R` formula does not depend on the `tcl-tk` formula), this PR explicitly disables Tcl/Tk support.

# Example

## Before change

```
% brew install R
==> Downloading https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz
Already downloaded: /Users/foo/Library/Caches/Homebrew/downloads/9506581d8e100d1a61e223bb75592a87462e111a2b197fef678891ec48b91e88--R-3.6.3.tar.gz
==> ./configure --prefix=/Users/foo/.prefix/sw/homebrew/Cellar/r/3.6.3_1 --enable-memory-profiling --without-cairo --without-x --with-aqua --with-lapack --enable-R-shlib SED=/usr/bin/sed --disable-java --with-blas=-L/Users/foo/.prefix/sw/homebrew/opt/openblas/lib -lopenblas
==> make
Last 15 lines from /Users/foo/Library/Logs/Homebrew/r/02.make:
#   include <X11/Xlib.h>
            ^~~~~~~~~~~~
1 error generated.
make[4]: *** [tcltk.d] Error 1
make[4]: *** Waiting for unfinished jobs....
In file included from tcltk.c:670:
/usr/local/include/tk.h:96:13: fatal error: 'X11/Xlib.h' file not found
#   include <X11/Xlib.h>
            ^~~~~~~~~~~~
1 error generated.
make[4]: *** [tcltk.o] Error 1
make[3]: *** [all] Error 1
make[2]: *** [R] Error 1
make[1]: *** [R] Error 1
make: *** [R] Error 1
```

## After change

```
% brew install R
==> Downloading https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz
Already downloaded: /Users/foo/Library/Caches/Homebrew/downloads/9506581d8e100d1a61e223bb75592a87462e111a2b197fef678891ec48b91e88--R-3.6.3.tar.gz
==> ./configure --prefix=/Users/foo/.prefix/sw/homebrew/Cellar/r/3.6.3_1 --enable-memory-profiling --without-cairo --without-tcltk --without-x --with-aqua --with-lapack --enable-R-shlib SED=/usr/bin/sed --disable-java --with-blas=-L/Users/foo/.prefix/sw/homebrew/opt/openblas/lib -lopenblas
==> make
==> make install
==> make
==> make install
🍺  /Users/foo/.prefix/sw/homebrew/Cellar/r/3.6.3_1: 2,122 files, 58.2MB, built in 8 minutes 31 seconds
```

- [✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
