### PR TITLE
workflows: use git-try-push action

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -76,18 +76,7 @@ jobs:
         run: |
           brew pr-pull --verbose ${{github.event.client_payload.pull_request}}
       - name: Push commits
-        run: |
-          for try in $(seq 20); do
-            git fetch
-            git rebase origin/master
-            if git push; then
-              exit 0
-            else
-              max=$(( $try + 10 ))
-              sleep $(shuf -i 3-$max -n 1)
-            fi
-          done
-          exit 1
+        uses: Homebrew/actions/git-try-push@master
       - name: Post comment on failure
         if: ${{!success()}}
         uses: actions/github-script@0.9.0


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/actions/pull/12

Latest test workflow run: https://github.com/Homebrew/actions/runs/817876482?check_suite_focus=true