### PR TITLE
nebula: add plist

### DIFF
--- a/Formula/nebula.rb
+++ b/Formula/nebula.rb
@@ -21,6 +21,38 @@ class Nebula < Formula
     prefix.install_metafiles
   end
 
+  plist_options :startup => true
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/nebula</string>
+          <string>-config</string>
+          <string>#{etc}/nebula/config.yml</string>
+        </array>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/nebula.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/nebula.log</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <dict>
+          <key>NetworkState</key>
+          <true/>
+        </dict>
+      </dict>
+      </plist>
+    EOS
+  end
+
   test do
     system "#{bin}/nebula-cert", "ca", "-name", "testorg"
     system "#{bin}/nebula-cert", "sign", "-name", "host", "-ip", "192.168.100.1/24"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](bre://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a plist to allow nebula to be run as a daemon.

It _may_ need the location of the config files (currently /usr/local/etc/nebula) documented somewhere obvious to the user, and it would probably make sense to install the example nebula config file, patched for /usr/local/etc. 