### PR TITLE
Aliases: add vimcat

### DIFF
--- a/Aliases/vimcat
+++ b/Aliases/vimcat
@@ -1,0 +1,1 @@
+../Formula/vimpager.rb


### PR DESCRIPTION
Hello,

I would like to submit this patch to make `vimcat` as an alias for [`vimpager` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/vimpager.rb), [since `vimcat` is part of `vimpager` project](https://github.com/rkitover/vimpager/blob/master/markdown/vimcat.md).

I think this patch will save developers from having to search to find out where they got `vimcat` script from.

Please let me know if I need to make further changes to get this patch accepted. Thank you very much.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?