### PR TITLE
aurora-cli: disable

### DIFF
--- a/Formula/aurora-cli.rb
+++ b/Formula/aurora-cli.rb
@@ -14,6 +14,10 @@ class AuroraCli < Formula
 
   depends_on "python"
 
+  # Does not build on catalina anymore
+  # Has been moved to the appache attic: https://github.com/apache/attic-aurora
+  disable!
+
   def install
     # No pants yet for Mojave, so we force High Sierra binaries there
     ENV["PANTS_BINARIES_PATH_BY_ID"] =


### PR DESCRIPTION
Does not build on Catalina
Has been moved to the appache attic: https://github.com/apache/attic-aurora

install: 40 (30 days), 98 (90 days), 334 (365 days)
install-on-request: 40 (30 days), 94 (90 days), 325 (365 day

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
