### PR TITLE
Add static libs to glib, pixman, gettext, libffi formulae

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -33,7 +33,8 @@ class Gettext < Formula
                           # Don't use VCS systems to create these archives
                           "--without-git",
                           "--without-cvs",
-                          "--without-xz"
+                          "--without-xz",
+                          "--enable-static"
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs
     system "make", "install"

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -38,6 +38,8 @@ class Glib < Formula
       -Dgio_module_dir=#{HOMEBREW_PREFIX}/lib/gio/modules
       -Dbsymbolic_functions=false
       -Ddtrace=false
+      -Ddefault_library=both
+      -Db_staticpic=true
     ]
 
     mkdir "build" do

--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -27,7 +27,7 @@ class Libffi < Formula
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--enable-static", "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -18,6 +18,7 @@ class Pixman < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-gtk",
                           "--disable-silent-rules",
+                          "--enable-static",
                           "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Add static libraries to the following formulae: glib, gettext, pixman and libffi.

There are no version bumps or other updates, just enabling static libs for these libraries. These changes were tested following https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request .
