### PR TITLE
archey: deprecate and move patch to `stable` block

### DIFF
--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -1,21 +1,24 @@
 class Archey < Formula
   desc "Graphical system information display for macOS"
   homepage "https://obihann.github.io/archey-osx/"
-  url "https://github.com/obihann/archey-osx/archive/1.6.0.tar.gz"
-  sha256 "0f0ffcf8c5f07610b98f0351dcb38bb8419001f40906d5dc4bfd28ef12dbd0f8"
   license "GPL-2.0"
   revision 1
   head "https://github.com/obihann/archey-osx.git"
 
-  bottle :unneeded
+  stable do
+    url "https://github.com/obihann/archey-osx/archive/1.6.0.tar.gz"
+    sha256 "0f0ffcf8c5f07610b98f0351dcb38bb8419001f40906d5dc4bfd28ef12dbd0f8"
 
-  # Fix double percent sign in battery output, remove in next release
-  unless build.head?
+    # Fix double percent sign in battery output
     patch do
       url "https://github.com/obihann/archey-osx/commit/cd125547d0936f066b64616553269bf647348e53.diff?full_index=1"
       sha256 "c03b80e4d5aa114b81ac04bfa77c46055fe01764ae877a8a061f3d43c9de8a72"
     end
   end
+
+  bottle :unneeded
+
+  deprecate! date: "2017-04-28"
 
   def install
     bin.install "bin/archey"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The GitHub repository has been archived: https://github.com/obihann/archey-osx

There appears to be a maintained fork https://github.com/athlonreg/archey-osx but it hasn't had a tagged release since 2018

-----

Moved `patch` to `stable` block to match similar formulae that have patches that only apply to `stable`

Originally part of #58864