### PR TITLE
ooniprobe: deprecate and fix patch url

### DIFF
--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -2,7 +2,7 @@ class Ooniprobe < Formula
   include Language::Python::Virtualenv
 
   desc "Network interference detection tool"
-  homepage "https://ooni.torproject.org/"
+  homepage "https://ooni.org/"
   url "https://files.pythonhosted.org/packages/d8/c0/b4a2ae442dd95160a75251110313d1f9b22834a76ef9bd8f70603b4a867a/ooniprobe-2.3.0.tar.gz"
   sha256 "b4c4a5665d37123b1a30f26ffb37b8c06bc722f7b829cf83f6c3300774b7acb6"
   revision 3
@@ -13,6 +13,10 @@ class Ooniprobe < Formula
     sha256 "e8e120b4342f22d48efbcfa45cde2faa28c9edd045121373f3b2ba8349e1d6fc" => :mojave
     sha256 "3e13549c0175e9f3167f24526ed0c45bd7096b84c0360042654be9b4dff980f7" => :high_sierra
   end
+
+  # Unmaintained. Last PyPI release on 2018-02-18
+  # Use https://github.com/ooni/probe-cli instead
+  deprecate! :date => "2018-02-18"
 
   depends_on "geoip"
   depends_on "libdnet"
@@ -142,7 +146,7 @@ class Ooniprobe < Formula
     # Adds support for the new CLT SDK with the 10.x
     # series of development tools.
     patch do
-      url "https://github.com/pynetwork/pypcap/pull/79.patch?full_index=1"
+      url "https://github.com/pynetwork/pypcap/commit/7c2a570823eeb45b0daf69960867d498faa6dd87.patch?full_index=1"
       sha256 "cb0c9b271d293e49e504793bed296e0fa73cca546dbc2814e0ea01351e66d9b2"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Use stable commit url rather than unstable PR url for patches