### PR TITLE
graphviz: remove duplicate dependency

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -15,7 +15,6 @@ class Graphviz < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "gd"
   depends_on "gts"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` ~(after doing `brew install <formula>`)~?

-----

This just removes `libtool` as a build dependency because it’s already a runtime dependency.
