### PR TITLE
hdf5: use `autogen.sh`

### DIFF
--- a/Formula/hdf5-mpi.rb
+++ b/Formula/hdf5-mpi.rb
@@ -31,7 +31,7 @@ class Hdf5Mpi < Formula
               "settingsdir=$(libdir)",
               "settingsdir=#{pkgshare}"
 
-    system "autoreconf", "-fiv"
+    system "./autogen.sh"
 
     args = %W[
       --disable-dependency-tracking

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -28,7 +28,7 @@ class Hdf5 < Formula
               "settingsdir=$(libdir)",
               "settingsdir=#{pkgshare}"
 
-    system "autoreconf", "-fiv"
+    system "./autogen.sh"
 
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
This helper script works on macOS and Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Refs.:
- https://github.com/Homebrew/linuxbrew-core/commit/aa01e7669408ea6f7afbab72c407a4dd03ec88ed: **not** added because `if OS....?` checks do not pass style checks here.
- https://github.com/Homebrew/linuxbrew-core/pull/20636