### PR TITLE
style: use one line inreplace when possible

### DIFF
--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -26,9 +26,8 @@ class GambitScheme < Formula
     system "./configure", *args
 
     # Fixed in gambit HEAD, but they haven't cut a release
-    inreplace "config.status" do |s|
-      s.gsub! %r{/usr/local/opt/openssl(?!@1\.1)}, "/usr/local/opt/openssl@1.1"
-    end
+    inreplace "config.status", %r{/usr/local/opt/openssl(?!@1\.1)}, "/usr/local/opt/openssl@1.1"
+
     system "./config.status"
 
     system "make"

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -53,9 +53,7 @@ class Mapserver < Formula
     args << "-DPHP_EXTENSION_DIR=#{lib}/php/extensions"
 
     # Install within our sandbox
-    inreplace "mapscript/python/CMakeLists.txt" do |s|
-      s.gsub! "${PYTHON_LIBRARIES}", "-Wl,-undefined,dynamic_lookup"
-    end
+    inreplace "mapscript/python/CMakeLists.txt", "${PYTHON_LIBRARIES}", "-Wl,-undefined,dynamic_lookup"
 
     # Using rpath on python module seems to cause problems if you attempt to
     # import it with an interpreter it wasn't built against.

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -59,9 +59,7 @@ class MitScheme < Formula
       s.gsub! /SDK=MacOSX\$\{MACOS\}$/, "SDK=MacOSX#{MacOS.sdk.version}"
     end
 
-    inreplace "edwin/compile.sh" do |s|
-      s.gsub! "mit-scheme", "#{bin}/mit-scheme"
-    end
+    inreplace "edwin/compile.sh", "mit-scheme", "#{bin}/mit-scheme"
 
     ENV.prepend_path "PATH", buildpath/"staging/bin"
 

--- a/Formula/pyenv-virtualenv.rb
+++ b/Formula/pyenv-virtualenv.rb
@@ -19,17 +19,11 @@ class PyenvVirtualenv < Formula
     # addresses the following issue and PR:
     # https://github.com/pyenv/pyenv-virtualenv/issues/307
     # https://github.com/pyenv/pyenv-virtualenv/pull/308
-    inreplace bin/"pyenv-virtualenv-prefix" do |s|
-      s.gsub!('"${BASH_SOURCE%/*}"/../libexec', libexec.to_s)
-    end
+    inreplace bin/"pyenv-virtualenv-prefix", '"${BASH_SOURCE%/*}"/../libexec', libexec
 
-    inreplace bin/"pyenv-virtualenvs" do |s|
-      s.gsub!('"${BASH_SOURCE%/*}"/../libexec', libexec.to_s)
-    end
+    inreplace bin/"pyenv-virtualenvs", '"${BASH_SOURCE%/*}"/../libexec', libexec
 
-    inreplace libexec/"pyenv-virtualenv-realpath" do |s|
-      s.gsub!('"${BASH_SOURCE%/*}"/../libexec', libexec.to_s)
-    end
+    inreplace libexec/"pyenv-virtualenv-realpath", '"${BASH_SOURCE%/*}"/../libexec', libexec
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Converts `inreplace` blocks with only one `s.gsub!` to one-line `inreplace` calls.

Example:

```ruby
inreplace "edwin/compile.sh" do |s|
    s.gsub! "mit-scheme", "#{bin}/mit-scheme"
end
```
becomes
```ruby
inreplace "edwin/compile.sh", "mit-scheme", "#{bin}/mit-scheme"
```

This style will be enforced in https://github.com/Homebrew/brew/pull/7909