### PR TITLE
qtads 3.0.0

### DIFF
--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -27,8 +27,8 @@ class Qtads < Formula
   def install
     sdl_sound_include = Formula["sdl_sound"].opt_include
     inreplace "qtads.pro",
-      "INCLUDEPATH += src $$T2DIR $$T3DIR $$HTDIR",
-      "INCLUDEPATH += src $$T2DIR $$T3DIR $$HTDIR #{sdl_sound_include}/SDL"
+      "$$T3DIR \\",
+      "$$T3DIR #{sdl_sound_include}/SDL \\"
 
     system "qmake", "DEFINES+=NO_STATIC_TEXTCODEC_PLUGINS"
     system "make"

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -6,15 +6,6 @@ class Qtads < Formula
   stable do
     url "https://downloads.sourceforge.net/project/qtads/v3.0.0/qtads-3.0.0-source.tar.xz"
     sha256 "430b5de04d2d2cafe4cd2614cd034c5fb71e0ba39ec1e5d058613b43a92e0407"
-
-    # Fix "error: ordered comparison between pointer and zero"
-    # Reported 11 Dec 2017 https://github.com/realnc/qtads/issues/7
-    if DevelopmentTools.clang_build_version >= "900"
-      patch do
-        url "https://raw.githubusercontent.com/Homebrew/formula-patches/e189341/qtads/xcode9.diff"
-        sha256 "2016fef6e867b7b8dfe1bd5db64d588161aad1357faa1962ee48edbe35042ddc"
-      end
-    end
   end
 
   bottle do

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -1,26 +1,11 @@
 class Qtads < Formula
   desc "TADS multimedia interpreter"
   homepage "https://qtads.sourceforge.io/"
-  revision 1
   head "https://github.com/realnc/qtads.git"
 
   stable do
-    url "https://downloads.sourceforge.net/project/qtads/qtads-2.x/2.1.7/qtads-2.1.7.tar.bz2"
-    sha256 "7477bb3cb1f74dcf7995a25579be8322c13f64fb02b7a6e3b2b95a36276ef231"
-
-    # Remove for > 2.1.7
-    # fix infinite recursion
-    patch do
-      url "https://github.com/realnc/qtads/commit/d22054b.patch?full_index=1"
-      sha256 "e6af1eb7a8a4af72c9319ac6032a0bb8ffa098e7dd64d76da08ed0c7e50eaa7f"
-    end
-
-    # Remove for > 2.1.7
-    # fix pointer/integer comparison
-    patch do
-      url "https://github.com/realnc/qtads/commit/46701a2.patch?full_index=1"
-      sha256 "02c86bfa44769ec15844bbefa066360fb83ac923360ced140545fb782f4f3397"
-    end
+    url "https://downloads.sourceforge.net/project/qtads/v3.0.0/qtads-3.0.0-source.tar.xz"
+    sha256 "430b5de04d2d2cafe4cd2614cd034c5fb71e0ba39ec1e5d058613b43a92e0407"
 
     # Fix "error: ordered comparison between pointer and zero"
     # Reported 11 Dec 2017 https://github.com/realnc/qtads/issues/7

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -19,6 +19,7 @@ class Qtads < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libsndfile"
   depends_on "qt"
   depends_on "sdl2"
   depends_on "sdl2_mixer"

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -1,12 +1,9 @@
 class Qtads < Formula
   desc "TADS multimedia interpreter"
   homepage "https://qtads.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/qtads/v3.0.0/qtads-3.0.0-source.tar.xz"
+  sha256 "430b5de04d2d2cafe4cd2614cd034c5fb71e0ba39ec1e5d058613b43a92e0407"
   head "https://github.com/realnc/qtads.git"
-
-  stable do
-    url "https://downloads.sourceforge.net/project/qtads/v3.0.0/qtads-3.0.0-source.tar.xz"
-    sha256 "430b5de04d2d2cafe4cd2614cd034c5fb71e0ba39ec1e5d058613b43a92e0407"
-  end
 
   bottle do
     cellar :any
@@ -20,6 +17,7 @@ class Qtads < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libsndfile"
+  depends_on "mpg123"
   depends_on "qt"
   depends_on "sdl2"
   depends_on "sdl2_mixer"

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -16,6 +16,7 @@ class Qtads < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "fluid-synth"
   depends_on "libsndfile"
   depends_on "mpg123"
   depends_on "qt"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Per https://realnc.github.io/qtads/
> The current version is 3.0, released on 2020-02-15. The list of changes since 2.1.7 can be found on the GitHub release page.