### PR TITLE
workflows/tests: update Homebrew before running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
       GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
     steps:
+      - name: Update Homebrew
+        run: brew update-reset
       - name: Checkout repository
         run: |
           cd $(brew --repo ${{github.repository}})


### PR DESCRIPTION
This never actually happens during the current process.

This can also make sure we are running the latest test-bot code before invoking `brew test-bot`.