### PR TITLE
ntfs-3g: correct option name from #56276

### DIFF
--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -45,7 +45,7 @@ class Ntfs3g < Formula
       --exec-prefix=#{prefix}
       --mandir=#{man}
       --with-fuse=external
-      --enable-extra
+      --enable-extras
     ]
 
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
I only realized I messed up when I received a merge conflict on `brew update`. There's a lesson to be learned about copy-and-pasting correctly or just doing git commit locally...

The revision is NOT bumped because it wouldn't have installed anyways. Apologies to anyone who got hit by my mistake.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
