### PR TITLE
Pidgin fixes and additional protocols

### DIFF
--- a/Formula/pidgin.rb
+++ b/Formula/pidgin.rb
@@ -54,6 +54,9 @@ class Pidgin < Formula
 
     ENV["ac_cv_func_perl_run"] = "yes" if MacOS.version == :high_sierra
 
+    # patch pidgin to read plugins and allow them to live in separate formulae which can
+    # all install their symlinks into these directories. See:
+    #   https://github.com/Homebrew/homebrew-core/pull/53557
     inreplace "finch/finch.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
     inreplace "libpurple/plugin.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
     inreplace "pidgin/gtkmain.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""

--- a/Formula/pidgin.rb
+++ b/Formula/pidgin.rb
@@ -3,7 +3,7 @@ class Pidgin < Formula
   homepage "https://pidgin.im/"
   url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.13.0/pidgin-2.13.0.tar.bz2"
   sha256 "2747150c6f711146bddd333c496870bfd55058bab22ffb7e4eb784018ec46d8f"
-  revision 3
+  revision 4
 
   bottle do
     rebuild 1
@@ -53,6 +53,11 @@ class Pidgin < Formula
     ]
 
     ENV["ac_cv_func_perl_run"] = "yes" if MacOS.version == :high_sierra
+
+    inreplace "finch/finch.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
+    inreplace "libpurple/plugin.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
+    inreplace "pidgin/gtkmain.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
+    inreplace "pidgin/gtkutils.c", "DATADIR", "\"#{HOMEBREW_PREFIX}/share\""
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi, I am the lead developer of [pidgin instant messenger](https://pidgin.im).  A user asked about how to install [purple-facebook](https://github.com/dequis/purple-facebook) with pidgin installed via homebrew, and rather than walk them through all of the arguments to configure, I decided it would be easier if I just packaged it.

No tests were run, because the existing formula does not have any and there isn't really a good way to test a GUI application.  That said, we could maybe add a version check?

However, when I went to do that, I discovered that pidgin was looking for plugins in a place that other formulas should not be installing files.  That is in `/usr/local/Cellar/pidgin/{VERSION}/lib/purple-2`.  So to address that, I updated the pidgin formula to 2.13.0_4 and used `inreplace` to change the directories that pidgin is looking for plugins.

By default pidgin just uses its `${PREFIX}`, but the due to the way that the homebrew tree is structured, it causes the above mentioned issue.  By instead replacing that code with the path `/usr/local/lib/purple-2` other formulas can just be installed and linked as normal and everything just works.

I've also included formulas for a lot of the new/modern instant messaging networks, however there's quite a bit of `inreplace`'s as their build systems are geared towards making things easier for users at the expense of packagers.  Also, absolutely none of these plugins have released tarballs, so they are all head only formulas.  I've left them requiring `--HEAD` to install, not sure if that was the right way to go or not.