### PR TITLE
vsearch 2.15.0 (new formula)

### DIFF
--- a/Formula/vsearch.rb
+++ b/Formula/vsearch.rb
@@ -1,0 +1,27 @@
+class Vsearch < Formula
+  desc "Versatile open-source tool for microbiome analysis"
+  homepage "https://github.com/torognes/vsearch"
+  url "https://github.com/torognes/vsearch/archive/v2.15.0.tar.gz"
+  sha256 "c5d6eca1e4bf0c6e28221356b806c1d2322b51c39f40888636ab094c4df2e231"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.fasta").write <<~EOS
+      >U00096.2:1-70
+      AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC
+    EOS
+    system bin/"vsearch", "--rereplicate", "test.fasta", "--output", "output.txt"
+    assert_predicate testpath/"output.txt", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Migrated from homebrew-science (and updated)

https://github.com/Homebrew/homebrew-science/blob/180d7e8e21543b6eda0f0042e8dd1137a15f8968/vsearch.rb