### PR TITLE
h2o: remove process.kill/wait

### DIFF
--- a/Formula/h2o.rb
+++ b/Formula/h2o.rb
@@ -84,16 +84,11 @@ class H2o < Formula
   test do
     port = free_port
     (testpath/"h2o.conf").write conf_example(port)
-    pid = fork do
+    fork do
       exec "#{bin}/h2o -c #{testpath}/h2o.conf"
     end
     sleep 2
 
-    begin
-      assert_match "Welcome to H2O", shell_output("curl localhost:#{port}")
-    ensure
-      Process.kill("SIGINT", pid)
-      Process.wait(pid)
-    end
+    assert_match "Welcome to H2O", shell_output("curl localhost:#{port}")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes `Process.kill`/`Process.wait` from the test (since `brew` does its own killing these days), in hopes of avoiding the `execution expired` timeout (as seen in #55191).