### PR TITLE
libvirt: Fix broken HEAD build

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -46,8 +46,8 @@ class Libvirt < Formula
     # Work around a gnulib issue with macOS Catalina
     args << "gl_cv_func_ftello_works=yes"
 
-    system "./autogen.sh" if build.head?
     mkdir "build" do
+      system "../autogen.sh" if build.head?
       system "../configure", *args
 
       # Compilation of docs doesn't get done if we jump straight to "make install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Before

```
==> ./autogen.sh
Last 15 lines from /Users/radeksimko/Library/Logs/Homebrew/libvirt/01.autogen.sh:
glibtoolize: copying file 'm4/ltsugar.m4'
glibtoolize: copying file 'm4/ltversion.m4'
glibtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoconf --force
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:53: installing 'build-aux/compile'
configure.ac:51: installing 'build-aux/config.guess'
configure.ac:51: installing 'build-aux/config.sub'
configure.ac:39: installing 'build-aux/install-sh'
configure.ac:39: installing 'build-aux/missing'
examples/Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: Leaving directory `.'
configure: error: Build directory must be different from source directory
```

## After

```
==> ../autogen.sh
==> ../configure --prefix=/usr/local/Cellar/libvirt/HEAD-ee62b98 --localstatedir=/usr/local/var --mandir=/usr/local/Cellar/libvirt/HEAD-ee62b98/share/man --s
==> make
==> make install
==> Caveats
To have launchd start libvirt now and restart at login:
  brew services start libvirt
Or, if you don't want/need a background service you can just run:
  libvirtd
==> Summary
🍺  /usr/local/Cellar/libvirt/HEAD-ee62b98: 555 files, 36.7MB, built in 8 minutes 46 seconds
```