### PR TITLE
clingo: migrate to python@3.8

### DIFF
--- a/Formula/clingo.rb
+++ b/Formula/clingo.rb
@@ -3,6 +3,7 @@ class Clingo < Formula
   homepage "https://potassco.org/"
   url "https://github.com/potassco/clingo/archive/v5.4.0.tar.gz"
   sha256 "e2de331ee0a6d254193aab5995338a621372517adcf91568092be8ac511c18f3"
+  revision 1
 
   bottle do
     sha256 "768f983bdeb5b7ec3c2aa69b4df169d67df7ec9b0b3f666da4c0be2df84d106a" => :catalina
@@ -14,7 +15,7 @@ class Clingo < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "lua"
-  depends_on "python"
+  depends_on "python@3.8"
 
   # This formula replaced the clasp & gringo formulae.
   # https://github.com/Homebrew/homebrew-core/pull/20281
@@ -24,12 +25,18 @@ class Clingo < Formula
   link_overwrite "bin/lpconvert"
   link_overwrite "bin/reify"
 
+  # Patch adds Python 3.8 compatibility
+  patch do
+    url "https://github.com/potassco/clingo/commit/13a896b6a762e48c2396e3dc9f2e794020f4e6e8.patch?full_index=1"
+    sha256 "f2840bc4ab5159c253c5390c845f0d003f5fef813f49ddca27dbd5245f535e79"
+  end
+
   def install
     system "cmake", ".", "-DCLINGO_BUILD_WITH_PYTHON=ON",
                          "-DCLINGO_BUILD_PY_SHARED=ON",
                          "-DPYCLINGO_USE_INSTALL_PREFIX=ON",
                          "-DCLINGO_BUILD_WITH_LUA=ON",
-                         "-DPYTHON_EXECUTABLE=#{Formula["python"].opt_bin}/python3",
+                         "-DPYTHON_EXECUTABLE=#{Formula["python@3.8"].opt_bin}/python3",
                          "-DPYCLINGO_DYNAMIC_LOOKUP=OFF",
                          *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Patch
Python 3.8 compatibility was added to clingo in https://github.com/potassco/clingo/commit/13a896b6a762e48c2396e3dc9f2e794020f4e6e8 but is not in the latest release. Added a patch to the formula to make it compatible.

## Old
Draft PR because running `brew install --build-from-source clingo` fails. (Note: I'm not sure whether this is reproducible)

The failure happens when running `make install`:
```
==> Downloading https://github.com/potassco/clingo/archive/v5.4.0.tar.gz
Already downloaded: /Users/rylanpolster/Library/Caches/Homebrew/downloads/282081681e68eb164309254470f26191985341e01010b48609b7316916ab63fc--clingo-5.4.0.tar.gz
==> Downloading https://github.com/potassco/clingo/archive/v5.4.0.tar.gz
Already downloaded: /Users/rylanpolster/Library/Caches/Homebrew/downloads/282081681e68eb164309254470f26191985341e01010b48609b7316916ab63fc--clingo-5.4.0.tar.gz
==> cmake . -DCLINGO_BUILD_WITH_PYTHON=ON -DCLINGO_BUILD_PY_SHARED=ON -DPYCLINGO_USE_INSTALL_PREFIX=ON -DCLINGO_BUILD_WITH_LUA=ON -DPYTHON_EXECUTABLE=/usr/local/opt/python@3.8/bin/python3 -DPYCLINGO_DYNAMIC_LOOKUP=OFF
==> make install
Last 15 lines from /Users/rylanpolster/Library/Logs/Homebrew/clingo/02.make:
                                                                    ^
/tmp/clingo-20200511-20550-1q27ma9/clingo-5.4.0/libpyclingo/pyclingo.cc:3493:37: note: in instantiation of function template specialization '(anonymous namespace)::EnumType<(anonymous namespace)::PropagatorCheckMode>::getAttr<int>' requested here
        return PropagatorCheckMode::getAttr(clingo_propagate_init_get_check_mode(init));
                                    ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[2]: *** [libpyclingo/CMakeFiles/libpyclingom.dir/pyclingo.cc.o] Error 1
make[1]: *** [libpyclingo/CMakeFiles/libpyclingom.dir/all] Error 2
[ 89%] Linking CXX static library ../lib/libluaclingo.a
cd /tmp/clingo-20200511-20550-1q27ma9/clingo-5.4.0/libluaclingo && /usr/local/Cellar/cmake/3.17.2/bin/cmake -P CMakeFiles/libluaclingo.dir/cmake_clean_target.cmake
cd /tmp/clingo-20200511-20550-1q27ma9/clingo-5.4.0/libluaclingo && /usr/local/Cellar/cmake/3.17.2/bin/cmake -E cmake_link_script CMakeFiles/libluaclingo.dir/link.txt --verbose=1
/usr/bin/ar qc ../lib/libluaclingo.a  CMakeFiles/libluaclingo.dir/luaclingo.cc.o
/usr/bin/ranlib ../lib/libluaclingo.a
[ 89%] Built target libluaclingo
make: *** [all] Error 2

READ THIS: https://docs.brew.sh/Troubleshooting
```

The full error list in `02.make` can be seen in the failed test output around [line 340](https://github.com/Homebrew/homebrew-core/pull/54589/checks?check_run_id=664438296#step:6:340)


The main error that seems to keep recurring is: 
```
error: cannot initialize a member subobject of type 'Py_ssize_t' (aka 'long') with an rvalue of type 'nullptr_t'
    nullptr,                                    // tp_print
    ^~~~~~~
```