### PR TITLE
curaengine: update resources to use tagged version

### DIFF
--- a/Formula/curaengine.rb
+++ b/Formula/curaengine.rb
@@ -15,14 +15,16 @@ class Curaengine < Formula
 
   depends_on "cmake" => :build
 
+  # The version tag in these resources (e.g., `/1.2.3/`) should be changed as
+  # part of updating this formula to a new version.
   resource "fdmextruder_defaults" do
-    url "https://raw.githubusercontent.com/Ultimaker/Cura/master/resources/definitions/fdmextruder.def.json"
-    sha256 "c56bdf9cc3e2edd85a158f14b891c8d719a1b6056c817145913495f7e907b1d2"
+    url "https://raw.githubusercontent.com/Ultimaker/Cura/4.6.1/resources/definitions/fdmextruder.def.json"
+    sha256 "9f0b42c98e023b32784c340db2db91a25f78fc30ca770a4914ae9c48a24d3db3"
   end
 
   resource "fdmprinter_defaults" do
-    url "https://raw.githubusercontent.com/Ultimaker/Cura/master/resources/definitions/fdmprinter.def.json"
-    sha256 "e16ffd9f6412dc7160485f3452041ac1d56ba786d8cf65a009bdfc4be526d070"
+    url "https://raw.githubusercontent.com/Ultimaker/Cura/4.6.1/resources/definitions/fdmprinter.def.json"
+    sha256 "142b4c17ed0270dfb76f23eb644a3a10c4e1c6be8ab35ff78ea2d3ea8a90f12d"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The test for `curaengine` was failing due to the `fdmprinter.def.json` resource having been updated, resulting in a checksum mismatch:

```
An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: e16ffd9f6412dc7160485f3452041ac1d56ba786d8cf65a009bdfc4be526d070
  Actual: fa0916a38e67299a3a5637246ade56b493b71e56dde421c27851fea935380466
 Archive: /Users/brew/Library/Caches/Homebrew/downloads/7b892c41f22fcc50c26807b05e0f3fff94a7e514cf9eb49c1282ecc6f8721119--fdmprinter.def.json
```

This resource is linked to the file in master, so it's expected to change whenever it's updated. The alternative is to pin the resource to a specific commit and check for a newer version as part of updating the formula for a new version. This would ensure that the resources aren't updated out from under us again, causing `brew test curaengine` to fail. People may simply run `brew bump-formula-pr` and ignore that the resources should be checked as part of updating but this is pretty much par for the course.

What do we think about this situation?

---
Past that, `curaengine` fails to build from source locally, failing during linking:

<details>
<summary>Output</summary>

