### PR TITLE
build libosinfo 1.8 correctly

### DIFF
--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -4,6 +4,7 @@ class Libosinfo < Formula
   url "https://releases.pagure.org/libosinfo/libosinfo-1.8.0.tar.xz"
   sha256 "49ff32be0d209f6c99480e28b94340ac3dd0158322ae4303adfbdfe973a108a5"
   license "GPL-2.0"
+  revision 1
 
   bottle do
     sha256 "4630d49afe37d27ddb3402e9630ba7366c22e461b2da61d394ee883d376d4568" => :catalina
@@ -21,19 +22,47 @@ class Libosinfo < Formula
   depends_on "libsoup"
   depends_on "libxml2"
 
+  resource "pci.ids" do
+    url "https://pci-ids.ucw.cz/v2.2/pci.ids.gz"
+    sha256 "09dc9980728dfeb123884ecedf51311f6441ffa8c5fa246e4cbea571ceae41b7"
+  end
+
+  resource "usb.ids" do
+    url "http://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2020.06.22.orig.tar.xz"
+    sha256 "d55befb3b8bdb5db799fb8894c4e27ef909b2975c062fa6437297902213456a7"
+  end
+
   def install
+    (share/"misc").install resource("pci.ids")
+    (share/"misc").install resource("usb.ids")
+
     mkdir "build" do
-      system "meson", *std_meson_args, "-Denable-gtk-doc=false", ".."
+      flags = %W[
+        -Denable-gtk-doc=false
+        -Dwith-pci-ids-path=#{share/"misc/pci.ids"}
+        -Dwith-usb-ids-path=#{share/"misc/usb.ids"}
+        -Dsysconfdir=#{etc}
+      ]
+      system "meson", *std_meson_args, *flags, ".."
       system "ninja", "install", "-v"
     end
+    (share/"osinfo/.keep").write ""
   end
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
       #include <osinfo/osinfo.h>
 
       int main(int argc, char *argv[]) {
+        GError *err = NULL;
         OsinfoPlatformList *list = osinfo_platformlist_new();
+        OsinfoLoader *loader = osinfo_loader_new();
+        osinfo_loader_process_system_path(loader, &err);
+        if (err != NULL) {
+          fprintf(stderr, "%s", err->message);
+          return 1;
+        }
         return 0;
       }
     EOS
@@ -53,5 +82,6 @@ class Libosinfo < Formula
     ]
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
+    system bin/"osinfo-query", "device"
   end
 end


### PR DESCRIPTION
libosinfo require pci.ids and usb.ids files:
```console
$ osinfo-query devices
Error loading OS data: Error opening file /usr/local/Cellar/libosinfo/1.8.0/share/libosinfo/pci.ids: No such file or directory
```

those files are downloaded by meson (using wget) if not found on the system, but we don't want that (as it hides downloads from homebrew and do not control the checksums).

this pr:
* adds 2 new formulas for usb.ids and pci.ids
* updates the libosinfo formula
  * new dependenies on the 2 new formula
  * fix the install function
  * improve the test function

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
