### PR TITLE
Skip redundant cd's to testpath

### DIFF
--- a/Formula/atool.rb
+++ b/Formula/atool.rb
@@ -23,13 +23,11 @@ class Atool < Formula
   end
 
   test do
-    mkdir "apple_juice"
-    cd testpath/"apple_juice" do
-      touch "example.txt"
-      touch "example2.txt"
-      system bin/"apack", "test.tar.gz", "example.txt", "example2.txt"
-    end
-    output = shell_output("#{bin}/als #{testpath}/apple_juice/test.tar.gz")
+    touch "example.txt"
+    touch "example2.txt"
+    system bin/"apack", "test.tar.gz", "example.txt", "example2.txt"
+
+    output = shell_output("#{bin}/als test.tar.gz")
     assert_match "example.txt", output
     assert_match "example2.txt", output
   end

--- a/Formula/aws-cdk.rb
+++ b/Formula/aws-cdk.rb
@@ -22,12 +22,13 @@ class AwsCdk < Formula
   end
 
   test do
-    mkdir "testapp"
-    cd testpath/"testapp"
-    shell_output("#{bin}/cdk init app --language=javascript")
-    list = shell_output("#{bin}/cdk list")
-    cdkversion = shell_output("#{bin}/cdk --version")
-    assert_match "TestappStack", list
-    assert_match version.to_s, cdkversion
+    # `cdk init` cannot be run in a non-empty directory
+    mkdir "testapp" do
+      shell_output("#{bin}/cdk init app --language=javascript")
+      list = shell_output("#{bin}/cdk list")
+      cdkversion = shell_output("#{bin}/cdk --version")
+      assert_match "TestappStack", list
+      assert_match version.to_s, cdkversion
+    end
   end
 end

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -185,14 +185,12 @@ class Gnuradio < Formula
     EOS
     system "python", testpath/"test.py"
 
-    cd testpath do
-      system "#{bin}/gr_modtool", "newmod", "test"
+    system "#{bin}/gr_modtool", "newmod", "test"
 
-      cd "gr-test" do
-        system "#{bin}/gr_modtool", "add", "-t", "general", "test_ff", "-l",
-               "python", "-y", "--argument-list=''", "--add-python-qa",
-               "--copyright=brew"
-      end
+    cd "gr-test" do
+      system "#{bin}/gr_modtool", "add", "-t", "general", "test_ff", "-l",
+              "python", "-y", "--argument-list=''", "--add-python-qa",
+              "--copyright=brew"
     end
   end
 end

--- a/Formula/jsonnet-bundler.rb
+++ b/Formula/jsonnet-bundler.rb
@@ -23,13 +23,11 @@ class JsonnetBundler < Formula
   test do
     assert_match "A jsonnet package manager", shell_output("#{bin}/jb 2>&1")
 
-    cd testpath.realpath do
-      system bin/"jb", "init"
-      assert_predicate testpath/"jsonnetfile.json", :exist?
+    system bin/"jb", "init"
+    assert_predicate testpath/"jsonnetfile.json", :exist?
 
-      system bin/"jb", "install", "https://github.com/grafana/grafonnet-lib"
-      assert_predicate testpath/"vendor", :directory?
-      assert_predicate testpath/"jsonnetfile.lock.json", :exist?
-    end
+    system bin/"jb", "install", "https://github.com/grafana/grafonnet-lib"
+    assert_predicate testpath/"vendor", :directory?
+    assert_predicate testpath/"jsonnetfile.lock.json", :exist?
   end
 end

--- a/Formula/mlpack.rb
+++ b/Formula/mlpack.rb
@@ -57,13 +57,11 @@ class Mlpack < Formula
   end
 
   test do
-    cd testpath do
-      system "#{bin}/mlpack_knn",
-        "-r", "#{pkgshare}/tests/data/GroupLensSmall.csv",
-        "-n", "neighbors.csv",
-        "-d", "distances.csv",
-        "-k", "5", "-v"
-    end
+    system "#{bin}/mlpack_knn",
+      "-r", "#{pkgshare}/tests/data/GroupLensSmall.csv",
+      "-n", "neighbors.csv",
+      "-d", "distances.csv",
+      "-k", "5", "-v"
 
     (testpath/"test.cpp").write <<-EOS
       #include <mlpack/core.hpp>

--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -97,25 +97,23 @@ class PreCommit < Formula
   end
 
   test do
-    testpath.cd do
-      system "git", "init"
-      (testpath/".pre-commit-config.yaml").write <<~EOS
-        -   repo: https://github.com/pre-commit/pre-commit-hooks
-            sha: v0.9.1
-            hooks:
-            -   id: trailing-whitespace
-      EOS
-      system bin/"pre-commit", "install"
-      (testpath/"f").write "hi\n"
-      system "git", "add", "f"
+    system "git", "init"
+    (testpath/".pre-commit-config.yaml").write <<~EOS
+      -   repo: https://github.com/pre-commit/pre-commit-hooks
+          sha: v0.9.1
+          hooks:
+          -   id: trailing-whitespace
+    EOS
+    system bin/"pre-commit", "install"
+    (testpath/"f").write "hi\n"
+    system "git", "add", "f"
 
-      ENV["GIT_AUTHOR_NAME"] = "test user"
-      ENV["GIT_AUTHOR_EMAIL"] = "test@example.com"
-      ENV["GIT_COMMITTER_NAME"] = "test user"
-      ENV["GIT_COMMITTER_EMAIL"] = "test@example.com"
-      git_exe = which("git")
-      ENV["PATH"] = "/usr/bin:/bin"
-      system git_exe, "commit", "-m", "test"
-    end
+    ENV["GIT_AUTHOR_NAME"] = "test user"
+    ENV["GIT_AUTHOR_EMAIL"] = "test@example.com"
+    ENV["GIT_COMMITTER_NAME"] = "test user"
+    ENV["GIT_COMMITTER_EMAIL"] = "test@example.com"
+    git_exe = which("git")
+    ENV["PATH"] = "/usr/bin:/bin"
+    system git_exe, "commit", "-m", "test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Known audit failure:

```console
$ brew audit --strict gnuradio
gnuradio:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      lib/libgnuradio-runtime.3.7.13.4.dylib
      lib/libvolk.1.4.dylib
Error: 1 problem in 1 formula detected
```
