### PR TITLE
apache-arrow: fix build-depends on boost

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -13,6 +13,7 @@ class ApacheArrow < Formula
     sha256 "b8f0b32f2da88189410c9588a9fbd44488477e087d71a92373c99e729318f3dc" => :high_sierra
   end
 
+  depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "brotli"
   depends_on "glog"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Unfortunately because https://github.com/Homebrew/homebrew-core/pull/53505 and https://github.com/Homebrew/homebrew-core/pull/53475 were submitted around the same time, this allowed a little bug to slip in.

Arrow still has a build-time dependency on header-only boost code. Previously this was redundant because boost was already indirectly a hard dependency via `thrift`, but this has been fixed in #53505. As a result, we now need to explicitly declare the build-time dependency on boost, to build arrow.

The important thing is that there is still no run-time dependency on boost, because it is all header-only and resolved when building arrow. The arrow user doesn't need boost, and we want to save them from dragging in boost as a dependency.


