### PR TITLE
pidgin: Fix plugin prefix

### DIFF
--- a/Formula/pidgin.rb
+++ b/Formula/pidgin.rb
@@ -3,7 +3,7 @@ class Pidgin < Formula
   homepage "https://pidgin.im/"
   url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.13.0/pidgin-2.13.0.tar.bz2"
   sha256 "2747150c6f711146bddd333c496870bfd55058bab22ffb7e4eb784018ec46d8f"
-  revision 4
+  revision 5
 
   bottle do
     sha256 "9b41ab1a1ca4b268d9b0ed7d2df4eb7a7df24f70323f5c7f3836d9adaebb895a" => :catalina
@@ -55,9 +55,9 @@ class Pidgin < Formula
     # patch pidgin to read plugins and allow them to live in separate formulae which can
     # all install their symlinks into these directories. See:
     #   https://github.com/Homebrew/homebrew-core/pull/53557
-    inreplace "finch/finch.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
+    inreplace "finch/finch.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/finch\""
     inreplace "libpurple/plugin.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
-    inreplace "pidgin/gtkmain.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/purple-2\""
+    inreplace "pidgin/gtkmain.c", "LIBDIR", "\"#{HOMEBREW_PREFIX}/lib/pidgin\""
     inreplace "pidgin/gtkutils.c", "DATADIR", "\"#{HOMEBREW_PREFIX}/share\""
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With https://github.com/Homebrew/homebrew-core/pull/53557 Pidgin only searches for plugins in `/usr/local/lib/purple-2`. Therefore it only finds libpurple plugins but not the UI specific Pidgin plugins in `/usr/local/lib/pidgin`. The same applies to finch (`/usr/local/lib/finch`).

This PR fixes it for both Pidgin and finch. (Both are in the same fomula.)