### PR TITLE
Vert.x 3.9.0

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,11 +1,11 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.8.5-full.tar.gz"
-  sha256 "ce21b4846f1ad485cdba76cc65690be9ec254c5db12cd57bab2cc8ee73ab9806"
-  revision 1
+  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.9.0-full.tar.gz"
+  sha256 "d00c138a1a43c7daf2d4a6a6b747f5c56989018edc4d210bc1b008e87548124c"
 
   bottle :unneeded
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
Update the vert.x formula to 3.9.0.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The https://vertx.io web site is not yet updated as homebrew is part of the release process.