### PR TITLE
go-jsonnet: install jsonnetfmt binary for HEAD

### DIFF
--- a/Formula/go-jsonnet.rb
+++ b/Formula/go-jsonnet.rb
@@ -18,8 +18,11 @@ class GoJsonnet < Formula
 
   def install
     system "go", "build", "-o", bin/"jsonnet", "./cmd/jsonnet"
-    # jsonnetfmt will only be added with the next release
-    # system "go", "build", "-o", bin/"jsonnetfmt", "./cmd/jsonnetfmt"
+
+    if build.head?
+      # jsonnetfmt will only be added with the next release
+      system "go", "build", "-o", bin/"jsonnetfmt", "./cmd/jsonnetfmt"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It'd be really nice to have the `jsonnetfmt` binary when installing from HEAD. We're still waiting for a new release https://github.com/google/go-jsonnet/issues/401, but this should unblock a bunch of use cases already.

Previous update to this formula: https://github.com/Homebrew/homebrew-core/pull/53133.