### PR TITLE
rethinkdb: add head

### DIFF
--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -3,7 +3,7 @@ class Rethinkdb < Formula
   homepage "https://rethinkdb.com/"
   url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.0.tgz"
   sha256 "bfb0708710595c6762f42e25613adec692cf568201cd61da74c254f49fa9ee4c"
-  revision 1
+  head "https://github.com/rethinkdb/rethinkdb.git", :branch => "next"
 
   bottle do
     cellar :any
@@ -22,6 +22,7 @@ class Rethinkdb < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
+    args += ["--allow-fetch"] if build.head?
 
     # rethinkdb requires that protobuf be linked against libc++
     # but brew's protobuf is sometimes linked against libstdc++


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the upstream GitHub repository as the `head` URL. I was able to build this locally using `brew install --HEAD rethinkdb` after making the one conditional addition to the configure `args`.