### PR TITLE
spotifyd 0.2.24 (new formula)

### DIFF
--- a/Formula/spotifyd.rb
+++ b/Formula/spotifyd.rb
@@ -1,0 +1,52 @@
+class Spotifyd < Formula
+  desc "Spotify daemon"
+  homepage "https://github.com/Spotifyd/spotifyd"
+  url "https://github.com/Spotifyd/spotifyd/archive/v0.2.24.tar.gz"
+  sha256 "d3763f4647217a8f98ee938b50e141d67a5f3d33e9378894fde2a92c9845ef80"
+  head "https://github.com/Spotifyd/spotifyd.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "dbus"
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", ".",
+      "--no-default-features", "--features=dbus_keyring,rodio_backend"
+  end
+
+  def caveats
+    <<~EOS
+      Configure spotifyd using these instructions:
+        https://github.com/Spotifyd/spotifyd#configuration-file
+    EOS
+  end
+
+  plist_options :startup => true
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>KeepAlive</key>
+          <true/>
+          <key>ThrottleInterval</key>
+          <integer>30</integer>
+          <key>ProgramArguments</key>
+          <array>
+              <string>#{opt_bin}/spotifyd</string>
+              <string>--no-daemon</string>
+          </array>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    cmd = "#{bin}/spotifyd --username homebrew_fake_user_for_testing --password homebrew --no-daemon --backend rodio"
+    assert_match /Authentication failed/, shell_output(cmd, 101)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Spotifyd streams music just like the official client, but is more lightweight and supports more platforms. Spotifyd also supports the Spotify Connect protocol, which makes it show up as a device that can be controlled from the official clients.