### PR TITLE
git: do not remove `git imap-send`

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -4,6 +4,7 @@ class Git < Formula
   # Note: Please keep these values in sync with git-gui.rb when updating.
   url "https://www.kernel.org/pub/software/scm/git/git-2.26.2.tar.xz"
   sha256 "6d65132471df9e531807cb2746f8be317e22a343b9385bbe11c9ce7f0d2fc848"
+  revision 1
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do
@@ -48,7 +49,6 @@ class Git < Formula
     # If these things are installed, tell Git build system not to use them
     ENV["NO_FINK"] = "1"
     ENV["NO_DARWIN_PORTS"] = "1"
-    ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
     ENV["PYTHON_PATH"] = which("python")
     ENV["PERL_PATH"] = which("perl")
     ENV["USE_LIBPCRE2"] = "1"
@@ -65,8 +65,6 @@ class Git < Formula
     ].uniq.map do |p|
       "#{p}/Library/Perl/#{perl_version}/darwin-thread-multi-2level"
     end.join(":")
-
-    ENV["NO_PERL_MAKEMAKER"] = "1" unless quiet_system ENV["PERL_PATH"], "-e", "use ExtUtils::MakeMaker"
 
     # Ensure we are using the correct system headers (for curl) to workaround
     # mismatched Xcode/CLT versions:
@@ -145,9 +143,6 @@ class Git < Formula
     chmod 0644, Dir["#{share}/doc/git-doc/**/*.{html,txt}"]
     chmod 0755, Dir["#{share}/doc/git-doc/{RelNotes,howto,technical}"]
 
-    # To avoid this feature hooking into the system OpenSSL, remove it
-    rm "#{libexec}/git-core/git-imap-send" if MacOS.version >= :yosemite
-
     # git-send-email needs Net::SMTP::SSL
     resource("Net::SMTP::SSL").stage do
       (share/"perl5").install "lib/Net"
@@ -178,6 +173,8 @@ class Git < Formula
     system bin/"git", "init"
     %w[haunted house].each { |f| touch testpath/f }
     system bin/"git", "add", "haunted", "house"
+    system bin/"git", "config", "user.name", "'A U Thor'"
+    system bin/"git", "config", "user.email", "author@example.com"
     system bin/"git", "commit", "-a", "-m", "Initial Commit"
     assert_equal "haunted\nhouse", shell_output("#{bin}/git ls-files").strip
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`git imap-send` is currently removed by the formula during installation
under macOS Yosemite and newer, because for these macOS versions Git is not
built with OpenSSL from Homebrew and we want to avoid linking with the
system OpenSSL. This was added in ab024b3 (git: fix openssl linkage,
2014-11-29).

However, `git imap-send` does not need to be linked with OpenSSL anymore
since it was reimplemented using libcurl in git/git@1e16b255b9
(git-imap-send: use libcurl for implementation, 2014-11-09). This
reimplmentation requires libcurl >= 7.34.0. With such libcurl, `git
imap-send` builds perfectly fine with `NO_OPENSSL`, which is how Git is
built in this formula for Yosemite and newer.

opensource.apple.com reveals Yosemite (10.10.0) ships with
"curl-83.1.2" [1], corresponding with curl 7.37.1 [2]. As such,
it is perfectly fine to keep `git imap-send` on Yosemite and newer.

[1] https://opensource.apple.com/release/os-x-1010.html
[2] https://opensource.apple.com/source/curl/curl-83.1.2/curl/include/curl/curlver.h.auto.html