### PR TITLE
terraformer: add head and deprecate gopath

### DIFF
--- a/Formula/terraformer.rb
+++ b/Formula/terraformer.rb
@@ -1,9 +1,8 @@
 class Terraformer < Formula
   desc "CLI tool to generate terraform files from existing infrastructure"
   homepage "https://github.com/GoogleCloudPlatform/terraformer"
-  url "https://github.com/GoogleCloudPlatform/terraformer.git",
-    :tag      => "0.8.7",
-    :revision => "9b154ac3d2237fb623c80eadbac17f1d3956bd7e"
+  url "https://github.com/GoogleCloudPlatform/terraformer/archive/0.8.7.tar.gz"
+  sha256 "8884528c84f2b70480f16e7c8a1f79e9723671415365b2bd36d21e5142eb4746"
   head "https://github.com/GoogleCloudPlatform/terraformer.git"
 
   bottle do
@@ -16,15 +15,8 @@ class Terraformer < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    dir = buildpath/"src/github.com/GoogleCloudPlatform/terraformer"
-    dir.install buildpath.children
-
-    cd dir do
-      system "go", "build", "-o", bin/"terraformer"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args
+    prefix.install_metafiles
   end
 
   test do

--- a/Formula/terraformer.rb
+++ b/Formula/terraformer.rb
@@ -4,6 +4,7 @@ class Terraformer < Formula
   url "https://github.com/GoogleCloudPlatform/terraformer.git",
     :tag      => "0.8.7",
     :revision => "9b154ac3d2237fb623c80eadbac17f1d3956bd7e"
+  head "https://github.com/GoogleCloudPlatform/terraformer.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This would allow me to use the latest versions of terraform :)

Right now, the latest release (v0.8.7) outputs an old version of terraform.