### PR TITLE
GLib: remove runtime dependency to Python

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -1,6 +1,4 @@
 class Glib < Formula
-  include Language::Python::Shebang
-
   desc "Core application library for C"
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.64/glib-2.64.4.tar.xz"
@@ -19,7 +17,6 @@ class Glib < Formula
   depends_on "gettext"
   depends_on "libffi"
   depends_on "pcre"
-  depends_on "python@3.8"
 
   on_linux do
     depends_on "util-linux"
@@ -49,7 +46,6 @@ class Glib < Formula
       system "meson", *args, ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
-      bin.find { |f| rewrite_shebang detected_python_shebang, f }
     end
 
     # ensure giomoduledir contains prefix, as this pkgconfig variable will be


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Meson used by GLib at build time depends on Python, but GLib itself does not need Python at runtime.
See https://gitlab.gnome.org/GNOME/glib/-/issues/1716

@tschoonj said it's a runtime dependency at #37690, but the `meson.build` mentioned at https://github.com/Homebrew/homebrew-core/issues/37651#issuecomment-470140663 is an meson's build configuration file which is used on build time and not on runtime.


