### PR TITLE
libtorrent-rakshasa 0.13.8 (new formula)

### DIFF
--- a/Formula/libtorrent-rakshasa.rb
+++ b/Formula/libtorrent-rakshasa.rb
@@ -1,0 +1,38 @@
+class LibtorrentRakshasa < Formula
+  desc "BitTorrent library with a focus on high performance"
+  homepage "https://github.com/rakshasa/libtorrent"
+  url "https://github.com/rakshasa/libtorrent/archive/v0.13.8.tar.gz"
+  sha256 "0f6c2e7ffd3a1723ab47fdac785ec40f85c0a5b5a42c1d002272205b988be722"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "openssl@1.1"
+
+  conflicts_with "libtorrent-rasterbar",
+    :because => "they both use the same libname"
+
+  def install
+    args = ["--prefix=#{prefix}", "--disable-debug",
+            "--disable-dependency-tracking"]
+
+    system "sh", "autogen.sh"
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <string>
+      #include <torrent/torrent.h>
+      int main(int argc, char* argv[])
+      {
+        return strcmp(torrent::version(), argv[1]);
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-L#{lib}", "-ltorrent"
+    system "./test", version.to_s
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Previous PRs:
https://github.com/Homebrew/homebrew-core/pull/369: `boneyard libtorrent/rtorrent` all tries failed to build it in macOS back in 2016.
https://github.com/Homebrew/homebrew-core/pull/32774 & https://github.com/Homebrew/homebrew-core/pull/35797 & https://github.com/Homebrew/homebrew-core/pull/37984: All failed because of issues with building on previous macOS versions, my formula depends on `Catalina` which build and work just fine with no hacks.