### PR TITLE
nmap: make compatible with Big Sur

### DIFF
--- a/Formula/nmap.rb
+++ b/Formula/nmap.rb
@@ -21,6 +21,13 @@ class Nmap < Formula
 
   conflicts_with "ndiff", :because => "both install `ndiff` binaries"
 
+  # Remove for > 7.80
+  # Big Sur fix; see also: https://github.com/nmap/nmap/pull/2085
+  patch do
+    url "https://github.com/nmap/nmap/commit/05763b620d4c92a7fe4afee649f3b317894f5ca6.patch?full_index=1"
+    sha256 "3efed6ca33f7a529053c8f913c62966014ebcc1b0ef406fe0c251767e1300d37"
+  end
+
   def install
     ENV.deparallelize
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds an [upstream patch](https://github.com/nmap/nmap/commit/05763b620d4c92a7fe4afee649f3b317894f5ca6) that fixes an [integer truncation issue](https://github.com/nmap/nmap/pull/2085), which prevented nmap from running on on Big Sur.
