### PR TITLE
pcre2 with JIT support for arm64

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -15,6 +15,15 @@ class Pcre2 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  if Hardware::CPU.arch == :arm64
+    patch do
+      # Remove when upstream fix is released
+      # https://bugs.exim.org/show_bug.cgi?id=2618
+      url "https://bugs.exim.org/attachment.cgi?id=1324"
+      sha256 "5e710997b822a14e0e71129e6d1232f91efb0f4d2a0aca15e1e09a31ba4c8ff2"
+    end
+  end
+
   def install
     args = %W[
       --disable-dependency-tracking
@@ -23,8 +32,9 @@ class Pcre2 < Formula
       --enable-pcre2-32
       --enable-pcre2grep-libz
       --enable-pcre2grep-libbz2
+      --enable-jit
     ]
-    args << "--enable-jit" if Hardware::CPU.arch == :x86_64
+    args << "--enable-jit-sealloc" if Hardware::CPU.arch == :arm64
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR enables JIT support by using the protected execute allocator, which is required for platforms that utilize [W^X](https://en.wikipedia.org/wiki/W%5EX) memory pages for additional security. 

[Bug and patch](https://bugs.exim.org/show_bug.cgi?id=2618) submitted to pcre2 project.

The changes are predominantly autotools configuration updates. The patch simply configures the build to use the protected memory allocator for the JIT.
