### PR TITLE
make node-lts an alias for node@12

### DIFF
--- a/Aliases/node-lts
+++ b/Aliases/node-lts
@@ -1,0 +1,1 @@
+../Formula/node@12.rb


### PR DESCRIPTION
Setup node-lts as an alias for the latest node LTS release, currently node@12.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
