### PR TITLE
k9s 0.21.2 (new formula)

### DIFF
--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -1,0 +1,26 @@
+class K9s < Formula
+  desc "Kubernetes CLI To Manage Your Clusters In Style!"
+  homepage "https://k9scli.io/"
+  url "https://github.com/derailed/k9s.git",
+      :tag      => "v0.21.2",
+      :revision => "977791627860a0febb3c217a5322702da109ecbb"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-ldflags",
+             "-s -w -X github.com/derailed/k9s/cmd.version=#{version}
+             -X github.com/derailed/k9s/cmd.commit=#{stable.specs[:revision]}",
+             *std_go_args
+  end
+
+  test do
+    # k9s consumes the Kubernetes configuration which per default is located at ~/.kube/config
+    # Its location can also be set with the KUBECONFIG environment variable
+    # Setting it to a non-existing location makes sure the test always fails as expected
+    ENV["KUBECONFIG"] = "testpath"
+    assert_equal "\e[31mBoom!! \e[0m\e[37mInvalid kubeconfig context detected.\e[0m",
+                  shell_output("#{bin}/k9s").split("\n").pop
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
k9s is an insanely handy and popular interactive CLI to deal with Kubernetes clusters. There is an official formula available here https://github.com/derailed/homebrew-k9s/blob/master/Formula/k9s.rb but I think it should be added to the core repo for more exposure.