### PR TITLE
fontconfig: update head, fix building from head

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -20,10 +20,11 @@ class Fontconfig < Formula
   end
 
   head do
-    url "https://anongit.freedesktop.org/git/fontconfig", :using => :git
+    url "https://anongit.freedesktop.org/git/fontconfig.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
+    depends_on "gettext" => :build
     depends_on "libtool" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with ~~`brew install --build-from-source <formula>`~~ `brew install --HEAD <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `head` URL to use the `.git` extension (removing `:using` in the process). This brings the formula in line with the vast majority of other formulae using a freedesktop.org Git repo (e.g., dbus, gstreamer, mesa, poppler, etc.). The only other formula using a freedesktop.org Git repo without a `.git` extension (and having to use `:using => :git`) seemed to be `cairo` and that's being handled in #55909.

It was also necessary to add `gettext` as a build dependency for `head` builds, to resolve the following build error:

```
==> autoreconf -iv
Last 15 lines from /Users/[REDACTED]/Library/Logs/Homebrew/fontconfig/01.autoreconf:
2020-06-06 22:31:28 -0400

autoreconf
-iv

autoreconf: Entering directory `.'
autoreconf: running: autopoint
Can't exec "autopoint": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 345.
autoreconf: failed to run autopoint: No such file or directory
autoreconf: autopoint is needed because this package uses Gettext
```