### PR TITLE
asimov 0.2.0 (new formula)

### DIFF
--- a/Formula/asimov.rb
+++ b/Formula/asimov.rb
@@ -1,0 +1,39 @@
+class Asimov < Formula
+  desc "Automatically exclude development dependencies from Time Machine backups"
+  homepage "https://github.com/stevegrunwell/asimov"
+  url "https://github.com/stevegrunwell/asimov/archive/v0.2.0.tar.gz"
+  sha256 "2efb456975af066a17f928787062522de06c14eb322b2d133a8bc3a764cc5376"
+  head "https://github.com/stevegrunwell/asimov.git", :branch => "develop"
+
+  bottle :unneeded
+
+  def install
+    bin.install buildpath/"asimov"
+  end
+
+  plist_options :startup => true, :manual => "asimov"
+
+  # Asimov will run in the background on a daily basis
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+          <dict>
+              <key>Label</key>
+              <string>#{plist_name}</string>
+              <key>Program</key>
+              <string>#{opt_bin}/asimov</string>
+              <key>StartInterval</key>
+              <!-- 24 hours = 60 * 60 * 24 -->
+              <integer>86400</integer>
+          </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    assert_match %r{Finding node_modules/ directories with corresponding ../package.json files...},
+                 shell_output("#{bin}/asimov")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the initial submission for [Asimov](https://github.com/stevegrunwell/asimov), a command line utility that automatically excludes development dependencies from Time Machine backups on macOS.

For example, Asimov will find `node_modules/` directories and, assuming it finds an adjacent `package.json` file, will use the Time Machine Utility (`tmutil`) program to exclude the `node_modules/` directory from Time Machine backups.

Fixes stevegrunwell/asimov#2.