### PR TITLE
libfabric: apply upstream patch for missing _ofi_process_vm_writev

### DIFF
--- a/Formula/libfabric.rb
+++ b/Formula/libfabric.rb
@@ -3,7 +3,7 @@ class Libfabric < Formula
   homepage "https://ofiwg.github.io/libfabric/"
   url "https://github.com/ofiwg/libfabric/releases/download/v1.10.1/libfabric-1.10.1.tar.bz2"
   sha256 "889fa8c99eed1ff2a5fd6faf6d5222f2cf38476b24f3b764f2cbb5900fee8284"
-  revision 1
+  revision 2
   head "https://github.com/ofiwg/libfabric.git"
 
   bottle do
@@ -16,6 +16,12 @@ class Libfabric < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool"  => :build
+
+  # https://github.com/ofiwg/libfabric/pull/6109 is merged upstream, remove this with next release
+  patch do
+    url "https://github.com/ofiwg/libfabric/commit/85c9732fd95f9970f5bcf793ca580d45ed7418f2.diff?full_index=1"
+    sha256 "d5beec5d57be89e0ab53aad44912af98172a85fd894d38a16330cd01dd92ae5b"
+  end
 
   def install
     system "autoreconf", "-fiv"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
