### PR TITLE
dgraph 20.03.1 (new formula)

### DIFF
--- a/Formula/dgraph.rb
+++ b/Formula/dgraph.rb
@@ -1,0 +1,62 @@
+class Dgraph < Formula
+  desc "Fast, Distributed Graph DB"
+  homepage "https://dgraph.io"
+  url "https://github.com/dgraph-io/dgraph/archive/v20.03.1.tar.gz"
+  sha256 "abe217853134d86b9dba2814d5ef521730cc9eb9c6e0825658cc62af2562b363"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOBIN"] = bin
+    system "make", "oss_install"
+  end
+
+  test do
+    fork do
+      exec bin/"dgraph", "zero"
+    end
+    fork do
+      exec bin/"dgraph", "alpha", "--lru_mb=1024"
+    end
+    sleep 10
+
+    (testpath/"mutate.json").write <<~EOS
+      {
+        "set": [
+          {
+            "name": "Karthic",
+            "age": 28,
+            "follows": {
+              "name": "Jessica",
+              "age": 31
+            }
+          }
+        ]
+      }
+    EOS
+
+    (testpath/"query.graphql").write <<~EOS
+      {
+        people(func: has(name), orderasc: name) {
+          name
+          age
+        }
+      }
+    EOS
+
+    system "curl", "-s", "-H", "Content-Type: application/json",
+      "-XPOST", "--data-binary", "@#{testpath}/mutate.json",
+      "http://localhost:8080/mutate?commitNow=true"
+
+    command = %W[
+      curl -s -H "Content-Type: application/graphql+-"
+      -XPOST --data-binary @#{testpath}/query.graphql
+      http://localhost:8080/query
+    ]
+    response = JSON.parse(shell_output(command.join(" ")))
+    expected = [{ "name" => "Jessica", "age" => 31 }, { "name" => "Karthic", "age" => 28 }]
+    assert_equal response["data"]["people"], expected
+  ensure
+    system "pkill", "-9", "-f", "dgraph"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds the OSS build of Dgraph, a fast graph database. The test is a bit long, but:

- two processes are needed - [Alpha and Zero](https://dgraph.io/docs/get-started/)
- it uses the example from [this tutorial](https://dgraph.io/docs/tutorial-1/) with an order for deterministic queries
- kill 9 used for this issue - https://github.com/dgraph-io/dgraph/issues/4035

cc https://github.com/dgraph-io/dgraph/issues/5186