### PR TITLE
freeciv: revision for gtk+3

### DIFF
--- a/Formula/freeciv.rb
+++ b/Formula/freeciv.rb
@@ -1,8 +1,9 @@
 class Freeciv < Formula
   desc "Free and Open Source empire-building strategy game"
-  homepage "https://freeciv.wikia.com/"
+  homepage "http://freeciv.org"
   url "https://downloads.sourceforge.net/project/freeciv/Freeciv%202.6/2.6.2/freeciv-2.6.2.tar.bz2"
   sha256 "6181ef3d3c76264383aabbe0eaf1550d8a65ca42639e6c17cc2938165e176c8f"
+  revision 1
 
   bottle do
     sha256 "827459a0ad236b5068cca01b5ccd64d5c59e833c98a5041ae0684f87813c01f3" => :catalina
@@ -21,18 +22,24 @@ class Freeciv < Formula
 
   depends_on "pkg-config" => :build
   depends_on "atk"
+  depends_on "cairo"
   depends_on "freetype"
+  depends_on "gdk-pixbuf"
   depends_on "gettext"
   depends_on "glib"
-  depends_on "gtk+"
+  depends_on "gtk+3"
+  depends_on "harfbuzz"
   depends_on "icu4c"
   depends_on "pango"
   depends_on "readline"
-  depends_on "sdl"
-  depends_on "sdl_gfx"
-  depends_on "sdl_image"
-  depends_on "sdl_mixer"
-  depends_on "sdl_ttf"
+  depends_on "sdl2"
+  depends_on "sdl2_mixer"
+  depends_on "readline"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "curl"
+  uses_from_macos "libiconv"
+  uses_from_macos "zlib"
 
   def install
     ENV["ac_cv_lib_lzma_lzma_code"] = "no"
@@ -41,6 +48,11 @@ class Freeciv < Formula
       --disable-debug
       --disable-dependency-tracking
       --disable-gtktest
+      --disable-silent-rules
+      --disable-sdltest
+      --disable-sdl2test
+      --disable-sdl2framework
+      --enable-fcdb=sqlite3
       --prefix=#{prefix}
       --with-readline=#{Formula["readline"].opt_prefix}
       CFLAGS=-I#{Formula["gettext"].include}
@@ -61,11 +73,10 @@ class Freeciv < Formula
     system bin/"freeciv-manual"
     assert_predicate testpath/"classic6.mediawiki", :exist?
 
-    server = fork do
+    fork do
       system bin/"freeciv-server", "-l", testpath/"test.log"
     end
     sleep 5
-    Process.kill("TERM", server)
     assert_predicate testpath/"test.log", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/53288

Per the [build instructions](https://freeciv.fandom.com/wiki/Build-MacOSX) the gtk+3 client is now preferred. Tested locally and I don't observe the crash with the old gtk+2 client. Sound also seems to work with sdl2_mixer.