### PR TITLE
mdds: fix building from head

### DIFF
--- a/Formula/mdds.rb
+++ b/Formula/mdds.rb
@@ -3,7 +3,6 @@ class Mdds < Formula
   homepage "https://gitlab.com/mdds/mdds"
   url "https://kohei.us/files/mdds/src/mdds-1.6.0.tar.bz2"
   sha256 "f1585c9cbd12f83a6d43d395ac1ab6a9d9d5d77f062c7b5f704e24ed72dae07d"
-  head "https://gitlab.com/mdds/mdds.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,15 +12,32 @@ class Mdds < Formula
     sha256 "3a34d290152006eb29ab3995754f57de22dddd7c8d95c95c98af206324a12041" => :high_sierra
   end
 
+  head do
+    url "https://gitlab.com/mdds/mdds.git"
+
+    depends_on "automake" => :build
+  end
+
   depends_on "autoconf" => :build
   depends_on "boost"
 
   def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-openmp
+    ]
+
     # Gets it to work when the CLT is installed
     inreplace "configure.ac", "$CPPFLAGS -I/usr/include -I/usr/local/include",
                               "$CPPFLAGS -I/usr/local/include"
-    system "autoconf"
-    system "./configure", "--prefix=#{prefix}", "--disable-openmp"
+
+    if build.head?
+      system "./autogen.sh", *args
+    else
+      system "autoconf"
+      system "./configure", *args
+    end
+
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A `head` URL was added to the `mdds` formula in #55950 but unfortunately no one checked to make sure that `brew install --HEAD mdds` actually worked before merging. Building from head current produces the following error:

```
autoconf

configure.ac:2: error: possibly undefined macro: AM_INIT_AUTOMAKE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:3: error: possibly undefined macro: AM_MAINTAINER_MODE
configure.ac:103: error: possibly undefined macro: AM_CONDITIONAL
```

This modifies the install steps to use `autogen.sh` when building from head and to `automake` as a `head` build dependency (as we get an `error: aclocal not found` error when executing `autogen.sh` otherwise).

This works and I've tried to minimize the changes but let me know if there's anything about this that can be improved.