### PR TITLE
workflows: tighten regexes for labelling

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -27,14 +27,14 @@ jobs:
                 }, {
                     "label": "bottle unneeded",
                     "path": "Formula/.+",
-                    "content": "bottle :unneeded"
+                    "content": "\n  bottle :unneeded\n"
                 }, {
                     "label": "formula deprecated",
                     "path": "Formula/.+",
-                    "content": "deprecate!"
+                    "content": "\n  deprecate!.*\n"
                 }, {
                     "label": "formula disabled",
                     "path": "Formula/.+",
-                    "content": "disable!"
+                    "content": "\n  disable!\n"
                 }
             ]


### PR DESCRIPTION
Make content regexes tighter, so we don't match on comments or something else.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----