### PR TITLE
libav: patch for image formats removed from libvpx

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -49,6 +49,10 @@ class Libav < Formula
     sha256 "7081183fed875f71d53cce1e71f6b58fb5d5eee9f30462d35f9367ec2210507b"
   end
 
+  # Fix for image formats removed from libvpx
+  # https://github.com/shirkdog/hardenedbsd-ports/blob/master/multimedia/libav/files/patch-libavcodec_libvpx.c
+  patch :DATA
+
   def install
     args = %W[
       --disable-debug
@@ -88,3 +92,51 @@ class Libav < Formula
     assert_predicate testpath/"video.mp4", :exist?
   end
 end
+
+__END__
+--- a/libavcodec/libvpx.c
++++ b/libavcodec/libvpx.c
+@@ -25,6 +25,7 @@
+ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt_t img)
+ {
+     switch (img) {
++#if VPX_IMAGE_ABI_VERSION < 5
+     case VPX_IMG_FMT_RGB24:     return AV_PIX_FMT_RGB24;
+     case VPX_IMG_FMT_RGB565:    return AV_PIX_FMT_RGB565BE;
+     case VPX_IMG_FMT_RGB555:    return AV_PIX_FMT_RGB555BE;
+@@ -36,10 +37,13 @@ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt
+     case VPX_IMG_FMT_ARGB_LE:   return AV_PIX_FMT_BGRA;
+     case VPX_IMG_FMT_RGB565_LE: return AV_PIX_FMT_RGB565LE;
+     case VPX_IMG_FMT_RGB555_LE: return AV_PIX_FMT_RGB555LE;
++#endif
+     case VPX_IMG_FMT_I420:      return AV_PIX_FMT_YUV420P;
+     case VPX_IMG_FMT_I422:      return AV_PIX_FMT_YUV422P;
+     case VPX_IMG_FMT_I444:      return AV_PIX_FMT_YUV444P;
++#if VPX_IMAGE_ABI_VERSION < 5
+     case VPX_IMG_FMT_444A:      return AV_PIX_FMT_YUVA444P;
++#endif
+ #if VPX_IMAGE_ABI_VERSION >= 3
+     case VPX_IMG_FMT_I440:      return AV_PIX_FMT_YUV440P;
+     case VPX_IMG_FMT_I42016:    return AV_PIX_FMT_YUV420P16BE;
+@@ -53,6 +57,7 @@ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt
+ vpx_img_fmt_t ff_vpx_pixfmt_to_imgfmt(enum AVPixelFormat pix)
+ {
+     switch (pix) {
++#if VPX_IMAGE_ABI_VERSION < 5
+     case AV_PIX_FMT_RGB24:        return VPX_IMG_FMT_RGB24;
+     case AV_PIX_FMT_RGB565BE:     return VPX_IMG_FMT_RGB565;
+     case AV_PIX_FMT_RGB555BE:     return VPX_IMG_FMT_RGB555;
+@@ -64,10 +69,13 @@ vpx_img_fmt_t ff_vpx_pixfmt_to_imgfmt(enum AVPixelForm
+     case AV_PIX_FMT_BGRA:         return VPX_IMG_FMT_ARGB_LE;
+     case AV_PIX_FMT_RGB565LE:     return VPX_IMG_FMT_RGB565_LE;
+     case AV_PIX_FMT_RGB555LE:     return VPX_IMG_FMT_RGB555_LE;
++#endif
+     case AV_PIX_FMT_YUV420P:      return VPX_IMG_FMT_I420;
+     case AV_PIX_FMT_YUV422P:      return VPX_IMG_FMT_I422;
+     case AV_PIX_FMT_YUV444P:      return VPX_IMG_FMT_I444;
++#if VPX_IMAGE_ABI_VERSION < 5
+     case AV_PIX_FMT_YUVA444P:     return VPX_IMG_FMT_444A;
++#endif
+ #if VPX_IMAGE_ABI_VERSION >= 3
+     case AV_PIX_FMT_YUV440P:      return VPX_IMG_FMT_I440;
+     case AV_PIX_FMT_YUV420P16BE:  return VPX_IMG_FMT_I42016;


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove references to image formats that were [removed from libvpx](https://chromium.googlesource.com/webm/libvpx/+/c9a459216dc3%5E!/), allowing this to build from source again. (xref #46840)