### PR TITLE
swiftgen 6.2.0

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,9 +2,9 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      :tag      => "6.1.0",
-      :revision => "c6477a6950d313c94c964c6c8ec960e3aeccb8f6"
-  head "https://github.com/SwiftGen/SwiftGen.git"
+      :tag      => "6.2.0",
+      :revision => "c62c7ff1c86323b9c1e4c12bccfca19737dd2e56"
+  head "https://github.com/SwiftGen/SwiftGen.git", :branch => "stable"
 
   bottle do
     cellar :any
@@ -13,7 +13,7 @@ class Swiftgen < Formula
   end
 
   depends_on "ruby" => :build if MacOS.version <= :sierra
-  depends_on :xcode => ["10.0", :build]
+  depends_on :xcode => ["11.4", :build]
 
   def install
     # Disable swiftlint build phase to avoid build errors if versions mismatch
@@ -27,22 +27,22 @@ class Swiftgen < Formula
     system "bundle", "exec", "rake", "cli:install[#{bin},#{lib},#{pkgshare}/templates]"
 
     fixtures = {
-      "Tests/Fixtures/Resources/Colors/colors.xml"                                   => "colors.xml",
-      "Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld"                         => "Model.xcdatamodeld",
-      "Tests/Fixtures/Resources/Fonts"                                               => "Fonts",
-      "Tests/Fixtures/Resources/IB-iOS"                                              => "IB-iOS",
-      "Tests/Fixtures/Resources/Plist/good"                                          => "Plist",
-      "Tests/Fixtures/Resources/Strings/Localizable.strings"                         => "Localizable.strings",
-      "Tests/Fixtures/Resources/XCAssets"                                            => "XCAssets",
-      "Tests/Fixtures/Resources/YAML/good"                                           => "YAML",
-      "Tests/Fixtures/Generated/Colors/swift4-context-defaults.swift"                => "colors.swift",
-      "Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift"              => "coredata.swift",
-      "Tests/Fixtures/Generated/Fonts/swift4-context-defaults.swift"                 => "fonts.swift",
-      "Tests/Fixtures/Generated/IB-iOS/scenes-swift4-context-all.swift"              => "ib-scenes.swift",
-      "Tests/Fixtures/Generated/Plist/runtime-swift4-context-all.swift"              => "plists.swift",
-      "Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift" => "strings.swift",
-      "Tests/Fixtures/Generated/XCAssets/swift4-context-all.swift"                   => "xcassets.swift",
-      "Tests/Fixtures/Generated/YAML/inline-swift4-context-all.swift"                => "yaml.swift",
+      "Tests/Fixtures/Resources/Colors/colors.xml"                           => "colors.xml",
+      "Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld"                 => "Model.xcdatamodeld",
+      "Tests/Fixtures/Resources/Fonts"                                       => "Fonts",
+      "Tests/Fixtures/Resources/IB-iOS"                                      => "IB-iOS",
+      "Tests/Fixtures/Resources/Plist/good"                                  => "Plist",
+      "Tests/Fixtures/Resources/Strings/Localizable.strings"                 => "Localizable.strings",
+      "Tests/Fixtures/Resources/XCAssets"                                    => "XCAssets",
+      "Tests/Fixtures/Resources/YAML/good"                                   => "YAML",
+      "Tests/Fixtures/Generated/Colors/swift5/defaults.swift"                => "colors.swift",
+      "Tests/Fixtures/Generated/CoreData/swift5/defaults.swift"              => "coredata.swift",
+      "Tests/Fixtures/Generated/Fonts/swift5/defaults.swift"                 => "fonts.swift",
+      "Tests/Fixtures/Generated/IB-iOS/scenes-swift5/all.swift"              => "ib-scenes.swift",
+      "Tests/Fixtures/Generated/Plist/runtime-swift5/all.swift"              => "plists.swift",
+      "Tests/Fixtures/Generated/Strings/structured-swift5/localizable.swift" => "strings.swift",
+      "Tests/Fixtures/Generated/XCAssets/swift5/all.swift"                   => "xcassets.swift",
+      "Tests/Fixtures/Generated/YAML/inline-swift5/all.swift"                => "yaml.swift",
     }
     (pkgshare/"fixtures").install fixtures
   end
