### PR TITLE
wxmac 3.1.3

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -3,7 +3,7 @@ class DiffPdf < Formula
   homepage "https://vslavik.github.io/diff-pdf/"
   url "https://github.com/vslavik/diff-pdf/releases/download/v0.4.1/diff-pdf-0.4.1.tar.gz"
   sha256 "0eb81af6b06593488acdc5924a199f74fe3df6ecf2a0f1be208823c021682686"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -4,6 +4,7 @@ class Erlang < Formula
   # Download tarball from GitHub; it is served faster than the official tarball.
   url "https://github.com/erlang/otp/archive/OTP-22.3.2.tar.gz"
   sha256 "4a3719c71a7998e4f57e73920439b4b1606f7c045e437a0f0f9f1613594d3eaa"
+  revision 1
   head "https://github.com/erlang/otp.git"
 
   bottle do

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -4,6 +4,7 @@ class ErlangAT20 < Formula
   # Download tarball from GitHub; it is served faster than the official tarball.
   url "https://github.com/erlang/otp/archive/OTP-20.3.8.26.tar.gz"
   sha256 "dce78b60938a48b887317e5222cff946fd4af36666153ab2f0f022aa91755813"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -4,6 +4,7 @@ class ErlangAT21 < Formula
   # Download tarball from GitHub; it is served faster than the official tarball.
   url "https://github.com/erlang/otp/archive/OTP-21.3.8.14.tar.gz"
   sha256 "036583f8e6aa539c89db2a32b8524366446c7f6f99b11999bb9eea69a7ce80fd"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/gambit.rb
+++ b/Formula/gambit.rb
@@ -3,6 +3,7 @@ class Gambit < Formula
   homepage "http://www.gambit-project.org"
   url "https://github.com/gambitproject/gambit/archive/v16.0.1.tar.gz"
   sha256 "56bb86fd17575827919194e275320a5dd498708fd8bb3b20845243d492c10fef"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/homeworlds.rb
+++ b/Formula/homeworlds.rb
@@ -3,6 +3,7 @@ class Homeworlds < Formula
   homepage "https://github.com/Quuxplusone/Homeworlds/"
   url "https://github.com/Quuxplusone/Homeworlds.git",
     :revision => "917cd7e7e6d0a5cdfcc56cd69b41e3e80b671cde"
+  revision 1
   version "20141022"
 
   bottle do

--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -3,6 +3,7 @@ class ScummvmTools < Formula
   homepage "https://www.scummvm.org/"
   url "https://www.scummvm.org/frs/scummvm-tools/2.1.0/scummvm-tools-2.1.0.tar.xz"
   sha256 "cfc62d285d0e304061db72691cdfb8ce4ead868cffb2658b1f1c81934f404665"
+  revision 1
   head "https://github.com/scummvm/scummvm-tools.git"
 
   bottle do

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -3,7 +3,7 @@ class SpatialiteGui < Formula
   homepage "https://www.gaia-gis.it/fossil/spatialite_gui/index"
   url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-1.7.1.tar.gz"
   sha256 "cb9cb1ede7f83a5fc5f52c83437e556ab9cb54d6ace3c545d31b317fd36f05e4"
-  revision 6
+  revision 7
 
   bottle do
     cellar :any

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,9 +1,8 @@
 class Wxmac < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2"
