### PR TITLE
livecheck: modify Formula urls

### DIFF
--- a/Formula/flawfinder.rb
+++ b/Formula/flawfinder.rb
@@ -3,7 +3,7 @@ class Flawfinder < Formula
   homepage "https://www.dwheeler.com/flawfinder/"
   url "https://www.dwheeler.com/flawfinder/flawfinder-2.0.11.tar.gz"
   sha256 "9b4929fca5c6703880d95f201e470b7f19262ff63e991b3ac4ea3257f712f5ec"
-  head "https://git.code.sf.net/p/flawfinder/code.git"
+  head "https://github.com/david-a-wheeler/flawfinder.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/ivykis.rb
+++ b/Formula/ivykis.rb
@@ -1,6 +1,6 @@
 class Ivykis < Formula
   desc "Async I/O-assisting library"
-  homepage "https://sourceforge.net/projects/libivykis"
+  homepage "https://sourceforge.net/projects/libivykis/"
   url "https://github.com/buytenh/ivykis/archive/v0.42.4-trunk.tar.gz"
   sha256 "b724516d6734f4d5c5f86ad80bde8fc7213c5a70ce2d46b9a2d86e8d150402b5"
 

--- a/Formula/mdds.rb
+++ b/Formula/mdds.rb
@@ -3,6 +3,7 @@ class Mdds < Formula
   homepage "https://gitlab.com/mdds/mdds"
   url "https://kohei.us/files/mdds/src/mdds-1.6.0.tar.bz2"
   sha256 "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d"
+  head "https://gitlab.com/mdds/mdds.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -3,7 +3,7 @@ class Pass < Formula
   homepage "https://www.passwordstore.org/"
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.3.tar.xz"
   sha256 "2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4"
-  head "https://git.zx2c4.com/password-store", :using => :git
+  head "https://git.zx2c4.com/password-store.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Changes required by `livecheck`'s Formula URL reference feature.

Changes:
* `ivykis`: Appending a `/` to the `homepage` url for `livecheck` to use it
* `flawfinder`: It seems like the repository is now at https://github.com/david-a-wheeler/flawfinder.git and not the previous `head` URL, which doesn't show anything (for me at least).
* `mdds`: Adding a `.git` suffix to the `homepage` URL as `livecheck` requires it
* `pass`: Adding a `.git` suffix to the `head` URL as `livecheck` requires it