### PR TITLE
wrangler: add a patch for latest erlang

### DIFF
--- a/Formula/wrangler.rb
+++ b/Formula/wrangler.rb
@@ -1,7 +1,7 @@
 class Wrangler < Formula
   desc "Refactoring tool for Erlang with emacs and Eclipse integration"
   homepage "https://www.cs.kent.ac.uk/projects/wrangler/Wrangler/"
-  revision 1
+  revision 2
   head "https://github.com/RefactoringTools/wrangler.git"
 
   stable do
@@ -10,8 +10,14 @@ class Wrangler < Formula
 
     # upstream commit "Fix -spec's to compile in Erlang/OTP 19"
     patch do
-      url "https://github.com/RefactoringTools/wrangler/commit/d81b888f.patch?full_index=1"
+      url "https://github.com/RefactoringTools/wrangler/commit/d81b888fd200dda17d341ec457d6786ef912b25d.patch?full_index=1"
       sha256 "b7911206315c32ee08fc89776015cf5b26c97b6cb4f6eff0b73dcf2d583cfe31"
+    end
+
+    # upstream commit "fixes to make wrangler compile with R21"
+    patch do
+      url "https://github.com/RefactoringTools/wrangler/commit/1149d6150eb92dcfefb91445179e7566952e184f.patch?full_index=1"
+      sha256 "e84cba2ead98f47a16d9bb50182bbf3edf3ea27afefa36b78adc5afdf4aeabd5"
     end
   end
 
@@ -23,7 +29,7 @@ class Wrangler < Formula
     sha256 "7708561c89c92c61b67907ca43fa351e9a39da572c43e1f9d15d4dc0cd4855da" => :high_sierra
   end
 
-  depends_on "erlang@20"
+  depends_on "erlang"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds a patch which makes `wrangler` compatible with the latest erlang and switches to it.

The patch doesn't apply clearly, but it still good enough to make it work:

```
==> Applying 1149d6150eb92dcfefb91445179e7566952e184f.patch
patch -g 0 -f -p1 -i /private/tmp/wrangler--patch-20200421-66012-iaark5/1149d6150eb92dcfefb91445179e7566952e184f.patch
patching file src/wrangler_syntax.erl
Hunk #2 succeeded at 3591 (offset -1 lines).
Hunk #3 succeeded at 5581 (offset -1 lines).
Hunk #4 succeeded at 5631 (offset -1 lines).
``` 