### PR TITLE
git: stop installing zsh completion

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -118,11 +118,10 @@ class Git < Formula
       git_core.install "git-subtree"
     end
 
-    # install the completion script first because it is inside "contrib"
+    # Install the bash completion script first because it is inside "contrib".
+    # Zsh ships with better git completion out of the box.
     bash_completion.install "contrib/completion/git-completion.bash"
     bash_completion.install "contrib/completion/git-prompt.sh"
-    zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
-    cp "#{bash_completion}/git-completion.bash", zsh_completion
 
     elisp.install Dir["contrib/emacs/*.el"]
     (share/"git-core").install "contrib"


### PR DESCRIPTION
Zsh ships with better completion for git and it works out of the box (as
long as completion works at all). There probably was some reason for the
git-completion.zsh script back in 2013, but with Zsh 5.x there is none.

See
https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_git

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The test fails on my machine due to `fatal: unable to auto-detect email address`. This change doesn't affect the test, though. Should I also edit the test to make it pass?