### PR TITLE
robotfindskitten: Add Git head, always autoreconf

### DIFF
--- a/Formula/robotfindskitten.rb
+++ b/Formula/robotfindskitten.rb
@@ -3,6 +3,8 @@ class Robotfindskitten < Formula
   homepage "http://robotfindskitten.org/"
   url "https://downloads.sourceforge.net/project/rfk/robotfindskitten-POSIX/ship_it_anyway/robotfindskitten-2.8284271.702.tar.gz"
   sha256 "020172e4f4630f7c4f62c03b6ffe2eeeba5637b60374d3e6952ae5816a9f99af"
+  revision 1
+  head "https://github.com/robotfindskitten/robotfindskitten.git", :branch => "main"
 
   bottle do
     sha256 "439c4c752b9606e645719ca46388b0143a0f3feb6ff248b4fd0d370f3192d506" => :catalina
@@ -10,7 +12,12 @@ class Robotfindskitten < Formula
     sha256 "667bd9a9abd587202ccd8519ace649638e3eeeb859021c2b9f2014ec55f69ea9" => :high_sierra
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    system "autoreconf", "-ivf"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install", "execgamesdir=#{bin}"


### PR DESCRIPTION
- Adds upstream robotfindskitten Git head
- Upstream repository does not include auto* scripts, so autoreconf
  must be run to build --HEAD.  This requires autoconf/automake/libtool.
  Technically this is only needed for --HEAD and could be worked around
  for official releases, but autoreconf is recommended build procedure
  anyway, as shipped scripts can lag behind auto* features.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
