### PR TITLE
clamav: use pcre2, add libxml2, bzip2 dependencies

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -4,6 +4,7 @@ class Clamav < Formula
   url "https://www.clamav.net/downloads/production/clamav-0.102.2.tar.gz"
   mirror "https://fossies.org/linux/misc/clamav-0.102.2.tar.gz"
   sha256 "89fcdcc0eba329ca84d270df09d2bb89ae55f5024b0c3bddb817512fb2c907d3"
+  revision 1
 
   bottle do
     sha256 "544f511ddd1c68b88a93f017617c968a4e5d34fc6a010af15e047a76c5b16a9f" => :catalina
@@ -21,11 +22,14 @@ class Clamav < Formula
 
   depends_on "pkg-config" => :build
   depends_on "json-c"
+  depends_on "libiconv"
   depends_on "openssl@1.1"
-  depends_on "pcre"
+  depends_on "pcre2"
   depends_on "yara"
 
+  uses_from_macos "bzip2"
   uses_from_macos "curl"
+  uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
   skip_clean "share/clamav"
@@ -38,11 +42,16 @@ class Clamav < Formula
       --libdir=#{lib}
       --sysconfdir=#{etc}/clamav
       --disable-zlib-vcheck
-      --enable-llvm=no
-      --with-libjson=#{Formula["json-c"].opt_prefix}
+      --with-llvm=yes
+      --with-system-llvm=no
+      --with-libiconv-prefix=#{Formula["libiconv"].opt_prefix}
+      --with-iconv=#{Formula["libiconv"].opt_prefix}
+      --with-libjson-static=#{Formula["json-c"].opt_prefix}/lib/libjson-c.a
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
-      --with-pcre=#{Formula["pcre"].opt_prefix}
+      --with-pcre=#{Formula["pcre2"].opt_prefix}
       --with-zlib=#{MacOS.sdk_path_if_needed}/usr
+      --with-libbz2-prefix=#{MacOS.sdk_path_if_needed}/usr
+      --with-xml=#{MacOS.sdk_path_if_needed}/usr
     ]
 
     pkgshare.mkpath


### PR DESCRIPTION
Switch from pcre dependency to pcre2. Pcre is an older project
and lacks some optimizations and bug fixes found in pcre2.

Adds missing libxml2 dependency and bzip2 dependency (from macOS).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
