### PR TITLE
popt: update homepage and stable url

### DIFF
--- a/Formula/popt.rb
+++ b/Formula/popt.rb
@@ -1,7 +1,7 @@
 class Popt < Formula
   desc "Library like getopt(3) with a number of enhancements"
-  homepage "https://web.archive.org/web/20190425081726/rpm5.org/"
-  url "https://web.archive.org/web/20170922140539/rpm5.org/files/popt/popt-1.16.tar.gz"
+  homepage "https://github.com/rpm-software-management/popt"
+  url "http://ftp.rpm.org/mirror/popt/popt-1.16.tar.gz"
   mirror "https://ftp.openbsd.org/pub/OpenBSD/distfiles/popt-1.16.tar.gz"
   sha256 "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in Homebrew/homebrew-livecheck#799 and elsewhere, RPM5 has disappeared for a bit and [rpm.org has rebooted development of `popt`](http://lists.rpm.org/pipermail/rpm-announce/2020-May/000077.html). We decided to update the homepage to the GitHub repo (since rpm.org doesn't provide a page describing `popt`) and to use the rpm.org mirror's stable archive.

Just to be clear, we aren't using the archive files on GitHub because they're simply snapshots of the code in the repo and don't contain a `configure` file, etc. like we find in the rpm.org archive files (and on mirrors). Using the GitHub archive would require updating the build process in the formula and we wouldn't be able to use any mirrors because the archive files are different (sha256 and contents).

The audit will predictably fail since there's no `test` block. Writing a test for this would seemingly require creating a test program and I don't have time to do so right now.