### PR TITLE
create-dmg 1.0.8

### DIFF
--- a/Formula/create-dmg.rb
+++ b/Formula/create-dmg.rb
@@ -1,8 +1,8 @@
 class CreateDmg < Formula
   desc "Shell script to build fancy DMGs"
-  homepage "https://github.com/andreyvit/create-dmg"
-  url "https://github.com/andreyvit/create-dmg/archive/v1.0.0.5.tar.gz"
-  sha256 "de76c8a7a1f4705720d61d39de7c87b7bc2acc7c35f6ec8d6d2dbdafcedc21b6"
+  homepage "https://github.com/create-dmg/create-dmg"
+  url "https://github.com/create-dmg/create-dmg/archive/v1.0.8.tar.gz"
+  sha256 "6eb256e6835e650e4a529c9ea0630c409e6d1d5413fc9076b94d231674fa4cae"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,8 +12,7 @@ class CreateDmg < Formula
   end
 
   def install
-    system "support/brew-me.sh"
-    bin.install "create-dmg"
+    system "make", "install", "prefix=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With the 1.0.8 release of `create-dmg`, I have taken over as project maintainer, with the blessing of the original project creator: https://github.com/create-dmg/create-dmg/issues/60#issuecomment-627481124.

The new canonical home of create-dmg is under a new GitHub group at https://github.com/create-dmg/create-dmg.

I have added some new sandboxing workarounds that fix the test failures encountered during the previous attempts to bump create-dmg to 1.0.0.7 in https://github.com/Homebrew/homebrew-core/pull/45310 and https://github.com/Homebrew/homebrew-core/pull/50981.

I hope this doesn't violate the Homebrew self-submission prohibition, since this is just a change in ownership of an existing project already in Homebrew core, and not a new self-submitted package.

I have also streamlined the create-dmg installation process to get rid of all the Homebrew-specific stuff.