### PR TITLE
redis: Update to support macOS 11

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -14,6 +14,13 @@ class Redis < Formula
 
   depends_on "openssl@1.1"
 
+  patch do
+    # Remove when upstream fix is released
+    # https://github.com/redis/redis/pull/7453
+    url "https://github.com/redis/redis/pull/7453.diff?full_index=1"
+    sha256 "e1df0543442b75fea67a43eeddade50097d655fe3fef948840bf9d99bb63c157"
+  end
+
   def install
     system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

redis will fail on arm64 due to different `ucontext_t` structs, which the approved pull request to the redis project resolves