### PR TITLE
protobuf-swift: use protobuf 3.11.x

### DIFF
--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -3,7 +3,7 @@ class ProtobufSwift < Formula
   homepage "https://github.com/alexeyxo/protobuf-swift"
   url "https://github.com/alexeyxo/protobuf-swift/archive/4.0.6.tar.gz"
   sha256 "598d9e459b4ac74bfbcf22857c7e8fda8f5219c10caac0aa18aea7d8710cce22"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -15,7 +15,7 @@ class ProtobufSwift < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "protobuf@3.7"
+  depends_on "protobuf"
 
   conflicts_with "swift-protobuf",
     :because => "both install `protoc-gen-swift` binaries"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`protobuf-swift` is the only formula using `protobuf@3.7`, bump the formula to use protobuf 3.11.x.

`swift-protobuf` is another swift protobuf library, and is using the latest protobuf.