### PR TITLE
Remove python 3.8 dependency (Big Sur)

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -13,7 +13,7 @@ class Node < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
+#   depends_on "python@3.8" => :build
   depends_on "icu4c"
 
   # We track major/minor from upstream Node releases.
@@ -25,7 +25,7 @@ class Node < Formula
 
   def install
     # make sure subprocesses spawned by make are using our Python 3
-    ENV["PYTHON"] = Formula["python@3.8"].opt_bin/"python3"
+    ENV["PYTHON"] = "$(which python3)"
 
     # Never install the bundled "npm", always prefer our
     # installation from tarball for better packaging control.


### PR DESCRIPTION
Uses the default python3 currently installed on the system since the current pre-release OSXI (Big Sur) does not build `python 3.8`, see https://github.com/Homebrew/homebrew-core/issues/56791

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