@@ -52,40 +52,40 @@ class Swiftgen < Formula
 
     fixtures = pkgshare/"fixtures"
 
-    assert_equal shell_output("#{bin}/swiftgen colors --templatePath " \
-                              "#{pkgshare/"templates/colors/swift4.stencil"} #{fixtures}/colors.xml").strip,
-      (fixtures/"colors.swift").read.strip, "swiftgen colors failed"
+    assert_equal shell_output("#{bin}/swiftgen run colors --templatePath " \
+                              "#{pkgshare/"templates/colors/swift5.stencil"} #{fixtures}/colors.xml").strip,
+      (fixtures/"colors.swift").read.strip, "swiftgen run colors failed"
 
-    assert_equal shell_output("#{bin}/swiftgen coredata --templatePath " \
-                              "#{pkgshare/"templates/coredata/swift4.stencil"} #{fixtures}/Model.xcdatamodeld").strip,
-      (fixtures/"coredata.swift").read.strip, "swiftgen coredata failed"
+    assert_equal shell_output("#{bin}/swiftgen run coredata --templatePath " \
+                              "#{pkgshare/"templates/coredata/swift5.stencil"} #{fixtures}/Model.xcdatamodeld").strip,
+      (fixtures/"coredata.swift").read.strip, "swiftgen run coredata failed"
 
-    assert_equal shell_output("#{bin}/swiftgen fonts --templatePath " \
-                              "#{pkgshare/"templates/fonts/swift4.stencil"} #{fixtures}/Fonts").strip,
-      (fixtures/"fonts.swift").read.strip, "swiftgen fonts failed"
+    assert_equal shell_output("#{bin}/swiftgen run fonts --templatePath " \
+                              "#{pkgshare/"templates/fonts/swift5.stencil"} #{fixtures}/Fonts").strip,
+      (fixtures/"fonts.swift").read.strip, "swiftgen run fonts failed"
 
