### PR TITLE
Get GMP building on Apple Silicon

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -21,7 +21,7 @@ class Gmp < Formula
 
     # Enable --with-pic to avoid linking issues with the static library
     args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
-    if Hardware::CPU.arm? 
+    if Hardware::CPU.arm?
       args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
       args << "--disable-assembly"
     else

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -12,14 +12,14 @@ class Gmp < Formula
     sha256 "63f220c9ac4ebc386711c8c4c5e1f955cfb0a784bdc41bfd6c701dc789be7fcc" => :high_sierra
   end
 
+  uses_from_macos "m4" => :build
+
   patch do
     # https://gmplib.org/list-archives/gmp-bugs/2020-July/004837.html
     # arm64-darwin patch
     url "https://gmplib.org/list-archives/gmp-bugs/attachments/20200703/6c9b827c/attachment.bin"
     sha256 "517ef7c22102e7ce15e71b75e4e4edcd2149dccfcf02a2b2f19f1407107fde18"
   end
-
-  uses_from_macos "m4" => :build
 
   depends_on "autoconf" if Hardware::CPU.arm?
   depends_on "automake" if Hardware::CPU.arm?

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -21,7 +21,12 @@ class Gmp < Formula
 
     # Enable --with-pic to avoid linking issues with the static library
     args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
-    args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+    if Hardware::CPU.arm? 
+      args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
+      args << "--disable-assembly"
+    else
+      args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+    end
     system "./configure", *args
     system "make"
     system "make", "check"

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -21,9 +21,15 @@ class Gmp < Formula
 
   uses_from_macos "m4" => :build
 
+  depends_on "autoconf" if Hardware::CPU.arm?
+  depends_on "automake" if Hardware::CPU.arm?
+  depends_on "libtool" if Hardware::CPU.arm?
+
   def install
     if Hardware::CPU.arm?
