### PR TITLE
deprecate versioned redis formulae

### DIFF
--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -14,6 +14,8 @@ class RedisAT32 < Formula
 
   keg_only :versioned_formula
 
+  deprecate!
+
   def install
     # Architecture isn't detected correctly on 32bit Snow Leopard without help
     ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"

--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -14,6 +14,8 @@ class RedisAT40 < Formula
 
   keg_only :versioned_formula
 
+  deprecate!
+
   def install
     # Architecture isn't detected correctly on 32bit Snow Leopard without help
     ENV["OBJARCH"] = "-arch #{MacOS.preferred_arch}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
