### PR TITLE
Secure/fix URLs

### DIFF
--- a/Formula/ahoy.rb
+++ b/Formula/ahoy.rb
@@ -1,6 +1,6 @@
 class Ahoy < Formula
   desc "Creates self documenting CLI programs from commands in YAML files"
-  homepage "http://www.ahoycli.com/"
+  homepage "https://ahoy-cli.readthedocs.io/"
   url "https://github.com/ahoy-cli/ahoy/archive/2.0.0.tar.gz"
   sha256 "cc3e426083bf7b7309e484fa69ed53b33c9b00adf9be879cbe74c19bdaef027c"
 

--- a/Formula/clipsafe.rb
+++ b/Formula/clipsafe.rb
@@ -1,7 +1,7 @@
 class Clipsafe < Formula
   desc "Command-line interface to Password Safe"
-  homepage "http://waxandwane.org/clipsafe.html"
-  url "http://waxandwane.org/download/clipsafe-1.1.tar.gz"
+  homepage "https://waxandwane.org/clipsafe.html"
+  url "https://waxandwane.org/download/clipsafe-1.1.tar.gz"
   sha256 "7a70b4f467094693a58814a42d272e98387916588c6337963fa7258bda7a3e48"
   revision 1
 

--- a/Formula/colorsvn.rb
+++ b/Formula/colorsvn.rb
@@ -1,7 +1,7 @@
 class Colorsvn < Formula
   desc "Subversion output colorizer"
-  homepage "http://colorsvn.tigris.org/"
-  url "http://colorsvn.tigris.org/files/documents/4414/49311/colorsvn-0.3.3.tar.gz"
+  homepage "https://web.archive.org/web/20170725092001/colorsvn.tigris.org/"
+  url "https://web.archive.org/web/20170725092001/colorsvn.tigris.org/files/documents/4414/49311/colorsvn-0.3.3.tar.gz"
   sha256 "db58d5b8f60f6d4def14f8f102ff137b87401257680c1acf2bce5680b801394e"
   revision 1
 

--- a/Formula/delta.rb
+++ b/Formula/delta.rb
@@ -1,6 +1,6 @@
 class Delta < Formula
   desc "Programatically minimize files to isolate features of interest"
-  homepage "http://delta.tigris.org/"
+  homepage "https://web.archive.org/web/20170805142100/delta.tigris.org/"
   url "https://deb.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
   sha256 "38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0"
 

--- a/Formula/gf-complete.rb
+++ b/Formula/gf-complete.rb
@@ -1,6 +1,6 @@
 class GfComplete < Formula
   desc "Comprehensive Library for Galois Field Arithmetic"
-  homepage "http://jerasure.org/"
+  homepage "https://web.archive.org/web/20191024182742/jerasure.org/"
   url "http://lab.jerasure.org/jerasure/gf-complete/repository/archive.tar.gz?ref=v2.0"
   sha256 "0654202fe3b0d3f8a220158699bdea722e47e7f9cbc0fd52e4857aba6a069ea9"
 

--- a/Formula/grsync.rb
+++ b/Formula/grsync.rb
@@ -1,6 +1,6 @@
 class Grsync < Formula
   desc "GUI for rsync"
-  homepage "http://www.opbyte.it/grsync/"
+  homepage "https://www.opbyte.it/grsync/"
   url "https://downloads.sourceforge.net/project/grsync/grsync-1.2.6.tar.gz"
   sha256 "66d5acea5e6767d6ed2082e1c6e250fe809cb1e797cbbee5c8e8a2d28a895619"
   revision 2

--- a/Formula/jerasure.rb
+++ b/Formula/jerasure.rb
@@ -1,6 +1,6 @@
 class Jerasure < Formula
   desc "Library in C that supports erasure coding in storage applications"
-  homepage "http://jerasure.org/"
+  homepage "https://web.archive.org/web/20191024182742/jerasure.org/"
   url "https://bitbucket.org/tsg-/jerasure/get/v2.0.0.tar.bz2"
   sha256 "f736646c1844c4e50dfe41ebd63c7d7b30c6e66a4aa7d3beea244871b0e43b9d"
   revision 1

--- a/Formula/libcroco.rb
+++ b/Formula/libcroco.rb
@@ -1,6 +1,6 @@
 class Libcroco < Formula
   desc "CSS parsing and manipulation toolkit for GNOME"
-  homepage "http://www.linuxfromscratch.org/blfs/view/svn/general/libcroco.html"
+  homepage "https://gitlab.gnome.org/GNOME/libcroco"
   url "https://download.gnome.org/sources/libcroco/0.6/libcroco-0.6.13.tar.xz"
   sha256 "767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4"
   revision 1

--- a/Formula/tenyr.rb
+++ b/Formula/tenyr.rb
@@ -1,6 +1,6 @@
 class Tenyr < Formula
   desc "32-bit computing environment (including simulated CPU)"
-  homepage "http://tenyr.info/"
+  homepage "https://tenyr.info/"
   url "https://github.com/kulp/tenyr/archive/v0.9.7.tar.gz"
   sha256 "f28e031acb14a0e4ff924479a0fd0087d9a15948a440f03b2dcf002723ccfdfa"
   head "https://github.com/kulp/tenyr.git", :branch => "develop"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Some issues, all preexisting:
```
> Formula/gf-complete.rb
gf-complete:
  * Stable: The URL http://lab.jerasure.org/jerasure/gf-complete/repository/archive.tar.gz?ref=v2.0 is not reachable
Error: 1 problem in 1 formula detected
> Formula/jerasure.rb
jerasure:
  * 'revision 1' should be removed
Error: 1 problem in 1 formula detected
> Formula/tenyr.rb
tenyr:
  * v0.9.7 is a GitHub prerelease
Error: 1 problem in 1 formula detected
```