### PR TITLE
multiple python formulas: migrate to python@3.8

### DIFF
--- a/Formula/anime-downloader.rb
+++ b/Formula/anime-downloader.rb
@@ -6,6 +6,7 @@ class AnimeDownloader < Formula
   url "https://files.pythonhosted.org/packages/9a/41/a4afd6d8f2473280210f24d5f9b1d24b20f4f3e78681196094aa8f631f32/anime-downloader-4.1.0.tar.gz"
   sha256 "0f14194488586e996824da80a7a29f7996790d524f04920e737366eff36f13b6"
   head "https://github.com/vn-ki/anime-downloader.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -94,7 +95,7 @@ class AnimeDownloader < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install "beautifulsoup4"
     venv.pip_install "certifi"
     venv.pip_install "cfscrape"

--- a/Formula/autopep8.rb
+++ b/Formula/autopep8.rb
@@ -5,6 +5,7 @@ class Autopep8 < Formula
   homepage "https://github.com/hhatto/autopep8"
   url "https://files.pythonhosted.org/packages/ca/d3/bb1c5781415b2a4f7d48bcd4c62e735d5ebf40d4f8c325d654870bedb7a6/autopep8-1.5.1.tar.gz"
   sha256 "cc6be1dfd46f2c7fa00e84a357f1a269683985b09eaffb47654ed551194399eb"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,10 +14,10 @@ class Autopep8 < Formula
     sha256 "9178c1e4b633eaad87163a18b55a7818969b3464569d6bb87ceba0e2d1fbb8b4" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -6,6 +6,7 @@ class AwsGoogleAuth < Formula
   url "https://github.com/cevoaustralia/aws-google-auth/archive/0.0.34.tar.gz"
   sha256 "d9051cdc91b1499f8ddd0aaf97ee42c9b7f8c5e9e0e0c47b13aa59f942a14a4b"
   head "https://github.com/cevoaustralia/aws-google-auth.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,7 +17,7 @@ class AwsGoogleAuth < Formula
 
   depends_on "freetype"
   depends_on "jpeg"
-  depends_on "python"
+  depends_on "python@3.8"
 
   uses_from_macos "libffi"
   uses_from_macos "libxml2"
@@ -141,7 +142,7 @@ class AwsGoogleAuth < Formula
     # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
 
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
 
     resource("entrypoints").stage do
       # Without removing this file, `pip` will ignore the `setup.py` file and

--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -6,6 +6,7 @@ class Awscli < Formula
   url "https://github.com/aws/aws-cli/archive/2.0.8.tar.gz"
   sha256 "16bc81eae154d2151b3e699e5377983a0032591256ea8d6a8cf217642dfd54b4"
   head "https://github.com/aws/aws-cli.git", :branch => "v2"
+  revision 1
 
   bottle do
     sha256 "333cb2cf92892bed6c8299c5520607549852960a2743bfb34f1ca8da0d4d16e6" => :catalina
@@ -20,7 +21,7 @@ class Awscli < Formula
   uses_from_macos "groff"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "-r", "requirements.txt",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "awscli"

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -6,6 +6,7 @@ class AwscliAT1 < Formula
   # awscli should only be updated every 10 releases on multiples of 10
   url "https://github.com/aws/aws-cli/archive/1.18.20.tar.gz"
   sha256 "b7490e7ef19337d77df7d2e965b6a41e09d1366c525aee7c5db79aee54ad5b12"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -23,7 +24,7 @@ class AwscliAT1 < Formula
   uses_from_macos "groff"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "awscli"

--- a/Formula/awsume.rb
+++ b/Formula/awsume.rb
@@ -6,6 +6,7 @@ class Awsume < Formula
   url "https://github.com/trek10inc/awsume/archive/4.4.1.tar.gz"
   sha256 "66d698b4716a1dc7c927778a8fe124a6ac2d99334aff2be5dac6b13598b4e08f"
   head "https://github.com/trek10inc/awsume.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -19,7 +20,7 @@ class Awsume < Formula
   uses_from_macos "sqlite"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "awsume"

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -7,6 +7,7 @@ class AzureCli < Formula
   version "2.3.1"
   sha256 "05b7c868afd2c95aa8362252336a9477aa88ccd0de91131ff9a1f1a46c2619f1"
   head "https://github.com/Azure/azure-cli.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -653,7 +654,7 @@ class AzureCli < Formula
     # https://code.videolan.org/videolan/libbluray/issues/20
     ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
 
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resources
 
     # Get the CLI components we'll install

