### PR TITLE
libraqm: fix libraqm dylib reference

### DIFF
--- a/Formula/libraqm.rb
+++ b/Formula/libraqm.rb
@@ -24,9 +24,6 @@ class Libraqm < Formula
     ENV["LIBTOOL"] = Formula["libtool"].bin
     ENV["PKG_CONFIG"] = Formula["pkg-config"].bin/"pkg-config"
 
-    ENV["HARFBUZZ_CFLAGS"] = "-I#{Formula["harfbuzz"].include/"harfbuzz"}"
-    ENV["HARFBUZZ_LIBS"] = Formula["harfbuzz"].lib
-
     # for the docs
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 


### PR DESCRIPTION
HARFBUZZ overrides break the shared library. Uses of it fails
with:

```
dyld: lazy symbol binding failed: Symbol not found: _hb_language_get_default
  Referenced from: /usr/local/lib/libraqm.dylib
  Expected in: flat namespace

dyld: Symbol not found: _hb_language_get_default
  Referenced from: /usr/local/lib/libraqm.dylib
  Expected in: flat namespace
```

This is done by using pillow in python with the libraqm text placement backend.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
