### PR TITLE
libsharp 1.0.0 (new formula)

### DIFF
--- a/Formula/libsharp.rb
+++ b/Formula/libsharp.rb
@@ -1,0 +1,30 @@
+class Libsharp < Formula
+  desc "Library for optimized Spherical Harmonics operations used by Healpix"
+  homepage "https://healpix.jpl.nasa.gov"
+  url "https://downloads.sourceforge.net/project/healpix/Healpix_3.60/libsharp-1.0.0.tar.gz"
+  sha256 "e98293315ee0f8a4c69c627bda36297b45e35e7afc33f510756f212d36c02f92"
+  license "GPL-2.0-or-later"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS
+      #include "libsharp/sharp.h"
+      #include "libsharp/sharp_almhelpers.h"
+
+      int main(){
+        sharp_alm_info *alm_info;
+        sharp_make_triangular_alm_info (0, 0, 0, &alm_info);
+        return sharp_alm_index(alm_info,0,0);  
+      }
+    EOS
+
+    system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lsharp"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This library is distributed as part of healpix, but needs to be build seperatly as of healpix 3.60.
The current formula for healpix builds but does not install libshap leading to unresolved symbols.
Since healpix needs to find libsharp at build time the perfered solution is to install it as a seperate
formula. Once this formula is accepted I will modify healpix's formula to build against this version of libsharp.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
