### PR TITLE
ripgrep: follow changes of 12.1.0

### DIFF
--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -3,6 +3,7 @@ class Ripgrep < Formula
   homepage "https://github.com/BurntSushi/ripgrep"
   url "https://github.com/BurntSushi/ripgrep/archive/12.1.0.tar.gz"
   sha256 "ca2d11dd7b7346734d47ad8073468e9c409fbe85842a608d372b8d4fb36be291"
+  revision 1
   head "https://github.com/BurntSushi/ripgrep.git"
 
   bottle do
@@ -12,15 +13,12 @@ class Ripgrep < Formula
     sha256 "be49cef17dbf58a02e02f45d062fd833424280e7b9402332186603397c1573c2" => :high_sierra
   end
 
-  depends_on "asciidoc" => :build
-  depends_on "docbook-xsl" => :build
+  depends_on "asciidoctor" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "pcre2"
 
   def install
-    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
-
     system "cargo", "install", "--locked",
                                "--root", prefix,
                                "--path", ".",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refer the [release note](https://github.com/BurntSushi/ripgrep/releases/tag/12.1.0) of ripgrep 12.1.0.