### PR TITLE
tcptrace: update comment

### DIFF
--- a/Formula/tcptrace.rb
+++ b/Formula/tcptrace.rb
@@ -1,6 +1,8 @@
 class Tcptrace < Formula
+  # The tcptrace.org site has a history of going down sometimes, which is why
+  # we're using mirrors even though the first-party site may be available.
   desc "Analyze tcpdump output"
-  homepage "http://www.tcptrace.org/" # site is currently offline
+  homepage "http://www.tcptrace.org/"
   url "https://www.mirrorservice.org/sites/distfiles.macports.org/tcptrace/tcptrace-6.6.7.tar.gz"
   mirror "https://distfiles.macports.org/tcptrace/tcptrace-6.6.7.tar.gz"
   sha256 "63380a4051933ca08979476a9dfc6f959308bc9f60d45255202e388eb56910bd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The first-party `tcptrace` website (http://www.tcptrace.org/) has a history of going down at times (as discussed in Homebrew/homebrew-livecheck#973). [The site briefly went missing in 2016-10](https://web.archive.org/web/20161007033535/http://www.tcptrace.org/) which led to #6223, where the stable URL was switched to a mirror and a `site is currently offline` comment was added. There was also a period from around July to August/September 2018 where the site was showing [a default OS X server message](https://web.archive.org/web/20180720013917/http://www.tcptrace.org/) instead of content.

The first-party site is available currently, so it makes sense to remove the `site is currently offline` comment. This PR does this while also adding a different comment to explain the situation and why we're using mirrors despite the first-party site being [potentially] available.