### PR TITLE
logcli 1.5.0 (new formula)

### DIFF
--- a/Formula/logcli.rb
+++ b/Formula/logcli.rb
@@ -1,0 +1,30 @@
+class Logcli < Formula
+  desc "Run LogQL queries against a Loki server"
+  homepage "https://grafana.com/loki"
+  url "https://github.com/grafana/loki/archive/v1.5.0.tar.gz"
+  sha256 "bd32bb96db1f8d90fa8c7f5473fbff4048364b8b8a0c9fdcd21155f6a062689d"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+  depends_on "loki" => :test
+
+  def install
+    system "go", "build", *std_go_args, "./cmd/logcli"
+  end
+
+  test do
+    port = free_port
+
+    cp etc/"loki-local-config.yaml", testpath
+    inreplace "loki-local-config.yaml" do |s|
+      s.gsub! "3100", port.to_s
+      s.gsub! var, testpath
+    end
+
+    fork { exec Formula["loki"].bin/"loki", "-config.file=loki-local-config.yaml" }
+    sleep 3
+
+    output = shell_output("#{bin}/logcli --addr=http://localhost:#{port} labels")
+    assert_match "__name__", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Split from Loki, as per https://github.com/Homebrew/homebrew-core/pull/58300#issuecomment-661736554

The test is dependent on `loki` and the config file `loki` places in `etc` (not sure if there's a better way to do this). Only the help and version commands work without a Loki server.