### PR TITLE
pinentry-mac: change patch url to point to commit

### DIFF
--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -20,7 +20,8 @@ class PinentryMac < Formula
 
   patch do
     # patch header locations for macOS 10.14
-    url "https://github.com/GPGTools/pinentry-mac/pull/7.patch?full_index=1"
+    # https://github.com/GPGTools/pinentry-mac/pull/7
+    url "https://github.com/GPGTools/pinentry-mac/commit/62fe9f9a3d21891e87883af2e0e3815155926b20.patch?full_index=1"
     sha256 "d4bcf2003fa1345ecb1809461140179a3737e8e03eb49d623435beb3c2f09b64"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Use stable commit url rather than unstable PR url for patches