### PR TITLE
ssh-audit use Mac python3 instead of brewed python3

### DIFF
--- a/Formula/ssh-audit.rb
+++ b/Formula/ssh-audit.rb
@@ -7,7 +7,7 @@ class SshAudit < Formula
 
   bottle :unneeded
 
-  depends_on "python"
+  uses_from_macos "python@3"
 
   def install
     bin.install "ssh-audit.py" => "ssh-audit"

--- a/Formula/ssh-audit.rb
+++ b/Formula/ssh-audit.rb
@@ -7,7 +7,11 @@ class SshAudit < Formula
 
   bottle :unneeded
 
-  uses_from_macos "python@3"
+  if MacOS.version >= :catalina
+    uses_from_macos "python@3"
+  else
+    depends_on "python"
+  end
 
   def install
     bin.install "ssh-audit.py" => "ssh-audit"


### PR DESCRIPTION
- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The python dependancy was [deleted](https://github.com/Homebrew/homebrew-core/pull/39717) last May only for it to be [replaced](https://github.com/Homebrew/homebrew-core/pull/43659) for ssh-audit version 2.

Now that Catalina supplies Python 3.7.3 there's no longer any need to depend on brewed python.

I'm not sure where this fits in with the python3.8 migration, but I don's see the point in upping the  python requirement to 3.8 when vermin says 3.5 is enough.