### PR TITLE
jsoncpp: fix download URL

### DIFF
--- a/Formula/jsoncpp.rb
+++ b/Formula/jsoncpp.rb
@@ -1,7 +1,7 @@
 class Jsoncpp < Formula
   desc "Library for interacting with JSON"
   homepage "https://github.com/open-source-parsers/jsoncpp"
-  url "https://github.com/open-source-parsers/jsoncpp/archive/v1.9.3.tar.gz"
+  url "https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz"
   sha256 "8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d"
   license "MIT"
   head "https://github.com/open-source-parsers/jsoncpp.git"


### PR DESCRIPTION
The old one prefixed with a `v` seems to be gone:

```
==> Downloading https://github.com/open-source-parsers/jsoncpp/archive/v1.9.3.tar.gz
==> Downloading from https://codeload.github.com/open-source-parsers/jsoncpp/tar.gz/v1.9.3

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "jsoncpp"
Download failed: https://github.com/open-source-parsers/jsoncpp/archive/v1.9.3.tar.gz
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
