### PR TITLE
license updates for apache.org formulae

### DIFF
--- a/Formula/activemq-cpp.rb
+++ b/Formula/activemq-cpp.rb
@@ -4,6 +4,7 @@ class ActivemqCpp < Formula
   url "https://www.apache.org/dyn/closer.lua?path=activemq/activemq-cpp/3.9.5/activemq-cpp-library-3.9.5-src.tar.bz2"
   mirror "https://archive.apache.org/dist/activemq/activemq-cpp/3.9.5/activemq-cpp-library-3.9.5-src.tar.bz2"
   sha256 "6bd794818ae5b5567dbdaeb30f0508cc7d03808a4b04e0d24695b2501ba70c15"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -4,6 +4,7 @@ class Activemq < Formula
   url "https://www.apache.org/dyn/closer.lua?path=activemq/5.16.0/apache-activemq-5.16.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/activemq/5.16.0/apache-activemq-5.16.0-bin.tar.gz"
   sha256 "d399f51a34944a48b49153ffbeb50cef42666185efbec6d5aa588a0d2ca1c874"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -4,6 +4,7 @@ class Ant < Formula
   url "https://www.apache.org/dyn/closer.lua?path=ant/binaries/apache-ant-1.10.8-bin.tar.xz"
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.tar.xz"
   sha256 "8be685aacf2bfe8515a1249fbebb0ccd861dfe05ee2c027c89fd7912c1ce2c2a"
+  license "Apache-2.0"
   revision 1
   head "https://git-wip-us.apache.org/repos/asf/ant.git"
 

--- a/Formula/ant@1.9.rb
+++ b/Formula/ant@1.9.rb
@@ -4,6 +4,7 @@ class AntAT19 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=ant/binaries/apache-ant-1.9.15-bin.tar.bz2"
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.15-bin.tar.bz2"
   sha256 "b91eb0c7412f7d4d7c205ea189cf3bfede4bed6a168144b2a222bcbc352edd79"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/apache-archiva.rb
+++ b/Formula/apache-archiva.rb
@@ -4,6 +4,7 @@ class ApacheArchiva < Formula
   url "https://www.apache.org/dyn/closer.lua?path=archiva/2.2.5/binaries/apache-archiva-2.2.5-bin.tar.gz"
   mirror "https://archive.apache.org/dist/archiva/2.2.5/binaries/apache-archiva-2.2.5-bin.tar.gz"
   sha256 "01119af2d9950eacbcce0b7f8db5067b166ad26c1e1701bef829105441bb6e29"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/apache-drill.rb
+++ b/Formula/apache-drill.rb
@@ -4,6 +4,7 @@ class ApacheDrill < Formula
   url "https://www.apache.org/dyn/closer.lua?path=drill/drill-1.17.0/apache-drill-1.17.0.tar.gz"
   mirror "https://archive.apache.org/dist/drill/drill-1.17.0/apache-drill-1.17.0.tar.gz"
   sha256 "a3d2d544bcc32b915fb53fced0f982670bd6fe2abd764423e566a5f6b54debf1"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/apache-forrest.rb
+++ b/Formula/apache-forrest.rb
@@ -4,6 +4,7 @@ class ApacheForrest < Formula
   url "https://www.apache.org/dyn/closer.lua?path=forrest/apache-forrest-0.9-sources.tar.gz"
   mirror "https://archive.apache.org/dist/forrest/apache-forrest-0.9-sources.tar.gz"
   sha256 "c6ac758db2eb0d4d91bd1733bbbc2dec4fdb33603895c464bcb47a34490fb64d"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/apache-geode.rb
+++ b/Formula/apache-geode.rb
@@ -5,6 +5,7 @@ class ApacheGeode < Formula
   mirror "https://archive.apache.org/dist/geode/1.12.0/apache-geode-1.12.0.tgz"
   mirror "https://www.apache.org/dist/geode/1.12.0/apache-geode-1.12.0.tgz"
   sha256 "063b473dac914aca53c09326487cc96c63ef84eecc8b053c8cc3d5110e82f179"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/apache-opennlp.rb
