### PR TITLE
Rebuild `dhall's` reverse dependencies

### DIFF
--- a/Formula/dhall-bash.rb
+++ b/Formula/dhall-bash.rb
@@ -7,6 +7,7 @@ class DhallBash < Formula
   homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-bash"
   url "https://hackage.haskell.org/package/dhall-bash-1.0.28/dhall-bash-1.0.28.tar.gz"
   sha256 "f20fc4bdd181f2ead61e5b92b4fc4c155e21d516bc21c0f7196c59ae5327782f"
+  revision 1
   head "https://github.com/dhall-lang/dhall-haskell.git"
 
   bottle do
@@ -17,7 +18,7 @@ class DhallBash < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.6" => :build
+  depends_on "ghc" => :build
 
   def install
     install_cabal_package

--- a/Formula/dhall-json.rb
+++ b/Formula/dhall-json.rb
@@ -7,6 +7,7 @@ class DhallJson < Formula
   homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-json"
   url "https://hackage.haskell.org/package/dhall-json-1.6.3/dhall-json-1.6.3.tar.gz"
   sha256 "6b41f69f1c97515061b02fdbb82f867076d7ad1c345c1d1a6249348b6ca6a6b6"
+  revision 1
   head "https://github.com/dhall-lang/dhall-haskell.git"
 
   bottle do
@@ -17,7 +18,7 @@ class DhallJson < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.6" => :build
+  depends_on "ghc" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"

--- a/Formula/dhall-lsp-server.rb
+++ b/Formula/dhall-lsp-server.rb
@@ -7,6 +7,7 @@ class DhallLspServer < Formula
   homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server"
   url "https://hackage.haskell.org/package/dhall-lsp-server-1.0.6/dhall-lsp-server-1.0.6.tar.gz"
   sha256 "9b5a963daf3b7c0622ea519433b5046127bc945a8c90df9ec37cd9ae92fe7ddd"
+  revision 1
   head "https://github.com/dhall-lang/dhall-haskell.git"
 
   bottle do

--- a/Formula/dhall-yaml.rb
+++ b/Formula/dhall-yaml.rb
@@ -7,6 +7,7 @@ class DhallYaml < Formula
   homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-yaml"
   url "https://hackage.haskell.org/package/dhall-yaml-1.0.3/dhall-yaml-1.0.3.tar.gz"
   sha256 "b6314d2e189d72dc56ad277c1bdef0fcfd12515b163635852befbf85b9b8ddd2"
+  revision 1
   head "https://github.com/dhall-lang/dhall-haskell.git"
 
   bottle do


### PR DESCRIPTION
The context for this is the following discussion:

https://discourse.brew.sh/t/rebuild-reverse-dependencies-of-a-changed-haskell-package/7516

To summarize things:

* `dhall-1.31.1` has a fix for a bug in `dhall-1.31.0`
* This change rebuilds reverse dependencies of `dhall` to ensure that they
  pick up the fix

I also fixed an additional thing caught by `brew audit --strict`, which
recommended using `ghc` instead of `ghc@8.6`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
