### PR TITLE
source-to-image: update for new upstream revision

### DIFF
--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -3,7 +3,8 @@ class SourceToImage < Formula
   homepage "https://github.com/openshift/source-to-image"
   url "https://github.com/openshift/source-to-image.git",
       :tag      => "v1.3.0",
-      :revision => "ecf5524df96eb4def4db8ef0969a9630e59ec890"
+      :revision => "eed2850f2187435ef5d83487e05bf3dc18622ceb"
+  revision 1
   head "https://github.com/openshift/source-to-image.git"
 
   bottle do
@@ -16,10 +17,6 @@ class SourceToImage < Formula
   depends_on "go" => :build
 
   def install
-    # Upstream issue from 28 Feb 2018 "Go 1.10 failure due to version comparison bug"
-    # See https://github.com/openshift/source-to-image/issues/851
-    inreplace "hack/common.sh", "go1.4", "go1.0"
-
     system "hack/build-go.sh"
     bin.install "_output/local/bin/darwin/amd64/s2i"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Confirmed upstream re-tag/re-release of v1.3.0 at https://github.com/openshift/source-to-image/issues/1047.