### PR TITLE
fish: backport fix to svn prompt

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -3,6 +3,7 @@ class Fish < Formula
   homepage "https://fishshell.com"
   url "https://github.com/fish-shell/fish-shell/releases/download/3.1.0/fish-3.1.0.tar.gz"
   sha256 "e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,6 +22,14 @@ class Fish < Formula
   depends_on "pcre2"
 
   uses_from_macos "ncurses"
+
+  # Fixes severe performance issues with one of the default prompt
+  # integrations. This has already been applied upstream and will
+  # be in the next release.
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/8743c955ae8809f692c92ef6b4bc78595bf98f50/fish/disable_svn_prompt.patch"
+    sha256 "953dfc21f45575022d8f47c8654da1908682de1711712a60d4220e3a4c8133b9"
+  end
 
   def install
     # In Homebrew's 'superenv' sed's path will be incompatible, so


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There's a severe performance issue with Fish's default prompt, specifically in its svn support. This was disabled by default upstream; this backports the patch. https://github.com/fish-shell/fish-shell/commit/0f34459fcef6fade5811c5efa9eacae2898f343e