### PR TITLE
libimobiledevice: revert sha256 to previous value

### DIFF
--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -2,7 +2,7 @@ class Libimobiledevice < Formula
   desc "Library to communicate with iOS devices natively"
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/libimobiledevice/releases/download/1.3.0/libimobiledevice-1.3.0.tar.bz2"
-  sha256 "5143eaf34011a22dd1951f10495a7568e77a2e862fb9f4dbae9bab2f784f926e"
+  sha256 "53f2640c6365cd9f302a6248f531822dc94a6cced3f17128d4479a77bd75b0f6"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

After following @Bo98’s [suggestion](https://github.com/Homebrew/homebrew-core/pull/57555#issuecomment-654295087) to use GitHub’s source release instead of GitHub’s source tarball, I forgot to revert the hash and to re-check whether `brew install` still worked.

This sets the hash back to the correct value, partially reverting commit 86a7bc16c1491f554d07fda79dc798b5804b981e.
