### PR TITLE
libinfinity: disable

### DIFF
--- a/Formula/libinfinity.rb
+++ b/Formula/libinfinity.rb
@@ -18,6 +18,11 @@ class Libinfinity < Formula
   depends_on "gsasl"
   depends_on "gtk+3"
 
+  # libinfinity is only used by gobby
+  # latest 0.7.1 does not work with gobby 0.5.0 due to open issue, https://github.com/gobby/gobby/issues/143
+  # gobby is disbled per #57501
+  disable!
+
   # MacPorts patch to fix pam include. This is still applicable to 0.6.4.
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/f8e3d2e4/libinfinity/patch-infinoted-infinoted-pam.c.diff"


### PR DESCRIPTION
libinfinity is only used by gobby
latest 0.7.1 does not work with gobby 0.5.0 due to open issue, https://github.com/gobby/gobby/issues/143
gobby is disbled per #57501

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

no active development and release since march 2018, disable the formula.