### PR TITLE
cbmc 5.12 (new formula)

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -1,0 +1,51 @@
+class Cbmc < Formula
+  desc "CBMC: The C Bounded Model Checker"
+  homepage "https://www.cprover.org/cbmc/"
+  url "https://github.com/diffblue/cbmc.git",
+      :using    => :git,
+      :tag      => "cbmc-5.12",
+      :revision => "d51243d346350127ecb269f1e546cbd850ef6955"
+  sha256 "1b9d003e1baffc714b36a38087e4ed42b47c04da5ebdb02bbce03262ea3acafd"
+
+  depends_on "cmake" => :build
+  depends_on "maven" => :build
+  depends_on "openjdk" => :build
+
+  def install
+    system "git", "submodule", "update", "--init"
+
+    # Build CBMC
+    system "cmake", std_cmake_args, "-S.", "-Bbuild"
+    system "cmake", "--build", "build"
+
+    # Install CBMC
+    #  CBMC 5.12 does not come with an install target
+    #  Pull request submitted to add install target to CBMC 5.13:
+    #    https://github.com/diffblue/cbmc/pull/5320
+    bin.install "build/bin/cbmc"
+    bin.install "build/bin/goto-analyzer"
+    bin.install "build/bin/goto-cc"
+    bin.install "build/bin/goto-diff"
+    bin.install "build/bin/goto-gcc"
+    bin.install "build/bin/goto-harness"
+    bin.install "build/bin/goto-instrument"
+    bin.install "build/bin/janalyzer"
+    bin.install "build/bin/java-unit"
+    bin.install "build/bin/jbmc"
+    bin.install "build/bin/jdiff"
+    man1.install "doc/man/cbmc.1"
+  end
+
+  test do
+    # Find a pointer out of bounds error
+    (testpath/"main.c").write <<~EOS
+      #include <stdlib.h>
+      int main() {
+        char *ptr = malloc(10);
+        char c = ptr[10];
+      }
+    EOS
+    assert_match "VERIFICATION FAILED",
+                 shell_output("#{bin}/cbmc --pointer-check main.c", 10)
+  end
+end


### PR DESCRIPTION
CBMC is the C Bounded Model Checker for C programs.  As the homepage
says, "CBMC verifies memory safety (which includes array bounds checks
and checks for the safe use of pointers), checks for exceptions,
checks for various variants of undefined behavior, and user-specified
assertions. Furthermore, it can check C and C++ for consistency with
other languages, such as Verilog. The verification is performed by
unwinding the loops in the program and passing the resulting equation
to a decision procedure."

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
