### PR TITLE
opa v0.19.1

### DIFF
--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -1,8 +1,9 @@
 class Opa < Formula
   desc "Open source, general-purpose policy engine"
   homepage "https://www.openpolicyagent.org"
-  url "https://github.com/open-policy-agent/opa/archive/v0.18.0.tar.gz"
-  sha256 "07e6eeb2cd2b54df57b40d6cdf4ab11dfc8c6fc4b2e17d56a62a4ce1dc0cec52"
+  url "https://github.com/open-policy-agent/opa/archive/v0.19.1.tar.gz"
+  sha256 "6edbc3d327ce401508b10f4969554cdc1cea73fd00037b42bd21af87a59cdb63"
+  head "https://github.com/open-policy-agent/opa.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,6 +17,8 @@ class Opa < Formula
   def install
     system "go", "build", "-o", bin/"opa", "-trimpath", "-ldflags",
                  "-X github.com/open-policy-agent/opa/version.Version=#{version}"
+    system "./build/gen-man.sh", "man1"
+    man.install "man1"
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
With the latest OPA release it can generate man page entries for the
OPA CLI. This updates the formula to use that functionality and then
install them with the binary.

The formula was also missing a `head`, this corrects that.

Signed-off-by: Patrick East <east.patrick@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
