### PR TITLE
style: separate shell commands

### DIFF
--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -19,7 +19,7 @@ class AwsIamAuthenticator < Formula
   def install
     # project = "github.com/kubernetes-sigs/aws-iam-authenticator"
     revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").strip
-    version = Utils.safe_popen_read("git describe --tags").strip
+    version = Utils.safe_popen_read("git", "describe", "--tags").strip
     ldflags = ["-s", "-w",
                "-X main.version=#{version}",
                "-X main.commit=#{revision}"]

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -16,7 +16,7 @@ class Buildkit < Formula
   depends_on "go" => :build
 
   def install
-    revision = Utils.safe_popen_read("git rev-parse HEAD").chomp
+    revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
     ldflags = %W[
       -s -w
       -X github.com/moby/buildkit/version.Version=#{version}

--- a/Formula/cassowary.rb
+++ b/Formula/cassowary.rb
@@ -19,7 +19,7 @@ class Cassowary < Formula
   end
 
   test do
-    system("#{bin}/cassowary run -u http://www.example.com -c 10 -n 100 --json-metrics")
+    system("#{bin}/cassowary", "run", "-u", "http://www.example.com", "-c", "10", "-n", "100", "--json-metrics")
     assert_match "\"base_url\":\"http://www.example.com\"", File.read("#{testpath}/out.json")
 
     assert_match version.to_s, shell_output("#{bin}/cassowary --version")

--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -25,7 +25,7 @@ class Cayley < Formula
       # Run packr to generate .go files that pack the static files into bytes that can be bundled into the Go binary.
       system "go", "run", "github.com/gobuffalo/packr/v2/packr2"
 
-      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
 
       ldflags = %W[
         -s -w

--- a/Formula/certigo.rb
+++ b/Formula/certigo.rb
@@ -19,11 +19,11 @@ class Certigo < Formula
     bin.install "bin/certigo"
 
     # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/certigo --completion-script-bash")
+    output = Utils.safe_popen_read("#{bin}/certigo", "--completion-script-bash")
     (bash_completion/"certigo").write output
 
     # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/certigo --completion-script-zsh")
+    output = Utils.safe_popen_read("#{bin}/certigo", "--completion-script-zsh")
     (zsh_completion/"_certigo").write output
   end
 

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -22,7 +22,7 @@ class Circleci < Formula
     dir.install buildpath.children
 
     cd dir do
-      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
       ldflags = %W[
         -s -w
         -X github.com/CircleCI-Public/circleci-cli/version.packageManager=homebrew

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -18,7 +18,7 @@ class Clojure < Formula
 
   test do
     ENV["TERM"] = "xterm"
-    system("#{bin}/clj -e nil")
+    system("#{bin}/clj", "-e", "nil")
     %w[clojure clj].each do |clj|
       assert_equal "2", shell_output("#{bin}/#{clj} -e \"(+ 1 1)\"").strip
     end

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -17,7 +17,7 @@ class ConsulTemplate < Formula
 
   def install
     project = "github.com/hashicorp/consul-template"
-    commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
     ldflags = %W[
       -s -w
       -X #{project}/version.Name=consul-template

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -78,7 +78,8 @@ class Crystal < Formula
     crystal_build_opts << "FLAGS=--no-debug"
     crystal_build_opts << "CRYSTAL_CONFIG_LIBRARY_PATH="
     if build.head?
-      crystal_build_opts << "CRYSTAL_CONFIG_BUILD_COMMIT=#{Utils.safe_popen_read("git rev-parse --short HEAD").strip}"
+      crystal_build_opts << "CRYSTAL_CONFIG_BUILD_COMMIT=#{Utils.safe_popen_read("git", "rev-parse",
+                                                                                        "--short", "HEAD").strip}"
     end
     (buildpath/".build").mkpath
     system "make", "deps"

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -47,9 +47,9 @@ class Deno < Formula
     end
 
     # Install bash and zsh completion
-    output = Utils.safe_popen_read("#{bin}/deno completions bash")
+    output = Utils.safe_popen_read("#{bin}/deno", "completions", "bash")
     (bash_completion/"deno").write output
-    output = Utils.safe_popen_read("#{bin}/deno completions zsh")
+    output = Utils.safe_popen_read("#{bin}/deno", "completions", "zsh")
     (zsh_completion/"_deno").write output
   end
 

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -20,7 +20,7 @@ class Docker < Formula
     dir = buildpath/"src/github.com/docker/cli"
     dir.install (buildpath/"components/cli").children
     cd dir do
-      commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
       build_time = Utils.safe_popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
       ldflags = ["-X \"github.com/docker/cli/cli/version.BuildTime=#{build_time}\"",
                  "-X github.com/docker/cli/cli/version.GitCommit=#{commit}",

--- a/Formula/flashrom.rb
+++ b/Formula/flashrom.rb
@@ -39,6 +39,6 @@ class Flashrom < Formula
   end
 
   test do
-    system "#{bin}/flashrom" " --version"
+    system bin/"flashrom", "--version"
   end
 end

--- a/Formula/gauge.rb
+++ b/Formula/gauge.rb
@@ -1,6 +1,6 @@
 class Gauge < Formula
   desc "Test automation tool that supports executable documentation"
-  homepage "https://getgauge.io"
+  homepage "https://gauge.org"
   url "https://github.com/getgauge/gauge/archive/v1.1.1.tar.gz"
   sha256 "b136727d0ed114ab18d9d380e1ff70ad70e60b56bbacf854be2aeddc9b20044a"
   head "https://github.com/getgauge/gauge.git"
@@ -28,10 +28,10 @@ class Gauge < Formula
       }
     EOS
 
-    system("#{bin}/gauge install")
+    system("#{bin}/gauge", "install")
     assert_predicate testpath/".gauge/plugins", :exist?
 
-    system("#{bin}/gauge config check_updates false")
+    system("#{bin}/gauge", "config", "check_updates", "false")
     assert_match "false", shell_output("#{bin}/gauge config check_updates")
 
     assert_match version.to_s, shell_output("#{bin}/gauge -v 2>&1")

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -25,9 +25,9 @@ class Gdcm < Formula
     python3 = Formula["python@3.8"].opt_bin/"python3"
     xy = Language::Python.major_minor_version python3
     python_include =
-      Utils.safe_popen_read("#{python3} -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'")
+      Utils.safe_popen_read(python3, "-c", "from distutils import sysconfig;print(sysconfig.get_python_inc(True))")
            .chomp
-    python_executable = Utils.safe_popen_read("#{python3} -c 'import sys;print(sys.executable)'").chomp
+    python_executable = Utils.safe_popen_read(python3, "-c", "import sys;print(sys.executable)").chomp
 
     args = std_cmake_args + %W[
       -GNinja

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -24,7 +24,7 @@ class Goofys < Formula
     ENV["GOPATH"] = gopath
 
     cd gopath/"src/github.com/kahing/goofys" do
-      commit = Utils.safe_popen_read("git rev-parse HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
       system "go", "build", "-o", "goofys", "-ldflags",
              "-X main.Version=#{commit}"
       bin.install "goofys"

--- a/Formula/gopass.rb
+++ b/Formula/gopass.rb
@@ -27,7 +27,7 @@ class Gopass < Formula
       system "make", "install"
     end
 
-    output = Utils.safe_popen_read("#{bin}/gopass completion bash")
+    output = Utils.safe_popen_read("#{bin}/gopass", "completion", "bash")
     (bash_completion/"gopass-completion").write output
   end
 

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -24,9 +24,9 @@ class Hcloud < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.safe_popen_read("#{bin}/hcloud completion bash")
+    output = Utils.safe_popen_read("#{bin}/hcloud", "completion", "bash")
     (bash_completion/"hcloud").write output
-    output = Utils.safe_popen_read("#{bin}/hcloud completion zsh")
+    output = Utils.safe_popen_read("#{bin}/hcloud", "completion", "zsh")
     (zsh_completion/"_hcloud").write output
   end
 

--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -23,10 +23,10 @@ class Kamel < Formula
 
     prefix.install_metafiles
 
-    output = Utils.safe_popen_read("#{bin}/kamel completion bash")
+    output = Utils.safe_popen_read("#{bin}/kamel", "completion", "bash")
     (bash_completion/"kamel").write output
 
-    output = Utils.safe_popen_read("#{bin}/kamel completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kamel", "completion", "zsh")
     (zsh_completion/"_kamel").write output
   end
 

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -19,8 +19,8 @@ class Kapacitor < Formula
     ENV["GOPATH"] = buildpath
     kapacitor_path = buildpath/"src/github.com/influxdata/kapacitor"
     kapacitor_path.install Dir["*"]
-    revision = Utils.safe_popen_read("git rev-parse HEAD").strip
-    version = Utils.safe_popen_read("git describe --tags").strip
+    revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").strip
+    version = Utils.safe_popen_read("git", "describe", "--tags").strip
 
     cd kapacitor_path do
       system "go", "install",

--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -19,11 +19,11 @@ class Kind < Formula
     prefix.install_metafiles
 
     # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/kind completion bash")
+    output = Utils.safe_popen_read("#{bin}/kind", "completion", "bash")
     (bash_completion/"kind").write output
 
     # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/kind completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kind", "completion", "zsh")
     (zsh_completion/"_kind").write output
   end
 

--- a/Formula/kompose.rb
+++ b/Formula/kompose.rb
@@ -20,10 +20,10 @@ class Kompose < Formula
     system "make", "bin"
     bin.install "kompose"
 
-    output = Utils.safe_popen_read("#{bin}/kompose completion bash")
+    output = Utils.safe_popen_read("#{bin}/kompose", "completion", "bash")
     (bash_completion/"kompose").write output
 
-    output = Utils.safe_popen_read("#{bin}/kompose completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kompose", "completion", "zsh")
     (zsh_completion/"_kompose").write output
   end
 

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -24,11 +24,11 @@ class Kops < Formula
     bin.install("bin/kops")
 
     # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/kops completion bash")
+    output = Utils.safe_popen_read("#{bin}/kops", "completion", "bash")
     (bash_completion/"kops").write output
 
     # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/kops completion zsh")
+    output = Utils.safe_popen_read("#{bin}/kops", "completion", "zsh")
     (zsh_completion/"_kops").write output
   end
 

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -23,9 +23,9 @@ class Kubecfg < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.safe_popen_read("#{bin}/kubecfg completion --shell bash")
+    output = Utils.safe_popen_read("#{bin}/kubecfg", "completion", "--shell", "bash")
     (bash_completion/"kubecfg").write output
-    output = Utils.safe_popen_read("#{bin}/kubecfg completion --shell zsh")
+    output = Utils.safe_popen_read("#{bin}/kubecfg", "completion", "--shell", "zsh")
     (zsh_completion/"_kubecfg").write output
   end
 

--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -32,11 +32,11 @@ class KubernetesCli < Formula
       bin.install "_output/local/bin/darwin/amd64/kubectl"
 
       # Install bash completion
-      output = Utils.safe_popen_read("#{bin}/kubectl completion bash")
+      output = Utils.safe_popen_read("#{bin}/kubectl", "completion", "bash")
       (bash_completion/"kubectl").write output
 
       # Install zsh completion
-      output = Utils.safe_popen_read("#{bin}/kubectl completion zsh")
+      output = Utils.safe_popen_read("#{bin}/kubectl", "completion", "zsh")
       (zsh_completion/"_kubectl").write output
 
       prefix.install_metafiles

--- a/Formula/linkerd.rb
+++ b/Formula/linkerd.rb
@@ -22,11 +22,11 @@ class Linkerd < Formula
     bin.install "target/cli/darwin/linkerd"
 
     # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/linkerd completion bash")
+    output = Utils.safe_popen_read("#{bin}/linkerd", "completion", "bash")
     (bash_completion/"linkerd").write output
 
     # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/linkerd completion zsh")
+    output = Utils.safe_popen_read("#{bin}/linkerd", "completion", "zsh")
     (zsh_completion/"linkerd").write output
 
     prefix.install_metafiles

--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -21,10 +21,10 @@ class Minikube < Formula
     system "make"
     bin.install "out/minikube"
 
-    output = Utils.safe_popen_read("#{bin}/minikube completion bash")
+    output = Utils.safe_popen_read("#{bin}/minikube", "completion", "bash")
     (bash_completion/"minikube").write output
 
-    output = Utils.safe_popen_read("#{bin}/minikube completion zsh")
+    output = Utils.safe_popen_read("#{bin}/minikube", "completion", "zsh")
     (zsh_completion/"_minikube").write output
   end
 

--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -18,16 +18,16 @@ class Mmctl < Formula
   def install
     ENV["GOBIN"] = buildpath/bin
     ENV["ADVANCED_VET"] = "FALSE"
-    ENV["BUILD_HASH"] = Utils.safe_popen_read("git rev-parse HEAD").chomp
+    ENV["BUILD_HASH"] = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
     ENV["BUILD_VERSION"] = version.to_s
     (buildpath/"src/github.com/mattermost/mmctl").install buildpath.children
     cd "src/github.com/mattermost/mmctl" do
       system "make", "install"
 
       # Install the zsh and bash completions
-      output = Utils.safe_popen_read("#{bin}/mmctl completion bash")
+      output = Utils.safe_popen_read("#{bin}/mmctl", "completion", "bash")
       (bash_completion/"mmctl").write output
-      output = Utils.safe_popen_read("#{bin}/mmctl completion zsh")
+      output = Utils.safe_popen_read("#{bin}/mmctl", "completion", "zsh")
       (zsh_completion/"_mmctl").write output
     end
   end

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -43,7 +43,7 @@ class Monetdb < Formula
 
   test do
     # assert_match "Usage", shell_output("#{bin}/mclient --help 2>&1")
-    system("#{bin}/monetdbd create #{testpath}/dbfarm")
+    system("#{bin}/monetdbd", "create", "#{testpath}/dbfarm")
     assert_predicate testpath/"dbfarm", :exist?
   end
 end

--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -31,11 +31,11 @@ class Nagios < Formula
   end
 
   def user
-    Utils.safe_popen_read("id -un").chomp
+    Utils.safe_popen_read("id", "-un").chomp
   end
 
   def group
-    Utils.safe_popen_read("id -gn").chomp
+    Utils.safe_popen_read("id", "-gn").chomp
   end
 
   def install

--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -19,9 +19,9 @@ class NewrelicCli < Formula
     system "make", "compile-only"
     bin.install "bin/darwin/newrelic"
 
-    output = Utils.safe_popen_read("#{bin}/newrelic completion --shell bash")
+    output = Utils.safe_popen_read("#{bin}/newrelic", "completion", "--shell", "bash")
     (bash_completion/"newrelic").write output
-    output = Utils.safe_popen_read("#{bin}/newrelic completion --shell zsh")
+    output = Utils.safe_popen_read("#{bin}/newrelic", "completion", "--shell", "zsh")
     (zsh_completion/"_newrelic").write output
   end
 

--- a/Formula/noweb.rb
+++ b/Formula/noweb.rb
@@ -22,7 +22,7 @@ class Noweb < Formula
   def install
     cd "src" do
       system "bash", "awkname", "awk"
-      system "make LIBSRC=icon ICONC=icont CFLAGS='-U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=1'"
+      system "make", "LIBSRC=icon", "ICONC=icont", "CFLAGS=-U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=1"
 
       bin.mkpath
       lib.mkpath

--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -32,7 +32,7 @@ class Octant < Formula
       system "go", "generate", "./pkg/icon"
       system "go", "run", "build.go", "web-build"
 
-      commit = Utils.safe_popen_read("git rev-parse HEAD").chomp
+      commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
       build_time = Utils.safe_popen_read("date -u +'%Y-%m-%dT%H:%M:%SZ' 2> /dev/null").chomp
       ldflags = ["-X \"main.version=#{version}\"",
                  "-X \"main.gitCommit=#{commit}\"",

--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -29,11 +29,11 @@ class OperatorSdk < Formula
       bin.install buildpath/"bin/operator-sdk"
 
       # Install bash completion
-      output = Utils.safe_popen_read("#{bin}/operator-sdk completion bash")
+      output = Utils.safe_popen_read("#{bin}/operator-sdk", "completion", "bash")
       (bash_completion/"operator-sdk").write output
 
       # Install zsh completion
-      output = Utils.safe_popen_read("#{bin}/operator-sdk completion zsh")
+      output = Utils.safe_popen_read("#{bin}/operator-sdk", "completion", "zsh")
       (zsh_completion/"_operator-sdk").write output
 
       prefix.install_metafiles

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -184,7 +184,7 @@ class Php < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -236,7 +236,7 @@ class Php < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -178,7 +178,7 @@ class PhpAT73 < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -235,7 +235,7 @@ class PhpAT73 < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -21,8 +21,8 @@ class Pjproject < Formula
     system "make"
     system "make", "install"
 
-    arch = Utils.safe_popen_read("uname -m").chomp
-    rel = Utils.safe_popen_read("uname -r").chomp
+    arch = Utils.safe_popen_read("uname", "-m").chomp
+    rel = Utils.safe_popen_read("uname", "-r").chomp
     bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{rel}" => "pjsua"
   end
 

--- a/Formula/pulp.rb
+++ b/Formula/pulp.rb
@@ -25,7 +25,7 @@ class Pulp < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/pulp --version")
 
-    system("#{bin}/pulp init")
+    system("#{bin}/pulp", "init")
     assert_predicate testpath/".gitignore", :exist?
     assert_predicate testpath/"bower.json", :exist?
   end

--- a/Formula/rack.rb
+++ b/Formula/rack.rb
@@ -31,7 +31,7 @@ class Rack < Formula
       # deciding whether to add a = or not on the ldflags, as mandated
       # by Go 1.7+.
       # https://github.com/rackspace/rack/issues/446
-      inreplace "script/build", "go1.5", Utils.safe_popen_read("go version")[/go1\.\d/]
+      inreplace "script/build", "go1.5", Utils.safe_popen_read("go", "version")[/go1\.\d/]
 
       ln_s "internal", "vendor"
       system "script/build", "rack"

--- a/Formula/serverless.rb
+++ b/Formula/serverless.rb
@@ -30,7 +30,7 @@ class Serverless < Formula
         region: eu-west-1
     EOS
 
-    system("#{bin}/serverless config credentials --provider aws --key aa --secret xx")
+    system("#{bin}/serverless", "config", "credentials", "--provider", "aws", "--key", "aa", "--secret", "xx")
     output = shell_output("#{bin}/serverless package")
     assert_match "Serverless: Packaging service...", output
   end

--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -23,10 +23,10 @@ class Skaffold < Formula
       system "make"
       bin.install "out/skaffold"
 
-      output = Utils.safe_popen_read("#{bin}/skaffold completion bash")
+      output = Utils.safe_popen_read("#{bin}/skaffold", "completion", "bash")
       (bash_completion/"skaffold").write output
 
-      output = Utils.safe_popen_read("#{bin}/skaffold completion zsh")
+      output = Utils.safe_popen_read("#{bin}/skaffold", "completion", "zsh")
       (zsh_completion/"_skaffold").write output
 
       prefix.install_metafiles

--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -20,7 +20,7 @@ class Skopeo < Formula
   def install
     ENV["CGO_ENABLED"] = "1"
     ENV.append "CGO_FLAGS", ENV.cppflags
-    ENV.append "CGO_FLAGS", Utils.safe_popen_read("#{Formula["gpgme"].bin}/gpgme-config --cflags")
+    ENV.append "CGO_FLAGS", Utils.safe_popen_read("#{Formula["gpgme"].bin}/gpgme-config", "--cflags")
 
     buildtags = [
       "containers_image_ostree_stub",

--- a/Formula/ssdb.rb
+++ b/Formula/ssdb.rb
@@ -80,7 +80,7 @@ class Ssdb < Formula
   test do
     pid = fork do
       Signal.trap("TERM") do
-        system("#{bin}/ssdb-server -d #{HOMEBREW_PREFIX}/etc/ssdb.conf")
+        system("#{bin}/ssdb-server", "-d", "#{HOMEBREW_PREFIX}/etc/ssdb.conf")
         exit
       end
     end

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -134,7 +134,7 @@ class Subversion < Formula
     system "make", "javahl"
     system "make", "install-javahl"
 
-    archlib = Utils.safe_popen_read("perl -MConfig -e 'print $Config{archlib}'")
+    archlib = Utils.safe_popen_read("perl", "-MConfig", "-e", "print $Config{archlib}")
     perl_core = Pathname.new(archlib)/"CORE"
     onoe "'#{perl_core}' does not exist" unless perl_core.exist?
 

--- a/Formula/tile38.rb
+++ b/Formula/tile38.rb
@@ -19,7 +19,7 @@ class Tile38 < Formula
   end
 
   def install
-    commit = Utils.safe_popen_read("git rev-parse --short HEAD").chomp
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
 
     ldflags = %W[
       -s -w

--- a/Formula/velero.rb
+++ b/Formula/velero.rb
@@ -25,11 +25,11 @@ class Velero < Formula
                    "./cmd/velero"
 
       # Install bash completion
-      output = Utils.safe_popen_read("#{bin}/velero completion bash")
+      output = Utils.safe_popen_read("#{bin}/velero", "completion", "bash")
       (bash_completion/"velero").write output
 
       # Install zsh completion
-      output = Utils.safe_popen_read("#{bin}/velero completion zsh")
+      output = Utils.safe_popen_read("#{bin}/velero", "completion", "zsh")
       (zsh_completion/"_velero").write output
 
       prefix.install_metafiles

--- a/Formula/virustotal-cli.rb
+++ b/Formula/virustotal-cli.rb
@@ -18,10 +18,10 @@ class VirustotalCli < Formula
             "-X cmd.Version=#{version}",
             "-o", bin/"vt", "./vt/main.go"
 
-    output = Utils.safe_popen_read("#{bin}/vt completion bash")
+    output = Utils.safe_popen_read("#{bin}/vt", "completion", "bash")
     (bash_completion/"vt").write output
 
-    output = Utils.safe_popen_read("#{bin}/vt completion zsh")
+    output = Utils.safe_popen_read("#{bin}/vt", "completion", "zsh")
     (zsh_completion/"_vt").write output
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the main PR to update the style for `system` and `Utils.popen` commands to separate shell command arguments (see https://github.com/Homebrew/brew/pull/7691).

Example:

```ruby
system "foo bar --baz"
```

should become

```ruby
system "foo", "bar", "--baz"
```

I have tested all of these locally without any issues, but the CI will likely take a long time to complete (there are 46 formulae changed here)

Just FYI: there will be two additional PRs that deal with formulae that needed more significant changes or had build/test/audit issues