### PR TITLE
krb5: add a fix for broken configure test

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -18,6 +18,15 @@ class Krb5 < Formula
 
   def install
     cd "src" do
+      # Newer versions of clang are very picky about missing includes.
+      # One configure test fails because it doesn't #include the header needed
+      # for some functions used in the rest. The test isn't actually testing
+      # those functions, just using them for the feature they're
+      # actually testing. Adding the include fixes this.
+      # https://krbdev.mit.edu/rt/Ticket/Display.html?id=8928
+      inreplace "configure", "void foo1() __attribute__((constructor));",
+                             "#include <unistd.h>\nvoid foo1() __attribute__((constructor));"
+
       system "./configure", "--disable-debug",
                             "--disable-dependency-tracking",
                             "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes krb5 on macOS 11, both ARM and x86_64. It turns out that clang's new pickiness about calling functions without their header definitions broke this test. The test is actually testing destructor attributes, and for convenience is using the C `unlink` function. That is defined in `unistd.h`, but the configure test doesn't `#include` this header.

I'll be submitting an upstream fix as well, but this `inreplace` fix gets us going.