### PR TITLE
cppzmq 4.6.0 (new formula)

### DIFF
--- a/Formula/cppzmq.rb
+++ b/Formula/cppzmq.rb
@@ -17,35 +17,16 @@ class Cppzmq < Formula
 
   test do
     (testpath/"test.cpp").write <<~EOS
-      #include <iostream>
-      #include <zmq_addon.hpp>
+      #include <zmq.hpp>
 
       int main()
       {
           zmq::context_t ctx;
-          zmq::socket_t sock1(ctx, zmq::socket_type::pair);
-          zmq::socket_t sock2(ctx, zmq::socket_type::pair);
-          sock1.bind("inproc://test");
-          sock2.connect("inproc://test");
 
-          std::array<zmq::const_buffer, 2> send_msgs = {
-              zmq::str_buffer("foo"),
-              zmq::str_buffer("bar!")
-          };
-          if (!zmq::send_multipart(sock1, send_msgs))
-              return 1;
-
-          std::vector<zmq::message_t> recv_msgs;
-          const auto ret = zmq::recv_multipart(
-              sock2, std::back_inserter(recv_msgs));
-          if (!ret)
-              return 1;
-          std::cout << "Got " << *ret
-                    << " messages" << std::endl;
           return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-L#{lib}", "-lzmq", "-o", "test"
+    system ENV.cxx, "test.cpp", "-lzmq", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/cppzmq.rb
+++ b/Formula/cppzmq.rb
@@ -1,0 +1,51 @@
+class Cppzmq < Formula
+  desc "Header-only C++ binding for libzmq"
+  homepage "https://www.zeromq.org"
+  url "https://github.com/zeromq/cppzmq/archive/v4.6.0.tar.gz"
+  sha256 "e9203391a0b913576153a2ad22a2dc1479b1ec325beb6c46a3237c669aef5a52"
+
+  head "https://github.com/zeromq/cppzmq.git"
+
+  depends_on "cmake" => :build
+
+  depends_on "zeromq"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <zmq_addon.hpp>
+
+      int main()
+      {
+          zmq::context_t ctx;
+          zmq::socket_t sock1(ctx, zmq::socket_type::pair);
+          zmq::socket_t sock2(ctx, zmq::socket_type::pair);
+          sock1.bind("inproc://test");
+          sock2.connect("inproc://test");
+
+          std::array<zmq::const_buffer, 2> send_msgs = {
+              zmq::str_buffer("foo"),
+              zmq::str_buffer("bar!")
+          };
+          if (!zmq::send_multipart(sock1, send_msgs))
+              return 1;
+
+          std::vector<zmq::message_t> recv_msgs;
+          const auto ret = zmq::recv_multipart(
+              sock2, std::back_inserter(recv_msgs));
+          if (!ret)
+              return 1;
+          std::cout << "Got " << *ret
+                    << " messages" << std::endl;
+          return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lzmq", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not quite sure why it is that the linking stage fails when running the test. `libzmq.dylib` exists in `/usr/local/lib` and is correctly installed as a dependency. Any thoughts on why that might be?

---

I'm aware of #4052, but (A) that was a couple of years ago and (B) it no longer just copies the files, it actually runs the tests and verifies that the code executes correctly before copying. It's also just useful because there really isn't another language specific dependency manager for which this would be useful.