### PR TITLE
S3cmd 2.1.0 update python-magic dependency

### DIFF
--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -5,6 +5,7 @@ class Fdroidserver < Formula
   homepage "https://f-droid.org"
   url "https://files.pythonhosted.org/packages/1b/91/7109fe628ad7cc70fe503d6fbbb81819d796346d08c3e52a2dcdcc8ddd5b/fdroidserver-1.1.7.tar.gz"
   sha256 "6b58b10299778b1d5c0d0caabd5a234acb5aa77784dbdc7180c3732fbb9815a7"
+  revision 1
 
   bottle do
     cellar :any

--- a/Formula/s3cmd.rb
+++ b/Formula/s3cmd.rb
@@ -5,6 +5,7 @@ class S3cmd < Formula
   homepage "https://s3tools.org/s3cmd"
   url "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
   sha256 "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
+  revision 1
   head "https://github.com/s3tools/s3cmd.git"
 
   bottle do
@@ -22,8 +23,8 @@ class S3cmd < Formula
   end
 
   resource "python-magic" do
-    url "https://files.pythonhosted.org/packages/84/30/80932401906eaf787f2e9bd86dc458f1d2e75b064b4c187341f29516945c/python-magic-0.4.15.tar.gz"
-    sha256 "f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
+    url "https://files.pythonhosted.org/packages/e3/85/1aff76b966622868a73717abd8b501a3c91890e23a65e5f574ff6df1970f/python-magic-0.4.18.tar.gz"
+    sha256 "b757db2a5289ea3f1ced9e60f072965243ea43a2221430048fd8cacab17be0ce"
   end
 
   resource "six" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Update s3cmd formula to use python-magic dependency to 0.4.18 to resolve the issue discussed in https://github.com/s3tools/s3cmd/issues/1107 - also update revision for fdroidserver as it has a dependency on s3cmd