### PR TITLE
kamel 0.3.4 (new formula)

### DIFF
--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -1,0 +1,54 @@
+class Kamel < Formula
+  desc "Apache Camel K CLI"
+  homepage "https://camel.apache.org/"
+
+  url "https://github.com/apache/camel-k.git",
+    :tag      => "0.3.4",
+    :revision => "c47fb2c85e89852f0fd111d1662f57917030ced5"
+  head "https://github.com/apache/camel-k.git"
+
+  depends_on "go" => :build
+  depends_on "openjdk" => :build
+
+  def install
+    system "make"
+    bin.install "kamel"
+
+    prefix.install_metafiles
+
+    output = Utils.popen_read("#{bin}/kamel completion bash")
+    (bash_completion/"kamel").write output
+
+    output = Utils.popen_read("#{bin}/kamel completion zsh")
+    (zsh_completion/"_kamel").write output
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kamel 2>&1")
+    assert_match "Apache Camel K is a lightweight", run_output
+
+    help_output = shell_output("echo $(#{bin}/kamel help 2>&1)")
+    assert_match "Error: cannot get current namespace", help_output.chomp
+
+    context_output = shell_output("#{bin}/kamel context 2>&1")
+    assert_match "Configure an Integration Context", context_output
+
+    get_output = shell_output("echo $(#{bin}/kamel get 2>&1)")
+    assert_match "Error: cannot get current namespace", get_output
+
+    version_output = shell_output("echo $(#{bin}/kamel version 2>&1)")
+    assert_match "Error: cannot get current namespace", version_output
+
+    version_config_output = shell_output("echo $(#{bin}/kamel version --config=\"/\"2>&1)")
+    assert_match "Error: cannot get current namespace", version_config_output
+
+    run_output = shell_output("echo $(#{bin}/kamel run 2>&1)")
+    assert_match "Error: accepts at least 1 arg, received 0", run_output
+
+    run_none_output = shell_output("echo $(#{bin}/kamel run None.java 2>&1)")
+    assert_match "Error: file None.java does not exist", run_none_output
+
+    reset_output = shell_output("echo $(#{bin}/kamel reset 2>&1)")
+    assert_match "Error: cannot get current namespace", reset_output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For more information, you can refer to [issue #1369](https://github.com/apache/camel-k/issues/1369).

---

**Build from source logs:**
```
$ brew install --build-from-source kamel                                                                                                      git:(master|) 
==> Installing kamel from ipolyzos/tap
==> Cloning https://github.com/apache/camel-k.git
Updating /Users/ipolyzos/Library/Caches/Homebrew/kamel--git
==> Checking out tag 1.0.0-RC2
HEAD is now at 24ddce5 Release 1.0.0-RC2
HEAD is now at 24ddce5 Release 1.0.0-RC2
==> make
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/kamel/1.0.0-RC2: 8 files, 59MB, built in 2 minutes 48 seconds
```

**Brew test logs:**
```
$ brew test kamel                                                                                                                            
Testing ipolyzos/tap/kamel
==> /usr/local/Cellar/kamel/1.0.0-RC2/bin/kamel 2>&1
==> /usr/local/Cellar/kamel/1.0.0-RC2/bin/kamel version 2>&1
```

**Brew audit logs:**
```
$ brew audit --strict kamel
$
```