### PR TITLE
tnftp: update desc and homepage

### DIFF
--- a/Formula/tnftp.rb
+++ b/Formula/tnftp.rb
@@ -1,6 +1,6 @@
 class Tnftp < Formula
-  desc "NetBSD's FTP client (built from macOS Sierra sources)"
-  homepage "https://opensource.apple.com/"
+  desc "NetBSD's FTP client"
+  homepage "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
   url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/tnftp-20151004.tar.gz"
   sha256 "c94a8a49d3f4aec1965feea831d4d5bf6f90c65fd8381ee0863d11a5029a43a0"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `tnftp` formula was recently updated to use the up-to-date NetBSD sources (instead of Apple's outdated ones) in #56608. In the process, I forgot to update the description to remove "(built from macOS Sierra sources)" and to update the homepage to something other than Apple's open source homepage.

I'm currently using https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/ as the homepage here (like Wikipedia) but the archive index page isn't super helpful. Would something like https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/net/tnftp/README.html, https://directory.fsf.org/wiki/Tnftp, or http://freshmeat.sourceforge.net/projects/tnftp/ be more appropriate (as they provide a little more information on the software)?