### PR TITLE
pulumi: add head version and fish completions

### DIFF
--- a/Formula/pulumi.rb
+++ b/Formula/pulumi.rb
@@ -4,6 +4,7 @@ class Pulumi < Formula
   url "https://github.com/pulumi/pulumi.git",
       :tag      => "v2.3.0",
       :revision => "aa5dfe4289bec3c48d1ec599bd0b747cfc3da33f"
+  head "https://github.com/pulumi/pulumi.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -39,6 +40,10 @@ class Pulumi < Formula
       # Install zsh completion
       output = Utils.popen_read("#{bin}/pulumi gen-completion zsh")
       (zsh_completion/"_pulumi").write output
+
+      # Install fish completion
+      output = Utils.popen_read("#{bin}/pulumi gen-completion fish")
+      (fish_completion/"_pulumi").write output
     end
   end
 


### PR DESCRIPTION
It's now possible to install pulumi from `--HEAD` and also have the fish completions installed where applicable.

* [x]  Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
* [x]  Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
* [x]  Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
* [x]  Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
* [x]  Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?