### PR TITLE
rust-analyzer 2020-04-20 (new formula)

### DIFF
--- a/Formula/rust-analyzer.rb
+++ b/Formula/rust-analyzer.rb
@@ -1,0 +1,64 @@
+class RustAnalyzer < Formula
+  desc "Experimental Rust compiler front-end for IDEs"
+  homepage "https://rust-analyzer.github.io/"
+  url "https://github.com/rust-analyzer/rust-analyzer/archive/2020-04-20.tar.gz"
+  sha256 "da47d24f24205c77bd8aeba4f0c2d6b7b12f2462ceab7e19473282c9946bd69c"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path",
+           "crates/rust-analyzer", "--bin", "rust-analyzer"
+  end
+
+  test do
+    def rpc(json)
+      "Content-Length: #{json.size}\r\n" \
+      "\r\n" \
+      "#{json}"
+    end
+
+    input = rpc <<-EOF
+    {
+      "jsonrpc":"2.0",
+      "id":1,
+      "method":"initialize",
+      "params": {
+        "rootUri": "file:/dev/null",
+        "capabilities": {}
+      }
+    }
+    EOF
+
+    input += rpc <<-EOF
+    {
+      "jsonrpc":"2.0",
+      "method":"initialized",
+      "params": {}
+    }
+    EOF
+
+    input += rpc <<-EOF
+    {
+      "jsonrpc":"2.0",
+      "id": 1,
+      "method":"shutdown",
+      "params": {}
+    }
+    EOF
+
+    input += rpc <<-EOF
+    {
+      "jsonrpc":"2.0",
+      "method":"exit",
+      "params": {}
+    }
+    EOF
+
+    output =
+      "Content-Length: 1317\r\n" \
+      "\r\n"
+
+    assert_match output, pipe_output("#{bin}/rust-analyzer", input, 0)
+  end
+end


### PR DESCRIPTION
Adds formula for [rust-analyzer.](https://github.com/rust-analyzer/rust-analyzer)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
