### PR TITLE
libcoap: add with-examples option

### DIFF
--- a/Formula/libcoap.rb
+++ b/Formula/libcoap.rb
@@ -11,6 +11,8 @@ class Libcoap < Formula
     sha256 "a68df19a4ca87c677173c14b534848592bb35e46a715ca066bcd114f8c735236" => :high_sierra
   end
 
+  option "with-examples", "Will build the included POSIX examples"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "doxygen" => :build
@@ -19,10 +21,15 @@ class Libcoap < Formula
   depends_on "openssl@1.1" if MacOS.version <= :sierra
 
   def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-manpages
+    ]
+
+    args << "--disable-examples" if !build.with? "examples"
+
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-examples",
-                          "--disable-manpages"
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
  - **Formula contains no tests.**
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - **Fails only on** `* C: 1: col 1: A test do test block should be added`

-----

Added option to include POSIX examples when installing libcoap. Those examples include tools such as `coap-client`. 

Formula was previously missing tests.

:thinking: Might be a good idea to create an alias for libcoap, in case someone search for binary `coap-client`? Not sure how aliases works though, might need help with that.