### PR TITLE
streamripper: update url

### DIFF
--- a/Formula/streamripper.rb
+++ b/Formula/streamripper.rb
@@ -1,7 +1,7 @@
 class Streamripper < Formula
   desc "Separate tracks via Shoutcasts title-streaming"
   homepage "https://streamripper.sourceforge.io/"
-  url "https://downloads.sourceforge.net/sourceforge/streamripper/streamripper-1.64.6.tar.gz"
+  url "https://downloads.sourceforge.net/project/streamripper/streamripper%20%28current%29/1.64.6/streamripper-1.64.6.tar.gz"
   sha256 "c1d75f2e9c7b38fd4695be66eff4533395248132f3cc61f375196403c4d8de42"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`streamripper` has moved from being a subfolder in the [SourceForge.net project](https://sourceforge.net/projects/sourceforge/) to its own [Streamripper project](https://sourceforge.net/projects/streamripper/).

As such, the current URL in the formula redirects from https://downloads.sourceforge.net/sourceforge/streamripper/streamripper-1.64.6.tar.gz to https://downloads.sourceforge.net/project/streamripper/streamripper%20%28current%29/1.64.6/streamripper-1.64.6.tar.gz.

This PR simply updates the URL to avoid the redirection. The checksum for the archive at the new URL remains the same, so nothing to worry about there.