### PR TITLE
Fix build of istioctl 1.6.2 to include charts

### DIFF
--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -4,6 +4,7 @@ class Istioctl < Formula
   url "https://github.com/istio/istio.git",
       :tag      => "1.6.2",
       :revision => "70f86ede30e826dd18542e95d856255e9780a24f"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -13,6 +13,7 @@ class Istioctl < Formula
   end
 
   depends_on "go" => :build
+  depends_on "go-bindata" => :build
 
   def install
     ENV["GOPATH"] = buildpath
@@ -26,7 +27,7 @@ class Istioctl < Formula
     srcpath.install buildpath.children
 
     cd srcpath do
-      system "make", "istioctl", "istioctl.completion"
+      system "make", "gen-charts", "istioctl", "istioctl.completion"
       prefix.install_metafiles
       bin.install outpath/"istioctl"
       bash_completion.install outpath/"release/istioctl.bash"


### PR DESCRIPTION
This fixes the error 
> Error: compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts

mentioned in https://github.com/Homebrew/homebrew-core/pull/56380#issuecomment-645211419

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
