### PR TITLE
style: separate shell commands supplement (supplemental)

### DIFF
--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -78,8 +78,8 @@ class BoostPython < Formula
     EOS
 
     pyprefix = `python-config --prefix`.chomp
-    pyincludes = Utils.popen_read("python-config --includes").chomp.split(" ")
-    pylib = Utils.popen_read("python-config --ldflags").chomp.split(" ")
+    pyincludes = Utils.popen_read("python-config", "--includes").chomp.split(" ")
+    pylib = Utils.popen_read("python-config", "--ldflags").chomp.split(" ")
 
     system ENV.cxx, "-shared", "hello.cpp", "-L#{lib}", "-lboost_python27",
                     "-o", "hello.so", "-I#{pyprefix}/include/python2.7",

--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -69,9 +69,9 @@ class Libswiften < Formula
         return 0;
       }
     EOS
-    cflags = `#{bin}/swiften-config --cflags`
-    ldflags = `#{bin}/swiften-config --libs`
-    system "#{ENV.cxx} -std=c++11 test.cpp #{cflags.chomp} #{ldflags.chomp} -o test"
+    cflags = `#{bin}/swiften-config --cflags`.chomp.split(/ /)
+    ldflags = `#{bin}/swiften-config --libs`.chomp.split(/ /)
+    system ENV.cxx, "-std=c++11", "test.cpp", *cflags, *ldflags, "-o", "test"
     system "./test"
   end
 end

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -179,7 +179,7 @@ class PhpAT72 < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     inreplace "php.ini-development", %r{; ?extension_dir = "\./"},
@@ -231,7 +231,7 @@ class PhpAT72 < Formula
     # Custom location for extensions installed via pecl
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config --extension-dir").chomp
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -50,7 +50,7 @@ class Rabbitmq < Formula
 
     sbin.install "rabbitmqadmin"
     (sbin/"rabbitmqadmin").chmod 0755
-    (bash_completion/"rabbitmqadmin.bash").write Utils.safe_popen_read("#{sbin}/rabbitmqadmin --bash-completion")
+    (bash_completion/"rabbitmqadmin.bash").write Utils.safe_popen_read("#{sbin}/rabbitmqadmin", "--bash-completion")
   end
 
   def caveats

--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -34,7 +34,7 @@ class Ruby < Formula
   end
 
   def api_version
-    Utils.safe_popen_read("#{bin}/ruby -e 'print Gem.ruby_api_version'")
+    Utils.safe_popen_read("#{bin}/ruby", "-e", "print Gem.ruby_api_version")
   end
 
   def rubygems_bindir

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -48,7 +48,8 @@ class SdlMixer < Formula
                    "-L#{lib}", "-lSDL_mixer",
                    "-L#{Formula["sdl"].lib}", "-lSDLmain", "-lSDL",
                    "-Wl,-framework,Cocoa"
-    system "SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=disk ./playwave #{test_fixtures("test.wav")}"
+    Utils.safe_popen_read({ "SDL_VIDEODRIVER" => "dummy", "SDL_AUDIODRIVER" => "disk" },
+                          "./playwave", test_fixtures("test.wav"))
     assert_predicate testpath/"sdlaudio.raw", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a companion PR to #57064.

This changes `system "foo bar --baz"` to `system "foo", "bar", "--baz"` in preparation for Homebrew/brew#7691.

-----

I've separated these formulae out because they either:
1. Required more significant changes than simply separating the arguments:
    - **sdl_mixer**: I switched from `system` to `Utils.safe_popen_read` to allow shell variables to be set in a hash. This was successful on my local machine.
2. Due to unrelated issues don't successfully build/test/audit
    - **boost-python**: this doesn't currently build from source or pass its tests. I've double-checked that the changes made in this PR don't have any effect on either of these.
    - **libswiften**: this doesn't currently build from source because the SSL certificate has expired. The changes in this PR are only in the `test` block, so they shouldn't affect libswiften's ability to be built. I've run the new tests successfully on the bottled version of libswiften.
    - **php@7.2**: this fails `brew audit --strict` saying that the `revision 1` line should be removed. Since this PR doesn't make any changes that should affect php@7.2's functionality, I think that `revision 1` should be kept and the audit failure can be ignored. I've successfully built and run the tests for php@7.2 locally.
    - **rabbitmq**: this does not currently pass its tests. This PR only changes the install process and has no impact on the tests.
    - **ruby**: ruby currently builds successfully but fails its tests. The changes in this PR don't affect the tests at all.

I think that this PR is okay to merge despite these failures, as none of them are actually related to the changes that I am making here, but I figured I should put them in a separate PR so there can be further discussion if needed.