### PR TITLE
Use free_port instead of TCPServer.new(0) in test

### DIFF
--- a/Formula/apache-brooklyn-cli.rb
+++ b/Formula/apache-brooklyn-cli.rb
@@ -23,9 +23,8 @@ class ApacheBrooklynCli < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new("localhost", 0)
+    port = free_port
+    server = TCPServer.new("localhost", port)
     pid_mock_brooklyn = fork do
       loop do
         socket = server.accept
@@ -41,7 +40,7 @@ class ApacheBrooklynCli < Formula
     end
 
     begin
-      mock_brooklyn_url = "http://localhost:#{server.addr[1]}"
+      mock_brooklyn_url = "http://localhost:#{port}"
       assert_equal "Connected to Brooklyn version 1.2.3 at #{mock_brooklyn_url}\n",
         shell_output("#{bin}/br login #{mock_brooklyn_url} username password")
     ensure

--- a/Formula/elasticsearch.rb
+++ b/Formula/elasticsearch.rb
@@ -116,12 +116,8 @@ class Elasticsearch < Formula
 
   test do
     assert_includes(stable.url, "-oss-")
-    require "socket"
 
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
+    port = free_port
     system "#{bin}/elasticsearch-plugin", "list"
     pid = testpath/"pid"
     begin
@@ -132,10 +128,7 @@ class Elasticsearch < Formula
       Process.kill(9, pid.read.to_i)
     end
 
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
+    port = free_port
     (testpath/"config/elasticsearch.yml").write <<~EOS
       path.data: #{testpath}/data
       path.logs: #{testpath}/logs

--- a/Formula/fn.rb
+++ b/Formula/fn.rb
@@ -19,13 +19,12 @@ class Fn < Formula
   end
 
   test do
-    require "socket"
     assert_match version.to_s, shell_output("#{bin}/fn --version")
     system "#{bin}/fn", "init", "--runtime", "go", "--name", "myfunc"
     assert_predicate testpath/"func.go", :exist?, "expected file func.go doesn't exist"
     assert_predicate testpath/"func.yaml", :exist?, "expected file func.yaml doesn't exist"
-    server = TCPServer.new("localhost", 0)
-    port = server.addr[1]
+    port = free_port
+    server = TCPServer.new("localhost", port)
     pid = fork do
       loop do
         socket = server.accept

--- a/Formula/glassfish.rb
+++ b/Formula/glassfish.rb
@@ -40,9 +40,7 @@ class Glassfish < Formula
     java8_home = Utils.popen_read(Language::Java.java_home_cmd("1.8")).chomp
     File.open(asenv_conf_path, "a") { |file| file.puts "AS_JAVA=\"#{java8_home}\"" }
 
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     # assign port to glassfish admin console
     text = File.read(domain_xml_path)

--- a/Formula/heartbeat.rb
+++ b/Formula/heartbeat.rb
@@ -87,11 +87,7 @@ class Heartbeat < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     (testpath/"config/heartbeat.yml").write <<~EOS
       heartbeat.monitors:

--- a/Formula/hss.rb
+++ b/Formula/hss.rb
@@ -20,10 +20,9 @@ class Hss < Formula
   end
 
   test do
-    require "socket"
+    port = free_port
     begin
-      server = TCPServer.new(0)
-      port = server.addr[1]
+      server = TCPServer.new(port)
       accept_pid = fork do
         msg = server.accept.gets
         assert_match "SSH", msg

--- a/Formula/http-server.rb
+++ b/Formula/http-server.rb
@@ -22,9 +22,7 @@ class HttpServer < Formula
   end
 
   test do
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     pid = fork do
       exec "#{bin}/http-server", "-p#{port}"

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -150,11 +150,7 @@ class Httpd < Formula
     assert_predicate lib/"httpd/modules/mod_xml2enc.so", :exist?
 
     begin
-      require "socket"
-
-      server = TCPServer.new(0)
-      port = server.addr[1]
-      server.close
+      port = free_port
 
       expected_output = "Hello world!"
       (testpath/"index.html").write expected_output

--- a/Formula/imgproxy.rb
+++ b/Formula/imgproxy.rb
@@ -24,11 +24,7 @@ class Imgproxy < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     cp(test_fixtures("test.jpg"), testpath/"test.jpg")
 

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -35,47 +35,33 @@ class Inlets < Formula
     Process.wait(pid)
   end
 
-  MOCK_RESPONSE = "INLETS OK".freeze
-  SECRET_TOKEN = "itsasecret-sssshhhhh".freeze
-
   test do
-    upstream_server = TCPServer.new(0)
-    upstream_port = upstream_server.addr[1]
-    remote_server = TCPServer.new(0)
-    remote_port = remote_server.addr[1]
-    upstream_server.close
-    remote_server.close
-
-    puts "Starting mock server on: localhost:#{upstream_port}"
+    upstream_port = free_port
+    remote_port = free_port
+    MOCK_RESPONSE = "INLETS OK".freeze
+    SECRET_TOKEN = "itsasecret-sssshhhhh".freeze
 
     (testpath/"mock_upstream_server.rb").write <<~EOS
       require 'socket'
