### PR TITLE
clang-format@8: add botle for version 8 (head is 10)

### DIFF
--- a/Aliases/clang-format@10
+++ b/Aliases/clang-format@10
@@ -1,0 +1,1 @@
+../Formula/clang-format.rb

--- a/Formula/clang-format@8.rb
+++ b/Formula/clang-format@8.rb
@@ -1,0 +1,50 @@
+class ClangFormatAT8 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz"
+  sha256 "44787a6d02f7140f145e2250d56c9f849334e11f9ae379827510ed72f12b75e7"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/cfe-8.0.1.src.tar.xz"
+    sha256 "70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646"
+  end
+
+  resource "libcxx" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/libcxx-8.0.1.src.tar.xz"
+    sha256 "7f0652c86a0307a250b5741ab6e82bb10766fb6f2b5a5602a63f30337e629b78"
+  end
+
+  def install
+    (buildpath/"projects/libcxx").install resource("libcxx")
+    (buildpath/"tools/clang").install resource("clang")
+
+    mkdir buildpath/"build" do
+      args = std_cmake_args
+      args << "-DLLVM_ENABLE_LIBCXX=ON"
+      args << ".."
+      system "cmake", "-G", "Ninja", *args
+      system "ninja", "clang-format"
+    end
+
+    bin.install buildpath/"build/bin/clang-format" => "clang-format-8"
+    bin.install buildpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-8"
+  end
+
+  test do
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-8 -style=Google test.c")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Sadly the clang-format versions are not backward compatible and there are no workaround. For instance if you participate to some Linux project you need to use the same version on macos as other participants on Linux. The version 8 match the version of stable Debian.

# Here is some backround for the pull request

## Versioning

On Linux is the same problem solved the same approached. There are several packages due to incompatibility and if you want to use command `clang-format` you have to set alternative or make link `clang-format` -> `clang-format-8`.

```console
(buster)6e5192c9d5e7 # apt-cache search clang-format
clang-format - Tool to format C/C++/Obj-C code
clang-format-6.0 - Tool to format C/C++/Obj-C code
clang-format-7 - Tool to format C/C++/Obj-C code
clang-format-8 - Tool to format C/C++/Obj-C code
```

## Which versions keep

On stable Debian (Buster) are these versions available:
- repo buster/main:
  - clang-format:     Candidate: 1:7.0-47
  - clang-format-6.0: Candidate: 1:6.0.1-10
  - clang-format-7:   Candidate: 1:7.0.1-8
- repo buster-backports/main:
  - clang-format-8:   Candidate: 1:8.0.1-3~bpo10+1

On testing Debian (Bullseye) is package `clang-format_9.0-49.1_amd64.deb`

I don't want to keep all version if nobody needs them. So, it sounds to me that on `stable` anybody can use version 8 from backports and when `testing` become `stable` I presume that the version 10 will be put to backport as well.
This is a reason why i didn't make botle for 9 as well. If you feel otherwice let me known.

## What is a breaking change?

Actually any new feature in formatting configuration. New version usually add some new configuration option and default value of this option changes behaviour. If this option is added to config file, the older `clang-format` fails on unknown option. So there is no way how to use one configuration along with two different version of `clang-format`.

