### PR TITLE
embree: 3.10.0 revision bump

### DIFF
--- a/Formula/embree.rb
+++ b/Formula/embree.rb
@@ -2,7 +2,8 @@ class Embree < Formula
   desc "High-performance ray tracing kernels"
   homepage "https://embree.github.io/"
   url "https://github.com/embree/embree/archive/v3.10.0.tar.gz"
-  sha256 "7af744b2c3a2f60aa54cdfcf7928c56f59aabec4a7310dbb96b09a6c64a5a7b0"
+  sha256 "f1f7237360165fb8859bf71ee5dd8caec1fe02d4d2f49e89c11d250afa067aff"
+  revision 1
   head "https://github.com/embree/embree.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - sha256 changed without the version also changing. They made changes to the release, hence the version bump https://github.com/embree/embree/commit/0e78b682dc631575b79f1cc43863931e8d411e3b

-----

Upstream fixed embree CMake usage (`embree-config.cmake`), adding back in certain variables, such as `EMBREE_LIBRARY`