### PR TITLE
bacula-fd 9.4.4 (new formula)

### DIFF
--- a/Formula/bacula-fd@9.4.rb
+++ b/Formula/bacula-fd@9.4.rb
@@ -1,0 +1,70 @@
+class BaculaFdAT94 < Formula
+  desc "Network backup solution"
+  homepage "https://www.bacula.org/"
+  url "https://downloads.sourceforge.net/project/bacula/bacula/9.4.4/bacula-9.4.4.tar.gz"
+  sha256 "0fe37a02ca768a720099d0d03509c364aff2390c05544d663f4819f8e7fc20be"
+
+  bottle do
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openssl@1.1"
+  depends_on "readline"
+
+  uses_from_macos "zlib"
+
+  def install
+    # * sets --disable-conio in order to force the use of readline
+    #   (conio support not tested)
+    # * working directory in /var/lib/bacula, reasonable place that
+    #   matches Debian's location.
+    system "./configure", "--prefix=#{prefix}",
+                          "--sbindir=#{bin}",
+                          "--with-working-dir=#{var}/lib/bacula",
+                          "--with-pid-dir=#{var}/run",
+                          "--with-logdir=#{var}/log/bacula",
+                          "--enable-client-only",
+                          "--disable-conio",
+                          "--with-readline=#{Formula["readline"].opt_prefix}"
+
+    system "make"
+    system "make", "install"
+
+    # Avoid references to the Homebrew shims directory
+    inreplace Dir[prefix/"etc/bacula_config"],
+              HOMEBREW_SHIMS_PATH/"mac/super/", ""
+
+    (var/"lib/bacula").mkpath
+  end
+
+  def post_install
+    (var/"run").mkpath
+  end
+
+  plist_options :startup => true, :manual => "bacula-fd"
+
+  def plist
+    <<~EOS
+      <?xml version="0.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/bacula-fd</string>
+            <string>-f</string>
+          </array>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bacula-fd -? 2>&1", 1)
+  end
+end

--- a/Formula/bacula-fd@9.4.rb
+++ b/Formula/bacula-fd@9.4.rb
@@ -4,8 +4,6 @@ class BaculaFdAT94 < Formula
   url "https://downloads.sourceforge.net/project/bacula/bacula/9.4.4/bacula-9.4.4.tar.gz"
   sha256 "0fe37a02ca768a720099d0d03509c364aff2390c05544d663f4819f8e7fc20be"
 
-  bottle do
-  end
 
   keg_only :versioned_formula
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Bacula only guarantees compatibility between the same minor versions, and Ubuntu ships with bacula 9.4.  This allows administrators to easily run the same minor version of bacula on Windows, Linux, and Mac.
