### PR TITLE
Use free_port instead of predefined in test

### DIFF
--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -24,12 +24,13 @@ class Algernon < Formula
   end
 
   test do
+    port = free_port
     pid = fork do
       exec "#{bin}/algernon", "-s", "-q", "--httponly", "--boltdb", "tmp.db",
-                              "--addr", ":45678"
+                              "--addr", ":#{port}"
     end
     sleep 20
-    output = shell_output("curl -sIm3 -o- http://localhost:45678")
+    output = shell_output("curl -sIm3 -o- http://localhost:#{port}")
     assert_match /200 OK.*Server: Algernon/m, output
   ensure
     Process.kill("HUP", pid)

--- a/Formula/anycable-go.rb
+++ b/Formula/anycable-go.rb
@@ -21,11 +21,12 @@ class AnycableGo < Formula
   end
 
   test do
+    port = free_port
     pid = fork do
-      exec "#{bin}/anycable-go"
+      exec "#{bin}/anycable-go --port=#{port}"
     end
     sleep 1
-    output = shell_output("curl -sI http://localhost:8080/health")
+    output = shell_output("curl -sI http://localhost:#{port}/health")
     assert_match(/200 OK/m, output)
   ensure
     Process.kill("HUP", pid)

--- a/Formula/app-engine-python.rb
+++ b/Formula/app-engine-python.rb
@@ -50,12 +50,14 @@ class AppEnginePython < Formula
         ('/', MainPage),
       ], debug=True)
     EOS
+
+    port = free_port
     begin
       pid = fork do
-        exec "#{pkgshare}/dev_appserver.py app.yaml --skip_sdk_update_check"
+        exec "#{pkgshare}/dev_appserver.py app.yaml --skip_sdk_update_check --port #{port}"
       end
       sleep 5
-      output = shell_output("curl -s http://localhost:8080/")
+      output = shell_output("curl -s http://localhost:#{port}/")
       assert_equal "Hello, World!", output.chomp
     ensure
       Process.kill("HUP", pid)

--- a/Formula/appium.rb
+++ b/Formula/appium.rb
@@ -24,13 +24,15 @@ class Appium < Formula
   test do
     output = shell_output("#{bin}/appium --show-config 2>&1")
     assert_match version.to_str, output
+
+    port = free_port
     begin
       pid = fork do
-        exec bin/"appium &>appium-start.out"
+        exec bin/"appium --port #{port} &>appium-start.out"
       end
       sleep 3
 
-      assert_match "The URL '/' did not map to a valid resource", shell_output("curl -s 127.0.0.1:4723")
+      assert_match "The URL '/' did not map to a valid resource", shell_output("curl -s 127.0.0.1:#{port}")
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/armor.rb
+++ b/Formula/armor.rb
@@ -21,11 +21,12 @@ class Armor < Formula
   end
 
   test do
+    port = free_port
     pid = fork do
-      exec "#{bin}/armor"
+      exec "#{bin}/armor --port #{port}"
     end
     sleep 1
-    output = shell_output("curl -sI http://localhost:8080")
+    output = shell_output("curl -sI http://localhost:#{port}")
     assert_match(/200 OK/m, output)
   ensure
     Process.kill("HUP", pid)

--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -35,16 +35,16 @@ class Asio < Formula
   end
 
   test do
-    found = [pkgshare/"examples/cpp11/http/server/http_server",
-             pkgshare/"examples/cpp03/http/server/http_server"].select(&:exist?)
+    found = Dir[pkgshare/"examples/cpp{11,03}/http/server/http_server"]
     raise "no http_server example file found" if found.empty?
 
+    port = free_port
     pid = fork do
-      exec found.first, "127.0.0.1", "8080", "."
+      exec found.first, "127.0.0.1", port.to_s, "."
     end
     sleep 1
     begin
-      assert_match /404 Not Found/, shell_output("curl http://127.0.0.1:8080")
+      assert_match /404 Not Found/, shell_output("curl http://127.0.0.1:#{port}")
     ensure
       Process.kill 9, pid
       Process.wait pid

