### PR TITLE
swift-format: change head branch

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -5,7 +5,8 @@ class SwiftFormat < Formula
     :tag      => "0.50200.1",
     :revision => "f22aade8a6ee061b4a7041601ededd8ad7bc2122"
   version_scheme 1
-  head "https://github.com/apple/swift-format.git"
+  head "https://github.com/apple/swift-format.git",
+    :branch => "swift-5.2-branch"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Current head branch requires a prerelease version of swift, whereas `swift-5.2-branch` contains prerelease changes for the current production version of swift.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?