### PR TITLE
publish-commit-bottles: Fix syntax?

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -28,8 +28,8 @@ jobs:
             core.setOutput("name", name)
             core.setOutput("email", email)
       - name: Post comment once started
-        if: context.actor != "BrewTestBot"
         uses: actions/github-script@0.9.0
+        if: context.actor != "BrewTestBot"
         with:
           github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- Sorry folks, 7dcd5e2be6b5d4e2bd698b87debb42d465900526 was bad:

> The workflow is not valid.
> .github/workflows/publish-commit-bottles.yml (Line: 31, Col: 13):
> Unrecognized named-value: 'context'. Located at position 1 within
> expression: context.actor != "BrewTestBot"

- Maybe if it does the `if` after the `uses`, it'll know what `context`
  is?
