### PR TITLE
workflows/tests: always upload bottles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           echo "$count bottles"
           echo "::set-output name=count::$count"
       - name: Upload bottles
-        if: steps.bottles.outputs.count > 0
+        if: always() && steps.bottles.outputs.count > 0
         uses: actions/upload-artifact@v1
         with:
           name: bottles


### PR DESCRIPTION
If we hit a flaky test on a dependent in a long build, it's not worth blocking bottles being uploaded as an artefact.