--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -5,7 +5,7 @@ class Conan < Formula
   homepage "https://github.com/conan-io/conan"
   url "https://github.com/conan-io/conan/archive/1.24.0.tar.gz"
   sha256 "fe7fc766d3ff4997a700d141485ba7dd2768cf78eb710fed413a6ccea8b7f9a1"
-  revision 1
+  revision 2
   head "https://github.com/conan-io/conan.git"
 
   bottle do
@@ -21,7 +21,7 @@ class Conan < Formula
   depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", "PyYAML==3.13", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name

--- a/Formula/conjure-up.rb
+++ b/Formula/conjure-up.rb
@@ -5,7 +5,7 @@ class ConjureUp < Formula
   homepage "https://conjure-up.io/"
   url "https://github.com/conjure-up/conjure-up/archive/2.6.9.tar.gz"
   sha256 "b5ebba187d27b3474b36acd715df015b198c0e5df8aefb32200ba4f3f3de17f4"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -254,7 +254,7 @@ class ConjureUp < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resource("cffi") # needs to be installed prior to bcrypt
     res = resources.map(&:name).to_set - ["cffi"]
 

--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -6,6 +6,7 @@ class DockerCompose < Formula
   url "https://github.com/docker/compose/archive/1.25.5.tar.gz"
   sha256 "c04d4858b456f5806618fe7a49fadd3f1ccb8f10cf6e499bcf7fdee80a93c21a"
   head "https://github.com/docker/compose.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,7 +22,7 @@ class DockerCompose < Formula
 
   def install
     system "./script/build/write-git-sha" if build.head?
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "docker-compose"

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -5,7 +5,7 @@ class Fdroidserver < Formula
   homepage "https://f-droid.org"
   url "https://files.pythonhosted.org/packages/e0/47/9e78f8d1072c684639b3f44c44e00f1efedc855cb57921dc1a27bef746a8/fdroidserver-1.1.6.tar.gz"
   sha256 "7a368c9224cefee7a3306c5a4e4cd81e50e7219373f325f5cf9505493e4d8001"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -334,7 +334,7 @@ class Fdroidserver < Formula
 
   def install
     bash_completion.install "completion/bash-completion" => "fdroid"
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
 
     resource("Pillow").stage do
       inreplace "setup.py" do |s|

--- a/Formula/gimme-aws-creds.rb
+++ b/Formula/gimme-aws-creds.rb
@@ -5,6 +5,7 @@ class GimmeAwsCreds < Formula
   homepage "https://github.com/Nike-Inc/gimme-aws-creds"
   url "https://files.pythonhosted.org/packages/e2/a7/53d5f021a1b41a680d5c558c683e37e3000085c1a4132695e3378e4b477d/gimme%20aws%20creds-2.3.3.tar.gz"
   sha256 "b7bc10cd09faf995e44063bb6125b910ee85cf2f3e95ddb2908afade4bbd3973"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,7 +19,7 @@ class GimmeAwsCreds < Formula
   uses_from_macos "libffi"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "gimme-aws-creds"

--- a/Formula/khal.rb
+++ b/Formula/khal.rb
@@ -7,6 +7,7 @@ class Khal < Formula
       :tag      => "v0.10.1",
       :revision => "a6d7d62388d33459e85dfb5cf57a31c46f120769"
   head "https://github.com/pimutils/khal.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,10 +17,10 @@ class Khal < Formula
     sha256 "f3fc8e90d8d5e5f452a56954563d2c5e40f17cbda7f1552ad9ad2bd5e8bda30a" => :sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name

--- a/Formula/libtorch.rb
+++ b/Formula/libtorch.rb
@@ -15,7 +15,7 @@ class Libtorch < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python" => :build
+  depends_on "python@3.8" => :build
   depends_on "eigen"
   depends_on "libomp"
   depends_on "protobuf"
