### PR TITLE
teensy_loader_cli: Workaround HID Manager initialization

### DIFF
--- a/Formula/teensy_loader_cli.rb
+++ b/Formula/teensy_loader_cli.rb
@@ -3,7 +3,7 @@ class TeensyLoaderCli < Formula
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
   url "https://github.com/PaulStoffregen/teensy_loader_cli/archive/2.1.tar.gz"
   sha256 "5c36fe45b9a3a71ac38848b076cd692bf7ca8826a69941c249daac3a1d95e388"
-  revision 1
+  revision 2
   head "https://github.com/PaulStoffregen/teensy_loader_cli.git"
 
   bottle do
@@ -18,6 +18,8 @@ class TeensyLoaderCli < Formula
   def install
     ENV["OS"] = "MACOSX"
     ENV["SDK"] = MacOS.sdk_path || "/"
+
+    inreplace "teensy_loader_cli.c", /ret != kIOReturnSuccess/, "0"
 
     system "make"
     bin.install "teensy_loader_cli"


### PR DESCRIPTION
Disable the HID Manager check on Mac OS. Port of [alswl's
fix](https://github.com/alswl/teensy_loader_cli/commit/9c16bb0add3ba847df5509328ad6bd5bc09d9ecd). More details at the [PRJC forum](https://forum.pjrc.com/threads/36546-teensy_loader_cli-on-OSX-quot-Error-opening-HID-Manager-quot).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
