### PR TITLE
workflows: run jobs on ubuntu VMs instead containers

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -5,9 +5,6 @@ on: repository_dispatch
 jobs:
   upload:
     runs-on: ubuntu-latest
-    container:
-      image: homebrew/brew
-      options: -v /usr/bin/unzip:/usr/bin/unzip
     env:
       HOMEBREW_DEVELOPER: 1
       HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,8 +9,6 @@ jobs:
   autopublish:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
-    container:
-      image: homebrew/brew
     env:
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew should be available in every ubuntu VM image now. No need to pull a Docker image anymore, which takes over 30 seconds.