### PR TITLE
telegraf: fix homepage

### DIFF
--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -1,6 +1,6 @@
 class Telegraf < Formula
   desc "Server-level metric gathering agent for InfluxDB"
-  homepage "https://influxdata.com"
+  homepage "https://www.influxdata.com/"
   url "https://github.com/influxdata/telegraf/archive/v1.15.1.tar.gz"
   sha256 "19cbf4ccc9625069e74fdf3881435eab5ab087e2d458833ec749f1484e31b455"
   license "MIT"


### PR DESCRIPTION
Seen on Linux at https://github.com/Homebrew/linuxbrew-core/runs/910967994?check_suite_focus=true

```
==> brew audit telegraf --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
telegraf:
  * https://influxdata.com permanently redirects to https://www.influxdata.com/
```

-----