### PR TITLE
monero: add protobuf and hidapi dependecy

### DIFF
--- a/Formula/monero.rb
+++ b/Formula/monero.rb
@@ -4,6 +4,7 @@ class Monero < Formula
   url "https://github.com/monero-project/monero.git",
       :tag      => "v0.15.0.5",
       :revision => "17ec003c06eb95207c91f0e9186889f83266e461"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,8 +16,10 @@ class Monero < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
+  depends_on "hidapi"
   depends_on "libsodium"
   depends_on "openssl@1.1"
+  depends_on "protobuf"
   depends_on "readline"
   depends_on "unbound"
   depends_on "zeromq"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While they are not required for compilation, adding these dependencies enables hardware wallet support for monero (cryptocurrency). The binaries on getmonero.org (official website) are compiled with hardware wallet support, so adding them here too is probably good to avoid confusion.