--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -52,14 +52,15 @@ class Caddy < Formula
   end
 
   test do
+    port = free_port
     begin
-      io = IO.popen("#{bin}/caddy")
+      io = IO.popen("#{bin}/caddy -port #{port}")
       sleep 2
     ensure
       Process.kill("SIGINT", io.pid)
       Process.wait(io.pid)
     end
 
-    io.read =~ /0\.0\.0\.0:2015/
+    io.read =~ /0\.0\.0\.0:#{port}/
   end
 end

--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -43,12 +43,13 @@ class Carrot2 < Formula
   test do
     cp_r Dir["#{prefix}/*"], testpath
     inreplace testpath/"bin/carrot2", "cd #{libexec}", "cd #{testpath}/libexec"
+    port = free_port
     begin
-      pid = fork { exec testpath/"bin/carrot2" }
+      pid = fork { exec testpath/"bin/carrot2", "-port", port.to_s }
       sleep 5
       assert_match /data mining/m,
         shell_output("curl -s -F dcs.c2stream=@#{libexec}/examples/shared/data-mining.xml " \
-                     "http://localhost:8080/dcs/rest")
+                     "http://localhost:#{port}/dcs/rest")
     ensure
       Process.kill "INT", pid
     end

--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -73,11 +73,12 @@ class Chronograf < Formula
   end
 
   test do
+    port = free_port
     pid = fork do
-      exec "#{bin}/chronograf"
+      exec "#{bin}/chronograf --port=#{port}"
     end
     sleep 10
-    output = shell_output("curl -s 0.0.0.0:8888/chronograf/v1/")
+    output = shell_output("curl -s 0.0.0.0:#{port}/chronograf/v1/")
     sleep 1
     assert_match %r{/chronograf/v1/layouts}, output
   ensure

--- a/Formula/cosi.rb
+++ b/Formula/cosi.rb
@@ -78,14 +78,15 @@ class Cosi < Formula
   end
 
   test do
+    port = free_port
     (testpath/"config.toml").write <<~EOS
       Public = "7b6d6361686d0c76d9f4b40961736eb5d0849f7db3f8bfd8f869b8015d831d45"
       Private = "01a80f4fef21db2aea18e5288fe9aa71324a8ad202609139e5cfffc4ffdc4484"
-      Addresses = ["0.0.0.0:6879"]
+      Addresses = ["0.0.0.0:#{port}"]
     EOS
     (testpath/"group.toml").write <<~EOS
       [[servers]]
-        Addresses = ["127.0.0.1:6879"]
+        Addresses = ["127.0.0.1:#{port}"]
         Public = "e21jYWhtDHbZ9LQJYXNutdCEn32z+L/Y+Gm4AV2DHUU="
     EOS
     begin

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -95,6 +95,8 @@ COUCHDB_BIN_DIR=$(canonical_readlink $0)'
     cp_r prefix/"etc", testpath
     # setting database path to testpath
     inreplace "#{testpath}/etc/default.ini", "#{var}/couchdb/data", "#{testpath}/data"
+    port = free_port
+    inreplace "#{testpath}/etc/default.ini", "port = 5984", "port = #{port}"
 
     # start CouchDB with test environment
     pid = fork do
@@ -103,7 +105,7 @@ COUCHDB_BIN_DIR=$(canonical_readlink $0)'
     sleep 2
 
     begin
-      assert_match "The Apache Software Foundation", shell_output("curl --silent localhost:5984")
+      assert_match "The Apache Software Foundation", shell_output("curl --silent localhost:#{port}")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/cppcms.rb
+++ b/Formula/cppcms.rb
@@ -65,11 +65,12 @@ class Cppcms < Formula
       }
     EOS
 
