### PR TITLE
osi 0.108.6 (new formula)

### DIFF
--- a/Formula/osi.rb
+++ b/Formula/osi.rb
@@ -1,0 +1,38 @@
+class Osi < Formula
+  desc "Open Solver Interface"
+  homepage "https://github.com/coin-or/Osi"
+  url "https://github.com/coin-or/Osi/archive/releases/0.108.6.tar.gz"
+  sha256 "984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5"
+  license "EPL-1.0"
+
+  depends_on "pkg-config" => :build
+  depends_on "coinutils"
+
+  def install
+    # Work around - same as clp formula
+    # Error 1: "mkdir: #{include}/osi/coin: File exists."
+    mkdir include/"osi/coin"
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--includedir=#{include}/osi"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <OsiSolverInterface.hpp>
+      int main() {
+        OsiSolverInterface *si;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-lOsi",
+                    "-I#{include}/osi/coin",
+                    "-I#{Formula["coinutils"].include}/coinutils/coin",
+                    "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi, I'm hoping to add Cbc, a popular open-source mixed integer programming solver, to Homebrew (and eventually Google's OR-Tools, which uses it). Cbc currently has two dependencies that aren't in Homebrew: Osi (this formula) and Cgl.

These packages were moved to GitHub somewhat recently (last year I think), and Osi and Cgl don't yet meet notability requirements, but have been around for a while and both have Ubuntu and Debian packages.

Additional notes:
- <strike>Build fails without `ENV.deparallelize`</strike> Added same workaround as `clp` formula (also confirmed that the workaround is still needed for `clp`)
- The test case isn't great since it's an abstract interface library (other Homebrew formula like `clp` benefit from it - I'll submit this with the Cgl formula since Cgl requires it to build)