### PR TITLE
unyaffs: update urls

### DIFF
--- a/Formula/unyaffs.rb
+++ b/Formula/unyaffs.rb
@@ -1,9 +1,9 @@
 class Unyaffs < Formula
   desc "Extract files from a YAFFS2 filesystem image"
-  homepage "https://git.bernhard-ehlers.de/ehlers/unyaffs/"
-  url "https://git.bernhard-ehlers.de/ehlers/unyaffs/archive/0.9.7.tar.gz"
+  homepage "https://git.b-ehlers.de/ehlers/unyaffs/"
+  url "https://git.b-ehlers.de/ehlers/unyaffs/archive/0.9.7.tar.gz"
   sha256 "17489fb07051d228ede6ed35c9138e25f81085492804104a8f52c51a1bd6750d"
-  head "https://git.bernhard-ehlers.de/ehlers/unyaffs.git"
+  head "https://git.b-ehlers.de/ehlers/unyaffs.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The homepage, stable, and head URLS were all redirecting from the related URL at https://git.bernhard-ehlers.de to https://git.b-ehlers.de. This updates the URLs to avoid the redirections.