### PR TITLE
Changes Manual Run Command in Info for postgresql

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -89,7 +89,8 @@ class Postgresql < Formula
     EOS
   end
 
-  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres start"
+  plist_options :manual => "brew services run postgres # starts postgres, will not auto start in future\n"\
+                            "  brew services stop postgres # stops postgres"
 
   def plist
     <<~EOS


### PR DESCRIPTION
Changes the command displayed when `brew info postgresql` is run to the run implementation of brew services.
Additionally displays the command to stop the service after it was started as prescribed.

I use two different brew services all the time when I'm developing, postgresql and redis, I was struck by the differences in instructions for running these two services manually. Because brew services supports running the service without auto starting in the future, I think this is the best approach for both these services, and I think they should be consistent.
I included the stop command even though this is not a Homebrew standard because I think it can be helpful.

Please note this is my very first (and very minor) contribution to Homebrew, I have not made a similar change to the redis formula but I will (famous last words) if this pr is welcomed and accepted.

- [ ✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [✅ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [✅ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
