### PR TITLE
prometheus: fixed manual command

### DIFF
--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -56,7 +56,7 @@ class Prometheus < Formula
     EOS
   end
 
-  plist_options :manual => "prometheus"
+  plist_options :manual => "prometheus --config.file=#{HOMEBREW_PREFIX}/etc/prometheus.yml"
 
   def plist
     <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without the `--config.file` option, the command fails with:

```txt
level=error ts=2020-07-10T02:35:16.225Z caller=main.go:758 err="error loading config from \"prometheus.yml\": couldn't load configuration (--config.file=\"prometheus.yml\"): open prometheus.yml: no such file or directory"
```