### PR TITLE
swift-format 5.2

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -1,8 +1,8 @@
 class SwiftFormat < Formula
   desc "Formatting technology for Swift source code"
   homepage "https://github.com/apple/swift-format"
-  url "https://github.com/apple/swift-format.git", :revision => "fc5a3da1d5d03143d7a31b12514349e2bf1aba8f"
-  version "5.1"
+  url "https://github.com/apple/swift-format.git", :revision => "5cdf916a09ee8b581ff348c0e395b221d02d253b"
+  version "5.2"
   head "https://github.com/apple/swift-format.git"
 
   bottle do

--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -11,7 +11,7 @@ class SwiftFormat < Formula
     sha256 "bab43b73e8322b8acf5478f282bc6b8f019632569dfb0f487715c2633ba869c8" => :mojave
   end
 
-  depends_on :xcode => ["11.0", :build]
+  depends_on :xcode => ["11.4", :build]
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"


### PR DESCRIPTION
Formula was recently added in https://github.com/Homebrew/homebrew-core/pull/51347 but broke when Xcode 11.4 shipped yesterday. See https://github.com/apple/swift-format/pull/163.

```
$ swift-format Foo.swift
Unable to format Foo.swift: SwiftSyntax parser library isn't compatible
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

CC: @pcr910303 @SMillerDev @chenrui333