### PR TITLE
git-annex: remove xdot as dependency

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -22,7 +22,6 @@ class GitAnnex < Formula
   depends_on "gsasl"
   depends_on "libmagic"
   depends_on "quvi"
-  depends_on "xdot"
 
   def install
     install_cabal_package "--constraint", "http-conduit>=2.3",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[As suggested by @jonchang in another issue](https://github.com/Homebrew/linuxbrew-core/pull/19192#issuecomment-589503282), this PR removes `xdot` as a dependency for `git-annex`. `xdot` is not really a dependency for `git-annex`:
- AFAIK, it is used only by [`git annex map`](https://git-annex.branchable.com/git-annex-map/), and even that command works fine without it, having `xdot` is used for display only if available
- [debian considers it "suggested" and not required](https://packages.debian.org/sid/git-annex)
- `xdot` itself has many `xorg`-related dependencies, which makes building very time-intensive (a pain for bottling).

This seemed like an appropriate use case for `:optional` but per the [Formula cookbook](https://docs.brew.sh/Formula-Cookbook) it seems that "options" are prohibited in `homebrew-core` (and it wasn't 100% clear to me whether this means `:optional` is also prohibited).