```
[100%] Linking CXX executable CuraEngine
/usr/local/Cellar/cmake/3.17.2/bin/cmake -E cmake_link_script CMakeFiles/CuraEngine.dir/link.txt --verbose=1
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++    -O3 -DNDEBUG -stdlib=libc++ -Wall -Xclang -fopenmp   -O3 -DNDEBUG -stdlib=libc++ -Wall -Ofast -funroll-loops -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/CuraEngine.dir/src/main.cpp.o  -o CuraEngine  lib_CuraEngine.a libclipper.a -lpthread
Undefined symbols for architecture x86_64:
  "___kmpc_barrier", referenced from:
      _.omp_outlined..38 in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
  "___kmpc_critical", referenced from:
      cura::logError(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logWarning(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logAlways(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::log(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logDebug(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logProgress(char const*, int, int, float) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::FffGcodeWriter::processLayer(cura::SliceDataStorage const&, cura::LayerIndex, unsigned long) const in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
      ...
  "___kmpc_dispatch_init_4", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      _.omp_outlined..38 in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined..47 in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined..53 in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(layerPart.cpp.o)
  "___kmpc_dispatch_next_4", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      _.omp_outlined..38 in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined..47 in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined..53 in lib_CuraEngine.a(support.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(layerPart.cpp.o)
  "___kmpc_end_critical", referenced from:
      cura::logError(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logWarning(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logAlways(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::log(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logDebug(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logProgress(char const*, int, int, float) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::FffGcodeWriter::processLayer(cura::SliceDataStorage const&, cura::LayerIndex, unsigned long) const in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
      ...
  "___kmpc_end_master", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(Application.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "___kmpc_for_static_fini", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(TreeSupport.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(slicer.cpp.o)
      _.omp_outlined..11 in lib_CuraEngine.a(slicer.cpp.o)
      _.omp_outlined..16 in lib_CuraEngine.a(slicer.cpp.o)
  "___kmpc_for_static_init_4", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(TreeSupport.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(slicer.cpp.o)
      _.omp_outlined..11 in lib_CuraEngine.a(slicer.cpp.o)
      _.omp_outlined..16 in lib_CuraEngine.a(slicer.cpp.o)
  "___kmpc_fork_call", referenced from:
      cura::Application::run(unsigned long, char**) in lib_CuraEngine.a(Application.cpp.o)
      cura::FffGcodeWriter::writeGCode(cura::SliceDataStorage&, cura::TimeKeeper&) in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
      cura::FffPolygonGenerator::processBasicWallsSkinInfill(cura::SliceDataStorage&, unsigned long, std::__1::vector<unsigned long, std::__1::allocator<unsigned long> > const&, cura::ProgressStageEstimator&) in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      cura::AreaSupport::generateOverhangAreasForMesh(cura::SliceDataStorage&, cura::SliceMeshStorage&) in lib_CuraEngine.a(support.cpp.o)
      cura::AreaSupport::generateSupportAreasForMesh(cura::SliceDataStorage&, cura::Settings const&, cura::Settings const&, cura::Settings const&, unsigned long, unsigned long, std::__1::vector<cura::Polygons, std::__1::allocator<cura::Polygons> >&) in lib_CuraEngine.a(support.cpp.o)
      cura::TreeSupport::drawCircles(cura::SliceDataStorage&, std::__1::vector<std::__1::unordered_set<cura::TreeSupport::Node*, std::__1::hash<cura::TreeSupport::Node*>, std::__1::equal_to<cura::TreeSupport::Node*>, std::__1::allocator<cura::TreeSupport::Node*> >, std::__1::allocator<std::__1::unordered_set<cura::TreeSupport::Node*, std::__1::hash<cura::TreeSupport::Node*>, std::__1::equal_to<cura::TreeSupport::Node*>, std::__1::allocator<cura::TreeSupport::Node*> > > > const&) in lib_CuraEngine.a(TreeSupport.cpp.o)
      cura::createLayerParts(cura::SliceMeshStorage&, cura::Slicer*) in lib_CuraEngine.a(layerPart.cpp.o)
      ...
  "___kmpc_global_thread_num", referenced from:
      cura::logError(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logWarning(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logAlways(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::log(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logDebug(char const*, ...) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::logProgress(char const*, int, int, float) in lib_CuraEngine.a(logoutput.cpp.o)
      cura::FffGcodeWriter::processLayer(cura::SliceDataStorage const&, cura::LayerIndex, unsigned long) const in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
      ...
  "___kmpc_master", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(Application.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "_omp_destroy_lock", referenced from:
      cura::FffGcodeWriter::writeGCode(cura::SliceDataStorage&, cura::TimeKeeper&) in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
      cura::GcodeLayerThreader<cura::LayerPlan>::GcodeLayerThreader(int, int, std::__1::function<cura::LayerPlan* (int)> const&, std::__1::function<void (cura::LayerPlan*)> const&, unsigned int) in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "_omp_get_num_threads", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(Application.cpp.o)
      _.omp_outlined. in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "_omp_get_thread_num", referenced from:
      _.omp_outlined. in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
      _.omp_outlined..38 in lib_CuraEngine.a(FffPolygonGenerator.cpp.o)
  "_omp_init_lock", referenced from:
      cura::GcodeLayerThreader<cura::LayerPlan>::GcodeLayerThreader(int, int, std::__1::function<cura::LayerPlan* (int)> const&, std::__1::function<void (cura::LayerPlan*)> const&, unsigned int) in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "_omp_set_num_threads", referenced from:
      cura::CommandLine::sliceNext() in lib_CuraEngine.a(CommandLine.cpp.o)
  "_omp_test_lock", referenced from:
      cura::GcodeLayerThreader<cura::LayerPlan>::act() in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
  "_omp_unset_lock", referenced from:
      cura::GcodeLayerThreader<cura::LayerPlan>::act() in lib_CuraEngine.a(FffGcodeWriter.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CuraEngine] Error 1
make[1]: *** [CMakeFiles/CuraEngine.dir/all] Error 2
make: *** [all] Error 2
```
</details>