### PR TITLE
reg 0.16.1 (new formula)

### DIFF
--- a/Formula/reg.rb
+++ b/Formula/reg.rb
@@ -1,0 +1,17 @@
+class Reg < Formula
+  desc "Docker registry v2 command-line client"
+  homepage "https://r.j3ss.co"
+  url "https://github.com/genuinetools/reg/archive/v0.16.1.tar.gz"
+  sha256 "b65787bff71bff21f21adc933799e70aa9b868d19b1e64f8fd24ebdc19058430"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args
+  end
+
+  test do
+    assert_match "buster", shell_output("#{bin}/reg tags debian")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Docker registry CLI (and nice client for recently added Clair - #58680)

Notes
- Test calls out to docker.io (official Docker registry) - not sure if that's an issue