### PR TITLE
workflows/tests: run tap_syntax job only on Linux.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,7 @@ on:
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Homebrew
       id: set-up-homebrew


### PR DESCRIPTION
Some food for thought as:

- the only thing that is different on macOS is the `brew readall` behaviour on differing macOS/Linux Formula code (and that's more likely to be already working and will be caught by our self-hosted workers)
- the Linux workers are dramatically faster than the macOS ones and this saves the macOS Actions workers for the cases where they are actually needed.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----