### PR TITLE
mit-scheme: Use x64 binaries instead of svm1

### DIFF
--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -1,10 +1,11 @@
 class MitScheme < Formula
   desc "MIT/GNU Scheme development tools and runtime library"
   homepage "https://www.gnu.org/software/mit-scheme/"
-  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10-svm1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10-svm1.tar.gz"
+  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10.tar.gz"
   version "10.1.10"
-  sha256 "36ad0aba50d60309c21e7f061c46c1aad1dda0ad73d2bb396684e49a268904e4"
+  sha256 "1513bd24ac16b8d94005c140dccea82782648b983d8f435e8139e463ea813d1e"
+  revision 1
 
   bottle do
     sha256 "aeec8e0d463f173b7e1bf1aa5840d7d119559379c9c4024f72ccbcc18649ee40" => :catalina
@@ -17,6 +18,11 @@ class MitScheme < Formula
   # https://github.com/Homebrew/homebrew-x11/issues/103#issuecomment-125014423
   depends_on :xcode => :build
   depends_on "openssl@1.1"
+
+  resource "bootstrap" do
+    url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10-x86-64.tar.gz"
+    sha256 "4f14dd754703736c1843a8c709cd704a24e92b02d6021652d57ae5d6a2d992e6"
+  end
 
   def install
     # Setting -march=native, which is what --build-from-source does, can fail
@@ -31,6 +37,13 @@ class MitScheme < Formula
     # the environment than to change_make_var, because there are Makefiles
     # littered everywhere
     ENV.deparallelize
+
+    resource("bootstrap").stage do
+      cd "src"
+      system "./configure", "--prefix=#{buildpath}/staging", "--without-x"
+      system "make"
+      system "make", "install"
+    end
 
     # Liarc builds must launch within the src dir, not using the top-level
     # Makefile
@@ -57,6 +70,8 @@ class MitScheme < Formula
     inreplace "edwin/compile.sh" do |s|
       s.gsub! "mit-scheme", "#{bin}/mit-scheme"
     end
+
+    ENV.prepend_path "PATH", buildpath/"staging/bin"
 
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
     system "make"

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -3,7 +3,6 @@ class MitScheme < Formula
   homepage "https://www.gnu.org/software/mit-scheme/"
   url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10.tar.gz"
   mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/10.1.10/mit-scheme-10.1.10.tar.gz"
-  version "10.1.10"
   sha256 "1513bd24ac16b8d94005c140dccea82782648b983d8f435e8139e463ea813d1e"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This resolves https://github.com/Homebrew/homebrew-core/issues/52925, by following the instructions outlined [here](https://github.com/Homebrew/homebrew-core/issues/52925#issuecomment-612570752).

This patch is patterned after the Rust formula, as suggested [here](https://github.com/Homebrew/homebrew-core/issues/52925#issuecomment-612590131).

Audit currently fails because of I changed the source from the svm1 bundle to the plain source bundle:
```
$ brew audit --strict mit-scheme
mit-scheme:
  * stable: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      lib/mit-scheme-x86-64/runtime.com
      lib/mit-scheme-x86-64/all.com
```

Using my local build, I see that I'm not using svm1 anymore:
```
Image saved on Friday May 22, 2020 at 5:26:53 PM
  Release 10.1.10 || Microcode 15.3 || Runtime 15.7 || SF 4.41 || LIAR/x86-64 4.118
```

Whereas the current bottle shows:
```
Image saved on Saturday August 10, 2019 at 7:30:42 PM
  Release 10.1.10 || Microcode 15.3 || Runtime 15.7 || SF 4.41 || CREF 2.6 || LIAR/svm1 4.118
```