### PR TITLE
mosh, tfenv: move patch inside `stable` block

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -1,10 +1,19 @@
 class Mosh < Formula
   desc "Remote terminal application"
   homepage "https://mosh.org"
-  url "https://mosh.org/mosh-1.3.2.tar.gz"
-  sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
   license "GPL-3.0"
   revision 11
+
+  stable do
+    url "https://mosh.org/mosh-1.3.2.tar.gz"
+    sha256 "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216"
+
+    # Fix mojave build.
+    patch do
+      url "https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0.patch?full_index=1"
+      sha256 "022bf82de1179b2ceb7dc6ae7b922961dfacd52fbccc30472c527cb7c87c96f0"
+    end
+  end
 
   bottle do
     cellar :any
@@ -26,14 +35,6 @@ class Mosh < Formula
 
   uses_from_macos "ncurses"
 
-  # Fix mojave build.
-  unless build.head?
-    patch do
-      url "https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0.patch?full_index=1"
-      sha256 "022bf82de1179b2ceb7dc6ae7b922961dfacd52fbccc30472c527cb7c87c96f0"
-    end
-  end
-
   def install
     ENV.cxx11
 
@@ -43,7 +44,6 @@ class Mosh < Formula
 
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}", "--enable-completion"
-    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -1,26 +1,27 @@
 class Tfenv < Formula
   desc "Terraform version manager inspired by rbenv"
   homepage "https://github.com/tfutils/tfenv"
-  url "https://github.com/tfutils/tfenv/archive/v2.0.0.tar.gz"
-  sha256 "de3dcf13768cb078e94d68ca85071b8d6e44104394336d952255ca558b854b0b"
   license "MIT"
   head "https://github.com/tfutils/tfenv.git"
+
+  stable do
+    url "https://github.com/tfutils/tfenv/archive/v2.0.0.tar.gz"
+    sha256 "de3dcf13768cb078e94d68ca85071b8d6e44104394336d952255ca558b854b0b"
+
+    # fix bash 3.x compatibility
+    # removed in the next release
+    # Original source: "https://github.com/tfutils/tfenv/pull/181.patch?full_index=1"
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/526faca9830646b974f563532fa27a1515e51ca1/tfenv/2.0.0.patch"
+      sha256 "b1365be51a8310a44b330f9b008dabcdfe2d16b0349f38988e7a24bcef6cae09"
+    end
+  end
 
   bottle :unneeded
 
   uses_from_macos "unzip"
 
   conflicts_with "terraform", because: "tfenv symlinks terraform binaries"
-
-  # fix bash 3.x compatibility
-  # removed in the next release
-  # Original source: "https://github.com/tfutils/tfenv/pull/181.patch?full_index=1"
-  unless build.head?
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/526faca9830646b974f563532fa27a1515e51ca1/tfenv/2.0.0.patch"
-      sha256 "b1365be51a8310a44b330f9b008dabcdfe2d16b0349f38988e7a24bcef6cae09"
-    end
-  end
 
   def install
     prefix.install %w[bin lib libexec share]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `mosh` and `tfenv` to match pretty much all other formulae that have patches that only apply to `stable`

`mosh` - removed `make check` to pass `brew audit`