### PR TITLE
lc0 0.25.1 (new formula)

### DIFF
--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -1,0 +1,34 @@
+class Lc0 < Formula
+  desc "Open source neural network based chess engine"
+  homepage "https://lczero.org/"
+
+  url "https://github.com/LeelaChessZero/lc0.git",
+      :tag      => "v0.25.1",
+      :revision => "69105b4eb0a3cf4fbc76960d18d519a0bdd19838"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "python" => :build
+
+  resource "network" do
+    url "https://training.lczero.org/get_network?sha=00af53b081e80147172e6f281c01daf5ca19ada173321438914c730370aa4267", :using => :nounzip
+    sha256 "12df03a12919e6392f3efbe6f461fc0ff5451b4105f755503da151adc7ab6d67"
+  end
+
+  def install
+    system "meson", *std_meson_args, "--buildtype", "release", "build/release"
+
+    cd "build/release" do
+      system "ninja", "-v"
+      libexec.install "lc0"
+    end
+
+    bin.write_exec_script libexec/"lc0"
+    libexec.install resource("network")
+  end
+
+  test do
+    assert_match /^bestmove e2e4$/,
+      shell_output("lc0 benchmark --backend=blas --nodes=1 --num-positions=1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add a new formula for Leela Chess Zero (`lc0`). Leela Chess Zero is
one of the strongest chess engines and is interesting because it is
neural-network-based (most strong chess engines aren't). This formula
compiles the `lc0` binary and then downloads a network file to use.

This formula uses a medium-size network as recommended in the project
documentation. Read more here:

https://github.com/LeelaChessZero/lc0/wiki/Best-Nets-for-Lc0

This formula is based on that of `leela-zero`, a similar engine for the
game Go.