### PR TITLE
publish-commit-bottles: Comment on a PR when someone triggers the Action

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -26,6 +26,26 @@ jobs:
             console.log("Dispatched by " + user.data.name + " <" + email + ">")
             core.setOutput("name", user.data.name)
             core.setOutput("email", email)
+      - name: Post comment once started
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          script: |
+            const run_id = process.env.GITHUB_RUN_ID
+            const actor = context.actor
+            const pr = context.payload.client_payload.pull_request
+            console.log("run_id=" + run_id)
+            console.log("actor=" + actor)
+            console.log("pr=" + pr)
+
+            const repository = context.repo.owner + '/' + context.repo.repo
+            const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
+
+            github.issues.createComment({
+              ...context.repo,
+              issue_number: pr,
+              body: '@' + actor + ' has triggered a merge, running bottle pull: ' + url
+            })
       - name: Update Homebrew
         run: |
           brew update-reset $(brew --repository)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- I went to do my first `brew pr-publish` on a "ready to merge" PR and
  it failed, because @dawidd6 had already started.
- We can't expect maintainers to pick through the Actions UI to find
  existing Actions that are running for the formula - the UI isn't
  that good.
- So this adds a comment to the PR, when the Action starts, to say who
  started it. It serves as a warning to other maintainers that it's in
  hand and to not try. Unless it fails for some reason.