### PR TITLE
pipenv: fix shell completions

### DIFF
--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -5,6 +5,7 @@ class Pipenv < Formula
   homepage "https://pipenv.pypa.io/"
   url "https://files.pythonhosted.org/packages/5f/0a/ef03dd42bed968f779eeaf9a98e32e875bfd18cf9ba61ede407364903c1e/pipenv-2020.5.28.tar.gz"
   sha256 "81862314929e3e532502e25bab3c6ba969c0cf67dcaa9d63c2c931ee2d61541c"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -67,10 +68,10 @@ class Pipenv < Formula
     }
     (bin/"pipenv").write_env_script(libexec/"bin/pipenv", env)
 
-    output = Utils.popen_read("SHELL=bash #{libexec}/bin/pipenv --completion")
+    output = Utils.safe_popen_read({ "SHELL" => "bash" }, libexec/"bin/pipenv", "--completion", { :err => :err })
     (bash_completion/"pipenv").write output
 
-    output = Utils.popen_read("SHELL=zsh #{libexec}/bin/pipenv --completion")
+    output = Utils.safe_popen_read({ "SHELL" => "zsh" }, libexec/"bin/pipenv", "--completion", { :err => :err })
     (zsh_completion/"_pipenv").write output
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #55614

The issue was that completions weren't being installed correctly. Pipenv was unable to determine the current shell when using `Utils.popen_read` (even with `SHELL=bash` or `SHELL=zsh`). When run manually, these commands worked and pipenv determined the shell based on the `SHELL` variable, but it seemed to use a different indicator when run by homebrew.

This solution uses backticks instead which seems to work correctly. I'm not sure what the implications are to using backticks as supposed to `popen_read`.