+    port = free_port
     (testpath/"config.json").write <<~EOS
       {
           "service" : {
               "api" : "http",
-              "port" : 8080,
+              "port" : #{port},
               "worker_threads": 1
           },
           "daemon" : {
@@ -86,7 +87,7 @@ class Cppcms < Formula
 
     sleep 1 # grace time for server start
     begin
-      assert_match(/Hello World/, shell_output("curl http://127.0.0.1:8080/hello"))
+      assert_match(/Hello World/, shell_output("curl http://127.0.0.1:#{port}/hello"))
     ensure
       Process.kill 9, pid
       Process.wait pid

--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -21,36 +21,20 @@ class Envconsul < Formula
   end
 
   test do
-    require "socket"
-    require "timeout"
-
-    CONSUL_DEFAULT_PORT = 8500
-    LOCALHOST_IP = "127.0.0.1".freeze
-
-    def port_open?(ip_address, port, seconds = 1)
-      Timeout.timeout(seconds) do
-        TCPSocket.new(ip_address, port).close
-      end
-      true
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Timeout::Error
-      false
-    end
-
+    port = free_port
     begin
-      if !port_open?(LOCALHOST_IP, CONSUL_DEFAULT_PORT)
-        fork do
-          exec "consul agent -dev -bind 127.0.0.1"
-          puts "consul started"
-        end
-        sleep 5
-      else
-        puts "Consul already running"
+      fork do
+        exec "consul agent -dev -bind 127.0.0.1 -http-port #{port}"
+        puts "consul started"
       end
-      system "consul", "kv", "put", "homebrew-recipe-test/working", "1"
-      output = shell_output("#{bin}/envconsul -consul-addr=127.0.0.1:8500 -upcase -prefix homebrew-recipe-test env")
+      sleep 5
+
+      system "consul", "kv", "put", "-http-addr", "127.0.0.1:#{port}", "homebrew-recipe-test/working", "1"
+      output = shell_output("#{bin}/envconsul -consul-addr=127.0.0.1:#{port} " \
+                            "-upcase -prefix homebrew-recipe-test env")
       assert_match "WORKING=1", output
     ensure
-      system "consul", "leave"
+      system "consul", "leave", "-http-addr", "127.0.0.1:#{port}"
     end
   end
 end

--- a/Formula/fortio.rb
+++ b/Formula/fortio.rb
@@ -28,12 +28,14 @@ class Fortio < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/fortio version -s")
+
+    port = free_port
     begin
       pid = fork do
-        exec bin/"fortio", "server", "-http-port", "8080"
+        exec bin/"fortio", "server", "-http-port", port.to_s
       end
       sleep 2
-      output = shell_output("#{bin}/fortio load http://localhost:8080/ 2>&1")
+      output = shell_output("#{bin}/fortio load http://localhost:#{port}/ 2>&1")
       assert_match /^All\sdone/, output.lines.last
     ensure
       Process.kill("SIGTERM", pid)

--- a/Formula/gnirehtet.rb
+++ b/Formula/gnirehtet.rb
@@ -51,15 +51,16 @@ class Gnirehtet < Formula
     gnirehtet_err = "#{testpath}/gnirehtet.err"
     gnirehtet_out = "#{testpath}/gnirehtet.out"
 
+    port = free_port
     begin
       child_pid = fork do
         Process.setsid
         $stdout.reopen(gnirehtet_out, "w")
         $stderr.reopen(gnirehtet_err, "w")
-        exec bin/"gnirehtet", "relay"
+        exec bin/"gnirehtet", "relay", "-p", port.to_s
       end
       sleep 3
-      system "socat", "-T", "1", "-", "TCP4:127.0.0.1:31416"
+      system "socat", "-T", "1", "-", "TCP4:127.0.0.1:#{port}"
     ensure
       pgid = Process.getpgid(child_pid)
       Process.kill("HUP", -pgid)

--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -37,11 +37,11 @@ class H2o < Formula
   end
 
   # This is simplified from examples/h2o/h2o.conf upstream.
-  def conf_example
+  def conf_example(port = 8080)
     <<~EOS
-      listen: 8080
+      listen: #{port}
       hosts:
-        "127.0.0.1.xip.io:8080":
+        "127.0.0.1.xip.io:#{port}":
           paths:
             /:
               file.dir: #{var}/h2o/
@@ -82,13 +82,15 @@ class H2o < Formula
   end
 
   test do
+    port = free_port
+    (testpath/"h2o.conf").write conf_example(port)
     pid = fork do
-      exec "#{bin}/h2o -c #{etc}/h2o/h2o.conf"
+      exec "#{bin}/h2o -c #{testpath}/h2o.conf"
     end
     sleep 2
 
     begin
-      assert_match "Welcome to H2O", shell_output("curl localhost:8080")
+      assert_match "Welcome to H2O", shell_output("curl localhost:#{port}")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -34,13 +34,18 @@ class Icecast < Formula
   end
 
   test do
+    port = free_port
+
+    cp etc/"icecast.xml", testpath/"icecast.xml"
+    inreplace testpath/"icecast.xml", "<port>8000</port>", "<port>#{port}</port>"
+
     pid = fork do
-      exec "icecast", "-c", etc/"icecast.xml", "2>", "/dev/null"
+      exec "icecast", "-c", testpath/"icecast.xml", "2>", "/dev/null"
     end
     sleep 3
 
     begin
-      assert_match "icestats", shell_output("curl localhost:8000/status-json.xsl")
+      assert_match "icestats", shell_output("curl localhost:#{port}/status-json.xsl")
     ensure
       Process.kill "TERM", pid
       Process.wait pid

--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -53,15 +53,16 @@ class JenkinsLts < Formula
 
   test do
     ENV["JENKINS_HOME"] = testpath
-    ENV.append "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}"
+    ENV.prepend "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}"
 
+    port = free_port
     pid = fork do
-      exec "#{bin}/jenkins-lts"
+      exec "#{bin}/jenkins-lts --httpPort=#{port}"
     end
     sleep 60
 
     begin
-      output = shell_output("curl localhost:8080/")
+      output = shell_output("curl localhost:#{port}/")
       assert_match(/Welcome to Jenkins!|Unlock Jenkins|Authentication required/, output)
     ensure
       Process.kill("SIGINT", pid)

--- a/Formula/jenkins.rb
+++ b/Formula/jenkins.rb
@@ -63,13 +63,16 @@ class Jenkins < Formula
   test do
     ENV["JENKINS_HOME"] = testpath
     ENV.prepend "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}"
+
+    port = free_port
     pid = fork do
-      exec "#{bin}/jenkins"
+      exec "#{bin}/jenkins --httpPort=#{port}"
     end
     sleep 60
 
     begin
-      assert_match /Welcome to Jenkins!|Unlock Jenkins|Authentication required/, shell_output("curl localhost:8080/")
+      output = shell_output("curl localhost:#{port}/")
+      assert_match(/Welcome to Jenkins!|Unlock Jenkins|Authentication required/, output)
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/jetty-runner.rb
+++ b/Formula/jetty-runner.rb
@@ -24,13 +24,14 @@ class JettyRunner < Formula
     ENV.append "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}"
     touch "#{testpath}/test.war"
 
+    port = free_port
     pid = fork do
-      exec "#{bin}/jetty-runner test.war"
+      exec "#{bin}/jetty-runner --port #{port} test.war"
     end
     sleep 5
 
     begin
-      output = shell_output("curl -I http://localhost:8080")
+      output = shell_output("curl -I http://localhost:#{port}")
       assert_match %r{HTTP\/1\.1 200 OK}, output
     ensure
       Process.kill 9, pid

--- a/Formula/leaps.rb
+++ b/Formula/leaps.rb
@@ -28,7 +28,7 @@ class Leaps < Formula
   end
 
   test do
-    port = ":8080"
+    port = ":#{free_port}"
 
     # Start the server in a fork
     leaps_pid = fork do

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -105,14 +105,21 @@ class Mpd < Formula
   end
 
   test do
+    port = free_port
+
+    (testpath/"mpd.conf").write <<~EOS
+      bind_to_address "127.0.0.1"
+      port "#{port}"
+    EOS
+
     pid = fork do
-      exec "#{bin}/mpd --stdout --no-daemon --no-config"
+      exec "#{bin}/mpd --stdout --no-daemon #{testpath}/mpd.conf"
     end
     sleep 2
 
     begin
-      ohai "Connect to MPD command (localhost:6600)"
-      TCPSocket.open("localhost", 6600) do |sock|
+      ohai "Connect to MPD command (localhost:#{port})"
+      TCPSocket.open("localhost", port) do |sock|
         assert_match "OK MPD", sock.gets
         ohai "Ping server"
         sock.puts("ping")

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -161,12 +161,13 @@ class Mysql < Formula
     system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
     "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
+    port = free_port
     pid = fork do
-      exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}"
+      exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}", "--port=#{port}"
     end
     sleep 2
 
