### PR TITLE
Add livecheck block to a52dec.rb

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -28,4 +28,9 @@ class A52dec < Formula
     touch testpath/"test"
     system "#{bin}/a52dec", "-o", "null", "test"
   end
+
+  livecheck do
+    url "http://liba52.sourceforge.net"
+    regex /a52dec-(\d+(?:\.\d+)+)/
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR aims to add a `livecheck` block to `a52dec.rb`. This is to test the new `livecheck` DSL being added to Homebrew/brew. See Issue Homebrew/brew#7027 and PR Homebrew/brew#7179 for more details. Attn: @MikeMcQuaid @samford 