### PR TITLE
yj: fix version flag

### DIFF
--- a/Formula/yj.rb
+++ b/Formula/yj.rb
@@ -16,7 +16,7 @@ class Yj < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args
+    system "go", "build", "-ldflags", "-X main.Version=#{version}", *std_go_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I made a mistake in #58620 and left out a build argument that's necessary for yj to correctly report its version.
Apologies for not double-checking this before opening the original PR. This should fix it up.

Before:
```shell
onyx:homebrew-core stephen$ yj -v
v0.0.0
```

After:
```shell
onyx:homebrew-core stephen$ yj -v
v5.0.0
```
