### PR TITLE
sqliteodbc: mirror for some older linux systems

### DIFF
--- a/Formula/sqliteodbc.rb
+++ b/Formula/sqliteodbc.rb
@@ -2,6 +2,7 @@ class Sqliteodbc < Formula
   desc "SQLite ODBC driver"
   homepage "https://ch-werner.homepage.t-online.de/sqliteodbc/"
   url "https://ch-werner.homepage.t-online.de/sqliteodbc/sqliteodbc-0.9997.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/sqliteodbc-0.9997.tar.gz"
   sha256 "a50cc328a7def2b3389eebeee43c598322ed338506cbd13d8e9d1892db5e0cfe"
 
   bottle do


### PR DESCRIPTION
Fixes:
curl: (60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none

on ubuntu 16.04

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
