### PR TITLE
Update formulae to use Utils.safe_popen_read

### DIFF
--- a/Formula/abcl.rb
+++ b/Formula/abcl.rb
@@ -18,7 +18,7 @@ class Abcl < Formula
 
   def install
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "ant"
 

--- a/Formula/acmetool.rb
+++ b/Formula/acmetool.rb
@@ -170,12 +170,12 @@ class Acmetool < Formula
         -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acmetool
         -X github.com/hlandau/acme/hooks.DefaultPath=#{lib}/hooks
         -X github.com/hlandau/acme/responder.StandardWebrootPath=#{var}/run/acmetool/acme-challenge
-        #{Utils.popen_read("#{buildpath}/src/github.com/hlandau/buildinfo/gen")}
+        #{Utils.safe_popen_read("#{buildpath}/src/github.com/hlandau/buildinfo/gen")}
       ]
       system "go", "build", "-o", bin/"acmetool", "-ldflags", ldflags.join(" ")
     end
 
-    (man8/"acmetool.8").write Utils.popen_read(bin/"acmetool", "--help-man")
+    (man8/"acmetool.8").write Utils.safe_popen_read(bin/"acmetool", "--help-man")
 
     doc.install Dir["_doc/*"]
   end

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -16,7 +16,7 @@ class ArduinoCli < Formula
   depends_on "go" => :build
 
   def install
-    commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+    commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
     system "go", "build", "-ldflags",
            "-s -w -X github.com/arduino/arduino-cli/version.versionString=#{version} " \
            "-X github.com/arduino/arduino-cli/version.commit=#{commit}",

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -34,6 +34,6 @@ class Armadillo < Formula
       }
     EOS
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-larmadillo", "-o", "test"
-    assert_equal Utils.popen_read("./test").to_i, version.to_s.to_i
+    assert_equal shell_output("./test").to_i, version.to_s.to_i
   end
 end

--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -18,8 +18,8 @@ class AwsIamAuthenticator < Formula
 
   def install
     # project = "github.com/kubernetes-sigs/aws-iam-authenticator"
-    revision = Utils.popen_read("git", "rev-parse", "HEAD").strip
-    version = Utils.popen_read("git describe --tags").strip
+    revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").strip
+    version = Utils.safe_popen_read("git describe --tags").strip
     ldflags = ["-s", "-w",
                "-X main.version=#{version}",
                "-X main.commit=#{revision}"]

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -88,8 +88,8 @@ class BoostPython3 < Formula
       }
     EOS
 
-    pyincludes = Utils.popen_read("#{Formula["python@3.8"].opt_bin}/python3-config --includes").chomp.split(" ")
-    pylib = Utils.popen_read("#{Formula["python@3.8"].opt_bin}/python3-config --ldflags --embed").chomp.split(" ")
+    pyincludes = shell_output("#{Formula["python@3.8"].opt_bin}/python3-config --includes").chomp.split(" ")
+    pylib = shell_output("#{Formula["python@3.8"].opt_bin}/python3-config --ldflags --embed").chomp.split(" ")
     pyver = Language::Python.major_minor_version(Formula["python@3.8"].opt_bin/"python3").to_s.delete(".")
 
     system ENV.cxx, "-shared", "hello.cpp", "-L#{lib}", "-lboost_python#{pyver}", "-o",

--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -38,7 +38,7 @@ class Botan < Formula
 
   test do
     (testpath/"test.txt").write "Homebrew"
-    (testpath/"testout.txt").write Utils.popen_read("#{bin}/botan base64_enc test.txt")
+    (testpath/"testout.txt").write shell_output("#{bin}/botan base64_enc test.txt")
     assert_match "Homebrew", shell_output("#{bin}/botan base64_dec testout.txt")
   end
 end

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -16,7 +16,7 @@ class Buildkit < Formula
   depends_on "go" => :build
 
   def install
