### PR TITLE
Update mlt.rb to add more effects for Kdenlive

### DIFF
--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -16,15 +16,36 @@ class Mlt < Formula
   depends_on "libdv"
   depends_on "libsamplerate"
   depends_on "libvorbis"
-  depends_on "sdl"
   depends_on "sox"
+
+  depends_on "sdl2" # Class SDLTranslatorResponder is implemented in both
+
+  depends_on "fftw" # fft, lightshow, dance
+
+  depends_on "qt5" # qtblend, qtext, audiospectrum
+  depends_on "libexif" # qt module needs libexif
+
+  # mlt >= v6.21.0
+  # depends_on "gdk-pixbuf"
+  # depends_on "pango"
+
+  # opencv.tracker
+  # mlt = v6.20.0
+  depends_on "opencv@3"
+  # mlt >= v6.21.0
+  # depends_on "opencv@4"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--disable-jackrack",
                           "--disable-swfdec",
                           "--disable-gtk",
-                          "--enable-gpl"
+                          "--disable-sdl", # Don't need SDL because we have SDL2
+                          "--enable-motion_est", # audiowaveform
+                          "--enable-gpl",
+                          "--enable-gpl3",
+                          "--enable-opencv", # opencv.tracker
+                          "--disable-gtk2" # mlt <= 6.20.0: "<gdk/gdk.h> not found" if "gdk-pixbuf" installed; remove >=6.21
     system "make"
     system "make", "install"
   end

--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -12,28 +12,19 @@ class Mlt < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
+  depends_on "fftw" # fft, lightshow, dance
   depends_on "frei0r"
   depends_on "libdv"
+  depends_on "libexif" # qt module needs libexif
   depends_on "libsamplerate"
   depends_on "libvorbis"
-  depends_on "sox"
-
+  # mlt >= v6.21.0: depends_on "gdk-pixbuf"
+  # mlt >= v6.21.0: depends_on "pango"
+  depends_on "opencv@3" # mlt = v6.20.0 - opencv.tracker
+  # mlt >= v6.21.0: depends_on "opencv@4" # opencv.tracker
+  depends_on "qt" # qtblend, qtext, audiospectrum
   depends_on "sdl2" # Class SDLTranslatorResponder is implemented in both
-
-  depends_on "fftw" # fft, lightshow, dance
-
-  depends_on "qt5" # qtblend, qtext, audiospectrum
-  depends_on "libexif" # qt module needs libexif
-
-  # mlt >= v6.21.0
-  # depends_on "gdk-pixbuf"
-  # depends_on "pango"
-
-  # opencv.tracker
-  # mlt = v6.20.0
-  depends_on "opencv@3"
-  # mlt >= v6.21.0
-  # depends_on "opencv@4"
+  depends_on "sox"
 
   def install
     system "./configure", "--prefix=#{prefix}",
@@ -45,7 +36,7 @@ class Mlt < Formula
                           "--enable-gpl",
                           "--enable-gpl3",
                           "--enable-opencv", # opencv.tracker
-                          "--disable-gtk2" # mlt <= 6.20.0: "<gdk/gdk.h> not found" if "gdk-pixbuf" installed; remove >=6.21
+                          "--disable-gtk2" # mlt <= 6.20.0, otherwise <gdk/gdk.h> not found if "gdk-pixbuf"
     system "make"
     system "make", "install"
   end

--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -36,7 +36,7 @@ class Mlt < Formula
                           "--enable-gpl",
                           "--enable-gpl3",
                           "--enable-opencv", # opencv.tracker
-                          "--disable-gtk2" # mlt <= 6.20.0, otherwise <gdk/gdk.h> not found if "gdk-pixbuf"
+                          "--disable-gtk2" # mlt <= 6.20.0: "<gdk/gdk.h> not found" if "gdk-pixbuf" installed; remove >=6.21
     system "make"
     system "make", "install"
   end

--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -36,7 +36,7 @@ class Mlt < Formula
                           "--enable-gpl",
                           "--enable-gpl3",
                           "--enable-opencv", # opencv.tracker
-                          "--disable-gtk2" # mlt <= 6.20.0: "<gdk/gdk.h> not found" if "gdk-pixbuf" installed; remove >=6.21
+                          "--disable-gtk2" # mlt <= 6.20.0, otherwise <gdk/gdk.h> not found if "gdk-pixbuf"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- Fixes warning "objc[41722]: Class SDLTranslatorResponder is implemented in both /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (0x100a82e90) and /usr/local/opt/sdl/lib/libSDL-1.2.0.dylib (0x1010a5d40). One of the two will be used. Which one is undefined."
- Enables more (Kdenlive effects)[https://community.kde.org/Kdenlive/Development/CleaningEffects#Table_of_effects] through satisfying more dependences for mlt
- Fixes https://github.com/KDE-mac/homebrew-kde/issues/363

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
