### PR TITLE
genometools: fix python3 path in test block

### DIFF
--- a/Formula/genometools.rb
+++ b/Formula/genometools.rb
@@ -37,6 +37,6 @@ class Genometools < Formula
 
   test do
     system "#{bin}/gt", "-test"
-    system "python3", "-c", "import gt"
+    system Formula["python@3.8"].opt_bin/"python3", "-c", "import gt"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
==> python3 -c import gt
Failed to execute: python3
Error: genometools: failed
An exception occurred within a child process:
  BuildError: Failed executing: python3 -c import\ gt
```