-    revision = Utils.popen_read("git rev-parse HEAD").chomp
+    revision = Utils.safe_popen_read("git rev-parse HEAD").chomp
     ldflags = %W[
       -s -w
       -X github.com/moby/buildkit/version.Version=#{version}

--- a/Formula/capnp.rb
+++ b/Formula/capnp.rb
@@ -25,7 +25,7 @@ class Capnp < Formula
     file = testpath/"test.capnp"
     text = "\"Is a happy little duck\""
 
-    file.write Utils.popen_read("#{bin}/capnp id").chomp + ";\n"
+    file.write shell_output("#{bin}/capnp id").chomp + ";\n"
     file.append_lines "const dave :Text = #{text};"
     assert_match text, shell_output("#{bin}/capnp eval #{file} dave")
   end

--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -25,7 +25,7 @@ class Cayley < Formula
       # Run packr to generate .go files that pack the static files into bytes that can be bundled into the Go binary.
       system "go", "run", "github.com/gobuffalo/packr/v2/packr2"
 
-      commit = Utils.popen_read("git rev-parse --short HEAD").chomp
+      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
 
       ldflags = %W[
         -s -w

--- a/Formula/certigo.rb
+++ b/Formula/certigo.rb
@@ -19,11 +19,11 @@ class Certigo < Formula
     bin.install "bin/certigo"
 
     # Install bash completion
-    output = Utils.popen_read("#{bin}/certigo --completion-script-bash")
+    output = Utils.safe_popen_read("#{bin}/certigo --completion-script-bash")
     (bash_completion/"certigo").write output
 
     # Install zsh completion
-    output = Utils.popen_read("#{bin}/certigo --completion-script-zsh")
+    output = Utils.safe_popen_read("#{bin}/certigo --completion-script-zsh")
     (zsh_completion/"_certigo").write output
   end
 

--- a/Formula/checkstyle.rb
+++ b/Formula/checkstyle.rb
@@ -15,7 +15,7 @@ class Checkstyle < Formula
     path = testpath/"foo.java"
     path.write "public class Foo{ }\n"
 
-    output = Utils.popen_read("#{bin}/checkstyle -c /sun_checks.xml #{path}")
+    output = shell_output("#{bin}/checkstyle -c /sun_checks.xml #{path}", 2)
     errors = output.lines.select { |line| line.start_with?("[ERROR] #{path}") }
     assert_match "#{path}:1:17: '{' is not preceded with whitespace.", errors.join(" ")
     assert_equal errors.size, $CHILD_STATUS.exitstatus

--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -15,7 +15,7 @@ class Chezmoi < Formula
   depends_on "go" => :build
 
   def install
-    commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+    commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
     ldflags = %W[
       -s -w
       -X main.version=#{version}

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -22,7 +22,7 @@ class Circleci < Formula
     dir.install buildpath.children
 
     cd dir do
-      commit = Utils.popen_read("git rev-parse --short HEAD").chomp
+      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
       ldflags = %W[
         -s -w
         -X github.com/CircleCI-Public/circleci-cli/version.packageManager=homebrew

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -17,7 +17,7 @@ class ConsulTemplate < Formula
 
   def install
     project = "github.com/hashicorp/consul-template"
-    commit = Utils.popen_read("git rev-parse --short HEAD").chomp
+    commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
     ldflags = %W[
       -s -w
       -X #{project}/version.Name=consul-template

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -77,7 +77,7 @@ class Crystal < Formula
     crystal_build_opts << "FLAGS=--no-debug"
     crystal_build_opts << "CRYSTAL_CONFIG_LIBRARY_PATH="
     if build.head?
-      crystal_build_opts << "CRYSTAL_CONFIG_BUILD_COMMIT=#{Utils.popen_read("git rev-parse --short HEAD").strip}"
+      crystal_build_opts << "CRYSTAL_CONFIG_BUILD_COMMIT=#{Utils.safe_popen_read("git rev-parse --short HEAD").strip}"
     end
     (buildpath/".build").mkpath
     system "make", "deps"

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -47,9 +47,9 @@ class Deno < Formula
     end
 
     # Install bash and zsh completion
-    output = Utils.popen_read("#{bin}/deno completions bash")
+    output = Utils.safe_popen_read("#{bin}/deno completions bash")
     (bash_completion/"deno").write output
-    output = Utils.popen_read("#{bin}/deno completions zsh")
+    output = Utils.safe_popen_read("#{bin}/deno completions zsh")
     (zsh_completion/"_deno").write output
   end
 

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -20,8 +20,8 @@ class Docker < Formula
     dir = buildpath/"src/github.com/docker/cli"
     dir.install (buildpath/"components/cli").children
     cd dir do
-      commit = Utils.popen_read("git rev-parse --short HEAD").chomp
-      build_time = Utils.popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
+      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+      build_time = Utils.safe_popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
       ldflags = ["-X \"github.com/docker/cli/cli/version.BuildTime=#{build_time}\"",
                  "-X github.com/docker/cli/cli/version.GitCommit=#{commit}",
                  "-X github.com/docker/cli/cli/version.Version=#{version}",

--- a/Formula/doitlive.rb
+++ b/Formula/doitlive.rb
@@ -54,10 +54,10 @@ class Doitlive < Formula
   def install
     virtualenv_install_with_resources
 
-    output = Utils.popen_read("SHELL=bash #{libexec}/bin/doitlive completion")
+    output = Utils.safe_popen_read("SHELL=bash #{libexec}/bin/doitlive completion")
     (bash_completion/"doitlive").write output
 
-    output = Utils.popen_read("SHELL=zsh #{libexec}/bin/doitlive completion")
+    output = Utils.safe_popen_read("SHELL=zsh #{libexec}/bin/doitlive completion")
     (zsh_completion/"_doitlive").write output
   end
 

--- a/Formula/elektra.rb
+++ b/Formula/elektra.rb
@@ -33,7 +33,7 @@ class Elektra < Formula
   test do
     output = shell_output("#{bin}/kdb get system/elektra/version/infos/licence")
     assert_match "BSD", output
-    Utils.popen_read("#{bin}/kdb", "plugin-list").split.each do |plugin|
+    shell_output("#{bin}/kdb plugin-list").split.each do |plugin|
       system "#{bin}/kdb", "plugin-check", plugin
     end
   end

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -21,7 +21,7 @@ class FaasCli < Formula
     (buildpath/"src/github.com/openfaas/faas-cli").install buildpath.children
     cd "src/github.com/openfaas/faas-cli" do
       project = "github.com/openfaas/faas-cli"
-      commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-ldflags",
              "-s -w -X #{project}/version.GitCommit=#{commit} -X #{project}/version.Version=#{version}", "-a",
              "-installsuffix", "cgo", "-o", bin/"faas-cli"

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -25,8 +25,9 @@ class Gdcm < Formula
     python3 = Formula["python@3.8"].opt_bin/"python3"
     xy = Language::Python.major_minor_version python3
     python_include =
-      Utils.popen_read("#{python3} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'").chomp
-    python_executable = Utils.popen_read("#{python3} -c 'import sys;print(sys.executable)'").chomp
+      Utils.safe_popen_read("#{python3} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'")
+           .chomp
+    python_executable = Utils.safe_popen_read("#{python3} -c 'import sys;print(sys.executable)'").chomp
 
     args = std_cmake_args + %W[
       -GNinja

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -21,7 +21,7 @@ class GitlabRunner < Formula
 
     cd dir do
       proj = "gitlab.com/gitlab-org/gitlab-runner"
-      commit = Utils.popen_read("git", "rev-parse", "--short=8", "HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "--short=8", "HEAD").chomp
       branch = version.to_s.split(".")[0..1].join("-") + "-stable"
       built = Time.new.strftime("%Y-%m-%dT%H:%M:%S%:z")
       system "go", "build", "-ldflags", <<~EOS

--- a/Formula/glassfish.rb
+++ b/Formula/glassfish.rb
@@ -37,7 +37,7 @@ class Glassfish < Formula
     domaindir_arg = "--domaindir=#{domains_path}"
 
     # tell glassfish to use Java 8
-    java8_home = Utils.popen_read(Language::Java.java_home_cmd("1.8")).chomp
+    java8_home = shell_output(Language::Java.java_home_cmd("1.8")).chomp
     File.open(asenv_conf_path, "a") { |file| file.puts "AS_JAVA=\"#{java8_home}\"" }
 
     port = free_port

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -24,7 +24,7 @@ class Goofys < Formula
     ENV["GOPATH"] = gopath
 
     cd gopath/"src/github.com/kahing/goofys" do
-      commit = Utils.popen_read("git rev-parse HEAD").chomp
+      commit = Utils.safe_popen_read("git rev-parse HEAD").chomp
       system "go", "build", "-o", "goofys", "-ldflags",
              "-X main.Version=#{commit}"
       bin.install "goofys"

--- a/Formula/gopass.rb
+++ b/Formula/gopass.rb
@@ -27,7 +27,7 @@ class Gopass < Formula
       system "make", "install"
     end
 
-    output = Utils.popen_read("#{bin}/gopass completion bash")
+    output = Utils.safe_popen_read("#{bin}/gopass completion bash")
     (bash_completion/"gopass-completion").write output
   end
 

--- a/Formula/gosu.rb
+++ b/Formula/gosu.rb
@@ -19,7 +19,7 @@ class Gosu < Formula
 
   def install
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "mvn", "package"
     libexec.install Dir["gosu/target/gosu-#{version}-full/gosu-#{version}/*"]

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -24,9 +24,9 @@ class Hcloud < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.popen_read("#{bin}/hcloud completion bash")
+    output = Utils.safe_popen_read("#{bin}/hcloud completion bash")
     (bash_completion/"hcloud").write output
-    output = Utils.popen_read("#{bin}/hcloud completion zsh")
+    output = Utils.safe_popen_read("#{bin}/hcloud completion zsh")
     (zsh_completion/"_hcloud").write output
   end
 

--- a/Formula/helm.rb
+++ b/Formula/helm.rb
@@ -29,10 +29,10 @@ class Helm < Formula
       bin.install "bin/helm"
       man1.install Dir["docs/man/man1/*"]
 
-      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      output = Utils.safe_popen_read("SHELL=bash #{bin}/helm completion bash")
       (bash_completion/"helm").write output
 
-      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      output = Utils.safe_popen_read("SHELL=zsh #{bin}/helm completion zsh")
       (zsh_completion/"_helm").write output
 
       prefix.install_metafiles

--- a/Formula/helm@2.rb
+++ b/Formula/helm@2.rb
@@ -33,10 +33,10 @@ class HelmAT2 < Formula
       bin.install "bin/tiller"
       man1.install Dir["docs/man/man1/*"]
 
-      output = Utils.popen_read("SHELL=bash #{bin}/helm completion bash")
+      output = Utils.safe_popen_read("SHELL=bash #{bin}/helm completion bash")
       (bash_completion/"helm").write output
 
-      output = Utils.popen_read("SHELL=zsh #{bin}/helm completion zsh")
+      output = Utils.safe_popen_read("SHELL=zsh #{bin}/helm completion zsh")
       (zsh_completion/"_helm").write output
 
       prefix.install_metafiles

--- a/Formula/htmlcleaner.rb
+++ b/Formula/htmlcleaner.rb
@@ -16,7 +16,7 @@ class Htmlcleaner < Formula
 
   def install
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "mvn", "--log-file", "build-output.log", "clean", "package"
     libexec.install Dir["target/htmlcleaner-*.jar"]

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -20,7 +20,7 @@ class Inlets < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/inlets/inlets").install buildpath.children
     cd "src/github.com/inlets/inlets" do
-      commit = Utils.popen_read("git", "rev-parse", "HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-ldflags",
              "-s -w -X main.GitCommit=#{commit} -X main.Version=#{version}",
              "-a",

--- a/Formula/jmxtrans.rb
+++ b/Formula/jmxtrans.rb
@@ -19,7 +19,7 @@ class Jmxtrans < Formula
 
   def install
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "mvn", "package", "-DskipTests=true",
                              "-Dmaven.javadoc.skip=true",

--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -23,10 +23,10 @@ class Kamel < Formula
 
     prefix.install_metafiles
 
-    output = Utils.popen_read("#{bin}/kamel completion bash")
+    output = Utils.safe_popen_read("#{bin}/kamel completion bash")
     (bash_completion/"kamel").write output
 
-    output = Utils.popen_read("#{bin}/kamel completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kamel completion zsh")
     (zsh_completion/"_kamel").write output
   end
 

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -19,8 +19,8 @@ class Kapacitor < Formula
     ENV["GOPATH"] = buildpath
     kapacitor_path = buildpath/"src/github.com/influxdata/kapacitor"
     kapacitor_path.install Dir["*"]
-    revision = Utils.popen_read("git rev-parse HEAD").strip
-    version = Utils.popen_read("git describe --tags").strip
+    revision = Utils.safe_popen_read("git rev-parse HEAD").strip
+    version = Utils.safe_popen_read("git describe --tags").strip
 
     cd kapacitor_path do
       system "go", "install",

--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -19,11 +19,11 @@ class Kind < Formula
     prefix.install_metafiles
 
     # Install bash completion
-    output = Utils.popen_read("#{bin}/kind completion bash")
+    output = Utils.safe_popen_read("#{bin}/kind completion bash")
     (bash_completion/"kind").write output
 
     # Install zsh completion
-    output = Utils.popen_read("#{bin}/kind completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kind completion zsh")
     (zsh_completion/"_kind").write output
   end
 

--- a/Formula/kompose.rb
+++ b/Formula/kompose.rb
@@ -20,10 +20,10 @@ class Kompose < Formula
     system "make", "bin"
     bin.install "kompose"
 
-    output = Utils.popen_read("#{bin}/kompose completion bash")
+    output = Utils.safe_popen_read("#{bin}/kompose completion bash")
     (bash_completion/"kompose").write output
 
-    output = Utils.popen_read("#{bin}/kompose completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kompose completion zsh")
     (zsh_completion/"_kompose").write output
   end
 

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -24,11 +24,11 @@ class Kops < Formula
     bin.install("bin/kops")
 
     # Install bash completion
-    output = Utils.popen_read("#{bin}/kops completion bash")
+    output = Utils.safe_popen_read("#{bin}/kops completion bash")
     (bash_completion/"kops").write output
 
     # Install zsh completion
-    output = Utils.popen_read("#{bin}/kops completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kops completion zsh")
     (zsh_completion/"_kops").write output
   end
 

--- a/Formula/krew.rb
+++ b/Formula/krew.rb
@@ -17,7 +17,7 @@ class Krew < Formula
   depends_on "kubernetes-cli"
 
   def install
-    commit = Utils.popen_read("git", "rev-parse", "--short=8", "HEAD").chomp
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short=8", "HEAD").chomp
     ENV["CGO_ENABLED"] = "0"
     # build in local dir to avoid this error:
     # go build: cannot write multiple packages to non-directory /usr/local/Cellar/krew/0.3.2/bin/krew

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -23,9 +23,9 @@ class Kubecfg < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.popen_read("#{bin}/kubecfg completion --shell bash")
+    output = Utils.safe_popen_read("#{bin}/kubecfg completion --shell bash")
     (bash_completion/"kubecfg").write output
-    output = Utils.popen_read("#{bin}/kubecfg completion --shell zsh")
+    output = Utils.safe_popen_read("#{bin}/kubecfg completion --shell zsh")
     (zsh_completion/"_kubecfg").write output
   end
 

--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -30,11 +30,11 @@ class KubernetesCli < Formula
       bin.install "_output/local/bin/darwin/amd64/kubectl"
 
       # Install bash completion
-      output = Utils.popen_read("#{bin}/kubectl completion bash")
+      output = Utils.safe_popen_read("#{bin}/kubectl completion bash")
       (bash_completion/"kubectl").write output
 
       # Install zsh completion
-      output = Utils.popen_read("#{bin}/kubectl completion zsh")
+      output = Utils.safe_popen_read("#{bin}/kubectl completion zsh")
       (zsh_completion/"_kubectl").write output
 
       prefix.install_metafiles

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -16,7 +16,7 @@ class Kustomize < Formula
   depends_on "go" => :build
 
   def install
-    revision = Utils.popen_read("git", "rev-parse", "HEAD").strip
+    revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").strip
 
     cd "kustomize" do
       ldflags = %W[

--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -30,7 +30,7 @@ class Libbluray < Formula
   def install
     # Need to set JAVA_HOME manually since ant overrides 1.8 with 1.8+
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
     ENV.append_to_cflags "-D_DARWIN_C_SOURCE"

--- a/Formula/linkerd.rb
+++ b/Formula/linkerd.rb
@@ -22,11 +22,11 @@ class Linkerd < Formula
     bin.install "target/cli/darwin/linkerd"
 
     # Install bash completion
-    output = Utils.popen_read("#{bin}/linkerd completion bash")
+    output = Utils.safe_popen_read("#{bin}/linkerd completion bash")
     (bash_completion/"linkerd").write output
 
     # Install zsh completion
-    output = Utils.popen_read("#{bin}/linkerd completion zsh")
+    output = Utils.safe_popen_read("#{bin}/linkerd completion zsh")
     (zsh_completion/"linkerd").write output
 
     prefix.install_metafiles

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -65,7 +65,7 @@ class Macvim < Formula
     assert_match "+ruby", output
 
     # Simple test to check if MacVim was linked to Homebrew's Python 3
-    py3_exec_prefix = Utils.popen_read(Formula["python@3.8"].opt_bin/"python3-config", "--exec-prefix")
+    py3_exec_prefix = shell_output(Formula["python@3.8"].opt_bin/"python3-config --exec-prefix")
     assert_match py3_exec_prefix.chomp, output
     (testpath/"commands.vim").write <<~EOS
       :python3 import vim; vim.current.buffer[0] = 'hello python3'

--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -21,10 +21,10 @@ class Minikube < Formula
     system "make"
     bin.install "out/minikube"
 
-    output = Utils.popen_read("#{bin}/minikube completion bash")
+    output = Utils.safe_popen_read("#{bin}/minikube completion bash")
     (bash_completion/"minikube").write output
 
-    output = Utils.popen_read("#{bin}/minikube completion zsh")
+    output = Utils.safe_popen_read("#{bin}/minikube completion zsh")
     (zsh_completion/"_minikube").write output
   end
 

--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -18,16 +18,16 @@ class Mmctl < Formula
   def install
     ENV["GOBIN"] = buildpath/bin
     ENV["ADVANCED_VET"] = "FALSE"
-    ENV["BUILD_HASH"] = Utils.popen_read("git rev-parse HEAD").chomp
+    ENV["BUILD_HASH"] = Utils.safe_popen_read("git rev-parse HEAD").chomp
     ENV["BUILD_VERSION"] = version.to_s
     (buildpath/"src/github.com/mattermost/mmctl").install buildpath.children
     cd "src/github.com/mattermost/mmctl" do
       system "make", "install"
 
       # Install the zsh and bash completions
-      output = Utils.popen_read("#{bin}/mmctl completion bash")
+      output = Utils.safe_popen_read("#{bin}/mmctl completion bash")
       (bash_completion/"mmctl").write output
-      output = Utils.popen_read("#{bin}/mmctl completion zsh")
+      output = Utils.safe_popen_read("#{bin}/mmctl completion zsh")
       (zsh_completion/"_mmctl").write output
     end
   end

--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -31,11 +31,11 @@ class Nagios < Formula
   end
 
   def user
-    Utils.popen_read("id -un").chomp
+    Utils.safe_popen_read("id -un").chomp
   end
 
   def group
-    Utils.popen_read("id -gn").chomp
+    Utils.safe_popen_read("id -gn").chomp
   end
 
   def install

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -68,7 +68,7 @@ class Neovim < Formula
       ].each do |rock|
         dir, rock = rock.split("/")
         cd "build/src/#{dir}" do
-          output = Utils.popen_read("luarocks", "unpack", lua_path, rock, "--tree=#{buildpath}/deps-build")
+          output = Utils.safe_popen_read("luarocks", "unpack", lua_path, rock, "--tree=#{buildpath}/deps-build")
           unpack_dir = output.split("\n")[-2]
           cd unpack_dir do
             system "luarocks", "make", lua_path, "--tree=#{buildpath}/deps-build"

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -64,7 +64,7 @@ class Netpbm < Formula
   end
 
   test do
-    fwrite = Utils.popen_read("#{bin}/pngtopam #{test_fixtures("test.png")} -alphapam")
+    fwrite = shell_output("#{bin}/pngtopam #{test_fixtures("test.png")} -alphapam")
     (testpath/"test.pam").write fwrite
     system "#{bin}/pamdice", "test.pam", "-outstem", testpath/"testing"
     assert_predicate testpath/"testing_0_0.", :exist?

--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -19,9 +19,9 @@ class NewrelicCli < Formula
     system "make", "compile-only"
     bin.install "bin/darwin/newrelic"
 
-    output = Utils.popen_read("#{bin}/newrelic completion --shell bash")
+    output = Utils.safe_popen_read("#{bin}/newrelic completion --shell bash")
     (bash_completion/"newrelic").write output
-    output = Utils.popen_read("#{bin}/newrelic completion --shell zsh")
+    output = Utils.safe_popen_read("#{bin}/newrelic completion --shell zsh")
     (zsh_completion/"_newrelic").write output
   end
 

--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -32,8 +32,8 @@ class Octant < Formula
       system "go", "generate", "./pkg/icon"
       system "go", "run", "build.go", "web-build"
 
-      commit = Utils.popen_read("git rev-parse HEAD").chomp
-      build_time = Utils.popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
+      commit = Utils.safe_popen_read("git rev-parse HEAD").chomp
+      build_time = Utils.safe_popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
       ldflags = ["-X \"main.version=#{version}\"",
                  "-X \"main.gitCommit=#{commit}\"",
                  "-X \"main.buildTime=#{build_time}\""]

--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -29,11 +29,11 @@ class OperatorSdk < Formula
       bin.install buildpath/"bin/operator-sdk"
 
       # Install bash completion
-      output = Utils.popen_read("#{bin}/operator-sdk completion bash")
+      output = Utils.safe_popen_read("#{bin}/operator-sdk completion bash")
       (bash_completion/"operator-sdk").write output
 
       # Install zsh completion
-      output = Utils.popen_read("#{bin}/operator-sdk completion zsh")
+      output = Utils.safe_popen_read("#{bin}/operator-sdk completion zsh")
       (zsh_completion/"_operator-sdk").write output
 
       prefix.install_metafiles

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -185,7 +185,7 @@ class Php < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -237,7 +237,7 @@ class Php < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -179,7 +179,7 @@ class PhpAT72 < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -231,7 +231,7 @@ class PhpAT72 < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -179,7 +179,7 @@ class PhpAT73 < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -236,7 +236,7 @@ class PhpAT73 < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -21,8 +21,8 @@ class Pjproject < Formula
     system "make"
     system "make", "install"
 
-    arch = Utils.popen_read("uname -m").chomp
-    rel = Utils.popen_read("uname -r").chomp
+    arch = Utils.safe_popen_read("uname -m").chomp
+    rel = Utils.safe_popen_read("uname -r").chomp
     bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{rel}" => "pjsua"
   end
 

--- a/Formula/qhull.rb
+++ b/Formula/qhull.rb
@@ -27,7 +27,7 @@ class Qhull < Formula
   end
 
   test do
-    input = Utils.popen_read(bin/"rbox", "c", "D2")
+    input = shell_output(bin/"rbox c D2")
     output = pipe_output("#{bin}/qconvex s n 2>&1", input, 0)
     assert_match "Number of facets: 4", output
   end

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -50,7 +50,7 @@ class Rabbitmq < Formula
 
     sbin.install "rabbitmqadmin"
     (sbin/"rabbitmqadmin").chmod 0755
-    (bash_completion/"rabbitmqadmin.bash").write Utils.popen_read("#{sbin}/rabbitmqadmin --bash-completion")
+    (bash_completion/"rabbitmqadmin.bash").write Utils.safe_popen_read("#{sbin}/rabbitmqadmin --bash-completion")
   end
 
   def caveats

--- a/Formula/rack.rb
+++ b/Formula/rack.rb
@@ -31,7 +31,7 @@ class Rack < Formula
       # deciding whether to add a = or not on the ldflags, as mandated
       # by Go 1.7+.
       # https://github.com/rackspace/rack/issues/446
-      inreplace "script/build", "go1.5", Utils.popen_read("go version")[/go1\.\d/]
+      inreplace "script/build", "go1.5", Utils.safe_popen_read("go version")[/go1\.\d/]
 
       ln_s "internal", "vendor"
       system "script/build", "rack"

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -34,7 +34,7 @@ class Ruby < Formula
   end
 
   def api_version
-    Utils.popen_read("#{bin}/ruby -e 'print Gem.ruby_api_version'")
+    Utils.safe_popen_read("#{bin}/ruby -e 'print Gem.ruby_api_version'")
   end
 
   def rubygems_bindir

--- a/Formula/s-nail.rb
+++ b/Formula/s-nail.rb
@@ -28,8 +28,8 @@ class SNail < Formula
   test do
     ENV["SOURCE_DATE_EPOCH"] = "844221007"
 
-    date1 = Utils.popen_read("date", "-r", "844221007", "+%a %b %e %T %Y")
-    date2 = Utils.popen_read("date", "-r", "844221007", "+%a, %d %b %Y %T %z")
+    date1 = shell_output("date -r 844221007 '+%a %b %e %T %Y'")
+    date2 = shell_output("date -r 844221007 '+%a, %d %b %Y %T %z'")
 
     expected = <<~EOS
       From reproducible_build #{date1.chomp}

--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -23,10 +23,10 @@ class Skaffold < Formula
       system "make"
       bin.install "out/skaffold"
 
-      output = Utils.popen_read("#{bin}/skaffold completion bash")
+      output = Utils.safe_popen_read("#{bin}/skaffold completion bash")
       (bash_completion/"skaffold").write output
 
-      output = Utils.popen_read("#{bin}/skaffold completion zsh")
+      output = Utils.safe_popen_read("#{bin}/skaffold completion zsh")
       (zsh_completion/"_skaffold").write output
 
       prefix.install_metafiles

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -134,7 +134,7 @@ class Subversion < Formula
     system "make", "javahl"
     system "make", "install-javahl"
 
-    archlib = Utils.popen_read("perl -MConfig -e 'print $Config{archlib}'")
+    archlib = Utils.safe_popen_read("perl -MConfig -e 'print $Config{archlib}'")
     perl_core = Pathname.new(archlib)/"CORE"
     onoe "'#{perl_core}' does not exist" unless perl_core.exist?
 

--- a/Formula/swagger-codegen.rb
+++ b/Formula/swagger-codegen.rb
@@ -18,7 +18,7 @@ class SwaggerCodegen < Formula
   def install
     # Need to set JAVA_HOME manually since maven overrides 1.8 with 1.7+
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "mvn", "clean", "package"
     libexec.install "modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"

--- a/Formula/swagger-codegen@2.rb
+++ b/Formula/swagger-codegen@2.rb
@@ -19,7 +19,7 @@ class SwaggerCodegenAT2 < Formula
   def install
     # Need to set JAVA_HOME manually since maven overrides 1.8 with 1.7+
     cmd = Language::Java.java_home_cmd("1.8")
-    ENV["JAVA_HOME"] = Utils.popen_read(cmd).chomp
+    ENV["JAVA_HOME"] = Utils.safe_popen_read(cmd).chomp
 
     system "mvn", "clean", "package"
     libexec.install "modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"

--- a/Formula/tektoncd-cli.rb
+++ b/Formula/tektoncd-cli.rb
@@ -17,9 +17,9 @@ class TektoncdCli < Formula
     system "make", "bin/tkn"
 
     bin.install "bin/tkn" => "tkn"
-    output = Utils.popen_read("SHELL=bash #{bin}/tkn completion bash")
+    output = Utils.safe_popen_read("SHELL=bash #{bin}/tkn completion bash")
     (bash_completion/"tkn").write output
-    output = Utils.popen_read("SHELL=zsh #{bin}/tkn completion zsh")
+    output = Utils.safe_popen_read("SHELL=zsh #{bin}/tkn completion zsh")
     (zsh_completion/"_tkn").write output
     prefix.install_metafiles
   end

--- a/Formula/tile38.rb
+++ b/Formula/tile38.rb
@@ -19,7 +19,7 @@ class Tile38 < Formula
   end
 
   def install
-    commit = Utils.popen_read("git rev-parse --short HEAD").chomp
+    commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
 
     ldflags = %W[
       -s -w

--- a/Formula/vegeta.rb
+++ b/Formula/vegeta.rb
@@ -14,7 +14,7 @@ class Vegeta < Formula
   depends_on "go" => :build
 
   def install
-    build_time = Utils.popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
+    build_time = Utils.safe_popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
 
     ldflags = %W[
       -s -w

--- a/Formula/velero.rb
+++ b/Formula/velero.rb
@@ -25,11 +25,11 @@ class Velero < Formula
                    "./cmd/velero"
 
       # Install bash completion
-      output = Utils.popen_read("#{bin}/velero completion bash")
+      output = Utils.safe_popen_read("#{bin}/velero completion bash")
       (bash_completion/"velero").write output
 
       # Install zsh completion
-      output = Utils.popen_read("#{bin}/velero completion zsh")
+      output = Utils.safe_popen_read("#{bin}/velero completion zsh")
       (zsh_completion/"_velero").write output
 
       prefix.install_metafiles

--- a/Formula/virustotal-cli.rb
+++ b/Formula/virustotal-cli.rb
@@ -27,10 +27,10 @@ class VirustotalCli < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.popen_read("#{bin}/vt completion bash")
+    output = Utils.safe_popen_read("#{bin}/vt completion bash")
     (bash_completion/"vt").write output
 
-    output = Utils.popen_read("#{bin}/vt completion zsh")
+    output = Utils.safe_popen_read("#{bin}/vt completion zsh")
     (zsh_completion/"_vt").write output
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Homebrew/brew/pull/7695.

This PR updates formulae to follow to the new RuboCop check for using `Utils.safe_popen_read` instead of `Utils.popen_read`

I put everything in one commit because it was easy to just run `brew style --fix` on the Formula directory.

There are no revision bumps right now but I can add those if desired