### PR TITLE
ksync 0.4.5 (new formula)

### DIFF
--- a/Formula/ksync.rb
+++ b/Formula/ksync.rb
@@ -1,0 +1,32 @@
+class Ksync < Formula
+  desc "Sync files between your local system and a kubernetes cluster"
+  homepage "https://ksync.github.io/ksync/"
+  url "https://github.com/ksync/ksync.git",
+    :tag      => "0.4.5",
+    :revision => "9f40bf134329814a57e1a58d73b84761a2b06c73"
+  sha256 "bd47c5b5418bfc6d2f08abe855a52d4189f8bf380747cdd4e5c1a3ca0a87498a"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    time = Utils.safe_popen_read("date", "+%Y%m%dT%H%M%S").chomp
+    goversion = "go#{Formula["go"].version}"
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
+    system "go", "build", "-ldflags",
+              "-w -X github.com/ksync/ksync/pkg/ksync.GitCommit=#{commit} \
+              -X github.com/ksync/ksync/pkg/ksync.GitTag=#{version} \
+              -X github.com/ksync/ksync/pkg/ksync.BuildDate=#{time} \
+              -X github.com/ksync/ksync/pkg/ksync.VersionString=Homebrew \
+              -X github.com/ksync/ksync/pkg/ksync.GoVersion=#{goversion}",
+              *std_go_args,
+              "github.com/ksync/ksync/cmd/ksync"
+  end
+
+  test do
+    # Basic build test. Potential for more sophisticated tests in the future
+    # Initialize the local client and see if it completes successfully
+    expected = "level=fatal"
+    assert_match expected.to_s, shell_output("#{bin}/ksync init --local --log-level debug", 1)
+  end
+end


### PR DESCRIPTION
New formula for Ksync, a tool for real-time sync of dev environments with a kubernetes cluster

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
