### PR TITLE
liblqr: fix homepage, update stable and head

### DIFF
--- a/Formula/liblqr.rb
+++ b/Formula/liblqr.rb
@@ -1,11 +1,10 @@
 class Liblqr < Formula
   desc "C/C++ seam carving library"
-  homepage "https://liblqr.wikidot.com/"
-  url "https://liblqr.wdfiles.com/local--files/en:download-page/liblqr-1-0.4.2.tar.bz2"
-  version "0.4.2"
-  sha256 "173a822efd207d72cda7d7f4e951c5000f31b10209366ff7f0f5972f7f9ff137"
+  homepage "http://liblqr.wikidot.com/"
+  url "https://github.com/carlobaldassi/liblqr/archive/v0.4.2.tar.gz"
+  sha256 "1019a2d91f3935f1f817eb204a51ec977a060d39704c6dafa183b110fd6280b0"
   revision 1
-  head "https://repo.or.cz/liblqr.git"
+  head "https://github.com/carlobaldassi/liblqr.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As mentioned in [a post on the website referenced in the formula](http://liblqr.wikidot.com/forum/t-905211/code-hosting-moved-to-github), the code for `liblqr` is now hosted on GitHub. This is also supported by the [download page](http://liblqr.wikidot.com/en:download-page) referencing the GitHub repo.

This was originally surfaced in Homebrew/homebrew-livecheck#810, for what it's worth.