### PR TITLE
vcpkg 2020.04 (new formula)

### DIFF
--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -1,0 +1,40 @@
+class Vcpkg < Formula
+  desc "C++ Library Manager"
+  homepage "https://github.com/microsoft/vcpkg"
+  url "https://github.com/microsoft/vcpkg/archive/2020.04.tar.gz"
+  sha256 "51bdc81d074407b760de5950760f43c253da6cd8135e13744967cf7c95e837fd"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  if MacOS.version <= :mojave
+    fails_with :clang do
+      cause "'file_status' is unavailable: introduced in macOS 10.15"
+    end
+  end
+
+  def install
+    # fix for conflicting declaration of 'char* ctermid(char*)' on Mojave
+    # https://github.com/microsoft/vcpkg/issues/9029
+    ENV.prepend "CXXFLAGS", "-D_CTERMID_H_" if MacOS.version == :mojave
+
+    args = %w[-useSystemBinaries -disableMetrics]
+    args << "-allowAppleClang" if MacOS.version > :mojave
+    system "./bootstrap-vcpkg.sh", *args
+
+    bin.install "vcpkg"
+    bin.env_script_all_files(libexec/"bin", :VCPKG_ROOT => libexec)
+    libexec.install Dir["*.txt", ".vcpkg-root", "{ports,scripts,triplets}"]
+  end
+
+  def post_install
+    (var/"vcpkg/installed").mkpath
+    (var/"vcpkg/packages").mkpath
+    ln_s var/"vcpkg/installed", libexec/"installed"
+    ln_s var/"vcpkg/packages", libexec/"packages"
+  end
+
+  test do
+    assert_match "sqlite3", shell_output("#{bin}/vcpkg search sqlite")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Notes:

1. This was attempted a few times previously in #36347, #44412, and #45002 (but feeling optimistic)
2. Works with Apple Clang on Catalina but requires GCC for Mojave and earlier (`error: 'file_status' is unavailable: introduced in macOS 10.15` with Clang on Mojave)
3. Four internal directories in `libexec` are used when packages are installed - `buildtrees` and `downloads` seem to be for temporary operations and `installed` and `packages` contain installed packages. This symlinks the latter two so packages persist across updates.
4. Without CXX flag on Mojave, errors with `conflicting declaration of 'char* ctermid(char*)' with 'C' linkage` - https://github.com/microsoft/vcpkg/issues/8670
5. Sorry for the noise