### PR TITLE
ispell: update homepage

### DIFF
--- a/Formula/ispell.rb
+++ b/Formula/ispell.rb
@@ -1,6 +1,6 @@
 class Ispell < Formula
   desc "International Ispell"
-  homepage "https://lasr.cs.ucla.edu/geoff/ispell.html"
+  homepage "https://www.cs.hmc.edu/~geoff/ispell.html"
   url "https://www.cs.hmc.edu/~geoff/tars/ispell-3.4.00.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/i/ispell/ispell_3.4.00.orig.tar.gz"
   sha256 "5dc42e458635f218032d3ae929528e5587b1e7247564f0e9f9d77d5ccab7aec2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing homepage for `ispell` (https://lasr.cs.ucla.edu/geoff/ispell.html) is outdated and, when it's working, it [redirects](https://web.archive.org/web/20200527052103/https://lasr.cs.ucla.edu/geoff/ispell.html) to the current homepage (https://www.cs.hmc.edu/~geoff/ispell.html). The stable archive comes from the same site as well but the homepage wasn't updated to align with it.

This PR simply updates the homepage to reflect the current website and avoid the redirection.