### PR TITLE
Patch Perl for macOS 11.x

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -13,15 +13,15 @@ class Perl < Formula
 
   uses_from_macos "expat"
 
+  # Prevent site_perl directories from being removed
+  skip_clean "lib/perl5/site_perl"
+
   patch do
     # Enable build support on macOS 11.x
     # https://github.com/Perl/perl5/pull/17946
     url "https://github.com/Perl/perl5/pull/17946.diff?full_index=1"
     sha256 "677a6e63412a4cfd2dc1fe16ccca53d789be5ac1acfb5ebb3130c40b51e5e94a"
   end
-
-  # Prevent site_perl directories from being removed
-  skip_clean "lib/perl5/site_perl"
 
   def install
     args = %W[

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -13,6 +13,13 @@ class Perl < Formula
 
   uses_from_macos "expat"
 
+  patch do
+    # Enable build support on macOS 11.x
+    # https://github.com/Perl/perl5/pull/17946
+    url "https://github.com/Perl/perl5/pull/17946.diff?full_index=1"
+    sha256 "677a6e63412a4cfd2dc1fe16ccca53d789be5ac1acfb5ebb3130c40b51e5e94a"
+  end
+
   # Prevent site_perl directories from being removed
   skip_clean "lib/perl5/site_perl"
 

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -19,7 +19,7 @@ class Perl < Formula
   patch do
     # Enable build support on macOS 11.x
     # Remove when https://github.com/Perl/perl5/pull/17946 is merged
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/perl/version_check.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/526faca9830646b974f563532fa27a1515e51ca1/perl/version_check.patch"
     sha256 "cff250437f141eb677ec2215a9f2dfcbacba77304dac06499db6c722c9d30b58"
   end
 

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -18,9 +18,9 @@ class Perl < Formula
 
   patch do
     # Enable build support on macOS 11.x
-    # https://github.com/Perl/perl5/pull/17946
-    url "https://github.com/Perl/perl5/pull/17946.diff?full_index=1"
-    sha256 "677a6e63412a4cfd2dc1fe16ccca53d789be5ac1acfb5ebb3130c40b51e5e94a"
+    # Temporary until https://github.com/Perl/perl5/pull/17946 is merged
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/perl/version_check.patch"
+    sha256 "cff250437f141eb677ec2215a9f2dfcbacba77304dac06499db6c722c9d30b58"
   end
 
   def install

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -18,7 +18,7 @@ class Perl < Formula
 
   patch do
     # Enable build support on macOS 11.x
-    # Temporary until https://github.com/Perl/perl5/pull/17946 is merged
+    # Remove when https://github.com/Perl/perl5/pull/17946 is merged
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/perl/version_check.patch"
     sha256 "cff250437f141eb677ec2215a9f2dfcbacba77304dac06499db6c722c9d30b58"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Perl will currently fail to build (Intel and Apple Silicon) as it is expecting to match the product version `10.x`, whereas Big Sur has been bumped to `11.0`. This is a temporary patch until support is available upstream (PR created: https://github.com/Perl/perl5/pull/17946)