### PR TITLE
libimobiledevice: use source from GitHub release

### DIFF
--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -1,8 +1,8 @@
 class Libimobiledevice < Formula
   desc "Library to communicate with iOS devices natively"
   homepage "https://www.libimobiledevice.org/"
-  url "https://www.libimobiledevice.org/downloads/libimobiledevice-1.3.0.tar.bz2"
-  sha256 "53f2640c6365cd9f302a6248f531822dc94a6cced3f17128d4479a77bd75b0f6"
+  url "https://github.com/libimobiledevice/libimobiledevice/releases/download/1.3.0/libimobiledevice-1.3.0.tar.bz2"
+  sha256 "5143eaf34011a22dd1951f10495a7568e77a2e862fb9f4dbae9bab2f784f926e"
 
   bottle do
     cellar :any
@@ -16,7 +16,6 @@ class Libimobiledevice < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "libxml2"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The previous URL returns a 404 so we have to switch over to the ~source tarball from the~ GitHub release.

The following additional changes have been made:

- SHA256 changed due to root folder names ~and missing `configure`~

- ~Call `autogen.sh` for the stable version, too~

- ~Add dependencies for autotools for the stable version, too~

- Remove [outdated](https://github.com/libimobiledevice/libimobiledevice/commit/185294a0f9a689a231d3d0d8cde1864d4b0bdaa0) `libxml2` dependency

Also pinging @rickmark, who authored https://github.com/Homebrew/homebrew-core/pull/53612.
