### PR TITLE
vert.x 3.9.2

### DIFF
--- a/Formula/vert.x.rb
+++ b/Formula/vert.x.rb
@@ -1,8 +1,8 @@
 class VertX < Formula
   desc "Toolkit for building reactive applications on the JVM"
   homepage "https://vertx.io/"
-  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.9.1-full.tar.gz"
-  sha256 "f0671566e3dc505282deee0aca2141583e45bd577e4d55ac7e961ad041be6472"
+  url "https://bintray.com/vertx/downloads/download_file?file_path=vert.x-3.9.2-full.zip"
+  sha256 "3f257bae643e31804816e5723ac39e5f8fe08fcb73034b74d4cc7ccb4e9e5a84"
 
   bottle :unneeded
 


### PR DESCRIPTION
Update the Eclipse vert.x formula to 3.9.2.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The https://vertx.io web site is not yet updated as homebrew is part of the release process.
