### PR TITLE
workflows: add more on-schedule workflows

### DIFF
--- a/.github/workflows/autocancel.yml
+++ b/.github/workflows/autocancel.yml
@@ -1,0 +1,18 @@
+name: Cancel previous runs
+
+on:
+  schedule:
+    # Once every 15 minutes
+    - cron: '*/15 * * * *'
+
+jobs:
+  autocancel:
+    if: github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel
+        uses: Homebrew/actions/cancel-previous-runs@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          workflow: tests.yml
+          event: pull_request

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,0 +1,28 @@
+name: Label pull requests
+
+on:
+  schedule:
+    # Once every 30 minutes
+    - cron: '*/30 * * * *'
+
+jobs:
+  autolabel:
+    if: github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label
+        uses: Homebrew/actions/label-pull-requests@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          def: |
+            [
+                {
+                    "label": "new formula",
+                    "status": "added",
+                    "path": "Formula/.+"
+                }, {
+                    "label": "marked for removal/rejection",
+                    "status": "removed",
+                    "path": "Formula/.+"
+                }
+            ]

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -1,4 +1,4 @@
-name: Scheduled tasks
+name: Publish and commit bottles on schedule
 
 on:
   schedule:
@@ -15,10 +15,8 @@ jobs:
       HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
     steps:
       - name: Update Homebrew
-        run: |
-          brew update-reset $(brew --repo)
+        run: brew update-reset $(brew --repo)
       - name: Run automerge
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-        run: |
-          brew pr-automerge --verbose --publish
+        run: brew pr-automerge --verbose --publish


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds 2 new workflows running on schedule:
- Action to label pull requests, only those adding new formula or removing an existing one for now
- Action to cancel previous workflow runs, so we don't have to do it manually and waste precious runners time

https://github.com/Homebrew/actions/pull/25
https://github.com/Homebrew/actions/pull/26