### PR TITLE
jenkins: fix jenkins-cli path

### DIFF
--- a/Formula/jenkins.rb
+++ b/Formula/jenkins.rb
@@ -20,9 +20,9 @@ class Jenkins < Formula
     else
       system "#{Formula["openjdk@11"].opt_bin}/jar", "xvf", "jenkins.war"
     end
-    libexec.install Dir["**/jenkins.war", "**/jenkins-cli.jar"]
+    libexec.install Dir["**/jenkins.war", "**/cli-#{version}.jar"]
     bin.write_jar_script libexec/"jenkins.war", "jenkins", :java_version => "11"
-    bin.write_jar_script libexec/"jenkins-cli.jar", "jenkins-cli", :java_version => "11"
+    bin.write_jar_script libexec/"cli-#{version}.jar", "jenkins-cli", :java_version => "11"
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `jenkins-cli` JAR script is installed, but the file it points to doesn't exist. Solution largely borrowed from the `jenkins-lts` formula.