### PR TITLE
binwalk: remove gcc dependency since is no longer needed

### DIFF
--- a/Formula/binwalk.rb
+++ b/Formula/binwalk.rb
@@ -5,7 +5,7 @@ class Binwalk < Formula
   homepage "https://github.com/ReFirmLabs/binwalk"
   url "https://github.com/ReFirmLabs/binwalk/archive/v2.2.0.tar.gz"
   sha256 "f5495f0e4c5575023d593f7c087c367675df6aeb7f4d9a2966e49763924daa27"
-  revision 1
+  revision 2
   head "https://github.com/ReFirmLabs/binwalk.git"
 
   bottle do
@@ -18,7 +18,6 @@ class Binwalk < Formula
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
   depends_on "freetype"
-  depends_on "gcc" # for gfortran
   depends_on "libpng"
   depends_on "p7zip"
   depends_on "python@3.8"


### PR DESCRIPTION
This PR addresses issue #56363

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
