### PR TITLE
lastpass-cli: Improve test and appease audit

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -29,7 +29,7 @@ class LastpassCli < Formula
 
     mkdir "build" do
       system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_MANDIR:PATH=#{man}"
-      system "make", "all", "lpass-test", "test", "install", "install-doc"
+      system "make", "install", "install-doc"
     end
 
     bash_completion.install "contrib/lpass_bash_completion"

--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -38,6 +38,7 @@ class LastpassCli < Formula
   end
 
   test do
-    system "#{bin}/lpass", "--version"
+    assert_equal("Error: Could not find decryption key. Perhaps you need to login with `#{bin}/lpass login`.",
+      shell_output("#{bin}/lpass passwd 2>&1", 1).chomp)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This tests that it's actually looking for a decryption key to retrieve a password, ie that the login mechanism works.
- While we're here, also appease `brew audit` by removing `make test`. Additionally, the `all` build command seemed redundant given this, and the `lpass-test` build command [doesn't exist any more](https://github.com/lastpass/lastpass-cli/blob/master/Makefile).