### PR TITLE
Remove OpenSSL provider from Botan formula

### DIFF
--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -4,6 +4,7 @@ class Botan < Formula
   url "https://botan.randombit.net/releases/Botan-2.15.0.tar.xz"
   sha256 "d88af1307f1fefac79aa4f2f524699478d69ce15a857cf2d0a90ac6bf2a50009"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/randombit/botan.git"
 
   bottle do
@@ -13,8 +14,8 @@ class Botan < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on :macos # Due to Python 2
-  depends_on "openssl@1.1"
+  depends_on "python@3.8"
+  depends_on "sqlite"
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
@@ -27,9 +28,10 @@ class Botan < Formula
       --docdir=share/doc
       --cc=#{ENV.compiler}
       --os=darwin
-      --with-openssl
       --with-zlib
       --with-bzip2
+      --with-sqlite3
+      --with-python-versions=3.8
     ]
 
     system "./configure.py", *args


### PR DESCRIPTION
The authors do not recommend building with
OpenSSL support. Additionally, they recommend
building with sqlite support.

See https://botan.randombit.net/handbook/packaging.html.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
