### PR TITLE
CONTRIBUTING: Communicate how merges are done for PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you are already well versed in the use of `git`, then you can find the local
 copy of the `homebrew-core` repository in this directory
 (`$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/`), modify the formula there
 leaving the section `bottle do ... end` unchanged, and prepare a pull request
-as you usually do.  Before submitting your pull request, be sure to test it
+as you usually do. Before submitting your pull request, be sure to test it
 with these commands:
 
 ```
@@ -55,3 +55,24 @@ follows:
 * open a pull request as described in the introduction linked to above, wait for the automated test results, and fix any failing tests
 
 Thanks!
+
+### Getting your pull request merged
+
+All Homebrew maintainers are volunteers. We make use of scheduled tasks to help
+us with merging pull requests, as we get hundreds a day. These are triggered by
+a maintainer submitting a valid approving review ("green tick") on your PR.
+Within an hour after that approval, our scheduled GitHub Action will merge your
+PR.
+
+If you push commits - for example to fix CI failures - after an approval has
+been granted by a maintainer, GitHub will dismiss the reviews and we'll have to
+start from scratch. Don't be discouraged, though - further improvements are
+welcome!
+
+If your PR fixes a formula security vulnerability, or is something we otherwise
+would like to release quickly, maintainers can run the commands manually to
+publish your changes right away.
+
+Your PR will show up as "closed, with unmerged commits", but this is normal:
+you'll still get author credit for the changes. In the GitHub UI, it will
+show up as "Closed in <master-branch-commit-sha>".


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

- As I was approving many PRs in a row, it occurred to me that contributors might be confused as to why approvals happen so far in advance of the merge to master taking place. So I wrote some words.
- This didn't feel like so much of a problem for the "ready to merge" label, but approvals are a GitHub-integrated thing that are defined in people's heads as "OK, this is go", potentially.
- Also, note some of the caveats for _how_ we merge PRs, like them showing up as "closed with unmerged commits", not "merged".
- I considered putting this in the docs.brew.sh page about "how to get a Homebrew PR merged", but GitHub signposts directly to `CONTRIBUTING.md` whenever people (especially new people) raise PRs, so this felt like a better place that people are fairly likely to read.
- It's worth noting that this will need some re-wording when this gets to Homebrew/linuxbrew-core, as there are no scheduled tasks for merges there (yet?) - but I'll deal with that later!
