### PR TITLE
juju 2.8.1

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -3,8 +3,8 @@ class Juju < Formula
   homepage "https://jujucharms.com/"
   # https://github.com/Homebrew/homebrew-core/pull/57456#issuecomment-656703975
   url "https://github.com/juju/juju.git",
-    :tag      => "juju-2.8.0",
-    :revision => "d816abe62fbf6787974e5c4e140818ca08586e44"
+    :tag      => "juju-2.8.1",
+    :revision => "16439b3d1c528b7a0e019a16c2122ccfcf6aa41f"
   license "AGPL-3.0"
   version_scheme 1
 


### PR DESCRIPTION
This moves juju to 2.8.1 and removes the version_scheme 1, as we're
moving forward in versions.

Juju has updated its release process, so any new releases that aren't
intended to be picked up by the livecheck are now tagged as
pre-releases.

See: https://github.com/Homebrew/homebrew-core/pull/57456

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
