### PR TITLE
field3d 1.7.3 (new formula)

### DIFF
--- a/Formula/field3d.rb
+++ b/Formula/field3d.rb
@@ -1,0 +1,35 @@
+class Field3d < Formula
+  desc "Library for storing voxel data on disk and in memory"
+  homepage "https://sites.google.com/site/field3d/"
+  url "https://github.com/imageworks/Field3D/archive/v1.7.3.tar.gz"
+  sha256 "b6168bc27abe0f5e9b8d01af7794b3268ae301ac72b753712df93125d51a0fd4"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "hdf5"
+  depends_on "ilmbase"
+
+  def install
+    ENV.cxx11
+    ENV.prepend "CXXFLAGS", "-DH5_USE_110_API"
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+    man1.install "man/f3dinfo.1"
+    pkgshare.install "contrib", "test", "apps/sample_code"
+  end
+
+  test do
+    system ENV.cxx, "-std=c++11", "-I#{include}", "-L#{lib}", "-lField3D",
+           "-I#{Formula["boost"].opt_include}",
+           "-L#{Formula["boost"].opt_lib}", "-lboost_system",
+           "-I#{Formula["hdf5"].opt_include}",
+           "-L#{Formula["hdf5"].opt_lib}", "-lhdf5",
+           "-I#{Formula["ilmbase"].opt_include}",
+           pkgshare/"sample_code/create_and_write/main.cpp",
+           "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Reinstates the `field3d` formula (originally removed in #51107) by switching to `cmake` and an older version of `hdf5`. 

