### PR TITLE
perkeep: depend on go@1.12

### DIFF
--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -1,10 +1,20 @@
 class Perkeep < Formula
   desc "Lets you permanently keep your stuff, for life"
   homepage "https://perkeep.org/"
-  url "https://github.com/perkeep/perkeep.git",
-      :tag      => "0.10",
-      :revision => "0cbe4d5e05a40a17efe7441d75ce0ffdf9d6b9f5"
-  head "https://github.com/perkeep/perkeep.git"
+
+  stable do
+    url "https://github.com/perkeep/perkeep.git",
+        :tag      => "0.10",
+        :revision => "0cbe4d5e05a40a17efe7441d75ce0ffdf9d6b9f5"
+
+    # gopherjs doesn't tag releases, so just pick the most recent revision for now
+    resource "gopherjs" do
+      url "https://github.com/gopherjs/gopherjs/archive/fce0ec30dd00773d3fa974351d04ce2737b5c4d9.tar.gz"
+      sha256 "e5e6ede5f710fde77e48aa1f6a9b75f5afeb1163223949f76c1300ae44263b84"
+    end
+
+    depends_on "go@1.12" => :build
+  end
 
   bottle do
     sha256 "1e51d2d991309cec65b66411ff9dbbd1d93ec40c4c595d1b91a786541c15d738" => :mojave
@@ -13,19 +23,37 @@ class Perkeep < Formula
     sha256 "e4e42c68017500af8a8aa7b542e89905849b09b398a547da818323f08a6e680a" => :el_capitan
   end
 
-  depends_on "go" => :build
+  head do
+    url "https://github.com/perkeep/perkeep.git"
+
+    depends_on "go" => :build
+  end
+
   depends_on "pkg-config" => :build
 
   conflicts_with "hello", :because => "both install `hello` binaries"
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/perkeep.org").install buildpath.children
-    cd "src/perkeep.org" do
+    if build.stable?
+      ENV["GOPATH"] = buildpath
+      ENV["CAMLI_GOPHERJS_GOROOT"] = Formula["go@1.12"].opt_libexec
+
+      (buildpath/"src/perkeep.org").install buildpath.children
+
+      # Vendored version of gopherjs requires go 1.10, so use the newest available gopherjs, which
+      # supports up to go 1.12
+      rm_rf buildpath/"src/perkeep.org/vendor/github.com/gopherjs/gopherjs"
+      resource("gopherjs").stage buildpath/"src/perkeep.org/vendor/github.com/gopherjs/gopherjs"
+
+      cd "src/perkeep.org" do
+        system "go", "run", "make.go"
+      end
+
+      bin.install Dir["bin/*"].select { |f| File.executable? f }
+    else
       system "go", "run", "make.go"
-      prefix.install_metafiles
+      bin.install Dir[".brew_home/go/bin/*"].select { |f| File.executable? f }
     end
-    bin.install Dir["bin/*"].select { |f| File.executable? f }
   end
 
   plist_options :manual => "perkeepd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR attempts to make `perkeep` buildable from source again by downgrading to `go@1.12`. I realize that this is generally not a good thing and that [a previous attempt to downgrade to `go@1.10` was turned away due to us carrying so many versions of `go`](https://github.com/Homebrew/homebrew-core/pull/52131), but trying to get up to the current `go` version would require an unacceptable amount of patching on our end.

The last tagged version of `perkeep` (which is the current version of the formula) depends on [`gopherjs`](https://github.com/gopherjs/gopherjs), and it is vendored in the subdirectory `vendor/github.com/gopherjs/gopherjs`. Unfortunately, this version of `gopherjs` is trapped at `go` 1.10 (compile will fail on newer `go` versions due to missing compilation symbols, etc.).

Thus, this PR replaces the vendored version of `gopherjs` that is shipped with the current latest tagged version of `gopherjs` with a newer version (from the `HEAD` of the `gopherjs` repo at time of writing, because surprise, surprise - `gopherjs` has no tagged releases either 🙃). This newer version of `gopherjs` builds with any version of `go`, but will still only _run_ with `go` 1.12 (specifically, it requires access to the `GOROOT` of `go` 1.12 in order to work properly). I've tried bypassing the checks in `gopherjs` that enforce this requirement, only to have much bigger compilation errors down the line.

[There has been work on getting support in `gopherjs` for Go 1.13/1.14](https://github.com/gopherjs/gopherjs/pull/964), but the PR seems to have stalled. The PR contains some 50 commits, so including them all isn't an option (unless we want to just compile them into one mega-patch to be hosted on `formula-patches`).

Meanwhile, the current `HEAD` version of `perkeep` doesn't seem to depend on `gopherjs` at all anymore and actually builds fine with `go` 1.14. **Thus the ideal solution would be for `perkeep` to cut a release (some 1700+ commits over the course of about two years now - thanks @roopakv for [following up with their team on this](https://github.com/perkeep/perkeep/issues/1307)) and everything should just work again™.**