### PR TITLE
screen: removed outdated patch from being applied to HEAD

### DIFF
--- a/Formula/screen.rb
+++ b/Formula/screen.rb
@@ -23,13 +23,6 @@ class Screen < Formula
 
   head do
     url "https://git.savannah.gnu.org/git/screen.git"
-
-    # This patch avoid a bug that prevents detached sessions to reattach
-    # See https://lists.gnu.org/archive/html/screen-users/2016-10/msg00007.html
-    patch do
-      url "https://gist.githubusercontent.com/sobrinho/5a7672e088868c2d036957dbe7825dd0/raw/c6fe5dc20cb7dbd0e23f9053aa3867fcbc01d983/diff.patch"
-      sha256 "47892633ccb137316a0532b034d0be81edc26fc72a6babca9761a1649bc67fd1"
-    end
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Long time user, new contributor. The patch that was being applied to head is outdated and fails the build. Should this be renamed to the `devel` definition?