### PR TITLE
Upgrade Micronaut to 2.0.0.RC1

### DIFF
--- a/Formula/micronaut.rb
+++ b/Formula/micronaut.rb
@@ -1,27 +1,25 @@
 class Micronaut < Formula
   desc "Modern JVM-based framework for building modular microservices"
   homepage "https://micronaut.io/"
-  version "2.0.0.RC1"
-  url "https://github.com/micronaut-projects/micronaut-starter/archive/v#{version}.zip"
-  sha256 "7bbbcab85e70c126ea4ffb20c178b1fc17f44b9758df7d2f348e20920c79aad5"
+  url "https://github.com/micronaut-projects/micronaut-starter/archive/v2.0.0.RC1.tar.gz"
+  sha256 "91dc71b200c598a91b95a20792dcc3f3cb160b8e169b581f6b98689dc713acad"
 
-  GRAALVM_HOME="./graalvm/Contents/Home"
-  
+  GRAALVM_HOME="./graalvm/Contents/Home".freeze
+
+  depends_on :java => ["1.8", :build]
+
   def install
     with_env "GRAAL_OS" => "darwin-amd64", "GRAAL_VERSION" => "20.1.0" do
       system "./install-graal.sh"
     end
-    
-    
     system "#{GRAALVM_HOME}/bin/gu", "install", "native-image"
-    
     with_env "JAVA_HOME" => GRAALVM_HOME do
       system "./gradlew", "micronaut-cli:shadowJar", "--no-daemon"
     end
-    
-    system "echo", "#{GRAALVM_HOME}/bin/native-image", "--no-fallback", "--no-server", "-cp", "starter-cli/build/libs/micronaut-cli-#{version}-all.jar" 
-    system "#{GRAALVM_HOME}/bin/native-image", "--no-fallback", "--no-server", "-cp", "starter-cli/build/libs/micronaut-cli-#{version}-all.jar" 
-    
+    system "echo", "#{GRAALVM_HOME}/bin/native-image", "--no-fallback", "--no-server", "-cp",
+            "starter-cli/build/libs/micronaut-cli-#{version}-all.jar"
+    system "#{GRAALVM_HOME}/bin/native-image", "--no-fallback", "--no-server", "-cp",
+            "starter-cli/build/libs/micronaut-cli-#{version}-all.jar"
     bin.install "mn"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

This PR upgrades Micronaut to the new 2.x binary packages. Compiled from source as requested in #56440 

`brew audit --strict` fails because v2.0.0.RC1 is a GitHub prerelease. However, there is no 2.x release (yet).

Hopefully this is ready to be merged 🙏 