### PR TITLE
terraformer: change patch url to point to commit

### DIFF
--- a/Formula/terraformer.rb
+++ b/Formula/terraformer.rb
@@ -16,8 +16,9 @@ class Terraformer < Formula
   depends_on "go" => :build
 
   # fix version check, remove in next release
+  # https://github.com/GoogleCloudPlatform/terraformer/pull/535
   patch do
-    url "https://github.com/GoogleCloudPlatform/terraformer/pull/535.patch?full_index=1"
+    url "https://github.com/GoogleCloudPlatform/terraformer/commit/3f75098f9e85e9630af5c4e0baa6529e52b0efb5.patch?full_index=1"
     sha256 "477581bc9a3be36427e181d2ccdcefcbf13b9230b8ddf5e9eea64de9357a6274"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Use stable commit url rather than unstable PR url for patches