### PR TITLE
coinutils: add head

### DIFF
--- a/Formula/coinutils.rb
+++ b/Formula/coinutils.rb
@@ -3,6 +3,7 @@ class Coinutils < Formula
   homepage "https://github.com/coin-or/CoinUtils"
   url "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
   sha256 "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81"
+  head "https://github.com/coin-or/CoinUtils.git"
   revision 1
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the GitHub repo as the `head` URL. This builds fine without any modifications but it's worth noting that the test currently won't work with a `head` build because the include directory is now named `coin-or` instead of `coin`.

It's possible to update the test to work around this in the interim time but I thought it would be better to just wait until the next `coinutils` release, when it will seemingly be necessary to update the test to use the `coin-or` folder name.