### PR TITLE
Add 32-bit ELF cross compilers (and improve x86_64 ones)

### DIFF
--- a/Formula/i686-elf-binutils.rb
+++ b/Formula/i686-elf-binutils.rb
@@ -1,0 +1,31 @@
+class I686ElfBinutils < Formula
+  desc "GNU Binutils for i686-elf cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.gz"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.34.tar.gz"
+  sha256 "53537d334820be13eeb8acb326d01c7c81418772d626715c7ae927a7d401cab3"
+
+  def install
+    system "./configure", "--target=i686-elf",
+                          "--prefix=#{prefix}",
+                          "--infodir=#{info}/i686-elf-binutils",
+                          "--disable-nls"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test-s.s").write <<~EOS
+      .section .data
+      .section .text
+      .globl _start
+      _start:
+          movl $1, %eax
+          movl $4, %ebx
+          int $0x80
+    EOS
+    system "#{bin}/i686-elf-as", "--32", "-o", "test-s.o", "test-s.s"
+    assert_match "file format elf32-i386",
+      shell_output("#{bin}/i686-elf-objdump -a test-s.o")
+  end
+end

--- a/Formula/i686-elf-gcc.rb
+++ b/Formula/i686-elf-gcc.rb
@@ -1,0 +1,48 @@
+class I686ElfGcc < Formula
+  desc "The GNU compiler collection for i686-elf"
+  homepage "https://gcc.gnu.org"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-9.3.0/gcc-9.3.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-9.3.0/gcc-9.3.0.tar.xz"
+  sha256 "71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1"
+
+  depends_on "gmp"
+  depends_on "i686-elf-binutils"
+  depends_on "libmpc"
+  depends_on "mpfr"
+
+  def install
+    mkdir "i686-elf-gcc-build" do
+      system "../configure", "--target=i686-elf",
+                             "--prefix=#{prefix}",
+                             "--infodir=#{info}/i686-elf-gcc",
+                             "--disable-nls",
+                             "--without-isl",
+                             "--without-headers",
+                             "--with-as=#{Formula["i686-elf-binutils"].bin}/i686-elf-as",
+                             "--with-ld=#{Formula["i686-elf-binutils"].bin}/i686-elf-ld",
+                             "--enable-languages=c,c++",
+                             "SED=/usr/bin/sed"
+      system "make", "all-gcc"
+      system "make", "install-gcc"
+      system "make", "all-target-libgcc"
+      system "make", "install-target-libgcc"
+
+      # FSF-related man pages may conflict with native gcc
+      (share/"man/man7").rmtree
+    end
+  end
+
+  test do
+    (testpath/"test-c.c").write <<~EOS
+      int main(void)
+      {
+        int i=0;
+        while(i<10) i++;
+        return i;
+      }
+    EOS
+    system "#{bin}/i686-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    assert_match "file format elf32-i386",
+      shell_output("#{Formula["i686-elf-binutils"].bin}/i686-elf-objdump -a test-c.o")
+  end
+end

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -13,10 +13,6 @@ class X8664ElfBinutils < Formula
 
   def install
     system "./configure", "--target=x86_64-elf",
-                          "--enable-targets=all",
-                          "--enable-multilib",
-                          "--enable-64-bit-bfd",
-                          "--disable-werror",
                           "--prefix=#{prefix}"
     system "make"
     system "make", "install"

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -13,7 +13,9 @@ class X8664ElfBinutils < Formula
 
   def install
     system "./configure", "--target=x86_64-elf",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--infodir=#{info}/x86_64-elf-binutils",
+                          "--disable-nls"
     system "make"
     system "make", "install"
   end

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -1,5 +1,5 @@
 class X8664ElfBinutils < Formula
-  desc "FSF Binutils for x86_64-elf cross development"
+  desc "GNU Binutils for x86_64-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.34.tar.gz"

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -4,6 +4,7 @@ class X8664ElfBinutils < Formula
   url "https://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.gz"
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.34.tar.gz"
   sha256 "53537d334820be13eeb8acb326d01c7c81418772d626715c7ae927a7d401cab3"
+  revision 1
 
   bottle do
     sha256 "57141264369389b9c50019aac6bb0f6dcf19935f20ea8fab57b56d4c4451066a" => :catalina
@@ -32,6 +33,6 @@ class X8664ElfBinutils < Formula
     EOS
     system "#{bin}/x86_64-elf-as", "--64", "-o", "test-s.o", "test-s.s"
     assert_match "file format elf64-x86-64",
-      shell_output("#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-objdump -a test-s.o")
+      shell_output("#{bin}/x86_64-elf-objdump -a test-s.o")
   end
 end

--- a/Formula/x86_64-elf-gcc.rb
+++ b/Formula/x86_64-elf-gcc.rb
@@ -4,6 +4,7 @@ class X8664ElfGcc < Formula
   url "https://ftp.gnu.org/gnu/gcc/gcc-9.3.0/gcc-9.3.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/gcc/gcc-9.3.0/gcc-9.3.0.tar.xz"
   sha256 "71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1"
+  revision 1
 
   bottle do
     sha256 "a18c6acf4979f96244584de989ab47791670bc5404e0eca8626708f9e3375702" => :catalina
@@ -20,6 +21,8 @@ class X8664ElfGcc < Formula
     mkdir "x86_64-elf-gcc-build" do
       system "../configure", "--target=x86_64-elf",
                              "--prefix=#{prefix}",
+                             "--infodir=#{info}/x86_64-elf-gcc",
+                             "--disable-nls",
                              "--without-isl",
                              "--without-headers",
                              "--with-as=#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-as",
@@ -30,6 +33,9 @@ class X8664ElfGcc < Formula
       system "make", "install-gcc"
       system "make", "all-target-libgcc"
       system "make", "install-target-libgcc"
+
+      # FSF-related man pages may conflict with native gcc
+      (share/"man/man7").rmtree
     end
   end
 

--- a/Formula/x86_64-elf-gcc.rb
+++ b/Formula/x86_64-elf-gcc.rb
@@ -19,15 +19,13 @@ class X8664ElfGcc < Formula
   def install
     mkdir "x86_64-elf-gcc-build" do
       system "../configure", "--target=x86_64-elf",
-                             "--enable-targets=all",
-                             "--enable-multilib",
                              "--prefix=#{prefix}",
                              "--without-isl",
-                             "--disable-werror",
                              "--without-headers",
                              "--with-as=#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-as",
                              "--with-ld=#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-ld",
-                             "--enable-languages=c,c++"
+                             "--enable-languages=c,c++",
+                             "SED=/usr/bin/sed"
       system "make", "all-gcc"
       system "make", "install-gcc"
       system "make", "all-target-libgcc"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The PR improves cross-compiler support on macOS by providing dedicated `i686-elf-` toolchain targeting 32-bit Intel CPUs.

Packaging of `x86_64-elf-binutils` and `x86_64-elf-gcc` was reworked to support installation of the second toolchain. Build options were pruned to carry only required options going forward.
