### PR TITLE
git-hooks: deprecate

### DIFF
--- a/Formula/git-hooks.rb
+++ b/Formula/git-hooks.rb
@@ -5,6 +5,12 @@ class GitHooks < Formula
   sha256 "8197ca1de975ff1f795a2b9cfcac1a6f7ee24276750c757eecf3bcb49b74808e"
   head "https://github.com/icefox/git-hooks.git"
 
+  # The icefox/git-hooks repository has been deleted and it doesn't appear to
+  # have moved to an alternative location. There is a rewrite in Go by a
+  # different author which someone may want to work into a new formula as a
+  # replacement: https://github.com/git-hooks/git-hooks
+  deprecate!
+
   bottle do
     cellar :any_skip_relocation
     sha256 "d33514436cb623e468314418876fe1e7bb8c31ee64fdcd3c9a297f26a7e7ae42" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream repository for `git-hooks` (https://github.com/icefox/git-hooks), has been deleted along with the user's other repositories. I searched GitHub for a new location (e.g., an organization, etc.), as well as GitLab and Bitbucket, and it doesn't seem to have been relocated.

The only alternative I found was a rewrite in Go by a different author: https://github.com/git-hooks/git-hooks

I left a comment before `deprecate!` to explain the situation and to suggest that any interested parties could create a new formula for the rewrite, if desired.