### PR TITLE
Update head for former bitbucket hg repos

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -3,7 +3,7 @@ class Ode < Formula
   homepage "https://www.ode.org/"
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.16.1.tar.gz"
   sha256 "b228acad81f33781d53eaf313437cc5d6f66aec5a4e56c515fc1b2d51e6e8eba"
-  head "https://bitbucket.org/odedevs/ode/", :using => :hg
+  head "https://bitbucket.org/odedevs/ode.git"
 
   bottle do
     cellar :any

--- a/Formula/open-tyrian.rb
+++ b/Formula/open-tyrian.rb
@@ -1,9 +1,9 @@
 class OpenTyrian < Formula
   desc "Open-source port of Tyrian"
-  homepage "https://bitbucket.org/opentyrian/opentyrian"
+  homepage "https://github.com/opentyrian/opentyrian"
   url "https://www.camanis.net/opentyrian/releases/opentyrian-2.1.20130907-src.tar.gz"
   sha256 "f54b6b3cedcefa187c9f605d6164aae29ec46a731a6df30d351af4c008dee45f"
-  head "https://bitbucket.org/opentyrian/opentyrian", :using => :hg
+  head "https://github.com/opentyrian/opentyrian.git"
 
   bottle do
     sha256 "6f880409157ba2da97e9753177aae05c5ad64bcb7f55f02f11b99e19f68763fe" => :catalina

--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -4,7 +4,7 @@ class Rubberband < Formula
   url "https://breakfastquay.com/files/releases/rubberband-1.8.2.tar.bz2"
   sha256 "86bed06b7115b64441d32ae53634fcc0539a50b9b648ef87443f936782f6c3ca"
   revision 1
-  head "https://bitbucket.org/breakfastquay/rubberband/", :using => :hg
+  head "https://hg.sr.ht/~breakfastquay/rubberband", :using => :hg
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

All bitbucket hg repositories will be deleted very soon. Some homebrew formulae we in bitbucket hg repositories but have since changed:

* ode: a git repo was created on bitbucket with the same name.
* open-tyrian: moved to github.
* rubberband: new hg host found.

I haven't tried building these, but I've confirmed that `brew fetch --head` is working.