### PR TITLE
deno 0.39.0

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -1,8 +1,8 @@
 class Deno < Formula
   desc "Command-line JavaScript / TypeScript engine"
   homepage "https://deno.land/"
-  url "https://github.com/denoland/deno/releases/download/v0.36.0/deno_src.tar.gz"
-  sha256 "23de3e13b87e40ac4cbd0d8f0362cf1afc50980f5226f381d3f44c67e603727e"
+  url "https://github.com/denoland/deno/releases/download/v0.39.0/deno_src.tar.gz"
+  sha256 "d2ed15722d7e114870979709bf1606e0da42ba5a3972c5838540b94909414efc"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,7 +11,7 @@ class Deno < Formula
     sha256 "d224a3b29b291ccea3fb0a6ed0fda61e0c45049b94f0b6fcd917fb140881ae4a" => :high_sierra
   end
 
-  depends_on "llvm" => :build if DevelopmentTools.clang_build_version < 1100
+  depends_on "llvm" => :build
   depends_on "ninja" => :build
   depends_on "rust" => :build
 
@@ -24,7 +24,7 @@ class Deno < Formula
 
   resource "gn" do
     url "https://gn.googlesource.com/gn.git",
-      :revision => "a5bcbd726ac7bd342ca6ee3e3a006478fd1f00b5"
+      :revision => "fd3d768bcfd44a8d9639fe278581bd9851d0ce3a"
   end
 
   def install
@@ -37,13 +37,13 @@ class Deno < Formula
 
     # env args for building a release build with our clang, ninja and gn
     ENV["GN"] = buildpath/"gn/out/gn"
-    if DevelopmentTools.clang_build_version < 1100
-      # build with llvm and link against system libc++ (no runtime dep)
-      ENV["CLANG_BASE_PATH"] = Formula["llvm"].prefix
-      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    else # build with system clang
-      ENV["CLANG_BASE_PATH"] = "/usr/"
-    end
+    # build rusty_v8 from source
+    ENV["V8_FROM_SOURCE"] = "1"
+    # overwrite Chromium minimum sdk version of 10.15
+    ENV["FORCE_MAC_SDK_MIN"] = "10.13"
+    # build with llvm and link against system libc++ (no runtime dep)
+    ENV["CLANG_BASE_PATH"] = Formula["llvm"].prefix
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
 
     cd "cli" do
       system "cargo", "install", "-vv", "--locked", "--root", prefix, "--path", "."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Supersedes: #52095.

I've moved all macOS versions over to use our `llvm` 10, because it supports the `-gno-inline-line-tables` flag and all (except one) of the unknown warning options you'd see when compiling with llvm 9- or system `clang` on Catalina. This saves us from having to manually disable the usage of `-gno-inline-line-tables` when compiling with Catalina's system `clang` and simplifies the build, which is now more consistent across all macOS version. (Refs: https://github.com/Homebrew/homebrew-core/pull/52095#discussion_r401265291)