### PR TITLE
workflows: set dispatch type to 'Publish *'

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -1,6 +1,9 @@
 name: Publish and commit bottles
 
-on: repository_dispatch
+on:
+  repository_dispatch:
+    types:
+      - 'Publish *'
 
 jobs:
   upload:


### PR DESCRIPTION
With `brew pr-publish` setting the dispatch' event type (name) to `Publish ##{PR}`,
we should tighten the dispatch type in workflow file too.

This is actually the first step made to `resolve` https://github.com/Homebrew/brew/issues/7804. More precisely, the first point in that issue.

I learned about this feature (dispatch type with wildcard) by trial and error in my test repo.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----