### PR TITLE
cairo: update head

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -12,7 +12,7 @@ class Cairo < Formula
   end
 
   head do
-    url "https://anongit.freedesktop.org/git/cairo", :using => :git
+    url "https://anongit.freedesktop.org/git/cairo.git"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with ~~`brew install --build-from-source <formula>`~~ `brew install --HEAD <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This simply updates the `head` URL to use the `.git` extension (removing `:using` in the process). This brings the formula in line with the vast majority of other formulae using a freedesktop.org Git repo (e.g., dbus, gstreamer, mesa, poppler, etc.).

The only other formula using a freedesktop.org Git repo without a `.git` extension (and having to use `:using => :git`) seems to be `fontconfig` and I'll be creating a PR to update that one next.