### PR TITLE
liblzf: replace mirror

### DIFF
--- a/Formula/liblzf.rb
+++ b/Formula/liblzf.rb
@@ -2,7 +2,6 @@ class Liblzf < Formula
   desc "Very small, very fast data compression library"
   homepage "http://oldhome.schmorp.de/marc/liblzf.html"
   url "http://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
-  mirror "http://download.openpkg.org/components/cache/liblzf/liblzf-3.6.tar.gz"
   sha256 "9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a"
 
   bottle do

--- a/Formula/liblzf.rb
+++ b/Formula/liblzf.rb
@@ -2,6 +2,7 @@ class Liblzf < Formula
   desc "Very small, very fast data compression library"
   homepage "http://oldhome.schmorp.de/marc/liblzf.html"
   url "http://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
+  mirror "http://deb.debian.org/debian/pool/main/libl/liblzf/liblzf_3.6.orig.tar.gz"
   sha256 "9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Current SHA256: 9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a
Mirror SHA256: 4fcb339460268c9ee18d309ff0a1ba05ffcea776f415e193442598db95e392a9

Related links:

- #50572 - checksum changed due to recompression
- http://download.openpkg.org/components/cache/liblzf/ - last modified: 07-Feb-2011
- http://dist.schmorp.de/liblzf/ - last modified: 2019-10-04