### PR TITLE
r: Fix errors on install.packages

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -3,7 +3,7 @@ class R < Formula
   homepage "https://www.r-project.org/"
   url "https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz"
   sha256 "89302990d8e8add536e12125ec591d6951022cf8475861b3690bc8bf1cefaa8f"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "87a9a56265163f342725418365989afbdab02abc997df0304e403034094f1117" => :catalina
@@ -22,7 +22,7 @@ class R < Formula
   depends_on "xz"
 
   # needed to preserve executable permissions on files without shebangs
-  skip_clean "lib/R/bin"
+  skip_clean "lib/R/bin", "lib/R/doc"
 
   resource "gss" do
     url "https://cloud.r-project.org/src/contrib/gss_2.1-12.tar.gz", :using => :nounzip


### PR DESCRIPTION
Some packages attempt to write to the $RHOME/doc folder.  This fails because the folder is `chmod 444`.  Applying the same fix as for the $RHOME/bin folder.

Fixes #17098

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?