### PR TITLE
Fix typo in git-extras.rb

### DIFF
--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -22,7 +22,7 @@ class GitExtras < Formula
 
   def caveats
     <<~EOS
-      To load Zsh completions, add the following to your .zschrc:
+      To load Zsh completions, add the following to your .zshrc:
         source #{opt_pkgshare}/git-extras-completion.zsh
     EOS
   end


### PR DESCRIPTION
It's .zshrc, not .zschrc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #56696.