### PR TITLE
acmetool: add versioned formula with HEAD enabled

### DIFF
--- a/Aliases/acmetool@0.0
+++ b/Aliases/acmetool@0.0
@@ -1,0 +1,1 @@
+../Formula/acmetool.rb

--- a/Formula/acmetool.rb
+++ b/Formula/acmetool.rb
@@ -1,8 +1,7 @@
-require "language/go"
-
 class Acmetool < Formula
   desc "Automatic certificate acquisition tool for ACME (Let's Encrypt)"
   homepage "https://github.com/hlandau/acme"
+  revision 1
   url "https://github.com/hlandau/acme.git",
       :tag      => "v0.0.67",
       :revision => "221ea15246f0bbcf254b350bee272d43a1820285"
@@ -17,172 +16,100 @@ class Acmetool < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/alecthomas/template" do
-    url "https://github.com/alecthomas/template.git",
-        :revision => "a0175ee3bccc567396460bf5acd36800cb10c49c"
-  end
-
-  go_resource "github.com/alecthomas/units" do
-    url "https://github.com/alecthomas/units.git",
-        :revision => "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
-  end
-
-  go_resource "github.com/coreos/go-systemd" do
-    url "https://github.com/coreos/go-systemd.git",
-        :revision => "cc4f39464dc797b91c8025330de585294c2a6950"
-  end
-
-  go_resource "github.com/hlandau/buildinfo" do
-    url "https://github.com/hlandau/buildinfo.git",
-        :revision => "337a29b5499734e584d4630ce535af64c5fe7813"
-  end
-
-  go_resource "github.com/hlandau/dexlogconfig" do
-    url "https://github.com/hlandau/dexlogconfig.git",
-        :revision => "244f29bd260884993b176cd14ef2f7631f6f3c18"
-  end
-
-  go_resource "github.com/hlandau/goutils" do
-    url "https://github.com/hlandau/goutils.git",
-        :revision => "0cdb66aea5b843822af6fdffc21286b8fe8379c4"
-  end
-
-  go_resource "github.com/hlandau/xlog" do
-    url "https://github.com/hlandau/xlog.git",
-        :revision => "197ef798aed28e08ed3e176e678fda81be993a31"
-  end
-
-  go_resource "github.com/jmhodges/clock" do
-    url "https://github.com/jmhodges/clock.git",
-        :revision => "880ee4c335489bc78d01e4d0a254ae880734bc15"
-  end
-
-  go_resource "github.com/mattn/go-isatty" do
-    url "https://github.com/mattn/go-isatty.git",
-        :revision => "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
-  end
-
-  go_resource "github.com/mattn/go-runewidth" do
-    url "https://github.com/mattn/go-runewidth.git",
-        :revision => "97311d9f7767e3d6f422ea06661bc2c7a19e8a5d"
-  end
-
-  go_resource "github.com/mitchellh/go-wordwrap" do
-    url "https://github.com/mitchellh/go-wordwrap.git",
-        :revision => "ad45545899c7b13c020ea92b2072220eefad42b8"
-  end
-
-  go_resource "github.com/ogier/pflag" do
-    url "https://github.com/ogier/pflag.git",
-        :revision => "45c278ab3607870051a2ea9040bb85fcb8557481"
-  end
-
-  go_resource "github.com/peterhellberg/link" do
-    url "https://github.com/peterhellberg/link.git",
-        :revision => "8768c6d4dc563b4a09f58ecda04997024452c057"
-  end
-
-  go_resource "github.com/satori/go.uuid" do
-    url "https://github.com/satori/go.uuid.git",
-        :revision => "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
-  end
-
-  go_resource "github.com/shiena/ansicolor" do
-    url "https://github.com/shiena/ansicolor.git",
-        :revision => "a422bbe96644373c5753384a59d678f7d261ff10"
-  end
-
-  go_resource "golang.org/x/crypto" do
-    url "https://go.googlesource.com/crypto.git",
-        :revision => "a6600008915114d9c087fad9f03d75087b1a74df"
-  end
-
-  go_resource "golang.org/x/net" do
-    url "https://go.googlesource.com/net.git",
-        :revision => "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
-  end
-
-  go_resource "golang.org/x/sys" do
-    url "https://go.googlesource.com/sys.git",
-        :revision => "2c42eef0765b9837fbdab12011af7830f55f88f0"
-  end
-
-  go_resource "golang.org/x/text" do
-    url "https://go.googlesource.com/text.git",
-        :revision => "e19ae1496984b1c655b8044a65c0300a3c878dd3"
-  end
-
-  go_resource "gopkg.in/alecthomas/kingpin.v2" do
-    url "https://gopkg.in/alecthomas/kingpin.v2.git",
-        :revision => "947dcec5ba9c011838740e680966fd7087a71d0d"
-  end
-
-  go_resource "gopkg.in/cheggaaa/pb.v1" do
-    url "https://gopkg.in/cheggaaa/pb.v1.git",
-        :revision => "43d64de27312b32812ca7e994fa0bb03ccf08fdf"
-  end
-
-  go_resource "gopkg.in/hlandau/configurable.v1" do
-    url "https://gopkg.in/hlandau/configurable.v1.git",
-        :revision => "41496864a1fe3e0fef2973f22372b755d2897402"
-  end
-
-  go_resource "gopkg.in/hlandau/easyconfig.v1" do
-    url "https://gopkg.in/hlandau/easyconfig.v1.git",
-        :revision => "7589cb96edce2f94f8c1e6eb261f8c2b06220fe7"
-  end
-
-  go_resource "gopkg.in/hlandau/service.v2" do
-    url "https://gopkg.in/hlandau/service.v2.git",
-        :revision => "b64b3467ebd16f64faec1640c25e318efc0c0d7b"
-  end
-
-  go_resource "gopkg.in/hlandau/svcutils.v1" do
-    url "https://gopkg.in/hlandau/svcutils.v1.git",
-        :revision => "c25dac49e50cbbcbef8c81b089f56156f4067729"
-  end
-
-  go_resource "gopkg.in/square/go-jose.v1" do
-    url "https://gopkg.in/square/go-jose.v1.git",
-        :revision => "aa2e30fdd1fe9dd3394119af66451ae790d50e0d"
-  end
-
-  go_resource "gopkg.in/tylerb/graceful.v1" do
-    url "https://gopkg.in/tylerb/graceful.v1.git",
-        :revision => "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb"
-  end
-
-  go_resource "gopkg.in/yaml.v2" do
-    url "https://gopkg.in/yaml.v2.git",
-        :revision => "d670f9405373e636a5a2765eea47fac0c9bc91a4"
-  end
+  conflicts_with "acmetool@0.2", :because => "Differing version of same formula"
 
   def install
