### PR TITLE
remove explicit use of --buildtype=release in meson

### DIFF
--- a/Formula/dav1d.rb
+++ b/Formula/dav1d.rb
@@ -22,7 +22,7 @@ class Dav1d < Formula
   end
 
   def install
-    system "meson", *std_meson_args, "build", "--buildtype", "release"
+    system "meson", *std_meson_args, "build"
     system "ninja", "install", "-C", "build"
   end
 

--- a/Formula/janet.rb
+++ b/Formula/janet.rb
@@ -17,7 +17,7 @@ class Janet < Formula
   depends_on "ninja" => :build
 
   def install
-    system "meson", "setup", "build", "--buildtype=release", *std_meson_args
+    system "meson", "setup", "build", *std_meson_args
     cd "build" do
       system "ninja"
       system "ninja", "install"

--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -24,7 +24,7 @@ class Lc0 < Formula
   end
 
   def install
-    system "meson", *std_meson_args, "-Dgtest=false", "--buildtype", "release", "build/release"
+    system "meson", *std_meson_args, "-Dgtest=false", "build/release"
 
     cd "build/release" do
       system "ninja", "-v"

--- a/Formula/libvmaf.rb
+++ b/Formula/libvmaf.rb
@@ -16,7 +16,7 @@ class Libvmaf < Formula
 
   def install
     Dir.chdir("libvmaf") do
-      system "meson", *std_meson_args, "build", "--buildtype", "release"
+      system "meson", *std_meson_args, "build"
       system "ninja", "-vC", "build"
       system "ninja", "-vC", "build", "install"
     end

--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -30,7 +30,6 @@ class Scrcpy < Formula
 
     mkdir "build" do
       system "meson", *std_meson_args,
-                      "--buildtype=release",
                       "-Dprebuilt_server=#{buildpath}/prebuilt-server.jar",
                       ".."
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
https://github.com/Homebrew/brew/pull/8000 added `--buildtype=release` to `std_meson_args`, so this PR removes it from explicitly being used in formulae since it's now redundant.