### PR TITLE
Update CGAL to 5.1

### DIFF
--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -1,8 +1,8 @@
 class Cgal < Formula
   desc "Computational Geometry Algorithms Library"
   homepage "https://www.cgal.org/"
-  url "https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-5.0.2/CGAL-5.0.2.tar.xz"
-  sha256 "bb3594ba390735404f0972ece301f369b1ff12646ad25e48056b4d49c976e1fa"
+  url "https://github.com/CGAL/cgal/releases/tag/releases%2FCGAL-5.1-beta2/CGAL-5.1-beta2.tar.xz"
+  sha256 "7f111880ec353e4111ab7ee4f522915361abd4be846f9f110addad6861b5f488"
   license "GPL-3.0"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

 This PR updates the CGAL version to 5.1. It is only to get the tests from the CI from now, as we are only in a beta version.