### PR TITLE
dps8m: Fix test/audit

### DIFF
--- a/Formula/dps8m.rb
+++ b/Formula/dps8m.rb
@@ -1,6 +1,6 @@
 class Dps8m < Formula
   desc "Simulator for the Multics dps-8/m mainframe"
-  homepage "https://ringzero.wikidot.com"
+  homepage "http://ringzero.wikidot.com/"
   url "https://gitlab.com/dps8m/dps8m/-/archive/R2.0/dps8m-R2.0.tar.gz"
   sha256 "bb0106d0419afd75bc615006bd9e3f1ff93e12649346feb19820b73c92d06f0d"
   head "https://gitlab.com/dps8m/dps8m.git"
@@ -27,11 +27,12 @@ class Dps8m < Formula
   test do
     (testpath/"test.exp").write <<~EOS
       spawn #{bin}/dps8
-      set timeout 5
+      set timeout 30
       expect {
         timeout { exit 1 }
         "sim>"
       }
+      set timeout 10
       send "help\r"
       expect {
         timeout { exit 2 }


### PR DESCRIPTION
The expect script is timing out on the runners.  Increase the initial
spawn timeout to 30 seconds, then subsequent commands to 10 seconds.

Also fix URL so audit --strict passes.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
