### PR TITLE
workflows: post comment on pr-publish failure

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -61,3 +61,24 @@ jobs:
             fi
           done
           exit 1
+      - name: Post comment on failure
+        if: failure()
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          script: |
+            const run_id = process.env.GITHUB_RUN_ID
+            const actor = context.actor
+            const pr = context.payload.client_payload.pull_request
+            console.log("run_id=" + run_id)
+            console.log("actor=" + actor)
+            console.log("pr=" + pr)
+
+            const repository = context.repo.owner + '/' + context.repo.repo
+            const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
+
+            github.issues.createComment({
+              ...context.repo,
+              issue_number: pr,
+              body: '@' + actor + ' bottle publish failed: ' + url
+            })


### PR DESCRIPTION
With this pull request, when a maintainer runs `brew pr-publish PR` and that publish job fails, BrewTestBot should post an issue comment pinging that maintainer in the pull request in question.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----