### PR TITLE
Stubby: install run en etc files in correct locations

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -17,7 +17,8 @@ class Stubby < Formula
   depends_on "libyaml"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-DCMAKE_INSTALL_RUNSTATEDIR=#{HOMEBREW_PREFIX}/var/run/", \
+                    "-DCMAKE_INSTALL_SYSCONFDIR=#{HOMEBREW_PREFIX}/etc", ".", *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix a bug in the stubby formula, which didn't install the config file and run state file into the correct directory:

```
╰─▶ sudo brew install  stubby
==> Downloading https://github.com/getdnsapi/stubby/archive/v0.3.0.tar.gz
Already downloaded: /opt/brew/Caches/downloads/2af9446a9ad6bd4d1027a0a173e07b2f476956dbd4c478595cc89c088e058543--stubby-0.3.0.tar.gz
==> cmake .
==> make install
Last 15 lines from /opt/brew/Logs/stubby/02.make:
[100%] Built target stubby-ui-helper
[100%] Built target stubby
/opt/brew/Cellar/cmake/3.17.2/bin/cmake -E cmake_progress_start /tmp/stubby-20200514-33034-c6gre9/stubby-0.3.0/CMakeFiles 0
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/Makefile2 preinstall
make[1]: Nothing to be done for `preinstall'.
Install the project...
/opt/brew/Cellar/cmake/3.17.2/bin/cmake -P cmake_install.cmake
-- Install configuration: "Release"
-- Up-to-date: /var/run/opt/brew/Cellar/stubby/0.3.0
CMake Error at cmake_install.cmake:44 (file):
  file INSTALL cannot set permissions on
  "/var/run/opt/brew/Cellar/stubby/0.3.0": Operation not permitted.


make: *** [install] Error 1
```

```
╰─▶ sudo brew install
Updating Homebrew...
==> Downloading https://github.com/getdnsapi/stubby/archive/v0.3.0.tar.gz
Already downloaded: /opt/brew/Caches/downloads/2af9446a9ad6bd4d1027a0a173e07b2f476956dbd4c478595cc89c088e058543--stubby-0.3.0.tar.gz
==> cmake -DCMAKE_INSTALL_RUNSTATEDIR=/opt/brew/var/run/ -DSTUBBYCONFDIR={HOMEBREW_PREFIX}/etc .
==> make install
Last 15 lines from /opt/brew/Logs/stubby/02.make:
-- Installing: /opt/brew/Cellar/stubby/0.3.0/bin/stubby
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/man/man1/stubby.1
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/doc/stubby/AUTHORS
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/doc/stubby/COPYING
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/doc/stubby/ChangeLog
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/doc/stubby/NEWS
-- Installing: /opt/brew/Cellar/stubby/0.3.0/share/doc/stubby/README.md
CMake Error at cmake_install.cmake:77 (file):
  file COPY cannot copy file
  "/tmp/stubby-20200514-39105-ydtmeh/stubby-0.3.0/stubby.yml" to
  "/etc/opt/brew/Cellar/stubby/0.3.0/stubby/stubby.yml": No such file or
  directory.


make: *** [install] Error 1
```