### PR TITLE
git-revise: install manpage

### DIFF
--- a/Formula/git-revise.rb
+++ b/Formula/git-revise.rb
@@ -19,6 +19,7 @@ class GitRevise < Formula
 
   def install
     virtualenv_install_with_resources
+    man1.install "git-revise.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add the git-revice manpage so that `git help revise` works.  Manpage is installed from the sources, but could be symlinked from `libexec` if that's preferable? I couldn't see how to do that in the documentation.