### PR TITLE
choose-rust 1.2.0 (new formula)

### DIFF
--- a/Formula/choose-gui.rb
+++ b/Formula/choose-gui.rb
@@ -14,6 +14,7 @@ class ChooseGui < Formula
   depends_on :xcode => :build
 
   conflicts_with "choose", :because => "both install a `choose` binary"
+  conflicts_with "choose-rust", :because => "both install a `choose` binary"
 
   def install
     xcodebuild "SDKROOT=", "SYMROOT=build"

--- a/Formula/choose-rust.rb
+++ b/Formula/choose-rust.rb
@@ -1,0 +1,20 @@
+class ChooseRust < Formula
+  desc "Human-friendly and fast alternative to cut and (sometimes) awk"
+  homepage "https://github.com/theryangeary/choose"
+  url "https://github.com/theryangeary/choose/archive/v1.2.0.tar.gz"
+  sha256 "5711a301e8cc7a5f257773feef992ce8da714a9ee167f234943203ee36c923ad"
+
+  depends_on "rust" => :build
+
+  conflicts_with "choose", :because => "both install a `choose` binary"
+  conflicts_with "choose-gui", :because => "both install a `choose` binary"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    input = "foo,  foobar,bar, baz"
+    assert_equal "foobar bar", pipe_output("#{bin}/choose -f ',\\s*' 1..=2", input).strip
+  end
+end

--- a/Formula/choose.rb
+++ b/Formula/choose.rb
@@ -16,6 +16,7 @@ class Choose < Formula
   depends_on "python@3.8"
 
   conflicts_with "choose-gui", :because => "both install a `choose` binary"
+  conflicts_with "choose-rust", :because => "both install a `choose` binary"
 
   resource "urwid" do
     url "https://files.pythonhosted.org/packages/45/dd/d57924f77b0914f8a61c81222647888fbb583f89168a376ffeb5613b02a6/urwid-2.1.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adding a formula for the `choose` utility from [theryangeary/choose](https://github.com/theryangeary/choose)
(the formula is named choose-rust since another, seemingly unmaintained, project has the same name)

I added conflict statements to this formula but not the others - let me know if you'd like me to add them