### PR TITLE
game-music-emu: revision bump

### DIFF
--- a/Formula/game-music-emu.rb
+++ b/Formula/game-music-emu.rb
@@ -3,6 +3,7 @@ class GameMusicEmu < Formula
   homepage "https://bitbucket.org/mpyne/game-music-emu"
   url "https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz"
   sha256 "aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d"
+  revision 1
   head "https://bitbucket.org/mpyne/game-music-emu.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `game-music-emu` test was failing on CI (in #55191) as well as locally using the bottled version:

```
==> brew test --verbose game-music-emu
==> FAILED
Testing game-music-emu
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200524-85496-c9uf22.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/game-music-emu.rb --verbose
==> /usr/bin/clang test.c -I/usr/local/Cellar/game-music-emu/0.6.3/include -L/usr/local/Cellar/game-music-emu/0.6.3/lib -lgme -o test -Os -w -pipe -march=nehalem -mmacosx-version-min=10.15 -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
==> ./test
dyld: Library not loaded: @rpath/libclang_rt.ubsan_osx_dynamic.dylib
  Referenced from: /usr/local/opt/game-music-emu/lib/libgme.0.dylib
  Reason: image not found
Error: game-music-emu: failed
An exception occurred within a child process:
  BuildError: Failed executing: ./test
```

The test works fine locally when `game-music-emu` is built from source, so it may have needed a revision bump at some point. This PR is testing the theory on CI.