### PR TITLE
Drop explicit python/python@3.8 dependency for formula which uses meson

### DIFF
--- a/Formula/babl.rb
+++ b/Formula/babl.rb
@@ -3,7 +3,7 @@ class Babl < Formula
   homepage "http://www.gegl.org/babl/"
   url "https://download.gimp.org/pub/babl/0.1/babl-0.1.74.tar.xz"
   sha256 "9a710b6950da37ada94cd9e2046cbce26de12473da32a7b79b7d1432fc66ce0e"
-  revision 1
+  revision 2
   # Use GitHub instead of GNOME's git. The latter is unreliable.
   head "https://github.com/GNOME/babl.git"
 
@@ -18,7 +18,6 @@ class Babl < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "little-cms2"
 
   def install

--- a/Formula/baobab.rb
+++ b/Formula/baobab.rb
@@ -3,7 +3,7 @@ class Baobab < Formula
   homepage "https://wiki.gnome.org/Apps/Baobab"
   url "https://download.gnome.org/sources/baobab/3.34/baobab-3.34.0.tar.xz"
   sha256 "46ebd9466da6a68c340653e9095f1e905b6fac79305879a9e644634f7da98607"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "3994419a1e326594308a62dc3e051f19c3bd611ad1b6b30b0f2098e2d5d9df6a" => :catalina
@@ -15,7 +15,6 @@ class Baobab < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "vala" => :build
   depends_on "adwaita-icon-theme"
   depends_on "gtk+3"

--- a/Formula/file-roller.rb
+++ b/Formula/file-roller.rb
@@ -3,6 +3,7 @@ class FileRoller < Formula
   homepage "https://wiki.gnome.org/Apps/FileRoller"
   url "https://download.gnome.org/sources/file-roller/3.36/file-roller-3.36.2.tar.xz"
   sha256 "268f7fdad8d2a78dfed5e82eb8710bad389c311b720666d6f07a04ed51056bd2"
+  revision 1
 
   bottle do
     sha256 "f5e19d928a57a9682fa124ca664dfe124a971276232f1c84734aa8f8494ad054" => :catalina
@@ -14,7 +15,6 @@ class FileRoller < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "adwaita-icon-theme"
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"

--- a/Formula/gcab.rb
+++ b/Formula/gcab.rb
@@ -3,6 +3,7 @@ class Gcab < Formula
   homepage "https://wiki.gnome.org/msitools"
   url "https://download.gnome.org/sources/gcab/1.4/gcab-1.4.tar.xz"
   sha256 "67a5fa9be6c923fbc9197de6332f36f69a33dadc9016a2b207859246711c048f"
+  revision 1
 
   bottle do
     sha256 "e570c13861c6c889291e1fc67a12c6f0df05129f2e9e80e52b3dbd1a0c406e94" => :catalina
@@ -14,7 +15,6 @@ class Gcab < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "vala" => :build
   depends_on "glib"
 

--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -3,6 +3,7 @@ class GdkPixbuf < Formula
   homepage "https://gtk.org"
   url "https://download.gnome.org/sources/gdk-pixbuf/2.40/gdk-pixbuf-2.40.0.tar.xz"
   sha256 "1582595099537ca8ff3b99c6804350b4c058bb8ad67411bbaae024ee7cead4e6"
+  revision 1
 
   bottle do
     sha256 "bb817292ab8e01a155b663ece6a1b887bb3340c7bfabf567b83b55c7e1b84bd6" => :catalina
@@ -14,7 +15,6 @@ class GdkPixbuf < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "glib"
   depends_on "jpeg"
   depends_on "libpng"

--- a/Formula/ghex.rb
+++ b/Formula/ghex.rb
@@ -3,7 +3,7 @@ class Ghex < Formula
   homepage "https://wiki.gnome.org/Apps/Ghex"
   url "https://download.gnome.org/sources/ghex/3.18/ghex-3.18.4.tar.xz"
   sha256 "c2d9c191ff5bce836618779865bee4059db81a3a0dff38bda3cc7a9e729637c0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "74ef6e73cc29bce3ee6d7a8a97eb54b54d5794fbfe7e924c85d8cfdde0431d45" => :catalina
