### PR TITLE
rke: update homepage link to latest version

### DIFF
--- a/Formula/rke.rb
+++ b/Formula/rke.rb
@@ -1,6 +1,6 @@
 class Rke < Formula
   desc "Rancher Kubernetes Engine, a Kubernetes installer that works everywhere"
-  homepage "https://rancher.com/docs/rke/v0.1.x/en/"
+  homepage "https://rancher.com/docs/rke/latest/en/"
   url "https://github.com/rancher/rke.git",
       :tag      => "v1.1.2",
       :revision => "cd9d26dc51b50ae7be47a9b7972fc09c128aa405"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the homepage link of rke to point to the latest version instead of an old 0.1.x version of the docs. By now the 0.1.x URL redirects to latest anyways.