### PR TITLE
confluent-platform:5.4.1 Added libexec to installation

### DIFF
--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -22,6 +22,7 @@ class ConfluentPlatform < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
+    mkdir "#{testpath}/.confluent"
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     shell_output("#{bin}/confluent local start")
     assert_equal "0\n", shell_output("echo $?")

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -21,5 +21,9 @@ class ConfluentPlatform < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
+
+    ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/)
+    shell_output("#{bin}/confluent local start")
+    assert_equal "0\n", shell_output("echo $?") 
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -20,9 +20,10 @@ class ConfluentPlatform < Formula
   end
 
   test do
+    (testpath/".confluent").mkpath
+
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
-    mkdir "#{testpath}/.confluent"
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     shell_output("#{bin}/confluent local start")
     assert_equal "0\n", shell_output("echo $?")

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -22,7 +22,11 @@ class ConfluentPlatform < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
-    ENV["HOME"] = "/tmp"
+    home = ENV["HOME"]
+    system "echo", "#{home}/.confluent"
+    system "mkdir", "#{home}/.confluent/"
+    system "ls", "#{home}/.confluent"
+
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     shell_output("#{bin}/confluent local status")
     assert_equal "0\n", shell_output("echo $?")

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -20,12 +20,10 @@ class ConfluentPlatform < Formula
   end
 
   test do
-    (testpath/".confluent").mkpath
-
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
-    shell_output("#{bin}/confluent local start")
+    shell_output("#{bin}/confluent local status")
     assert_equal "0\n", shell_output("echo $?")
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -28,7 +28,7 @@ class ConfluentPlatform < Formula
     system "ls", "#{home}/.confluent"
 
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
-    shell_output("#{bin}/confluent local status")
+    system "#{bin}/confluent", "local", "status"
     assert_equal "0\n", shell_output("echo $?")
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -15,6 +15,7 @@ class ConfluentPlatform < Formula
     prefix.install "bin"
     rm_rf "#{bin}/windows"
     prefix.install "etc"
+    prefix.install "libexec"
     prefix.install "share"
   end
 

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -22,6 +22,7 @@ class ConfluentPlatform < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
+    ENV["HOME"] = "/tmp"
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     shell_output("#{bin}/confluent local status")
     assert_equal "0\n", shell_output("echo $?")

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -27,12 +27,8 @@ class ConfluentPlatform < Formula
     system "mkdir", "#{home}/.confluent/"
     system "ls", "#{home}/.confluent"
 
-    (testpath/".confluent/config.json").write <<~EOS
-{"disable_updates": true}
-    EOS
-
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
-    system "#{bin}/confluent", "local", "status"
+    system "#{bin}/confluent", "--version"
     assert_equal "0\n", shell_output("echo $?")
     home = ENV["HOME"]
     system "echo", "#{home}/.confluent"

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -22,15 +22,8 @@ class ConfluentPlatform < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
-    home = ENV["HOME"]
-    system "echo", "#{home}/.confluent"
-    system "mkdir", "#{home}/.confluent/"
-    system "ls", "#{home}/.confluent"
-
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     system "#{bin}/confluent", "--version"
     assert_equal "0\n", shell_output("echo $?")
-    home = ENV["HOME"]
-    system "echo", "#{home}/.confluent"
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -22,8 +22,8 @@ class ConfluentPlatform < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
-    ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/)
+    ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     shell_output("#{bin}/confluent local start")
-    assert_equal "0\n", shell_output("echo $?") 
+    assert_equal "0\n", shell_output("echo $?")
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -27,8 +27,14 @@ class ConfluentPlatform < Formula
     system "mkdir", "#{home}/.confluent/"
     system "ls", "#{home}/.confluent"
 
+    (testpath/".confluent/config.json").write <<~EOS
+{"disable_updates": true}
+    EOS
+
     ENV["CONFLUENT_HOME"] = "/usr/local/Cellar/confluent-platform/5.4.1/"
     system "#{bin}/confluent", "local", "status"
     assert_equal "0\n", shell_output("echo $?")
+    home = ENV["HOME"]
+    system "echo", "#{home}/.confluent"
   end
 end


### PR DESCRIPTION
Added the following to .bashrc to make "confluent" script work

export CONFLUENT_HOME="/usr/local/Cellar/confluent-platform/5.4.1/"
export PATH="$PATH:$CONFLUENT_HOME/bin"

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
