### PR TITLE
oxipng: update sha256

### DIFF
--- a/Formula/oxipng.rb
+++ b/Formula/oxipng.rb
@@ -2,7 +2,7 @@ class Oxipng < Formula
   desc "Multithreaded PNG optimizer written in Rust"
   homepage "https://github.com/shssoichiro/oxipng"
   url "https://github.com/shssoichiro/oxipng/archive/v3.0.0.tar.gz"
-  sha256 "00edbe20dc18f80b00f96dc6389b15c90c9f6068b207d3b282cef3c75fed0fe9"
+  sha256 "fd7584299375a630322b152878756297b0083492b7e4b9b17ae9978662e8c36a"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Rust 1.44.0 PR (#55793) surfaced an issue with the `oxipng` SHA256 having changed for the v3.0.0 release. I opened an upstream issue (shssoichiro/oxipng#237) and the explanation from the owner was as follows:

> There were some issues with the deploy action that creates the release binaries. A few attempts at fixing this resulted in the binaries getting uploaded more than once. The binaries should have identical functionality, but may not be byte-identical due to multithreaded compilation.