### PR TITLE
auditbeat 7.7.1

### DIFF
--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -2,8 +2,8 @@ class Auditbeat < Formula
   desc "Lightweight Shipper for Audit Data"
   homepage "https://www.elastic.co/products/beats/auditbeat"
   url "https://github.com/elastic/beats.git",
-      :tag      => "v6.8.7",
-      :revision => "c3db7425739e1c0d1eeefe77f4c0b735a90a3254"
+      :tag      => "v7.7.1",
+      :revision => "932b273e8940575e15f10390882be205bad29e1f"
   head "https://github.com/elastic/beats.git"
 
   bottle do
@@ -14,19 +14,11 @@ class Auditbeat < Formula
   end
 
   depends_on "go" => :build
-  depends_on :macos # Due to Python 2
+  depends_on "python@3.8" => :build
 
-  # Newer virtualenvs are not compatible with Python 2.7.10 on high sierra, use an old version
   resource "virtualenv" do
     url "https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz"
     sha256 "02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a"
-  end
-
-  # Patch required to build against go 1.11 (Can be removed with v7.0.0)
-  # partially backport of https://github.com/elastic/beats/commit/8d8eaf34a6cb5f3b4565bf40ca0dc9681efea93c
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a0f8cdc0/auditbeat/go1.11.diff"
-    sha256 "8a00cb0265b6e2de3bc76f14f2ee4f1a5355dad490f3db9288d968b3e95ae0eb"
   end
 
   def install
@@ -36,10 +28,11 @@ class Auditbeat < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/elastic/beats").install buildpath.children
 
-    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python2.7/site-packages"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
 
     resource("virtualenv").stage do
-      system "python", *Language::Python.setup_install_args(buildpath/"vendor")
+      system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(buildpath/"vendor")
     end
 
     ENV.prepend_path "PATH", buildpath/"vendor/bin" # for virtualenv
@@ -48,8 +41,8 @@ class Auditbeat < Formula
     cd "src/github.com/elastic/beats/auditbeat" do
       # don't build docs because it would fail creating the combined OSS/x-pack
       # docs and we aren't installing them anyway
-      inreplace "magefile.go", "mage.GenerateModuleIncludeListGo, Docs)",
-                               "mage.GenerateModuleIncludeListGo)"
+      inreplace "magefile.go", "devtools.GenerateModuleIncludeListGo, Docs)",
+                               "devtools.GenerateModuleIncludeListGo)"
 
       system "make", "mage"
       # prevent downloading binary wheels during python setup
@@ -111,21 +104,15 @@ class Auditbeat < Formula
         path: "#{testpath}/auditbeat"
         filename: auditbeat
     EOS
-    pid = fork do
+    fork do
       exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
     sleep 5
-
-    begin
-      touch testpath/"files/touch"
-      sleep 30
-      s = IO.readlines(testpath/"auditbeat/auditbeat").last(1)[0]
-      assert_match "\"action\":\[\"created\"\]", s
-      realdirpath = File.realdirpath(testpath)
-      assert_match "\"path\":\"#{realdirpath}/files/touch\"", s
-    ensure
-      Process.kill "SIGINT", pid
-      Process.wait pid
-    end
+    touch testpath/"files/touch"
+    sleep 30
+    s = IO.readlines(testpath/"auditbeat/auditbeat").last(1)[0]
+    assert_match /"action":\["(initial_scan|created)"\]/, s
+    realdirpath = File.realdirpath(testpath)
+    assert_match "\"path\":\"#{realdirpath}/files/touch\"", s
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR upgrades `auditbeat` to version 7.7.1 and moves it to use `python@3.8`.

Refs: #55419
Please merge this together with the rest of the eleastic 7 formulae.

ToDo:
* [ ] test everything
* [x] merge together with `elasticsearch` #55419
* [x] merge together with `kibana` #55967
* [x] merge together with `auditbeat` #56035
* [x] merge together with `filebeat` #56036
* [x] merge together with `metricbeat` #56041
* [x] merge together with `heartbeat` #56135
* [x] merge together with `packetbeat` #56143

