### PR TITLE
skopeo + jabba: fix issues

### DIFF
--- a/Formula/jabba.rb
+++ b/Formula/jabba.rb
@@ -31,9 +31,9 @@ class Jabba < Formula
 
   test do
     ENV["JABBA_HOME"] = testpath/"jabba_home"
-    system bin/"jabba", "install", "1.13.0"
-    jdk_path = Utils.popen_read("#{bin}/jabba which 1.13.0").strip
-    assert_match 'java version "13.0',
+    system bin/"jabba", "install", "openjdk@1.14.0"
+    jdk_path = shell_output("#{bin}/jabba which openjdk@1.14.0").strip
+    assert_match 'openjdk version "14',
                  shell_output("#{jdk_path}/Contents/Home/bin/java -version 2>&1")
   end
 end

--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -21,16 +21,15 @@ class Skopeo < Formula
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "1"
     ENV.append "CGO_FLAGS", ENV.cppflags
-    ENV.append "CGO_FLAGS", Utils.popen_read("#{Formula["gpgme"].bin}/gpgme-config --cflags")
+    ENV.append "CGO_FLAGS", Utils.safe_popen_read("#{Formula["gpgme"].bin}/gpgme-config --cflags")
 
     (buildpath/"src/github.com/containers/skopeo").install buildpath.children
     cd buildpath/"src/github.com/containers/skopeo" do
       buildtags = [
         "containers_image_ostree_stub",
-        Utils.popen_read("hack/btrfs_tag.sh").chomp,
-        Utils.popen_read("hack/btrfs_installed_tag.sh").chomp,
-        Utils.popen_read("hack/libdm_tag.sh").chomp,
-        Utils.popen_read("hack/ostree_tag.sh").chomp,
+        Utils.safe_popen_read("hack/btrfs_tag.sh").chomp,
+        Utils.safe_popen_read("hack/btrfs_installed_tag.sh").chomp,
+        Utils.safe_popen_read("hack/libdm_tag.sh").chomp,
       ].uniq.join(" ")
 
       ldflags = [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes issues with skopeo and jabba while also updating the style to conform with #55934

Changes:
- **jabba**: The JDK that was being installed by the test was no longer available. This uses a different JDK for the test (see https://github.com/shyiko/jabba/issues/645)
- **skopeo**: A file was being used by `Utils.popen_read` that had been removed upstream. This removed the reference to that file and switched to using `Utils.safe_popen_read` for highlighting these issues in the future (upstream removed in https://github.com/containers/skopeo/pull/751)