### PR TITLE
boost-build: patch for Xcode 11.4

### DIFF
--- a/Formula/boost-build.rb
+++ b/Formula/boost-build.rb
@@ -3,6 +3,7 @@ class BoostBuild < Formula
   homepage "https://www.boost.org/build/"
   url "https://github.com/boostorg/build/archive/boost-1.72.0.tar.gz"
   sha256 "657d175aa59bcb307f75990fe2ae43793d30e40540c6d964b96ab5db3aa8629c"
+  revision 1
   version_scheme 1
   head "https://github.com/boostorg/build.git"
 
@@ -14,6 +15,13 @@ class BoostBuild < Formula
   end
 
   conflicts_with "b2-tools", :because => "both install `b2` binaries"
+
+  # Fix Xcode 11.4 compatibility.
+  # Remove with the next release.
+  patch do
+    url "https://github.com/boostorg/build/commit/b3a59d265929a213f02a451bb63cea75d668a4d9.patch?full_index=1"
+    sha256 "04a4df38ed9c5a4346fbb50ae4ccc948a1440328beac03cb3586c8e2e241be08"
+  end
 
   def install
     system "./bootstrap.sh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Part 1 of the Boost patching. This one is separate as it requires a revision bump.