### PR TITLE
tbb: update version scheme

### DIFF
--- a/Formula/bowtie2.rb
+++ b/Formula/bowtie2.rb
@@ -12,6 +12,7 @@ class Bowtie2 < Formula
     sha256 "61597b46c1e6bd55d74c89e107342c4bdb5014d3a7ea37628d544b6f429bef9c" => :high_sierra
   end
 
+  depends_on "python@3.8"
   depends_on "tbb"
 
   def install

--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -2,7 +2,6 @@ class Tbb < Formula
   desc "Rich and complete approach to parallelism in C++"
   homepage "https://www.threadingbuildingblocks.org/"
   url "https://github.com/intel/tbb/archive/v2020.2.tar.gz"
-  version "2020_U2"
   sha256 "4804320e1e6cbe3a5421997b52199e3c1a3829b2ecb6489641da4b8e32faf500"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related thread: https://discourse.brew.sh/t/8256

> The current version scheme is an artifact from pre-2020 releases (e.g. 2019_U9) while new releases are tagged as v2020.*
>
> Granted, releases are still titled as “Threading Building Blocks 2020 Update 2” which is the same format as “Threading Building Blocks 2019 Update 9”