### PR TITLE
tcping 1.3.6

### DIFF
--- a/Formula/tcping.rb
+++ b/Formula/tcping.rb
@@ -1,8 +1,9 @@
 class Tcping < Formula
   desc "TCP connect to the given IP/port combo"
-  homepage "https://web.archive.org/web/20171102193822/linuxco.de/tcping/tcping.html"
-  url "https://mirrors.kernel.org/gentoo/distfiles/tcping-1.3.5.tar.gz"
-  sha256 "1ad52e904094d12b225ac4a0bc75297555e931c11a1501445faa548ff5ecdbd0"
+  homepage "https://github.com/mkirchner/tcping"
+  url "https://github.com/mkirchner/tcping/archive/1.3.6.tar.gz"
+  sha256 "a731f0e48ff931d7b2a0e896e4db40867043740fe901dd225780f2164fdbdcf3"
+  head "https://github.com/mkirchner/tcping.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The previous website for `tcping` (http://www.linuxco.de:80/tcping/tcping.html) disappeared sometime between [November 2017](https://web.archive.org/web/20171102193822/http://linuxco.de/tcping/tcping.html) and [May 2018](https://web.archive.org/web/20180529080329/http://www.linuxco.de:80/tcping/tcping.html), based on the Wayback Machine's archives. The formula has been using an [archived version of the site](https://web.archive.org/web/20171102193822/linuxco.de/tcping/tcping.html) as the homepage and a [Gentoo stable archive](https://mirrors.kernel.org/gentoo/distfiles/tcping-1.3.5.tar.gz).

Development appears to have moved to https://github.com/mkirchner/tcping and the [README](https://github.com/mkirchner/tcping/blob/master/README) lists that repo as the new homepage as of 2016. The GitHub release archive for 1.3.5 has a different checksum than the existing archive but the files inside are identical. The GitHub repo also has a 1.3.6 release from 2019-10-24.

This PR updates `tcping` to the 1.3.6 release from GitHub while also updating the homepage to use the GitHub repo (in accordance with the README) and adding the GitHub repo as the `head` URL.

---

[FreeBSD](https://www.freshports.org/net/tcping/) and [Gentoo](https://packages.gentoo.org/packages/net-analyzer/tcping) both reference the GitHub site as canonical these days. Unfortunately the first-party site didn't direct to the GitHub repo before it disappeared. Besides that, he GitHub repo is also by a Marc Kirchner, which aligns with the "kirchner" references on the previous first-party website.

Some other software managers are using the 1.3.6 release and I think we're fine making these changes but I wanted to provide some supporting evidence, at least.