### PR TITLE
subversion: explicitly specify the prefix for swig

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -103,6 +103,7 @@ class Subversion < Formula
       --with-py3c=#{py3c_prefix}
       --with-serf=#{serf_prefix}
       --with-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-swig=#{Formula["swig"].opt_prefix}
       --with-zlib=#{MacOS.sdk_path_if_needed}/usr
       --without-apache-libexecdir
       --without-berkeley-db


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`subversion`, by default, will try to find `swig` in `/usr/local`, however if Howebrew is not installed into the standard prefix, `subversion` will fail to locate `swig`.

A revision bump is not needed here.