### PR TITLE
kde-extra-cmake-modules: update head

### DIFF
--- a/Formula/kde-extra-cmake-modules.rb
+++ b/Formula/kde-extra-cmake-modules.rb
@@ -3,8 +3,7 @@ class KdeExtraCmakeModules < Formula
   homepage "https://api.kde.org/frameworks/extra-cmake-modules/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.70/extra-cmake-modules-5.70.0.tar.xz"
   sha256 "830da8d84cc737e024ac90d6ed767d10f9e21531e5f576a1660d4ca88bee8581"
-
-  head "git://anongit.kde.org/extra-cmake-modules"
+  head "https://invent.kde.org/frameworks/extra-cmake-modules.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing HEAD URL for `kde-extra-cmake-modules` wasn't working anymore and `brew audit --online` gave the following error: `HEAD: The URL git://anongit.kde.org/extra-cmake-modules is not a valid git URL`.

This updates the HEAD URL to use the current upstream repo for the software.
