### PR TITLE
fd: Add caveat about -l/--list-details and coreutils

### DIFF
--- a/Formula/fd.rb
+++ b/Formula/fd.rb
@@ -27,6 +27,13 @@ class Fd < Formula
     zsh_completion.install "_fd"
   end
 
+  def caveats
+    <<~EOS
+      Install the optional dependency coreutils for -l/--list-details support:
+        brew install coreutils
+    EOS
+  end
+
   test do
     touch "foo_file"
     touch "test_file"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> Package maintainers on MacOS and Windows might think about adding (GNU) `ls` as an optional dependency for `fd` to make full use of `fd`s new `-l`/`--list-details` option. For MacOS, `fd` relies on `gls` which should be available via `coreutils`.
>
> – https://github.com/sharkdp/fd/releases/tag/v8.0.0