### PR TITLE
sqlite: Enable SQLITE_ENABLE_UNLOCK_NOTIFY

### DIFF
--- a/Formula/sqlite.rb
+++ b/Formula/sqlite.rb
@@ -26,6 +26,7 @@ class Sqlite < Formula
     ENV.append "CPPFLAGS", "-DSQLITE_ENABLE_RTREE=1"
     ENV.append "CPPFLAGS", "-DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1"
     ENV.append "CPPFLAGS", "-DSQLITE_ENABLE_JSON1=1"
+    ENV.append "CPPFLAGS", "-DSQLITE_ENABLE_UNLOCK_NOTIFY"
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Would you consider enabling this sqlite feature? It is useful for multithreaded programs. It is enabled in the [Debian](https://sources.debian.org/src/sqlite3/3.31.1-5/debian/rules/#L39), [Fedora](https://src.fedoraproject.org/rpms/sqlite/blob/master/f/sqlite.spec#_159) and [OpenWrt](https://github.com/openwrt/packages/blob/master/libs/sqlite3/Makefile#L98) packages.