### PR TITLE
sile 0.10.5

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,9 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://www.sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.10.4/sile-0.10.4.tar.bz2"
-  sha256 "d136fbe9bc86c3e235d34db170d48af14779c36e8b0b03f542ffdbabcdde4222"
-  revision 2
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.10.5/sile-0.10.5.tar.bz2"
+  sha256 "a14fe23af242ba723aed699048b10abf60d1809390ac543140b80e057c4b4b9b"
 
   head "https://github.com/sile-typesetter/sile.git", :shallow => false
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Not on macOS here so this is a blind update. There shouldn't be any significant build changes in this maintenance release. See [upstream release](https://github.com/sile-typesetter/sile/releases/tag/v0.10.5). The new `make check` is optional but a fast way to make sure everything worked. It might not actually run here because of the need for Lua environment stuff normally taken care of for the Brew builds by a wrapper script. If that's the case it's probably safe to just ditch it.