### PR TITLE
scummvm: update patch URL

### DIFF
--- a/Formula/scummvm.rb
+++ b/Formula/scummvm.rb
@@ -26,7 +26,7 @@ class Scummvm < Formula
 
   # Support fluid-synth 2.1
   patch do
-    url "https://sources.debian.org/data/main/s/scummvm/2.1.1+dfsg1-1/debian/patches/git_fluidsynth_update.patch"
+    url "https://sources.debian.org/data/main/s/scummvm/2.1.2+dfsg1-1/debian/patches/git_fluidsynth_update.patch"
     sha256 "4e03d4b685bf38c2367bb669867175bd4b84039a678613bf6e32a34591b382c6"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Update the fluid-synth patch URL as per [this comment](https://github.com/Homebrew/homebrew-core/pull/52496#issuecomment-645529618).