### PR TITLE
cpputest: fix sha256

### DIFF
--- a/Formula/cpputest.rb
+++ b/Formula/cpputest.rb
@@ -2,7 +2,7 @@ class Cpputest < Formula
   desc "C /C++ based unit xUnit test framework"
   homepage "https://www.cpputest.org/"
   url "https://github.com/cpputest/cpputest/releases/download/v4.0/cpputest-4.0.tar.gz"
-  sha256 "81c4958a3ec20ebe87b2cb658c334d27496c715972ddb71262357f449a7c1df3"
+  sha256 "21c692105db15299b5529af81a11a7ad80397f92c122bd7bf1e4a4b0e85654f7"
   head "https://github.com/cpputest/cpputest.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

(Sorry for this. I had updated the release tag as it was missing the version update. I hadn't realized that would cause a SHA mismatch and cause a warning. Fixed asap)