### PR TITLE
ponysay: add head and build dependencies

### DIFF
--- a/Formula/ponysay.rb
+++ b/Formula/ponysay.rb
@@ -1,9 +1,19 @@
 class Ponysay < Formula
   desc "Cowsay but with ponies"
   homepage "https://github.com/erkin/ponysay/"
-  url "https://github.com/erkin/ponysay/archive/3.0.3.tar.gz"
-  sha256 "c382d7f299fa63667d1a4469e1ffbf10b6813dcd29e861de6be55e56dc52b28a"
-  revision 4
+  revision 5
+  head "https://github.com/erkin/ponysay.git"
+
+  stable do
+    url "https://github.com/erkin/ponysay/archive/3.0.3.tar.gz"
+    sha256 "c382d7f299fa63667d1a4469e1ffbf10b6813dcd29e861de6be55e56dc52b28a"
+
+    # upstream commit 16 Nov 2019, `fix: do not compare literal with "is not"`
+    patch do
+      url "https://github.com/erkin/ponysay/commit/69c23e3a.diff?full_index=1"
+      sha256 "4343703851dee3ea09f153f57c4dbd1731e5eeab582d3316fbbf938f36100542"
+    end
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -12,8 +22,11 @@ class Ponysay < Formula
     sha256 "a502ed3340bc2c7591788c8747c8175e0ac7902bfbfdf73454aef09d39a0db16" => :high_sierra
   end
 
+  depends_on "gzip" => :build
   depends_on "coreutils"
   depends_on "python@3.8"
+
+  uses_from_macos "texinfo" => :build
 
   def install
     system "./setup.py",
@@ -26,6 +39,8 @@ class Ponysay < Formula
   end
 
   test do
-    system "#{bin}/ponysay", "-A"
+    output = shell_output("#{bin}/ponysay test")
+    assert_match "test", output
+    assert_match "____", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I'm sorry, I can't run `brew audit` because it is failing on my machine same as Homebrew/brew#7062

