### PR TITLE
workflows: use workflow_dispatch for publishing workflow

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -1,9 +1,11 @@
 name: Publish and commit bottles
 
 on:
-  repository_dispatch:
-    types:
-      - 'Publish *'
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
 
 jobs:
   upload:
@@ -18,47 +20,53 @@ jobs:
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-          issue: ${{github.event.client_payload.pull_request}}
+          issue: ${{github.event.inputs.pull_request}}
           body: ':shipit: @${{github.actor}} has [triggered a merge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
           bot_body: ':robot: A scheduled task has [triggered a merge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
           bot: BrewTestBot
+
       - name: Update Homebrew
-        run: |
-          brew update-reset $(brew --repository)
+        run: brew update-reset $(brew --repository)
+
       - name: Checkout tap
         uses: actions/checkout@v2
         with:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           fetch-depth: 0
+
       - name: Setup tap
         run: |
           rm -rf $(brew --repository ${{github.repository}})
           ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+
       - name: Setup git
         uses: Homebrew/actions/git-user-config@master
+
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           HOMEBREW_BINTRAY_USER: brewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-        run: |
-          brew pr-pull --verbose ${{github.event.client_payload.pull_request}}
+        run: brew pr-pull --verbose ${{github.event.inputs.pull_request}}
+
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
+
       - name: Post comment on failure
         if: ${{!success()}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-          issue: ${{github.event.client_payload.pull_request}}
+          issue: ${{github.event.inputs.pull_request}}
           body: ':warning: @${{github.actor}} bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
           bot_body: ':warning: Bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
           bot: BrewTestBot
+
       - name: Dismiss approvals on failure
         if: ${{!success()}}
         uses: Homebrew/actions/dismiss-approvals@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-          pr: ${{github.event.client_payload.pull_request}}
+          pr: ${{github.event.inputs.pull_request}}
           message: 'bottle publish failed'
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This will create an option to trigger bottle publish via GitHub UI, as shown here: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

Needs to be merged in sync with: https://github.com/Homebrew/brew/pull/8116

I also inserted newlines between steps for better readability, as it is done in `tests.yml`.