### PR TITLE
libspng 0.6.0

### DIFF
--- a/Formula/libspng.rb
+++ b/Formula/libspng.rb
@@ -1,8 +1,8 @@
 class Libspng < Formula
   desc "C library for reading and writing PNG format files"
   homepage "https://libspng.org/"
-  url "https://gitlab.com/randy408/libspng/uploads/3d980bac86c51368f40af2f1ac79a057/libspng-0.5.0.tar.xz"
-  sha256 "220a653802559943ae43fd48f03ba6ff3935a5243766d9ee5ff905240d4399a7"
+  url "https://github.com/randy408/libspng/archive/v0.6.0.tar.gz"
+  sha256 "81fea8d8a2e0c8aa51769605ad0e49a682e88697c6b5b60105f5c3806efaa3a3"
   license "BSD-2-Clause"
 
   bottle do
@@ -30,7 +30,11 @@ class Libspng < Formula
     fixture = test_fixtures("test.png")
     cp pkgshare/"example.c", testpath/"example.c"
     system ENV.cc, "example.c", "-L#{lib}", "-I#{include}", "-lspng", "-o", "example"
-    output = shell_output("./example #{fixture}")
+
+    # example.c returns 73 ("no text chunk") for the test.png fixture
+    # this will probably be changed in v0.7,
+    # see: https://github.com/randy408/libspng/issues/109
+    output = shell_output("./example #{fixture}", 73)
     assert_match "width: 8\nheight: 8\nbit depth: 1\ncolor type: 3 - indexed color\n" \
                  "compression method: 0\nfilter method: 0\ninterlace method: 0", output
   end


### PR DESCRIPTION
The main repo has moved to github, see:

https://libspng.org/download

I've had to disable part of the test. v0.6 example.c will return non-zero error codes, even for valid PNG files. In this case, it'll return 73, meaning no text chunk. I've told the maintainer and this behaviour may be revised in later versions of libspng.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
