### PR TITLE
gupnp: depend on python@3.8

### DIFF
--- a/Formula/gupnp.rb
+++ b/Formula/gupnp.rb
@@ -19,8 +19,10 @@ class Gupnp < Formula
   depends_on "glib"
   depends_on "gssdp"
   depends_on "libsoup"
+  depends_on "python@3.8"
 
   def install
+    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
     mkdir "build" do
       system "meson", *std_meson_args, ".."
       system "ninja"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
==> brew test --verbose gupnp
==> FAILED
Testing gupnp
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200519-12754-yhat2x.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gupnp.rb --verbose
==> /usr/local/Cellar/gupnp/1.2.2/bin/gupnp-binding-tool-1.2 --help
env: python3: No such file or directory
Error: gupnp: failed
```