### PR TITLE
joplin: use brewed libs

### DIFF
--- a/Formula/joplin.rb
+++ b/Formula/joplin.rb
@@ -5,6 +5,7 @@ class Joplin < Formula
   homepage "https://joplin.cozic.net/"
   url "https://registry.npmjs.org/joplin/-/joplin-1.0.161.tgz"
   sha256 "e5a277075d672fcb0a6d22e8de4794dc14f2602d460c35a51e69d0ff7ecbfac1"
+  revision 1
 
   bottle do
     sha256 "c0c365534133c7f48e9e015a9279e7f719331f62a07e2bcadb284934092d30a5" => :catalina
@@ -12,10 +13,14 @@ class Joplin < Formula
     sha256 "956a5a259965459dd343bb9cc9f85a9c221b4f337216f399030386bc130ab463" => :high_sierra
   end
 
+  depends_on "pkg-config" => :build
   depends_on "node"
+  depends_on "sqlite"
+  depends_on "vips"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec),
+                             "--sqlite=#{Formula["sqlite"].opt_prefix}"
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION
* The node module `sharp` ships with prebuilt libraries for vips and its dependencies. This is not acceptable in homebrew-core.
* The node module `sqlite3` builds its own version of sqlite3. Let's make it use brewed sqlite3 instead.