### PR TITLE
duktape 2.5.0 (new formula)

### DIFF
--- a/Formula/duktape.rb
+++ b/Formula/duktape.rb
@@ -1,0 +1,31 @@
+class Duktape < Formula
+  desc "Embeddable Javascript engine with compact footprint"
+  homepage "https://duktape.org"
+  url "https://duktape.org/duktape-2.5.0.tar.xz"
+  sha256 "83d411560a1cd36ea132bd81d8d9885efe9285c6bc6685c4b71e69a0c4329616"
+
+  def install
+    inreplace "Makefile.sharedlibrary" do |s|
+      s.gsub! %r{\/usr\/local}, prefix
+    end
+    system "make", "-f", "Makefile.sharedlibrary"
+    system "make", "-f", "Makefile.sharedlibrary", "install"
+  end
+
+  test do
+    (testpath/"test.cc").write <<~EOS
+      #include <stdio.h>
+      #include \"duktape.h\"
+      int main(int argc, char *argv[]) {
+        duk_context *ctx = duk_create_heap_default();
+        duk_eval_string(ctx, \"1+2\");
+        printf(\"1+2=%d\\n\", (int) duk_get_int(ctx, -1));
+        duk_destroy_heap(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", "-L#{lib}", "-lduktape",
+           testpath/"test.cc", "-o", testpath/"test"
+    assert_equal "1+2=3", shell_output(testpath/"test").strip, "Duktape can add number"
+  end
+end


### PR DESCRIPTION
Duktape is an embeddable JavaScript engine. We recently started using it for the OpenRCT2 project, and would like to make it easier for macOS to install this dependency.

~Caveat: in the current stage of the PR, `brew test duktape` is failing in the linker stage. I'm not sure why, as invoking the test manually appears to link and work fine. Please advise.~

This PR is following up on PR #28480. Hence:

Co-authored-by: Eamonn
Co-authored-by: Andrew Janke

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?