### PR TITLE
glib: fix inreplace

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -58,8 +58,8 @@ class Glib < Formula
     inreplace lib+"pkgconfig/glib-2.0.pc" do |s|
       s.gsub! "Libs: -L${libdir} -lglib-2.0 -lintl",
               "Libs: -L${libdir} -lglib-2.0 -L#{gettext}/lib -lintl"
-      s.gsub! "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
-              "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
+      s.gsub! "Cflags:-I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include",
+              "Cflags:-I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
     end
 
     # `pkg-config --print-requires-private gobject-2.0` includes libffi,


### PR DESCRIPTION
Fails with
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
/usr/local/Cellar/glib/2.64.1_1/lib/pkgconfig/glib-2.0.pc:
  expected replacement of "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include" with "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I/usr/local/opt/gettext/include"

This is due to the latest meson update (0.54.0)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
