### PR TITLE
gnucobol updated to 3.1rc1

### DIFF
--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -1,8 +1,8 @@
 class GnuCobol < Formula
-  desc "Implements much of the COBOL 85 and COBOL 2002 standards"
-  homepage "https://sourceforge.net/projects/open-cobol/"
-  url "https://downloads.sourceforge.net/project/open-cobol/gnucobol/2.2/gnucobol-2.2.tar.xz"
-  sha256 "dc18fc45c269debfe86a4bbe20a7250983cba6238ea1917e135df5926cd024a0"
+  desc "a free and modern COBOL compiler, implements much of COBOL 85-202x standards and lots of extensions"
+  homepage "https://www.gnu.org/software/gnucobol/"
+  url "https://alpha.gnu.org/gnu/gnucobol/gnucobol-3.1-rc1.tar.xz"
+  sha256 "DC18FC45C269DEBFE86A4BBE20A7250983CBA6238EA1917E135DF5926CD024A0"
   revision 1
 
   bottle do
@@ -12,13 +12,32 @@ class GnuCobol < Formula
     sha256 "257ab86b68ebb00c5e29ae347cd71f041644a779ab0c1dcf6146509546603a46" => :high_sierra
   end
 
+  head do
+    url "https://svn.code.sf.net/p/open-cobol/code/trunk", :using => :svn
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gnu-sed" => :build
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+    depends_on "help2man" => :build
+    depends_on "texinfo" => :build
+  end
+
   depends_on "berkeley-db"
   depends_on "gmp"
+  depends_on "cjson" => :recommended
+  # actually berkeley-db is recommended, if not used then configure must use --without-db
+  # further optional packages:
+  #    libxml2 and ncurses, but may be used from macos
+  #    lmdb  -> only for "head"
+  
 
   def install
     # both environment variables are needed to be set
     # the cobol compiler takes these variables for calling cc during its run
     # if the paths to gmp and bdb are not provided, the run of cobc fails
+    # preferable alternative: use pkg-config to set it up during configure
     gmp = Formula["gmp"]
     bdb = Formula["berkeley-db"]
     ENV.append "CPPFLAGS", "-I#{gmp.opt_include} -I#{bdb.opt_include}"

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -1,5 +1,5 @@
 class GnuCobol < Formula
-  desc "GnuCOBOL, a free and modern COBOL compiler, implements much of COBOL 85-202x standards and lots of extensions"
+  desc "COBOL85-202x compiler supporting lots of dialect specific extensions"
   homepage "https://www.gnu.org/software/gnucobol/"
   url "https://alpha.gnu.org/gnu/gnucobol/gnucobol-3.1-rc1.tar.xz"
   sha256 "dc18fc45c269debfe86a4bbe20a7250983cba6238ea1917e135df5926cd024a0"

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -2,7 +2,7 @@ class GnuCobol < Formula
   desc "COBOL85-202x compiler supporting lots of dialect specific extensions"
   homepage "https://www.gnu.org/software/gnucobol/"
   url "https://alpha.gnu.org/gnu/gnucobol/gnucobol-3.1-rc1.tar.xz"
-  sha256 "dc18fc45c269debfe86a4bbe20a7250983cba6238ea1917e135df5926cd024a0"
+  sha256 "c2e41c2ba520681a67c570d7246d25c31f7f55c8a145aaec3f6273a500a93a76"
   revision 1
 
   bottle do
@@ -13,7 +13,7 @@ class GnuCobol < Formula
   end
 
   head do
-    url "https://svn.code.sf.net/p/open-cobol/code/trunk", :using => :svn
+    url "https://svn.code.sf.net/p/open-cobol/code/trunk"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -26,8 +26,9 @@ class GnuCobol < Formula
 
   depends_on "berkeley-db"
   depends_on "gmp"
-  depends_on "cjson" => :recommended
+  depends_on "cjson"
   # actually berkeley-db is recommended, if not used then configure must use --without-db
+  # cjson is also only recommended - but for homebrew-core this attribute should not be used
   # further optional packages:
   #    libxml2 and ncurses, but may be used from macos
   #    lmdb  -> only for "head"

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -25,8 +25,8 @@ class GnuCobol < Formula
   end
 
   depends_on "berkeley-db"
-  depends_on "gmp"
   depends_on "cjson"
+  depends_on "gmp"
   # actually berkeley-db is recommended, if not used then configure must use --without-db
   # cjson is also only recommended - but for homebrew-core this attribute should not be used
   # further optional packages:

--- a/Formula/gnu-cobol.rb
+++ b/Formula/gnu-cobol.rb
@@ -1,8 +1,8 @@
 class GnuCobol < Formula
-  desc "a free and modern COBOL compiler, implements much of COBOL 85-202x standards and lots of extensions"
+  desc "GnuCOBOL, a free and modern COBOL compiler, implements much of COBOL 85-202x standards and lots of extensions"
   homepage "https://www.gnu.org/software/gnucobol/"
   url "https://alpha.gnu.org/gnu/gnucobol/gnucobol-3.1-rc1.tar.xz"
-  sha256 "DC18FC45C269DEBFE86A4BBE20A7250983CBA6238EA1917E135DF5926CD024A0"
+  sha256 "dc18fc45c269debfe86a4bbe20a7250983cba6238ea1917e135df5926cd024a0"
   revision 1
 
   bottle do
@@ -17,9 +17,9 @@ class GnuCobol < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "gnu-sed" => :build
     depends_on "bison" => :build
     depends_on "flex" => :build
+    depends_on "gnu-sed" => :build
     depends_on "help2man" => :build
     depends_on "texinfo" => :build
   end
@@ -31,7 +31,6 @@ class GnuCobol < Formula
   # further optional packages:
   #    libxml2 and ncurses, but may be used from macos
   #    lmdb  -> only for "head"
-  
 
   def install
     # both environment variables are needed to be set


### PR DESCRIPTION
Done:
* improved description
* prefer official web pages and download urls
* added missing parts for "head"
* add recommended cjson

ToDo:
* sha for the bottle was not changed
* possibly more recommended/optional bottles to activate
* test the build ([worked on CI](https://ci.appveyor.com/project/GitMensch/gnucobol-3-x-macos) from vcs checkout with tools included in "head", just fails some internal tests but the 2.2 version fail much more)
* test head
* ideally should be moved to "gnucobol", using the actual package name, with an entry to "formerly known as gnu-cobol"  

Note: done by someone not actually using a Mac and used brew the first time....

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
