### PR TITLE
workflows/tests: untap mongodb on macOS.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,10 @@ jobs:
         git checkout --force -B master FETCH_HEAD
         cd -
 
-        if [ "$RUNNER_OS" = "Linux" ]; then
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          # don't care about `brew audit` here.
+          brew untap mongodb/brew
+        else
           sudo chown -R "$USER" "$HOMEBREW_PREFIX"
           sudo chmod -R g-w,o-w "$HOMEBREW_CORE_REPOSITORY"
         fi

--- a/Formula/flow.rb
+++ b/Formula/flow.rb
@@ -20,10 +20,6 @@ class Flow < Formula
   uses_from_macos "rsync" => :build
   uses_from_macos "unzip" => :build
 
-  on_linux do
-    depends_on "elfutils"
-  end
-
   def install
     system "make", "all-homebrew"
 

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -25,7 +25,6 @@ class Freerdp < Formula
   on_linux do
     depends_on "ffmpeg"
     depends_on "glib"
-    depends_on "systemd"
   end
 
   def install


### PR DESCRIPTION
This will enable `brew audit` to pass.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----