### PR TITLE
coredns 1.6.9 (new formula)

### DIFF
--- a/Formula/coredns.rb
+++ b/Formula/coredns.rb
@@ -1,0 +1,55 @@
+class Coredns < Formula
+  desc "DNS server that chains plugins"
+  homepage "https://coredns.io/"
+  url "https://github.com/coredns/coredns/archive/v1.6.9.tar.gz"
+  sha256 "e100a946d5d60d936cb313bdb04fd96162d5a7229e08887ad497660acee4b36f"
+  head "https://github.com/coredns/coredns.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "make"
+    bin.install "coredns"
+  end
+
+  plist_options :startup => true
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/coredns</string>
+            <string>-conf</string>
+            <string>#{etc}/coredns/Corefile</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>KeepAlive</key>
+          <true/>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/coredns.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/coredns.log</string>
+          <key>WorkingDirectory</key>
+          <string>#{HOMEBREW_PREFIX}</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    port = free_port
+    fork do
+      exec bin/"coredns", "-dns.port=#{port}"
+    end
+    sleep(2)
+    output = shell_output("dig @127.0.0.1 -p #{port} example.com.")
+    assert_match(/example\.com\.\t\t0\tIN\tA\t127\.0\.0\.1\n/, output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

CoreDNS developers made the decision to remove the Homebrew Formula that was previously hosted in their own Homebrew Tap on [April 23, 2020](https://github.com/coredns/deployment/commit/f51d10388e85647a7f2f). I find this decision unfortunate and would like to propose the addition of the Formula to the core library for others to use.

The default settings will proxy all requests to hostnames not found in your host file to Cloudflare, Google or IBM Threat Safe DNS servers in that specific order. Users are encouraged to edit the configuration file before starting the service.