### PR TITLE
opentsdb: fix test

### DIFF
--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -112,6 +112,7 @@ class Opentsdb < Formula
       s.gsub! /(hbase.zookeeper.property.dataDir.*)\n.*/, "\\1\n<value>#{testpath}/zookeeper</value>"
     end
 
+    ENV.prepend "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}/tmp"
     ENV["HBASE_LOG_DIR"]  = testpath/"logs"
     ENV["HBASE_CONF_DIR"] = testpath/"conf"
     ENV["HBASE_PID_DIR"]  = testpath/"pid"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The internal HTTP server was failing to start which caused a lot of subsequent connection timeouts resulting in the whole test taking longer than the maximum allowed 5 minutes.

The error on startup all stemed from it not liking the permissions for the /tmp directory. Setting the temp directory to be within the `testpath` fixed the error and made the whole test now take less than a minute.