### PR TITLE
apr: apply upstream patch to fix macOS 11 compile

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -15,8 +15,17 @@ class Apr < Formula
 
   keg_only :provided_by_macos, "Apple's CLT provides apr"
 
+  depends_on "autoconf" => :build
+
   on_linux do
     depends_on "util-linux"
+  end
+
+  # Apply r1871981 which fixes a compile error on macOS 11.0.
+  # Remove with the next release, along with the autoconf call & dependency.
+  patch :p0 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/7e2246542543bbd3111a4ec29f801e6e4d538f88/apr/r1871981-macos11.patch"
+    sha256 "8754b8089d0eb53a7c4fd435c9a9300560b675a8ff2c32315a5e9303408447fe"
   end
 
   def install
@@ -25,6 +34,9 @@ class Apr < Formula
     # https://bz.apache.org/bugzilla/show_bug.cgi?id=57359
     # The internal libtool throws an enormous strop if we don't do...
     ENV.deparallelize
+
+    # Needed to apply the patch.
+    system "autoconf"
 
     # Stick it in libexec otherwise it pollutes lib with a .exp file.
     system "./configure", "--prefix=#{libexec}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Due to an error in the configure script, APR failed to build on macOS 11 with the following error:

```
In file included from encoding/apr_encode.c:28:
In file included from ./include/apr_encode.h:24:
./include/apr.h:561:2: error: Can not determine the proper size for pid_t
#error Can not determine the proper size for pid_t
 ^
In file included from encoding/apr_encode.c:30:
In file included from ./include/apr_strings.h:52:
./include/apr_want.h:94:8: error: redefinition of 'iovec'
struct iovec
       ^
/Library/Developer/CommandLineTools/SDKs/MacOSX10.16.sdk/usr/include/sys/_types/_iovec_t.h:31:8: note: previous definition is here
struct iovec {
       ^
2 errors generated.
make: *** [encoding/apr_encode.lo] Error 1
```

The issue being that the configure script incorrectly detected that `iovec` is not available.

However, there happened to already be a SVN revision upstream from the end of last year that changes how `iovec` detection works (among others like the `pid_t` size). Applying that patch fixes the issue.

This change doesn't warrant new bottles and so can be merged via GitHub UI.