@@ -31,7 +31,7 @@ class Libtorch < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resources
 
     args = %W[

--- a/Formula/magic-wormhole.rb
+++ b/Formula/magic-wormhole.rb
@@ -5,6 +5,7 @@ class MagicWormhole < Formula
   homepage "https://github.com/warner/magic-wormhole"
   url "https://files.pythonhosted.org/packages/d4/62/5e4a86f7c4b111e016577f1b304063ebe604f430db15465ac58b13993608/magic-wormhole-0.12.0.tar.gz"
   sha256 "1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160"
+  revision 1
 
   bottle do
     cellar :any
@@ -151,7 +152,7 @@ class MagicWormhole < Formula
 
   def install
     ENV["SODIUM_INSTALL"] = "system"
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resource("cffi")
     virtualenv_install_with_resources
   end

--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -6,6 +6,7 @@ class Mitmproxy < Formula
   url "https://github.com/mitmproxy/mitmproxy/archive/v5.1.1.tar.gz"
   sha256 "555bbe9612e01d41858fbbe9f5d841b65bef3ac989ec26bb5c4c3d12a19dd57c"
   head "https://github.com/mitmproxy/mitmproxy.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -189,7 +190,7 @@ class Mitmproxy < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resource("cffi")
     venv.pip_install resources
     venv.pip_install_and_link buildpath

--- a/Formula/notifiers.rb
+++ b/Formula/notifiers.rb
@@ -5,6 +5,7 @@ class Notifiers < Formula
   homepage "https://pypi.org/project/notifiers/"
   url "https://files.pythonhosted.org/packages/4f/36/4c300f55949b9be84284d51253ae48d564dc2c4f2bffb94f26c8c1485f07/notifiers-1.2.1.tar.gz"
   sha256 "34625af405f4aa19293eaaefe145ccc92c6018ae9798f53a03a7fcc996e541aa"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,10 +14,10 @@ class Notifiers < Formula
     sha256 "991eb6cde6f98169be00a5ff9e9a6f5cc5d65e73e09d1a48e3c8ba3b5160cbea" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "notifiers"

--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -5,7 +5,7 @@ class Pipenv < Formula
   homepage "https://pipenv.pypa.io/"
   url "https://files.pythonhosted.org/packages/fd/e9/01822318551caa0d62a181ba3b10f0f3757bb1e270da97165bd52db92776/pipenv-2018.11.26.tar.gz"
   sha256 "a673e606e8452185e9817a987572b55360f4d28b50831ef3b42ac3cab3fee846"
-  revision 4
+  revision 5
 
   bottle do
     cellar :any_skip_relocation
@@ -55,7 +55,7 @@ class Pipenv < Formula
     # Using the virtualenv DSL here because the alternative of using
     # write_env_script to set a PYTHONPATH breaks things.
     # https://github.com/Homebrew/homebrew-core/pull/19060#issuecomment-338397417
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resources
     venv.pip_install buildpath
 

--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -5,6 +5,7 @@ class PreCommit < Formula
   homepage "https://pre-commit.com/"
   url "https://github.com/pre-commit/pre-commit/archive/v2.2.0.tar.gz"
   sha256 "53a5d39e8b2063a004ecdabd4b459ae826cfe47eca449720e4fdde06a7d43cc0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,15 +17,15 @@ class PreCommit < Formula
   # To avoid breaking existing git hooks when we update Python,
   # we should never depend on a versioned Python formula and
   # always use the "default".
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
     # Make sure we are actually using Homebrew's Python
     inreplace "pre_commit/commands/install_uninstall.py",
               "f'#!/usr/bin/env {py}'",
-              "'#!#{Formula["python"].opt_bin}/python3'"
+              "'#!#{Formula["python@3.8"].opt_bin}/python3'"
 
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "pre-commit"

--- a/Formula/recon-ng.rb
+++ b/Formula/recon-ng.rb
@@ -5,6 +5,7 @@ class ReconNg < Formula
   homepage "https://github.com/lanmaster53/recon-ng"
   url "https://github.com/lanmaster53/recon-ng/archive/v5.1.1.tar.gz"
   sha256 "470e293e931c23a0dc76e6915098e04db7f2e254a0639bb2c0383e0758c4fbc2"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +14,7 @@ class ReconNg < Formula
     sha256 "fcf86a9934bcc8fb7cb5611736361225a0ec4f2141be5ba965bfc79f0b327f38" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
@@ -88,11 +89,11 @@ class ReconNg < Formula
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
 
     libexec.install Dir["*"]
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     venv.pip_install resources
 
     # Replace shebang with virtualenv python
-    inreplace libexec/"recon-ng", "#!/usr/bin/env python3", "#!#{libexec}/bin/python"
+    inreplace libexec/"recon-ng", "#!/usr/bin/env python3", "'#!#{Formula["python@3.8"].opt_bin}/python3'"
 
     bin.install_symlink libexec/"recon-ng"
   end

--- a/Formula/rtv.rb
+++ b/Formula/rtv.rb
@@ -5,7 +5,7 @@ class Rtv < Formula
   homepage "https://github.com/michael-lazar/rtv"
   url "https://github.com/michael-lazar/rtv/archive/v1.27.0.tar.gz"
   sha256 "c57a6cbb2525160b6aaa9180aec0293962b6969675f8ac0f2cfacff3cbd00d7c"
-  revision 2
+  revision 3
   head "https://github.com/michael-lazar/rtv.git"
 
   bottle do
@@ -18,7 +18,7 @@ class Rtv < Formula
   depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -5,6 +5,7 @@ class S3ql < Formula
   homepage "https://github.com/s3ql/s3ql"
   url "https://github.com/s3ql/s3ql/releases/download/release-3.3.2/s3ql-3.3.2.tar.bz2"
   sha256 "72b310052752e281a17468a8bbe9006db7fa1f0184b83b38c5667239dfd59e73"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,7 @@ class S3ql < Formula
 
   depends_on "pkg-config" => :build
   depends_on :osxfuse
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "apsw" do
     url "https://files.pythonhosted.org/packages/b5/a1/3de5a2d35fc34939672f4e1bd7d68cca359a31b76926f00d95f434c63aaa/apsw-3.9.2-r1.tar.gz"
@@ -128,7 +129,7 @@ class S3ql < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     resources.each do |r|
       venv.pip_install r
     end
@@ -139,7 +140,7 @@ class S3ql < Formula
     # Final names: fsck_s3ql, mkfs_s3ql, mount_s3ql, umount_s3ql
     inreplace "setup.py", /'(?:(mkfs|fsck|mount|umount)\.)s3ql =/, "'\\1_s3ql ="
 
-    system libexec/"bin/python3", "setup.py", "build_ext", "--inplace"
+    system Formula["python@3.8"].opt_bin/"python3", "setup.py", "build_ext", "--inplace"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/sslyze.rb
+++ b/Formula/sslyze.rb
@@ -14,6 +14,8 @@ class Sslyze < Formula
     end
   end
 
+  revision 1
+
   bottle do
     cellar :any
     sha256 "65e5b3d3127c1ca9899c22fff2234a0b4347b5e053869ad2c412d2c0f053f73e" => :catalina
@@ -33,7 +35,7 @@ class Sslyze < Formula
   depends_on :arch => :x86_64
   depends_on "libffi"
   depends_on "openssl@1.1"
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/9f/3d/8beae739ed8c1c8f00ceac0ab6b0e97299b42da869e24cf82851b27a9123/asn1crypto-1.3.0.tar.gz"
@@ -71,7 +73,7 @@ class Sslyze < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
 
     res = resources.map(&:name).to_set
     res -= %w[nassl]

--- a/Formula/statik.rb
+++ b/Formula/statik.rb
@@ -6,6 +6,7 @@ class Statik < Formula
   url "https://github.com/thanethomson/statik/archive/v0.23.0.tar.gz"
   sha256 "6159066f486811e5773da318d6e8d1b1dd4c99ac140f1a3c660ef1c1f5e7124f"
   head "https://github.com/thanethomson/statik.git"
+  revision 1
 
   bottle do
     cellar :any
@@ -22,7 +23,7 @@ class Statik < Formula
   conflicts_with "go-statik", :because => "both install `statik` binaries"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "statik"

--- a/Formula/termius.rb
+++ b/Formula/termius.rb
@@ -5,7 +5,7 @@ class Termius < Formula
   homepage "https://termius.com"
   url "https://github.com/Crystalnix/termius-cli/archive/v1.2.12.tar.gz"
   sha256 "89be6d35e5c4918c0d9e3f2410620d3a84c7108e52c2c87cfa6166c5612e08ee"
-  revision 1
+  revision 2
   head "https://github.com/Crystalnix/termius-cli.git", :branch => "master"
 
   bottle do
@@ -19,11 +19,11 @@ class Termius < Formula
   depends_on "bash-completion"
   depends_on "libyaml"
   depends_on "openssl@1.1"
-  depends_on "python"
+  depends_on "python@3.8"
   depends_on "zsh-completions"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "termius"

--- a/Formula/termtosvg.rb
+++ b/Formula/termtosvg.rb
@@ -5,6 +5,7 @@ class Termtosvg < Formula
   homepage "https://nbedos.github.io/termtosvg"
   url "https://github.com/nbedos/termtosvg/archive/1.1.0.tar.gz"
   sha256 "53e9ad5976978684699d14b83cac37bf173d76c787f1b849859ad8aef55f22d2"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -13,10 +14,10 @@ class Termtosvg < Formula
     sha256 "24b342f95d1700df9485dba70ef456a7f8bb64391a3b58502ca4c651e330f494" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-U", "-e", "."
     venv.pip_install_and_link buildpath
     bin.install_symlink libexec/"bin/termtosvg"

--- a/Formula/twarc.rb
+++ b/Formula/twarc.rb
@@ -5,6 +5,7 @@ class Twarc < Formula
   homepage "https://github.com/DocNow/twarc"
   url "https://files.pythonhosted.org/packages/d9/e7/d65758f2cb7267b2fb8a905b53987ce4f21240a40d0317d8d085c83875a8/twarc-1.8.3.tar.gz"
   sha256 "7b1d9f418152e00ebd709a8a64b12a1b0b102823409dc4524288173e36b948f1"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,7 @@ class Twarc < Formula
   depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "twarc"

--- a/Formula/txt2tags.rb
+++ b/Formula/txt2tags.rb
@@ -5,6 +5,7 @@ class Txt2tags < Formula
   homepage "https://txt2tags.org/"
   url "https://files.pythonhosted.org/packages/0e/80/dc4215b549ddbe1d1251bc4cd47ad6f4a65e1f9803815997817ff297d22e/txt2tags-3.7.tar.gz"
   sha256 "27969387206d12b4e4a0eb13d0d5dd957d71dbb932451b0dceeab5e3dbb6178a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,7 @@ class Txt2tags < Formula
   depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", "txt2tags"

--- a/Formula/vdirsyncer.rb
+++ b/Formula/vdirsyncer.rb
@@ -17,10 +17,10 @@ class Vdirsyncer < Formula
     sha256 "81eaa19b3cbc91007a0a5cfe9979cca1f207b2ac2a72b87aabca41ae019838f7" => :el_capitan
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", "requests-oauthlib",
                               buildpath

--- a/Formula/vit.rb
+++ b/Formula/vit.rb
@@ -6,6 +6,7 @@ class Vit < Formula
   url "https://github.com/scottkosty/vit/archive/v2.0.0.tar.gz"
   sha256 "0c8739c16b5922880e762bd38f887240923d16181b2f85bb88c4f9f6faf38d6d"
   head "https://github.com/scottkosty/vit.git", :branch => "2.x"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,11 +15,11 @@ class Vit < Formula
     sha256 "220f52f07f57fc07e7805a5d3162e9fbde3f08b8255177b6cefddb4748f6988b" => :high_sierra
   end
 
-  depends_on "python"
+  depends_on "python@3.8"
   depends_on "task"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
     system libexec/"bin/pip", "install", "-v", "--no-binary", ":all:",
                               "--ignore-installed", buildpath
     system libexec/"bin/pip", "uninstall", "-y", name

--- a/Formula/weboob.rb
+++ b/Formula/weboob.rb
@@ -6,6 +6,7 @@ class Weboob < Formula
   url "https://git.weboob.org/weboob/weboob/uploads/7b91875f693b60e93c5976daa051034b/weboob-2.0.tar.gz"
   mirror "https://files.pythonhosted.org/packages/88/c1/b3423348d8e2a557c7e0d53b5977cf1a382703c7b4d1397876836184b493/weboob-2.0.tar.gz"
   sha256 "fc8be1f77ad3a53285cef8b20a8b747960c163fad729c56838043d8ddcdfc9b0"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,7 +19,7 @@ class Weboob < Formula
   depends_on "gnupg"
   depends_on "jpeg"
   depends_on "libyaml"
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "Pillow" do
     url "https://files.pythonhosted.org/packages/3c/7e/443be24431324bd34d22dd9d11cc845d995bcd3b500676bcf23142756975/Pillow-5.4.1.tar.gz"
@@ -111,7 +112,7 @@ class Weboob < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
 
     resource("Pillow").stage do
       inreplace "setup.py" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


when I tried to migrate `autopep8` from `python` to `python@3.8`, I notice there are 2 implementations in the code base: both of them have already have `depends_on "python@3.8"` in place

(1)
```python
venv = virtualenv_create(libexec, "python3")
```  
(2)
```python
venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
```  


I think only the (2) actually uses the python@3.8? correct me if I am wrong.

So I do a bulk update in this PR