### PR TITLE
scons: remove deprecated rewrite_python_shebang

### DIFF
--- a/Formula/scons.rb
+++ b/Formula/scons.rb
@@ -1,9 +1,11 @@
 class Scons < Formula
+  include Language::Python::Shebang
+
   desc "Substitute for classic 'make' tool with autoconf/automake functionality"
   homepage "https://www.scons.org/"
   url "https://downloads.sourceforge.net/project/scons/scons/3.1.2/scons-3.1.2.tar.gz"
   sha256 "7801f3f62f654528e272df780be10c0e9337e897650b62ddcee9f39fde13f8fb"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,8 +17,6 @@ class Scons < Formula
   depends_on "python@3.8"
 
   def install
-    Language::Python.rewrite_python_shebang(Formula["python@3.8"].opt_bin/"python3")
-
     man1.install gzip("scons-time.1", "scons.1", "sconsign.1")
     system Formula["python@3.8"].opt_bin/"python3", "setup.py", "install",
              "--prefix=#{prefix}",
@@ -28,6 +28,7 @@ class Scons < Formula
              "--install-data=#{libexec}",
              "--no-version-script", "--no-install-man"
 
+    bin.find { |f| rewrite_shebang detected_python_shebang, f }
     # Re-root scripts to libexec so they can import SCons and symlink back into
     # bin. Similar tactics are used in the duplicity formula.
     bin.children.each do |p|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#55255 - `rewrite_python_shebang` is deprecated, use `rewrite_shebang` instead.