### PR TITLE
caffe: fix protobuf issue

### DIFF
--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -4,7 +4,7 @@ class Caffe < Formula
   url "https://github.com/BVLC/caffe/archive/1.0.tar.gz"
   sha256 "71d3c9eb8a183150f965a465824d01fe82826c22505f7aa314f700ace03fa77f"
   license "BSD-2-Clause"
-  revision 23
+  revision 24
 
   bottle do
     sha256 "1dd02fe2006ffb88eccbac465ef6764497b0830ba7f578a441d945adb6016fc9" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A change in Protobuf 3.12.3 (https://github.com/protocolbuffers/protobuf/pull/7496) is causing an error when trying to build projects with Caffe.

```txt
/usr/local/opt/caffe/include/caffe/proto/caffe.pb.h:49:51: error: no type named 'AuxillaryParseTableField' in namespace 'google::protobuf::internal'; did you mean 'AuxiliaryParseTableField'?
  static const ::PROTOBUF_NAMESPACE_ID::internal::AuxillaryParseTableField aux[]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                                  AuxiliaryParseTableField
/usr/local/include/google/protobuf/generated_message_table_driven.h:141:7: note: 'AuxiliaryParseTableField' declared here
```

There isn't an error when building from source, so bumping the revision should fix it (last revision was before Protobuf 3.12.3 was released).