-    output = shell_output("curl 127.0.0.1:3306")
+    output = shell_output("curl 127.0.0.1:#{port}")
     output.force_encoding("ASCII-8BIT") if output.respond_to?(:force_encoding)
     assert_match version.to_s, output
   ensure

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -139,12 +139,13 @@ class MysqlAT56 < Formula
     system bin/"mysql_install_db", "--user=#{ENV["USER"]}",
     "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
+    port = free_port
     pid = fork do
-      exec bin/"mysqld", "--datadir=#{dir}"
+      exec bin/"mysqld", "--datadir=#{dir}", "--port=#{port}"
     end
     sleep 2
 
-    output = shell_output("curl 127.0.0.1:3306")
+    output = shell_output("curl 127.0.0.1:#{port}")
     output.force_encoding("ASCII-8BIT") if output.respond_to?(:force_encoding)
     assert_match version.to_s, output
   ensure

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -137,12 +137,13 @@ class MysqlAT57 < Formula
     system bin/"mysqld", "--initialize-insecure", "--user=#{ENV["USER"]}",
     "--basedir=#{prefix}", "--datadir=#{dir}", "--tmpdir=#{dir}"
 
+    port = free_port
     pid = fork do
-      exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}"
+      exec bin/"mysqld", "--bind-address=127.0.0.1", "--datadir=#{dir}", "--port=#{port}"
     end
     sleep 2
 