+++ b/Formula/apache-opennlp.rb
@@ -4,6 +4,7 @@ class ApacheOpennlp < Formula
   url "https://www.apache.org/dyn/closer.lua?path=opennlp/opennlp-1.9.2/apache-opennlp-1.9.2-bin.tar.gz"
   mirror "https://archive.apache.org/dist/opennlp/opennlp-1.9.2/apache-opennlp-1.9.2-bin.tar.gz"
   sha256 "26b55416a6c330e9c91bf9ad31183f3ed3104643b3d74ad2ee6e16b0c0e44f3b"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/apr-util.rb
+++ b/Formula/apr-util.rb
@@ -4,6 +4,7 @@ class AprUtil < Formula
   url "https://www.apache.org/dyn/closer.lua?path=apr/apr-util-1.6.1.tar.bz2"
   mirror "https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2"
   sha256 "d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b"
+  license "Apache-2.0"
   revision 3
 
   bottle do

--- a/Formula/avro-tools.rb
+++ b/Formula/avro-tools.rb
@@ -4,6 +4,7 @@ class AvroTools < Formula
   url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.10.0/java/avro-tools-1.10.0.jar"
   mirror "https://archive.apache.org/dist/avro/avro-1.10.0/java/avro-tools-1.10.0.jar"
   sha256 "74c037354ba1bb43e07d336d46d95d54bc347f2d8073d7cf1087d447b5978a56"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/batik.rb
+++ b/Formula/batik.rb
@@ -4,6 +4,7 @@ class Batik < Formula
   url "https://www.apache.org/dyn/closer.lua?path=xmlgraphics/batik/binaries/batik-bin-1.13.tar.gz"
   mirror "https://archive.apache.org/dist/xmlgraphics/batik/binaries/batik-bin-1.13.tar.gz"
   sha256 "7c565899e4377a72edee216ffdf168d7b6928d5e1a8cdf477dfa1abd2c48589b"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -4,6 +4,7 @@ class Cassandra < Formula
   url "https://www.apache.org/dyn/closer.lua?path=cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz"
   mirror "https://archive.apache.org/dist/cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz"
   sha256 "ce34edebd1b6bb35216ae97bd06d3efc338c05b273b78267556a99f85d30e45b"
+  license "Apache-2.0"
   revision 2
 
   bottle do

--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -4,6 +4,7 @@ class CassandraAT21 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=cassandra/2.1.21/apache-cassandra-2.1.21-bin.tar.gz"
   mirror "https://archive.apache.org/dist/cassandra/2.1.21/apache-cassandra-2.1.21-bin.tar.gz"
   sha256 "992080ce42bb90173b1a910edffadc7f917b5a6e598db5154ff32ae8e2d00ad3"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -4,6 +4,7 @@ class Couchdb < Formula
   url "https://www.apache.org/dyn/closer.lua?path=couchdb/source/3.1.0/apache-couchdb-3.1.0.tar.gz"
   mirror "https://archive.apache.org/dist/couchdb/source/3.1.0/apache-couchdb-3.1.0.tar.gz"
   sha256 "4867c796a1ff6f0794b7bd3863089ea6397bd5c47544f9b97db8cdacff90f8ed"
+  license "Apache-2.0"
   revision 2
 
   bottle do

--- a/Formula/derby.rb
+++ b/Formula/derby.rb
@@ -4,6 +4,7 @@ class Derby < Formula
   url "https://www.apache.org/dyn/closer.lua?path=db/derby/db-derby-10.15.2.0/db-derby-10.15.2.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/db/derby/db-derby-10.15.2.0/db-derby-10.15.2.0-bin.tar.gz"
   sha256 "ac51246a2d9eef70cecd6562075b30aa9953f622cbd2cd3551bc3d239dc6f02a"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/flume.rb
+++ b/Formula/flume.rb
@@ -4,6 +4,7 @@ class Flume < Formula
   url "https://www.apache.org/dyn/closer.lua?path=flume/1.9.0/apache-flume-1.9.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/flume/1.9.0/apache-flume-1.9.0-bin.tar.gz"
   sha256 "0373ed5abfd44dc4ab23d9a02251ffd7e3b32c02d83a03546e97ec15a7b23619"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/fop.rb
+++ b/Formula/fop.rb
@@ -4,6 +4,7 @@ class Fop < Formula
   url "https://www.apache.org/dyn/closer.lua?path=xmlgraphics/fop/binaries/fop-2.5-bin.tar.gz"
   mirror "https://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-2.5-bin.tar.gz"
   sha256 "6a3c5f8915be5ef90fff202c818152d8252bb45b96d9c5d6550594903739e5ed"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/fuseki.rb
