### PR TITLE
makepkg: update stable and head urls

### DIFF
--- a/Formula/makepkg.rb
+++ b/Formula/makepkg.rb
@@ -1,11 +1,10 @@
 class Makepkg < Formula
   desc "Compile and build packages suitable for installation with pacman"
   homepage "https://wiki.archlinux.org/index.php/makepkg"
-  url "https://projects.archlinux.org/git/pacman.git",
+  url "https://git.archlinux.org/pacman.git",
       :tag      => "v5.0.2",
       :revision => "0c633c27eaeab2a9d30efb01199579896ccf63c9"
-  revision 1
-  head "https://projects.archlinux.org/git/pacman.git"
+  head "https://git.archlinux.org/pacman.git"
 
   bottle do
     sha256 "d57aacac971c91dc50c67e1549ace86763107a3dd2f29f3053f6b4517ef1097e" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` ~~(after doing `brew install <formula>`)~~?

-----

The current stable and HEAD Git repo URLs for `makepkg` (`https://projects.archlinux.org/git/pacman.git`) is redirecting to `https://git.archlinux.org/pacman.git`, so this updates head to avoid the redirection.