### PR TITLE
bzt: Bump revision

### DIFF
--- a/Formula/bzt.rb
+++ b/Formula/bzt.rb
@@ -6,7 +6,7 @@ class Bzt < Formula
   url "https://files.pythonhosted.org/packages/3a/e5/04383f5a7b060b753a6ce741b9e3bf4150c83b0ff9b7a07cc3c6c18ebfb8/bzt-1.14.2.tar.gz"
   sha256 "b79298e80516e42997c68951d15bce772d366eed2d23d1d42ac7f24b06345837"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/Blazemeter/taurus.git"
 
   bottle do


### PR DESCRIPTION
bzt-1.14.2_1 is currently missing on bintray; bump to rebuild.

==> brew fetch --retry bzt
==> FAILED
==> Downloading https://homebrew.bintray.com/bottles/bzt-1.14.2_1.catalina.bottle.tar.gz
curl: (22) The requested URL returned error: 404 Not Found

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
