### PR TITLE
libvirt: Load config in plist by default

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -3,6 +3,7 @@ class Libvirt < Formula
   homepage "https://www.libvirt.org"
   url "https://libvirt.org/sources/libvirt-6.2.0.tar.xz"
   sha256 "aec8881f236917c4f8064918df546ed3aacd0bb8a2f312f4d37485721cce0fb1"
+  revision 1
   head "https://github.com/libvirt/libvirt.git"
 
   bottle do
@@ -75,6 +76,8 @@ class Libvirt < Formula
           <key>ProgramArguments</key>
           <array>
             <string>#{sbin}/libvirtd</string>
+            <string>-f</string>
+            <string>#{etc}/libvirt/libvirtd.conf</string>
           </array>
           <key>KeepAlive</key>
           <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sometimes (often?) users may need to configure various aspects of libvirtd, rather than just run it with default options. In order to do that they have to take two steps:

1. add `-f` flag to the plist file in `/usr/local/Cellar/libvirt/<VERSION>/homebrew.mxcl.libvirt.plist`
2. edit `libvirtd.conf`
3. run `brew services (re)start libvirt`

Here I'm removing the first step and reducing it to just modification of the config and restart. This should be harmless since the default config is shipped with no options enabled (all commented out), so it will behave effectively the same as if there was no config provided.

Avoiding modification of plist is also better practice since the file is coupled with the formula version, hence modifications don't survive upgrades, unlike modifications of configs in `/usr/local/etc`.