### PR TITLE
tre-command 0.3.1 (new formula)

### DIFF
--- a/Formula/tre-command.rb
+++ b/Formula/tre-command.rb
@@ -1,0 +1,20 @@
+class TreCommand < Formula
+  desc "Tree command, improved"
+  homepage "https://github.com/dduan/tre"
+  url "https://github.com/dduan/tre/archive/v0.3.1.tar.gz"
+  sha256 "3d7a7784ed85dd5301f350a3d05eca839f24846997eb0a44b749467f0f4dd032"
+  head "https://github.com/dduan/tre.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked",
+                               "--root", prefix,
+                               "--path", "."
+  end
+
+  test do
+    (testpath/"foo.txt").write("")
+    assert_match("── foo.txt", shell_output("#{bin}/tre"))
+  end
+end


### PR DESCRIPTION
[tre](https://github.com/dduan/tre) is a cross-platform CLI tool that
improves upon the classic `tree` Unix command. It's been distributed
[with Nix][] for a while. It's time to add it to Homebrew core!

Unfortunately, there's an existing library `tre`. So the `-command` is
chosen as part of the package name.

(I'm the author and maintainer of the tool).

[with Nix]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/system/tre-command/default.nix

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
