### PR TITLE
ffmpeg: Fix finding snappy

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -3,7 +3,7 @@ class Ffmpeg < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.3.tar.xz"
   sha256 "1d0ad06484f44bcb97eba5e93c40bcb893890f9f64aeb43e46cd9bb4cbd6795d"
-  revision 1
+  revision 2
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
@@ -50,6 +50,8 @@ class Ffmpeg < Formula
   uses_from_macos "zlib"
 
   def install
+    ENV.append "CFLAGS", "-I#{Formula["snappy"].opt_include}"
+    ENV.append "LDFLAGS", "-L#{Formula["snappy"].opt_lib}"
     args = %W[
       --prefix=#{prefix}
       --enable-shared


### PR DESCRIPTION
Since snappy doesn't install a pkg-config file, ffmpeg wouldn't find it
when brew is installed in a custom location. Override CFLAGS and LDFLAGS
to let configure know where snappy is installed

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
