### PR TITLE
yafc: Fix test server

### DIFF
--- a/Formula/yafc.rb
+++ b/Formula/yafc.rb
@@ -27,9 +27,9 @@ class Yafc < Formula
   end
 
   test do
-    download_file = testpath/"512KB.zip"
-    expected_checksum = Checksum.new("sha256", "07854d2fef297a06ba81685e660c332de36d5d18d546927d30daad6d7fda1541")
-    output = pipe_output("#{bin}/yafc -W #{testpath} -a ftp://speedtest.tele2.net/",
+    download_file = testpath/"gcc-10.2.0.tar.xz.sig"
+    expected_checksum = Checksum.new("sha256", "8e271266e0e3312bb1c384c48b01374e9c97305df781599760944e0a093fad38")
+    output = pipe_output("#{bin}/yafc -W #{testpath} -a ftp://ftp.gnu.org/gnu/gcc/gcc-10.2.0/",
                          "get #{download_file.basename}", 0)
     assert_match version.to_s, output
     download_file.verify_checksum expected_checksum


### PR DESCRIPTION
speedtest.tele2.net hasn't been working for a long time. Replace
with ftp.gnu.org which is the least likely to go away anytime soon
(though I wouldn't trust any FTP server staying around these days)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
