### PR TITLE
llvm: skip OpenMP on Apple Silicon

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -88,9 +88,11 @@ class Llvm < Formula
       clang-tools-extra
       lld
       lldb
-      openmp
       polly
     ]
+    # OpenMP currently fails to build on ARM
+    # https://github.com/Homebrew/brew/issues/7857#issuecomment-661484670
+    projects << "openmp" unless Hardware::CPU.arm?
     runtimes = %w[
       compiler-rt
       libcxx


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

OpenMP is currently broken even in `HEAD` builds. We're seeing this error, where it appears to be trying to build using x86_64 ASM in a portion of this file regardless of requested architecture.

```
/tmp/llvm-20200719-2288-bsnm08/llvm-10.0.0.src/openmp/runtime/src/z_Linux_asm.S:1752:5: error: unknown directive
    .size __kmp_unnamed_critical_addr,8
    ^
make[2]: *** [projects/openmp/runtime/src/CMakeFiles/omp.dir/z_Linux_asm.S.o] Error 1
make[1]: *** [projects/openmp/runtime/src/CMakeFiles/omp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[  6%] Building CXX object lib/Support/CMakeFiles/LLVMSupport.dir/CommandLine.cpp.o
```

cc @Bo98 