### PR TITLE
cattle: Fix homepage URL

### DIFF
--- a/Formula/cattle.rb
+++ b/Formula/cattle.rb
@@ -1,6 +1,6 @@
 class Cattle < Formula
   desc "Brainfuck language toolkit"
-  homepage "https://github.com/andreabolognani/cattle"
+  homepage "https://kiyuko.org/software/cattle"
   url "https://kiyuko.org/software/cattle/releases/cattle-1.4.0.tar.xz"
   sha256 "9ba2d746f940978b5bfc6c39570dde7dc55d5b4d09d0d25f29252d6a25fb562f"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The GitHub repository is just a mirror of [the official one](https://git.kiyuko.org/cattle/), and should _definitely_ not be considered the homepage for the project.

I did not perform any build/install checks because I don't have convenient access to a macOS host; that said, I don't expect such a trivial change to cause any trouble. Famous last words? :)

Being unsure whether this kind of change warranted bumping the revision, I haven't done so. If bumping it is necessary, please let me know and I'll update the PR accordingly.