### PR TITLE
aom: fix build on Apple Silicon

### DIFF
--- a/Formula/aom.rb
+++ b/Formula/aom.rb
@@ -27,12 +27,14 @@ class Aom < Formula
     ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
 
     mkdir "macbuild" do
-      system "cmake", "..", *std_cmake_args,
-                      "-DENABLE_DOCS=off",
-                      "-DENABLE_EXAMPLES=on",
-                      "-DENABLE_TESTDATA=off",
-                      "-DENABLE_TESTS=off",
-                      "-DENABLE_TOOLS=off"
+      args = std_cmake_args.concat(["-DENABLE_DOCS=off",
+                                    "-DENABLE_EXAMPLES=on",
+                                    "-DENABLE_TESTDATA=off",
+                                    "-DENABLE_TESTS=off",
+                                    "-DENABLE_TOOLS=off"])
+      # Runtime CPU detection is not currently enabled for ARM on macOS.
+      args << "-DCONFIG_RUNTIME_CPU_DETECT=0" if Hardware::CPU.arm?
+      system "cmake", "..", *args
 
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

AOM currently doesn't have runtime CPU detection for ARM on macOS. This leads to the following compiletime error:

```
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/aom-20200714-71065-13zya5m -I/tmp/aom-20200714-71065-13zya5m/macbuild -I/tmp/aom-20200714-71065-13zya5m/apps -I/tmp/aom-20200714-71065-13zya5m/common -I/tmp/aom-20200714-71065-13zya5m/examples -I/tmp/aom-20200714-71065-13zya5m/stats -I/tmp/aom-20200714-71065-13zya5m/third_party/libyuv/include -I/tmp/aom-20200714-71065-13zya5m/third_party/libwebm  -fno-stack-check -DNDEBUG -std=c99 -Wall -Wdisabled-optimization -Wextra -Wfloat-conversion -Wimplicit-function-declaration -Wlogical-op -Wpointer-arith -Wshorten-64-to-32 -Wsign-compare -Wstring-conversion -Wtype-limits -Wuninitialized -Wunused -Wvla -Wstack-usage=100000 -Wshadow -Wundef -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk   -o CMakeFiles/aom_encoder_app_util.dir/common/ivfenc.c.o   -c /tmp/aom-20200714-71065-13zya5m/common/ivfenc.c
/tmp/aom-20200714-71065-13zya5m/aom_ports/arm_cpudetect.c:147:2: error: "--enable-runtime-cpu-detect selected, but no CPU detection method " "available for your platform. Reconfigure with --disable-runtime-cpu-detect."
#error \
 ^
1 error generated.
```

As noted by that message, we can disable runtime CPU detection and it will build and run properly. I've left runtime CPU detection on for all other platforms, since it works there. In the future, AOM will likely gain runtime CPU detection on macOS and we'll be able to remove this at some point.