### PR TITLE
ideviceinstaller: fix download URL

### DIFF
--- a/Formula/ideviceinstaller.rb
+++ b/Formula/ideviceinstaller.rb
@@ -1,7 +1,7 @@
 class Ideviceinstaller < Formula
   desc "Tool for managing apps on iOS devices"
   homepage "https://www.libimobiledevice.org/"
-  url "https://www.libimobiledevice.org/downloads/ideviceinstaller-1.1.1.tar.bz2"
+  url "https://github.com/libimobiledevice/ideviceinstaller/releases/download/1.1.1/ideviceinstaller-1.1.1.tar.bz2"
   sha256 "deb883ec97f2f88115aab39f701b83c843e9f2b67fe02f5e00a9a7d6196c3063"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Looks like the download URL has changed. The previous URL returns a 404.
