### PR TITLE
komposition: change patch url to point to commit

### DIFF
--- a/Formula/komposition.rb
+++ b/Formula/komposition.rb
@@ -33,7 +33,7 @@ class Komposition < Formula
   # remove once new version with
   # https://github.com/owickstrom/komposition/pull/102 is included
   patch do
-    url "https://github.com/owickstrom/komposition/pull/102.diff?full_index=1"
+    url "https://github.com/owickstrom/komposition/commit/e6c575cf8eddc3be30471df9a9dd92b3cb9f70c1.diff?full_index=1"
     sha256 "bdf561d07f1b8d41a4c030e121becab3b70882da8ccee53c1e91c6c0931fee0c"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Use stable commit url rather than unstable PR url for patches