### PR TITLE
guile: allow installing site modules

### DIFF
--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -61,6 +61,24 @@ class Guile < Formula
     (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.scm"]
   end
 
+  def post_install
+    # Create directories so installed modules can create links inside.
+    (HOMEBREW_PREFIX/"lib/guile/3.0/site-ccache").mkpath
+    (HOMEBREW_PREFIX/"share/guile/site/3.0").mkpath
+  end
+
+  def caveats
+    <<~EOS
+      Guile libraries can now be installed here:
+          Source files: #{HOMEBREW_PREFIX}/share/guile/site/3.0
+        Compiled files: #{HOMEBREW_PREFIX}/lib/guile/3.0/site-ccache
+
+      Add the following to your .bashrc or equivalent:
+        export GUILE_LOAD_PATH="#{HOMEBREW_PREFIX}/share/guile/site/3.0"
+        export GUILE_LOAD_COMPILED_PATH="#{HOMEBREW_PREFIX}/lib/guile/3.0/site-ccache"
+    EOS
+  end
+
   test do
     hello = testpath/"hello.scm"
     hello.write <<~EOS


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change allows installing Guile modules using Homebrew. I already started by creating a Tap with a few projects as an example. If this change is accepted I will start adding more.

https://github.com/aconchillo/homebrew-guile

Installing Guile modules requires a bit of knowledge so having a tap will hopefully hep some people that might want to try Guile.