### PR TITLE
pg_top: update homepage

### DIFF
--- a/Formula/pg_top.rb
+++ b/Formula/pg_top.rb
@@ -1,6 +1,6 @@
 class PgTop < Formula
   desc "Monitor PostgreSQL processes"
-  homepage "https://git.postgresql.org/gitweb/?p=pg_top.git"
+  homepage "https://pg_top.gitlab.io"
   url "https://ftp.postgresql.org/pub/projects/pgFoundry/ptop/pg_top/3.7.0/pg_top-3.7.0.tar.bz2"
   mirror "https://mirrorservice.org/sites/ftp.postgresql.org/projects/pgFoundry/ptop/pg_top/3.7.0/pg_top-3.7.0.tar.bz2"
   sha256 "c48d726e8cd778712e712373a428086d95e2b29932e545ff2a948d043de5a6a2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` ~~(after doing `brew install <formula>`)~~?

-----

The existing Git repo URL used as the homepage for `pg_top` (`https://git.postgresql.org/gitweb/?p=pg_top.git`) has disappeared. There's now a homepage for `pg_top` at https://pg_top.gitlab.io and the Git repo is found at `https://gitlab.com/pg_top/pg_top.git`.

I haven't added the `head` URL here because it currently doesn't build from HEAD properly, even after adding special build instructions (e.g., adding `cmake` as a HEAD build dependency and executing it in `install` before `make install`). It currently encounters a `Cannot find source file: machine/m_darwin.c` error. I've tried copying the `m_macosx.c` file to `m_darwin.c` but the build simply fails in other ways and `pg_top` will seemingly need to be updated upstream to work properly. Once that happens, it should be possible to update this formula to do a proper HEAD build.