### PR TITLE
libwebsockets - Add LWS_WITH_ZIP_FOPS cmake option

### DIFF
--- a/Formula/libwebsockets.rb
+++ b/Formula/libwebsockets.rb
@@ -19,9 +19,14 @@ class Libwebsockets < Formula
   uses_from_macos "zlib"
 
   def install
+    # Upstream recommends using -DLWS_WITH_DISTRO_RECOMMENDED=ON,
+    # which enables a lot more features and options.
+    # Consider doing that (or at least more of the recommended options), though
+    # note it enables LWS_WITH_LIBEV which conflicts with LWS_WITH_LIBEVENT.
     system "cmake", ".", *std_cmake_args,
                     "-DLWS_IPV6=ON",
                     "-DLWS_WITH_HTTP2=ON",
+                    "-DLWS_WITH_ZIP_FOPS=ON",
                     "-DLWS_WITH_LIBEVENT=ON",
                     "-DLWS_WITH_LIBUV=ON",
                     "-DLWS_WITH_PLUGINS=ON",


### PR DESCRIPTION
LWS_WITH_ZIP_FOPS is recommended for DomTerm (see issue #50074).
Also add comment about LWS_WITH_DISTRO_RECOMMENDED.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
