### PR TITLE
scalapack: fix patch url

### DIFF
--- a/Formula/scalapack.rb
+++ b/Formula/scalapack.rb
@@ -18,9 +18,10 @@ class Scalapack < Formula
   depends_on "openblas"
 
   # Patch for compatibility with GCC 10
+  # https://github.com/Reference-ScaLAPACK/scalapack/pull/26
   patch do
-    url "https://github.com/Reference-ScaLAPACK/scalapack/pull/23.diff?full_index=1"
-    sha256 "6e97008a0dd8624a63718a0882aa870f31883ec00d7bfac49e9e901979359039"
+    url "https://github.com/Reference-ScaLAPACK/scalapack/commit/bc6cad585362aa58e05186bb85d4b619080c45a9.patch?full_index=1"
+    sha256 "f0892888e5a83d984e023e76eabae8864ad89b90ae3a41d472b960c95fdab981"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Relates to https://github.com/Homebrew/brew/pull/8075

https://github.com/Reference-ScaLAPACK/scalapack/pull/23 was superseded by https://github.com/Reference-ScaLAPACK/scalapack/pull/26 which merged the commit in this PR.