### PR TITLE
Macaulay2 1.16 (new formula)

### DIFF
--- a/Aliases/m2
+++ b/Aliases/m2
@@ -1,0 +1,1 @@
+../Formula/macaulay2.rb

--- a/Formula/macaulay2.rb
+++ b/Formula/macaulay2.rb
@@ -1,0 +1,60 @@
+class Macaulay2 < Formula
+  @name = "M2"
+  desc "Software system for algebraic geometry research"
+  homepage "http://macaulay2.com"
+  url "https://github.com/Macaulay2/M2.git", :using => :git, :branch => "release-1.16"
+  version "1.16"
+  license "GPL-3.0"
+  revision 1
+
+  head do
+    url "https://github.com/Macaulay2/M2.git", :using => :git, :branch => "development"
+  end
+
+  # autoconf, automake, and libtool are required to build
+  # libraries not available via brew, such as factory
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "bison" => :build
+  depends_on "cmake" => :build
+  depends_on "libtool" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+
+  # libraries available via brew
+  depends_on "bdw-gc"
+  depends_on "boost"
+  depends_on "cddlib"
+  depends_on "eigen"
+  depends_on "flint"
+  depends_on "gdbm"
+  depends_on "glpk"
+  depends_on "gmp"
+  depends_on "libatomic_ops"
+  depends_on "libomp"
+  depends_on "libxml2"
+  depends_on "mpfr"
+  depends_on "ntl"
+  depends_on "openblas"
+  depends_on "readline"
+  depends_on "tbb"
+
+  def install
+    build_path = "M2/BUILD/brew"
+    extra_args = ["-GNinja", "-DUSING_MPIR=OFF", "-DBLA_VENDOR=OpenBLAS", "-DCMAKE_INSTALL_LIBDIR=lib"]
+
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+    ENV["SDKROOT"] = MacOS.sdk_path
+
+    system "cmake", "-SM2", "-B#{build_path}", *std_cmake_args, *extra_args
+    system "cmake", "--build", build_path, "--target", "build-libraries", "build-programs"
+    system "cmake", "--build", build_path, "--target", "M2-core", "M2-emacs"
+    system "cmake", "--build", build_path, "--target", "install-packages"
+    system "cmake", "--install", build_path
+  end
+
+  test do
+    system "#{bin}/M2", "--version"
+    system "#{bin}/M2", "--check", "1", "-e", "exit 0"
+  end
+end


### PR DESCRIPTION
Adds a brew formula for Macaulay2, a software system for algebraic geometry research.

The formula uses the CMake build for Macaulay2, which begins with building a number of library and program dependencies not available via brew. After building Macaulay2, the examples are executed and the documentation is generated. In total, the build can up to two hours.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

One question: should I make a separate PR for linuxbrew, or will this formula be made available there automatically?