### PR TITLE
dnsdist: features closer to official releases

### DIFF
--- a/Formula/dnsdist.rb
+++ b/Formula/dnsdist.rb
@@ -3,6 +3,7 @@ class Dnsdist < Formula
   homepage "https://www.dnsdist.org/"
   url "https://downloads.powerdns.com/releases/dnsdist-1.4.0.tar.bz2"
   sha256 "a336fa2c3eb381c2464d9d9790014fd6d4505029ed2c1b73ee1dc9115a2f1dc0"
+  revision 1
 
   bottle do
     cellar :any
@@ -13,7 +14,14 @@ class Dnsdist < Formula
 
   depends_on "boost" => :build
   depends_on "pkg-config" => :build
-  depends_on "lua"
+  depends_on "cdb"
+  depends_on "fstrm"
+  depends_on "h2o"
+  depends_on "libsodium"
+  depends_on "luajit"
+  depends_on "openssl@1.1"
+  depends_on "protobuf"
+  depends_on "re2"
 
   uses_from_macos "libedit"
 
@@ -25,6 +33,10 @@ class Dnsdist < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--without-net-snmp",
+                          "--enable-dns-over-tls",
+                          "--enable-dns-over-https",
+                          "--enable-dnscrypt",
+                          "--with-re2",
                           "--sysconfdir=#{etc}/dnsdist"
     system "make", "install"
   end


### PR DESCRIPTION
Bring the dnsdist feature set closer to official dnsdist releases, including:

- Use LuaJIT instead of plain Lua
- Enable DNS over HTTPS
- Enable DNS over TLS

dnsdist --version output:

    dnsdist 1.4.0 (Lua 5.1.4 [LuaJIT 2.1.0-beta3])
    Enabled features: cdb dns-over-tls(openssl) dns-over-https(DOH)
                      dnscrypt fstrm ipcipher libsodium protobuf re2

Before this change only 'cdb' was enabled locally.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
