### PR TITLE
libcapn: fix patch url

### DIFF
--- a/Formula/libcapn.rb
+++ b/Formula/libcapn.rb
@@ -26,9 +26,14 @@ class Libcapn < Formula
   depends_on "openssl@1.1"
 
   # Compatibility with OpenSSL 1.1
+  # Original: https://github.com/adobkin/libcapn/pull/46.diff?full_index=1
   patch do
-    url "https://github.com/adobkin/libcapn/pull/46.diff?full_index=1"
-    sha256 "9d90edd1c8e3fa479554f48fe9f92afd771e5852ced595e7f66f6174d805530b"
+    url "https://github.com/adobkin/libcapn/commit/d5e7cd219b7a82156de74d04bc3668a07ec96629.diff?full_index=1"
+    sha256 "18db4435c4417cbb3052714808f50f32827effbd7f03f9ae37ab7659af53050f"
+  end
+  patch do
+    url "https://github.com/adobkin/libcapn/commit/5fde3a8faa6ce0da0bfe67834bec684a9c6fc992.diff?full_index=1"
+    sha256 "d0c87b4ffb514fa1f8a1930a73e53b76e6512b39d69fc02ed74456307c3521ae"
   end
 
   def install


### PR DESCRIPTION
In support of https://github.com/Homebrew/brew/pull/8075

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
