### PR TITLE
hdf5-mpi 1.12.0 (new formula)

### DIFF
--- a/Formula/hdf5-mpi.rb
+++ b/Formula/hdf5-mpi.rb
@@ -1,0 +1,91 @@
+class Hdf5Mpi < Formula
+  desc "File format designed to store large amounts of data"
+  homepage "https://www.hdfgroup.org/HDF5"
+  url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2"
+  sha256 "97906268640a6e9ce0cde703d5a71c9ac3092eded729591279bf2e3ca9765f61"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "open-mpi"
+  depends_on "szip"
+
+  uses_from_macos "zlib"
+
+  conflicts_with "hdf5", :because => "hdf5-mpi is a variant of hdf5, one can only use one or the other"
+
+  def install
+    inreplace %w[c++/src/h5c++.in fortran/src/h5fc.in bin/h5cc.in],
+      "${libdir}/libhdf5.settings",
+      "#{pkgshare}/libhdf5.settings"
+
+    inreplace "src/Makefile.am",
+              "settingsdir=$(libdir)",
+              "settingsdir=#{pkgshare}"
+
+    system "autoreconf", "-fiv"
+
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-szlib=#{Formula["szip"].opt_prefix}
+      --enable-build-mode=production
+      --enable-fortran
+      --enable-parallel
+      CC=mpicc
+      CXX=mpic++
+      FC=mpifort
+      F77=mpif77
+      F90=mpif90
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include "hdf5.h"
+      int main()
+      {
+        printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
+        return 0;
+      }
+    EOS
+    system "#{bin}/h5pcc", "test.c"
+    assert_equal version.to_s, shell_output("./a.out").chomp
+
+    (testpath/"test.f90").write <<~EOS
+      use hdf5
+      integer(hid_t) :: f, dspace, dset
+      integer(hsize_t), dimension(2) :: dims = [2, 2]
+      integer :: error = 0, major, minor, rel
+
+      call h5open_f (error)
+      if (error /= 0) call abort
+      call h5fcreate_f ("test.h5", H5F_ACC_TRUNC_F, f, error)
+      if (error /= 0) call abort
+      call h5screate_simple_f (2, dims, dspace, error)
+      if (error /= 0) call abort
+      call h5dcreate_f (f, "data", H5T_NATIVE_INTEGER, dspace, dset, error)
+      if (error /= 0) call abort
+      call h5dclose_f (dset, error)
+      if (error /= 0) call abort
+      call h5sclose_f (dspace, error)
+      if (error /= 0) call abort
+      call h5fclose_f (f, error)
+      if (error /= 0) call abort
+      call h5close_f (error)
+      if (error /= 0) call abort
+      CALL h5get_libversion_f (major, minor, rel, error)
+      if (error /= 0) call abort
+      write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
+      end
+    EOS
+    system "#{bin}/h5pfc", "test.f90"
+    assert_equal version.to_s, shell_output("./a.out").chomp
+  end
+end


### PR DESCRIPTION
MPI-Parallel HDF5 is very popular for development and takes long to build. This is regularly requested on discourse, would benefit greatly from a bottled Formula and the current practice of redirecting many users to (outdated and not reviewed) HDF5 third-party taps is far from ideal.

Due to CI limitations outlined in #31510 this needs to be its own package instead of an option of `hdf5.rb`. Please see the comments in #45997 for more details, cc @zbeekman.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
