### PR TITLE
natalie: update build arguments

### DIFF
--- a/Formula/natalie.rb
+++ b/Formula/natalie.rb
@@ -4,6 +4,7 @@ class Natalie < Formula
   url "https://github.com/krzyzanowskim/Natalie/archive/0.7.0.tar.gz"
   sha256 "f7959915595495ce922b2b6987368118fa28ba7d13ac3961fd513ec8dfdb21c8"
   head "https://github.com/krzyzanowskim/Natalie.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,14 +15,13 @@ class Natalie < Formula
   depends_on :xcode => ["9.4", :build]
 
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc",
-           "-static-stdlib"
+    system "swift", "build", "--disable-sandbox", "-c", "release", "--static-swift-stdlib"
     bin.install ".build/release/natalie"
     share.install "NatalieExample"
   end
 
   test do
-    generated_code = Utils.popen_read("#{bin}/natalie #{share}/NatalieExample")
+    generated_code = shell_output("#{bin}/natalie #{share}/NatalieExample")
     assert generated_code.lines.count > 1, "Natalie failed to generate code!"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, `brew install -s natalie` fails saying:

<details><summary>Error Message</summary>
<pre><code>==> swift build --disable-sandbox -c release -Xswiftc -static-stdlib
Last 15 lines from /Users/rylanpolster/Library/Logs/Homebrew/natalie/01.swift:
2020-06-11 10:03:04 -0400

swift
build
--disable-sandbox
-c
release
-Xswiftc
-static-stdlib

&lt;unknown&gt;:0: error: -static-stdlib is no longer supported on Apple platforms
READ THIS: https://docs.brew.sh/Troubleshooting
</code></pre></details>

The [upstream install script](https://github.com/krzyzanowskim/Natalie/blob/master/scripts/build.sh) for natalie calls `swift build -c release --static-swift-stdlib`

Also changes `Utils.popen_read` to `shell_output` in the `test` block