### PR TITLE
prometheus: fix service executable

### DIFF
--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -3,6 +3,7 @@ class Prometheus < Formula
   homepage "https://prometheus.io/"
   url "https://github.com/prometheus/prometheus/archive/v2.18.0.tar.gz"
   sha256 "5eaffd8017309c61e37752599cd53821a4f204a489524e9e520a237d9c471a5c"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -26,7 +27,7 @@ class Prometheus < Formula
 
     (bin/"prometheus_brew_services").write <<~EOS
       #!/bin/bash
-      exec #{bin}/prometheus_brew_services $(<#{etc}/prometheus.args)
+      exec #{bin}/prometheus $(<#{etc}/prometheus.args)
     EOS
 
     (buildpath/"prometheus.args").write <<~EOS


### PR DESCRIPTION
Prometheus bin/prometheus_brew_services run script incorrectly executed itself instead of bin/prometheus. That resulted in an infinite execution loop and Prometheus not being launched. Fixed the script to correclty exec bin/prometheus.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