-    output = shell_output("curl 127.0.0.1:3306")
+    output = shell_output("curl 127.0.0.1:#{port}")
     output.force_encoding("ASCII-8BIT") if output.respond_to?(:force_encoding)
     assert_match version.to_s, output
   ensure

--- a/Formula/nanomsg.rb
+++ b/Formula/nanomsg.rb
@@ -21,7 +21,7 @@ class Nanomsg < Formula
   end
 
   test do
-    bind = "tcp://127.0.0.1:8000"
+    bind = "tcp://127.0.0.1:#{free_port}"
 
     pid = fork do
       exec "#{bin}/nanocat --rep --bind #{bind} --format ascii --data home"

--- a/Formula/nng.rb
+++ b/Formula/nng.rb
@@ -23,7 +23,7 @@ class Nng < Formula
   end
 
   test do
-    bind = "tcp://127.0.0.1:8000"
+    bind = "tcp://127.0.0.1:#{free_port}"
 
     pid = fork do
       exec "#{bin}/nngcat --rep --bind #{bind} --format ascii --data home"

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -72,10 +72,11 @@ class Openssh < Formula
   test do
     assert_match "OpenSSH_", shell_output("#{bin}/ssh -V 2>&1")
 
+    port = free_port
     begin
-      pid = fork { exec sbin/"sshd", "-D", "-p", "8022" }
+      pid = fork { exec sbin/"sshd", "-D", "-p", port.to_s }
       sleep 2
-      assert_match "sshd", shell_output("lsof -i :8022")
+      assert_match "sshd", shell_output("lsof -i :#{port}")
     ensure
       Process.kill(9, pid)
       Process.wait(pid)

--- a/Formula/polynote.rb
+++ b/Formula/polynote.rb
@@ -2,7 +2,6 @@ class Polynote < Formula
   desc "The polyglot notebook with first-class Scala support"
   homepage "https://polynote.org/"
   url "https://github.com/polynote/polynote/releases/download/0.3.0/polynote-dist.tar.gz"
-  version "0.3.0"
   sha256 "b0ad435bd93b36ffcf07da2de5ab1755c02953d902892c5e4a2948144ca5b92f"
 
   bottle :unneeded
