### PR TITLE
vsts-cli: deprecate

### DIFF
--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -14,6 +14,9 @@ class VstsCli < Formula
     sha256 "59d1ccaa24e3356771bd998de79c226803957811170765933d5ca03f3547f99a" => :high_sierra
   end
 
+  # https://github.com/Azure/azure-devops-cli-extension/pull/219#issuecomment-456404611
+  deprecate! date: "2019-01-22"
+
   depends_on "python@3.8"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to [this comment](https://github.com/Azure/azure-devops-cli-extension/pull/219#issuecomment-456404611) and [this repo's README](https://github.com/Azure/azure-devops-cli-extension), `vsts-cli` has been deprecated for a while.

I've chosen to provide the comment's URL as it's the only one that gives us the date on which the Formula was deprecated.