### PR TITLE
ntfs-3g: enable extra programs and xattr

### DIFF
--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -1,7 +1,7 @@
 class Ntfs3g < Formula
   desc "Read-write NTFS driver for FUSE"
   homepage "https://www.tuxera.com/community/open-source-ntfs-3g/"
-  revision 2
+  revision 3
   stable do
     url "https://tuxera.com/opensource/ntfs-3g_ntfsprogs-2017.3.23.tgz"
     sha256 "3e5a021d7b761261836dcb305370af299793eedbded731df3d6943802e1262d5"
@@ -45,6 +45,7 @@ class Ntfs3g < Formula
       --exec-prefix=#{prefix}
       --mandir=#{man}
       --with-fuse=external
+      --enable-extra
     ]
 
     system "./autogen.sh" if build.head?
@@ -64,23 +65,22 @@ class Ntfs3g < Formula
         USER_ID=#{Process.uid}
         GROUP_ID=#{Process.gid}
 
-        if [ `/usr/bin/stat -f %u /dev/console` -ne 0 ]; then
-          USER_ID=`/usr/bin/stat -f %u /dev/console`
-          GROUP_ID=`/usr/bin/stat -f %g /dev/console`
+        if [ "$(/usr/bin/stat -f %u /dev/console)" -ne 0 ]; then
+          USER_ID=$(/usr/bin/stat -f %u /dev/console)
+          GROUP_ID=$(/usr/bin/stat -f %g /dev/console)
         fi
 
         #{opt_bin}/ntfs-3g \\
           -o volname="${VOLUME_NAME}" \\
           -o local \\
           -o negative_vncache \\
-          -o auto_xattr \\
           -o auto_cache \\
           -o noatime \\
           -o windows_names \\
-          -o user_xattr \\
+          -o streams_interface=openxattr \\
           -o inherit \\
-          -o uid=$USER_ID \\
-          -o gid=$GROUP_ID \\
+          -o uid="$USER_ID" \\
+          -o gid="$GROUP_ID" \\
           -o allow_other \\
           -o big_writes \\
           "$@" >> /var/log/mount-ntfs-3g.log 2>&1


### PR DESCRIPTION
NTFS-3G comes with a handful of extra programs that are hidden behind `--enable-extra`. The most useful of them is `ntfsusermap`, a command used to map Windows ownership & permissions onto Unix users. It can be pretty useful for people who also have a Windows system partition and don't want to accidentally delete system32 without `sudo`.

The other change enables native xattr handling on NTFS-3G by default instead of resorting to `._` AppleDouble files. We all see AppleDouble files as an annoyance, and it really doesn't make sense to use them when the underlying FS has perfect support for xattr.

I tested all changes on a Catalina with a Windows 10 system partition. The permission change will not activate unless a user explicitly goes through the mapping wizard program and puts a mapping file there.

* * *

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
