### PR TITLE
xgboost: add OpenMP support

### DIFF
--- a/Formula/xgboost.rb
+++ b/Formula/xgboost.rb
@@ -4,6 +4,7 @@ class Xgboost < Formula
   url "https://github.com/dmlc/xgboost.git",
       :tag      => "v1.0.2",
       :revision => "917b0a7b46954e9be36cbc430a1727bb093234bb"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,10 +14,11 @@ class Xgboost < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "libomp"
 
   def install
     mkdir "build" do
-      system "cmake", *std_cmake_args, "-DUSE_OPENMP=0", ".."
+      system "cmake", *std_cmake_args, ".."
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

XGBoost is significantly faster with OpenMP, which allows it to use multiple cores.

In the past, there's been different advice on whether to use libomp (https://github.com/Homebrew/homebrew-core/pull/43246#discussion_r324419379) or gcc (https://github.com/Homebrew/homebrew-core/pull/50467#discussion_r382724402). Since libomp seems more lightweight and this formula is very similar to [LightGBM](https://github.com/Homebrew/homebrew-core/blob/410105e2a54e56d7e2a1dec133866af67ed3d472/Formula/lightgbm.rb), I've used libomp here.