+++ b/Formula/fuseki.rb
@@ -4,6 +4,7 @@ class Fuseki < Formula
   url "https://www.apache.org/dyn/closer.lua?path=jena/binaries/apache-jena-fuseki-3.16.0.tar.gz"
   mirror "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-3.16.0.tar.gz"
   sha256 "8494b016db4cec3ba17460fde0e25bd12518c038603f09cdf8dc6ac93253ab21"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -4,6 +4,7 @@ class Hadoop < Formula
   url "https://www.apache.org/dyn/closer.lua?path=hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz"
   mirror "https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz"
   sha256 "ea1a0f0afcdfb9b6b9d261cdce5a99023d7e8f72d26409e87f69bda65c663688"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/hive.rb
+++ b/Formula/hive.rb
@@ -4,6 +4,7 @@ class Hive < Formula
   url "https://www.apache.org/dyn/closer.lua?path=hive/hive-3.1.2/apache-hive-3.1.2-bin.tar.gz"
   mirror "https://archive.apache.org/dist/hive/hive-3.1.2/apache-hive-3.1.2-bin.tar.gz"
   sha256 "d75dcf36908b4e7b9b0ec9aec57a46a6628b97b276c233cb2c2f1a3e89b13462"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/ivy.rb
+++ b/Formula/ivy.rb
@@ -4,6 +4,7 @@ class Ivy < Formula
   url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz"
   sha256 "3855a5769b5dbeafa9fb6a00f130467fd0f89da684a0b33a91e3dc5dae2715c7"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/jena.rb
+++ b/Formula/jena.rb
@@ -4,6 +4,7 @@ class Jena < Formula
   url "https://www.apache.org/dyn/closer.lua?path=jena/binaries/apache-jena-3.16.0.tar.gz"
   mirror "https://archive.apache.org/dist/jena/binaries/apache-jena-3.16.0.tar.gz"
   sha256 "6ef65ab3e24948f6f8fa97281a936276d74a8732fb4a14c624c1aa9fa93adb30"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/jsvc.rb
+++ b/Formula/jsvc.rb
@@ -4,6 +4,7 @@ class Jsvc < Formula
   url "https://www.apache.org/dyn/closer.lua?path=commons/daemon/source/commons-daemon-1.2.2-src.tar.gz"
   mirror "https://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.2.2-src.tar.gz"
   sha256 "ebd9d50989ee2009cc83f501e6793ad5978672ecea97be5198135a081a8aac71"
+  license "Apache-2.0"
   revision 2
 
   bottle do

--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -4,6 +4,7 @@ class Log4cxx < Formula
   url "https://www.apache.org/dyn/closer.lua?path=logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
   mirror "https://archive.apache.org/dist/logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
   sha256 "0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/mahout.rb
+++ b/Formula/mahout.rb
@@ -4,6 +4,7 @@ class Mahout < Formula
   url "https://www.apache.org/dyn/closer.lua?path=mahout/0.13.0/apache-mahout-distribution-0.13.0.tar.gz"
   mirror "https://archive.apache.org/dist/mahout/0.13.0/apache-mahout-distribution-0.13.0.tar.gz"
   sha256 "87bdc86e16b5817d6b5a810b94d7389604887f7de9c680f34faaf0cbb8dabf6f"
+  license "Apache-2.0"
   revision 1
 
   head do

--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -4,6 +4,7 @@ class Maven < Formula
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
   mirror "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
   sha256 "26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/maven@3.2.rb
+++ b/Formula/maven@3.2.rb
@@ -4,6 +4,7 @@ class MavenAT32 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz"
   mirror "https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz"
   sha256 "8c190264bdf591ff9f1268dc0ad940a2726f9e958e367716a09b8aaa7e74a755"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/maven@3.3.rb
+++ b/Formula/maven@3.3.rb
@@ -4,6 +4,7 @@ class MavenAT33 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
   mirror "https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
   sha256 "6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/maven@3.5.rb
+++ b/Formula/maven@3.5.rb
@@ -4,6 +4,7 @@ class MavenAT35 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz"
   mirror "https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz"
   sha256 "ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/mesos.rb
