### PR TITLE
mesa: update stable url, remove redundant mirror

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -1,8 +1,7 @@
 class Mesa < Formula
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
-  url "https://mesa.freedesktop.org/archive/mesa-20.1.1.tar.xz"
-  mirror "https://www.mesa3d.org/archive/mesa-20.1.1.tar.xz"
+  url "https://archive.mesa3d.org/mesa-20.1.1.tar.xz"
   sha256 "3ea6e46ea7881c656f7b4724639eaa4672d4e0e0b70869651e8f955ebae3d476"
   head "https://gitlab.freedesktop.org/mesa/mesa.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing stable archive URL for `mesa` redirects from https://mesa.freedesktop.org/archive/mesa-20.1.1.tar.xz to https://archive.mesa3d.org//mesa-20.1.1.tar.xz. This PR updates the stable URL to the new URL, albeit without the unnecessary double forward slash.

The existing mirror redirects from https://www.mesa3d.org/archive/mesa-20.1.1.tar.xz to https://archive.mesa3d.org//mesa-20.1.1.tar.xz as well. This is the same as the stable URL, so it's no longer a mirror and I've removed it here.