### PR TITLE
Update deprecate date format

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -9,7 +9,7 @@ class ElasticsearchAT24 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "February 28, 2018"
+  deprecate! :date => "2018-02-28"
 
   depends_on :java => "1.8"
 

--- a/Formula/elasticsearch@5.6.rb
+++ b/Formula/elasticsearch@5.6.rb
@@ -8,7 +8,7 @@ class ElasticsearchAT56 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "March 11, 2019"
+  deprecate! :date => "2019-03-11"
 
   depends_on :java => "1.8"
 

--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -14,7 +14,7 @@ class GoAT110 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "February 25, 2019"
+  deprecate! :date => "2019-02-25"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -14,7 +14,7 @@ class GoAT111 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "September 3, 2019"
+  deprecate! :date => "2019-09-03"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.12.rb
+++ b/Formula/go@1.12.rb
@@ -14,7 +14,7 @@ class GoAT112 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "February 25, 2020"
+  deprecate! :date => "2020-02-25"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -14,7 +14,7 @@ class GoAT19 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "August 4, 2018"
+  deprecate! :date => "2018-08-04"
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/gradio.rb
+++ b/Formula/gradio.rb
@@ -10,7 +10,7 @@ class Gradio < Formula
     sha256 "5c3f745ad431c61ef3d19b4a2a03d6f24eb99dd47768178e6d1810edba4f12fa" => :high_sierra
   end
 
-  deprecate! :date => "November 16, 2019"
+  deprecate! :date => "2019-11-16"
 
   depends_on "meson" => :build
   depends_on "ninja" => :build

--- a/Formula/kibana@5.6.rb
+++ b/Formula/kibana@5.6.rb
@@ -17,7 +17,7 @@ class KibanaAT56 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "March 11, 2019"
+  deprecate! :date => "2019-03-11"
 
   resource "node" do
     url "https://nodejs.org/dist/v6.17.0/node-v6.17.0.tar.xz"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -15,7 +15,7 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "November 30, 2020"
+  deprecate! :date => "2020-11-30"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -14,7 +14,7 @@ class PhpAT73 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "December 6, 2021"
+  deprecate! :date => "2021-12-06"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -13,7 +13,7 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! :date => "February 13, 2020"
+  deprecate! :date => "2020-02-13"
 
   depends_on "openssl@1.1"
   depends_on "readline"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There was internal discussion about the varying date formats used for `deprecate! :date => "..."`. At present, there are two formats in use: "January 1, 2020" and "2020-01-01" (ISO 8601).

There's a vocal contingent among us who are strongly in favor of ISO 8601 and believe there's value in this format over others, so this PR updates the existing deprecations accordingly.