### PR TITLE
UPDATE Gopass dependency

### DIFF
--- a/Formula/gopass.rb
+++ b/Formula/gopass.rb
@@ -3,6 +3,7 @@ class Gopass < Formula
   homepage "https://github.com/gopasspw/gopass"
   url "https://github.com/gopasspw/gopass/releases/download/v1.9.2/gopass-1.9.2.tar.gz"
   sha256 "1017264678d3a2cdc862fc81e3829f390facce6c4a334cb314192ff321837bf5"
+  revision 1
   head "https://github.com/gopasspw/gopass.git"
 
   bottle do
@@ -14,6 +15,7 @@ class Gopass < Formula
 
   depends_on "go" => :build
   depends_on "gnupg"
+  depends_on "terminal-notifier"
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Hi all,

just a small update for gopass.
Last year I implemented a new notification style for gopass that was based on "terminal-notifier".
But at the moment it was missing in the brew file.

The update just add the "terminal-notifier" dependency for better notifications.

Here some links to the PR to gopass:
- [GorReleaser Brew File](https://github.com/gopasspw/gopass/blob/6c53574275072ae8503abc45d39699ec2cf9c28f/.goreleaser.yml#L74)
- [MacOS Notifications](https://github.com/gopasspw/gopass/pull/1189)

Kind regards