-      args = "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
+      args =  %W[--prefix=#{prefix}]
+      args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
+      system "autoreconf", "-fiv"
     else
       # Work around macOS Catalina / Xcode 11 code generation bug
       # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -15,6 +15,7 @@ class Gmp < Formula
   uses_from_macos "m4" => :build
 
   patch do
+    # Remove when upstream fix is released
     # https://gmplib.org/list-archives/gmp-bugs/2020-July/004837.html
     # arm64-darwin patch
     url "https://gmplib.org/list-archives/gmp-bugs/attachments/20200703/6c9b827c/attachment.bin"

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -18,7 +18,7 @@ class Gmp < Formula
     # Remove when upstream fix is released
     # https://gmplib.org/list-archives/gmp-bugs/2020-July/004837.html
     # arm64-darwin patch
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6f75ed4d/gmp/6.2.0-arm.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c53834b4/gmp/6.2.0-arm.patch"
     sha256 "4c5b926f47c78f9cc6f900130d020e7f3aa6f31a6e84246e8886f6da04f7424c"
   end
 

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -18,13 +18,9 @@ class Gmp < Formula
     # Remove when upstream fix is released
     # https://gmplib.org/list-archives/gmp-bugs/2020-July/004837.html
     # arm64-darwin patch
-    url "https://gmplib.org/list-archives/gmp-bugs/attachments/20200703/6c9b827c/attachment.bin"
-    sha256 "517ef7c22102e7ce15e71b75e4e4edcd2149dccfcf02a2b2f19f1407107fde18"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6f75ed4d/gmp/6.2.0-arm.patch"
+    sha256 "4c5b926f47c78f9cc6f900130d020e7f3aa6f31a6e84246e8886f6da04f7424c"
   end
-
-  # Remove when upstream fix is released
-  # Fixes arm64-darwin assembly/linkage issue
-  patch :DATA
 
   if Hardware::CPU.arm?
     depends_on "autoconf" => :build
@@ -76,32 +72,3 @@ class Gmp < Formula
     system "./test"
   end
 end
-__END__
-diff --git a/mpn/arm64/bdiv_q_1.asm b/mpn/arm64/bdiv_q_1.asm
-index ecc4fbc..4226524 100644
---- a/mpn/arm64/bdiv_q_1.asm
-+++ b/mpn/arm64/bdiv_q_1.asm
-@@ -75,7 +75,7 @@ PROLOGUE(mpn_bdiv_q_1)
- 	mul	x6, x6, x6
- 	msub	di, x6, d, x7
- 
--	b	mpn_pi1_bdiv_q_1
-+	b	__pi1_bdiv_q_1
- EPILOGUE()
- 
- PROLOGUE(mpn_pi1_bdiv_q_1)
-diff --git a/mpn/asm-defs.m4 b/mpn/asm-defs.m4
-index 7b7e53e..5032f69 100644
---- a/mpn/asm-defs.m4
-+++ b/mpn/asm-defs.m4
-@@ -1508,6 +1508,10 @@ deflit(__clz_tab,
- m4_assert_defined(`GSYM_PREFIX')
- `GSYM_PREFIX`'MPN(`clz_tab')')
- 
-+deflit(__pi1_bdiv_q_1,
-+m4_assert_defined(`GSYM_PREFIX')
-+`GSYM_PREFIX`'MPN(`pi1_bdiv_q_1')')
-+
- deflit(binvert_limb_table,
- m4_assert_defined(`GSYM_PREFIX')
- `GSYM_PREFIX`'__gmp_binvert_limb_table')

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -12,19 +12,25 @@ class Gmp < Formula
     sha256 "63f220c9ac4ebc386711c8c4c5e1f955cfb0a784bdc41bfd6c701dc789be7fcc" => :high_sierra
   end
 
+  patch do
+    # https://gmplib.org/list-archives/gmp-bugs/2020-July/004837.html
+    # arm64-darwin patch
+    url "https://gmplib.org/list-archives/gmp-bugs/attachments/20200703/6c9b827c/attachment.bin"
+    sha256 "517ef7c22102e7ce15e71b75e4e4edcd2149dccfcf02a2b2f19f1407107fde18"
+  end
+
   uses_from_macos "m4" => :build
 
   def install
-    # Work around macOS Catalina / Xcode 11 code generation bug
-    # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
-    ENV.append_to_cflags "-fno-stack-check"
-
-    # Enable --with-pic to avoid linking issues with the static library
-    args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
     if Hardware::CPU.arm?
-      args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
-      args << "--disable-assembly"
+      args = "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
     else
+      # Work around macOS Catalina / Xcode 11 code generation bug
+      # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
+      ENV.append_to_cflags "-fno-stack-check"
+
+      # Enable --with-pic to avoid linking issues with the static library
+      args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
       args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
     end
     system "./configure", *args

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -22,6 +22,10 @@ class Gmp < Formula
     sha256 "517ef7c22102e7ce15e71b75e4e4edcd2149dccfcf02a2b2f19f1407107fde18"
   end
 
+  # Remove when upstream fix is released
+  # Fixes arm64-darwin assembly/linkage issue
+  patch :DATA
+
   depends_on "autoconf" if Hardware::CPU.arm?
   depends_on "automake" if Hardware::CPU.arm?
   depends_on "libtool" if Hardware::CPU.arm?
@@ -70,3 +74,32 @@ class Gmp < Formula
     system "./test"
   end
 end
+__END__
+diff --git a/mpn/arm64/bdiv_q_1.asm b/mpn/arm64/bdiv_q_1.asm
+index ecc4fbc..4226524 100644
+--- a/mpn/arm64/bdiv_q_1.asm
++++ b/mpn/arm64/bdiv_q_1.asm
+@@ -75,7 +75,7 @@ PROLOGUE(mpn_bdiv_q_1)
+ 	mul	x6, x6, x6
+ 	msub	di, x6, d, x7
+ 
+-	b	mpn_pi1_bdiv_q_1
++	b	__pi1_bdiv_q_1
+ EPILOGUE()
+ 
+ PROLOGUE(mpn_pi1_bdiv_q_1)
+diff --git a/mpn/asm-defs.m4 b/mpn/asm-defs.m4
+index 7b7e53e..5032f69 100644
+--- a/mpn/asm-defs.m4
++++ b/mpn/asm-defs.m4
+@@ -1508,6 +1508,10 @@ deflit(__clz_tab,
+ m4_assert_defined(`GSYM_PREFIX')
+ `GSYM_PREFIX`'MPN(`clz_tab')')
+ 
++deflit(__pi1_bdiv_q_1,
++m4_assert_defined(`GSYM_PREFIX')
++`GSYM_PREFIX`'MPN(`pi1_bdiv_q_1')')
++
+ deflit(binvert_limb_table,
+ m4_assert_defined(`GSYM_PREFIX')
+ `GSYM_PREFIX`'__gmp_binvert_limb_table')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a bit of a halfway fix to get GMP building and working on Apple Silicon. The architecture is not yet supported officially, so while we wait this will produce a generic C build - according to the documentation this may run slowly, but at least it gets it working for now!