### PR TITLE
workflows: don't ping BrewTestBot on schedule

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -42,10 +42,18 @@ jobs:
             const repository = context.repo.owner + '/' + context.repo.repo
             const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
 
+            let comment = ''
+            if (actor == 'BrewTestBot') {
+                comment += ':robot: A scheduled task'
+            } else {
+                comment += ':shipit: @' + actor
+            }
+            comment += ' has [triggered a merge](' + url + ').'
+
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' has [triggered a merge](' + url + ').'
+              body: comment
             })
       - name: Update Homebrew
         run: |
@@ -98,10 +106,16 @@ jobs:
             const repository = context.repo.owner + '/' + context.repo.repo
             const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
 
+            let comment = ':warning: '
+            if (actor != 'BrewTestBot') {
+                comment += '@' + actor
+            }
+            comment += ' bottle publish [failed](' + url + ').'
+
             github.issues.createComment({
               ...context.repo,
               issue_number: pr,
-              body: '@' + actor + ' bottle publish [failed](' + url + ').'
+              body: comment
             })
 
             github.issues.removeLabel({


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Re-try our attempts to get this done in 7dcd5e2 and a7ce130.

https://github.com/Homebrew/homebrew-core/pull/53801