### PR TITLE
file-formula: bump revision to pick up the latest libmagic

### DIFF
--- a/Formula/file-formula.rb
+++ b/Formula/file-formula.rb
@@ -4,6 +4,7 @@ class FileFormula < Formula
   homepage "https://www.darwinsys.com/file/"
   url "https://astron.com/pub/file/file-5.39.tar.gz"
   sha256 "f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1"
+  revision 1
   head "https://github.com/file/file.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`file-formula` was built once when `libmagic` was still 5.38. Need a revision bump to pick up the latest libmagic.

Otherwise, we will have:

```sh
$ file

file: Compiled magic version [538] does not match with shared library magic version [539]
```

In the future, it would be nice to bump both `libmagic` and `file-formula` in a same pull request.