### PR TITLE
nanomsg: remove process.kill/wait

### DIFF
--- a/Formula/nanomsg.rb
+++ b/Formula/nanomsg.rb
@@ -23,17 +23,12 @@ class Nanomsg < Formula
   test do
     bind = "tcp://127.0.0.1:#{free_port}"
 
-    pid = fork do
+    fork do
       exec "#{bin}/nanocat --rep --bind #{bind} --format ascii --data home"
     end
     sleep 2
 
-    begin
-      output = shell_output("#{bin}/nanocat --req --connect #{bind} --format ascii --data brew")
-      assert_match /home/, output
-    ensure
-      Process.kill("SIGINT", pid)
-      Process.wait(pid)
-    end
+    output = shell_output("#{bin}/nanocat --req --connect #{bind} --format ascii --data brew")
+    assert_match /home/, output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes `Process.kill`/`Process.wait` from the test (since `brew` does its own killing these days), in hopes of avoiding the `execution expired` timeout (as seen in #55191).