### PR TITLE
Fix for nettle on Apple Silicon

### DIFF
--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -26,9 +26,13 @@ class Nettle < Formula
                                           "get_pc_thunk|(_*chkstk_darwin)"
     end
 
+    # Disable assembly as a temporary measure
+    args = "--disable-assembler" if Hardware::CPU.arm?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--enable-shared"
+                          "--enable-shared",
+                          *args
     system "make"
     system "make", "install"
     system "make", "check"

--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -26,7 +26,8 @@ class Nettle < Formula
                                           "get_pc_thunk|(_*chkstk_darwin)"
     end
 
-    args = "--build=aarch64-apple-darwin#{`uname -r`.to_i}" if Hardware::CPU.arm?
+    args = []
+    args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}" if Hardware::CPU.arm?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -27,7 +27,7 @@ class Nettle < Formula
     end
 
     args = []
-    args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}" if Hardware::CPU.arm?
+    args << "--build=aarch64-apple-darwin#{`uname -r`.chomp}" if Hardware::CPU.arm?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -26,8 +26,7 @@ class Nettle < Formula
                                           "get_pc_thunk|(_*chkstk_darwin)"
     end
 
-    # Disable assembly as a temporary measure
-    args = "--disable-assembler" if Hardware::CPU.arm?
+    args = "--build=aarch64-apple-darwin#{`uname -r`.to_i}" if Hardware::CPU.arm?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Disabling the attempt to build with assembly optimisations which causes a failure on Apple Silicon. This is very much a temporary fix for now as it will cause some performance hit. This should get it working until arm64 support is available upstream.