### PR TITLE
bleachbit 4.0.0 (new formula)

### DIFF
--- a/Formula/bleachbit.rb
+++ b/Formula/bleachbit.rb
@@ -14,6 +14,8 @@ class Bleachbit < Formula
     system "python3", "setup.py", "install", "--prefix=#{prefix}",
                       "--single-version-externally-managed",
                       "--record=installed.txt"
+    (libexec/"bin").install "bleachbit.py"
+    (bin/"bleachbit").write_env_script libexec/"bin/bleachbit.py", :PYTHONHOME => libexec/"bin/python3.8", :PYTHONPATH => libexec/"lib/python3.8/site-packages"
     venv.pip_install_and_link buildpath
   end
 

--- a/Formula/bleachbit.rb
+++ b/Formula/bleachbit.rb
@@ -10,14 +10,10 @@ class Bleachbit < Formula
   depends_on "python@3.8"
 
   def install
-    venv = virtualenv_create(libexec, "python3")
-    system "python3", "setup.py", "install", "--prefix=#{prefix}",
-                      "--single-version-externally-managed",
-                      "--record=installed.txt"
+    virtualenv_install_with_resources
     (libexec/"bin").install "bleachbit.py"
     (bin/"bleachbit").write_env_script libexec/"bin/bleachbit.py",
       :PYTHONPATH => libexec/"lib/python3.8/site-packages"
-    venv.pip_install_and_link buildpath
   end
 
   test do

--- a/Formula/bleachbit.rb
+++ b/Formula/bleachbit.rb
@@ -16,7 +16,6 @@ class Bleachbit < Formula
                       "--record=installed.txt"
     (libexec/"bin").install "bleachbit.py"
     (bin/"bleachbit").write_env_script libexec/"bin/bleachbit.py",
-      :PYTHONHOME => libexec,
       :PYTHONPATH => libexec/"lib/python3.8/site-packages"
     venv.pip_install_and_link buildpath
   end

--- a/Formula/bleachbit.rb
+++ b/Formula/bleachbit.rb
@@ -1,0 +1,23 @@
+class Bleachbit < Formula
+  include Language::Python::Virtualenv
+
+  desc "Antiforensics and privacy system disk cleaner"
+  homepage "https://www.bleachbit.org"
+  url "https://github.com/bleachbit/bleachbit/archive/v4.0.0.tar.gz"
+  sha256 "5f7813b1ecda32647b1a31564b66f369fbd0d50d67924f256a0d414abc07501b"
+
+  depends_on "pygobject3"
+  depends_on "python@3.8"
+
+  def install
+    venv = virtualenv_create(libexec, "python3")
+    system "python3", "setup.py", "install", "--prefix=#{prefix}",
+                      "--single-version-externally-managed",
+                      "--record=installed.txt"
+    venv.pip_install_and_link buildpath
+  end
+
+  test do
+    assert_match "BleachBit version ", shell_output("#{bin}/bleachbit --sysinfo")
+  end
+end

--- a/Formula/bleachbit.rb
+++ b/Formula/bleachbit.rb
@@ -15,7 +15,9 @@ class Bleachbit < Formula
                       "--single-version-externally-managed",
                       "--record=installed.txt"
     (libexec/"bin").install "bleachbit.py"
-    (bin/"bleachbit").write_env_script libexec/"bin/bleachbit.py", :PYTHONHOME => libexec/"bin/python3.8", :PYTHONPATH => libexec/"lib/python3.8/site-packages"
+    (bin/"bleachbit").write_env_script libexec/"bin/bleachbit.py",
+      :PYTHONHOME => libexec,
+      :PYTHONPATH => libexec/"lib/python3.8/site-packages"
     venv.pip_install_and_link buildpath
   end
 


### PR DESCRIPTION
## Progress

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

## Description

This is the first attempt at packaging [BleachBit](https://github.com/bleachbit/bleachbit/) for macOS. If the software is [designed to run on macOS](https://github.com/bleachbit/bleachbit/pull/139), it was never properly made into an `.app` or `.dmg` by the maintainers. This PR is a work in progress to share progress with BleachBit community and fix all remaining issues on the packaging.

## Manual install

Here is a proof BleachBit runs fine on macOS:

```shell-session
$ git clone https://github.com/bleachbit/bleachbit.git   
(...)

$ cd bleachbit
(...)

$ brew install pygobject3
(...)

$ /usr/local/opt/python@3.8/bin/python3.8 ./bleachbit.py --version
BleachBit version 4.0.1
(...)
```

```
$ /usr/local/opt/python@3.8/bin/python3.8 ./bleachbit.py --gui

(bleachbit.py:29612): Gtk-WARNING **: 10:20:59.372: Drawing a gadget with negative dimensions. Did you forget to allocate a size? (node text owner GtkProgressBar)

(bleachbit.py:29612): Gtk-WARNING **: 10:20:59.592: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.
```

<img width="870" alt="Screen Shot 2020-06-19 at 10 21 20" src="https://user-images.githubusercontent.com/159718/85117399-16888f00-b21f-11ea-91f7-c834c0d5a6b0.png">

Now all we need is to package it! :)

## Python 3.8

Also related, we depends on `python@3.8` as our main dependency, [`pygobject3`, is already packaged for Python 3.8](https://github.com/Homebrew/homebrew-core/blob/50345f7e93d931eff4835c0d0bb5c7bcbbf358d0/Formula/pygobject3.rb#L19):

```
$ brew info python@3.8
python@3.8: stable 3.8.3 (bottled) [keg-only]
(...)
python@3.8 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.
(...)

$ python --version
Python 3.7.7

$ ls -lah /usr/local/lib/python3.8/site-packages/
(...)
drwxr-xr-x 20 user staff  640 Jun 19 08:52 gi/
(...)
```

For more context on Python 3.8 situation, see: https://github.com/Homebrew/homebrew-core/issues/47274