### PR TITLE
mpv: revert removed Vapoursynth support

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -3,7 +3,7 @@ class Mpv < Formula
   homepage "https://mpv.io"
   url "https://github.com/mpv-player/mpv/archive/v0.32.0.tar.gz"
   sha256 "9163f64832226d22e24bbc4874ebd6ac02372cd717bef15c28a0aa858c5fe592"
-  revision 4
+  revision 5
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do
@@ -25,6 +25,7 @@ class Mpv < Formula
   depends_on "lua@5.1"
   depends_on "mujs"
   depends_on "uchardet"
+  depends_on "vapoursynth"
   depends_on "youtube-dl"
 
   def install
@@ -59,5 +60,6 @@ class Mpv < Formula
 
   test do
     system bin/"mpv", "--ao=null", test_fixtures("test.wav")
+    assert_match "vapoursynth", shell_output(bin/"mpv --vf=help")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----