### PR TITLE
juju 2.8.0 (downgrade)

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -1,9 +1,11 @@
 class Juju < Formula
   desc "DevOps management tool"
   homepage "https://jujucharms.com/"
+  # https://github.com/Homebrew/homebrew-core/pull/57456#issuecomment-656703975
   url "https://github.com/juju/juju.git",
-    :tag      => "juju-2.8.1",
-    :revision => "16439b3d1c528b7a0e019a16c2122ccfcf6aa41f"
+    :tag      => "juju-2.8.0",
+    :revision => "d816abe62fbf6787974e5c4e140818ca08586e44"
+  version_scheme 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/pull/57456#issuecomment-656703975

> Can we revert this, we haven't released the 2.8.1 version. As we've not officially released the 2.8.1 and only have 2.8.1 in proposed, users of the client will have to use --agent-stream in order to fix and that's not something we want users to have to do.