### PR TITLE
confluent-platform: Support the executables "confluent" and "confluent-hub"

### DIFF
--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -12,13 +12,23 @@ class ConfluentPlatform < Formula
   conflicts_with "kafka", :because => "kafka also ships with identically named Kafka related executables"
 
   def install
-    prefix.install "bin"
-    rm_rf "#{bin}/windows"
-    prefix.install "etc"
-    prefix.install "share"
+    libexec.install %w[bin etc libexec share]
+    rm_rf libexec/"bin/windows"
+
+    bin.write_exec_script Dir["#{libexec}/bin/*"]
   end
 
   test do
+    require "open3"
+
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
+
+    # The executable "confluent" tries to create .confluent under the home directory
+    # without considering the envrionment variable "HOME", so the execution will fail
+    # due to sandbox-exec.
+    # The message "unable to load config" means that the execution will succeed
+    # if the user has write permission.
+    err, = Open3.capture2e("#{bin}/confluent")
+    assert_match /\Aunable to load config/, err
   end
 end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -11,6 +11,8 @@ class ConfluentPlatform < Formula
 
   conflicts_with "kafka", :because => "kafka also ships with identically named Kafka related executables"
 
+  patch :p0, :DATA
+
   def install
     libexec.install %w[bin etc libexec share]
     rm_rf libexec/"bin/windows"
@@ -30,5 +32,23 @@ class ConfluentPlatform < Formula
     # if the user has write permission.
     err, = Open3.capture2e("#{bin}/confluent")
     assert_match /\Aunable to load config/, err
+
+    assert_match /usage: confluent-hub/, shell_output("#{bin}/confluent-hub help")
   end
 end
+
+__END__
+--- bin/confluent-hub.orig	2020-03-03 08:53:14.000000000 +0900
++++ bin/confluent-hub	2020-05-18 03:57:04.000000000 +0900
+@@ -4,11 +4,6 @@
+ 
+ base_dir=$(dirname $0)
+ 
+-if [ -L /usr/local/bin/confluent-hub ]; then
+-    #brew cask installation
+-    base_dir=$(dirname $( ls -l /usr/local/bin/confluent-hub | awk '{print $11}' ))
+-    #base_dir refers to Caskrooom/confluent-hub-client
+-fi
+ #cd -P deals with symlink from /bin to /usr/bin
+ java_base_dir=$( cd -P "$base_dir/../share/java" && pwd )
+ HUB_CLI_CLASSPATH="${HUB_CLI_CLASSPATH}:${java_base_dir}/confluent-hub-client/*"

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -17,13 +17,7 @@ class ConfluentPlatform < Formula
 
     # Delete some lines to avoid the error like
     # "cd: ../Cellar/confluent-platform/5.4.1/bin/../share/java: No such file or directory"
-    inreplace libexec/"bin/confluent-hub", <<~'EOS', ""
-      if [ -L /usr/local/bin/confluent-hub ]; then
-          #brew cask installation
-          base_dir=$(dirname $( ls -l /usr/local/bin/confluent-hub | awk '{print $11}' ))
-          #base_dir refers to Caskrooom/confluent-hub-client
-      fi
-    EOS
+    inreplace libexec/"bin/confluent-hub", "[ -L /usr/local/bin/confluent-hub ]", "false"
 
     bin.write_exec_script Dir["#{libexec}/bin/*"]
   end

--- a/Formula/confluent-platform.rb
+++ b/Formula/confluent-platform.rb
@@ -21,8 +21,6 @@ class ConfluentPlatform < Formula
   end
 
   test do
-    require "open3"
-
     assert_match version.to_s, shell_output("#{bin}/kafka-broker-api-versions --version")
 
     # The executable "confluent" tries to create .confluent under the home directory
@@ -30,8 +28,7 @@ class ConfluentPlatform < Formula
     # due to sandbox-exec.
     # The message "unable to load config" means that the execution will succeed
     # if the user has write permission.
-    err, = Open3.capture2e("#{bin}/confluent")
-    assert_match /\Aunable to load config/, err
+    assert_match /unable to load config/, shell_output("#{bin}/confluent 2>&1", 1)
 
     assert_match /usage: confluent-hub/, shell_output("#{bin}/confluent-hub help")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
    - https://github.com/Homebrew/homebrew-core/pull/52991 exists, but it is not active. In addition, even if I apply the changes, I can't still execute `confluent`.
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR will resolve the following errors:

```
% confluent --version
confluentinc/cli crit executable /usr/local/bin/../libexec/cli/darwin_amd64/confluent does not exist.  Make sure this script is up-to-date and resides at bin/confluent in the Confluent Platform release directory.
% confluent-hub help
/usr/local/bin/confluent-hub: line 13: cd: ../Cellar/confluent-platform/5.4.1/bin/../share/java: No such file or directory
Error: Could not find or load main class io.confluent.connect.hub.cli.ConfluentHubClient
Caused by: java.lang.ClassNotFoundException: io.confluent.connect.hub.cli.ConfluentHubClient
```