-    assert_equal shell_output("#{bin}/swiftgen ib --templatePath " \
-                              "#{pkgshare/"templates/ib/scenes-swift4.stencil"} --param module=SwiftGen " \
+    assert_equal shell_output("#{bin}/swiftgen run ib --templatePath " \
+                              "#{pkgshare/"templates/ib/scenes-swift5.stencil"} --param module=SwiftGen " \
                               "#{fixtures}/IB-iOS").strip,
-      (fixtures/"ib-scenes.swift").read.strip, "swiftgen ib failed"
+      (fixtures/"ib-scenes.swift").read.strip, "swiftgen run ib failed"
 
-    assert_equal shell_output("#{bin}/swiftgen plist --templatePath " \
-                              "#{pkgshare/"templates/plist/runtime-swift4.stencil"} #{fixtures}/Plist").strip,
-      (fixtures/"plists.swift").read.strip, "swiftgen plist failed"
+    assert_equal shell_output("#{bin}/swiftgen run plist --templatePath " \
+                              "#{pkgshare/"templates/plist/runtime-swift5.stencil"} #{fixtures}/Plist").strip,
+      (fixtures/"plists.swift").read.strip, "swiftgen run plist failed"
 
-    assert_equal shell_output("#{bin}/swiftgen strings --templatePath " \
-                              "#{pkgshare/"templates/strings/structured-swift4.stencil"} " \
+    assert_equal shell_output("#{bin}/swiftgen run strings --templatePath " \
+                              "#{pkgshare/"templates/strings/structured-swift5.stencil"} " \
                               "#{fixtures}/Localizable.strings").strip,
-      (fixtures/"strings.swift").read.strip, "swiftgen strings failed"
+      (fixtures/"strings.swift").read.strip, "swiftgen run strings failed"
 
-    assert_equal shell_output("#{bin}/swiftgen xcassets --templatePath " \
-                              "#{pkgshare/"templates/xcassets/swift4.stencil"} " \
+    assert_equal shell_output("#{bin}/swiftgen run xcassets --templatePath " \
+                              "#{pkgshare/"templates/xcassets/swift5.stencil"} " \
                               "#{fixtures}/XCAssets/*.xcassets").strip,
-      (fixtures/"xcassets.swift").read.strip, "swiftgen xcassets failed"
+      (fixtures/"xcassets.swift").read.strip, "swiftgen run xcassets failed"
 
-    assert_equal shell_output("#{bin}/swiftgen yaml --templatePath " \
-                              "#{pkgshare/"templates/yaml/inline-swift4.stencil"} --filter '.(json|ya?ml)$' " \
+    assert_equal shell_output("#{bin}/swiftgen run yaml --templatePath " \
+                              "#{pkgshare/"templates/yaml/inline-swift5.stencil"} --filter '.(json|ya?ml)$' " \
                               "#{fixtures}/YAML").strip,
-      (fixtures/"yaml.swift").read.strip, "swiftgen yaml failed"
+      (fixtures/"yaml.swift").read.strip, "swiftgen run yaml failed"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew install` locally generates an issue during `brew link` when trying to fix the dylib ID of Kanna. Not sure why and what to do about it.

Let's see if the bottles build on Homebrew's Jenkins have the same issue or if it's just a local glitch of my machine…

<details><summary><tt>brew install swiftgen --verbose</tt></summary>

```
==> Cloning https://github.com/SwiftGen/SwiftGen.git
Updating /Users/olivier/Library/Caches/Homebrew/swiftgen--git
git config remote.origin.url https://github.com/SwiftGen/SwiftGen.git
git config remote.origin.fetch \+refs/tags/6.2.0:refs/tags/6.2.0
git config remote.origin.tagOpt --no-tags
==> Checking out tag 6.2.0
git checkout -f 6.2.0 --
HEAD is now at b2278f1 Merge pull request #718 from SwiftGen/release/6.2.0
git reset --hard 6.2.0 --
HEAD is now at b2278f1 Merge pull request #718 from SwiftGen/release/6.2.0
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200618-32729-6ssqga.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/swiftgen.rb --verbose
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Documentation/. /private/tmp/d20200618-32730-j9zz14/Documentation
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.swift-version /private/tmp/d20200618-32730-j9zz14/.swift-version
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.ruby-version /private/tmp/d20200618-32730-j9zz14/.ruby-version
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/COMMUNITY.md /private/tmp/d20200618-32730-j9zz14/COMMUNITY.md
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/CHANGELOG.md /private/tmp/d20200618-32730-j9zz14/CHANGELOG.md
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.swiftlint.yml /private/tmp/d20200618-32730-j9zz14/.swiftlint.yml
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Package.resources /private/tmp/d20200618-32730-j9zz14/Package.resources
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Resources/. /private/tmp/d20200618-32730-j9zz14/Resources
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/rakelib/. /private/tmp/d20200618-32730-j9zz14/rakelib
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/DEPENDENCIES.md /private/tmp/d20200618-32730-j9zz14/DEPENDENCIES.md
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Tests/. /private/tmp/d20200618-32730-j9zz14/Tests
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/README.md /private/tmp/d20200618-32730-j9zz14/README.md
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/SwiftGen.xcworkspace/. /private/tmp/d20200618-32730-j9zz14/SwiftGen.xcworkspace
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Rakefile /private/tmp/d20200618-32730-j9zz14/Rakefile
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Package.resolved /private/tmp/d20200618-32730-j9zz14/Package.resolved
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Pods/. /private/tmp/d20200618-32730-j9zz14/Pods
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.gitignore /private/tmp/d20200618-32730-j9zz14/.gitignore
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/CONTRIBUTING.md /private/tmp/d20200618-32730-j9zz14/CONTRIBUTING.md
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Scripts/. /private/tmp/d20200618-32730-j9zz14/Scripts
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.github/. /private/tmp/d20200618-32730-j9zz14/.github
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Dangerfile /private/tmp/d20200618-32730-j9zz14/Dangerfile
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Package.swift /private/tmp/d20200618-32730-j9zz14/Package.swift
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Gemfile /private/tmp/d20200618-32730-j9zz14/Gemfile
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Sources/. /private/tmp/d20200618-32730-j9zz14/Sources
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/SwiftGen.xcodeproj/. /private/tmp/d20200618-32730-j9zz14/SwiftGen.xcodeproj
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/templates/. /private/tmp/d20200618-32730-j9zz14/templates
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Gemfile.lock /private/tmp/d20200618-32730-j9zz14/Gemfile.lock
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Podfile /private/tmp/d20200618-32730-j9zz14/Podfile
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/SwiftGenKit.podspec /private/tmp/d20200618-32730-j9zz14/SwiftGenKit.podspec
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.git/. /private/tmp/d20200618-32730-j9zz14/.git
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/SwiftGen.playground/. /private/tmp/d20200618-32730-j9zz14/SwiftGen.playground
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/.circleci/. /private/tmp/d20200618-32730-j9zz14/.circleci
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/SwiftGen.podspec /private/tmp/d20200618-32730-j9zz14/SwiftGen.podspec
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/Podfile.lock /private/tmp/d20200618-32730-j9zz14/Podfile.lock
cp -pR /Users/olivier/Library/Caches/Homebrew/swiftgen--git/LICENCE /private/tmp/d20200618-32730-j9zz14/LICENCE
cp -pR /private/tmp/d20200618-32730-j9zz14/Documentation/. /private/tmp/swiftgen-20200618-32730-v4bksb/Documentation
cp -pR /private/tmp/d20200618-32730-j9zz14/.swift-version /private/tmp/swiftgen-20200618-32730-v4bksb/.swift-version
cp -pR /private/tmp/d20200618-32730-j9zz14/.ruby-version /private/tmp/swiftgen-20200618-32730-v4bksb/.ruby-version
cp -pR /private/tmp/d20200618-32730-j9zz14/COMMUNITY.md /private/tmp/swiftgen-20200618-32730-v4bksb/COMMUNITY.md
cp -pR /private/tmp/d20200618-32730-j9zz14/CHANGELOG.md /private/tmp/swiftgen-20200618-32730-v4bksb/CHANGELOG.md
cp -pR /private/tmp/d20200618-32730-j9zz14/.swiftlint.yml /private/tmp/swiftgen-20200618-32730-v4bksb/.swiftlint.yml
cp -pR /private/tmp/d20200618-32730-j9zz14/Package.resources /private/tmp/swiftgen-20200618-32730-v4bksb/Package.resources
cp -pR /private/tmp/d20200618-32730-j9zz14/Resources/. /private/tmp/swiftgen-20200618-32730-v4bksb/Resources
cp -pR /private/tmp/d20200618-32730-j9zz14/rakelib/. /private/tmp/swiftgen-20200618-32730-v4bksb/rakelib
cp -pR /private/tmp/d20200618-32730-j9zz14/DEPENDENCIES.md /private/tmp/swiftgen-20200618-32730-v4bksb/DEPENDENCIES.md
cp -pR /private/tmp/d20200618-32730-j9zz14/Tests/. /private/tmp/swiftgen-20200618-32730-v4bksb/Tests
cp -pR /private/tmp/d20200618-32730-j9zz14/README.md /private/tmp/swiftgen-20200618-32730-v4bksb/README.md
cp -pR /private/tmp/d20200618-32730-j9zz14/SwiftGen.xcworkspace/. /private/tmp/swiftgen-20200618-32730-v4bksb/SwiftGen.xcworkspace
cp -pR /private/tmp/d20200618-32730-j9zz14/Rakefile /private/tmp/swiftgen-20200618-32730-v4bksb/Rakefile
cp -pR /private/tmp/d20200618-32730-j9zz14/Package.resolved /private/tmp/swiftgen-20200618-32730-v4bksb/Package.resolved
cp -pR /private/tmp/d20200618-32730-j9zz14/Pods/. /private/tmp/swiftgen-20200618-32730-v4bksb/Pods
cp -pR /private/tmp/d20200618-32730-j9zz14/.gitignore /private/tmp/swiftgen-20200618-32730-v4bksb/.gitignore
cp -pR /private/tmp/d20200618-32730-j9zz14/CONTRIBUTING.md /private/tmp/swiftgen-20200618-32730-v4bksb/CONTRIBUTING.md
cp -pR /private/tmp/d20200618-32730-j9zz14/Scripts/. /private/tmp/swiftgen-20200618-32730-v4bksb/Scripts
cp -pR /private/tmp/d20200618-32730-j9zz14/.github/. /private/tmp/swiftgen-20200618-32730-v4bksb/.github
cp -pR /private/tmp/d20200618-32730-j9zz14/Dangerfile /private/tmp/swiftgen-20200618-32730-v4bksb/Dangerfile
cp -pR /private/tmp/d20200618-32730-j9zz14/Package.swift /private/tmp/swiftgen-20200618-32730-v4bksb/Package.swift
cp -pR /private/tmp/d20200618-32730-j9zz14/Gemfile /private/tmp/swiftgen-20200618-32730-v4bksb/Gemfile
cp -pR /private/tmp/d20200618-32730-j9zz14/Sources/. /private/tmp/swiftgen-20200618-32730-v4bksb/Sources
cp -pR /private/tmp/d20200618-32730-j9zz14/SwiftGen.xcodeproj/. /private/tmp/swiftgen-20200618-32730-v4bksb/SwiftGen.xcodeproj
cp -pR /private/tmp/d20200618-32730-j9zz14/templates/. /private/tmp/swiftgen-20200618-32730-v4bksb/templates
cp -pR /private/tmp/d20200618-32730-j9zz14/Gemfile.lock /private/tmp/swiftgen-20200618-32730-v4bksb/Gemfile.lock
cp -pR /private/tmp/d20200618-32730-j9zz14/Podfile /private/tmp/swiftgen-20200618-32730-v4bksb/Podfile
cp -pR /private/tmp/d20200618-32730-j9zz14/SwiftGenKit.podspec /private/tmp/swiftgen-20200618-32730-v4bksb/SwiftGenKit.podspec
cp -pR /private/tmp/d20200618-32730-j9zz14/.git/. /private/tmp/swiftgen-20200618-32730-v4bksb/.git
cp -pR /private/tmp/d20200618-32730-j9zz14/SwiftGen.playground/. /private/tmp/swiftgen-20200618-32730-v4bksb/SwiftGen.playground
cp -pR /private/tmp/d20200618-32730-j9zz14/.circleci/. /private/tmp/swiftgen-20200618-32730-v4bksb/.circleci
cp -pR /private/tmp/d20200618-32730-j9zz14/SwiftGen.podspec /private/tmp/swiftgen-20200618-32730-v4bksb/SwiftGen.podspec
cp -pR /private/tmp/d20200618-32730-j9zz14/Podfile.lock /private/tmp/swiftgen-20200618-32730-v4bksb/Podfile.lock
cp -pR /private/tmp/d20200618-32730-j9zz14/LICENCE /private/tmp/swiftgen-20200618-32730-v4bksb/LICENCE
chmod -Rf +w /private/tmp/d20200618-32730-j9zz14
==> gem install bundler
Successfully installed bundler-2.1.4
Parsing documentation for bundler-2.1.4
Installing ri documentation for bundler-2.1.4
Done installing documentation for bundler after 2 seconds
1 gem installed
==> bundle install --without development release
Fetching gem metadata from https://rubygems.org/..
Fetching rake 13.0.1
Installing rake 13.0.1
Using bundler 1.17.2
Fetching rouge 2.0.7
Installing rouge 2.0.7
Fetching xcpretty 0.3.0
Installing xcpretty 0.3.0
Bundle complete! 7 Gemfile dependencies, 4 gems now installed.
Gems in the groups development and release were not installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
==> bundle exec rake cli:install[/usr/local/Cellar/swiftgen/6.2.0/bin,/usr/local/Cellar/swiftgen/6.2.0/lib,/usr/local/Cellar/swiftgen/6.2.0/share/swiftgen/templates]
== Building Binary ==
set -o pipefail && (\
 xcrun xcodebuild -workspace "SwiftGen.xcworkspace" -scheme "swiftgen" -configuration "Release" -derivedDataPath "/private/tmp/swiftgen-20200618-32730-v4bksb/build" TEMPLATE_PATH="../share/swiftgen/templates" SWIFTGEN_OTHER_LDFLAGS="-sectcreate __TEXT __info_plist /private/tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/swiftgen.app/Contents/Info.plist" \
) | bundle exec xcpretty -c
▸ Processing Yams-Info.plist
▸ Copying Yams.h
▸ Copying yaml_private.h
▸ Copying yaml.h
▸ Copying CYaml.h
▸ Copying Yams-umbrella.h
▸ Processing PathKit-Info.plist
▸ Copying PathKit-umbrella.h
▸ Processing Kanna-Info.plist
▸ Copying Kanna-umbrella.h
▸ Copying Kanna.h
▸ Processing Commander-Info.plist
▸ Copying Commander-umbrella.h
▸ Compiling PathKit.swift

⚠️  /tmp/swiftgen-20200618-32730-v4bksb/Pods/PathKit/Sources/PathKit.swift:98:14: 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'Path' to 'Hashable' by implementing 'hash(into:)' instead

  public var hashValue: Int {
             ^


▸ Compiling PathKit-dummy.m
▸ Compiling PathKit_vers.c
▸ Linking PathKit
▸ Generating 'PathKit.framework.dSYM'
▸ Touching PathKit.framework (in target 'PathKit' from project 'PathKit')
▸ Processing Stencil-Info.plist
▸ Copying Stencil-umbrella.h

⚠️  /tmp/swiftgen-20200618-32730-v4bksb/Pods/Stencil/Sources/Template.swift:11:3: 'internal(set)' modifier is redundant for an internal property

  internal(set) var environment: Environment
  ^~~~~~~~~~~~~~


▸ Compiling Kanna_vers.c
▸ Compiling Kanna-dummy.m
▸ Linking Kanna
▸ Generating 'Kanna.framework.dSYM'
▸ Touching Kanna.framework (in target 'Kanna' from project 'Kanna')
▸ Compiling writer.c
▸ Compiling scanner.c
▸ Compiling reader.c
▸ Compiling parser.c
▸ Compiling emitter.c
▸ Compiling api.c
▸ Compiling Yams_vers.c
▸ Compiling Yams-dummy.m
▸ Compiling Commander_vers.c
▸ Compiling Commander-dummy.m
▸ Linking Commander
▸ Linking Yams
▸ Generating 'Commander.framework.dSYM'
▸ Touching Commander.framework (in target 'Commander' from project 'Commander')
▸ Generating 'Yams.framework.dSYM'
▸ Touching Yams.framework (in target 'Yams' from project 'Yams')
▸ Processing Pods-SwiftGenKit-Info.plist
▸ Copying Pods-SwiftGenKit-umbrella.h
▸ Compiling Pods-SwiftGenKit-dummy.m
▸ Compiling Pods_SwiftGenKit_vers.c
▸ Touching Pods_SwiftGenKit.framework (in target 'Pods-SwiftGenKit' from project 'Pods')
▸ Processing SwiftGenKit-Info.plist
▸ Running script '[CP] Check Pods Manifest.lock'
▸ Running script '⚠️ SwiftLint'
▸ Compiling Stencil-dummy.m
▸ Compiling Stencil_vers.c
▸ Linking Stencil
▸ Generating 'Stencil.framework.dSYM'
▸ Touching Stencil.framework (in target 'Stencil' from project 'Stencil')
▸ Processing StencilSwiftKit-Info.plist
▸ Copying StencilSwiftKit-umbrella.h

⚠️  /tmp/swiftgen-20200618-32730-v4bksb/Pods/StencilSwiftKit/Sources/StencilSwiftKit/Environment.swift:10:3: 'public' modifier is redundant for instance method declared in a public extension

  public func registerStencilSwiftExtensions() {
  ^~~~~~~


▸ Compiling StencilSwiftKit_vers.c
▸ Compiling StencilSwiftKit-dummy.m
▸ Linking StencilSwiftKit
▸ Generating 'StencilSwiftKit.framework.dSYM'
▸ Touching StencilSwiftKit.framework (in target 'StencilSwiftKit' from project 'StencilSwiftKit')
▸ Copying Pods-swiftgen-umbrella.h
▸ Processing Pods-swiftgen-Info.plist
▸ Compiling Pods-swiftgen-dummy.m
▸ Compiling Pods_swiftgen_vers.c
▸ Touching Pods_swiftgen.framework (in target 'Pods-swiftgen' from project 'Pods')
▸ Compiling SwiftGenKit_vers.c
▸ Linking SwiftGenKit
▸ Signing /tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/SwiftGenKit.framework
▸ Generating 'SwiftGenKit.framework.dSYM'
▸ Touching SwiftGenKit.framework (in target 'SwiftGenKit' from project 'SwiftGen')
▸ Processing SwiftGen-Info.plist
▸ Running script '[CP] Check Pods Manifest.lock'
▸ Running script '⚠️ SwiftLint'
▸ Linking swiftgen
▸ Copying /tmp/swiftgen-20200618-32730-v4bksb/templates
▸ Generating 'swiftgen.app.dSYM'
▸ Copying /tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/SwiftGenKit.framework
▸ Signing /tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/swiftgen.app/Contents/Frameworks/SwiftGenKit.framework
▸ Running script '[CP] Embed Pods Frameworks'
▸ Touching swiftgen.app (in target 'swiftgen' from project 'SwiftGen')
▸ Build Succeeded
mkdir -p "/usr/local/Cellar/swiftgen/6.2.0/bin" && \
cp -f "/private/tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/swiftgen.app/Contents/MacOS/swiftgen" "/usr/local/Cellar/swiftgen/6.2.0/bin/swiftgen"
== Installing binary in /usr/local/Cellar/swiftgen/6.2.0/bin ==
if [ -d "/usr/local/Cellar/swiftgen/6.2.0/lib" ]; then rm -rf "/usr/local/Cellar/swiftgen/6.2.0/lib"; fi && \
mkdir -p "/usr/local/Cellar/swiftgen/6.2.0/lib" && \
cp -fR "/private/tmp/swiftgen-20200618-32730-v4bksb/build/Build/Products/Release/swiftgen.app/Contents/Frameworks/" "/usr/local/Cellar/swiftgen/6.2.0/lib"
== Installing frameworks in /usr/local/Cellar/swiftgen/6.2.0/lib ==
 xcrun install_name_tool -delete_rpath "@executable_path/../Frameworks" "/usr/local/Cellar/swiftgen/6.2.0/bin/swiftgen" && \
 xcrun install_name_tool -add_rpath "@executable_path/../lib" "/usr/local/Cellar/swiftgen/6.2.0/bin/swiftgen"
== Fixing binary's @rpath ==
mkdir -p "/usr/local/Cellar/swiftgen/6.2.0/share/swiftgen/templates" && \
cp -r "templates/" "/usr/local/Cellar/swiftgen/6.2.0/share/swiftgen/templates"
== Installing templates in /usr/local/Cellar/swiftgen/6.2.0/share/swiftgen/templates ==
Finished installing. Binary is available in: /usr/local/Cellar/swiftgen/6.2.0/bin
==> Cleaning
```
</details>

```
==> Finishing up
ln -s ../Cellar/swiftgen/6.2.0/bin/swiftgen swiftgen
ln -s ../Cellar/swiftgen/6.2.0/share/swiftgen swiftgen
ln -s ../Cellar/swiftgen/6.2.0/lib/Commander.framework Commander.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/Kanna.framework Kanna.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/PathKit.framework PathKit.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/Stencil.framework Stencil.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/StencilSwiftKit.framework StencilSwiftKit.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/SwiftGenKit.framework SwiftGenKit.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/Yams.framework Yams.framework
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftCore.dylib libswiftCore.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftCoreFoundation.dylib libswiftCoreFoundation.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftCoreGraphics.dylib libswiftCoreGraphics.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftDarwin.dylib libswiftDarwin.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftDispatch.dylib libswiftDispatch.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftFoundation.dylib libswiftFoundation.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftIOKit.dylib libswiftIOKit.dylib
ln -s ../Cellar/swiftgen/6.2.0/lib/libswiftObjectiveC.dylib libswiftObjectiveC.dylib
Error: Failed changing dylib ID of /usr/local/Cellar/swiftgen/6.2.0/lib/Kanna.framework/Versions/A/Kanna
  from @rpath/Kanna.framework/Versions/A/Kanna
    to /usr/local/opt/swiftgen/lib/Kanna.framework/Versions/A/Kanna
Error: Failed to fix install linkage
The formula built, but you may encounter issues using it or linking other
formulae against it.
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200618-33331-je6jm5.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/postinstall.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/swiftgen.rb
==> Summary
🍺  /usr/local/Cellar/swiftgen/6.2.0: 209 files, 26.2MB, built in 56 seconds
```
