### PR TITLE
gdbm: --enable-libgdbm-compat

### DIFF
--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -5,6 +5,7 @@ class Gdbm < Formula
   mirror "https://ftpmirror.gnu.org/gdbm/gdbm-1.18.1.tar.gz"
   sha256 "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
   license "GPL-3.0"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,18 +16,25 @@ class Gdbm < Formula
     sha256 "89d6db4fbffbe2184b4531faaebf0432a4b01e1ed92678ce6bd2f95c69dc9803" => :sierra
   end
 
+  # --enable-libgdbm-compat for dbm.h / gdbm-ndbm.h compatibility:
+  #   https://www.gnu.org.ua/software/gdbm/manual/html_chapter/gdbm_19.html
   # Use --without-readline because readline detection is broken in 1.13
   # https://github.com/Homebrew/homebrew-core/pull/10903
   def install
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
+      --enable-libgdbm-compat
       --without-readline
       --prefix=#{prefix}
     ]
 
     system "./configure", *args
     system "make", "install"
+
+    # Avoid conflicting with macOS SDK's ndbm.h.  Renaming to gdbm-ndbm.h
+    # matches Debian's convention for gdbm's ndbm.h (libgdbm-compat-dev).
+    mv include/"ndbm.h", include/"gdbm-ndbm.h"
   end
 
   test do


### PR DESCRIPTION
This PR is not blocked or waiting on submitter feedback. Summary of replies and comments made within the last month:
* --enable-libgdbm-compat provides gdbm's compatibility ndbm.h library (which is different than POSIX ndbm.h).
* This is enabled on every other distribution's gdbm package, except Homebrew. It is of use to developers who need to compile software against gdbm's ndbm variant.
* It is renamed to gdbm-ndbm.h to not conflict with macOS's ndbm.h.  This is consistent with Debian and Fedora's (and their derivatives') naming, and possibly others.
* The build is not failing. The failures are from reverse dependencies, which are failing regardless of this change.  The change does not introduce any new failures of reverse dependencies.

---

--enable-libgdbm-compat for dbm.h / gdbm-ndbm.h compatibility:
  https://www.gnu.org.ua/software/gdbm/manual/html_chapter/gdbm_19.html

("compat" in this sense means compatibility with gdbm's older dbm / ndbm implementations, which have differences to POSIX ndbm, if you're wondering "why not just use macOS's ndbm.h?"

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
