### PR TITLE
terraform-ls 0.4.0 (new formula)

### DIFF
--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -1,0 +1,36 @@
+class TerraformLs < Formula
+  desc "Terraform Language Server"
+  homepage "https://github.com/hashicorp/terraform-ls"
+  url "https://github.com/hashicorp/terraform-ls/archive/v0.4.0.tar.gz"
+  sha256 "b0279de3016a19d6e3055c71d482a6e22856aa8cf2a70153bb8d5c335edf88ce"
+  license "MPL-2.0"
+  head "https://github.com/hashicorp/terraform-ls.git"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+  end
+
+  test do
+    port = free_port
+
+    pid = fork do
+      exec "#{bin}/terraform-ls serve -port #{port} /dev/null"
+    end
+    sleep 2
+
+    begin
+      tcp_socket = TCPSocket.new("localhost", port)
+      tcp_socket.puts <<~EOF
+        Content-Length: 59
+
+        {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+      EOF
+      assert_match "Content-Type", tcp_socket.gets("\n")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a formula for `terraform-ls`, a language server for Terraform created and maintained by Hashicorp.