### PR TITLE
scw: add scw@2 and move legacy scw as scw@1 formula

### DIFF
--- a/Aliases/scw@2
+++ b/Aliases/scw@2
@@ -1,0 +1,1 @@
+../Formula/scw.rb

--- a/Formula/scw@1.rb
+++ b/Formula/scw@1.rb
@@ -1,0 +1,28 @@
+class ScwAT1 < Formula
+  desc "Manage BareMetal Servers from command-line (as easily as with Docker)"
+  homepage "https://github.com/scaleway/scaleway-cli"
+  url "https://github.com/scaleway/scaleway-cli/archive/v1.20.tar.gz"
+  sha256 "4c50725be7bebdab17b8ef77acd230525e773631fef4051979f8ff91c86bebf8"
+  license "MIT"
+
+  keg_only :versioned_formula
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["GOBIN"] = buildpath
+    (buildpath/"src/github.com/scaleway/scaleway-cli").install Dir["*"]
+
+    system "go", "build", "-o", "#{bin}/scw", "-v", "-ldflags",
+           "-X github.com/scaleway/scaleway-cli/pkg/scwversion.GITCOMMIT=homebrew",
+           "github.com/scaleway/scaleway-cli/cmd/scw/"
+
+    bash_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/bash/scw.bash"
+    zsh_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/zsh/_scw"
+  end
+
+  test do
+    output = shell_output(bin/"scw images 2>&1", 1)
+    assert_match "You need to login first: 'scw login'", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

> Versioned software should build on all Homebrew’s supported versions of macOS.

Done

> Versioned formulae should differ in major/minor (not patch) versions from the current stable release. This is because patch versions indicate bug or security updates and we want to ensure you apply security updates.

Differs in major. scw v1 and scw v2 won't be compatible

> Unstable versions (alpha, beta, development versions) are not acceptable for versioned (or unversioned) formulae.

scw@1 will be the current stable scw release. The release of scw v2 stable will come soon.

> Upstream should have a release branch for the versioned formulae version and still make security updates for that version, when necessary. For example, PHP 5.5 was not a supported version but PHP 7.2 was in January 2018.

We will use this branch https://github.com/scaleway/scaleway-cli/tree/v1 for keeping this version in the same repository.

> Versioned formulae share a codebase with the main formula. If the project is split into a different repository we recommend creating a new formula (formula2 rather than formula@2 or formula@1).

We use the same repository. https://github.com/scaleway/scaleway-cli

> Formulae that depend on versioned formulae must not depend on the same formulae at two different versions twice in their recursive dependencies. For example, if you depend on openssl@1.0 and foo, and foo depends on openssl then you must instead use openssl.

We only depend on go

> Versioned formulae should only be linkable at the same time as their non-versioned counterpart if the upstream project provides support for it, e.g. using suffixed binaries. If this is not possible, use keg_only :versioned_formula to allow users to have multiple versions installed at once.

The binary installed by scw@1 could be renamed to scwv1 and should work the same to avoid conflicts with the version 2 that will be installed as scw.

> A keg_only :versioned_formula should not post_install anything in the HOMEBREW_PREFIX that conflicts with or duplicates the non-versioned counterpart (or other versioned formulae). For example, a node@6 formula should not install its npm into HOMEBREW_PREFIX like the node formula does.

We are not using keg_only

> Versioned formulae submitted should be expected to be used by a large number of people. If this ceases to be the case: they will be removed. We will aim not to remove those in the top 3,000 install_on_request formulae.

We are in the top 3000 (#2434)

> Versioned formulae should not have resources that require security updates. For example, a node@6 formula should not have an npm resource but instead rely on the npm provided by the upstream tarball.

We don't have resources.

> Versioned formulae should be as similar as possible and sensible compared to the non-versioned formulae. Creating or updating a versioned formula should be a chance to ask questions of the non-versioned formula, e.g. can some unused or useless options be removed or made default?

Scaleway CLIv2 will be built using a very similar formula. It is still a golang binary and will be built in a very similar way.

> No more than five versions of a formula (including the non-versioned one) will be supported at any given time, regardless of usage. When removing formulae that violate this we will aim to do so based on usage and support status rather than age.

We are below this threshold.

-----

We are going to release the Scaleway CLI v2 soon. This release will have a totally different API and will be incompatible.
We are looking for a way to give the option to our users to keep using v1 if they want to. The first seems to be to explicitly tag this version as v1.
