### PR TITLE
sdl: Fix HEAD installation

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -1,9 +1,32 @@
 class Sdl < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick and graphics"
   homepage "https://www.libsdl.org/"
-  url "https://www.libsdl.org/release/SDL-1.2.15.tar.gz"
-  sha256 "d6d316a793e5e348155f0dd93b979798933fb98aa1edebcc108829d6474aad00"
   revision 1
+
+  stable do
+    url "https://www.libsdl.org/release/SDL-1.2.15.tar.gz"
+    sha256 "d6d316a793e5e348155f0dd93b979798933fb98aa1edebcc108829d6474aad00"
+    # Fix for a bug preventing SDL from building at all on OSX 10.9 Mavericks
+    # Related ticket: https://bugzilla.libsdl.org/show_bug.cgi?id=2085
+    patch do
+      url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1320"
+      sha256 "ba0bf2dd8b3f7605db761be11ee97a686c8516a809821a4bc79be738473ddbf5"
+    end
+
+    # Fix compilation error on 10.6 introduced by the above patch
+    patch do
+      url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1324"
+      sha256 "ee7eccb51cefff15c6bf8313a7cc7a3f347dc8e9fdba7a3c3bd73f958070b3eb"
+    end
+
+    # Fix mouse cursor transparency on 10.13, https://bugzilla.libsdl.org/show_bug.cgi?id=4076
+    if MacOS.version == :high_sierra
+      patch do
+        url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3721"
+        sha256 "954875a277d9246bcc444b4e067e75c29b7d3f3d2ace5318a6aab7d7a502f740"
+      end
+    end
+  end
 
   bottle do
     cellar :any
@@ -19,27 +42,6 @@ class Sdl < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-  end
-
-  # Fix for a bug preventing SDL from building at all on OSX 10.9 Mavericks
-  # Related ticket: https://bugzilla.libsdl.org/show_bug.cgi?id=2085
-  patch do
-    url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1320"
-    sha256 "ba0bf2dd8b3f7605db761be11ee97a686c8516a809821a4bc79be738473ddbf5"
-  end
-
-  # Fix compilation error on 10.6 introduced by the above patch
-  patch do
-    url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=1324"
-    sha256 "ee7eccb51cefff15c6bf8313a7cc7a3f347dc8e9fdba7a3c3bd73f958070b3eb"
-  end
-
-  # Fix mouse cursor transparency on 10.13, https://bugzilla.libsdl.org/show_bug.cgi?id=4076
-  if MacOS.version == :high_sierra
-    patch do
-      url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3721"
-      sha256 "954875a277d9246bcc444b4e067e75c29b7d3f3d2ace5318a6aab7d7a502f740"
-    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There are three patches in the formula that are already in the `--HEAD` SDL1.2 code. See:

- https://bugzilla.libsdl.org/show_bug.cgi?id=2085#c5
- https://bugzilla.libsdl.org/show_bug.cgi?id=4076#c11

Those patches are giving errors when running `brew install sdl --HEAD` as they are very old. Moving them to be applied only when compiling 'stable' allows sdl to be installed with all latest `--HEAD` fixes in Catalina (the only OS I have tested), some of these changes being very important for macOS like this one: https://hg.libsdl.org/SDL/rev/ab7529cb9558)