### PR TITLE
Suggest the correct path in zsh-completions caveats

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -16,7 +16,7 @@ class ZshCompletions < Formula
       To activate these completions, add the following to your .zshrc:
 
         if type brew &>/dev/null; then
-          FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
+          FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
 
           autoload -Uz compinit
           compinit


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes the path that's suggested after `zsh-completions` installation. It currently suggest adding `$(brew --prefix)/share/zsh/site-functions` to your PATH, while it should suggest `$(brew --prefix)/share/zsh-completions`.

Close #51956
