### PR TITLE
gcc 10.2.0

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -1,9 +1,9 @@
 class Gcc < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-10.1.0/gcc-10.1.0.tar.xz"
-  sha256 "b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
+  sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   license "GPL-3.0"
   head "https://gcc.gnu.org/git/gcc.git"
 

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -4,7 +4,7 @@ class Ipopt < Formula
   url "https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.13.tgz"
   sha256 "aac9bb4d8a257fdfacc54ff3f1cbfdf6e2d61fb0cf395749e3b0c0664d3e7e96"
   license "EPL-1.0"
-  revision 8
+  revision 9
   head "https://github.com/coin-or/Ipopt.git"
 
   bottle do


### PR DESCRIPTION
> GCC 10.2 is a bug-fix release from the GCC 10 branch
containing important fixes for regressions and serious bugs in
GCC 10.1 with more than 94 bugs fixed since the previous release.
