### PR TITLE
Label GitHub Sponsors

### DIFF
--- a/.github/workflows/label-sponsors.yml
+++ b/.github/workflows/label-sponsors.yml
@@ -1,0 +1,14 @@
+name: Label GitHub Sponsors
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
+jobs:
+  build:
+    name: is-sponsor-label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JasonEtco/is-sponsor-label-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use https://github.com/JasonEtco/is-sponsor-label-action to label the people who have sponsored us on GitHub.