### PR TITLE
spdylay: deprecate

### DIFF
--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -13,6 +13,9 @@ class Spdylay < Formula
     sha256 "2f24051eb854a2345e88a1e023aa76fa6c2cb7522ec0fd7644af15694b456f27" => :sierra
   end
 
+  # The SPDY protocol itself is deprecated and most websites no longer support it
+  deprecate!
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The test continues to break because websites continue to drop support for SPDY. The only websites I can find that still support SPDY are some Chinese ones.

Even though the library itself isn't explicitly deprecated, the SPDY protocol itself is deprecated and this library is unlikely to receive an update again as there is now very little use for it.

Deprecation will mean it will no longer be tested as a dependent in other PRs.