+++ b/Formula/mesos.rb
@@ -4,6 +4,7 @@ class Mesos < Formula
   url "https://www.apache.org/dyn/closer.lua?path=mesos/1.8.1/mesos-1.8.1.tar.gz"
   mirror "https://archive.apache.org/dist/mesos/1.8.1/mesos-1.8.1.tar.gz"
   sha256 "583f2ad0de36c3e3ce08609a6df1a3ef1145e84f453b3d56fd8332767c3a84e7"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/nifi-registry.rb
+++ b/Formula/nifi-registry.rb
@@ -4,6 +4,7 @@ class NifiRegistry < Formula
   url "https://www.apache.org/dyn/closer.lua?path=nifi/nifi-registry/nifi-registry-0.6.0/nifi-registry-0.6.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/nifi/nifi-registry/nifi-registry-0.6.0/nifi-registry-0.6.0-bin.tar.gz"
   sha256 "e52d07e5689dbab5a04fa6afb4e89b316980daac781144c9651aa81a68c38068"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/nifi.rb
+++ b/Formula/nifi.rb
@@ -4,6 +4,7 @@ class Nifi < Formula
   url "https://www.apache.org/dyn/closer.lua?path=/nifi/1.11.4/nifi-1.11.4-bin.tar.gz"
   mirror "https://archive.apache.org/dist/nifi/1.11.4/nifi-1.11.4-bin.tar.gz"
   sha256 "5bb68014f818f74b475bcd774ce8c446fc20368ec3062c5ef86e4af9b2ba9aef"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/pig.rb
+++ b/Formula/pig.rb
@@ -4,6 +4,7 @@ class Pig < Formula
   url "https://www.apache.org/dyn/closer.lua?path=pig/pig-0.17.0/pig-0.17.0.tar.gz"
   mirror "https://archive.apache.org/dist/pig/pig-0.17.0/pig-0.17.0.tar.gz"
   sha256 "6d613768e9a6435ae8fa758f8eef4bd4f9d7f336a209bba3cd89b843387897f3"
+  license "Apache-2.0"
   revision 1
 
   bottle :unneeded

--- a/Formula/predictionio.rb
+++ b/Formula/predictionio.rb
@@ -4,6 +4,7 @@ class Predictionio < Formula
   url "https://www.apache.org/dyn/closer.lua?path=predictionio/0.14.0/apache-predictionio-0.14.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/predictionio/0.14.0/apache-predictionio-0.14.0-bin.tar.gz"
   sha256 "049c9147ad9a6e2beddc2befcac5c73071845b2150c05a71118164c975de6ed7"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -4,6 +4,7 @@ class Solr < Formula
   url "https://www.apache.org/dyn/closer.lua?path=lucene/solr/8.5.2/solr-8.5.2.tgz"
   mirror "https://archive.apache.org/dist/lucene/solr/8.5.2/solr-8.5.2.tgz"
   sha256 "c457d6c7243241cad141e1df34c6f669d58a6c60e537f4217d032616dd066dcf"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -4,6 +4,7 @@ class SolrAT77 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=lucene/solr/7.7.3/solr-7.7.3.tgz"
   mirror "https://archive.apache.org/dist/lucene/solr/7.7.3/solr-7.7.3.tgz"
   sha256 "3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -5,6 +5,7 @@ class Sqoop < Formula
   mirror "https://archive.apache.org/dist/sqoop/1.4.7/sqoop-1.4.7.bin__hadoop-2.6.0.tar.gz"
   version "1.4.7"
   sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/storm.rb
+++ b/Formula/storm.rb
@@ -4,6 +4,7 @@ class Storm < Formula
   url "https://www.apache.org/dyn/closer.lua?path=storm/apache-storm-2.2.0/apache-storm-2.2.0.tar.gz"
   mirror "https://archive.apache.org/dist/storm/apache-storm-2.2.0/apache-storm-2.2.0.tar.gz"
   sha256 "f621163f349a8e85130bc3d2fbb34e3b08f9c039ccac5474f3724e47a3a38675"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/subversion@1.8.rb
+++ b/Formula/subversion@1.8.rb
@@ -4,6 +4,7 @@ class SubversionAT18 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=subversion/subversion-1.8.19.tar.bz2"
   mirror "https://archive.apache.org/dist/subversion/subversion-1.8.19.tar.bz2"
   sha256 "56e869b0db59519867f7077849c9c0962c599974f1412ea235eab7f98c20e6be"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/tika.rb
