### PR TITLE
snap7: remove MacOS.preferred_arch

### DIFF
--- a/Formula/snap7.rb
+++ b/Formula/snap7.rb
@@ -17,7 +17,7 @@ class Snap7 < Formula
   def install
     lib.mkpath
     system "make", "-C", "build/osx",
-                   "-f", "#{MacOS.preferred_arch}_osx.mk",
+                   "-f", "x86_64_osx.mk",
                    "install", "LibInstall=#{lib}"
     include.install "release/Wrappers/c-cpp/snap7.h"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Part of #55254. `revision` not bumped because `MacOS.preferred_arch` is only used for `Makefile` selection, which should be `x86_64` for our currently supported versions, so no bottle rebuild is necessary.

We could also use some conditional logic with `Hardware::CPU.arch` to allow for this to still build on older platforms, but I'm not sure which is the preferred resolution here - hardcoding `x86_64` or introducing a conditional.

On a tangent, the test uses `python` but formula does not refer to Python at all (whether as a `uses_from_macos`, or a proper `depends_on`). Not sure if this is something that needs to be addressed.