### PR TITLE
git-filter-repo: remove deprecated rewrite_python_shebang

### DIFF
--- a/Formula/git-filter-repo.rb
+++ b/Formula/git-filter-repo.rb
@@ -1,4 +1,6 @@
 class GitFilterRepo < Formula
+  include Language::Python::Shebang
+
   desc "Quickly rewrite git repository history"
   homepage "https://github.com/newren/git-filter-repo"
   url "https://github.com/newren/git-filter-repo/releases/download/v2.27.0/git-filter-repo-2.27.0.tar.xz"
@@ -14,7 +16,7 @@ class GitFilterRepo < Formula
   depends_on "python@3.8"
 
   def install
-    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
+    rewrite_shebang detected_python_shebang, "git-filter-repo"
     bin.install "git-filter-repo"
     man1.install "Documentation/man1/git-filter-repo.1"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#55255 - `Python.rewrite_python_shebang` is deprecated, using `Python::Sheban.rewrite_shebang` instead.