### PR TITLE
libnetworkit (7.0) new formula

### DIFF
--- a/Formula/libnetworkit.rb
+++ b/Formula/libnetworkit.rb
@@ -1,0 +1,36 @@
+class Libnetworkit < Formula
+  desc "NetworKit is an OS-toolkit for large-scale network analysis"
+  homepage "https://networkit.github.io"
+  url "https://github.com/networkit/networkit/archive/7.0.tar.gz"
+  sha256 "4faf16c5fae3e14d3c1b6f30e25c6e093dcf6a3dbf021235f3161ac2a527f682"
+
+  depends_on "cmake" => :build
+  depends_on "libomp"
+  depends_on "tlx"
+
+  def install
+    mkdir "build" do
+      system "cmake", ".", *std_cmake_args,
+                           "-DNETWORKIT_EXT_TLX=#{Formula["tlx"].opt_prefix}",
+                           "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I#{Formula["libomp"].opt_prefix}/include'",
+                           "-DOpenMP_CXX_LIB_NAMES='omp'",
+                           "-DOpenMP_omp_LIBRARY=#{Formula["libomp"].opt_prefix}/lib/libomp.dylib",
+                           ".."
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <networkit/graph/Graph.hpp>
+      int main()
+      {
+        // Try to create a graph with five nodes
+        NetworKit::Graph g(5);
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lnetworkit", "-o", "test", "-std=c++11"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is based on a previously closed PR #52078 for version 6.1. The patch, enabling support for AppleClang 11.03 is now part of the new release.