### PR TITLE
curl-libressl 7.71.1,  nghttp2-libressl 1.41.0, libevent-libressl 2.1.12 (new formulae)

### DIFF
--- a/Formula/curl-libressl.rb
+++ b/Formula/curl-libressl.rb
@@ -1,0 +1,65 @@
+class CurlLibressl < Formula
+  desc "Get a file from an HTTP, HTTPS or FTP server"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.71.1.tar.bz2"
+  sha256 "9d52a4d80554f9b0d460ea2be5d7be99897a1a9f681ffafe739169afd6b4f224"
+  license "curl"
+
+  head do
+    url "https://github.com/curl/curl.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  keg_only :shadowed_by_macos, "macOS provides curl"
+
+  depends_on "pkg-config" => :build
+  depends_on "libressl"
+  depends_on "nghttp2-libressl"
+
+  uses_from_macos "zlib"
+
+  def install
+    system "./buildconf" if build.head?
+
+    libressl = Formula["libressl"]
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --disable-tls-srp
+      --enable-hidden-symbols
+      --enable-threaded-resolver
+      --prefix=#{prefix}
+      --with-ca-bundle=#{libressl.pkgetc}/cert.pem
+      --with-ca-path=#{libressl.pkgetc}/certs
+      --with-default-ssl-backend=openssl
+      --with-gssapi
+      --with-secure-transport
+      --with-ssl=#{libressl.opt_prefix}
+      --without-brotli
+      --without-libidn2
+      --without-libpsl
+      --without-librtmp
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+    system "make", "install", "-C", "scripts"
+    libexec.install "lib/mk-ca-bundle.pl"
+  end
+
+  test do
+    # Fetch the curl tarball and see that the checksum matches.
+    # This requires a network connection, but so does Homebrew in general.
+    filename = (testpath/"test.tar.gz")
+    system "#{bin}/curl", "-L", stable.url, "-o", filename
+    filename.verify_checksum stable.checksum
+
+    system libexec/"mk-ca-bundle.pl", "test.pem"
+    assert_predicate testpath/"test.pem", :exist?
+    assert_predicate testpath/"certdata.txt", :exist?
+  end
+end

--- a/Formula/libevent-libressl.rb
+++ b/Formula/libevent-libressl.rb
@@ -1,0 +1,40 @@
+class LibeventLibressl < Formula
+  desc "Asynchronous event library"
+  homepage "https://libevent.org/"
+  url "https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"
+  sha256 "7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24"
+  license "BSD-3-Clause"
+
+  keg_only "libevent-libressl is not linked to prevent conflicts with the standard libevent"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libressl"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-debug-mode",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <event2/event.h>
+
+      int main()
+      {
+        struct event_base *base;
+        base = event_base_new();
+        event_base_free(base);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-levent", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/nghttp2-libressl.rb
+++ b/Formula/nghttp2-libressl.rb
@@ -1,0 +1,53 @@
+class Nghttp2Libressl < Formula
+  desc "HTTP/2 C Library"
+  homepage "https://nghttp2.org/"
+  url "https://github.com/nghttp2/nghttp2/releases/download/v1.41.0/nghttp2-1.41.0.tar.xz"
+  sha256 "abc25b8dc601f5b3fefe084ce50fcbdc63e3385621bee0cbfa7b57f9ec3e67c2"
+  license "MIT"
+
+  head do
+    url "https://github.com/nghttp2/nghttp2.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  keg_only "nghttp2-libressl is not linked to prevent conflicts with the standard nghttp2"
+
+  depends_on "cunit" => :build
+  depends_on "pkg-config" => :build
+  depends_on "sphinx-doc" => :build
+  depends_on "c-ares"
+  depends_on "jansson"
+  depends_on "jemalloc"
+  depends_on "libev"
+  depends_on "libevent-libressl"
+  depends_on "libressl"
+
+  uses_from_macos "zlib"
+
+  def install
+    ENV.cxx11
+
+    args = %W[
+      --prefix=#{prefix}
+      --disable-silent-rules
+      --enable-app
+      --disable-python-bindings
+      --with-xml-prefix=/usr
+    ]
+
+    # requires thread-local storage features only available in 10.11+
+    args << "--disable-threads" if MacOS.version < :el_capitan
+
+    system "autoreconf", "-ivf" if build.head?
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"nghttp", "-nv", "https://nghttp2.org"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related: #57931

> Another solution would be to create a new `curl-libressl` formula, like we have a `curl-openssl` formula, and vendor libressl in it.
> 
> Whatever we do we need to be extra cautious because all of this touches core security aspects of all our libraries and we would like to avoid bad surprises to our end users. People have been used to get `curl` and `curl-openssl` like they are right now, so changing what we ship might potentially have an impact on our users. As far as I know there is right now only 1 or 2 persons interested in having curl with a newer `libressl` version, which is not that many people compared to our whole user base.

-----

> The new `libressl` formulae should be `keg_only :provided_by_macos`.

Should be noted that `nghttp2` and `libevent` are not provided by macOS but by `homebrew/core`

-----

```console
% brew deps --tree curl-libressl
curl-libressl
├── libressl
├── c-ares
├── jansson
├── jemalloc
├── libev
├── libevent-libressl
│   └── libressl
└── nghttp2-libressl
    ├── c-ares
    ├── jansson
    ├── jemalloc
    ├── libev
    ├── libressl
    └── libevent-libressl
        └── libressl
```