### PR TITLE
packetbeat 7.7.1

### DIFF
--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -1,0 +1,86 @@
+class Packetbeat < Formula
+  desc "Lightweight Shipper for Network Data"
+  homepage "https://www.elastic.co/products/beats/packetbeat"
+  url "https://github.com/elastic/beats.git",
+    :tag      => "v7.7.1",
+    :revision => "932b273e8940575e15f10390882be205bad29e1f"
+  head "https://github.com/elastic/beats.git"
+
+  depends_on "go" => :build
+  depends_on "python@3.8" => :build
+
+  resource "virtualenv" do
+    url "https://files.pythonhosted.org/packages/b1/72/2d70c5a1de409ceb3a27ff2ec007ecdd5cc52239e7c74990e32af57affe9/virtualenv-15.2.0.tar.gz"
+    sha256 "1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54"
+  end
+
+  def install
+    # remove non open source files
+    rm_rf "x-pack"
+
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/elastic/beats").install buildpath.children
+
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
+
+    resource("virtualenv").stage do
+      system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(buildpath/"vendor")
+    end
+
+    ENV.prepend_path "PATH", buildpath/"vendor/bin" # for virtualenv
+    ENV.prepend_path "PATH", buildpath/"bin" # for mage (build tool)
+
+    cd "src/github.com/elastic/beats/packetbeat" do
+      system "make", "mage"
+      # prevent downloading binary wheels during python setup
+      system "make", "PIP_INSTALL_COMMANDS=--no-binary :all", "python-env"
+      system "mage", "-v", "build"
+      ENV.deparallelize
+      system "mage", "-v", "update"
+
+      inreplace "packetbeat.yml", "packetbeat.interfaces.device: any", "packetbeat.interfaces.device: en0"
+
+      (etc/"packetbeat").install Dir["packetbeat.*", "fields.yml"]
+      (libexec/"bin").install "packetbeat"
+      prefix.install "_meta/kibana"
+    end
+
+    prefix.install_metafiles buildpath/"src/github.com/elastic/beats"
+
+    (bin/"packetbeat").write <<~EOS
+      #!/bin/sh
+      exec #{libexec}/bin/packetbeat \
+        --path.config #{etc}/packetbeat \
+        --path.data #{var}/lib/packetbeat \
+        --path.home #{prefix} \
+        --path.logs #{var}/log/packetbeat \
+        "$@"
+    EOS
+  end
+
+  plist_options :manual => "packetbeat"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>Program</key>
+          <string>#{opt_bin}/packetbeat</string>
+          <key>RunAtLoad</key>
+          <true/>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    assert_match "0: en0", shell_output("#{bin}/packetbeat devices")
+    assert_match version.to_s, shell_output("#{bin}/packetbeat version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR restores the `packetbeat`. It was previously removed in #43861 for the lack of Python 3 support, but that was fixed in version 7+.

Refs: #55419
Please merge this together with the rest of the eleastic 7 formulae.

ToDo:
* [ ] test everything
* [x] merge together with `elasticsearch` #55419
* [x] merge together with `kibana` #55967
* [x] merge together with `auditbeat` #56035
* [x] merge together with `filebeat` #56036
* [x] merge together with `metricbeat` #56041
* [x] merge together with `heartbeat` #56135
* [x] merge together with `packetbeat` #56143