-
       server = TCPServer.new('localhost', #{upstream_port})
-
       loop do
         socket = server.accept
         request = socket.gets
         STDERR.puts request
-
         response = "OK\\n"
         shutdown = false
-
         if request.include? "inlets-test"
           response = "#{MOCK_RESPONSE}\\n"
           shutdown = true
         end
-
         socket.print "HTTP/1.1 200 OK\\r\\n" +
                     "Host: localhost:#{upstream_port}\\r\\n" +
                     "Content-Type: text/plain\\r\\n" +
                     "Content-Length: \#\{response.bytesize\}\\r\\n" +
                     "Connection: close\\r\\n"
-
         socket.print "\\r\\n"
         socket.print response
         socket.close
-
         if shutdown
           puts "Exiting test server"
           exit 0
@@ -88,9 +74,6 @@ class Inlets < Formula
     end
 
     begin
-      require "uri"
-      require "net/http"
-
       stable_resource = stable.instance_variable_get(:@resource)
       commit = stable_resource.instance_variable_get(:@specs)[:revision]
 
@@ -103,28 +86,19 @@ class Inlets < Formula
       # This test involves establishing a client-server inlets tunnel on the
       # remote_port, running a mock server on the upstream_port and then
       # testing that we can hit the mock server upstream_port via the tunnel remote_port
-      puts "Waiting for mock server"
-      sleep 3
+      sleep 3 # Waiting for mock server
       server_pid = fork do
-        puts "Starting inlets server with port #{remote_port}"
         exec "#{bin}/inlets server --port #{remote_port} --token #{SECRET_TOKEN}"
       end
 
       client_pid = fork do
-        puts "Starting inlets client with remote localhost:#{remote_port}, " \
-             "upstream localhost:#{upstream_port}, token: #{SECRET_TOKEN}"
+        # Starting inlets client
         exec "#{bin}/inlets client --remote localhost:#{remote_port} " \
              "--upstream localhost:#{upstream_port} --token #{SECRET_TOKEN}"
       end
 
-      puts "Waiting for inlets websocket tunnel"
-      sleep 3
-
-      uri = URI("http://localhost:#{remote_port}/inlets-test")
-      puts "Querying upstream endpoint via inlets remote: #{uri}"
-      response = Net::HTTP.get_response(uri)
-      assert_match MOCK_RESPONSE, response.body
-      assert_equal response.code, "200"
+      sleep 3 # Waiting for inlets websocket tunnel
+      assert_match MOCK_RESPONSE, shell_output("curl -s http://localhost:#{remote_port}/inlets-test")
     ensure
       cleanup("Mock Server", mock_upstream_server_pid)
       cleanup("Inlets Server", server_pid)

--- a/Formula/kubeless.rb
+++ b/Formula/kubeless.rb
@@ -24,10 +24,9 @@ class Kubeless < Formula
   end
 
   test do
-    require "socket"
+    port = free_port
+    server = TCPServer.new("127.0.0.1", port)
 
-    server = TCPServer.new("127.0.0.1", 0)
-    port = server.addr[1]
     pid = fork do
       loop do
         socket = server.accept

--- a/Formula/libhttpserver.rb
+++ b/Formula/libhttpserver.rb
@@ -37,11 +37,7 @@ class Libhttpserver < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     cp pkgshare/"examples/hello_world.cpp", testpath
     inreplace "hello_world.cpp", "create_webserver(8080)",

--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -26,12 +26,7 @@ class Miniserve < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
+    port = free_port
     pid = fork do
       exec "#{bin}/miniserve", "#{bin}/miniserve", "-i", "127.0.0.1", "--port", port.to_s
     end

--- a/Formula/mockserver.rb
+++ b/Formula/mockserver.rb
@@ -22,11 +22,7 @@ class Mockserver < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     mockserver = fork do
       exec "#{bin}/mockserver", "-serverPort", port.to_s

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -55,13 +55,9 @@ class Oauth2Proxy < Formula
   end
 
   test do
-    require "socket"
     require "timeout"
 
-    # Get an unused TCP port.
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     pid = fork do
       exec "#{bin}/oauth2_proxy",

--- a/Formula/pgweb.rb
+++ b/Formula/pgweb.rb
@@ -29,11 +29,7 @@ class Pgweb < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     begin
       pid = fork do

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -340,14 +340,8 @@ class Php < Formula
     assert_no_match /^snmp$/, shell_output("#{bin}/php -m"),
       "SNMP extension doesn't work reliably with Homebrew on High Sierra"
     begin
-      require "socket"
-
-      server = TCPServer.new(0)
-      port = server.addr[1]
-      server_fpm = TCPServer.new(0)
-      port_fpm = server_fpm.addr[1]
-      server.close
-      server_fpm.close
+      port = free_port
+      port_fpm = free_port
 
       expected_output = /^Hello world!$/
       (testpath/"index.php").write <<~EOS

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -332,14 +332,8 @@ class PhpAT72 < Formula
     assert_no_match /^snmp$/, shell_output("#{bin}/php -m"),
       "SNMP extension doesn't work reliably with Homebrew on High Sierra"
     begin
-      require "socket"
-
-      server = TCPServer.new(0)
-      port = server.addr[1]
-      server_fpm = TCPServer.new(0)
-      port_fpm = server_fpm.addr[1]
-      server.close
-      server_fpm.close
+      port = free_port
+      port_fpm = free_port
 
       expected_output = /^Hello world!$/
       (testpath/"index.php").write <<~EOS

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -337,14 +337,8 @@ class PhpAT73 < Formula
     assert_no_match /^snmp$/, shell_output("#{bin}/php -m"),
       "SNMP extension doesn't work reliably with Homebrew on High Sierra"
     begin
-      require "socket"
-
-      server = TCPServer.new(0)
-      port = server.addr[1]
-      server_fpm = TCPServer.new(0)
-      port_fpm = server_fpm.addr[1]
-      server.close
-      server_fpm.close
+      port = free_port
+      port_fpm = free_port
 
       expected_output = /^Hello world!$/
       (testpath/"index.php").write <<~EOS

--- a/Formula/restview.rb
+++ b/Formula/restview.rb
@@ -94,14 +94,9 @@ class Restview < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
     testpath.install resource("sample")
 
+    port = free_port
     begin
       pid = fork do
         exec bin/"restview", "--listen=#{port}", "--no-browser", "sample.rst"

--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -58,11 +58,7 @@ class Solr < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     # Info detects no Solr node => exit code 3
     shell_output(bin/"solr -i", 3)

--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -59,11 +59,7 @@ class SolrAT77 < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     # Info detects no Solr node => exit code 3
     shell_output(bin/"solr -i", 3)

--- a/Formula/sslsplit.rb
+++ b/Formula/sslsplit.rb
@@ -26,11 +26,7 @@ class Sslsplit < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     cmd = "#{bin}/sslsplit -D http 0.0.0.0 #{port} www.roe.ch 80"
     output = pipe_output("(#{cmd} & PID=$! && sleep 3 ; kill $PID) 2>&1")

--- a/Formula/traefik.rb
+++ b/Formula/traefik.rb
@@ -58,14 +58,8 @@ class Traefik < Formula
   end
 
   test do
-    require "socket"
-
-    ui_server = TCPServer.new(0)
-    http_server = TCPServer.new(0)
-    ui_port = ui_server.addr[1]
-    http_port = http_server.addr[1]
-    ui_server.close
-    http_server.close
+    ui_port = free_port
+    http_port = free_port
 
     (testpath/"traefik.toml").write <<~EOS
       [entryPoints]

--- a/Formula/traefik@1.rb
+++ b/Formula/traefik@1.rb
@@ -69,14 +69,8 @@ class TraefikAT1 < Formula
   end
 
   test do
-    require "socket"
-
-    web_server = TCPServer.new(0)
-    http_server = TCPServer.new(0)
-    web_port = web_server.addr[1]
-    http_port = http_server.addr[1]
-    web_server.close
-    http_server.close
+    web_port = free_port
+    http_port = free_port
 
     (testpath/"traefik.toml").write <<~EOS
       [web]

--- a/Formula/ungit.rb
+++ b/Formula/ungit.rb
@@ -21,10 +21,7 @@ class Ungit < Formula
   end
 
   test do
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
+    port = free_port
     ppid = fork do
       exec bin/"ungit", "--no-launchBrowser", "--port=#{port}", "--autoShutdownTimeout=6000"
     end

--- a/Formula/uwsgi.rb
+++ b/Formula/uwsgi.rb
@@ -126,9 +126,7 @@ class Uwsgi < Formula
         return [b"Hello World"]
     EOS
 
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     pid = fork do
       exec "#{bin}/uwsgi --http-socket 127.0.0.1:#{port} --protocol=http --plugin python3 -w helloworld"

--- a/Formula/wildfly-as.rb
+++ b/Formula/wildfly-as.rb
@@ -66,9 +66,7 @@ class WildflyAs < Formula
     ENV["JBOSS_HOME"] = opt_libexec
     system "#{opt_libexec}/bin/standalone.sh --version | grep #{version}"
 
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     pidfile = testpath/"pidfile"
     ENV["LAUNCH_JBOSS_IN_BACKGROUND"] = "true"

--- a/Formula/wiremock-standalone.rb
+++ b/Formula/wiremock-standalone.rb
@@ -18,11 +18,7 @@ class WiremockStandalone < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
 
     wiremock = fork do
       exec "#{bin}/wiremock", "-port", port.to_s

--- a/Formula/woof.rb
+++ b/Formula/woof.rb
@@ -12,12 +12,7 @@ class Woof < Formula
   end
 
   test do
-    require "socket"
-
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
-
+    port = free_port
     pid = fork do
       exec "#{bin}/woof", "-s", "-p", port.to_s
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR applies following changes:

```diff
-    server = TCPServer.new(0)
-    port = server.addr[1]
-    server.close
+    port = free_port
```

DO NOT MERGE until the next homebrew release with https://github.com/Homebrew/brew/pull/7225