### PR TITLE
macos-trash 1.1.0 (new formula)

### DIFF
--- a/Formula/macos-trash.rb
+++ b/Formula/macos-trash.rb
@@ -1,0 +1,23 @@
+class MacosTrash < Formula
+  desc "Move files and folders to the trash"
+  homepage "https://github.com/sindresorhus/macos-trash"
+  url "https://github.com/sindresorhus/macos-trash/archive/1.1.0.tar.gz"
+  sha256 "31c09d385bb50b0f76818a1fe2c850cf56b9575c9fa27ea963cba38dfaba7d04"
+  head "https://github.com/sindresorhus/macos-trash.git"
+
+  depends_on :xcode => ["11.0", :build]
+  depends_on :macos => :yosemite
+
+  conflicts_with "trash", :because => "both install a `trash` binary"
+  conflicts_with "trash-cli", :because => "both install a `trash` binary"
+
+  def install
+    system "./build"
+    bin.install "trash"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/trash --version")
+    system "#{bin}/trash", "--help"
+  end
+end

--- a/Formula/trash-cli.rb
+++ b/Formula/trash-cli.rb
@@ -17,6 +17,7 @@ class TrashCli < Formula
 
   depends_on "python@3.8"
 
+  conflicts_with "macos-trash", :because => "both install a `trash` binary"
   conflicts_with "trash", :because => "both install a `trash` binary"
 
   def install

--- a/Formula/trash.rb
+++ b/Formula/trash.rb
@@ -14,6 +14,7 @@ class Trash < Formula
     sha256 "75cebaa2b12cd75eeb1bb8deb4737639064f68f010cab94e378bd5ce727d4c34" => :el_capitan
   end
 
+  conflicts_with "macos-trash", :because => "both install a `trash` binary"
   conflicts_with "trash-cli", :because => "both install a `trash` binary"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not sure how to name this formula. The logical choice is just `trash` but that conflicts with existing one 🤔 