### PR TITLE
workflows/tests: cleanup tapping.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,8 @@ jobs:
 
     - name: Install taps
       run: |
+        export HOMEBREW_NO_AUTO_UPDATE=1
         brew tap homebrew/test-bot
-        brew update-reset "$(brew --repo)/Library/Taps/homebrew/homebrew-test-bot"
 
     - name: Run brew test-bot --only-tap-syntax
       run: brew test-bot --only-tap-syntax


### PR DESCRIPTION
- Don't auto-update (can mess with branches)
- Don't need to `update-reset` as `test-bot` isn't in Actions images