### PR TITLE
redex: fix compilation on High Sierra

### DIFF
--- a/Formula/redex.rb
+++ b/Formula/redex.rb
@@ -1,10 +1,17 @@
 class Redex < Formula
   desc "Bytecode optimizer for Android apps"
   homepage "https://fbredex.com"
-  url "https://github.com/facebook/redex/archive/v2017.10.31.tar.gz"
-  sha256 "18a840e4db0fc51f79e17dfd749b2ffcce65a28e7ef9c2b3c255c5ad89f6fd6f"
   revision 3
   head "https://github.com/facebook/redex.git"
+
+  stable do
+    url "https://github.com/facebook/redex/archive/v2017.10.31.tar.gz"
+    sha256 "18a840e4db0fc51f79e17dfd749b2ffcce65a28e7ef9c2b3c255c5ad89f6fd6f"
+
+    # Fix compilation on High Sierra
+    # Remove for next release
+    patch :DATA
+  end
 
   bottle do
     cellar :any
@@ -40,3 +47,17 @@ class Redex < Formula
     end
   end
 end
+
+__END__
+diff --git a/libresource/RedexResources.cpp b/libresource/RedexResources.cpp
+index 525601ec..a359f49f 100644
+--- a/libresource/RedexResources.cpp
++++ b/libresource/RedexResources.cpp
+@@ -16,6 +16,7 @@
+ #include <map>
+ #include <boost/regex.hpp>
+ #include <sstream>
++#include <stack>
+ #include <string>
+ #include <unordered_set>
+ #include <vector>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This patch fixes compilation on High Sierra. Originally found in https://github.com/Homebrew/homebrew-core/pull/49702#issuecomment-618721811

It's hard to say when and how it was broken since the latest release was more than 2.5 years ago and the formula successfully build with on latest HEAD `brew install redex --HEAD` (https://github.com/facebook/redex/tree/314c3714b13ad1ee4e3e2e3c13d15f70e53d7b9d)