### PR TITLE
swift-format 0.50200.1

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -1,8 +1,10 @@
 class SwiftFormat < Formula
   desc "Formatting technology for Swift source code"
   homepage "https://github.com/apple/swift-format"
-  url "https://github.com/apple/swift-format.git", :revision => "5cdf916a09ee8b581ff348c0e395b221d02d253b"
-  version "5.2"
+  url "https://github.com/apple/swift-format.git",
+    :tag      => "0.50200.1",
+    :revision => "f22aade8a6ee061b4a7041601ededd8ad7bc2122"
+  version_scheme 1
   head "https://github.com/apple/swift-format.git"
 
   bottle do


### PR DESCRIPTION
This requires a manual formula bump due to:
- Adding a `tag` key where one was not present before
- Changing version semantics to match the repository, which nominally causes a version downgrade from the previous `5.2`

These inconsistencies appear to stem from the fact that [the upstream repository](https://github.com/apple/swift-format) had [its first official release](https://github.com/apple/swift-format/releases) after the revision of the previous version of this formula, so there were no tags prior to that and the original formula author guessed at the versioning scheme.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
