### PR TITLE
fcct 0.5.0 (new formula)

### DIFF
--- a/Formula/fcct.rb
+++ b/Formula/fcct.rb
@@ -1,0 +1,51 @@
+class Fcct < Formula
+  desc "Fedora CoreOS Config Transpiler"
+  homepage "https://github.com/coreos/fcct"
+  url "https://github.com/coreos/fcct/archive/v0.5.0.tar.gz"
+  sha256 "50912f67ecc2da62b45f597522a685350422998d5840a18828fc9505a5dc51db"
+  head "https://github.com/coreos/fcct.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-mod=vendor",
+      "-ldflags", "-w -X github.com/coreos/fcct/internal/version.Raw=#{version}",
+      *std_go_args, "internal/main.go"
+
+    prefix.install_metafiles
+  end
+
+  test do
+    (testpath/"example.fcc").write <<~EOS
+      variant: fcos
+      version: 1.0.0
+      passwd:
+        users:
+          - name: core
+            ssh_authorized_keys:
+              - ssh-rsa mykey
+    EOS
+
+    (testpath/"broken.fcc").write <<~EOS
+      variant: fcos
+      version: 1.0.0
+      passwd:
+        users:
+          - name: core
+            broken_authorized_keys:
+              - ssh-rsa mykey
+    EOS
+
+    system "#{bin}/fcct", "--strict", "--output=#{testpath}/example.ign", "#{testpath}/example.fcc"
+    assert_predicate testpath/"example.ign", :exist?
+    assert_match /.*"sshAuthorizedKeys":\["ssh-rsa mykey"\].*/m, File.read(testpath/"example.ign").strip
+
+    output = shell_output("#{bin}/fcct --strict #{testpath}/example.fcc")
+    assert_match /.*"sshAuthorizedKeys":\["ssh-rsa mykey"\].*/m, output.strip
+
+    shell_output("#{bin}/fcct --strict --output=#{testpath}/broken.ign #{testpath}/broken.fcc", 1)
+    refute_predicate testpath/"broken.ign", :exist?
+
+    assert_match version.to_s, shell_output("#{bin}/fcct --version 2>&1")
+  end
+end


### PR DESCRIPTION
Adds a formula for the Fedora CoreOS Config Transpiler to create config files for Fedora CoreOS VMs. Fedora CoreOS is the successor to CoreOS Container Linux and Fedora Atomic Host. This tool (fcct) is necessary to produce the config files that are used to provision Fedora CoreOS VMs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Brew audit is not fine based on the rule `GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)`. I am submitting this pull request regardless of that because `fcct` is a replacement for `coreos-ct` (which exists as formula) and necessary for migrating away from the EOL'ed CoreOS Container Linux.