### PR TITLE
pkg-config: withdraw support for Homebrew supplied *.pc files

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -4,6 +4,7 @@ class PkgConfig < Formula
   url "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/pkg-config-0.29.2.tar.gz"
   sha256 "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -19,7 +20,6 @@ class PkgConfig < Formula
       #{HOMEBREW_PREFIX}/share/pkgconfig
       /usr/local/lib/pkgconfig
       /usr/lib/pkgconfig
-      #{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}
     ].uniq.join(File::PATH_SEPARATOR)
 
     system "./configure", "--disable-debug",
@@ -28,11 +28,27 @@ class PkgConfig < Formula
                           "--with-internal-glib",
                           "--with-pc-path=#{pc_path}"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/pkg-config", "--libs", "libpcre"
+    (testpath/"foo.pc").write <<~EOS
+      prefix=/usr
+      exec_prefix=${prefix}
+      includedir=${prefix}/include
+      libdir=${exec_prefix}/lib
+
+      Name: foo
+      Description: The foo library
+      Version: 1.0.0
+      Cflags: -I${includedir}/foo
+      Libs: -L${libdir} -lfoo
+    EOS
+
+    ENV["PKG_CONFIG_LIBDIR"] = testpath
+    system bin/"pkg-config", "--validate", "foo"
+    assert_equal "1.0.0\n", shell_output("#{bin}/pkg-config --modversion foo")
+    assert_equal "-lfoo\n", shell_output("#{bin}/pkg-config --libs foo")
+    assert_equal "-I/usr/include/foo\n", shell_output("#{bin}/pkg-config --cflags foo")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Discussion in Homebrew/brew#5068.

Support will continue to be available in the Homebrew superenv.