### PR TITLE
pcre: Made JIT require x86_64 for now.

### DIFF
--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -35,7 +35,7 @@ class Pcre < Formula
       --enable-pcregrep-libz
       --enable-pcregrep-libbz2
     ]
-    args << "--enable-jit" if MacOS.version >= :sierra
+    args << "--enable-jit" if MacOS.version >= :sierra && Hardware::CPU.arch == :x86_64
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR allow pcre to install on MacOS Big Sur running on ARM hardware by turning off JIT. A better fix for later would be to update PCRE itself to allow JIT on ARM. (This is a new PR to replace the one where I messed up the change doing a squash).