### PR TITLE
rrdtool: remove MacOS.preferred_arch

### DIFF
--- a/Formula/rrdtool.rb
+++ b/Formula/rrdtool.rb
@@ -3,6 +3,7 @@ class Rrdtool < Formula
   homepage "https://oss.oetiker.ch/rrdtool/index.en.html"
   url "https://github.com/oetiker/rrdtool-1.x/releases/download/v1.7.2/rrdtool-1.7.2.tar.gz"
   sha256 "a199faeb7eff7cafc46fac253e682d833d08932f3db93a550a4a5af180ca58db"
+  revision 1
 
   bottle do
     sha256 "a4d3e8bf312569dc26aca0b029ffcc297f6db4ebbef7d0317b02cf500d5cce28" => :catalina
@@ -39,11 +40,7 @@ class Rrdtool < Formula
     system "./bootstrap" if build.head?
     system "./configure", *args
 
-    # Needed to build proper Ruby bundle
-    ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}"
-
     system "make", "CC=#{ENV.cc}", "CXX=#{ENV.cxx}", "install"
-    prefix.install "bindings/ruby/test.rb"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Part of #55254. Interestingly, the Ruby bindings were never getting built (the bindings don't get built through the actual build process; we have to go into `bindings/<language>` and manually build with language-specific build processes - see [`ruby-librrd` build instructions](https://github.com/oetiker/rrdtool-1.x/blob/master/bindings/ruby/README)) and the `test.rb` being installed was always broken.