### PR TITLE
purescript: use release flag

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -3,6 +3,7 @@ class Purescript < Formula
   homepage "https://www.purescript.org/"
   url "https://hackage.haskell.org/package/purescript-0.13.8/purescript-0.13.8.tar.gz"
   sha256 "701fac49de867ec01252b067185e8bbd1b72e4b96997044bac3cca91e3f8096a"
+  revision 1
   head "https://github.com/purescript/purescript.git"
 
   bottle do
@@ -24,7 +25,7 @@ class Purescript < Formula
     system "hpack" if build.head?
 
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "v2-install", "-frelease", *std_cabal_v2_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Trying to get rid of version extras:
```
❯ /usr/local/opt/purescript/bin/purs --version
0.13.8 [development build; commit: UNKNOWN]
```