### PR TITLE
miniserve: Note not to bump this unless it's using Rust stable

### DIFF
--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -1,6 +1,8 @@
 class Miniserve < Formula
   desc "High performance static file server"
   homepage "https://github.com/svenstaro/miniserve"
+  # Bumpable only when it doesn't use features only available in Rust Nightly.
+  # Check for resolution of https://github.com/svenstaro/miniserve/issues/291.
   url "https://github.com/svenstaro/miniserve/archive/v0.3.0.tar.gz"
   sha256 "80ee5d661730ddad14671f961b560467f3b3a9f0544b9b11dec65098eb4a1f7e"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- We had to [downgrade this](https://github.com/Homebrew/homebrew-core/pull/53095) when we audited all formulae that built using Rust Nightly.
- There's an issue upstream (linked in the comment in the formula) asking to build using Rust stable.
- There have been [attempts to bump the version](https://github.com/Homebrew/homebrew-core/pull/55693), which wastes maintainer time and CI time, so it's worth a note here to make it more obvious.
