### PR TITLE
biogeme: deprecate as of oct 2018

### DIFF
--- a/Formula/biogeme.rb
+++ b/Formula/biogeme.rb
@@ -1,9 +1,9 @@
 class Biogeme < Formula
   desc "Maximum likelihood estimation of choice models"
   homepage "https://biogeme.epfl.ch/"
-  url "https://biogeme.epfl.ch/distrib/biogeme-2.6a.tar.gz"
-  sha256 "f6de0ea12f83ed183f31a41b9a56d1ec7226d2305549fb89ea7b1de8273ede49"
-  revision 5
+  url "https://files.pythonhosted.org/packages/0a/8b/1228805ea0ad03dbfac3c15e22be6451b09a40438524cf2bff2aeeb4075d/biogeme-3.2.5.tar.gz"
+  sha256 "cbee2d318dddb6cf4bd6714961435aae201440b78185f2bc3eeab16cf28a98d6"
+  revision 6
 
   bottle do
     cellar :any
@@ -13,14 +13,41 @@ class Biogeme < Formula
     sha256 "cad38740685b800f07bece9dd13238b900427155697582fc689bd3eee42e8c38" => :sierra
   end
 
-  deprecate! :date => "October 1, 2018"
+  depends_on "cython" => :build
+  depends_on "python@3.8"
+  depends_on "numpy"
+  depends_on "scipy"
 
-  depends_on "gtkmm3"
-  depends_on "python"
+  resource "Unidecode" do
+    url "https://files.pythonhosted.org/packages/b1/d6/7e2a98e98c43cf11406de6097e2656d31559f788e9210326ce6544bd7d40/Unidecode-1.1.1.tar.gz"
+    sha256 "2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8"
+  end
+
+  resource "pandas" do
+    url "https://files.pythonhosted.org/packages/2f/79/f236ab1cfde94bac03d7b58f3f2ab0b1cc71d6a8bda3b25ce370a9fe4ab1/pandas-1.0.3.tar.gz"
+    sha256 "32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586"
+  end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
-    system "make", "install"
+    xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
+
+    vendor_site_packages = libexec/"vendor/lib/python#{xy}/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", vendor_site_packages
+
+    ENV.prepend "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python#{xy}/site-packages"
+    %w[numpy scipy].each do |d|
+      ENV.prepend "PYTHONPATH", Formula[d].opt_lib/"python#{xy}/site-packages"
+    end
+
+    resources.each do |r|
+      r.stage do
+        system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+
+    site_packages = libexec/"lib/python#{xy}/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", site_packages
+    system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
   end
 
   test do

--- a/Formula/biogeme.rb
+++ b/Formula/biogeme.rb
@@ -13,9 +13,8 @@ class Biogeme < Formula
     sha256 "cad38740685b800f07bece9dd13238b900427155697582fc689bd3eee42e8c38" => :sierra
   end
 
-  # depends_on "cython" => :build
-  depends_on "python@3.8"
   depends_on "numpy"
+  depends_on "python@3.8"
   depends_on "scipy"
 
   resource "Cython" do
@@ -49,6 +48,7 @@ class Biogeme < Formula
 
     resources.each do |r|
       next if r.name == "Cython"
+
       r.stage do
         system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
       end

--- a/Formula/biogeme.rb
+++ b/Formula/biogeme.rb
@@ -13,10 +13,15 @@ class Biogeme < Formula
     sha256 "cad38740685b800f07bece9dd13238b900427155697582fc689bd3eee42e8c38" => :sierra
   end
 
-  depends_on "cython" => :build
+  # depends_on "cython" => :build
   depends_on "python@3.8"
   depends_on "numpy"
   depends_on "scipy"
+
+  resource "Cython" do
+    url "https://files.pythonhosted.org/packages/79/36/69246177114d0b6cb7bd4f9aef177b434c0f4a767e05201b373e8c8d7092/Cython-0.29.19.tar.gz"
+    sha256 "97f98a7dc0d58ea833dc1f8f8b3ce07adf4c0f030d1886c5399a2135ed415258"
+  end
 
   resource "Unidecode" do
     url "https://files.pythonhosted.org/packages/b1/d6/7e2a98e98c43cf11406de6097e2656d31559f788e9210326ce6544bd7d40/Unidecode-1.1.1.tar.gz"
@@ -34,12 +39,16 @@ class Biogeme < Formula
     vendor_site_packages = libexec/"vendor/lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", vendor_site_packages
 
-    ENV.prepend "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python#{xy}/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"cython/lib/python#{xy}/site-packages"
+    resource("Cython").stage do
+      system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(buildpath/"cython")
+    end
     %w[numpy scipy].each do |d|
       ENV.prepend "PYTHONPATH", Formula[d].opt_lib/"python#{xy}/site-packages"
     end
 
     resources.each do |r|
+      next if r.name == "Cython"
       r.stage do
         system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
       end

--- a/Formula/biogeme.rb
+++ b/Formula/biogeme.rb
@@ -13,6 +13,8 @@ class Biogeme < Formula
     sha256 "cad38740685b800f07bece9dd13238b900427155697582fc689bd3eee42e8c38" => :sierra
   end
 
+  deprecate! :date => "October 1, 2018"
+
   depends_on "gtkmm3"
   depends_on "python"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to [`biogeme`'s homepage](http://biogeme.epfl.ch/), the command-line `pythonbiogeme` has been deprecated since late 2018. The new project, `PandasBiogeme`, is purely a pip package and is hosted on PyPI ([release history](https://pypi.org/project/biogeme/#history)).

From the homepage:
```
PythonBiogeme
    Around 2010, a more flexible version was designed for general purpose parametric models. 
    The modeling language was extended, and based on the Python language.
    A series of discrete choice models were precoded for an easy use.
    Also written in GNU C++, it is distributed on the homebrew package manager.
    The distributions can be found here. 

PandasBiogeme
    In 2018, a completely new version of the software was released.
    It was not anymore a standalone executable, but a Python package.
    The package is written in Python, with the exception of the core calculations of the models, that are written in C++ for the sake of efficiency.
    The motivation was to combine the simplicity of the usage (especially for teaching purposes), with the sophistication provided by Python (for research and applications purposes).
    Morever, the management of the data relies on the package Pandas, which has become the workhorse of data scientists.
    Therefore, the name PandasBiogeme has been adopted.
    It is distributed on the Python Package Index repository.
```

Tagging @michelbierlaire - user account that first introduced `biogeme` package. Is it ok to deprecate this from homebrew? Are most user-installs now focused on the PyPI-distributed `PandasBiogeme` rather than the command-line tool, or is `PythonBiogeme` still being used?

https://formulae.brew.sh/formula/biogeme#default

This is one of the formulae remaining before the python3.8 switch - #47274