### PR TITLE
rethinkdb: replace download server url

### DIFF
--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -3,7 +3,6 @@ class Rethinkdb < Formula
   homepage "https://rethinkdb.com/"
   url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.0.tgz"
   sha256 "bfb0708710595c6762f42e25613adec692cf568201cd61da74c254f49fa9ee4c"
-  revision 1
 
   bottle do
     cellar :any

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -3,6 +3,7 @@ class Rethinkdb < Formula
   homepage "https://rethinkdb.com/"
   url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.0.tgz"
   sha256 "bfb0708710595c6762f42e25613adec692cf568201cd61da74c254f49fa9ee4c"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -1,6 +1,6 @@
 class Rethinkdb < Formula
   desc "The open-source database for the realtime web"
-  homepage "https://www.rethinkdb.com/"
+  homepage "https://rethinkdb.com/"
   url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.0.tgz"
   sha256 "bfb0708710595c6762f42e25613adec692cf568201cd61da74c254f49fa9ee4c"
   revision 1

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -1,7 +1,7 @@
 class Rethinkdb < Formula
   desc "The open-source database for the realtime web"
   homepage "https://www.rethinkdb.com/"
-  url "https://download.rethinkdb.com/dist/rethinkdb-2.4.0.tgz"
+  url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.0.tgz"
   sha256 "bfb0708710595c6762f42e25613adec692cf568201cd61da74c254f49fa9ee4c"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

~- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?`~

~- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~

~- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?~

-----

This PR is opened because RethinkDB download server [will be replaced](https://rethinkdb.com/blog/download-server-changes) at 29th of May (this Friday). We would like to make sure we are prepared, so if you agree with the change, please approve the PR but let us merge it 😊 😇 