### PR TITLE
fish: Only apply patch on non-HEAD installs

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -26,9 +26,11 @@ class Fish < Formula
   # Fixes severe performance issues with one of the default prompt
   # integrations. This has already been applied upstream and will
   # be in the next release.
-  patch do
-    url "https://github.com/Homebrew/formula-patches/raw/8743c955ae8809f692c92ef6b4bc78595bf98f50/fish/disable_svn_prompt.patch"
-    sha256 "953dfc21f45575022d8f47c8654da1908682de1711712a60d4220e3a4c8133b9"
+  unless build.head?
+    patch do
+      url "https://github.com/Homebrew/formula-patches/raw/8743c955ae8809f692c92ef6b4bc78595bf98f50/fish/disable_svn_prompt.patch"
+      sha256 "953dfc21f45575022d8f47c8654da1908682de1711712a60d4220e3a4c8133b9"
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes the following issue introduced in https://github.com/Homebrew/homebrew-core/pull/52181:

```
==> Upgrading fish HEAD-1406d63 -> HEAD-23339ae_1
==> Cloning https://github.com/fish-shell/fish-shell.git
Updating /Users/george/Library/Caches/Homebrew/fish--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 23339ae1 added mysql completions
==> Downloading https://github.com/Homebrew/formula-patches/raw/8743c955ae8809f692c92ef6b4bc78595bf98f50/fish/disable_svn_prompt.patch
==> Downloading from https://raw.githubusercontent.com/Homebrew/formula-patches/8743c955ae8809f692c92ef6b4bc78595bf98f50/fish/disable_svn_prompt.patch
######################################################################## 100.0%
==> Patching
==> Applying disable_svn_prompt.patch
patching file share/functions/fish_vcs_prompt.fish
Hunk #1 FAILED at 3.
1 out of 1 hunk FAILED -- saving rejects to file share/functions/fish_vcs_prompt.fish.rej
Error: Failure while executing; `patch -g 0 -f -p1 -i /private/tmp/fish--patch-20200328-11193-g6aa8g/disable_svn_prompt.patch` exited with 1.
```

---

Ping @mistydemeo 