### PR TITLE
postgresql*: fix build on CLT-only installs

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -3,7 +3,7 @@ class Postgresql < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v12.3/postgresql-12.3.tar.bz2"
   sha256 "94ed64a6179048190695c86ec707cc25d016056ce10fc9d229267d9a8f1dcf41"
-  revision 2
+  revision 3
   head "https://github.com/postgres/postgres.git"
 
   bottle do
@@ -51,6 +51,10 @@ class Postgresql < Formula
       --with-tcl
       --with-uuid=e2fs
     ]
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
     system "./configure", *args
     system "make"

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -3,7 +3,7 @@ class PostgresqlAT10 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v10.13/postgresql-10.13.tar.bz2"
   sha256 "4d701f450cd92ffb123cf6c296e9656abbc2ab7ea6507894ff1e2475ae0754e1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "ef796bc0e8079e784258059aca1593dd7b067bc1e8e6773f909396d562bf333f" => :catalina
@@ -45,6 +45,10 @@ class PostgresqlAT10 < Formula
       --with-tcl
       --with-uuid=e2fs
     ]
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
     system "./configure", *args
     system "make"

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -3,7 +3,7 @@ class PostgresqlAT11 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v11.8/postgresql-11.8.tar.bz2"
   sha256 "eaf2f4329ccc349c89e950761b81daf8c99bb8966abcab5665ccd6ee95c77ae2"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "0b7485f02a4645bc0c835d5bfd5766c871c27282acbcc0dedfce8652c318cae8" => :catalina
@@ -47,6 +47,10 @@ class PostgresqlAT11 < Formula
       --with-tcl
       --with-uuid=e2fs
     ]
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
     system "./configure", *args
     system "make"

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -3,7 +3,7 @@ class PostgresqlAT95 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v9.5.22/postgresql-9.5.22.tar.bz2"
   sha256 "48555470a17248cb204d25ab1ad4231ef16295db55161922f006b9942d69640f"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "9ad944bf158f180a3a3c8771b6f3d179b96b099b9921069d47842126d9a41766" => :catalina
@@ -45,6 +45,10 @@ class PostgresqlAT95 < Formula
       --with-tcl
       --with-uuid=e2fs
     ]
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
     system "./configure", *args
     system "make"

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -3,7 +3,7 @@ class PostgresqlAT96 < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v9.6.18/postgresql-9.6.18.tar.bz2"
   sha256 "517ec282b785e6d22f360c30ba0c5e2a506fca5ca07dcc545427511d94c89999"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "f347514af589033fde29c8760afb57e319c1eee18b844a53973e0b9622ecad6d" => :catalina
@@ -45,6 +45,10 @@ class PostgresqlAT96 < Formula
       --with-tcl
       --with-uuid=e2fs
     ]
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if MacOS.sdk_root_needed?
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream use `xcodebuild` to determine the default `PG_SYSROOT`, which does not work without Xcode installed. Instead, let's make it match what SDK Homebrew chooses.