### PR TITLE
exodriver: patch for dyld error

### DIFF
--- a/Formula/exodriver.rb
+++ b/Formula/exodriver.rb
@@ -1,9 +1,20 @@
 class Exodriver < Formula
   desc "Thin interface to LabJack devices"
   homepage "https://labjack.com/support/linux-and-mac-os-x-drivers"
-  url "https://github.com/labjack/exodriver/archive/v2.5.3.tar.gz"
-  sha256 "24cae64bbbb29dc0ef13f482f065a14d075d2e975b7765abed91f1f8504ac2a5"
+  revision 1
   head "https://github.com/labjack/exodriver.git"
+
+  stable do
+    url "https://github.com/labjack/exodriver/archive/v2.5.3.tar.gz"
+    sha256 "24cae64bbbb29dc0ef13f482f065a14d075d2e975b7765abed91f1f8504ac2a5"
+
+    # Fix "__dyld section not supported".
+    # Remove with the next release.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/f33e3149628486cd4db494e259001f4ee59f8694/exodriver/2.5.3-dyld.patch"
+      sha256 "9098aabb25c65d4e9bafcab9640f3422e28a9000603c4d5c26525a51fe880bbb"
+    end
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
dyld: __dyld section not supported in /usr/local/Cellar/exodriver/2.5.3/lib/liblabjackusb.dylib
```