### PR TITLE
fontforge: fix patch url (rollup)

### DIFF
--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -34,12 +34,11 @@ class Fontforge < Formula
   uses_from_macos "libxml2"
 
   # Remove with next release (cmake: adjust Python linkage)
-  # https://github.com/fontforge/fontforge/pull/4258
+  # Original patchset: https://github.com/fontforge/fontforge/pull/4258
   patch do
-    url "https://github.com/fontforge/fontforge/pull/4258.patch?full_index=1"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/99af4b5/fontforge/20200314.patch"
     sha256 "3deed4d79a1fdf5fb6de2fca7da8ffe14301acbeb015441574a7a28e902561f5"
   end
-
   def install
     mkdir "build" do
       system "cmake", "..",


### PR DESCRIPTION
In support of https://github.com/Homebrew/brew/pull/8075

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
