### PR TITLE
detekt: update homepage

### DIFF
--- a/Formula/detekt.rb
+++ b/Formula/detekt.rb
@@ -1,6 +1,6 @@
 class Detekt < Formula
   desc "Static code analysis for Kotlin"
-  homepage "https://github.com/arturbosch/detekt"
+  homepage "https://github.com/detekt/detekt"
   url "https://jcenter.bintray.com/io/gitlab/arturbosch/detekt/detekt-cli/1.9.1/detekt-cli-1.9.1-all.jar"
   sha256 "42937cb0284e2b8af99901bd9debde0c15899c06732cb350f0617885f445b5dd"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates the `homepage` for Formula `detekt`. The repository has been moved to a GitHub organisation named `detekt` and is now available at https://github.com/detekt/detekt while the author maintains a personal fork at the previous homepage url.