### PR TITLE
jemalloc: backport upstream type fix

### DIFF
--- a/Formula/jemalloc.rb
+++ b/Formula/jemalloc.rb
@@ -3,6 +3,7 @@ class Jemalloc < Formula
   homepage "http://jemalloc.net/"
   url "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
   sha256 "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,14 @@ class Jemalloc < Formula
 
     depends_on "autoconf" => :build
     depends_on "docbook-xsl" => :build
+  end
+
+  # Fixes an issue where jemalloc's types conflict with the system
+  # types, preventing their use. Merged upstream.
+  # https://github.com/jemalloc/jemalloc/commit/3b4a03b92b2e415415a08f0150fdb9eeb659cd52
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/d3d5ad2b5683c1a435a185eec9c593749c7ca41a/jemalloc/fix_nothrow_type.patch"
+    sha256 "d79f5c8767695059ff541f291db3fbc57c9b67299dc129848dd365c2f51b214a"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is important with the new macOS/CLT release, which exposes an issue that's causing many users' jemalloc-based builds to fail.