### PR TITLE
rust-analyzer: explicit version

### DIFF
--- a/Formula/rust-analyzer.rb
+++ b/Formula/rust-analyzer.rb
@@ -2,6 +2,7 @@ class RustAnalyzer < Formula
   desc "Experimental Rust compiler front-end for IDEs"
   homepage "https://rust-analyzer.github.io/"
   url "https://github.com/rust-analyzer/rust-analyzer/archive/2020-07-20.tar.gz"
+  version "2020-07-20"
   sha256 "0b2277f7e1a359c6a5ddf69ba1a8acda769dd2709b1b5b65117531ee56e6d734"
 
   bottle do


### PR DESCRIPTION
It is improperly interpreted by brew as MONTH-DAY:

```
==> Downloading https://homebrew.bintray.com/bottles/rust-analyzer-07-20.catalina.bottle.tar.gz
```

when it should be: YEAR-MONTH-DAY.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----