@@ -24,10 +23,11 @@ class Polynote < Formula
     output = shell_output("#{bin}/polynote version 2>&1", 1)
     assert_match "Unknown command version", output
 
+    port = free_port
     (testpath/"config.yml").write <<~EOS
       listen:
         host: 127.0.0.1
-        port: 8080
+        port: #{port}
       storage:
         dir: #{testpath}/notebooks
     EOS
@@ -38,7 +38,7 @@ class Polynote < Formula
       end
       sleep 5
 
-      assert_match "<title>Polynote</title>", shell_output("curl -s 127.0.0.1:8080")
+      assert_match "<title>Polynote</title>", shell_output("curl -s 127.0.0.1:#{port}")
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/privoxy.rb
+++ b/Formula/privoxy.rb
@@ -63,7 +63,7 @@ class Privoxy < Formula
   end
 
   test do
-    bind_address = "127.0.0.1:8118"
+    bind_address = "127.0.0.1:#{free_port}"
     (testpath/"config").write("listen-address #{bind_address}\n")
     begin
       server = IO.popen("#{sbin}/privoxy --no-daemon #{testpath}/config")

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -51,14 +51,14 @@ class SeleniumServerStandalone < Formula
   end
 
   test do
-    port = 4444
+    port = free_port
     pid = fork do
       exec "#{bin}/selenium-server -port #{port}"
     end
     sleep 3
 
     begin
-      output = shell_output("curl --silent localhost:4444/wd/hub/status")
+      output = shell_output("curl --silent localhost:#{port}/wd/hub/status")
       output = JSON.parse(output)
 
       assert_equal 0, output["status"]

--- a/Formula/serve.rb
+++ b/Formula/serve.rb
@@ -27,11 +27,12 @@ class Serve < Formula
   end
 
   test do
+    port = free_port
     pid = fork do
-      exec "#{bin}/serve"
+      exec "#{bin}/serve -port #{port}"
     end
     sleep 1
-    output = shell_output("curl -sI http://localhost:8080")
+    output = shell_output("curl -sI http://localhost:#{port}")
     assert_match(/200 OK/m, output)
   ensure
     Process.kill("HUP", pid)

--- a/Formula/serveit.rb
+++ b/Formula/serveit.rb
@@ -13,9 +13,10 @@ class Serveit < Formula
   end
 
   test do
-    pid = fork { exec bin/"serveit" }
+    port = free_port
+    pid = fork { exec bin/"serveit", "-p", port.to_s }
     sleep 2
-    assert_match(/Listing for/, shell_output("curl localhost:8000"))
+    assert_match(/Listing for/, shell_output("curl localhost:#{port}"))
   ensure
     Process.kill("SIGINT", pid)
     Process.wait(pid)

--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -76,12 +76,15 @@ class ShadowsocksLibev < Formula
   end
 
   test do
