### PR TITLE
(WIP) Kiwix-tools and dependencies

### DIFF
--- a/Formula/kiwix-lib.rb
+++ b/Formula/kiwix-lib.rb
@@ -1,0 +1,41 @@
+class KiwixLib < Formula
+  desc "Common code base for all Kiwix ports"
+  homepage "https://github.com/kiwix/kiwix-lib"
+  url "https://github.com/kiwix/kiwix-lib/archive/9.3.1.tar.gz"
+  sha256 "b36500af589797e220d0a5fc551047f016c8914ac2d4b04666daef977aa0a4ce"
+  license "GPL-3.0+"
+
+  depends_on "libkainjow-mustache" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "aria2"
+  depends_on "icu4c"
+  depends_on "libmicrohttpd"
+  depends_on "libzim"
+  depends_on "pugixml"
+
+  uses_from_macos "curl"
+
+  def install
+    inreplace "meson.build", "/usr/include/kainjow", "/usr/local/include/kainjow"
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test kiwix-lib`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/Formula/kiwix-tools.rb
+++ b/Formula/kiwix-tools.rb
@@ -1,0 +1,31 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+class KiwixTools < Formula
+  desc "Command-line Kiwix tools: kiwix-serve, kiwix-manage,"
+  homepage "https://download.kiwix.org/release/kiwix-tools/"
+  url "https://github.com/kiwix/kiwix-tools/archive/3.1.2.tar.gz"
+  sha256 "86325ec31976d40357f08c520806cf223fa1b0a5edb02ad106c2a0d6746ca364"
+  license "GPL-3.0+"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "kiwix-lib"
+  depends_on "libmicrohttpd"
+
+  uses_from_macos "zlib"
+
+  def install
+    # ENV.deparallelize  # if your formula fails when building in parallel
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    system "#{bin}/kiwix-serve", "--version"
+  end
+end

--- a/Formula/libkainjow-mustache.rb
+++ b/Formula/libkainjow-mustache.rb
@@ -1,0 +1,16 @@
+class LibkainjowMustache < Formula
+  desc "Mustache text templates for modern C++ (header-only)"
+  homepage "https://github.com/kainjow/Mustache"
+  url "https://github.com/kainjow/Mustache/archive/v4.1.tar.gz"
+  sha256 "acd66359feb4318b421f9574cfc5a511133a77d916d0b13c7caa3783c0bfe167"
+  license "BSL-1.0"
+
+  def install
+    (include/"kainjow").mkpath
+    (include/"kainjow").install "mustache.hpp"
+  end
+
+  test do
+    system "test", "-e", "#{include}/kainjow/mustache.hpp"
+  end
+end

--- a/Formula/libzim.rb
+++ b/Formula/libzim.rb
@@ -1,0 +1,39 @@
+class Libzim < Formula
+  desc "Reference implementation of the ZIM specification"
+  homepage "https://github.com/openzim/libzim"
+  url "https://download.openzim.org/release/libzim/libzim-6.1.8.tar.xz"
+  sha256 "b9b8fed4f45f42abf206ead54f0ff5560a3b6940002d0884a04ef3b74a48f9e1"
+  license "GPL-2.0+"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "icu4c"
+  depends_on "xapian"
+  depends_on "xz"
+  depends_on "zstd"
+
+  # libuuid is provided by macos
+  uses_from_macos "zlib"
+
+  def install
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test libzim`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Kiwix is a thing for reading websites or books dumped onto ZIM files. It's mostly known for its wikipedia-on-a-dvd sort of projects. libzim is the dependency for reading ZIM files.

Although we do have the Kiwix application as a cask, that thing does not have the capacity of serving the books via HTTP. Hence this bunch of formulae for building it.

The tests for libzim and kiwix-libs are missing, since I need to read the API docs to figure out a good smoke-test. As far as I can see, gtest doesn't seem like an option for the `test` part.