### PR TITLE
picat: bump revision for bottle missing

### DIFF
--- a/Formula/picat.rb
+++ b/Formula/picat.rb
@@ -4,6 +4,7 @@ class Picat < Formula
   url "http://picat-lang.org/download/picat28_5_src.tar.gz"
   version "2.8#5"
   sha256 "3e88f2d2afdda77754e3dde2da50b7a6ee738c98766b03fb9e25cd006ee13652"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
$ brew reinstall picat
==> Reinstalling picat
==> Downloading https://homebrew.bintray.com/bottles/picat-2.8#5.catalina.bottle.tar.gz
##O=#  #
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "picat"
Download failed: https://homebrew.bintray.com/bottles/picat-2.8#5.catalina.bottle.tar.gz
Warning: Bottle installation failed: building from source.
==> Downloading http://picat-lang.org/download/picat28_5_src.tar.gz
######################################################################## 100.0%
```