### PR TITLE
workflows: don't checkout whole repo on upload

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -27,18 +27,20 @@ jobs:
           bot: BrewTestBot
 
       - name: Update Homebrew
-        run: brew update-reset $(brew --repository)
-
-      - name: Checkout tap
-        uses: actions/checkout@v2
-        with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-          fetch-depth: 0
+        run: brew update-reset $(brew --repo)
 
       - name: Setup tap
         run: |
-          rm -rf $(brew --repository ${{github.repository}})
-          ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+          cd ..
+          rmdir ${{github.workspace}}
+          ln -s $(brew --repo ${{github.repository}}) ${{github.workspace}}
+
+      - name: Checkout tap
+        run:
+          git remote set-url origin ${{github.event.repository.clone_url}}
+          git fetch --prune --force origin master
+          git reset --hard origin/master
+          git log -1
 
       - name: Setup git
         uses: Homebrew/actions/git-user-config@master
@@ -52,6 +54,8 @@ jobs:
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
 
       - name: Post comment on failure
         if: ${{!success()}}


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR aims to avoid the need to check out whole repository with full history each time a publish job is run.
Rather, reuse the existing repo in VM image and just reset it from `linuxbrew-core` to `homebrew-core`.