### PR TITLE
Changes Manual Run Command in Info for Redis

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -31,7 +31,8 @@ class Redis < Formula
     etc.install "sentinel.conf" => "redis-sentinel.conf"
   end
 
-  plist_options :manual => "redis-server #{HOMEBREW_PREFIX}/etc/redis.conf"
+  plist_options :manual => "brew services start redis # starts redis, will not auto start in future\n"\
+                            "  brew services stop redis # stops redis"
 
   def plist
     <<~EOS


### PR DESCRIPTION
Changes the command displayed when `brew info redis` is run to the run implementation of brew services.
Additionally displays the command to stop the service after it was started as prescribed.

I use two different brew services all the time when I'm developing, postgresql and redis. I don't want them running all the time, because I often use my machine for extended periods when I am not actively developing and I like to conserve battery and ram. I was struck by the differences in instructions for running these two services manually. Because brew services supports running the service without auto starting in the future, I think this is the best approach for both these services, and I think they should be consistent. 

I included the stop command even though this is not a Homebrew standard because I think it can be helpful.

I realize that this is a potentially whole can of worms with various services. I'm not sure if there has been any high level discussion as to a direction for these instructions, but I am in favor of a standard method across the board to the extent possible.

I have a nearly [identical PR open for postgresql](https://github.com/Homebrew/homebrew-core/pull/52175)



- [ ✅] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ✅] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ✅] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ✅] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ✅] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
