### PR TITLE
healpix: actually install libsharp and correctly link with libsharp

### DIFF
--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -4,7 +4,8 @@ class Healpix < Formula
   url "https://downloads.sourceforge.net/project/healpix/Healpix_3.60/Healpix_3.60_2019Dec18.tar.gz"
   version "3.60"
   sha256 "bf1797022fb57b5b8381290955e8c4161e3ca9b9d88e3e32d55b092a4a04b500"
-  revision 1
+  license "GPL-2.0-or-later"
+  revision 2
 
   bottle do
     cellar :any
@@ -32,13 +33,13 @@ class Healpix < Formula
     end
 
     cd "src/common_libraries/libsharp" do
-      system "./configure", "--prefix=#{buildpath}/libsharp", *configure_args
+      system "./configure", "--prefix=#{prefix}", *configure_args
       system "make", "install"
     end
 
     cd "src/cxx" do
-      ENV["SHARP_CFLAGS"] = "-I#{buildpath}/libsharp/include"
-      ENV["SHARP_LIBS"] = "-L#{buildpath}/libsharp/lib"
+      ENV["SHARP_CFLAGS"] = "-I#{include}"
+      ENV["SHARP_LIBS"] = "-L#{lib} -lsharp"
       system "./configure", "--prefix=#{prefix}", *configure_args
       system "make", "install"
     end


### PR DESCRIPTION
The previous revision installed libsharp to the temporary build directory leaving unresolved symbols in libhealpix_cxx. This update instead installs libsharp to #{prefix} as well as correctly sets the linker flags.

Also the correct licence field is added for healpix

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
