### PR TITLE
git-absorb: install the man page

### DIFF
--- a/Formula/git-absorb.rb
+++ b/Formula/git-absorb.rb
@@ -3,6 +3,7 @@ class GitAbsorb < Formula
   homepage "https://github.com/tummychow/git-absorb"
   url "https://github.com/tummychow/git-absorb/archive/0.6.0.tar.gz"
   sha256 "945534d1f6bf99314085c16d2c13ec9d0fe75c8b3e88b83723858004c5e6e928"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -17,6 +18,7 @@ class GitAbsorb < Formula
 
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    man1.install "Documentation/git-absorb.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x]  Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One of the new features of git-absorb 0.6.0 is that it includes a man page - let's install it.