### PR TITLE
aspectj: depend on openjdk

### DIFF
--- a/Formula/aspectj.rb
+++ b/Formula/aspectj.rb
@@ -3,16 +3,17 @@ class Aspectj < Formula
   homepage "https://eclipse.org/aspectj/"
   url "https://www.eclipse.org/downloads/download.php?r=1&file=/tools/aspectj/aspectj-1.9.6.jar"
   sha256 "afec62c03fe154adeecf9cd599ce033fff258d1d373a82511e5df54f79ab03e2"
+  revision 1
 
   bottle :unneeded
 
-  depends_on java: "1.8"
+  depends_on "openjdk"
 
   def install
     mkdir_p "#{libexec}/#{name}"
-    system "java", "-jar", "aspectj-#{version}.jar", "-to", "#{libexec}/#{name}"
+    system "#{Formula["openjdk"].bin}/java", "-jar", "aspectj-#{version}.jar", "-to", "#{libexec}/#{name}"
     bin.install Dir["#{libexec}/#{name}/bin/*"]
-    bin.env_script_all_files(libexec/"#{name}/bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files libexec/"#{name}/bin", Language::Java.overridable_java_home_env
     chmod 0555, Dir["#{libexec}/#{name}/bin/*"] # avoid 0777
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Not sure if `revision` bump is needed but added it for now.

> What Java versions does AspectJ require and support?
> 
> The AspectJ compiler produces programs for any released version of the Java platform (jdk1.1 and later). When running, your program classes must be able to reach classes in the small (< 100K) runtime library (aspectjrt.jar) from the distribution. The tools themselves require J2SE 1.3 or later to run, but the compiler can produce classes for any 1.1-compliant version of the Java platform. 