### PR TITLE
ejabberd 20.07

### DIFF
--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -1,8 +1,8 @@
 class Ejabberd < Formula
   desc "XMPP application server"
   homepage "https://www.ejabberd.im"
-  url "https://static.process-one.net/ejabberd/downloads/20.04/ejabberd-20.04.tgz"
-  sha256 "130673a835a9768a47c78c6bfe9c622a3b5916dd8aaf12aad0acd2d0f7f3a5cf"
+  url "https://static.process-one.net/ejabberd/downloads/20.07/ejabberd-20.07.tgz"
+  sha256 "9e922b938458ae9d72d4e5fdd2d08a1fbad651aae47c9a9d15b79d0bbd1e11f8"
   license "GPL-2.0"
   revision 1
 
@@ -56,6 +56,14 @@ class Ejabberd < Formula
   def post_install
     (var/"lib/ejabberd").mkpath
     (var/"spool/ejabberd").mkpath
+
+    # Create the vm.args file, to generate a cookie
+    require "securerandom"
+    cookie = SecureRandom.hex
+    vm_args_file = etc/"ejabberd/vm.args"
+    vm_args_file.write <<~EOS
+      -setcookie #{cookie}
+    EOS
   end
 
   def caveats


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR updates ejabberd to upstream version 20.07.

It also improves Erlang cookie management to be able to start ejabberd through `brew services` command and still be able to interact with it using `ejabberdctl` command line tool.