### PR TITLE
publish-commit-bottles: Revert 7dcd5e2 and a7ce130

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -29,7 +29,6 @@ jobs:
             core.setOutput("email", email)
       - name: Post comment once started
         uses: actions/github-script@0.9.0
-        if: context.actor != "BrewTestBot"
         with:
           github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           script: |


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- The "potentially fix syntax" commit did not fix it.
- Revert to make `brew pr-publish` work again, so we can ship software to users.
- Dinner calls, and even though we could probably do an `if` in the main `script` code, I don't trust myself to write JS well enough after this!
