### PR TITLE
miniserve: downgrade, use stable rust.

### DIFF
--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -1,27 +1,19 @@
 class Miniserve < Formula
   desc "High performance static file server"
   homepage "https://github.com/svenstaro/miniserve"
-  url "https://github.com/svenstaro/miniserve/archive/v0.6.0.tar.gz"
-  sha256 "cad2608ff5459e5497b73b6b8635b76b0c38ce0bcee24bf4f2192984f386de93"
+  url "https://github.com/svenstaro/miniserve/archive/v0.3.0.tar.gz"
+  sha256 "80ee5d661730ddad14671f961b560467f3b3a9f0544b9b11dec65098eb4a1f7e"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "534cd0d7b79d8c06a5246a3d11dfb0fbbaac5aad634922883ebfd5fe958b2711" => :catalina
-    sha256 "b150191be231782aec0a73ed3a83245de22eedf9682ace58532d67857c042f47" => :mojave
-    sha256 "ccae720adeff3ef96f858a1709657c9a1608fd7a86689f9947174824cf9a4081" => :high_sierra
+    sha256 "e8955f888b8c0828d741d5541a2ae6567704d78db99600d59b3d9a02dc571089" => :mojave
+    sha256 "8711ae0bb727abd3ed3ad8d1335275d26fbc473f19bacfbad76b10b5a0bf4efc" => :high_sierra
+    sha256 "a00b82cfce9fecd067b62ec3135a0e9cc59d3133f97ed3c0e7b815e4921c32d0" => :sierra
   end
 
-  # Miniserve requires a known-good Rust nightly release to use.
-  resource "rust-nightly" do
-    url "https://static.rust-lang.org/dist/2020-03-14/rust-nightly-x86_64-apple-darwin.tar.xz"
-    sha256 "6cfe5b598502d4bc6afb1bec3b1e87306d3b4057ce1ffcd8a306817c2ff5fc87"
-  end
+  depends_on "rust"
 
   def install
-    resource("rust-nightly").stage do
-      system "./install.sh", "--prefix=#{buildpath}/rust-nightly"
-      ENV.prepend_path "PATH", "#{buildpath}/rust-nightly/bin"
-    end
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end
 


### PR DESCRIPTION
The current version uses a rust nightly which is forbidden in homebrew/core.
    
This will likely fail CI due to being a downgrade but we don't want to intentionally downgrade anyone.

Note to self: if this is merged, you can remove this from the Homebrew/brew rubocop whitelist.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----