### PR TITLE
profanity: Add OMEMO support

### DIFF
--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -3,6 +3,7 @@ class Profanity < Formula
   homepage "https://profanity-im.github.io"
   url "https://profanity-im.github.io/profanity-0.8.1.tar.gz"
   sha256 "6b7ff1f0f1b54ed3a55efce40237db775fe9475af276e5e4ed342e91a3e8d997"
+  revision 1
 
   bottle do
     sha256 "301cf17605c91fc2c1d61a6ca5c08bca3b91676133f6cb208be0cd4539a4657b" => :catalina
@@ -24,6 +25,7 @@ class Profanity < Formula
   depends_on "gnutls"
   depends_on "gpgme"
   depends_on "libotr"
+  depends_on "libsignal-protocol-c"
   depends_on "libstrophe"
   depends_on "openssl@1.1"
   depends_on "readline"


### PR DESCRIPTION
profanity: Add OMEMO support

Add OMEMO support according to profanity's documentation: ["Building with OMEMO support"][1].

This change introduces adding the `libsignal-protocol-c` library as a dependency to the Formula.
It also adds the `revision 1` line to force the bottle to be rebuilt and redistributed.

***

[1]: https://profanity-im.github.io/guide/latest/omemo.html#installing-omemo

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?