### PR TITLE
jc 1.13.1

### DIFF
--- a/Formula/jc.rb
+++ b/Formula/jc.rb
@@ -3,8 +3,8 @@ class Jc < Formula
 
   desc "Serializes the output of command-line tools to structured JSON output"
   homepage "https://github.com/kellyjonbrazil/jc"
-  url "https://files.pythonhosted.org/packages/bf/34/1145fb85a333524b06d562f803a85e09e73902f8adf88c8e48cd4e23ae29/jc-1.12.1.tar.gz"
-  sha256 "b7ffbc90720681fd09033e21301471b673cebfaa29016cdd01630055e3c9226d"
+  url "https://files.pythonhosted.org/packages/ef/95/d1b5aa0662572629110fb73c3730c4664040fbc2adc92f4e2d04ec789642/jc-1.13.1.tar.gz"
+  sha256 "0d743199ed58c3ce09f4171c97e5aaa7df91fc42bc18854a773f2e19041d9d1a"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
bump to v1.13.1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Submitting manually since `brew bump-formula-pr --strict jc --url=https://files.pythonhosted.org/packages/ef/95/d1b5aa0662572629110fb73c3730c4664040fbc2adc92f4e2d04ec789642/jc-1.13.1.tar.gz --sha256=0d743199ed58c3ce09f4171c97e5aaa7df91fc42bc18854a773f2e19041d9d1a` is giving me the following error: 
```
Updating Homebrew...
==> Auto-updated Homebrew!
Updated Homebrew from f4f4d911c to c115d59b2.
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 1 formula.

==> replace /https:\/\/files\.pythonhosted\.org\/packages\/bf\/34\/1145fb85a333524b06d562f803a85e
==> replace "b7ffbc90720681fd09033e21301471b673cebfaa29016cdd01630055e3c9226d" with "0d743199ed58
==> brew update-python-resources jc
Error: Unable to determine dependencies for "jc" because of a failure when running
`pipgrip --json jc==1.13.1`. Please update the resources for "jc" manually.
```
