### PR TITLE
gatsby-cli: throttle the revision bump

### DIFF
--- a/Formula/gatsby-cli.rb
+++ b/Formula/gatsby-cli.rb
@@ -3,6 +3,7 @@ require "language/node"
 class GatsbyCli < Formula
   desc "Gatsby command-line interface"
   homepage "https://www.gatsbyjs.org/docs/gatsby-cli/"
+  # gatsby-cli should only be updated every 10 releases on multiples of 10
   url "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.12.56.tgz"
   sha256 "cc8658c75108fd1ed1aaeae928b7bc61ea854d4c2d77ec501bc2c44981800336"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

relates to Homebrew/brew#7883