### PR TITLE
caf: Use correct sha256 for 0.17.6

### DIFF
--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -3,8 +3,9 @@ class Caf < Formula
   desc "Implementation of the Actor Model for C++"
   homepage "https://actor-framework.org/"
   url "https://github.com/actor-framework/actor-framework/archive/0.17.6.tar.gz"
-  sha256 "2a39beed5b10a7632b9501317d16d9460da8dc303a4c3e7a30cb72f87b612440"
+  sha256 "e2bf5bd243f08bb7d8adde197cfe3e6d71314ed3378fe0692f8932f4c3b3928c"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/actor-framework/actor-framework.git"
 
   bottle do

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -4,6 +4,7 @@ class Zeek < Formula
   url "https://github.com/zeek/zeek.git",
       :tag      => "v3.1.4",
       :revision => "6747d93745a00d24a376d4633280a47a60961e10"
+  revision 1
   head "https://github.com/zeek/zeek.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

After a mistake in releasing CAF 0.17.6, the tag was moved to a newer commit that contained a fix. See actor-framework/actor-framework#1122 for context.