### PR TITLE
opencv@2 deprecate

### DIFF
--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -11,6 +11,8 @@ class OpencvAT2 < Formula
     sha256 "b90a2e7e26ef9d18a2f87a954a786a6bc983047fbcae2280b662df66e254e76c" => :high_sierra
   end
 
+  deprecate! :date => "2015-02-01"
+
   keg_only :versioned_formula
 
   depends_on "cmake" => :build

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -11,6 +11,7 @@ class OpencvAT2 < Formula
     sha256 "b90a2e7e26ef9d18a2f87a954a786a6bc983047fbcae2280b662df66e254e76c" => :high_sierra
   end
 
+  # https://www.slideshare.net/EugeneKhvedchenya/opencv-30-latest-news-and-the-roadmap
   deprecate! :date => "2015-02-01"
 
   keg_only :versioned_formula


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to https://www.slideshare.net/EugeneKhvedchenya/opencv-30-latest-news-and-the-roadmap it has been deprecated for a while