### PR TITLE
qemu: add snappy missing dependency

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -3,7 +3,7 @@ class Qemu < Formula
   homepage "https://www.qemu.org/"
   url "https://download.qemu.org/qemu-5.0.0.tar.xz"
   sha256 "2f13a92a0fa5c8b69ff0796b59b86b080bbb92ebad5d301a7724dd06b5e78cb6"
-  revision 1
+  revision 2
   head "https://git.qemu.org/git/qemu.git"
 
   bottle do
@@ -24,6 +24,7 @@ class Qemu < Formula
   depends_on "ncurses"
   depends_on "nettle"
   depends_on "pixman"
+  depends_on "snappy"
   depends_on "vde"
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
@@ -62,7 +63,38 @@ class Qemu < Formula
 
   test do
     expected = build.stable? ? version.to_s : "QEMU Project"
+    assert_match expected, shell_output("#{bin}/qemu-system-aarch64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-alpha --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-arm --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-cris --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-hppa --version")
     assert_match expected, shell_output("#{bin}/qemu-system-i386 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-lm32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-m68k --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblaze --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblazeel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64el --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mipsel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-moxie --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-nios2 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-or1k --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-riscv32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-riscv64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-rx --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-s390x --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4eb --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-tricore --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-unicore32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-x86_64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensa --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensaeb --version")
     resource("test-image").stage testpath
     assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
   end


### PR DESCRIPTION
The `qemu-system-x86_64` binary depends on the `libsnappy` dynamic
library, which is provided by the `snappy` package.

dyld: Library not loaded: /usr/local/opt/snappy/lib/libsnappy.1.dylib
  Referenced from: /usr/local/bin/qemu-system-x86_64
  Reason: image not found
Abort trap: 6

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>