### PR TITLE
weighttp: update head

### DIFF
--- a/Formula/weighttp.rb
+++ b/Formula/weighttp.rb
@@ -3,7 +3,7 @@ class Weighttp < Formula
   homepage "https://redmine.lighttpd.net/projects/weighttp/wiki"
   url "https://github.com/lighttpd/weighttp/archive/weighttp-0.4.tar.gz"
   sha256 "b4954f2a1eca118260ffd503a8e3504dd32942e2e61d0fa18ccb6b8166594447"
-  head "https://git.lighttpd.net/weighttp.git"
+  head "https://git.lighttpd.net/lighttpd/weighttp.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream Git repo situation has changed a bit and now the repos (such as `weighttp`) are owned by a `lighttpd` user and the URL is like GitHub's user/repo setup. This updates the `head` URL accordingly.