### PR TITLE
workflow: introduce pre-bottling tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,69 @@ name: GitHub Actions CI
 on:
   pull_request: []
 jobs:
+  pretests:
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew
+    env:
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Setup tap
+        run: |
+          cd $(brew --repo ${{github.repository}})
+          git clean -ffdx
+          git remote set-url origin https://github.com/${{github.repository}}
+          git fetch --prune --force origin master
+          git fetch --prune --force origin ${{github.sha}}
+          git checkout --force ${{github.sha}}
+          git clean -ffdx
+          git log -1
+          rm -rf $GITHUB_WORKSPACE
+          ln -s $(brew --repository ${{github.repository}}) $GITHUB_WORKSPACE
+      - name: Check formulae
+        run: brew readall
+      - name: Audit changed formulae
+        run: |
+          cat > brew-audit.json <<EOS
+          { "problemMatcher": [ {
+              "owner": "brew-audit",
+              "pattern": [ {
+                  "regexp": "^(.+): \\\* (?:[RCWEF]: (\\\d+): )?(?:col (\\\d+): )?(.+)$",
+                  "file": 1,
+                  "line": 2,
+                  "column": 3,
+                  "message": 4
+                  } ] } ] }
+          EOS
+
+          echo "::add-matcher::brew-audit.json"
+
+          cd $(brew --repo ${{github.repository}})
+          start_sha=$(git rev-parse origin/$GITHUB_BASE_REF)
+          end_sha=$GITHUB_SHA
+
+          cat <<EOS
+          Testing with:
+            diff_start_sha1 $start_sha
+            diff_end_sha1   $end_sha
+          EOS
+
+          new_formulae=$(git diff-tree -r --name-only --diff-filter=A $start_sha $end_sha -- Formula/)
+          modified_formulae=$(git diff-tree -r --name-only --diff-filter=M $start_sha $end_sha -- Formula/)
+
+          cat <<EOS
+          Formula to be audited:
+            added formulae    $new_formulae
+            modified formulae $modified_formulae
+          EOS
+
+          [ ! -z "$new_formulae" ] && brew audit --display-filename --new-formula --online $new_formulae
+          [ ! -z "$modified_formulae" ] && brew audit --display-filename --online $modified_formulae
+          echo "::remove-matcher owner=brew-audit::"
   tests:
+    needs: pretests
     strategy:
       matrix:
         version: [10.15, 10.14, 10.13]

--- a/Formula/hello.rb
+++ b/Formula/hello.rb
@@ -1,8 +1,8 @@
 class Hello < Formula
   desc "Program providing model for GNU coding standards and practices"
   homepage "https://www.gnu.org/software/hello/"
-  url "https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz"
   sha256 "31e066137a962676e89f69d1b65382de95a7ef7d914b8cb956f41ea72e0f516b"
+  url "https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Run some simple tests first (`brew readall`, `brew audit`) which can be done on more plentiful GitHub-hosted Linux runners, and save expensive bottling work for our macOS self-hosted runners.

This is a proof of concept, don't merge this until we like and refine this approach.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----