### PR TITLE
jsonnet-bundler 0.4.0 (new formula)

### DIFF
--- a/Formula/jsonnet-bundler.rb
+++ b/Formula/jsonnet-bundler.rb
@@ -1,0 +1,28 @@
+class JsonnetBundler < Formula
+  desc "Package manager for Jsonnet"
+  homepage "https://github.com/jsonnet-bundler/jsonnet-bundler"
+  url "https://github.com/jsonnet-bundler/jsonnet-bundler.git",
+    tag:      "v0.4.0",
+    revision: "447344d5a038562d320a3f0dca052611ade29280"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "make", "static"
+    bin.install "_output/jb"
+  end
+
+  test do
+    assert_match "A jsonnet package manager", shell_output("#{bin}/jb 2>&1")
+
+    cd testpath.realpath do
+      system bin/"jb", "init"
+      assert_predicate testpath/"jsonnetfile.json", :exist?
+
+      system bin/"jb", "install", "https://github.com/grafana/grafonnet-lib"
+      assert_predicate testpath/"vendor", :directory?
+      assert_predicate testpath/"jsonnetfile.lock.json", :exist?
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Scott Crooks <scott.crooks@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds the **jsonnet-bundler** formula, which installs the `jb` binary. Basically, this allows a user to perform vendoring for Jsonnet libraries like https://github.com/grafana/grafonnet-lib. This way, local development can occur against a locked version of the library.