### PR TITLE
qt: Add a patch to Qt3d to build on Linux

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -7,6 +7,7 @@ class Qt < Formula
   mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.0/single/qt-everywhere-src-5.15.0.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.0/single/qt-everywhere-src-5.15.0.tar.xz"
   sha256 "22b63d7a7a45183865cc4141124f12b673e7a17b1fe2b91e433f6547c5d548c3"
+  revision 1
 
   head "https://code.qt.io/qt/qt5.git", :branch => "dev", :shallow => false
 
@@ -26,6 +27,10 @@ class Qt < Formula
   uses_from_macos "bison"
   uses_from_macos "flex"
   uses_from_macos "sqlite"
+
+  # Fix build on Linux when the build system has AVX2
+  # Patch submitted at https://bugreports.qt.io/browse/QTBUG-84851
+  patch :DATA
 
   def install
     args = %W[
@@ -111,3 +116,45 @@ class Qt < Formula
     system "./hello"
   end
 end
+
+__END__
+--- a/qt3d/src/core/transforms/vector3d_sse.cpp	2020-03-03 14:10:30.000000000 +0100
++++ b/qt3d/src/core/transforms/vector3d_sse.cpp	2020-06-09 11:12:36.660465360 +0200
+@@ -39,7 +39,7 @@
+
+ #include <private/qsimd_p.h>
+
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+ #include "matrix4x4_avx2_p.h"
+ #else
+ #include "matrix4x4_sse_p.h"
+@@ -66,7 +66,7 @@
+     m_xyzw = _mm_mul_ps(v.m_xyzw, _mm_set_ps(0.0f, 1.0f, 1.0f, 1.0f));
+ }
+
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+
+ Vector3D_SSE Vector3D_SSE::unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const
+ {
+--- a/qt3d/src/core/transforms/vector3d_sse_p.h	2020-03-03 14:10:30.000000000 +0100
++++ b/qt3d/src/core/transforms/vector3d_sse_p.h	2020-06-09 11:12:30.405425659 +0200
+@@ -178,7 +178,7 @@
+         return ((_mm_movemask_ps(_mm_cmpeq_ps(m_xyzw, _mm_set_ps1(0.0f))) & 0x7) == 0x7);
+     }
+
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
+     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE project(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
+ #else
+@@ -348,7 +348,7 @@
+
+     friend class Vector4D_SSE;
+
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+     friend class Matrix4x4_AVX2;
+     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Vector3D_SSE &vector, const Matrix4x4_AVX2 &matrix);
+     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Matrix4x4_AVX2 &matrix, const Vector3D_SSE &vector);

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -7,7 +7,6 @@ class Qt < Formula
   mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.0/single/qt-everywhere-src-5.15.0.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.0/single/qt-everywhere-src-5.15.0.tar.xz"
   sha256 "22b63d7a7a45183865cc4141124f12b673e7a17b1fe2b91e433f6547c5d548c3"
-  revision 1
 
   head "https://code.qt.io/qt/qt5.git", :branch => "dev", :shallow => false
 

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -28,8 +28,12 @@ class Qt < Formula
   uses_from_macos "sqlite"
 
   # Fix build on Linux when the build system has AVX2
-  # Patch submitted at https://bugreports.qt.io/browse/QTBUG-84851
-  patch :DATA
+  # Patch submitted at https://codereview.qt-project.org/c/qt/qt3d/+/303993
+  patch do
+    url "https://codereview.qt-project.org/gitweb?p=qt/qt3d.git;a=patch;h=b456a7d47a36dc3429a5e7bac7665b12d257efea"
+    sha256 "e47071f5feb6f24958b3670d83071502fe87243456b29fdc731c6eba677d9a59"
+    directory "qt3d"
+  end
 
   def install
     args = %W[
@@ -115,45 +119,3 @@ class Qt < Formula
     system "./hello"
   end
 end
-
-__END__
---- a/qt3d/src/core/transforms/vector3d_sse.cpp	2020-03-03 14:10:30.000000000 +0100
-+++ b/qt3d/src/core/transforms/vector3d_sse.cpp	2020-06-09 11:12:36.660465360 +0200
-@@ -39,7 +39,7 @@
-
- #include <private/qsimd_p.h>
-
--#ifdef __AVX2__
-+#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
- #include "matrix4x4_avx2_p.h"
- #else
- #include "matrix4x4_sse_p.h"
-@@ -66,7 +66,7 @@
-     m_xyzw = _mm_mul_ps(v.m_xyzw, _mm_set_ps(0.0f, 1.0f, 1.0f, 1.0f));
- }
-
--#ifdef __AVX2__
-+#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
-
- Vector3D_SSE Vector3D_SSE::unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const
- {
---- a/qt3d/src/core/transforms/vector3d_sse_p.h	2020-03-03 14:10:30.000000000 +0100
-+++ b/qt3d/src/core/transforms/vector3d_sse_p.h	2020-06-09 11:12:30.405425659 +0200
-@@ -178,7 +178,7 @@
-         return ((_mm_movemask_ps(_mm_cmpeq_ps(m_xyzw, _mm_set_ps1(0.0f))) & 0x7) == 0x7);
-     }
-
--#ifdef __AVX2__
-+#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
-     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
-     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE project(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
- #else
-@@ -348,7 +348,7 @@
-
-     friend class Vector4D_SSE;
-
--#ifdef __AVX2__
-+#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
-     friend class Matrix4x4_AVX2;
-     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Vector3D_SSE &vector, const Matrix4x4_AVX2 &matrix);
-     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Matrix4x4_AVX2 &matrix, const Vector3D_SSE &vector);


### PR DESCRIPTION
That fixes a build error on Linux when the build system has AVX2.

Reported upstream: https://bugreports.qt.io/browse/QTBUG-84851

This fixes the build error reported in https://github.com/Homebrew/linuxbrew-core/issues/20487.

-----
Here is the checklist for PRs:
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


