### PR TITLE
thrift: mark boost as build-depends

### DIFF
--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -22,7 +22,7 @@ class Thrift < Formula
   end
 
   depends_on "bison" => :build
-  depends_on "boost"
+  depends_on "boost" => [:build, :test]
   depends_on "openssl@1.1"
 
   def install
@@ -59,6 +59,17 @@ class Thrift < Formula
   end
 
   test do
-    system "#{bin}/thrift", "--version"
+    (testpath/"test.thrift").write <<~'EOS'
+      service MultiplicationService {
+        i32 multiply(1:i32 x, 2:i32 y),
+      }
+    EOS
+
+    system "#{bin}/thrift", "-r", "--gen", "cpp", "test.thrift"
+
+    system ENV.cxx, "-std=c++11", "gen-cpp/MultiplicationService.cpp",
+      "gen-cpp/MultiplicationService_server.skeleton.cpp",
+      "-I#{include}/include",
+      "-L#{lib}", "-lthrift"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I think that these days thrift only uses the header-only part of boost, and there is no runtime dependency.

If we look at the dynamic library we see it is not linking to any boost libs:

```
otool -L /usr/local/opt/thrift/lib/libthrift.dylib
## /usr/local/opt/thrift/lib/libthrift.dylib:
## 	/usr/local/opt/thrift/lib/libthrift-0.13.0.dylib (compatibility version 0.0.0, current version 0.0.0)
## 	/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
## 	/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
## 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
## 	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
```

Also the `thrift.pc` file does not mention any boost linker flags:

```
Name: Thrift
Description: Thrift C++ API
Version: 0.13.0
Libs: -L${libdir} -lthrift
Cflags: -I${includedir}
```

We can see the same in Debian: [thrift 0.13.0](https://packages.debian.org/bullseye/libthrift-0.13.0) does not list any hard dependencies on boost libs. The debian `control` file shows:

```
Build-Depends:  libboost-all-dev
```

So that means it is not a runtime dep. This wasn't always the case: if we look at [boost 0.11.0](https://packages.debian.org/buster/libthrift-0.11.0) in an older Debian we do see a dependency on ` libboost-atomic1.67.0`.
