### PR TITLE
publish-commit-bottles: Improve the style of "merge triggered" message

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -44,7 +44,7 @@ jobs:
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' has triggered a merge, running bottle pull: ' + url
+              body: '@' + actor + ' has [triggered a merge](%s).', url
             })
       - name: Update Homebrew
         run: |
@@ -100,5 +100,5 @@ jobs:
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' bottle publish failed: ' + url
+              body: '@' + actor + ' bottle publish [failed](%s).', url
             })


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- It was probably not entirely clear to users what "bottle pull" meant.
- We can use Markdown style links to make the message shorter.
- Tested in a browser with `console.log()` as that's as far as my JS goes!