### PR TITLE
rsync 3.2.0

### DIFF
--- a/Formula/rsync.rb
+++ b/Formula/rsync.rb
@@ -1,11 +1,10 @@
 class Rsync < Formula
   desc "Utility that provides fast incremental file transfer"
   homepage "https://rsync.samba.org/"
-  url "https://rsync.samba.org/ftp/rsync/rsync-3.1.3.tar.gz"
-  mirror "https://mirrors.kernel.org/gentoo/distfiles/rsync-3.1.3.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.1.3.tar.gz"
-  sha256 "55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0"
-  revision 1
+  url "https://rsync.samba.org/ftp/rsync/rsync-3.2.0.tar.gz"
+  mirror "https://mirrors.kernel.org/gentoo/distfiles/rsync-3.2.0.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.2.0.tar.gz"
+  sha256 "90127fdfb1a0c5fa655f2577e5495a40907903ac98f346f225f867141424fa25"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,35 +14,65 @@ class Rsync < Formula
     sha256 "cc355e9492df6bab4952e835dd8575de86fa169f6451218c5d2c777c4d9462a5" => :high_sierra
   end
 
-  depends_on "autoconf" => :build
+  depends_on "lz4"
+  depends_on "openssl@1.1"
+  depends_on "popt"
+  depends_on "xxhash"
+  depends_on "zstd"
 
-  # hfs-compression.diff is marked by upstream as broken as of 3.1.3
+  uses_from_macos "zlib"
+
+  # hfs-compression.diff has been marked by upstream as broken since 3.1.3
+  # and has not been reported fixed as of 3.2.0
   patch do
-    url "https://download.samba.org/pub/rsync/src/rsync-patches-3.1.3.tar.gz"
-    mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-patches-3.1.3.tar.gz"
-    mirror "https://launchpad.net/rsync/main/3.1.2/+download/rsync-patches-3.1.3.tar.gz"
-    sha256 "0dc2848f20ca75c07a30c3237ccf8d61b61082ae7de94758a27dac350c99fb98"
+    url "https://download.samba.org/pub/rsync/src/rsync-patches-3.2.0.tar.gz"
+    mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-patches-3.2.0.tar.gz"
+    sha256 "bad70e6caad30ad12f0333529911b0f9c63f2ed096d6d649c2db2f6d9eec6e58"
     apply "patches/fileflags.diff",
           "patches/crtimes.diff"
   end
 
-  # Fix "error: too few arguments to function call, expected 4, have 2"
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/344bf3b/rsync/fix-crtimes-patch-3.1.3.diff"
-    sha256 "1a3c9043e19b55290bd6a6bc480544fe79a155c2c7ed003de185521f7516ecc3"
-  end
-
   def install
-    system "./prepare-source"
-    system "./configure", "--disable-debug",
-                          "--prefix=#{prefix}",
-                          "--with-rsyncd-conf=#{etc}/rsyncd.conf",
-                          "--enable-ipv6"
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --with-rsyncd-conf=#{etc}/rsyncd.conf
+      --with-included-popt=no
+      --with-included-zlib=no
+      --enable-ipv6
+    ]
+
+    # SIMD code throws ICE or is outright unsupported due to lack of support for
+    # function multiversioning on older verions of macOS
+    args << "--disable-simd" if MacOS.version < :catalina
+
+    # Fix assembly to build correctly on macOS. Issue already resolved upstream,
+    # but source file has already been modified heavily since release, so applying
+    # upstream patches would be cumbersome. Remove on next release.
+    inreplace "lib/md5-asm-x86_64.s" do |s|
+      s.gsub! ".type md5_process_asm,@function\n", ""
+      s.gsub! ".L_md5_process_asm_end:\n" \
+              ".size md5_process_asm,.L_md5_process_asm_end-md5_process_asm\n",
+              ""
+    end
+
+    system "./configure", *args
     system "make"
     system "make", "install"
   end
 
   test do
-    system bin/"rsync", "--version"
+    mkdir "a"
+    mkdir "b"
+
+    ["foo\n", "bar\n", "baz\n"].map.with_index do |s, i|
+      (testpath/"a/#{i + 1}.txt").write s
+    end
+
+    system bin/"rsync", "-artv", testpath/"a/", testpath/"b/"
+
+    (1..3).each do |i|
+      assert_equal (testpath/"a/#{i}.txt").read, (testpath/"b/#{i}.txt").read
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[`rsync` 3.2.0 has landed](https://download.samba.org/pub/rsync/src/rsync-3.2.0-NEWS), and we could certainly disable some of the new features and reduce dependencies if we want to. However, I feel that since macOS already ships with an older version of `rsync`, it seems suitable for us to have a more full-featured version here (especially when these features are enabled by default).

`rsync` does ship with its own copy of `popt` and `zlib` but I figured it would be best to reuse system/Homebrew dependencies where possible.