### PR TITLE
oauth2_proxy 5.0.0

### DIFF
--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -1,9 +1,9 @@
 class Oauth2Proxy < Formula
   desc "Reverse proxy for authenticating users via OAuth 2 providers"
-  homepage "https://github.com/bitly/oauth2_proxy"
-  url "https://github.com/bitly/oauth2_proxy/archive/v2.2.tar.gz"
-  sha256 "dae9bae213ccf2a98bf36177e04c1edf4688989c58c383525258956679ddcc19"
-  head "https://github.com/bitly/oauth2_proxy.git"
+  homepage "https://pusher.github.io/oauth2_proxy"
+  url "https://github.com/pusher/oauth2_proxy/archive/v5.0.0.tar.gz"
+  sha256 "a775357f3a8952da2495b423765fe7d77e2fbbe4c9282fc28e910642e27caafb"
+  head "https://github.com/pusher/oauth2_proxy.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,17 +15,13 @@ class Oauth2Proxy < Formula
   end
 
   depends_on "go" => :build
-  depends_on "gpm" => :build
 
   def install
-    mkdir_p "#{buildpath}/src/github.com/bitly"
-    ln_s buildpath, "#{buildpath}/src/github.com/bitly/oauth2_proxy"
-
-    ENV["GOPATH"] = buildpath
-
-    system "gpm", "install"
-    system "go", "build", "-o", "#{bin}/oauth2_proxy"
+    system "go", "build", "-ldflags", "-s -w -X main.VERSION=#{version}",
+                          "-trimpath",
+                          "-o", bin/"oauth2_proxy"
     (etc/"oauth2_proxy").install "contrib/oauth2_proxy.cfg.example"
+    bash_completion.install "contrib/oauth2_proxy_autocomplete.sh" => "oauth2_proxy"
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note that this switches to a fork. This fork was [endorsed](https://github.com/bitly/oauth2_proxy/blob/master/README.md) by Bitly just before they archived the repo. It is the "official hard fork". Bitly no longer maintain their version of oauth2_proxy and are directing people to submit issues and pull requests to the said fork.