### PR TITLE
workflows: label more

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -24,5 +24,17 @@ jobs:
                     "label": "marked for removal/rejection",
                     "status": "removed",
                     "path": "Formula/.+"
+                }, {
+                    "label": "bottle unneeded",
+                    "path": "Formula/.+",
+                    "content": "bottle :unneeded"
+                }, {
+                    "label": "formula deprecated",
+                    "path": "Formula/.+",
+                    "content": "deprecate!"
+                }, {
+                    "label": "formula disabled",
+                    "path": "Formula/.+",
+                    "content": "disable!"
                 }
             ]


### PR DESCRIPTION
Label PRs with `bottle unneeded` label, if `bottle :unneeded` string is found in PR files and more...

Currently in this PR:
- bottle unneeded
- formula deprecated
- formula disabled

----

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----