### PR TITLE
gradle: Add settings.gradle to Gradle test

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -18,6 +18,7 @@ class Gradle < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gradle --version")
 
+    (testpath/"settings.gradle").write ""
     (testpath/"build.gradle").write <<~EOS
       println "gradle works!"
     EOS


### PR DESCRIPTION
This prevents it from searching recursively up the directory structure looking for a parent project.

Suggested by https://github.com/Homebrew/homebrew-core/pull/58466#discussion_r459522588

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?