### PR TITLE
percona-server: add conflicts_with for protobuf

### DIFF
--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -25,6 +25,8 @@ class PerconaServer < Formula
 
   conflicts_with "mariadb", "mysql",
     :because => "percona, mariadb, and mysql install the same binaries."
+  conflicts_with "protobuf",
+    :because => "both install libprotobuf(-lite) libraries."
 
   # https://bugs.mysql.com/bug.php?id=86711
   # https://github.com/Homebrew/homebrew-core/pull/20538


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `conflicts_with` for `protobuf` since `percona-server` also installs `libprotobuf` and `libprotobuf-lite` (as seen in #55191).