### PR TITLE
premake: deprecate

### DIFF
--- a/Formula/premake.rb
+++ b/Formula/premake.rb
@@ -16,6 +16,9 @@ class Premake < Formula
     sha256 "4b1ce1c63cc3ecca7e195d4c0350fb6f823f659c36ff6c1193fd99023ed25b12" => :yosemite
   end
 
+  # See: https://groups.google.com/g/premake-development/c/i1uA1Wk6zYM/m/kbp9q4Awu70J
+  deprecate! :date => "2015-05-28"
+
   def install
     if build.head?
       system "make", "-f", "Bootstrap.mak", "osx"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR deprecates `premake` due to reasons discussed in this thread: https://github.com/Homebrew/homebrew-core/pull/55875#issuecomment-645058431

Primary motivations are:
1. current formula version bottles `premake4` which never actually had a stable release and is not actively developed anymore
2. upcoming `premake5` is still in alpha