### PR TITLE
publish-commit-bottles: Fix bug with error message syntax from #53098

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -44,7 +44,7 @@ jobs:
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' has [triggered a merge](%s).', url
+              body: '@' + actor + ' has [triggered a merge](' + url + ').'
             })
       - name: Update Homebrew
         run: |
@@ -100,5 +100,5 @@ jobs:
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' bottle publish [failed](%s).', url
+              body: '@' + actor + ' bottle publish [failed](' + url + ').'
             })


### PR DESCRIPTION
- I tried to be too clever. Given that I don't know JS, that was a bad
  idea. Let's do this the less elegant but (hopefully) definitely
  working way to avoid cryptic errors like:

```
[error]Cookies must be enabled to use GitHub.
```

from [`pr-publish` Actions runs](https://github.com/Homebrew/homebrew-core/runs/583194836?check_suite_focus=true).