### PR TITLE
chezmoi: fix zsh completion

### DIFF
--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -4,6 +4,7 @@ class Chezmoi < Formula
   url "https://github.com/twpayne/chezmoi.git",
       :tag      => "v1.8.1",
       :revision => "4def4f3b96cb01cefe8d7887e8dbfb77908ef267"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -27,7 +28,7 @@ class Chezmoi < Formula
 
     bash_completion.install "completions/chezmoi-completion.bash"
     fish_completion.install "completions/chezmoi.fish"
-    zsh_completion.install "completions/chezmoi.zsh"
+    zsh_completion.install "completions/chezmoi.zsh" => "_chezmoi"
 
     prefix.install_metafiles
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The installation chezmoi zsh completion was missing a rename of `chezmoi.zsh` to `_chezmoi`, which broke zsh completion for chezmoi. This PR fixes that.

Refs https://github.com/twpayne/chezmoi/issues/534.