### PR TITLE
diesel: use std_cargo_args

### DIFF
--- a/Formula/diesel.rb
+++ b/Formula/diesel.rb
@@ -23,7 +23,9 @@ class Diesel < Formula
     # Remove with 1.5.x.
     ENV["RUSTFLAGS"] = "--cap-lints allow"
 
-    system "cargo", "install", "--root", prefix, "--path", "diesel_cli"
+    cd "diesel_cli" do
+      system "cargo", "install", *std_cargo_args
+    end
 
     system "#{bin}/diesel completions bash > diesel.bash"
     system "#{bin}/diesel completions zsh > _diesel"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Although Rust docs clearly state that building project without lockfile using `--locked` flag would result in a build failure that is not true 🤦 (source: https://doc.rust-lang.org/cargo/commands/cargo-install.html)

That means diesel CLI's build process can be safely converted to use `std_carg_args`.