+    server_port = free_port
+    local_port = free_port
+
     (testpath/"shadowsocks-libev.json").write <<~EOS
       {
           "server":"127.0.0.1",
-          "server_port":9998,
+          "server_port":#{server_port},
           "local":"127.0.0.1",
-          "local_port":9999,
+          "local_port":#{local_port},
           "password":"test",
           "timeout":600,
           "method":null
@@ -91,7 +94,7 @@ class ShadowsocksLibev < Formula
     client = fork { exec bin/"ss-local", "-c", testpath/"shadowsocks-libev.json" }
     sleep 3
     begin
-      system "curl", "--socks5", "127.0.0.1:9999", "github.com"
+      system "curl", "--socks5", "127.0.0.1:#{local_port}", "github.com"
     ensure
       Process.kill 9, server
       Process.wait server

--- a/Formula/tinyproxy.rb
+++ b/Formula/tinyproxy.rb
@@ -1,6 +1,6 @@
 class Tinyproxy < Formula
   desc "HTTP/HTTPS proxy for POSIX systems"
-  homepage "https://www.banu.com/tinyproxy/"
+  homepage "https://tinyproxy.github.io/"
   url "https://github.com/tinyproxy/tinyproxy/releases/download/1.10.0/tinyproxy-1.10.0.tar.xz"
   sha256 "59be87689c415ba0d9c9bc6babbdd3df3b372d60b21e526b118d722dbc995682"
   revision 1
@@ -67,13 +67,17 @@ class Tinyproxy < Formula
   end
 
   test do
+    port = free_port
+    cp etc/"tinyproxy/tinyproxy.conf", testpath/"tinyproxy.conf"
+    inreplace testpath/"tinyproxy.conf", "Port 8888", "Port #{port}"
+
     pid = fork do
-      exec "#{bin}/tinyproxy"
+      exec "#{bin}/tinyproxy", "-c", testpath/"tinyproxy.conf"
     end
     sleep 2
 
     begin
-      assert_match /tinyproxy/, shell_output("curl localhost:8888")
+      assert_match /tinyproxy/, shell_output("curl localhost:#{port}")
     ensure
       Process.kill("SIGINT", pid)
       Process.wait(pid)

--- a/Formula/webdis.rb
+++ b/Formula/webdis.rb
@@ -59,12 +59,16 @@ class Webdis < Formula
   end
 
   test do
+    port = free_port
+    cp "#{etc}/webdis.json", "#{testpath}/webdis.json"
+    inreplace "#{testpath}/webdis.json", "\"http_port\":\t7379,", "\"http_port\":\t#{port},"
+
     server = fork do
-      exec "#{bin}/webdis", "#{etc}/webdis.json"
+      exec "#{bin}/webdis", "#{testpath}/webdis.json"
     end
     sleep 0.5
     # Test that the response is from webdis
-    assert_match(/Server: Webdis/, shell_output("curl --silent -XGET -I http://localhost:7379/PING"))
+    assert_match(/Server: Webdis/, shell_output("curl --silent -XGET -I http://localhost:#{port}/PING"))
   ensure
     Process.kill "TERM", server
     Process.wait server

--- a/Formula/webfs.rb
+++ b/Formula/webfs.rb
@@ -17,7 +17,7 @@ class Webfs < Formula
   depends_on "openssl@1.1"
 
   patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/0518a6d1/webfs/patch-ls.c"
+    url "https://github.com/Homebrew/formula-patches/raw/0518a6d1ed821aebf0de4de78e39b57d6e60e296/webfs/patch-ls.c"
     sha256 "8ddb6cb1a15f0020bbb14ef54a8ae5c6748a109564fa461219901e7e34826170"
   end
 
@@ -27,9 +27,10 @@ class Webfs < Formula
   end
 
   test do
-    pid = fork { exec bin/"webfsd", "-F" }
-    sleep 2
-    assert_match %r{webfs\/1.21}, shell_output("curl localhost:8000")
+    port = free_port
+    pid = fork { exec bin/"webfsd", "-F", "-p", port.to_s }
+    sleep 5
+    assert_match %r{webfs\/1.21}, shell_output("curl localhost:#{port}")
   ensure
     Process.kill("SIGINT", pid)
     Process.wait(pid)

--- a/Formula/websocketd.rb
+++ b/Formula/websocketd.rb
@@ -27,11 +27,12 @@ class Websocketd < Formula
   end
 
   test do
-    pid = Process.fork { exec "#{bin}/websocketd", "--port=8080", "echo", "ok" }
+    port = free_port
+    pid = Process.fork { exec "#{bin}/websocketd", "--port=#{port}", "echo", "ok" }
     sleep 2
 
     begin
-      assert_equal("404 page not found\n", shell_output("curl -s http://localhost:8080"))
+      assert_equal("404 page not found\n", shell_output("curl -s http://localhost:#{port}"))
     ensure
       Process.kill 9, pid
       Process.wait pid


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces usages of predefined ports with provided by [`free_port`](https://github.com/Homebrew/brew/pull/7225).

DO NOT MERGE until the next homebrew release with https://github.com/Homebrew/brew/pull/7225

PS: Not all the formula with predefined ports are fixed. I've use `git grep -l -P ':\d{4}' Formula/ ` to find suspicious formulae
