### PR TITLE
gitless: fix patch url

### DIFF
--- a/Formula/gitless.rb
+++ b/Formula/gitless.rb
@@ -67,8 +67,8 @@ class Gitless < Formula
   # Allow to be dependent on pygit2 1.1.1
   # Remove for next version
   patch do
-    url "https://github.com/gitless-vcs/gitless/pull/230.patch?full_index=1"
-    sha256 "fd4ef60552add5f95944083a8ba867a3b34a197bdbad6b13afcf5ab29ebe09be"
+    url "https://github.com/gitless-vcs/gitless/commit/daf352cae1f830bd4ca9adc949884b606cccdf49.diff?full_index=1"
+    sha256 "a8ef93c73a9055d59b496b1c8a1a78f42f8743b4224dd676dbe1b29ab086b3b4"
   end
 
   def install


### PR DESCRIPTION
In support of https://github.com/Homebrew/brew/pull/8075

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
