### PR TITLE
astrometry-net: fix image2pnm and other python scripts.

### DIFF
--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -31,12 +31,9 @@ class AstrometryNet < Formula
   end
 
   def install
-    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
-
     ENV["NETPBM_INC"] = "-I#{Formula["netpbm"].opt_include}/netpbm"
     ENV["NETPBM_LIB"] = "-L#{Formula["netpbm"].opt_lib} -lnetpbm"
     ENV["SYSTEM_GSL"] = "yes"
-    ENV["PYTHON_SCRIPT"] = Formula["python@3.8"].opt_bin/"python3"
     ENV["PYTHON"] = Formula["python@3.8"].opt_bin/"python3"
 
     venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
@@ -46,6 +43,7 @@ class AstrometryNet < Formula
     xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
     ENV["PY_BASE_INSTALL_DIR"] = libexec/"lib/python#{xy}/site-packages/astrometry"
     ENV["PY_BASE_LINK_DIR"] = libexec/"lib/python#{xy}/site-packages/astrometry"
+    ENV["PYTHON_SCRIPT"] = libexec/"bin/python3"
 
     system "make"
     system "make", "py"
@@ -57,6 +55,7 @@ class AstrometryNet < Formula
   test do
     xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
     ENV["PYTHONPATH"] = libexec/"lib/python#{xy}/site-packages"
+    system "#{bin}/image2pnm", "-h"
     system "#{bin}/build-astrometry-index", "-d", "3", "-o", "index-9918.fits",
                                             "-P", "18", "-S", "mag", "-B", "0.1",
                                             "-s", "0", "-r", "1", "-I", "9918", "-M",

--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -5,6 +5,7 @@ class AstrometryNet < Formula
   homepage "https://github.com/dstndstn/astrometry.net"
   url "https://github.com/dstndstn/astrometry.net/releases/download/0.80/astrometry.net-0.80.tar.gz"
   sha256 "6eb73c2371df30324d6532955c46d5f324f2aad87f1af67c12f9354cfd4a7864"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -54,8 +54,6 @@ class AstrometryNet < Formula
   end
 
   test do
-    xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
-    ENV["PYTHONPATH"] = libexec/"lib/python#{xy}/site-packages"
     system "#{bin}/image2pnm", "-h"
     system "#{bin}/build-astrometry-index", "-d", "3", "-o", "index-9918.fits",
                                             "-P", "18", "-S", "mag", "-B", "0.1",


### PR DESCRIPTION
- do not replace the shebang; the Makefile already does that based on the PYTHON_SCRIPT envvar.
- PYTHON_SCRIPT *must* be set to the virtualenv that is created.
- Add test of the 'image2pnm' script that uses this.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
