### PR TITLE
innoextract: don't patch when using HEAD version

### DIFF
--- a/Formula/innoextract.rb
+++ b/Formula/innoextract.rb
@@ -1,9 +1,18 @@
 class Innoextract < Formula
   desc "Tool to unpack installers created by Inno Setup"
   homepage "https://constexpr.org/innoextract/"
-  url "https://constexpr.org/innoextract/files/innoextract-1.8.tar.gz"
-  sha256 "5e78f6295119eeda08a54dcac75306a1a4a40d0cb812ff3cd405e9862c285269"
   head "https://github.com/dscharrer/innoextract.git"
+  stable do
+    url "https://constexpr.org/innoextract/files/innoextract-1.8.tar.gz"
+    sha256 "5e78f6295119eeda08a54dcac75306a1a4a40d0cb812ff3cd405e9862c285269"
+
+    # Boost 1.70+ compatibility. Remove with next release. b47f46 is
+    # already in master.
+    patch do
+      url "https://github.com/dscharrer/innoextract/commit/b47f46102bccf1d813ca159230029b0cd820ceff.patch?full_index=1"
+      sha256 "92d321d552a65e16ae6df992a653839fb19de79aa77388c651bf57b3c582d546"
+    end
+  end
 
   bottle do
     cellar :any
@@ -15,12 +24,6 @@ class Innoextract < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "xz"
-
-  # Boost 1.70+ compatibility. Remove with next release.
-  patch do
-    url "https://github.com/dscharrer/innoextract/commit/b47f46102bccf1d813ca159230029b0cd820ceff.patch?full_index=1"
-    sha256 "92d321d552a65e16ae6df992a653839fb19de79aa77388c651bf57b3c582d546"
-  end
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? _(yes, in addition to `brew install --HEAD`)_
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Installing `--head` version of `innoextract` results in the following error:

```
==> Installing innoextract --HEAD
==> Cloning https://github.com/dscharrer/innoextract.git
Cloning into '/Users/kolen/Library/Caches/Homebrew/innoextract--git'...
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
==> Downloading https://github.com/dscharrer/innoextract/commit/b47f46102bccf1d813ca159230029b0cd820ceff.patch?full_index=1
######################################################################## 100.0%
==> Patching
==> Applying b47f46102bccf1d813ca159230029b0cd820ceff.patch
patching file CMakeLists.txt
Hunk #1 FAILED at 158.
Hunk #2 FAILED at 175.
Hunk #3 FAILED at 208.
Hunk #4 FAILED at 224.
4 out of 4 hunks FAILED -- saving rejects to file CMakeLists.txt.rej
patching file cmake/CompileCheck.cmake
Hunk #1 FAILED at 192.
1 out of 1 hunk FAILED -- saving rejects to file cmake/CompileCheck.cmake.rej
Error: Failure while executing; `patch -g 0 -f -p1 -i /private/tmp/innoextract--patch-20200330-85880-e1u6ji/b47f46102bccf1d813ca159230029b0cd820ceff.patch` exited with 1.
``` 

As this [`b47f46`](https://github.com/dscharrer/innoextract/commit/b47f46102bccf1d813ca159230029b0cd820ceff) commit is already in upstream's master, I added condition to skip patching when `build.head?`.