### PR TITLE
cmake: add macOS 11.0/arm64 compatibility

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -13,6 +13,13 @@ class Cmake < Formula
       url "https://gitlab.kitware.com/cmake/cmake/-/commit/c841d43d70036830c9fe16a6dbf1f28acf49d7e3.diff"
       sha256 "87de737abaf5f8c071abc4a4ae2e9cccced6a9780f4066b32ce08a9bc5d8edd5"
     end
+
+    # Adds macOS 11.0 compatibility.
+    # Remove with 3.18.0.
+    patch do
+      url "https://gitlab.kitware.com/cmake/cmake/-/commit/a0c4c27443afe1c423c08063e2eaf96ffa2f54fb.diff"
+      sha256 "7b84bc0dbb71c620939fb1e354f671e1d0007c9c8060ed3f2afe54a11f5e578c"
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This patch makes the formula compatible with macOS 11.0.

Apple’s [macOS 11 Beta release notes](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11-beta-release-notes) say cmake 3.18.0-rc1 is required but we want to avoid pulling in non-stable releases if possible.

Thanks to a [hint](https://gitlab.kitware.com/cmake/cmake/-/issues/20863#note_789365) in cmake’s issue tracker, I was able to cherry-pick a single commit, which is part of 3.18.0-rc1 and [fixes the issue](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4779). I also double-checked that `brew install -s` and `brew test` work now on macOS 11.
