### PR TITLE
util-linux: Add caveat to explain missing binaries

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -43,6 +43,21 @@ class UtilLinux < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      The following tools are not supported under macOS, and are therefore not included:
+        addpart agetty blkdiscard blkzone blockdev chcpu chmem choom chrt ctrlaltdel delpart
+        dmesg eject fallocate fdformat fincore findmnt fsck fsfreeze fstrim hwclock ionice
+        ipcrm ipcs kill last ldattach losetup lsblk lscpu lsipc lslocks lslogins lsmem lsns
+        mount mountpoint nsenter partx pivot_root prlimit raw readprofile resizepart rfkill
+        rtcwake script scriptlive setarch setterm sulogin swapoff swapon switch_root taskset
+        umount unshare utmpdump uuidd wall wdctl zramctl
+
+      The following tools are already shipped by macOS, and are therefore not included:
+        cal col colcrt colrm getopt hexdump logger look mesg more nologin renice rev ul whereis
+    EOS
+  end
+
   test do
     stat  = File.stat "/usr"
     owner = Etc.getpwuid(stat.uid).name


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Almost 75% of the binaries in a typical Linux install of `util-linux` can't be built in macOS, so I think a caveat to inform users is warranted.

Addresses https://discourse.brew.sh/t/blkdiscard-on-macos-10-11/8337