### PR TITLE
subversion: remove MacOS.preferred_arch

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -139,7 +139,7 @@ class Subversion < Formula
 
     inreplace "Makefile" do |s|
       s.change_make_var! "SWIG_PL_INCLUDES",
-        "$(SWIG_INCLUDES) -arch #{MacOS.preferred_arch} -g -pipe -fno-common " \
+        "$(SWIG_INCLUDES) -arch x86_64 -g -pipe -fno-common " \
         "-DPERL_DARWIN -fno-strict-aliasing -I#{HOMEBREW_PREFIX}/include -I#{perl_core}"
     end
     system "make", "swig-pl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Part of #55254. The `inreplace` should already be substituting in `x86_64`, so no `revision` bump needed.