+++ b/Formula/tika.rb
@@ -4,6 +4,7 @@ class Tika < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tika/tika-app-1.24.1.jar"
   mirror "https://archive.apache.org/dist/tika/tika-app-1.24.1.jar"
   sha256 "e56d2e38be4755c78b511f316bda2a55af5c3b3b36e7e5536d3584c71239b187"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -4,6 +4,7 @@ class Tomcat < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-9/v9.0.37/bin/apache-tomcat-9.0.37.tar.gz"
   mirror "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.37/bin/apache-tomcat-9.0.37.tar.gz"
   sha256 "8fb4cfa459a3f027b855334fbdc7197fa5378e504853a98009281d8e149b1bc7"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomcat@7.rb
+++ b/Formula/tomcat@7.rb
@@ -4,6 +4,7 @@ class TomcatAT7 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-7/v7.0.105/bin/apache-tomcat-7.0.105.tar.gz"
   mirror "https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.105/bin/apache-tomcat-7.0.105.tar.gz"
   sha256 "1a36882b5e25fff4f5d8c10e4029f29e43b1db96e0df03bdbed1fa913038392f"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomcat@8.rb
+++ b/Formula/tomcat@8.rb
@@ -4,6 +4,7 @@ class TomcatAT8 < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-8/v8.5.57/bin/apache-tomcat-8.5.57.tar.gz"
   mirror "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.57/bin/apache-tomcat-8.5.57.tar.gz"
   sha256 "2615839daf1899cd705f9b82f2df6bd21adb29a93a05afdea0a6192ce54025c4"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomee-plume.rb
+++ b/Formula/tomee-plume.rb
@@ -4,6 +4,7 @@ class TomeePlume < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.3/apache-tomee-8.0.3-plume.tar.gz"
   mirror "https://archive.apache.org/dist/tomee/tomee-8.0.3/apache-tomee-8.0.3-plume.tar.gz"
   sha256 "8d08324eed84e183f35911ef35020590668ee591e43678d34d2f8545c1a78883"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomee-plus.rb
+++ b/Formula/tomee-plus.rb
@@ -4,6 +4,7 @@ class TomeePlus < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.3/apache-tomee-8.0.3-plus.tar.gz"
   mirror "https://archive.apache.org/dist/tomee/tomee-8.0.3/apache-tomee-8.0.3-plus.tar.gz"
   sha256 "7b5bad40ea64a67cfb59763fb628b6611a65aa4762a1022e2a335d8a7289ffdd"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/tomee-webprofile.rb
+++ b/Formula/tomee-webprofile.rb
@@ -4,6 +4,7 @@ class TomeeWebprofile < Formula
   url "https://www.apache.org/dyn/closer.lua?path=tomee/tomee-8.0.3/apache-tomee-8.0.3-webprofile.tar.gz"
   mirror "https://archive.apache.org/dist/tomee/tomee-8.0.3/apache-tomee-8.0.3-webprofile.tar.gz"
   sha256 "ff9921913c0a6e24514a139703db066e90d2e51c37cfde948595c7d5d5e4168b"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -4,6 +4,7 @@ class XalanC < Formula
   url "https://www.apache.org/dyn/closer.lua?path=xalan/xalan-c/sources/xalan_c-1.11-src.tar.gz"
   mirror "https://archive.apache.org/dist/xalan/xalan-c/sources/xalan_c-1.11-src.tar.gz"
   sha256 "4f5e7f75733d72e30a2165f9fdb9371831cf6ff0d1997b1fb64cdd5dc2126a28"
+  license "Apache-2.0"
   revision 1
 
   bottle do

--- a/Formula/xml-security-c.rb
+++ b/Formula/xml-security-c.rb
@@ -4,6 +4,7 @@ class XmlSecurityC < Formula
   url "https://www.apache.org/dyn/closer.lua?path=santuario/c-library/xml-security-c-2.0.2.tar.bz2"
   mirror "https://archive.apache.org/dist/santuario/c-library/xml-security-c-2.0.2.tar.bz2"
   sha256 "39e963ab4da477b7bda058f06db37228664c68fe68902d86e334614dd06e046b"
+  license "Apache-2.0"
   revision 1
 
   bottle do


### PR DESCRIPTION
add licenses for all `apache.org` formulae with `Apache-2.0` designations