### PR TITLE
ossp-uuid: update homepage

### DIFF
--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -1,6 +1,6 @@
 class OsspUuid < Formula
   desc "ISO-C API and CLI for generating UUIDs"
-  homepage "https://web.archive.org/web/www.ossp.org/pkg/lib/uuid/"
+  homepage "http://www.ossp.org/pkg/lib/uuid/"
   url "https://deb.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
   sha256 "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"
   revision 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not sure if the web.archive.org URL for `homepage` was intentional, but their website seems to be up and I thought I'd change it. Came across this while adding a Livecheckable for this formula, and trying to use `:homepage`.

Edit: Just to add, Livecheck does work with the existing homepage URL, but I thought we shouldn't use the Wayback Machine URL when the original page is up. If this assumption is wrong, feel free to close the PR.