### PR TITLE
xz: Remove liblzma as it clashes with the macOS provided liblzma

### DIFF
--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -21,6 +21,8 @@ class Xz < Formula
                           "--prefix=#{prefix}"
     system "make", "check"
     system "make", "install"
+    # macOS already provides liblzma, remove it so it isn't linked!
+    rm Dir["#{lib}/liblzma.*"]
   end
 
   test do


### PR DESCRIPTION
At least on macOS Catalina, liblzma already comes with the system in
/usr/lib/liblzma.dylib. xz ends up linking another liblzma.dylib on top
of this which does not always play nicely when building other software.
Rather than make the formula keg-only (since it also contains a lot of
binary utilities), this removes the liblzma that comes with it.

This was discussed on [discourse](https://discourse.brew.sh/t/xz-provides-a-liblzma-that-shadows-the-macos-provided-usr-lib-liblzma-dylib/7700/2), but I'm aware that this is probably not the optimal solution and has the potential to break existing Formulae that depend on xz. Opening this PR anyway for discussion, in case anyone knows any better ways of addressing this

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