@@ -15,7 +15,6 @@ class Ghex < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"
 

--- a/Formula/glib-networking.rb
+++ b/Formula/glib-networking.rb
@@ -1,8 +1,9 @@
 class GlibNetworking < Formula
   desc "Network related modules for glib"
-  homepage "https://launchpad.net/glib-networking"
+  homepage "https://gitlab.gnome.org/GNOME/glib-networking"
   url "https://download.gnome.org/sources/glib-networking/2.64/glib-networking-2.64.2.tar.xz"
   sha256 "45def0715c551f9b0b41a4e4f730ac95f3d5d4f3de8162260fbf9421cff695a7"
+  revision 1
 
   bottle do
     sha256 "3cbb58f638d28668205aef4a314cab88b092c77823189ef0e262e6293cacbc33" => :catalina
@@ -13,7 +14,6 @@ class GlibNetworking < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "glib"
   depends_on "gnutls"
   depends_on "gsettings-desktop-schemas"

--- a/Formula/gnome-recipes.rb
+++ b/Formula/gnome-recipes.rb
@@ -3,7 +3,7 @@ class GnomeRecipes < Formula
   homepage "https://wiki.gnome.org/Apps/Recipes"
   url "https://download.gnome.org/sources/gnome-recipes/2.0/gnome-recipes-2.0.2.tar.xz"
   sha256 "1be9d2fcb7404a97aa029d2409880643f15071c37039247a6a4320e7478cd5fb"
-  revision 11
+  revision 12
 
   bottle do
     sha256 "11b15754a891fa31f6f21d15a0604694828b8ba11f3339675e5694481093bd81" => :catalina
@@ -15,7 +15,6 @@ class GnomeRecipes < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "adwaita-icon-theme"
   depends_on "gnome-autoar"
   depends_on "gnu-tar"

--- a/Formula/graphene.rb
+++ b/Formula/graphene.rb
@@ -3,7 +3,7 @@ class Graphene < Formula
   homepage "https://ebassi.github.io/graphene/"
   url "https://download.gnome.org/sources/graphene/1.10/graphene-1.10.0.tar.xz"
   sha256 "406d97f51dd4ca61e91f84666a00c3e976d3e667cd248b76d92fdb35ce876499"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,7 +16,6 @@ class Graphene < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "glib"
 
   def install

--- a/Formula/gsettings-desktop-schemas.rb
+++ b/Formula/gsettings-desktop-schemas.rb
@@ -3,6 +3,7 @@ class GsettingsDesktopSchemas < Formula
   homepage "https://download.gnome.org/sources/gsettings-desktop-schemas/"
   url "https://download.gnome.org/sources/gsettings-desktop-schemas/3.36/gsettings-desktop-schemas-3.36.1.tar.xz"
   sha256 "004bdbe43cf8290f2de7d8537e14d8957610ca479a4fa368e34dbd03f03ec9d9"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +16,6 @@ class GsettingsDesktopSchemas < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "glib"
 
   uses_from_macos "expat"

--- a/Formula/gtranslator.rb
+++ b/Formula/gtranslator.rb
@@ -3,7 +3,7 @@ class Gtranslator < Formula
   homepage "https://wiki.gnome.org/Design/Apps/Translator"
   url "https://download.gnome.org/sources/gtranslator/3.36/gtranslator-3.36.0.tar.xz"
   sha256 "2daa1d3b59b4a35ef54df087345b03e1703e725081f9dac543539228a715add3"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "c6a2ccb9f675452a8d7a306a671576d4c3a4341ce1cd820be7452f1beb7e04c3" => :catalina
@@ -14,7 +14,6 @@ class Gtranslator < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "adwaita-icon-theme"
   depends_on "glib"
   depends_on "gspell"

