### PR TITLE
spades: remove deprecated rewrite_python_shebang

### DIFF
--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -1,9 +1,12 @@
 class Spades < Formula
+  include Language::Python::Shebang
+
   desc "De novo genome sequence assembly"
   homepage "http://cab.spbu.ru/software/spades/"
   url "https://github.com/ablab/spades/releases/download/v3.14.1/SPAdes-3.14.1.tar.gz"
   mirror "http://cab.spbu.ru/files/release3.14.1/SPAdes-3.14.1.tar.gz"
-  sha256 "d71ce756daa0a889b8881bd129a761200a0bb971e6fd2bed1384a1df9b585d1b"
+  sha256 "d629b78f7e74c82534ac20f5b3c2eb367f245e6840a67b9ef6a76f6fac5323ca"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -21,12 +24,11 @@ class Spades < Formula
   uses_from_macos "zlib"
 
   def install
-    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
-
     mkdir "src/build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
+    bin.find { |f| rewrite_shebang detected_python_shebang, f }
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#55255 - `rewrite_python_shebang` is deprecated, use `rewrite_shebang` instead.

Additionally, the sha seems to have changed. According to the [changelog](http://cab.spbu.ru/files/release3.14.1/changelog.html), version 3.14.1 was released on May 1, but the formula was bumped on [April 28](https://github.com/Homebrew/homebrew-core/pull/53935). Not sure exactly what happened but I'm thinking that upstream released version 3.14.1 twice...