### PR TITLE
crystal 0.35.1_1: Remove `/usr/lib` from CRYSTAL_LIBRARY_PATH

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -1,6 +1,7 @@
 class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
+  revision 1
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.35.1.tar.gz"
@@ -110,7 +111,7 @@ class Crystal < Formula
       #!/bin/bash
       EMBEDDED_CRYSTAL_PATH=$("#{libexec/"crystal"}" env CRYSTAL_PATH)
       export CRYSTAL_PATH="${CRYSTAL_PATH:-"$EMBEDDED_CRYSTAL_PATH:#{prefix/"src"}"}"
-      export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}#{prefix/"embedded/lib"}:/usr/lib:/usr/local/lib"
+      export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}#{prefix/"embedded/lib"}:/usr/local/lib"
       export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}#{Formula["openssl"].opt_lib/"pkgconfig"}"
       exec "#{libexec/"crystal"}" "${@}"
     SH


### PR DESCRIPTION
This is causing trouble at least in High Sierra (https://github.com/crystal-lang/crystal/issues/9477), where versions of `libssl` and `libcrypto` are available in `/usr/lib`. Latest version of Crystal is putting `CRYSTAL_LIBRARY_PATH` with more precedence than paths obtained from `pkg-config`. We probably should remove `/usr/local/lib` as well, but I'll perform more testing before that.

