### PR TITLE
CODEOWNERS: add file, MikeMcQuaid.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# Note that the naming of this file is incorrect for our case: these people do not "own" the provided files but are
+# people with write-access to this repository (i.e. @Homebrew/core) who wish to be notified of changes to these
+# files.
+#
+# Their review is not required to merge PRs that change these files but just an indication that they wish to follow
+# along changes to these files without having to "watch" this repository on GitHub.
+#
+# To be explicit: we will never accept changes to this file adding people from outside the Homebrew GitHub
+# organisation. If you are not a Homebrew maintainer: you do not personally "own" or "maintain" any formulae.
+
+CODEOWNERS            @MikeMcQuaid
+CONTRIBUTING.md       @MikeMcQuaid
+tap_migrations.json   @MikeMcQuaid
+.github/              @MikeMcQuaid
+cmd/                  @MikeMcQuaid
+
+LICENSE.txt           @Homebrew/plc @MikeMcQuaid


### PR DESCRIPTION
I don't watch Homebrew/homebrew-core any more (as other maintainers are doing a great job of the formula work without my help) but I do want to ensure that I keep on top of changes to certain files.

As a result, add a `CODEOWNERS` file so I can be requested for review on changes to these files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

@Homebrew/core any objections to the use of this pattern or the current file contents? Similarly: if any of you would like to be requested for review on any files or formulae (you/I won't "own" them regardless): feel free to suggest here or submit PRs to this file after it is merged. Another option we could consider would be using GitHub teams for any/all of these instead (e.g. I could see @Homebrew/plc wanting to be consulted on any license file changes).