### PR TITLE
librsvg: remove unused libcroco dependency

### DIFF
--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -16,7 +16,6 @@ class Librsvg < Formula
   depends_on "cairo"
   depends_on "gdk-pixbuf"
   depends_on "glib"
-  depends_on "libcroco"
   depends_on "pango"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Unused since version 2.47.1, see: https://download.gnome.org/sources/librsvg/2.47/librsvg-2.47.1.news
> Librsvg no longer depends on libcroco!  It now does all CSS
> processing using Rust crates from Mozilla Servo; these are also the
> crates that are in use in recent versions of Firefox.  As a result,
> librsvg can now handle much more complex CSS selectors than before.