### PR TITLE
util-linux: Add caveat to explain missing binaries

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -4,6 +4,7 @@ class UtilLinux < Formula
   url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.35/util-linux-2.35.2.tar.xz"
   sha256 "21b7431e82f6bcd9441a01beeec3d57ed33ee948f8a5b41da577073c372eb58a"
   license "GPL-2.0"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,6 +18,21 @@ class UtilLinux < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
+  # These binaries are already available in macOS
+  def system_bins
+    %w[
+      cal col colcrt colrm
+      getopt
+      hexdump
+      logger look
+      mesg more
+      nologin
+      renice rev
+      ul
+      whereis
+    ]
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -29,7 +45,7 @@ class UtilLinux < Formula
     system "make", "install"
 
     # Remove binaries already shipped by macOS
-    %w[cal col colcrt colrm getopt hexdump logger nologin look mesg more renice rev ul whereis].each do |prog|
+    system_bins.each do |prog|
       rm_f bin/prog
       rm_f sbin/prog
       rm_f man1/"#{prog}.1"
@@ -41,6 +57,36 @@ class UtilLinux < Formula
     Pathname.glob("bash-completion/*") do |prog|
       bash_completion.install prog if (bin/prog.basename).exist? || (sbin/prog.basename).exist?
     end
+  end
+
+  def caveats
+    linux_only_bins = %w[
+      addpart agetty
+      blkdiscard blkzone blockdev
+      chcpu chmem choom chrt ctrlaltdel
+      delpart dmesg
+      eject
+      fallocate fdformat fincore findmnt fsck fsfreeze fstrim
+      hwclock
+      ionice ipcrm ipcs
+      kill
+      last ldattach losetup lsblk lscpu lsipc lslocks lslogins lsmem lsns
+      mount mountpoint
+      nsenter
+      partx pivot_root prlimit
+      raw readprofile resizepart rfkill rtcwake
+      script scriptlive setarch setterm sulogin swapoff swapon switch_root
+      taskset
+      umount unshare utmpdump uuidd
+      wall wdctl
+      zramctl
+    ]
+    <<~EOS
+      The following tools are not supported under macOS, and are therefore not included:
+      #{Formatter.wrap(Formatter.columns(linux_only_bins), 80)}
+      The following tools are already shipped by macOS, and are therefore not included:
+      #{Formatter.wrap(Formatter.columns(system_bins), 80)}
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Almost 75% of the binaries in a typical Linux install of `util-linux` can't be built in macOS, so I think a caveat to inform users is warranted. I'm bumping the revision because `install` now uses a function that's shared with `caveats`.

Addresses https://discourse.brew.sh/t/blkdiscard-on-macos-10-11/8337