### PR TITLE
add wavpack support for MPD

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -3,7 +3,7 @@ class Mpd < Formula
   homepage "https://www.musicpd.org/"
   url "https://www.musicpd.org/download/mpd/0.21/mpd-0.21.22.tar.xz"
   sha256 "565687d1899b585350cd66b603e46e5b79affc0a0e36d96d8953c6ccc6f69ba2"
-  revision 1
+  revision 2
   head "https://github.com/MusicPlayerDaemon/MPD.git"
 
   bottle do
@@ -35,6 +35,7 @@ class Mpd < Formula
   depends_on "libvorbis"
   depends_on "opus"
   depends_on "sqlite"
+  depends_on "wavpack"
 
   def install
     # mpd specifies -std=gnu++0x, but clang appears to try to build
@@ -57,6 +58,7 @@ class Mpd < Formula
       -Dnfs=enabled
       -Dupnp=enabled
       -Dvorbisenc=enabled
+      -Dwavpack=enabled
     ]
 
     system "meson", *args, "output/release", "."


### PR DESCRIPTION
- [√ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [√ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [√ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [√ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [√ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
FFMpeg provides only partial wavpack support. 