### PR TITLE
kamel formula v1.0.0

### DIFF
--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -3,16 +3,9 @@ class Kamel < Formula
   homepage "https://camel.apache.org/"
 
   url "https://github.com/apache/camel-k.git",
-    :tag      => "0.3.4",
-    :revision => "c47fb2c85e89852f0fd111d1662f57917030ced5"
+    :tag      => "1.0.0",
+    :revision => "38c24698b16da41926be5f7984115d428a825a02"
   head "https://github.com/apache/camel-k.git"
-
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "1bca7ed6593fd50b219353b033b76195881576d5edce8154241edb3d249f665e" => :catalina
-    sha256 "349b58bd34eeb004baca62ee0e56746cb1256979c83f87aceb62882003b902a3" => :mojave
-    sha256 "7dc0dd18e8b3fa8ebaf322db37369929909510c65e8b5472a4624ee822771698" => :high_sierra
-  end
 
   depends_on "go" => :build
   depends_on "openjdk" => :build
@@ -35,27 +28,27 @@ class Kamel < Formula
     assert_match "Apache Camel K is a lightweight", run_output
 
     help_output = shell_output("echo $(#{bin}/kamel help 2>&1)")
-    assert_match "Error: cannot get current namespace", help_output.chomp
-
-    context_output = shell_output("#{bin}/kamel context 2>&1")
-    assert_match "Configure an Integration Context", context_output
+    assert_match "Error: cannot get command client: could not locate a kubeconfig", help_output.chomp
 
     get_output = shell_output("echo $(#{bin}/kamel get 2>&1)")
-    assert_match "Error: cannot get current namespace", get_output
+    assert_match "Error: cannot get command client: could not locate a kubeconfig", get_output
 
     version_output = shell_output("echo $(#{bin}/kamel version 2>&1)")
-    assert_match "Error: cannot get current namespace", version_output
-
-    version_config_output = shell_output("echo $(#{bin}/kamel version --config=\"/\"2>&1)")
-    assert_match "Error: cannot get current namespace", version_config_output
+    assert_match "1.0.0", version_output
 
     run_output = shell_output("echo $(#{bin}/kamel run 2>&1)")
-    assert_match "Error: accepts at least 1 arg, received 0", run_output
+    assert_match "Error: run expects at least 1 argument, received 0", run_output
 
     run_none_output = shell_output("echo $(#{bin}/kamel run None.java 2>&1)")
-    assert_match "Error: file None.java does not exist", run_none_output
+    assert_match "Error: cannot read file None.java: open None.java: no such file or directory", run_none_output
 
     reset_output = shell_output("echo $(#{bin}/kamel reset 2>&1)")
-    assert_match "Error: cannot get current namespace", reset_output
+    assert_match "Error: cannot get command client: could not locate a kubeconfig", reset_output
+
+    rebuild_output = shell_output("echo $(#{bin}/kamel rebuild 2>&1)")
+    assert_match "Config not found", rebuild_output
+
+    reset_output = shell_output("echo $(#{bin}/kamel reset 2>&1)")
+    assert_match "Config not found", reset_output
   end
 end


### PR DESCRIPTION
Upgrade kamel formula to v1.0.0 as releases of today

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Below you can find the logs for _build from source_  and _audit_ runs.

* brew --build-from-source**
```
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
cake

==> Cloning https://github.com/apache/camel-k.git
Updating /Users/ipolyzos/Library/Caches/Homebrew/kamel--git
==> Checking out tag 1.0.0
HEAD is now at 38c2469 Release 1.0.0
==> make
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/kamel/1.0.0: 8 files, 53.5MB, built in 2 minutes 43 seconds
```
**brew audit**
```
Fetching gem metadata from https://rubygems.org/.........
Using concurrent-ruby 1.1.6
Using minitest 5.14.1
Using thread_safe 0.3.6
Using zeitwerk 2.3.0
Using ast 2.4.0
Using bundler 1.17.2
Using byebug 11.1.3
Using json 2.3.0
Using docile 1.3.2
Using simplecov-html 0.10.2
Using sync 0.5.0
Using thor 1.0.1
Using diff-lcs 1.3
Using unf_ext 0.0.7.7
Using hpricot 0.8.6
Using mime-types-data 3.2020.0512
Using net-http-digest_auth 1.4.1
Using mini_portile2 2.4.0
Using ntlm-http 0.1.1
Using webrobots 0.1.2
Using mustache 1.1.1
Using parallel 1.19.1
Using plist 3.5.0
Using rainbow 3.0.0
Using rdiscount 2.2.0.1
Using rexml 3.2.4
Using rspec-support 3.9.3
Using ruby-progressbar 1.10.1
Using unicode-display_width 1.7.0
Using ruby-macho 2.2.0
Fetching connection_pool 2.2.3
Fetching regexp_parser 1.7.1
Fetching i18n 1.8.3
Installing connection_pool 2.2.3
Installing i18n 1.8.3
Installing regexp_parser 1.7.1
Using tzinfo 1.2.7
Using simplecov 0.16.1
Using tins 1.25.0
Using unf 0.1.4
Using mime-types 3.3.1
Using nokogiri 1.10.9
Using parallel_tests 2.32.0
Using parser 2.7.1.3
Using ronn 0.7.3
Using rspec-core 3.9.2
Using rspec-expectations 3.9.2
Using rspec-mocks 3.9.1
Using net-http-persistent 4.0.0
Using term-ansicolor 1.7.1
Using domain_name 0.5.20190701
Using coveralls 0.8.23
Using http-cookie 1.0.3
Using rspec 3.9.0
Using rspec-its 1.3.0
Using rspec-retry 0.6.2
Using rubocop-ast 0.0.3
Using mechanize 2.7.6
Using rspec-wait 0.0.9
Using activesupport 6.0.3.1
Fetching rubocop 0.85.1
Installing rubocop 0.85.1
Using rubocop-rspec 1.39.0
Fetching rubocop-performance 1.6.1
Installing rubocop-performance 1.6.1
Bundle complete! 17 Gemfile dependencies, 60 gems now installed.
Bundled gems are installed into `../../../../usr/local/Homebrew/Library/Homebrew/vendor/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Removing rubocop-performance (1.6.0)
Removing i18n (1.8.2)
Removing rubocop (0.84.0)
Removing connection_pool (2.2.2)
```
**brew test**
```
Testing kamel
==> /usr/local/Cellar/kamel/1.0.0/bin/kamel 2>&1
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel help 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel get 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel version 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel run 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel run None.java 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.0.0/bin/kamel reset 2>&1)
```
