### PR TITLE
ghostscript: Fix build error on Apple silicon

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -39,6 +39,13 @@ class Ghostscript < Formula
     sha256 "0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401"
   end
 
+  # Fix build on ARM Big Sur, updating config.{guess,sub}
+  # https://bugs.ghostscript.com/show_bug.cgi?id=703095
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/98c39e09/ghostscript/config.patch"
+    sha256 "155cf2ee5a498d441c3194ba3d75cb7812beaa3f507a72017174a884bf742862"
+  end
+
   patch :DATA # Uncomment macOS-specific make vars
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When build ghostscript on Apple silicon, it fails about compiling arm neon code with following message.

```
==> make install
Last 15 lines from /Users/watson/Library/Logs/Homebrew/ghostscript/02.make:
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/gpcl6] Error 1
make: *** Waiting for unfinished jobs....
Undefined symbols for architecture arm64:
  "_png_init_filter_functions_neon", referenced from:
      _png_read_filter_row in pngrutil.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/gs] Error 1
Undefined symbols for architecture arm64:
  "_png_init_filter_functions_neon", referenced from:
      _png_read_filter_row in pngrutil.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/gxps] Error 1
```

This patch will disable compiling arm neon of libpng bundled in ghostscript.

<img width="50%" src="https://user-images.githubusercontent.com/199156/88345892-f8640080-cd81-11ea-8b81-226a7ae4643a.png">

Related to https://github.com/Homebrew/brew/issues/7857