### PR TITLE
clamav: remove llvm runtime

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -4,7 +4,7 @@ class Clamav < Formula
   url "https://www.clamav.net/downloads/production/clamav-0.102.2.tar.gz"
   mirror "https://fossies.org/linux/misc/clamav-0.102.2.tar.gz"
   sha256 "89fcdcc0eba329ca84d270df09d2bb89ae55f5024b0c3bddb817512fb2c907d3"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "af683074259e803315ec885285e9fbf587d0ad477e6bec9b582b78f8750a04c6" => :catalina
@@ -42,8 +42,7 @@ class Clamav < Formula
       --libdir=#{lib}
       --sysconfdir=#{etc}/clamav
       --disable-zlib-vcheck
-      --with-llvm=yes
-      --with-system-llvm=no
+      --with-llvm=no
       --with-libiconv-prefix=#{Formula["libiconv"].opt_prefix}
       --with-iconv=#{Formula["libiconv"].opt_prefix}
       --with-libjson-static=#{Formula["json-c"].opt_prefix}/lib/libjson-c.a


### PR DESCRIPTION
My previous patch added llvm while addressing a few other issues, in the
interest in improved runtime peformance for bytecode signatures. It
seems it broke clamav's ability to run bytecode signatures. The reason
isn't clear, and a local build outside of brew seems fine. I'll continue
to investigate. In the meantime, this Formula update is necessary to get
clamav working again for Brew users.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
