### PR TITLE
Fix telnetd for Apple Silicon

### DIFF
--- a/Formula/telnetd.rb
+++ b/Formula/telnetd.rb
@@ -20,8 +20,7 @@ class Telnetd < Formula
 
   def install
     resource("libtelnet").stage do
-      # Force 64 bit-only build, otherwise it fails on Mojave
-      xcodebuild "SYMROOT=build", "-arch", "x86_64"
+      xcodebuild "SYMROOT=build", "-arch", Hardware::CPU.arch
 
       libtelnet_dst = buildpath/"telnetd.tproj/build/Products"
       libtelnet_dst.install "build/Release/libtelnet.a"
@@ -35,7 +34,7 @@ class Telnetd < Formula
                    "CC=#{ENV.cc}",
                    "CFLAGS=$(CC_Flags) -isystembuild/Products/",
                    "LDFLAGS=$(LD_Flags) -Lbuild/Products/",
-                   "RC_ARCHS=x86_64" # Force 64-bit build for Mojave
+                   "RC_ARCHS=#{Hardware::CPU.arch}"
 
     sbin.install "telnetd.tproj/build/Products/telnetd"
     man8.install "telnetd.tproj/telnetd.8"


### PR DESCRIPTION
- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [*] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR allows `telnetd` to be built for Apple Silicon. Without these changes it will try to build for x86_64 and fails during the build process