### PR TITLE
jansson: update homepage and stable urls

### DIFF
--- a/Formula/jansson.rb
+++ b/Formula/jansson.rb
@@ -1,7 +1,7 @@
 class Jansson < Formula
   desc "C library for encoding, decoding, and manipulating JSON"
-  homepage "https://www.digip.org/jansson/"
-  url "https://www.digip.org/jansson/releases/jansson-2.13.1.tar.gz"
+  homepage "https://digip.org/jansson/"
+  url "https://digip.org/jansson/releases/jansson-2.13.1.tar.gz"
   sha256 "f4f377da17b10201a60c1108613e78ee15df6b12016b116b6de42209f47a474f"
   license "MIT"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `homepage` and stable `url` for `jansson` were redirecting from https://www.digip.org/jansson/ to https://digip.org/jansson/, so this updates the URLs to avoid the redirections.