### PR TITLE
ruby: create symlink to Gem binaries in unversioned path

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -3,6 +3,7 @@ class Ruby < Formula
   homepage "https://www.ruby-lang.org/"
   url "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.xz"
   sha256 "b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7"
+  revision 1
 
   bottle do
     sha256 "7f5ed2afb15b25f9616b617ecca2ee376eb67cf6c105790df22221b7be9c1ef9" => :catalina
@@ -122,6 +123,9 @@ class Ruby < Formula
     %w[sitearchdir vendorarchdir].each do |dir|
       mkdir_p `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["#{dir}"]'`
     end
+
+    rm_f prefix/"gembin"
+    prefix.install_symlink rubygems_bindir => "gembin"
   end
 
   def rubygems_config(api_version)
@@ -200,7 +204,7 @@ class Ruby < Formula
   def caveats
     <<~EOS
       By default, binaries installed by gem will be placed into:
-        #{rubygems_bindir}
+        #{opt_prefix}/gembin
 
       You may want to add this to your PATH.
     EOS


### PR DESCRIPTION
Currently, the gem binaries are install at path like `/usr/local/lib/ruby/gems/2.7.0/bin`,
which includes the ruby version number. This has the disadvantage that users are required to
manually update their PATH environment whenever there is a major ruby release.

To fix this, we create a symlink in prefix to point to the `rubygems_bindir`.
As such, users can instead add `/usr/local/opt/ruby/gembin` to the PATH.

This change is also compatible with existing setup.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
