### PR TITLE
breezy: Add brz alias

### DIFF
--- a/Aliases/brz.rb
+++ b/Aliases/brz.rb
@@ -1,0 +1,1 @@
+../Formula/breezy.rb


### PR DESCRIPTION
While the upstream is canonically named "breezy", its main program is
named brz (with a compatibility symlink to bzr), and other distributions
usually package breezy as "brz".  This alias also mirrors bazaar's bzr
alias.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
