### PR TITLE
workflows/autolabel: add gopath deprecation

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -29,6 +29,10 @@ jobs:
                     "path": "Formula/.+",
                     "content": "\n  bottle :unneeded\n"
                 }, {
+                    "label": "gopath deprecation",
+                    "path": "Formula/.+",
+                    "content": "\"GOPATH\""
+                }, {
                     "label": "formula deprecated",
                     "path": "Formula/.+",
                     "content": "\n  deprecate!.*\n"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds `gopath deprecation` label if any occurrences of `"GOPATH"` (including `"`) are found in modified formulae

Related: #47627