### PR TITLE
libunistring: use correct header for u32_uctomb

### DIFF
--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -27,7 +27,7 @@ class Libunistring < Formula
     (testpath/"test.c").write <<~EOS
       #include <uniname.h>
       #include <unistdio.h>
-      #include <stdio.h>
+      #include <unistr.h>
       #include <stdlib.h>
       int main (void) {
         uint32_t s[2] = {};


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- `u32_uctomb` is declared in `unistr.h`, which was missing, and caused `brew test` to fail.
- `stdio.h` seems to be unnecessary, so this PR removes it while we’re on it.
