### PR TITLE
mas: fix build on Apple Silicon

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -20,10 +20,13 @@ class Mas < Formula
     # Working around build issues in dependencies
     # - Prevent warnings from causing build failures
     # - Prevent linker errors by telling all lib builds to use max size install names
+    # - Ensure dependencies build for the current CPU; otherwise Commandant will
+    #   build for x86_64 when running arm64
     xcconfig = buildpath/"Overrides.xcconfig"
     xcconfig.write <<~EOS
       GCC_TREAT_WARNINGS_AS_ERRORS = NO
       OTHER_LDFLAGS = -headerpad_max_install_names
+      VALID_ARCHS = #{Hardware::CPU.arch}
     EOS
     ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes an issue where `mas`'s dependency, `Commandant`, will only build for x86_64 unless explicitly requested to build for something else. Sample error:

```
CompileSwift normal arm64 (in target 'MasKit' from project 'mas-cli')
    cd /tmp/mas-20200720-80309-1yta3w3
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Account.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Formatters/AppInfoFormatter.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Controllers/AppLibrary.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/CKSoftwareMap+SoftwareMap.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/CKSoftwareProduct+SoftwareProduct.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Extensions/Dictionary+StringOrEmpty.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/Downloader.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/ExternalCommands/ExternalCommand.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Home.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Info.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Install.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/ISStoreAccount.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/List.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Lucky.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Controllers/MasAppLibrary.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Errors/MASError.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Controllers/MasStoreSearch.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Network/NetworkManager.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Network/NetworkResult.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Network/NetworkSession.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Open.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/ExternalCommands/OpenSystemCommand.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Outdated.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Purchase.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/PurchaseDownloadObserver.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Reset.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Search.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Models/SearchResult.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Formatters/SearchResultFormatter.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Models/SearchResultList.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/SignIn.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/SignOut.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Controllers/SoftwareMap.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Models/SoftwareProduct.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/SSPurchase.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/AppStore/StoreAccount.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Controllers/StoreSearch.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Extensions/String+PercentEncoding.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Uninstall.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Upgrade.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Network/URLSession+NetworkSession.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Formatters/Utilities.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Vendor.swift /tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Version.swift -supplementary-output-file-map /private/tmp/supplementaryOutputs-e7ac23 -target arm64-apple-macos10.11 -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk -I /private/tmp/mas-20200720-80309-1yta3w3/build/Release -I /tmp/mas-20200720-80309-1yta3w3/PrivateFrameworks/CommerceKit -I /tmp/mas-20200720-80309-1yta3w3/PrivateFrameworks/StoreFoundation -F /private/tmp/mas-20200720-80309-1yta3w3/build/Release -F /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/PrivateFrameworks -F /tmp/mas-20200720-80309-1yta3w3/Carthage/Build/Mac -g -import-underlying-module -module-cache-path /Users/mistydemeo/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -swift-version 5 -enforce-exclusivity\=checked -O -serialize-debugging-options -Xcc -working-directory -Xcc /tmp/mas-20200720-80309-1yta3w3 -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/swift-overrides.hmap -Xcc -iquote -Xcc /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/MasKit-generated-files.hmap -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/MasKit-own-target-headers.hmap -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/MasKit-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/all-product-headers.yaml -Xcc -iquote -Xcc /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/MasKit-project-headers.hmap -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/Release/include -Xcc -I/tmp/mas-20200720-80309-1yta3w3/App/PrivateHeaders -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/DerivedSources-normal/arm64 -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/DerivedSources/arm64 -Xcc -I/private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/DerivedSources -Xcc -ivfsoverlay -Xcc /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/unextended-module-overlay.yaml -target-sdk-version 11.0 -module-name MasKit -num-threads 8 -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Account.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/AppInfoFormatter.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/AppLibrary.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/CKSoftwareMap+SoftwareMap.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/CKSoftwareProduct+SoftwareProduct.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Dictionary+StringOrEmpty.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Downloader.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/ExternalCommand.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Home.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Info.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Install.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/ISStoreAccount.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/List.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Lucky.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/MasAppLibrary.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/MASError.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/MasStoreSearch.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/NetworkManager.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/NetworkResult.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/NetworkSession.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Open.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/OpenSystemCommand.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Outdated.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Purchase.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/PurchaseDownloadObserver.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Reset.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Search.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SearchResult.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SearchResultFormatter.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SearchResultList.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SignIn.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SignOut.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SoftwareMap.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SoftwareProduct.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/SSPurchase.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/StoreAccount.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/StoreSearch.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/String+PercentEncoding.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Uninstall.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Upgrade.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/URLSession+NetworkSession.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Utilities.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Vendor.o -o /private/tmp/mas-20200720-80309-1yta3w3/build/mas-cli.build/Release/MasKit.build/Objects-normal/arm64/Version.o
/tmp/mas-20200720-80309-1yta3w3/MasKit/Commands/Account.swift:9:8: error: could not find module 'Commandant' for target 'arm64-apple-macos'; found: x86_64, x86_64-apple-macos
import Commandant
       ^
```