### PR TITLE
gr-osmosdr: use system python

### DIFF
--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -3,7 +3,7 @@ class GrOsmosdr < Formula
   homepage "https://osmocom.org/projects/sdr/wiki/GrOsmoSDR"
   url "https://github.com/osmocom/gr-osmosdr/archive/v0.1.4.tar.gz"
   sha256 "bcf9a9b1760e667c41a354e8cd41ef911d0929d5e4a18e0594ccb3320d735066"
-  revision 9
+  revision 10
 
   bottle do
     cellar :any
@@ -19,7 +19,7 @@ class GrOsmosdr < Formula
   depends_on "gnuradio"
   depends_on "hackrf"
   depends_on "librtlsdr"
-  depends_on "python"
+  depends_on :macos # gnuradio uses Python 2
   depends_on "uhd"
 
   resource "Cheetah" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit --strict gr-osmosdr` fails saying:

```
gr-osmosdr:
  * Packages have been installed for:
      Python 2.7
    but this formula depends on:
      Python 3.8
Error: 1 problem in 1 formula detected
```

It's worth noting that the formula installs successfully and passes the tests, just not the audit.

As far as I can tell, brew is using python3. The `libexec` directory contains `vendor/lib/python3.8/site-packages/` and no Python 2.7 directory.

Cheetah seems to be the only package that is needed. It seems that Cheetah has been replaced with Cheetah3, and [the changelog](https://cheetahtemplate.org/news.html) says that version 3.2.5 works with Python 3.8. Note that when I tried to install Cheetah with pip in a Python 3.8 virtual environment it didn't work, while installing Cheetah3 did. 

I used [poet](https://github.com/tdsmith/homebrew-pypi-poet) to generate the updated resource block.

---

When installing, brew gives this warning (although it doesn't seem related to me):

```
Warning: gr-osmosdr dependency gcc was built with a different C++ standard
library (libstdc++ from clang). This may cause problems at runtime.
```

I based these changes off of [pyside](Formula/pyside.rb) (#54755) as well as using [urh](Formula/urh.rb) and [xdot](Formula/xdot.rb) as references. In those files, the `xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"` line is used. I added that here as it looks like it will make updating versions in the future easier, although I'm not sure that will be necessary until Python 4 so this change might not be needed. It's worth noting that this change doesn't seem to affect the audit error.