### PR TITLE
libvirt: Avoid replacing correct paths in config

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -54,12 +54,6 @@ class Libvirt < Formula
       system "make"
       system "make", "install"
     end
-
-    # Update the libvirt daemon config file to reflect the Homebrew prefix
-    inreplace "#{etc}/libvirt/libvirtd.conf" do |s|
-      s.gsub! "/etc/", "#{etc}/"
-      s.gsub! "/var/", "#{var}/"
-    end
   end
 
   plist_options :manual => "libvirtd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libvirt appears to be already generating correct paths based on `localstatedir` and `sysconfdir` arguments which are already being passed to `configure` as part of the build.

This means that the existing logic replaces correct paths, resulting in a config which contains for example the following
```ini
# Set the name of the directory in which sockets will be found/created.
#
# This setting is not required or honoured if using systemd socket
# activation with systemd version >= 227
#
#unix_sock_dir = "/usr/local/usr/local/var/run/libvirt"
```
In other words the replacement logic is redundant, most likely since libvirt `5.7.0`:
https://github.com/libvirt/libvirt/commit/cc5311e73071f463ef29d9cb1cdd3eb3e19ef93a