### PR TITLE
glassfish: remove deprecated Java.java_home_cmd

### DIFF
--- a/Formula/glassfish.rb
+++ b/Formula/glassfish.rb
@@ -37,7 +37,7 @@ class Glassfish < Formula
     domaindir_arg = "--domaindir=#{domains_path}"
 
     # tell glassfish to use Java 8
-    java8_home = shell_output(Language::Java.java_home_cmd("1.8")).chomp
+    java8_home = Language::Java.java_home("1.8")
     File.open(asenv_conf_path, "a") { |file| file.puts "AS_JAVA=\"#{java8_home}\"" }
 
     port = free_port


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Replace deprecated `Language::Java.java_home_cmd` with `Language::Java.java_home`. Also removes the now-unnecessary `Utils.popen_read`.