-----
I add head to this formula because I want to use it. Without head build, ponysay output would have some error like this shown below:
![error](https://i.imgur.com/77DEXQM.png)

but that issue already solved on their master branch, which is we need `head` formula.

This is the result from my local edited build with `--HEAD` args:
![success](https://i.imgur.com/Ex27Wnq.png)

Also, I add the build dependencies according to their [build dependencies requirements](https://github.com/erkin/ponysay#package-building-dependencies).
Because I encounter error in my machine without that build dependencies as shown below:
```log
==> Installing ponysay
==> ./setup.py --freedom=partial --prefix=/home/linuxbrew/.linuxbrew/Cellar/ponysay/3.0.3_4 --cache-dir=/home/linuxbrew/.linuxbrew/Cell
Last 15 lines from /home/latipun7/.cache/Homebrew/Logs/ponysay/01.setup.py:
::Compiling...
Creating uncompressed zip file ponysay.zip with files from src: __main__.py kms.py spellocorrecter.py ponysaytool.py ucs.py balloon.py ponysay.py colourstack.py common.py argparser.py lists.py backend.py metadata.py
gzip -9 -f < manuals/manpage.6.install > manuals/manpage.6.gz
makeinfo manuals/ponysay.texinfo
gzip -9 -f < ponysay.info > ponysay.info.gz
Traceback (most recent call last):
  File "./setup.py", line 1239, in <module>
    Setup()
  File "./setup.py", line 295, in __init__
    self.build(conf)
  File "./setup.py", line 477, in build
    compress('ponysay.info', 'ponysay.info.' + ext, ext)
  File "./setup.py", line 383, in compress
    filein = open(source, 'r')
FileNotFoundError: [Errno 2] No such file or directory: 'ponysay.info'

READ THIS: https://docs.brew.sh/Troubleshooting

Installing ponysay has failed!
```
That's failed because I don't have `texinfo` dependencies anywhere.

-----
<details><summary>Brew audit error logs</summary>
<p>

```log
$ brew audit --strict ponysay
Fetching gem metadata from https://rubygems.org/.........
Using concurrent-ruby 1.1.6
Using minitest 5.14.1
Using thread_safe 0.3.6
Using bundler 1.17.2
Using byebug 11.1.3
Using ast 2.4.0
Using connection_pool 2.2.2
Using json 2.3.0
Using docile 1.3.2
Using simplecov-html 0.10.2
Using sync 0.5.0
Using thor 1.0.1
Using unf_ext 0.0.7.7
Using hpricot 0.8.6
Using zeitwerk 2.3.0
Using net-http-digest_auth 1.4.1
Using diff-lcs 1.3
Using mini_portile2 2.4.0
Using ntlm-http 0.1.1
Using webrobots 0.1.2
Using mime-types-data 3.2020.0512
Using plist 3.5.0
Using rainbow 3.0.0
Using rdiscount 2.2.0.1
Using rexml 3.2.4
Using rspec-support 3.9.3
Using parallel 1.19.1
Using ruby-progressbar 1.10.1
Using unicode-display_width 1.7.0
Using ruby-macho 2.2.0
Using i18n 1.8.2
Using tzinfo 1.2.7
Using simplecov 0.16.1
Using tins 1.25.0
Using net-http-persistent 4.0.0
Using parser 2.7.1.3
Using mime-types 3.3.1
Using unf 0.1.4
Using activesupport 6.0.3.1
Using term-ansicolor 1.7.1
Fetching nokogiri 1.10.9
Using parallel_tests 2.32.0
Using rspec-core 3.9.2
Using rspec-expectations 3.9.2
Using mustache 1.1.1
Using rspec-mocks 3.9.1
Using rubocop-ast 0.0.3
Using domain_name 0.5.20190701
Using rspec-retry 0.6.2
Using ronn 0.7.3
Using rspec-its 1.3.0
Using rubocop 0.84.0
Using coveralls 0.8.23
Using rspec 3.9.0
Using http-cookie 1.0.3
Using rubocop-rspec 1.39.0
Using rubocop-performance 1.6.0
Using rspec-wait 0.0.9
Installing nokogiri 1.10.9 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/nokogiri-1.10.9/ext/nokogiri
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/bin/ruby -I
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0 -r ./siteconf20200602-32190-16ffnbh.rb
extconf.rb
checking if the C compiler accepts ... yes
Building nokogiri using packaged libraries.
Using mini_portile version 2.4.0
checking for gzdopen() in -lz... no
zlib is missing; necessary for building libxml2
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/bin/$(RUBY_BASE_NAME)
        --help
        --clean
        --use-system-libraries
        --enable-static
        --disable-static
        --with-zlib-dir
        --without-zlib-dir
        --with-zlib-include
        --without-zlib-include=${zlib-dir}/include
        --with-zlib-lib
        --without-zlib-lib=${zlib-dir}/lib
        --enable-cross-build
        --disable-cross-build

To see why this extension failed to compile, please check the mkmf.log which can be found here:

/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/x86_64-linux/2.6.0-static/nokogiri-1.10.9/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/nokogiri-1.10.9
for inspection.
Results logged to
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/x86_64-linux/2.6.0-static/nokogiri-1.10.9/gem_make.out

An error occurred while installing nokogiri (1.10.9), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.10.9' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  mechanize was resolved to 2.7.6, which depends on
    nokogiri
Error: failed to run `/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/bin/bundle install`!
```

`mkmf.log`
```log
$ cat /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/x86_64-linux/2.6.0-static/nokogiri-1.10.9/mkmf.log
"cc -o conftest -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/x86_64-linux -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/ruby/backward -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0 -I.  -I/home/linuxbrew/.linuxbrew/opt/portable-readline/include -I/home/linuxbrew/.linuxbrew/opt/portable-libyaml/include -I/home/linuxbrew/.linuxbrew/opt/portable-openssl/include -I/home/linuxbrew/.linuxbrew/opt/portable-ncurses/include -I/home/linuxbrew/.linuxbrew/opt/portable-zlib/include   -O3 -ggdb3 -Wall -Wextra -Wdeclaration-after-statement -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=noreturn -Wunused-variable  conftest.c  -L. -L/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib     -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -lruby-static -lpthread -lrt -lrt -lrt -ldl -lcrypt -lm   -lm   -lc "
checked program was:
/* begin */
1: #include "ruby.h"
2:
3: int main(int argc, char **argv)
4: {
5:   return 0;
6: }
/* end */

"cc -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/x86_64-linux -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/ruby/backward -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0 -I.  -I/home/linuxbrew/.linuxbrew/opt/portable-readline/include -I/home/linuxbrew/.linuxbrew/opt/portable-libyaml/include -I/home/linuxbrew/.linuxbrew/opt/portable-openssl/include -I/home/linuxbrew/.linuxbrew/opt/portable-ncurses/include -I/home/linuxbrew/.linuxbrew/opt/portable-zlib/include   -O3 -ggdb3 -Wall -Wextra -Wdeclaration-after-statement -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=noreturn -Wunused-variable    -Werror -c conftest.c"
checked program was:
/* begin */
1: #include "ruby.h"
2:
3: int main() {return 0;}
/* end */

have_library: checking for gzdopen() in -lz... -------------------- no

"cc -o conftest -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/x86_64-linux -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/ruby/backward -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0 -I.  -I/home/linuxbrew/.linuxbrew/opt/portable-readline/include -I/home/linuxbrew/.linuxbrew/opt/portable-libyaml/include -I/home/linuxbrew/.linuxbrew/opt/portable-openssl/include -I/home/linuxbrew/.linuxbrew/opt/portable-ncurses/include -I/home/linuxbrew/.linuxbrew/opt/portable-zlib/include   -O3 -ggdb3 -Wall -Wextra -Wdeclaration-after-statement -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=noreturn -Wunused-variable  -g -DXP_UNIX conftest.c  -L. -L/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib     -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -lruby-static -lpthread -lrt -lrt -lrt -ldl -lcrypt -lm  -lz  -lm   -lc "
conftest.c:3:10: fatal error: zlib.h: No such file or directory
    3 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
checked program was:
/* begin */
 1: #include "ruby.h"
 2:
 3: #include <zlib.h>
 4:
 5: /*top*/
 6: extern int t(void);
 7: int main(int argc, char **argv)
 8: {
 9:   if (argc > 1000000) {
10:     int (* volatile tp)(void)=(int (*)(void))&t;
11:     printf("%d", (*tp)());
12:   }
13:
14:   return 0;
15: }
16: int t(void) { void ((*volatile p)()); p = (void ((*)()))gzdopen; return !p; }
/* end */

"cc -o conftest -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/x86_64-linux -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0/ruby/backward -I/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/include/ruby-2.6.0 -I.  -I/home/linuxbrew/.linuxbrew/opt/portable-readline/include -I/home/linuxbrew/.linuxbrew/opt/portable-libyaml/include -I/home/linuxbrew/.linuxbrew/opt/portable-openssl/include -I/home/linuxbrew/.linuxbrew/opt/portable-ncurses/include -I/home/linuxbrew/.linuxbrew/opt/portable-zlib/include   -O3 -ggdb3 -Wall -Wextra -Wdeclaration-after-statement -Wdeprecated-declarations -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=noreturn -Wunused-variable  -g -DXP_UNIX conftest.c  -L. -L/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib -L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/home/linuxbrew/.linuxbrew/opt/portable-readline/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-readline/lib -L/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-openssl/lib -L/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-ncurses/lib -L/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/portable-zlib/lib     -Wl,-rpath,/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib -lruby-static -lpthread -lrt -lrt -lrt -ldl -lcrypt -lm  -lz  -lm   -lc "
conftest.c:3:10: fatal error: zlib.h: No such file or directory
    3 | #include <zlib.h>
      |          ^~~~~~~~
compilation terminated.
checked program was:
/* begin */
 1: #include "ruby.h"
 2:
 3: #include <zlib.h>
 4:
 5: /*top*/
 6: extern int t(void);
 7: int main(int argc, char **argv)
 8: {
 9:   if (argc > 1000000) {
10:     int (* volatile tp)(void)=(int (*)(void))&t;
11:     printf("%d", (*tp)());
12:   }
13:
14:   return 0;
15: }
16: extern void gzdopen();
17: int t(void) { gzdopen(); return 0; }
/* end */

--------------------
```

</p>
</details>