### PR TITLE
vroom 1.6.0 (new formula)

### DIFF
--- a/Formula/vroom.rb
+++ b/Formula/vroom.rb
@@ -1,0 +1,24 @@
+class Vroom < Formula
+  desc "Vehicle Routing Open-Source Optimization Machine"
+  homepage "http://vroom-project.org/"
+  url "https://github.com/VROOM-Project/vroom/archive/v1.6.0.tar.gz"
+  sha256 "6bd8736f68c121cd8867f16b654cd36924605ebffea65f1e20fe042e4292175b"
+
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "openssl@1.1"
+
+  def install
+    chdir "src" do
+      system "make"
+    end
+    bin.install "bin/vroom"
+    pkgshare.install "docs"
+  end
+
+  test do
+    output = shell_output("#{bin}/vroom -i #{pkgshare}/docs/example_2.json")
+    expected_routes = JSON.parse((pkgshare/"docs/example_2_sol.json").read)["routes"]
+    assert_equal expected_routes, JSON.parse(output)["routes"]
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds open source vehicle routing. A few notes:

1. The library doesn't have a `make install` task
2. The output includes timing info, so the test just looks at the routes