### PR TITLE
gradio: deprecate formula

### DIFF
--- a/Formula/gradio.rb
+++ b/Formula/gradio.rb
@@ -10,6 +10,8 @@ class Gradio < Formula
     sha256 "5c3f745ad431c61ef3d19b4a2a03d6f24eb99dd47768178e6d1810edba4f12fa" => :high_sierra
   end
 
+  deprecate! :date => "November 16, 2019"
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "adwaita-icon-theme"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] n/a Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] n/a Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] n/a Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Looks like `gradio` has been deprecated upstream: https://github.com/haecker-felix/Gradio

Owner/Readme points towards new project [Shortwave](https://gitlab.gnome.org/World/Shortwave) (which actually should maybe be a cask rather than a formula anyway).

This is also one of the leftover formula depending on `python` (https://github.com/Homebrew/homebrew-core/issues/47274).