### PR TITLE
Build fix for cloog, bastoul.net (no longer?) serves HTTPS

### DIFF
--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -1,7 +1,7 @@
 class Cloog < Formula
   desc "Generate code for scanning Z-polyhedra"
   homepage "https://www.bastoul.net/cloog/"
-  url "https://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
   sha256 "325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e"
   revision 3
 

--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -1,6 +1,6 @@
 class Cloog < Formula
   desc "Generate code for scanning Z-polyhedra"
-  homepage "https://www.bastoul.net/cloog/"
+  homepage "http://www.cloog.org"
   url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
   sha256 "325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e"
   revision 3


### PR DESCRIPTION
Also see: https://github.com/periscop/cloog/issues/40

Less than perfect, but whatcha gonna do?

The problem:
```
$ brew reinstall cloog --build-from-source
==> Reinstalling cloog 
==> Downloading https://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz

curl: (35) error:14004438:SSL routines:CONNECT_CR_SRVR_HELLO:tlsv1 alert internal error
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "cloog"
Download failed: https://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz
```