### PR TITLE
clinfo: add head

### DIFF
--- a/Formula/clinfo.rb
+++ b/Formula/clinfo.rb
@@ -3,6 +3,7 @@ class Clinfo < Formula
   homepage "https://github.com/Oblomov/clinfo"
   url "https://github.com/Oblomov/clinfo/archive/2.2.18.04.06.tar.gz"
   sha256 "f77021a57b3afcdebc73107e2254b95780026a9df9aa4f8db6aff11c03f0ec6c"
+  head "https://github.com/Oblomov/clinfo.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This simply adds the upstream GitHub repo as the `head` URL. I've tested this locally and it builds and tests fine with `brew install --HEAD clinfo` without any modifications.