### PR TITLE
qhull 2020.1

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -4,7 +4,7 @@ class Octave < Formula
   url "https://ftp.gnu.org/gnu/octave/octave-5.2.0.tar.xz"
   mirror "https://ftpmirror.gnu.org/octave/octave-5.2.0.tar.xz"
   sha256 "2757b5cc1854c9326d6c99d2900c7cec2909ac7ed500212d170d0df592bfd26b"
-  revision 7
+  revision 8
 
   bottle do
     sha256 "2dbe2a6d85122f0e3f011c334cb8196752ea88f046f8d5135be6ff0840e72b04" => :catalina

--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -3,7 +3,7 @@ class Pcl < Formula
   homepage "https://pointclouds.org/"
   url "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.9.1.tar.gz"
   sha256 "0add34d53cd27f8c468a59b8e931a636ad3174b60581c0387abb98a9fc9cddb6"
-  revision 8
+  revision 9
   head "https://github.com/PointCloudLibrary/pcl.git"
 
   bottle do

--- a/Formula/qhull.rb
+++ b/Formula/qhull.rb
@@ -1,9 +1,10 @@
 class Qhull < Formula
   desc "Computes convex hulls in n dimensions"
   homepage "http://www.qhull.org/"
-  url "http://www.qhull.org/download/qhull-2019-src-7.3.2.tgz"
-  version "2019.1"
-  sha256 "2b7990558c363076261564f61b74db4d0d73b71869755108a469038c07dc43fb"
+  url "http://www.qhull.org/download/qhull-2020-src-8.0.0.tgz"
+  version "2020.1"
+  sha256 "1ac92a5538f61e297c72aebe4d4ffd731ceb3e6045d6d15faf1c212713798df4"
+  head "https://github.com/qhull/qhull.git"
 
   bottle do
     cellar :any
@@ -14,16 +15,13 @@ class Qhull < Formula
 
   depends_on "cmake" => :build
 
-  # fixes build on case-insensitive filesystems
-  # see https://github.com/qhull/qhull/issues/48
-  patch do
-    url "https://github.com/qhull/qhull/commit/6052739c827bff64de3f05343e45fd080909759c.patch?full_index=1"
-    sha256 "ed97d5920ad9c09e028a26da1f0e8d9d313f3e757d52c14ea562827d6c865804"
-  end
-
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    ENV.cxx11
+
+    cd "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do

--- a/Formula/visp.rb
+++ b/Formula/visp.rb
@@ -3,7 +3,7 @@ class Visp < Formula
   homepage "https://visp.inria.fr/"
   url "https://gforge.inria.fr/frs/download.php/latestfile/475/visp-3.3.0.tar.gz"
   sha256 "f2ed11f8fee52c89487e6e24ba6a31fa604b326e08fb0f561a22c877ebdb640d"
-  revision 5
+  revision 6
 
   bottle do
     sha256 "ba28b194717945e8114583256144012b67aefb09f81f3ce4301e0390433a9a57" => :catalina

--- a/Formula/visp.rb
+++ b/Formula/visp.rb
@@ -27,6 +27,16 @@ class Visp < Formula
 
     sdk = MacOS::CLT.installed? ? "" : MacOS.sdk_path
 
+    # Avoid superenv shim references
+    inreplace "CMakeLists.txt" do |s|
+      s.sub! /CMake build tool:"\s+\${CMAKE_BUILD_TOOL}/,
+             "CMake build tool:            gmake\""
+      s.sub! /C\+\+ Compiler:"\s+\${VISP_COMPILER_STR}/,
+             "C++ Compiler:                clang++\""
+      s.sub! /C Compiler:"\s+\${CMAKE_C_COMPILER}/,
+             "C Compiler:                  clang\""
+    end
+
     system "cmake", ".", "-DBUILD_DEMOS=OFF",
                          "-DBUILD_EXAMPLES=OFF",
                          "-DBUILD_TESTS=OFF",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This bumps the formula to the latest version (2020.1) and also adds the GitHub repo as `head` (it builds fine without any special modifications). [I removed the previous patch because it's incorporated into this version and no longer applicable.]

It was necessary to add `ENV.cxx11` to `install`, since parts of `qhull` now require C++ 11 and the build will fail otherwise. I updated the build steps to align more with what's described in the `qhull` documentation while I was at it.

I've built both version 2020.1 and HEAD from source and tested both and it all looks good. Let me know if any of this could be improved or if anything needs to be changed.