### PR TITLE
workflows/generate: split & streamline steps

### DIFF
--- a/.github/workflows/generate_formulae.brew.sh_data.yml
+++ b/.github/workflows/generate_formulae.brew.sh_data.yml
@@ -1,4 +1,4 @@
-name: Generate formulae.brew.sh data.
+name: Generate formulae.brew.sh
 
 on:
   push:
@@ -9,37 +9,40 @@ jobs:
   generate:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: macos-latest
+    env:
+      HOMEBREW_COLOR: 1
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - uses: actions/checkout@master
-      - uses: Homebrew/actions/git-ssh@master
+      - name: Set up git-ssh
+        uses: Homebrew/actions/git-ssh@master
         with:
           git_user: BrewTestBot
           git_email: homebrew-test-bot@lists.sfconservancy.org
           key: ${{ secrets.FORMULAE_DEPLOY_KEY }}
-      - run: |
-          brew update-reset "$(brew --repository)"
-          brew tap "$GITHUB_REPOSITORY"
-          brew update-reset "$(brew --repository "$GITHUB_REPOSITORY")"
 
-          export PATH="$(brew --repo)/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH"
+      - name: Set up Homebrew
+        run: |
+          brew update-reset $(brew --repository)
+          brew tap ${{ github.repository }}
+          brew update-reset $(brew --repository ${{ github.repository }})
+          echo ${{ secrets.ANALYTICS_JSON_KEY }} > ~/.homebrew_analytics.json
 
-          git clone --depth=1 git@github.com:Homebrew/formulae.brew.sh
+      - name: Build and push formulae.brew.sh
+        run: |
+          # clone formulae.brew.sh with SSH so we can push back
+          git clone --depth=1 --quiet git@github.com:Homebrew/formulae.brew.sh
           cd formulae.brew.sh
 
-          # setup analytics
-          echo "$ANALYTICS_JSON_KEY" > ~/.homebrew_analytics.json
-
-          # run rake (without a rake binary)
-          ruby -e "load Gem.bin_path('rake', 'rake')"
+          # run Rakefile
+          /usr/bin/rake
 
           # commit and push generated files
           git add _data/formula api/formula formula
 
           if ! git diff --exit-code HEAD -- _data/analytics _data/formula api/formula formula cask; then
-            git commit -m "formula: update from ${GITHUB_REPOSITORY} push" _data/analytics _data/formula api/formula formula
+            git commit -m "formula: update from ${{ github.repository }} push" _data/analytics _data/formula api/formula formula
             git fetch
             git rebase origin/master
             git push
           fi
-        env:
-          ANALYTICS_JSON_KEY: ${{ secrets.ANALYTICS_JSON_KEY }}


### PR DESCRIPTION
Splits the workflow into distinct setup and generation steps. Also, I don't believe the `actions/checkout` step is required.