### PR TITLE
libolm 3.1.4 (new formula)

### DIFF
--- a/Formula/libolm.rb
+++ b/Formula/libolm.rb
@@ -1,0 +1,37 @@
+class Libolm < Formula
+  desc "Implementation of the Double Ratchet cryptographic ratchet"
+  homepage "https://gitlab.matrix.org/matrix-org/olm"
+  url "https://gitlab.matrix.org/matrix-org/olm/-/archive/3.1.4/olm-3.1.4.tar.gz"
+  sha256 "1ca9926ce71d778fb7352d1ee77513194db8c7f49c0d69d38ac49ec3bafcea38"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", "-Bbuild", "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+    system "cmake", "--build", "build", "--target", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <vector>
+
+      #include "olm/olm.h"
+
+      using std::cout;
+
+      int main() {
+        void * utility_buffer = malloc(::olm_utility_size());
+        ::OlmUtility * utility = ::olm_utility(utility_buffer);
+
+        uint8_t output[43];
+        ::olm_sha256(utility, "Hello, World", 12, output, 43);
+        cout << output;
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lolm", "-lstdc++", "-o", "test"
+    assert_equal "A2daxT/5zRU1zMffzfosRYxSGDcfQY3BNvLRmsH76KU", shell_output("./test").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds libolm which is an implementation of the olm and megolm cryptographic ratchets. This is used by various Matrix clients like https://github.com/tulir/gomuks, https://github.com/poljar/weechat-matrix, and https://github.com/Nheko-Reborn/nheko.