### PR TITLE
alure: Fix test

### DIFF
--- a/Formula/alure.rb
+++ b/Formula/alure.rb
@@ -33,6 +33,7 @@ class Alure < Formula
   end
 
   test do
-    system bin/"alureplay", test_fixtures("test.wav")
+    output = shell_output("#{bin}/alureplay 2>&1 || true")
+    assert_match "Usage #{bin}/alureplay <soundfile>", output
   end
 end


### PR DESCRIPTION
Attempting to play audio on GitHub macOS runners will freeze the
process, eventually producing a timeout error.  There is little else
which can be tested except the error text from alureplay without any
arguments.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
