### PR TITLE
dromeaudio: fix test

### DIFF
--- a/Formula/dromeaudio.rb
+++ b/Formula/dromeaudio.rb
@@ -23,6 +23,16 @@ class Dromeaudio < Formula
   end
 
   test do
-    system "#{bin}/DromeAudioPlayer", test_fixtures("test.mp3")
+    assert_predicate include/"DromeAudio", :exist?
+    assert_predicate lib/"libDromeAudio.a", :exist?
+
+    # We don't test DromeAudioPlayer with an audio file because it only works
+    # with certain audio devices and will fail on CI with this error:
+    #   DromeAudio Exception: AudioDriverOSX::AudioDriverOSX():
+    #   AudioUnitSetProperty (for StreamFormat) failed
+    #
+    # Related PR: https://github.com/Homebrew/homebrew-core/pull/55292
+    assert_match /Usage: .*?DromeAudioPlayer <filename>/i,
+                 shell_output(bin/"DromeAudioPlayer 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR has been revised to only rework the test so it won't fail on CI. This is necessary because `DromeAudioPlayer` will fail with an error when executed it's executed with an audio file on CI. `DromeAudioPlayer` _does_ work with some audio devices (like the speakers/headphone output of a MacBook Pro) but apparently not the audio device in our CI environment.

-----

**The original content of this PR has been preserved below for posterity:**

Building `dromeaudio` from source was failing with the following error:

```
/tmp/dromeaudio-20200525-6573-1r4rest/DromeAudio-0.3.0/src/DromeAudio/VorbisSound.cpp:30:10: fatal error: 'vorbisfile.h' file not found
#include <vorbisfile.h>
         ^~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/DromeAudio/CMakeFiles/DromeAudio.dir/VorbisSound.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/DromeAudio/CMakeFiles/DromeAudio.dir/all] Error 2
make: *** [all] Error 2
```

Adding `libvorbis` as a dependency resolves the issue.

The other goal of this PR is to see how the `dromeaudio` test does on CI, since it failed in #55191. Depending on what audio devices I have connected to my computer, the test can reliably fail or pass for me locally. It may be that this test will always fail on CI due to the environment.