-  sha256 "96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"
-  revision 2
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2"
+  sha256 "fffc1d34dac54ff7008df327907984b156c50cff5a2f36ee3da6052744ab554a"
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   bottle do
@@ -17,11 +16,6 @@ class Wxmac < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-
-  # Adjust assertion which fails for wxGLCanvas due to changes in macOS 10.14.
-  # Patch taken from upstream WX_3_0_BRANCH:
-  # https://github.com/wxWidgets/wxWidgets/commit/531fdbcb64b265e6f24f1f0cc7469f308b9fb697
-  patch :DATA
 
   def install
     args = [
@@ -64,29 +58,3 @@ class Wxmac < Formula
     system bin/"wx-config", "--libs"
   end
 end
-
-__END__
---- a/src/osx/carbon/dcclient.cpp
-+++ b/src/osx/carbon/dcclient.cpp
-@@ -189,10 +189,20 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner )
- {
- }
-
-+#if wxDEBUG_LEVEL
-+static bool IsGLCanvas( wxWindow * window )
-+{
-+    // If the wx gl library isn't loaded then ciGLCanvas will be NULL.
-+    static const wxClassInfo* const ciGLCanvas = wxClassInfo::FindClass("wxGLCanvas");
-+    return ciGLCanvas && window->IsKindOf(ciGLCanvas);
-+}
-+#endif
-+
- wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *window ) :
-     wxWindowDCImpl( owner, window )
- {
--    wxASSERT_MSG( window->MacGetCGContextRef() != NULL, wxT("using wxPaintDC without being in a native paint event") );
-+    // With macOS 10.14, wxGLCanvas windows have a NULL CGContextRef.
-+    wxASSERT_MSG( window->MacGetCGContextRef() != NULL || IsGLCanvas(window), wxT("using wxPaintDC without being in a native paint event") );
-     wxPoint origin = window->GetClientAreaOrigin() ;
-     m_window->GetClientSize( &m_width , &m_height);
-     SetDeviceOrigin( origin.x, origin.y );

--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -3,6 +3,7 @@ class Wxmaxima < Formula
   homepage "https://wxmaxima-developers.github.io/wxmaxima/"
   url "https://github.com/wxMaxima-developers/wxmaxima/archive/Version-20.03.1.tar.gz"
   sha256 "2a06fdf235276cf30c1fc5a64b0e0965e5bd843610d4dc599bf7c63c0ea985bb"
+  revision 1
   head "https://github.com/wxMaxima-developers/wxmaxima.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Need help getting newer wxwidgets v3.1.0 to compile, so that BOINC developers can start using this formula. The current build error is:

```console
$ brew install -s wxwidgets
fatal: Needed a single revision
invalid upstream 'origin/master'
==> Downloading https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/1764
######################################################################## 100.0%
==> Patching
patching file src/osx/carbon/dcclient.cpp
Hunk #1 succeeded at 149 (offset -40 lines).
==> ./configure --prefix=/usr/local/Cellar/wxmac/3.1.0_2 --enable-clipboard --enable-cont
==> make install
Last 15 lines from /Users/andrew/Library/Logs/Homebrew/wxmac/02.make:
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_utils_osx.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/utils_osx.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_window_osx.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/window_osx.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_core_bitmap.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/bitmap.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_core_colour.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/colour.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_core_dcmemory.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/dcmemory.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_core_display.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/display.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_core_fontenum.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/fontenum.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_hid.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/hid.cpp
/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/bk-deps clang++ -mmacosx-version-min=10.15 -c -o coredll_printmac.o  -D__WXOSX_COCOA__      -DWXBUILDING      -I./src/regex  -DWXUSINGDLL -DWXMAKINGDLL_CORE -DwxUSE_BASE=0 -dynamic -fPIC -DPIC -Wall -Wundef -Wunused-parameter -Wno-ctor-dtor-privacy -Woverloaded-virtual -Wno-deprecated-declarations -D_FILE_OFFSET_BITS=64 -I/private/tmp/wxmac-20200326-41381-1h92oys/wxWidgets-3.1.0/lib/wx/include/osx_cocoa-unicode-3.1 -I./include -O2 -fno-common -fvisibility=hidden -fvisibility-inlines-hidden ./src/osx/core/printmac.cpp
./src/osx/core/bitmap.cpp:977:5: error: use of undeclared identifier 'verify_noerr'
    verify_noerr( AcquireIconRef(icon) );
    ^
1 error generated.
make: *** [coredll_core_bitmap.o] Error 1
make: *** Waiting for unfinished jobs....

READ THIS: https://docs.brew.sh/Troubleshooting
```