### PR TITLE
batik: Fix app jar script creation

### DIFF
--- a/Formula/batik.rb
+++ b/Formula/batik.rb
@@ -4,14 +4,15 @@ class Batik < Formula
   url "https://www.apache.org/dyn/closer.lua?path=xmlgraphics/batik/binaries/batik-bin-1.13.tar.gz"
   mirror "https://archive.apache.org/dist/xmlgraphics/batik/binaries/batik-bin-1.13.tar.gz"
   sha256 "7c565899e4377a72edee216ffdf168d7b6928d5e1a8cdf477dfa1abd2c48589b"
+  revision 1
 
   bottle :unneeded
 
   def install
     libexec.install "lib", Dir["*.jar"]
-    bin.write_jar_script libexec/"batik-rasterizer-#{version}.jar", "batik-rasterizer"
-    bin.write_jar_script libexec/"batik-#{version}.jar", "batik"
-    bin.write_jar_script libexec/"batik-ttf2svg-#{version}.jar", "batik-ttf2svg"
+    Dir[libexec/"*.jar"].each do |f|
+      bin.write_jar_script f, File.basename(f, "-#{version}.jar")
+    end
   end
 
   test do


### PR DESCRIPTION
The original formula created scripts for a hardcoded list of JARs. This update scripts against the JARs that are actually installed.

Fixes #57695.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
