### PR TITLE
sratoolkit 2.10.8

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -1,8 +1,8 @@
 class Sratoolkit < Formula
   desc "Data tools for INSDC Sequence Read Archive"
   homepage "https://github.com/ncbi/sra-tools"
-  url "https://github.com/ncbi/sra-tools/archive/2.10.0.tar.gz"
-  sha256 "6d2b02bad674cde6b9677a522f62da092da5471d23738976abce8eae5710fa0c"
+  url "https://github.com/ncbi/sra-tools/archive/2.10.8.tar.gz"
+  sha256 "4adb969a9a998f6a50020f99aa66f6ae27916f7dc83ddf6722fc0fea4a3a4d17"
   head "https://github.com/ncbi/sra-tools.git"
 
   bottle do
@@ -23,13 +23,13 @@ class Sratoolkit < Formula
   end
 
   resource "ngs-sdk" do
-    url "https://github.com/ncbi/ngs/archive/2.10.0.tar.gz"
-    sha256 "4139adff83af213d7880bc80d1c0f5ee9b00c6c4e615d00aa47aaa267e40ed25"
+    url "https://github.com/ncbi/ngs/archive/2.10.8.tar.gz"
+    sha256 "f20fae21439b69b6a3573c864a175e0f9aa47ca6dd12bea15e429b7c5a9b81b5"
   end
 
   resource "ncbi-vdb" do
-    url "https://github.com/ncbi/ncbi-vdb/archive/2.10.0.tar.gz"
-    sha256 "a6cc88e8d12f536dc96d5f60698d0ef4cf2f63e31d3d12d23da39b1de39563e1"
+    url "https://github.com/ncbi/ncbi-vdb/archive/2.10.8.tar.gz"
+    sha256 "7a593aa22584db9443bb56ac01409707bca01b8f9601fe530dac81b73f1a44df"
   end
 
   def install
@@ -73,6 +73,12 @@ class Sratoolkit < Formula
   end
 
   test do
+    # For testing purposes, generate a sample config noninteractively in lieu of running vdb-config --interactive
+    # See upstream issue: https://github.com/ncbi/sra-tools/issues/291
+    require "securerandom"
+    mkdir ".ncbi"
+    (testpath/".ncbi/user-settings.mkfg").write "/LIBS/GUID = \"#{SecureRandom.uuid}\"\n"
+
     assert_match "Read 1 spots for SRR000001", shell_output("#{bin}/fastq-dump -N 1 -X 1 SRR000001")
     assert_match "@SRR000001.1 EM7LVYS02FOYNU length=284", File.read("SRR000001.fastq")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This update adds a workaround for the configuration needed in the test block (see https://github.com/ncbi/sra-tools/issues/291 for information on upstream change).

End users should probably still run the configuration interactively on their own as upstream suggests, but this little hack should suffice for our simple testing purposes.

Thanks to @SeekingMeaning for pointing out the upstream issue and providing a quick workaround.