### PR TITLE
eigen: bitbucket -> gitlab

### DIFF
--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -1,9 +1,9 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
   homepage "https://eigen.tuxfamily.org/"
-  url "https://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2"
-  sha256 "9f13cf90dedbe3e52a19f43000d71fdf72e986beb9a5436dddcd61ff9d77a3ce"
-  head "https://bitbucket.org/eigen/eigen", :using => :hg
+  url "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2"
+  sha256 "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11"
+  head "https://gitlab.com/libeigen/eigen"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The eigen project has moved from bitbucket to gitlab, and the bitbucket repository will be [deleted on June 1](https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Expected audit failure:

~~~
brew audit --strict eigen --online
eigen:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
Error: 1 problem in 1 formula detected
~~~