### PR TITLE
ansible@2.8 Revert back to python 3.7

### DIFF
--- a/Formula/ansible@2.8.rb
+++ b/Formula/ansible@2.8.rb
@@ -5,6 +5,7 @@ class AnsibleAT28 < Formula
   homepage "https://www.ansible.com/"
   url "https://releases.ansible.com/ansible/ansible-2.8.12.tar.gz"
   sha256 "2a4ce2a3f387d2595ee3f968c3ea50d6db0ab2d8306f0e81ab96c2a15a683124"
+  revision 1
 
   bottle do
     cellar :any
@@ -18,7 +19,9 @@ class AnsibleAT28 < Formula
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python"
+  # Ansible 2.8 would probably never work with Python > 3.7
+  # https://github.com/ansible/ansible/issues/63973
 
   uses_from_macos "libffi"
   uses_from_macos "libxslt"
@@ -593,7 +596,7 @@ class AnsibleAT28 < Formula
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.8"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
 
     # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra


### PR DESCRIPTION
Hello,

I had issues using ansible 2.8 after upgrading to v2.8.12; the issue that I got is described on [ansible/ansible issue 63973](https://github.com/ansible/ansible/issues/63973). On the issue thread it's [mentioned](https://github.com/ansible/ansible/issues/63973#issuecomment-546995228) by a member of the ansible group, that the bug is caused by python 3.8 which isn't supported.

For that reason I reverted [3808861e8d * ansible@2.8: migrate to python@3.8](https://github.com/Homebrew/homebrew-core/commit/3808861e8d) which solved all my issue

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----