### PR TITLE
zig: patch for static linkage issues

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -3,6 +3,7 @@ class Zig < Formula
   homepage "https://ziglang.org/"
   url "https://ziglang.org/download/0.6.0/zig-0.6.0.tar.xz"
   sha256 "5d167dc19354282dd35dd17b38e99e1763713b9be8a4ba9e9e69284e059e7204"
+  revision 1
   head "https://github.com/ziglang/zig.git"
 
   bottle do
@@ -15,8 +16,12 @@ class Zig < Formula
   depends_on "cmake" => :build
   depends_on "llvm"
 
+  # Fix linking issues
+  # https://github.com/Homebrew/homebrew-core/issues/53198
+  patch :DATA
+
   def install
-    system "cmake", ".", *std_cmake_args, "-DZIG_PREFER_CLANG_CPP_DYLIB=ON"
+    system "cmake", ".", *std_cmake_args
     system "make", "install"
   end
 
@@ -32,3 +37,15 @@ class Zig < Formula
     assert_equal "Hello, world!", shell_output("./hello")
   end
 end
+
+__END__
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,6 +384,9 @@ target_link_libraries(zig_cpp LINK_PUBLIC
+     ${CLANG_LIBRARIES}
+     ${LLD_LIBRARIES}
+     ${LLVM_LIBRARIES}
++    "-Wl,/usr/local/opt/llvm/lib/libPolly.a"
++    "-Wl,/usr/local/opt/llvm/lib/libPollyPPCG.a"
++    "-Wl,/usr/local/opt/llvm/lib/libPollyISL.a"
+ )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #53198.

Note for future maintainers: if there's a LLD shared library in the future it would be worth revisiting linking dynamically - it's what we, as well as many other package mangers, strongly prefer. We unfortunately cannot here until a LLD shared library becomes available.