### PR TITLE
iproute2mac 1.3.0

### DIFF
--- a/Formula/iproute2mac.rb
+++ b/Formula/iproute2mac.rb
@@ -1,14 +1,19 @@
 class Iproute2mac < Formula
+  include Language::Python::Shebang
+
   desc "CLI wrapper for basic network utilities on macOS - ip command"
   homepage "https://github.com/brona/iproute2mac"
-  url "https://github.com/brona/iproute2mac/releases/download/v1.2.3/iproute2mac-1.2.3.tar.gz"
-  sha256 "95ef8d4b0e32e4d3e3d975afa11d7aa0797d59b0f2c21b73a4e26d357bd6f93f"
+  url "https://github.com/brona/iproute2mac/releases/download/v1.3.0/iproute2mac-1.3.0.tar.gz"
+  sha256 "3fefce6b0f5e166355fdb04934cbdd906211b64e5adb6a385469696dc51233b7"
   license "MIT"
 
   bottle :unneeded
 
+  depends_on "python@3.8"
+
   def install
     bin.install "src/ip.py" => "ip"
+    rewrite_shebang detected_python_shebang, bin/"ip"
   end
 
   test do


### PR DESCRIPTION
Upgrading iproute2mac and adding Python 3 dependency as Python 2 is no longer supported by iproute2mac.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?