### PR TITLE
CGAL: Add Qt5 components

### DIFF
--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -10,54 +10,58 @@ class Cgal < Formula
     sha256 "642c67e59a4bcfc9e22a15f2f7149045ce037c639eb9a8cf2deb3d3195e69ad0" => :mojave
     sha256 "642c67e59a4bcfc9e22a15f2f7149045ce037c639eb9a8cf2deb3d3195e69ad0" => :high_sierra
   end
-
+  
   depends_on "cmake" => [:build, :test]
   depends_on "boost"
+  depends_on "cgal"
   depends_on "eigen"
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "qt" => [:build, :test]
 
   def install
-    args = std_cmake_args + %W[
+    args = std_cmake_args + %w[
       -DCMAKE_CXX_FLAGS='-std=c++14'
-      -DWITH_Eigen3=ON
-      -DWITH_LAPACK=ON
-      -DWITH_CGAL_Qt5=OFF
-      -DWITH_CGAL_ImageIO=OFF
+      -DWITH_CGAL_Qt5=ON
+    ]
+
+    args_qt5 = %w[
+      -DCOMPONENT=CGAL_Qt5
+      -P
+      cmake_install.cmake
     ]
 
     system "cmake", ".", *args
-    system "make", "install"
+    system "cmake", *args_qt5
   end
-
   test do
-    # https://doc.cgal.org/latest/Algebraic_foundations/Algebraic_foundations_2interoperable_8cpp-example.html
+    # https://doc.cgal.org/latest/Triangulation_2/Triangulation_2_2draw_triangulation_2_8cpp-example.html
     (testpath/"surprise.cpp").write <<~EOS
-      #include <CGAL/basic.h>
-      #include <CGAL/Coercion_traits.h>
-      #include <CGAL/IO/io.h>
-      template <typename A, typename B>
-      typename CGAL::Coercion_traits<A,B>::Type
-      binary_func(const A& a , const B& b){
-          typedef CGAL::Coercion_traits<A,B> CT;
-          CGAL_static_assertion((CT::Are_explicit_interoperable::value));
-          typename CT::Cast cast;
-          return cast(a)*cast(b);
-      }
-      int main(){
-          std::cout<< binary_func(double(3), int(5)) << std::endl;
-          std::cout<< binary_func(int(3), double(5)) << std::endl;
-          return 0;
-      }
+      #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+      #include <CGAL/Triangulation_2.h>
+      #include <CGAL/draw_triangulation_2.h>
+      #include <fstream>
+      typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+      typedef CGAL::Triangulation_2<K>                            Triangulation;
+      typedef Triangulation::Point                                Point;
+      int main() {
+        std::ifstream in("data/triangulation_prog1.cin");
+        std::istream_iterator<Point> begin(in);
+        std::istream_iterator<Point> end;
+        Triangulation t;
+        t.insert(begin, end);
+        CGAL::draw(t);
+        return EXIT_SUCCESS;
+       }
     EOS
     (testpath/"CMakeLists.txt").write <<~EOS
-      cmake_minimum_required(VERSION 3.1...3.13)
-      find_package(CGAL)
+      cmake_minimum_required(VERSION 3.1...3.15)
+      find_package(CGAL COMPONENTS Qt5)
+      add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
       add_executable(surprise surprise.cpp)
-      target_link_libraries(surprise PRIVATE CGAL::CGAL)
+      target_link_libraries(surprise PUBLIC CGAL::CGAL_Qt5)
     EOS
-    system "cmake", "-L", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
+    system "cmake", "-L", "-DQt5_DIR=#{HOMEBREW_PREFIX}/opt/qt/lib/cmake/Qt5", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
     system "cmake", "--build", ".", "-v"
-    assert_equal "15\n15", shell_output("./surprise").chomp
   end
 end

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -13,11 +13,11 @@ class Cgal < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "qt" => [:build, :test]
   depends_on "boost"
   depends_on "eigen"
   depends_on "gmp"
   depends_on "mpfr"
-  depends_on "qt" => [:build, :test]
 
   def install
     args = std_cmake_args + %w[
@@ -41,13 +41,13 @@ class Cgal < Formula
       typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
       typedef CGAL::Triangulation_2<K>                            Triangulation;
       typedef Triangulation::Point                                Point;
- 
+
       template <typename A, typename B>
-      typename CGAL::Coercion_traits<A,B>::Type	      
-      binary_func(const A& a , const B& b){	      
-          typedef CGAL::Coercion_traits<A,B> CT;	      
-          CGAL_static_assertion((CT::Are_explicit_interoperable::value));	      
-          typename CT::Cast cast;	        
+      typename CGAL::Coercion_traits<A,B>::Type
+      binary_func(const A& a , const B& b){
+          typedef CGAL::Coercion_traits<A,B> CT;
+          CGAL_static_assertion((CT::Are_explicit_interoperable::value));
+          typename CT::Cast cast;
           return cast(a)*cast(b);
       }
 
@@ -71,7 +71,8 @@ class Cgal < Formula
       add_executable(surprise surprise.cpp)
       target_link_libraries(surprise PUBLIC CGAL::CGAL_Qt5)
     EOS
-    system "cmake", "-L", "-DQt5_DIR=#{HOMEBREW_PREFIX}/opt/qt/lib/cmake/Qt5", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
+    system "cmake", "-L", "-DQt5_DIR=#{HOMEBREW_PREFIX}/opt/qt/lib/cmake/Qt5",
+           "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
     system "cmake", "--build", ".", "-v"
     assert_equal "15\n15", shell_output("./surprise").chomp
   end

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -3,6 +3,7 @@ class Cgal < Formula
   homepage "https://www.cgal.org/"
   url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-5.0.2/CGAL-5.0.2.tar.xz"
   sha256 "bb3594ba390735404f0972ece301f369b1ff12646ad25e48056b4d49c976e1fa"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -50,7 +51,7 @@ class Cgal < Formula
           return cast(a)*cast(b);
       }
 
-      int main() {
+      int main(int argc, char**) {
         std::cout<< binary_func(double(3), int(5)) << std::endl;
         std::cout<< binary_func(int(3), double(5)) << std::endl;
         std::ifstream in("data/triangulation_prog1.cin");
@@ -58,7 +59,8 @@ class Cgal < Formula
         std::istream_iterator<Point> end;
         Triangulation t;
         t.insert(begin, end);
-        CGAL::draw(t);
+        if(argc == 3) // do not test Qt5 at runtime
+          CGAL::draw(t);
         return EXIT_SUCCESS;
        }
     EOS
@@ -71,5 +73,6 @@ class Cgal < Formula
     EOS
     system "cmake", "-L", "-DQt5_DIR=#{HOMEBREW_PREFIX}/opt/qt/lib/cmake/Qt5", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
     system "cmake", "--build", ".", "-v"
+    assert_equal "15\n15", shell_output("./surprise").chomp
   end
 end

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -71,7 +71,7 @@ class Cgal < Formula
       add_executable(surprise surprise.cpp)
       target_link_libraries(surprise PUBLIC CGAL::CGAL_Qt5)
     EOS
-    system "cmake", "-L", "-DQt5_DIR=#{HOMEBREW_PREFIX}/opt/qt/lib/cmake/Qt5",
+    system "cmake", "-L", "-DQt5_DIR=#{Formula["qt"].opt_lib}/cmake/Qt5",
            "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
     system "cmake", "--build", ".", "-v"
     assert_equal "15\n15", shell_output("./surprise").chomp


### PR DESCRIPTION
This PR  is a replacement for #50022.
It adds Qt as a build and test dependency, so that users that have qt installed in their brew environment can access CGAL graphics components.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
