### PR TITLE
libffi: fix build on Apple Silicon

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -23,9 +23,14 @@ class Libffi < Formula
   keg_only :provided_by_macos
 
   def install
+    # This can be removed in the future when libffi properly detects the CPU on ARM.
+    # https://github.com/libffi/libffi/issues/571#issuecomment-655223391
+    extra_args = []
+    extra_args << "--build=aarch64-apple-darwin#{`uname -r`.chomp}" if Hardware::CPU.arm?
+
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}", *extra_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've confirmed this builds and `brew test` works as expected. I think the failure was because the missing functions we were seeing are defined in platform-specific ASM, and libffi is improperly detecting the platform.

There's a broader set of patches that will be included in a future version, but those are not ready yet. They've been submitted by Apple here: https://github.com/libffi/libffi/pull/565