### PR TITLE
llvm: remove obsolete workaround

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -96,16 +96,14 @@ class Llvm < Formula
       libcxx
       libunwind
     ]
+    # Can likely be added to the base runtimes array when 11.0.0 is released.
+    runtimes << "libcxxabi" if build.head?
 
     llvmpath = buildpath/"llvm"
     unless build.head?
       llvmpath.install buildpath.children - [buildpath/".brew_home"]
       (projects + runtimes).each { |p| resource(p).stage(buildpath/p) }
     end
-
-    # Needed until https://reviews.llvm.org/D63883 lands again.
-    # Use system libcxxabi.
-    rm_r "libcxxabi" if build.head?
 
     py_ver = "3.8"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This workaround is no longer needed, and in fact the `HEAD` build now fails unless this is removed.

cc @Bo98 