### PR TITLE
r: fix build with using gss_2.2-0

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -3,6 +3,7 @@ class R < Formula
   homepage "https://www.r-project.org/"
   url "https://cran.r-project.org/src/base/R-4/R-4.0.0.tar.gz"
   sha256 "06beb0291b569978484eb0dcb5d2339665ec745737bdfb4e873e7a5a75492940"
+  revision 1
 
   bottle do
     sha256 "3bef9d95610f3430495684b54276459bc9536fe36ba03d5bfa9471af2be59c49" => :catalina
@@ -24,9 +25,9 @@ class R < Formula
   skip_clean "lib/R/bin", "lib/R/doc"
 
   resource "gss" do
-    url "https://cloud.r-project.org/src/contrib/gss_2.1-12.tar.gz", :using => :nounzip
-    mirror "https://mirror.las.iastate.edu/CRAN/src/contrib/gss_2.1-12.tar.gz"
-    sha256 "bcc92bb621671dbf94684e11a0b1c2b6c423f57d7d4ed8c7eeba4f4e51ef170b"
+    url "https://cloud.r-project.org/src/contrib/gss_2.2-0.tar.gz", :using => :nounzip
+    mirror "https://mirror.las.iastate.edu/CRAN/src/contrib/gss_2.2-0.tar.gz"
+    sha256 "3436f3cedd877e232a5dda99fe7f22ea217a0553d6da5c06c002be57f0790e36"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Found in #54520, the r formula is not re-buildable as gss_2.11-12 is gone, however, upstream did publish gss_2.2-0, so trying that to fix the build.