### PR TITLE
Update code-server to refetch latest release

### DIFF
--- a/Formula/code-server.rb
+++ b/Formula/code-server.rb
@@ -3,6 +3,7 @@ class CodeServer < Formula
   homepage "https://github.com/cdr/code-server"
   url "https://registry.npmjs.org/code-server/-/code-server-3.4.1.tgz"
   sha256 "38f14f7e9307e4fea7eeeaabdcbd7ff414c41136337a04530692207263101a2a"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Fixes a bug with the bundled version of node.

The release was updated in place but the bug will
be mentioned in the next release's notes.

Updating here now to fix for users.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----