### PR TITLE
proguard 7.0.0

### DIFF
--- a/Formula/proguard.rb
+++ b/Formula/proguard.rb
@@ -1,10 +1,13 @@
 class Proguard < Formula
   desc "Java class file shrinker, optimizer, and obfuscator"
-  homepage "https://proguard.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/proguard/proguard/6.2/proguard6.2.2.tar.gz"
-  sha256 "e38c56f2e96809686e1584f21d4f95ed2433ff1a80406174d44e52c27b36fadd"
+  homepage "https://www.guardsquare.com/en/products/proguard"
+  url "https://github.com/Guardsquare/proguard/releases/download/v7.0.0/proguard-7.0.0.tar.gz"
+  sha256 "699f16644024000e90c2555083fa6f78a9cdf1d71f384535e82bf987d764f9fb"
+  license "GPL-2.0"
 
   bottle :unneeded
+
+  depends_on "openjdk"
 
   def install
     libexec.install "lib/proguard.jar"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Message from https://sourceforge.net/projects/proguard/:
> ProGuard has moved to Github now: https://github.com/Guardsquare/proguard

I added the `openjdk` dependency after noticing that we're using `write_jar_script` here, which will fall back to Homebrew `openjdk` in the absence of `JAVA_HOME`.