### PR TITLE
vips: uses zlib from macos

### DIFF
--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -35,7 +35,7 @@ class Vips < Formula
   depends_on "poppler"
   depends_on "webp"
 
-  uses_from_macos "curl"
+  uses_from_macos "zlib"
 
   def install
     # mozjpeg needs to appear before libjpeg, otherwise it's not used


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

libvips does not use anything from curl. It only uses zlib for gzip compressed SVG files when built with librsvg.