### PR TITLE
Fix dialog on Big Sur

### DIFF
--- a/Formula/dialog.rb
+++ b/Formula/dialog.rb
@@ -15,7 +15,7 @@ class Dialog < Formula
   uses_from_macos "ncurses"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--with-ncurses"
     system "make", "install-full"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Building `dialog` on  Big Sur fails with:

```
configure: error: No curses header-files found
```

This PR enables the `--with-ncurses` configure flag to rectify this. 

Builds and tests fine on both Intel and Apple Silicon - on the latter this produces a native arm64 binary 