### PR TITLE
re2: fix soname overwriting

### DIFF
--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -4,6 +4,7 @@ class Re2 < Formula
   url "https://github.com/google/re2/archive/2020-05-01.tar.gz"
   version "20200501"
   sha256 "88864d7f5126bb17daa1aa8f41b05599aa6e3222e7b28a90e372db53c1c49aeb"
+  revision 1
   head "https://github.com/google/re2.git"
 
   bottle do
@@ -17,9 +18,6 @@ class Re2 < Formula
     ENV.cxx11
 
     system "make", "install", "prefix=#{prefix}"
-    MachO::Tools.change_dylib_id("#{lib}/libre2.7.0.0.dylib", "#{lib}/libre2.0.dylib")
-    lib.install_symlink "libre2.7.0.0.dylib" => "libre2.0.dylib"
-    lib.install_symlink "libre2.7.0.0.dylib" => "libre2.dylib"
   end
 
   test do


### PR DESCRIPTION
The re2 formula has been overwriting the soname of the libre2 shared library to 0 even though it has changed to [1][0], [6][1] and, most recently, [7][2]. This means that [any software linking to the library isn't aware of breaking ABI changes][3].

Fix this by no longer changing the soname to 0 and remove the extra symlinks as re2 itself will generate symlinks from libre2.dylib and libre2.7.dylib to the relevant version.

  [0]: https://github.com/google/re2/commit/f734980e70ee217cc45d3e5535b47cd2422c8f4b#diff-b67911656ef5d18c4ae36cb6741b7965
  [1]: https://github.com/google/re2/commit/d067ca501c5c2d50fd672d399a2f76019e24a671#diff-b67911656ef5d18c4ae36cb6741b7965
  [2]: https://github.com/google/re2/commit/ac65d4531798ffc9bf807d1f7c09efb0eec70480#diff-b67911656ef5d18c4ae36cb6741b7965
  [3]: https://github.com/mudge/re2/issues/43

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?