### PR TITLE
duti: add support for macOS 10.15, 10.16, 11.0

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -3,6 +3,7 @@ class Duti < Formula
   homepage "https://github.com/moretension/duti/"
   url "https://github.com/moretension/duti/archive/duti-1.5.4.tar.gz"
   sha256 "3f8f599899a0c3b85549190417e4433502f97e332ce96cd8fa95c0a9adbe56de"
+  revision 1
   head "https://github.com/moretension/duti.git"
 
   bottle do
@@ -17,8 +18,14 @@ class Duti < Formula
 
   # Fix compilation on macOS 10.14 Mojave
   patch do
-    url "https://github.com/moretension/duti/pull/32.patch?full_index=1"
+    url "https://github.com/moretension/duti/commit/825b5e6a92770611b000ebdd6e3d3ef8f47f1c47.patch?full_index=1"
     sha256 "0f6013b156b79aa498881f951172bcd1ceac53807c061f95c5252a8d6df2a21a"
+  end
+
+  # Fix compilation on macOS >= 10.15
+  patch do
+    url "https://github.com/moretension/duti/commit/4a1f54faf29af4f125134aef3a47cfe05c7755ff.patch?full_index=1"
+    sha256 "7c90efd1606438f419ac2fa668c587f2a63ce20673c600ed0c45046fd8b14ea6"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a patch to support macOS 10.15, 10.16 (both x86_64) and 11.0 (x86_64 and arm64).
