### PR TITLE
rbenv-gemset: disable

### DIFF
--- a/Formula/rbenv-gemset.rb
+++ b/Formula/rbenv-gemset.rb
@@ -3,9 +3,12 @@ class RbenvGemset < Formula
   homepage "https://github.com/jf/rbenv-gemset"
   url "https://github.com/jf/rbenv-gemset/archive/v0.5.9.tar.gz"
   sha256 "856aa45ce1e9ac56d476667e2ca58f5f312600879fec4243073edc88a41954da"
-  license "Unlicense"
   revision 1
   head "https://github.com/jf/rbenv-gemset.git"
+
+  # Does not have a valid license
+  # https://github.com/jf/rbenv-gemset/issues/93
+  disable!
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to the [`README`](https://github.com/jf/rbenv-gemset#license):

> ## License
>
> This code is placed in the public domain by the author, Jamis Buck. Use it as you wish. Please prefer good over evil.

While unlicensed, this doesn't use the [`Unlicense` license](https://spdx.org/licenses/Unlicense.html#licenseText).

The formula is being deleted because it does not have an OSI-approved license.

See https://github.com/Homebrew/homebrew-core/issues/58225#issuecomment-667749880 and https://github.com/jf/rbenv-gemset/issues/93