### PR TITLE
publish-commit-bottles: Don't comment if it's a @BrewTestBot auto-merge

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -28,6 +28,7 @@ jobs:
             core.setOutput("name", name)
             core.setOutput("email", email)
       - name: Post comment once started
+        if: context.actor != "BrewTestBot"
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- This was annoying me, and it must have been weird to contributors too, to have a bot reference itself.
- Since PRs can still be merged with `brew pr-publish` _outside_ of the auto-merge process, ie if things are particularly urgent, I've kept this in for human maintainers who trigger the action.
- The "publish failed" message is still useful in all cases.
