### PR TITLE
wxmac 3.0.5.1 with wxwebview enabled

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -3,6 +3,7 @@ class Wxmac < Formula
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
   sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
+  revision 1
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   bottle do
@@ -29,6 +30,7 @@ class Wxmac < Formula
       "--enable-svg",
       "--enable-unicode",
       "--enable-webkit",
+      "--enable-webview",
       "--with-expat",
       "--with-libjpeg",
       "--with-libpng",


### PR DESCRIPTION
This is a simple PR that includes support for the wxWebView library.  The original formula is otherwise unchanged.  This uses the current wxWidgets package version 3.0.5.1.  Tested on Catalina

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
