### PR TITLE
akka: deprecate

### DIFF
--- a/Formula/akka.rb
+++ b/Formula/akka.rb
@@ -7,6 +7,10 @@ class Akka < Formula
 
   bottle :unneeded
 
+  # Recommended to use Akka with a build tool
+  # https://github.com/akka/akka/issues/25046
+  deprecate!
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/akka/akka/issues/25046

> We don't have a zip download for Akka 2.5.x because we recommend using Akka with a build tool. It doesn't make much sense to me to have a Homebrew forumula of Akka since it's not something you install.