### PR TITLE
chamber: match the macOS version output to the version output of the downloadable binaries

### DIFF
--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -15,7 +15,7 @@ class Chamber < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.Version=#{version}", "-trimpath", "-o", bin/"chamber"
+    system "go", "build", "-ldflags", "-s -w -X main.Version=v#{version}", "-trimpath", "-o", bin/"chamber"
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes an issue noted here: https://github.com/segmentio/chamber/issues/253

The binaries released by the project have a `v` as a prefix when asking for the version, giving values like `v2.8.1`. But the brew formula leaves out the `v` so that the version is `2.8.1`. This mismatch makes it difficult to compare installed versions with automated tools.

Building locally from the formula with the above command gave the expected output which includes the `v` character:

```
$ chamber version
chamber v2.8.1
```