### PR TITLE
pcre2: Only enabled JIT on x86_64 as workaround to ARM crash.

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -16,13 +16,17 @@ class Pcre2 < Formula
   uses_from_macos "zlib"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-pcre2-16",
-                          "--enable-pcre2-32",
-                          "--enable-pcre2grep-libz",
-                          "--enable-pcre2grep-libbz2",
-                          "--enable-jit"
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --enable-pcre2-16
+      --enable-pcre2-32
+      --enable-pcre2grep-libz
+      --enable-pcre2grep-libbz2
+    ]
+    args << "--enable-jit" if Hardware::CPU.arch == :x86_64
+
+    system "./configure", *args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The JIT implementation in pcre2 crashes during test on Big Sur / ARM. This change restricts the JIT functionality to x86_64 for now, allowing the formula to work successfully on ARM.

Tested on both architectures. I have filed a similar PR for pcre. 