### PR TITLE
imap-uw: add livecheck block

### DIFF
--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -2,11 +2,15 @@ class ImapUw < Formula
   # imap-uw is unmaintained software; the author has passed away and there is
   # no active successor project.
   desc "University of Washington IMAP toolkit"
-  homepage "https://www.washington.edu/imap/"
+  homepage "https://web.archive.org/web/20191028114408/https://www.washington.edu/imap/"
   url "https://mirrorservice.org/sites/ftp.cac.washington.edu/imap/imap-2007f.tar.gz"
   mirror "https://fossies.org/linux/misc/old/imap-2007f.tar.gz"
   sha256 "53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28"
   revision 1
+
+  livecheck do
+    skip "Not maintained"
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Attempting to add a `livecheck` block to `imap-uw.rb`. This formula has to be skipped by `livecheck`. Ref #54565.