### PR TITLE
[liboping] Fix pinging unreachable hosts on the local networks

### DIFF
--- a/Formula/liboping.rb
+++ b/Formula/liboping.rb
@@ -3,6 +3,7 @@ class Liboping < Formula
   homepage "https://noping.cc/"
   url "https://noping.cc/files/liboping-1.10.0.tar.bz2"
   sha256 "eb38aa93f93e8ab282d97e2582fbaea88b3f889a08cbc9dbf20059c3779d5cd8"
+  revision 1
 
   bottle do
     sha256 "997e8eb17c7878cbd0c34bd6532b76ef804899751a58b3b434656d1b9ced07d9" => :catalina
@@ -14,6 +15,11 @@ class Liboping < Formula
   end
 
   uses_from_macos "ncurses"
+
+  patch do
+    url "https://github.com/octo/liboping/pull/55/commits/b5c5091d0214dd2c6cc504c02e2f78907abdee00.patch?full_index=1"
+    sha256 "5f91925a692acd4ca81697faddedd4419e5647d269c6b55b70731d7a39b14b67"
+  end
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
On *BSD and macOS different error than Linux can be reported.
This fixes liboping here. For more details see:

https://github.com/octo/liboping/pull/55

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
