### PR TITLE
stubby: remove process.kill/wait

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -64,16 +64,13 @@ class Stubby < Formula
     EOS
     output = shell_output("#{bin}/stubby -i -C stubby_test.yml")
     assert_match "bindata for 145.100.185.15", output
-    pid = fork do
+
+    fork do
       exec "#{bin}/stubby", "-C", testpath/"stubby_test.yml"
     end
-    begin
-      sleep 2
-      output = shell_output("dig @127.0.0.1 -p 5553 getdnsapi.net")
-      assert_match "status: NOERROR", output
-    ensure
-      Process.kill 9, pid
-      Process.wait pid
-    end
+    sleep 2
+
+    output = shell_output("dig @127.0.0.1 -p 5553 getdnsapi.net")
+    assert_match "status: NOERROR", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes `Process.kill`/`Process.wait` from the test (since `brew` does its own killing these days), in hopes of avoiding the `execution expired` timeout (as seen in #55191).