### PR TITLE
libfido2: apply patch

### DIFF
--- a/Formula/libfido2.rb
+++ b/Formula/libfido2.rb
@@ -3,7 +3,7 @@ class Libfido2 < Formula
   homepage "https://developers.yubico.com/libfido2/"
   url "https://github.com/Yubico/libfido2/archive/1.4.0.tar.gz"
   sha256 "ad921fbe7d4bb70e4a971e564cd01f341daf9b5ed5d69b3cbab94a8a811d2a6c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -17,6 +17,12 @@ class Libfido2 < Formula
   depends_on "pkg-config" => :build
   depends_on "libcbor"
   depends_on "openssl@1.1"
+
+  # Apply fix for https://github.com/Yubico/libfido2/issues/166 (also https://github.com/Yubico/libfido2/issues/179)
+  patch do
+    url "https://github.com/Yubico/libfido2/commit/39544a2c342b0438a8f341b4a4ff20f650f701a3.diff?full_index=1"
+    sha256 "664a95d68502a266835839002d32149ae391aef5b902d33a990c00539a68fe32"
+  end
 
   def install
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
add patch that resolves https://github.com/Yubico/libfido2/issues/166 which prevents some security keys from working. Also see https://github.com/Yubico/libfido2/issues/179