### PR TITLE
fix libelf archive url

### DIFF
--- a/Formula/libelf.rb
+++ b/Formula/libelf.rb
@@ -1,7 +1,7 @@
 class Libelf < Formula
   desc "ELF object file access library"
   homepage "https://web.archive.org/web/20181111033959/www.mr511.de/software/english.html"
-  url "https://web.archive.org/web/20181111033959/www.mr511.de/software/libelf-0.8.13.tar.gz"
+  url "https://dl.bintray.com/homebrew/mirror/libelf-0.8.13.tar.gz" # using this url since original source is offline ( https://github.com/Homebrew/homebrew-core/pull/54887 )
   sha256 "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d"
   revision 1
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
updating url/homepage since the previous link ( https://web.archive.org/web/20181111033959/www.mr511.de/software/libelf-0.8.13.tar.gz ) is not currently resolving