### PR TITLE
jp2a: downgrade from 1.0.7 to 1.0.6

### DIFF
--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -1,8 +1,9 @@
 class Jp2a < Formula
   desc "Convert JPG images to ASCII"
   homepage "https://csl.name/jp2a/"
-  url "https://github.com/cslarsen/jp2a/archive/v1.0.7.tar.gz"
-  sha256 "e509d8bbf9434afde5c342568b21d11831a61d9942ca8cb1633d4295b7bc5059"
+  url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
+  sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
+  revision 1
 
   bottle do
     cellar :any
@@ -12,13 +13,12 @@ class Jp2a < Formula
     sha256 "a45231943df5bffc1589114b20b5b6c9745f909fd1e85db63da40e28bec02709" => :sierra
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "jpeg"
 
   def install
-    system "autoreconf", "-ivf"
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -4,7 +4,7 @@ class Jp2a < Formula
   # Do not change source from SourceForge to GitHub until this issue is resolved:
   # https://github.com/cslarsen/jp2a/issues/8
   # Currently, GitHub only has jp2a v1.0.7, which is broken as described above.
-  # jp2a v1.0.6 is stable, but it is only available on SourceForge, not GitHub. 
+  # jp2a v1.0.6 is stable, but it is only available on SourceForge, not GitHub.
   url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
   sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
   version_scheme 1

--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -1,9 +1,13 @@
 class Jp2a < Formula
   desc "Convert JPG images to ASCII"
   homepage "https://csl.name/jp2a/"
+  # Do not change source from SourceForge to GitHub until this issue is resolved:
+  # https://github.com/cslarsen/jp2a/issues/8
+  # Currently, GitHub only has jp2a v1.0.7, which is broken as described above.
+  # jp2a v1.0.6 is stable, but it is only available on SourceForge, not GitHub. 
   url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
   sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
-  revision 1
+  version_scheme 1
 
   bottle do
     cellar :any

--- a/Formula/jp2a.rb
+++ b/Formula/jp2a.rb
@@ -7,6 +7,7 @@ class Jp2a < Formula
   # jp2a v1.0.6 is stable, but it is only available on SourceForge, not GitHub.
   url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
   sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
+  revision 1
   version_scheme 1
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Continuing discussion from the ["Downgrade jp2a formula to v1.0.6"](https://discourse.brew.sh/t/downgrade-jp2a-formula-to-v1-0-6/7294) Discourse thread. As requested by @SMillerDev, I'm opening a PR. I'm copying the details from that post here.

The jp2a formula is currently "broken" and has been since #39096, which was meant to acknowledge the migration of jp2a's source repository from SourceForge to Github.

However, jp2a's migration to GitHub was not a smooth transition. Its GitHub repository is lacking v1.0.6, which was available on SourceForge. The only release on GitHub is v1.0.7, which turned out to be a "dud" in the sense that it contained various issues that were not immediately obvious by just running `test.jpg` through it.

I'm not personally aware of all the errors in v1.0.7, but these issues are well-known enough that the MacPorts community has intentionally kept their jp2a package at v1.0.6:

https://github.com/cslarsen/jp2a/issues/8

Unfortunately, there has been no action on part of the author to tag a v1.0.8 for 3 years. However, jp2a v1.0.6, which is still available from SourceForge, works great.

Can we please revert this formula to point at v1.0.6 on SourceForge? This PR is my attempt to do so, but I'm not sure how to go about reverting to an earlier version. The test ran fine, but the audit produced this error:

```
imoskv$ brew audit --strict jp2a
jp2a:
  * stable version should not decrease (from 1.0.7 to 1.0.6)
Error: 1 problem in 1 formula detected
```