### PR TITLE
pango: fix the build on newer clang releases

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -6,7 +6,7 @@ class Glib < Formula
   url "https://download.gnome.org/sources/glib/2.64/glib-2.64.4.tar.xz"
   sha256 "f7e0b325b272281f0462e0f7fff25a833820cac19911ff677251daf6d87bce50"
   license "LGPL-2.1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "5b4079bc14d3e16b745686b6cc7a3bca8877ac914f4ea11b82cda7e5af21c51c" => :catalina
@@ -40,6 +40,14 @@ class Glib < Formula
   patch do
     url "https://gitlab.gnome.org/GNOME/glib/-/commit/c60d6599c9182ce44fdfaa8dde2955f55fc0d628.patch"
     sha256 "9e3de41571edaa4bce03959abf885aad4edd069a622a5b642bf40294d748792e"
+  end
+
+  # Enables G_GNUC_FALLTHROUGH on clang.
+  # Necessary for pango to build on recent versions of clang.
+  # Will be in the next release.
+  patch do
+    url "https://gitlab.gnome.org/GNOME/glib/-/commit/5f38ae5ffca3213addc5b279a46d537792d031db.patch"
+    sha256 "12128966a693dd45d2e20286437aea13b1fe554aed0907cbc33131d3b76be890"
   end
 
   def install

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -1,9 +1,20 @@
 class Pango < Formula
   desc "Framework for layout and rendering of i18n text"
   homepage "https://www.pango.org/"
-  url "https://download.gnome.org/sources/pango/1.44/pango-1.44.7.tar.xz"
-  sha256 "66a5b6cc13db73efed67b8e933584509f8ddb7b10a8a40c3850ca4a985ea1b1f"
   license "GPL-2.0"
+
+  stable do
+    url "https://download.gnome.org/sources/pango/1.44/pango-1.44.7.tar.xz"
+    sha256 "66a5b6cc13db73efed67b8e933584509f8ddb7b10a8a40c3850ca4a985ea1b1f"
+
+    # Adopts an upstream patch to fix compilers that are picky about
+    # fallthrough (e.g., newer clang).
+    # Can be removed on the next release.
+    patch do
+      url "https://gitlab.gnome.org/GNOME/pango/-/commit/0b3cd20be5249c51ec981a66c07a39d54d1d1c9d.patch"
+      sha256 "252378845c5b1b09bf5ae1e06200bba7bf3d4bd679aff2888e95233cf8762a76"
+    end
+  end
 
   bottle do
     sha256 "38a8cab63ed7ea37fc5448b74dae21b7f935d4f4ea9c08b658f3553f20ec8f28" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes the build on upcoming versions of clang, which are stricter about fallthrough in `switch` statements. Thankfully the appropriate fix is already applied upstream; we just need to apply it. This requires backporting an additional upstream patch for `glib` in order to ensure the appropriate macro is defined.