### PR TITLE
Do not install Git completion for Zsh

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -114,8 +114,6 @@ class Git < Formula
     # install the completion script first because it is inside "contrib"
     bash_completion.install "contrib/completion/git-completion.bash"
     bash_completion.install "contrib/completion/git-prompt.sh"
-    zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
-    cp "#{bash_completion}/git-completion.bash", zsh_completion
 
     elisp.install Dir["contrib/emacs/*.el"]
     (share/"git-core").install "contrib"


### PR DESCRIPTION
The Zsh completion supplied with Git is buggy and outdated.
Zsh itself includes much better Git completion out of the box.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