--- a/Formula/jsonrpc-glib.rb
+++ b/Formula/jsonrpc-glib.rb
@@ -3,6 +3,7 @@ class JsonrpcGlib < Formula
   homepage "https://gitlab.gnome.org/GNOME/jsonrpc-glib"
   url "https://download.gnome.org/sources/jsonrpc-glib/3.34/jsonrpc-glib-3.34.0.tar.xz"
   sha256 "d1ceb24b503e49e7bfe6e44630c03abc65f2d047a68271eb62e332b13be90548"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,7 +17,6 @@ class JsonrpcGlib < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "vala" => :build
   depends_on "glib"
   depends_on "json-glib"

--- a/Formula/libdazzle.rb
+++ b/Formula/libdazzle.rb
@@ -3,6 +3,7 @@ class Libdazzle < Formula
   homepage "https://gitlab.gnome.org/GNOME/libdazzle"
   url "https://download.gnome.org/sources/libdazzle/3.36/libdazzle-3.36.0.tar.xz"
   sha256 "82b31bbf550fc62970c78bf7f9d55e5fae5b8ea13b24fe2d13c8c6039409d958"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,6 @@ class Libdazzle < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "vala" => :build
   depends_on "glib"
   depends_on "gtk+3"

--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -3,6 +3,7 @@ class Libepoxy < Formula
   homepage "https://github.com/anholt/libepoxy"
   url "https://download.gnome.org/sources/libepoxy/1.5/libepoxy-1.5.4.tar.xz"
   sha256 "0bd2cc681dfeffdef739cb29913f8c3caa47a88a451fd2bc6e606c02997289d2"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,6 @@ class Libepoxy < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
 
   def install
     mkdir "build" do

--- a/Formula/libgweather.rb
+++ b/Formula/libgweather.rb
@@ -3,6 +3,7 @@ class Libgweather < Formula
   homepage "https://wiki.gnome.org/Projects/LibGWeather"
   url "https://download.gnome.org/sources/libgweather/3.36/libgweather-3.36.0.tar.xz"
   sha256 "d2ffeec01788d03d1bbf35113fc2f054c6c3600721088f827bcc31e5c603a32d"
+  revision 1
 
   bottle do
     sha256 "f0cf67eaf633582b06a77d8b4eec9585e8fc1ff21184758e7cdc32d3b71d4624" => :catalina
@@ -14,7 +15,6 @@ class Libgweather < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "geocode-glib"
   depends_on "gtk+3"
   depends_on "libsoup"

--- a/Formula/simple-scan.rb
+++ b/Formula/simple-scan.rb
@@ -3,6 +3,7 @@ class SimpleScan < Formula
   homepage "https://gitlab.gnome.org/GNOME/simple-scan"
   url "https://download.gnome.org/sources/simple-scan/3.36/simple-scan-3.36.2.1.tar.xz"
   sha256 "bb8ce5750cd0405e14e4ac8b09f4a587c2fa3a418614ad425a6694c981bb012b"
+  revision 1
 
   bottle do
     sha256 "fb4c476289f457aabb84ba10ebad5c8443c90ebb02df82a1ecf841fe8fbf748f" => :catalina
@@ -14,7 +15,6 @@ class SimpleScan < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "vala" => :build
   depends_on "glib"
   depends_on "gtk+3"

--- a/Formula/template-glib.rb
+++ b/Formula/template-glib.rb
@@ -3,7 +3,7 @@ class TemplateGlib < Formula
   homepage "https://gitlab.gnome.org/GNOME/template-glib"
   url "https://download.gnome.org/sources/template-glib/3.34/template-glib-3.34.0.tar.xz"
   sha256 "216bef6ac3607666b8ca72b936467f7020ce6421c02755c301d079576c9c3dfd"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -16,7 +16,6 @@ class TemplateGlib < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
   depends_on "glib"
   depends_on "gobject-introspection"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Initially, this PR was about migration a couple of formula to `python@3.8`, then it transformed to dropping `python`/`python@3.8` after @tschoonj comment https://github.com/Homebrew/homebrew-core/pull/54390#issuecomment-626114624