### PR TITLE
sd: Install man page and shell completions

### DIFF
--- a/Formula/sd.rb
+++ b/Formula/sd.rb
@@ -15,6 +15,13 @@ class Sd < Formula
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+
+    # Completion scripts and manpage are generated in the crate's build
+    # directory, which includes a fingerprint hash. Try to locate it first
+    out_dir = Dir["target/release/build/sd-*/out"].first
+    man1.install "#{out_dir}/sd.1"
+    bash_completion.install "#{out_dir}/sd.bash"
+    zsh_completion.install "#{out_dir}/_sd"
   end
 
   test do

--- a/Formula/sd.rb
+++ b/Formula/sd.rb
@@ -3,6 +3,7 @@ class Sd < Formula
   homepage "https://github.com/chmln/sd"
   url "https://github.com/chmln/sd/archive/v0.7.5.tar.gz"
   sha256 "f4731fd6bd992eed06ed9326cdef22093605ff97df1dd856e31c5015f0720c66"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Also install `sd`'s man page and shell completions for bash and zsh, similar to how the [`ripgrep`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ripgrep.rb#L29) formula does.