+    ENV["GO111MODULE"] = "on"
     ENV["GOPATH"] = buildpath
+    # https://github.com/hlandau/acme/blob/221ea15246f0bbcf254b350bee272d43a1820285/_doc/PACKAGING-PATHS.md
+    ldflags = %W[
+      -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acmetool
+      -X github.com/hlandau/acme/hooks.DefaultPath=#{lib}/hooks
+      -X github.com/hlandau/acme/responder.StandardWebrootPath=#{var}/run/acmetool/acme-challenge
+    ]
 
-    (buildpath/"src/github.com/hlandau").mkpath
-    ln_sf buildpath, buildpath/"src/github.com/hlandau/acme"
-    Language::Go.stage_deps resources, buildpath/"src"
-
-    cd "cmd/acmetool" do
-      # https://github.com/hlandau/acme/blob/master/_doc/PACKAGING-PATHS.md
-      ldflags = %W[
-        -X github.com/hlandau/acme/storage.RecommendedPath=#{var}/lib/acmetool
-        -X github.com/hlandau/acme/hooks.DefaultPath=#{lib}/hooks
-        -X github.com/hlandau/acme/responder.StandardWebrootPath=#{var}/run/acmetool/acme-challenge
-        #{Utils.popen_read("#{buildpath}/src/github.com/hlandau/buildinfo/gen")}
-      ]
-      system "go", "build", "-o", bin/"acmetool", "-ldflags", ldflags.join(" ")
+    inreplace "Makefile" do |s|
+      s.sub! /-ldflags "(.*)"/, '\1'
+      s.sub! /(\$\(call BUILDINFO.*\)\))/, '-ldflags "$(LDFLAGS) \1"'
+      s.sub! /(install) -Dp/, '\1 -d $(DESTDIR)$(PREFIX)/bin && \1 -p'
+      s.sub! /(go install.* ..BINARIES.)/, 'pushd "src/$(PROJNAME)"; \1; popd'
+      s.sub! /\$\(call .*#{Regexp.escape "/..."}/, ""
     end
+
+    (buildpath/"go.mod").write <<~EOS
+      module github.com/hlandau/acme
+      require (
+        github.com/BurntSushi/toml v0.3.1 // indirect
+        github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+        github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+        github.com/btcsuite/winsvc v1.0.0 // indirect
+        github.com/coreos/go-systemd v0.0.0-20180108085132-cc4f39464dc7 // indirect
+        github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83 // indirect
+        github.com/hlandau/acmetool v0.0.67 // indirect
+        github.com/hlandau/dexlogconfig v0.0.0-20161112114350-244f29bd2608
+        github.com/hlandau/goutils v0.0.0-20160722130800-0cdb66aea5b8
+        github.com/hlandau/xlog v1.0.0
+        github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
+        github.com/mattn/go-isatty v0.0.4 // indirect
+        github.com/mattn/go-runewidth v0.0.3-0.20170510074858-97311d9f7767 // indirect
+        github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7
+        github.com/ogier/pflag v0.0.2-0.20160129220114-45c278ab3607 // indirect
+        github.com/peterhellberg/link v1.0.1-0.20171231092049-8768c6d4dc56
+        github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5
+        github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 // indirect
+        golang.org/x/crypto v0.0.0-20180119165957-a66000089151
+        golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b
+        golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b // indirect
+        golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984 // indirect
+        gopkg.in/alecthomas/kingpin.v2 v2.2.6
+        gopkg.in/cheggaaa/pb.v1 v1.0.20
+        gopkg.in/hlandau/configurable.v1 v1.0.1 // indirect
+        gopkg.in/hlandau/easyconfig.v1 v1.0.16
+        gopkg.in/hlandau/service.v2 v2.0.16
+        gopkg.in/hlandau/svcutils.v1 v1.0.10
+        gopkg.in/square/go-jose.v1 v1.1.0
+        gopkg.in/tylerb/graceful.v1 v1.2.15
+        gopkg.in/yaml.v2 v2.0.0
+      )
+    EOS
+
+    buildinfo_pkg = "github.com/hlandau/buildinfo"
+    (buildpath/"src/#{buildinfo_pkg}").mkpath
+    (buildpath/"src/#{buildinfo_pkg}/gen").write <<~EOS
+      #!/bin/bash
+      BUILDNAME="$(date -u "+%Y%m%d%H%M%S") on $(hostname -f)"
+      cd "$GOPATH/src/$1"; while [ ! -f go.mod -a "$PWD" != "$GOPATH" ]; do cd ..; done
+      echo -X github.com/hlandau/buildinfo.RawBuildInfo=$( \
+        (echo built $BUILDNAME; go list -m all | sed "1d") | base64 | tr -d \'\\n\' \
+      )
+    EOS
+    chmod "+x", buildpath/"src/#{buildinfo_pkg}/gen"
+
+    system "make", "LDFLAGS=#{ldflags.join(" ")}", "PREFIX=#{prefix}", "USE_BUILDINFO=1", "V=1", "install"
 
     (man8/"acmetool.8").write Utils.popen_read(bin/"acmetool", "--help-man")
 
-    doc.install Dir["_doc/*"]
+    doc.install Dir["doc/*"]
   end
 
   def post_install
     (var/"lib/acmetool").mkpath
     (var/"run/acmetool").mkpath
+  end
+
+  def caveats
+    <<~EOS
+      As of June 2020, subscribers to the Let's Encrypt service are no longer allowed
+      to validate new domains through the ACMEv1 protocol, and renewal of existing
+      certificates will occasionally be disabled starting early 2021, before the final
+      EoL of ACMEv1 by June 2021.
+
+      New users should therefore use \x1B[3m\x1B[1macmetool@0.2\x1B[0m to obtain certificates via ACMEv2
+      unless they intend to import existing accounts from another tool. Current users
+      should also consider upgrading to ACMEv2, though this has to be done manually
+      for the time being. Please follow \x1B[4mhttps://github.com/hlandau/acmetool/issues/322\x1B[0m
+      for upgrade instructions and discussion on the future of acmetool.
+    EOS
   end
 
   test do

--- a/Formula/acmetool@0.2.rb
+++ b/Formula/acmetool@0.2.rb
@@ -4,7 +4,7 @@ class AcmetoolAT02 < Formula
   url "https://github.com/hlandau/acmetool.git",
       :tag      => "v0.2.1",
       :revision => "f68b275d0a0ca526525b1d11e58be9b7e995251f"
-  head "https://github.com/hlandau/acmetool.git"
+  # head "https://github.com/hlandau/acmetool.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +12,8 @@ class AcmetoolAT02 < Formula
 
   depends_on "go" => :build
 
-  conflicts_with "acmetool", :because => "Differing version of same formula"
+  # conflicts_with "acmetool", :because => "Differing version of same formula"
+  keg_only :versioned_formula
 
   def install
     ENV["GO111MODULE"] = "on"

--- a/Formula/acmetool@0.2.rb
+++ b/Formula/acmetool@0.2.rb
@@ -1,0 +1,114 @@
+class AcmetoolAT02 < Formula
+  desc "Automatic certificate acquisition tool for ACME (Let's Encrypt) v2"
+  homepage "https://github.com/hlandau/acmetool"
+  url "https://github.com/hlandau/acmetool.git",
+      :tag      => "v0.2.1",
+      :revision => "f68b275d0a0ca526525b1d11e58be9b7e995251f"
+  head "https://github.com/hlandau/acmetool.git"
+
+  bottle do
+    cellar :any_skip_relocation
+  end
+
+  depends_on "go" => :build
+
+  conflicts_with "acmetool", :because => "Differing version of same formula"
+
+  def install
+    ENV["GO111MODULE"] = "on"
+    ENV["GOPATH"] = buildpath
+    # https://github.com/hlandau/acme/blob/221ea15246f0bbcf254b350bee272d43a1820285/_doc/PACKAGING-PATHS.md
+    ldflags = %W[
+      -X github.com/hlandau/acmetool/storage.RecommendedPath=#{var}/lib/acmetool
+      -X github.com/hlandau/acmetool/hooks.DefaultPath=#{lib}/hooks
+      -X github.com/hlandau/acmetool/responder.StandardWebrootPath=#{var}/run/acmetool/acme-challenge
+    ]
+
+    inreplace "Makefile" do |s|
+      s.sub! /-ldflags "(.*)"/, '\1'
+      s.sub! /(\$\(call BUILDINFO.*\)\))/, '-ldflags "$(LDFLAGS) \1"'
+      s.sub! /(install) -Dp/, '\1 -d $(DESTDIR)$(PREFIX)/bin && \1 -p'
+      s.sub! /(go install.* ..BINARIES.)/, 'pushd "src/$(PROJNAME)"; \1; popd'
+      s.sub! /(\$\(call .*)#{Regexp.escape "/..."}/, build.head? ? 'pushd "src/$(PROJNAME)"; \1@master; popd' : ""
+      s.gsub! "git.devever.net/hlandau/acmetool", "github.com/hlandau/acmetool"
+    end
+
+    if build.head?
+      (buildpath/"go.mod").write <<~EOS
+        module github.com/hlandau/acme
+        require github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
+        replace github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 latest
+      EOS
+    else
+      (buildpath/"go.mod").write <<~EOS
+        module github.com/hlandau/acme
+        require (
+          github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+          github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+          github.com/btcsuite/winsvc v1.0.0 // indirect
+          github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
+          github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83 // indirect
+          github.com/fatih/color v1.9.0 // indirect
+          github.com/godbus/dbus v4.1.0+incompatible // indirect
+          github.com/google/go-cmp v0.4.1 // indirect
+          github.com/hlandau/acmetool v0.2.1
+          github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997 // indirect
+          github.com/hlandau/dexlogconfig v0.0.0-20161112114350-244f29bd2608
+          github.com/hlandau/goutils v0.0.0-20160722130800-0cdb66aea5b8
+          github.com/hlandau/xlog v1.0.0
+          github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
+          github.com/mattn/go-colorable v0.1.6 // indirect
+          github.com/mattn/go-isatty v0.0.13-0.20200128103942-cb30d6282491 // indirect
+          github.com/mattn/go-runewidth v0.0.9 // indirect
+          github.com/mitchellh/go-wordwrap v1.0.0
+          github.com/ogier/pflag v0.0.2-0.20160129220114-45c278ab3607 // indirect
+          github.com/peterhellberg/link v1.1.0 // indirect
+          github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
+          github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 // indirect
+          golang.org/x/crypto v0.0.0-20200602180216-279210d13fed // indirect
+          golang.org/x/net v0.0.0-20200602114024-627f9648deb9
+          golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
+          golang.org/x/text v0.3.3-0.20200513185708-81608d7e9c68 // indirect
+          gopkg.in/alecthomas/kingpin.v2 v2.2.6
+          gopkg.in/cheggaaa/pb.v1 v1.0.28
+          gopkg.in/hlandau/acmeapi.v2 v2.0.1
+          gopkg.in/hlandau/configurable.v1 v1.0.1 // indirect
+          gopkg.in/hlandau/easyconfig.v1 v1.0.17
+          gopkg.in/hlandau/service.v2 v2.0.16
+          gopkg.in/hlandau/svcutils.v1 v1.0.10
+          gopkg.in/square/go-jose.v1 v1.1.2
+          gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+          gopkg.in/tylerb/graceful.v1 v1.2.15
+          gopkg.in/yaml.v2 v2.3.0
+        )
+      EOS
+    end
+
+    buildinfo_pkg = "github.com/hlandau/buildinfo"
+    (buildpath/"src/#{buildinfo_pkg}").mkpath
+    (buildpath/"src/#{buildinfo_pkg}/gen").write <<~EOS
+      #!/bin/bash
+      BUILDNAME="$(date -u "+%Y%m%d%H%M%S") on $(hostname -f)"
+      cd "$GOPATH/src/$1"; while [ ! -f go.mod -a "$PWD" != "$GOPATH" ]; do cd ..; done
+      echo -X github.com/hlandau/buildinfo.RawBuildInfo=$( \
+        (echo built $BUILDNAME; go list -m all | sed "1d") | base64 | tr -d \'\\n\' \
+      )
+    EOS
+    chmod "+x", buildpath/"src/#{buildinfo_pkg}/gen"
+
+    system "make", "LDFLAGS=#{ldflags.join(" ")}", "PREFIX=#{prefix}", "USE_BUILDINFO=1", "V=1", "install"
+
+    (man8/"acmetool.8").write Utils.popen_read(bin/"acmetool", "--help-man")
+
+    doc.install Dir["doc/*"]
+  end
+
+  def post_install
+    (var/"lib/acmetool").mkpath
+    (var/"run/acmetool").mkpath
+  end
+
+  test do
+    assert_match Regexp.new(version.to_s.gsub(/.*-/, "acmetool .*-")), shell_output("#{bin}/acmetool --version", 2)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x]  Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a follow-up PR to https://github.com/Homebrew/homebrew-core/pull/55762, as my other approach to bottle both versions during the transition period from ACMEv1 to ACMEv2. This version tries to conform to current formula policies in homebrew-core, by making use of/hacking `go.mod` supplied at build time (as the author has gone stale). The author's original code for dependency version generation (via `git describe`) is replaced with that of Go's native module-based dependency management system, also injected via an embedded script.

`brew audit --strict acmetool` passes, but not with `acmetool@0.2` for obvious reasons (edit: related code are commented out temporarily). Better solutions are highly appreciated.