### PR TITLE
daemontools: use Homebrew’s etc directory

### DIFF
--- a/Formula/daemontools.rb
+++ b/Formula/daemontools.rb
@@ -3,6 +3,7 @@ class Daemontools < Formula
   homepage "https://cr.yp.to/daemontools.html"
   url "https://cr.yp.to/daemontools/daemontools-0.76.tar.gz"
   sha256 "a55535012b2be7a52dcd9eccabb9a198b13be50d0384143bd3b32b8710df4c1f"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,16 +16,28 @@ class Daemontools < Formula
 
   def install
     cd "daemontools-#{version}" do
+      inreplace ["package/run", "src/svscanboot.sh"] do |s|
+        s.gsub! "/service", "#{etc}/service"
+      end
+
       system "package/compile"
       bin.install Dir["command/*"]
     end
   end
 
+  def post_install
+    (etc/"service").mkpath
+
+    Pathname.glob("/service/*") do |original|
+      target = "#{etc}/service/#{original.basename}"
+      ln_s original, target unless File.exist?(target)
+    end
+  end
+
   def caveats
     <<~EOS
-      You must create the /service directory before starting svscan:
-        sudo mkdir /service
-        sudo brew services start daemontools
+      Services are stored in:
+        #{etc}/service/
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Due to macOS’s file system restrictions from 10.15 and onwards, using the `/service` directory is no longer a viable option.
This PR changes the service directory to `$(brew --prefix)/etc/service`.

One side effect is that Homebrew now creates the directory at formula install time. This makes the caveat section simpler.
The caveat is also updated to alert existing users that they need to move their service directory.~ 

**Update:** In case services are found under the old location at install time, symlinks are created pointing to that old location.
Existing users are still encouraged to migrate their services to the new location before they upgrade to 10.15+, hence the new caveat.

Fixes #58222.
