### PR TITLE
osc, glib-openssl: use up-to-date cert.pem file

### DIFF
--- a/Formula/glib-openssl.rb
+++ b/Formula/glib-openssl.rb
@@ -3,7 +3,7 @@ class GlibOpenssl < Formula
   homepage "https://launchpad.net/glib-networking"
   url "https://download.gnome.org/sources/glib-openssl/2.50/glib-openssl-2.50.8.tar.xz"
   sha256 "869f08e4e9a719c1df411c2fb5554400f6b24a9db0cb94c4359db8dad18d185f"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -24,7 +24,7 @@ class GlibOpenssl < Formula
                           "--disable-silent-rules",
                           "--disable-static",
                           "--prefix=#{prefix}",
-                          "--with-ca-certificates=#{etc}/openssl/cert.pem"
+                          "--with-ca-certificates=#{etc}/openssl@1.1/cert.pem"
     system "make", "install"
 
     # Delete the cache, will regenerate it in post_install

--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -5,7 +5,7 @@ class Osc < Formula
   homepage "https://github.com/openSUSE/osc"
   url "https://github.com/openSUSE/osc/archive/0.168.2.tar.gz"
   sha256 "070637e052ad18416cf27b49b53685f802addac8da9f9a36ac8069dcdb1757c4"
-  revision 1
+  revision 2
   head "https://github.com/openSUSE/osc.git"
 
   bottle do
@@ -34,7 +34,7 @@ class Osc < Formula
   def install
     ENV["SWIG_FEATURES"] = "-I#{Formula["openssl@1.1"].opt_include}"
 
-    inreplace "osc/conf.py", "'/etc/ssl/certs'", "'#{etc}/openssl/cert.pem'"
+    inreplace "osc/conf.py", "'/etc/ssl/certs'", "'#{etc}/openssl@1.1/cert.pem'"
     virtualenv_install_with_resources
     mv bin/"osc-wrapper.py", bin/"osc"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`/usr/local/etc/openssl/cert.pem` is a potentially out of date or missing file left behind by the defunct `openssl` Formula. `openssl@1.1` provides `/usr/local/etc/openssl@1.1/cert.pem` instead.

Note that `weechat` also uses `/usr/local/etc/openssl/cert.pem`, but depends on `gnutls`, which creates its own version of that file.

This is a potential security issue, made possible by leaving behind a security sensitive file without security updates. See #54235.